### PR TITLE
[express-http-proxy]: fix typings for proxyRes, proxyReq

### DIFF
--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -164,4 +164,4 @@ proxy("www.google.com", {
         const modifiedHTML = proxyResData;
         return modifiedHTML;
     },
-})
+});

--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -153,3 +153,15 @@ proxy("www.google.com", {
         });
     },
 });
+
+proxy("www.google.com", {
+    userResDecorator(proxyRes, proxyResData, userReq, userRes) {
+        const contentType = proxyRes.headers["content-type"];
+        if (contentType !== "text/html") {
+            return proxyResData;
+        }
+        // apply some transformation to proxyResData's HTML if you need
+        const modifiedHTML = proxyResData;
+        return modifiedHTML;
+    },
+})

--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -58,7 +58,7 @@ proxy("www.google.com", {
 proxy("www.google.com", {
     userResHeaderDecorator(headers, userReq, userRes, proxyReq, proxyRes) {
         console.log(userReq.url, userRes.statusCode);
-        console.log(proxyReq.url, proxyRes.statusCode);
+        console.log(proxyReq.host, proxyRes.statusCode);
         if (headers["content-type"] === "image/png") {
             headers["x-custom-header"] = "additional-info";
         }

--- a/types/express-http-proxy/index.d.ts
+++ b/types/express-http-proxy/index.d.ts
@@ -10,7 +10,7 @@
 // TypeScript Version: 2.3
 
 import { RequestHandler, Request, Response, NextFunction } from "express";
-import { RequestOptions, IncomingHttpHeaders, OutgoingHttpHeaders } from "http";
+import { RequestOptions, IncomingHttpHeaders, OutgoingHttpHeaders, ClientRequest, IncomingMessage } from "http";
 
 declare namespace proxy {
     interface ProxyOptions {
@@ -34,11 +34,11 @@ declare namespace proxy {
             headers: IncomingHttpHeaders,
             userReq: Request,
             userRes: Response,
-            proxyReq: Request,
-            proxyRes: Response
+            proxyReq: ClientRequest,
+            proxyRes: IncomingMessage
         ) => OutgoingHttpHeaders) | undefined;
         userResDecorator?: ((
-            proxyRes: Response,
+            proxyRes: IncomingMessage,
             proxyResData: any,
             userReq: Request,
             userRes: Response
@@ -48,7 +48,7 @@ declare namespace proxy {
          * Return true to continue to execute proxy; return false-y to skip proxy for this request.
          */
         filter?: ((req: Request, res: Response) => boolean | Promise<boolean>) | undefined;
-        skipToNextHandlerFilter?: ((proxyRes: Response) => boolean) | undefined;
+        skipToNextHandlerFilter?: ((proxyRes: IncomingMessage) => boolean) | undefined;
         proxyReqBodyDecorator?: ((bodyContent: any, srcReq: Request) => any) | undefined;
         preserveHostHdr?: boolean | undefined;
         parseReqBody?: boolean | undefined;


### PR DESCRIPTION
TL;DR: `proxyRes` and `proxyReq` come from calling `request` from the `http` or `https` Node.js libraries.

The request is made in [`sendProxyRequest`](https://github.com/villadora/express-http-proxy/blob/master/app/steps/sendProxyRequest.js#L12-L13), and `requestModule` is set in [`resolveProxyHost`](https://github.com/villadora/express-http-proxy/blob/master/app/steps/resolveProxyHost.js#L15) through the [`parseHost`](https://github.com/villadora/express-http-proxy/blob/2aec18894bfe4d06fc61d959cf718c9e1496226e/lib/requestOptions.js#L23) function, which sets the `module` property to the `http` or `https` Node.js modules.