### PR TITLE
[ioredis] add missing definition of bitfield command

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -205,6 +205,9 @@ declare namespace IORedis {
         bitcount(key: KeyType): Promise<number>;
         bitcount(key: KeyType, start: number, end: number): Promise<number>;
 
+        bitfield(key: KeyType, args: ValueType, callback: Callback<number[]>): void;
+        bitfield(key: KeyType, args: ValueType): Promise<number[]>;
+
         get(key: KeyType, callback: Callback<string | null>): void;
         get(key: KeyType): Promise<string | null>;
 
@@ -1305,6 +1308,8 @@ declare namespace IORedis {
 
         bitcount(key: KeyType, callback?: Callback<number>): Pipeline;
         bitcount(key: KeyType, start: number, end: number, callback?: Callback<number>): Pipeline;
+
+        bitfield(key: KeyType, args: ValueType, callback?: Callback<number[]>): Pipeline;
 
         get(key: KeyType, callback?: Callback<string>): Pipeline;
         getBuffer(key: KeyType, callback?: Callback<Buffer>): Pipeline;

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -168,6 +168,8 @@ redis.zscan('key', 0, 'MATCH', '*foo*', 'COUNT', 100).then(console.log);
 redis.zscan('key', 0, 'MATCH', '*foo*', 'COUNT', 100, cb);
 redis.pfadd('key', 'a', 'b', 'c').then(console.log);
 redis.pfadd('key', 'a', 'b', 'c', cbNumber);
+redis.bitfield('key', ['INCRBY', 'i5', '100', '1', 'GET', 'u4', '0'], cb);
+redis.bitfield('key', ['INCRBY', 'i5', '100', '1', 'GET', 'u4', '0']).then(console.log);
 
 // Test OverloadedKeyedHashCommand for hset
 redis.hset('foo', '1', '2', '3', 4, '5', new Buffer([])).then(console.log);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

Reference: [official document of BITFIELD command](https://redis.io/commands/bitfield)

Adding missing definition of BITFIELD command, which was missing.

Please point out if there is any weird part of the changes that I've made. I'll try to fix as soon as I recognize.
