### PR TITLE
[Luxon] Fix is* input to be unknown

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -549,7 +549,7 @@ export class DateTime {
      *
      * @param o
      */
-    static isDateTime(o: object): o is DateTime;
+    static isDateTime(o: unknown): o is DateTime;
 
     // INFO
 

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -164,7 +164,7 @@ export class Duration {
      *
      * @param o
      */
-    static isDuration(o: object): o is Duration;
+    static isDuration(o: unknown): o is Duration;
 
     /**
      * Get  the locale of a Duration, such 'en-GB'

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -72,7 +72,7 @@ export class Interval {
      *
      * @param o
      */
-    static isInterval(o: object): o is Interval;
+    static isInterval(o: unknown): o is Interval;
 
     /**
      * Returns the start of the Interval

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -28,6 +28,7 @@ DateTime.utc(); // $ExpectType DateTime
 DateTime.utc({ locale: 'en-US' }); // $ExpectType DateTime
 DateTime.utc(2018, 5, 31, 23, { numberingSystem: 'arabext' }); // $ExpectType DateTime
 DateTime.utc(2019, { locale: 'en-GB' }, 5); // $ExpectError
+DateTime.isDateTime(0 as unknown); // $ExpectType boolean
 
 const dt = DateTime.local(2017, 5, 15, 8, 30);
 
@@ -215,6 +216,7 @@ if (Duration.isDuration(anything)) {
 }
 Duration.invalid(); // $ExpectError
 Duration.invalid('code', 'because I said so'); // $ExpectType Duration
+Duration.isDuration(0 as unknown); // $ExpectType boolean
 
 /* Interval */
 const later = DateTime.local();
@@ -240,6 +242,7 @@ if (Interval.isInterval(anything)) {
 }
 Interval.invalid(); // $ExpectError
 Interval.invalid('code', 'because I said so'); // $ExpectType Interval
+Interval.isInterval(0 as unknown); // $ExpectType boolean
 
 /* Info */
 Info.months();


### PR DESCRIPTION
Regression from v1 types. Luxon supports anything as input not just objects.
https://github.com/moment/luxon/blob/c869041f6948a97661ab3d230547ee0fe04e9cb2/src/datetime.js#L890

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
