### PR TITLE
sql.js: Support import sql.js/dist/sql*

### DIFF
--- a/types/sql.js/OTHER_FILES.txt
+++ b/types/sql.js/OTHER_FILES.txt
@@ -1,0 +1,5 @@
+dist/sql-asm-debug.d.ts
+dist/sql-asm-memory-growth.d.ts
+dist/sql-asm.d.ts
+dist/sql-wasm-debug.d.ts
+dist/sql-wasm.d.ts

--- a/types/sql.js/dist/sql-asm-debug.d.ts
+++ b/types/sql.js/dist/sql-asm-debug.d.ts
@@ -1,0 +1,3 @@
+import initSqlJs from '..';
+export default initSqlJs;
+export * from '..';

--- a/types/sql.js/dist/sql-asm-memory-growth.d.ts
+++ b/types/sql.js/dist/sql-asm-memory-growth.d.ts
@@ -1,0 +1,3 @@
+import initSqlJs from '..';
+export default initSqlJs;
+export * from '..';

--- a/types/sql.js/dist/sql-asm.d.ts
+++ b/types/sql.js/dist/sql-asm.d.ts
@@ -1,0 +1,3 @@
+import initSqlJs from '..';
+export default initSqlJs;
+export * from '..';

--- a/types/sql.js/dist/sql-wasm-debug.d.ts
+++ b/types/sql.js/dist/sql-wasm-debug.d.ts
@@ -1,0 +1,3 @@
+import initSqlJs from '..';
+export default initSqlJs;
+export * from '..';

--- a/types/sql.js/dist/sql-wasm.d.ts
+++ b/types/sql.js/dist/sql-wasm.d.ts
@@ -1,0 +1,3 @@
+import initSqlJs from '..';
+export default initSqlJs;
+export * from '..';

--- a/types/sql.js/sql.js-tests.ts
+++ b/types/sql.js/sql.js-tests.ts
@@ -1,6 +1,13 @@
 import fs = require('fs');
 
 import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import initAsmDebugSqlJs, { Database as AsmDebugSqlJsDatabase } from 'sql.js/dist/sql-asm-debug.js';
+import initAsmMemoryGrowthSqlJs, {
+    Database as AsmMemoryGrowthSqlJsDatabase,
+} from 'sql.js/dist/sql-asm-memory-growth.js';
+import initAsmSqlJs, { Database as AsmSqlJsDatabase } from 'sql.js/dist/sql-asm.js';
+import initWasmDebugSqlJs, { Database as WasmDebugSqlJsDatabase } from 'sql.js/dist/sql-wasm-debug.js';
+import initWasmSqlJs, { Database as WasmSqlJsDatabase } from 'sql.js/dist/sql-wasm.js';
 
 const DB_PATH = 'data.db';
 
@@ -101,4 +108,29 @@ initSqlJs().then(SqlJs => {
     x.value.step();
 
     db.run('DROP TABLE test;');
+});
+
+initAsmDebugSqlJs().then(async SqlJs => {
+    const db: AsmDebugSqlJsDatabase = new SqlJs.Database();
+    db.exec('SELECT sqlite_version() AS version');
+});
+
+initAsmMemoryGrowthSqlJs().then(async SqlJs => {
+    const db: AsmMemoryGrowthSqlJsDatabase = new SqlJs.Database();
+    db.exec('SELECT sqlite_version() AS version');
+});
+
+initAsmSqlJs().then(async SqlJs => {
+    const db: AsmSqlJsDatabase = new SqlJs.Database();
+    db.exec('SELECT sqlite_version() AS version');
+});
+
+initWasmDebugSqlJs().then(async SqlJs => {
+    const db: WasmDebugSqlJsDatabase = new SqlJs.Database();
+    db.exec('SELECT sqlite_version() AS version');
+});
+
+initWasmSqlJs().then(async SqlJs => {
+    const db: WasmSqlJsDatabase = new SqlJs.Database();
+    db.exec('SELECT sqlite_version() AS version');
 });


### PR DESCRIPTION
sql.js exposes different entry points with the same API, just different
implementations. With the change the following are supported:

```typescript
import initSqlJs from 'sql.js/dist/sql-asm-debug.js';
import initSqlJs from 'sql.js/dist/sql-asm-memory-growth.js';
import initSqlJs from 'sql.js/dist/sql-asm.js';
import initSqlJs from 'sql.js/dist/sql-wasm-debug.js';
import initSqlJs from 'sql.js/dist/sql-wasm.js';
```

in addition to the existing:

```typescript
import initSqlJs from 'sql.js';
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sql.js.org/#/?id=versions-of-sqljs-included-in-the-distributed-artifacts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
