### PR TITLE
pdf-fill-form: Add writeSync, allow other types

### DIFF
--- a/types/pdf-fill-form/index.d.ts
+++ b/types/pdf-fill-form/index.d.ts
@@ -5,7 +5,7 @@
 /// <reference types="node" />
 
 export interface WritableFields {
-    [key: string]: string;
+    [key: string]: string | boolean | number;
 }
 
 export type ReadableFields = Array<{
@@ -38,6 +38,7 @@ export function readBuffer(sourceBuffer: Buffer): Promise<ReadableFields>;
 export function readBufferSync(sourceBuffer: Buffer): ReadableFields;
 
 export function write(sourceFile: string, fields: WritableFields, options?: Options): Promise<Buffer>;
+export function writeSync(sourceFile: string, fields: WritableFields, options?: Options): Buffer;
 export function writeBuffer(sourceBuffer: Buffer, fields: WritableFields, options?: Options): Promise<Buffer>;
 export function writeBufferSync(sourceBuffer: Buffer, fields: WritableFields, options?: Options): Buffer;
 

--- a/types/pdf-fill-form/pdf-fill-form-tests.ts
+++ b/types/pdf-fill-form/pdf-fill-form-tests.ts
@@ -1,4 +1,14 @@
-import { write, writeBuffer, read, readBuffer, writeAsync, ReadableFields } from 'pdf-fill-form';
+import {
+    write,
+    writeBuffer,
+    read,
+    readBuffer,
+    writeAsync,
+    ReadableFields,
+    writeSync,
+    readSync,
+    readBufferSync,
+} from 'pdf-fill-form';
 import { readFileSync } from 'fs';
 
 const buffer = readFileSync('test.pdf');
@@ -11,14 +21,26 @@ async function main() {
     // $ExpectType ReadableFields || { name: string; page: number; value: string; id: number; type: string; }[]
     await readBuffer(buffer);
 
+    // $ExpectType ReadableFields || { name: string; page: number; value: string; id: number; type: string; }[]
+    readSync('./test.pdf');
+
+    // $ExpectType ReadableFields || { name: string; page: number; value: string; id: number; type: string; }[]
+    readBufferSync(buffer);
+
     // $ExpectType Buffer
     await write('test.pdf', { field: 'test' }, { save: 'pdf' });
 
     // $ExpectType Buffer
+    writeSync('test.pdf', { field: 'test' }, { save: 'pdf' });
+
+    // $ExpectType Buffer
     await writeBuffer(buffer, { otherField: '123' }, { save: 'imgpdf', antialias: true });
 
+    // $ExpectType Buffer
+    await writeBuffer(buffer, { field: 123, otherField: true });
+
     // $ExpectError
-    await writeBuffer(buffer, { field: 123 });
+    await writeBuffer(buffer, { field: ['123', 'test'] });
 }
 
 main();


### PR DESCRIPTION
- Function `writeSync` added as documented in package README.
- Boolean and Number values are now allowed as "WritableFields" values, (passing bools and nums as strings does work, however it makes code slightly messier and less elegant)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/tpisto/pdf-fill-form/blob/master/README.md#using-callbacks>
