### PR TITLE
[README] Restore markdown link checks

### DIFF
--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npx remark --use validate-links . .github
+      - run: npx remark --use validate-links --frail . .github


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#51067

@orta I think this can be reverted now that https://github.com/Flet/github-slugger/pull/38 has been released, in github-slugger 1.4.0?

validate-links checks for typos in markdown heading references (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49667).

github-slugger previously computed the wrong slugs for (some) unicode headings (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50583).

#51067 (the change I propose reverting) downgraded those errors (spurious and accurate) to warnings. Now that the problem has been corrected and released, I think those errors can be restored?