### PR TITLE
Add scorm-browser package definition

### DIFF
--- a/types/scorm-browser/1.2/CMIDataTypes.d.ts
+++ b/types/scorm-browser/1.2/CMIDataTypes.d.ts
@@ -1,0 +1,149 @@
+/**
+ * A single character, 0 to 9, a to z.
+ */
+export type Char =
+    | '0'
+    | '1'
+    | '2'
+    | '3'
+    | '4'
+    | '5'
+    | '6'
+    | '7'
+    | '8'
+    | '9'
+    | 'a'
+    | 'b'
+    | 'c'
+    | 'd'
+    | 'e'
+    | 'f'
+    | 'g'
+    | 'h'
+    | 'i'
+    | 'j'
+    | 'k'
+    | 'l'
+    | 'm'
+    | 'n'
+    | 'o'
+    | 'p'
+    | 'q'
+    | 'r'
+    | 's'
+    | 't'
+    | 'u'
+    | 'v'
+    | 'w'
+    | 'x'
+    | 'y'
+    | 'z';
+
+/**
+ * An empty string ("").
+ */
+export type CMIBlank = '';
+
+/**
+ * A vocabulary of two words ("true" or "false").
+ */
+export type CMIBoolean = 'true' | 'false';
+
+/**
+ * A number that may have a decimal point. If not preceded by a minus sign, the number is presumed to be positive. Examples are "2", "2.2" and "-2.2".
+ */
+export type CMIDecimal = `${string}`;
+
+/**
+ * Feedback is one of the following single characters: "0", "1", "t" or "f".
+ */
+export type CMIFeedbackTrueFalse = '0' | '1' | 't' | 'f';
+
+/**
+ * Feedback is one or more single characters separated by a comma. Legal characters are "0" to "9" and "a" to "z". If all the characters must be chosen to assume the feedback is correct, then the
+ * comma-separated list must be surrounded by curly brackets: {}
+ */
+export type CMIFeedbackChoice = `{${string}}` | string;
+
+/**
+ * Any alpha-numeric string up to 255 characters in length. After the first letter spaces are significant.
+ */
+export type CMIFeedbackFillIn = string;
+
+/**
+ * A number that may have a decimal point. If not preceded by a minus sign, the number is presumed to be positive. Examples are "2", "2.2" and "-2.2".
+ */
+export type CMIFeedbackNumeric = CMIDecimal;
+
+/**
+ * Single character. Legal characters are 0 to 9 and a to z.
+ */
+export type CMIFeedbackLikert = Char;
+
+/**
+ * One or more pairs of identifiers. Each identifier is a single letter or number (0 to 9 and a to z). The identifiers in a pair are separated by a period. Commas separate the pairs. If all pairs
+ * must be matched correctly to consider the interaction correct, then the comma separated list of pairs are surrounded by curly brackets: {}
+ */
+export type CMIFeedbackMatching = `{${string}}` | string;
+
+/**
+ * This is a very flexible format. Essentially an alphanumeric string of 255 characters or less.
+ */
+export type CMIFeedbackPerformance = string;
+
+/**
+ * A series of single characters separated by commas. Legal characters are 0 to 9 and a to z. The order of the characters determines the correctness of the feedback.
+ */
+export type CMIFeedbackSequencing = string;
+
+/**
+ * A structured description of a student response in an interaction. The structure and contents of the feedback depends upon the type of interaction.
+ */
+export type CMIFeedback =
+    | CMIFeedbackTrueFalse
+    | CMIFeedbackChoice
+    | CMIFeedbackFillIn
+    | CMIFeedbackNumeric
+    | CMIFeedbackLikert
+    | CMIFeedbackMatching
+    | CMIFeedbackPerformance;
+
+/**
+ * An alphanumeric group of characters with no white space or unprintable characters in it. Maximum of 255 characters.
+ */
+export type CMIIdentifier = string;
+
+/**
+ * An integer number from 0 to 65536.
+ */
+export type CMIInteger = string;
+
+/**
+ * A signed integer number from -32768 to +32768.
+ */
+export type CMISInteger = string;
+
+/**
+ * A set of ASCII characters with a maximum length of 255 characters.
+ */
+export type CMIString255 = string;
+
+/**
+ * A set of ASCII characters with a maximum length of 4096 characters.
+ */
+export type CMIString4096 = string;
+
+/**
+ * A chronological point in a 24 hour clock. Identified in hours, minutes and seconds in the format: HH:MM:SS.SS.
+ *
+ * Hours and minutes shall contain exactly 2 digits. Seconds shall contain 2 digits, with an optional decimal point and 1 or 2 additional digits (i.e. 34.45).
+ */
+export type CMITime = `${string}:${string}:${string}`;
+
+/**
+ * A length of time in hours, minutes and seconds shown in the following numerical format: HHHH:MM:SS.SS.
+ *
+ * Hours have a minimum of 2 digits and a maximum of 4 digits. Minutes shall consist of exactly 2 digits. Seconds shall contain 2 digits, with an optional decimal point and 1 or 2 additional digits
+ * (i.e. 34.45).
+ */
+export type CMITimeSpan = `${string}:${string}:${string}`;

--- a/types/scorm-browser/1.2/CMIElement.d.ts
+++ b/types/scorm-browser/1.2/CMIElement.d.ts
@@ -1,0 +1,251 @@
+export type n = string; // NOTE: Ideally this would be number but it would force the developer to use template literals over the toString method
+
+/**
+ * Listing of supported data model elements
+ */
+export type CMIElementCoreChildren = 'cmi.core._children';
+
+/**
+ * Identifies the student on behalf of whom the SCO was launched
+ */
+export type CMIElementCoreStudentId = 'cmi.core.student_id';
+
+/**
+ * Name provided for the student by the LMS
+ */
+export type CMIElementCoreStudentName = 'cmi.core.student_name';
+
+/**
+ * The learner’s current location in the SCO
+ */
+export type CMIElementCoreLessonLocation = 'cmi.core.lesson_location';
+
+/**
+ * Indicates whether the learner will be credited for performance in the SCO
+ */
+export type CMIElementCoreCredit = 'cmi.core.credit';
+
+/**
+ * Indicates whether the learner has completed and satisfied the requirements for the SCO
+ */
+export type CMIElementCoreLessonStatus = 'cmi.core.lesson_status';
+
+/**
+ * Asserts whether the learner has previously accessed the SCO
+ */
+export type CMIElementCoreEntry = 'cmi.core.entry';
+
+/**
+ * Listing of supported data model elements
+ */
+export type CMIElementCoreScoreChildren = 'cmi.core.score_children';
+
+/**
+ * Number that reflects the performance of the learner relative to the range bounded by the values of min and max
+ */
+export type CMIElementCoreScoreRaw = 'cmi.core.score.raw';
+
+/**
+ * Maximum value in the range for the raw score
+ */
+export type CMIElementCoreScoreMax = 'cmi.core.score.max';
+
+/**
+ * Minimum value in the range for the raw score
+ */
+export type CMIElementCoreScoreMin = 'cmi.core.score.min';
+
+/**
+ * Sum of all of the learner’s session times accumulated in the current learner attempt
+ */
+export type CMIElementCoreTotalTime = 'cmi.core.total_time';
+
+/**
+ * Identifies one of three possible modes in which the SCO may be presented to the learner
+ */
+export type CMIElementCoreLessonMode = 'cmi.core.lesson_mode';
+
+/**
+ * Indicates how or why the learner left the SCO
+ */
+export type CMIElementCoreExit = 'cmi.core.exit';
+
+/**
+ * Amount of time that the learner has spent in the current learner session for this SCO
+ */
+export type CMIElementCoreSessionTime = 'cmi.core.session_time';
+
+/**
+ * Provides space to store and retrieve data between learner sessions
+ */
+export type CMIElementSuspendData = 'cmi.suspend_data';
+
+/**
+ * Data provided to a SCO after launch, initialized from the dataFromLMS manifest element
+ */
+export type CMIElementLaunchData = 'cmi.launch_data';
+
+/**
+ * Textual input from the learner about the SCO
+ */
+export type CMIElementComments = 'cmi.comments';
+
+/**
+ * Comments or annotations associated with a SCO
+ */
+export type CMIElementCommentsFromLMS = 'cmi.comments_from_lms';
+
+/**
+ * Listing of supported data model elements
+ */
+export type CMIElementObjectivesChildren = 'cmi.objectives._children';
+
+/**
+ * Current number of objectives being stored by the LMS
+ */
+export type CMIElementObjectivesCount = 'cmi.objectives._count';
+
+/**
+ * Unique label for the objective
+ */
+export type CMIElementObjectivesNID = `cmi.objectives.${n}.id`;
+
+/**
+ * Listing of supported data model elements
+ */
+export type CMIElementObjectivesNScoreChildren = `cmi.objectives.${n}.score._children`;
+
+/**
+ * Number that reflects the performance of the learner, for the objective, relative to the range bounded by the values of min and max
+ */
+export type CMIElementObjectivesNScoreRaw = `cmi.objectives.${n}.score.raw`;
+
+/**
+ * Maximum value, for the objective, in the range for the raw
+ */
+export type CMIElementObjectivesNScoreMax = `cmi.objectives.${n}.score.max`;
+
+/**
+ * Minimum value, for the objective, in the range for the raw
+ */
+export type CMIElementObjectivesNScoreMin = `cmi.objectives.${n}.score.min`;
+
+/**
+ * Indicates whether the learner has completed or satisfied the objective
+ */
+export type CMIElementObjectivesNStatus = `cmi.objectives.${n}.status`;
+
+/**
+ * Listing of supported data model elements
+ */
+export type CMIElementStudentDataChildren = 'cmi.student_data._children';
+
+/**
+ * Passing score required to master the SCO
+ */
+export type CMIElementStudentDataMasteryScore = 'cmi.student_data.mastery_score';
+
+/**
+ * Amount of accumulated time the learner is allowed to use a SCO
+ */
+export type CMIElementStudentDataMaxTimeAllowed = 'cmi.student_data.max_time_allowed';
+
+/**
+ * Indicates what the SCO should do when max_time_allowed is exceeded
+ */
+export type CMIElementStudentDataTimeLimitAction = 'cmi.student_data.time_limit_action';
+
+/**
+ * Listing of supported data model elements
+ */
+export type CMIElementStudentPreferenceChildren = 'cmi.student_preference._children';
+
+/**
+ * Specifies an intended change in perceived audio level
+ */
+export type CMIElementStudentPreferenceAudio = 'cmi.student_preference.audio';
+
+/**
+ * The student’s preferred language for SCOs with multilingual capability
+ */
+export type CMIElementStudentPreferenceLanguage = 'cmi.student_preference.language';
+
+/**
+ * The learner’s preferred relative speed of content delivery
+ */
+export type CMIElementStudentPreferenceSpeed = 'cmi.student_preference.speed';
+
+/**
+ * Specifies whether captioning text corresponding to audio is displayed
+ */
+export type CMIElementStudentPreferenceText = 'cmi.student_preference.text';
+
+/**
+ * Listing of supported data model elements
+ */
+export type CMIElementInteractionsChildren = 'cmi.interactions._children';
+
+/**
+ * Current number of interactions being stored by the LMS
+ */
+export type CMIElementInteractionsCount = 'cmi.interactions._count';
+
+/**
+ * Unique label for the interaction
+ */
+export type CMIElementInteractionsNID = `cmi.interactions.${n}.id`;
+
+/**
+ * Current number of objectives (i.e., objective identifiers) being stored by the LMS for this interaction
+ */
+export type CMIElementInteractionsNObjectivesCount = `cmi.interactions.${n}.objectives._count`;
+
+/**
+ * Label for objectives associated with the interaction
+ */
+export type CMIElementInteractionsNObjectivesID = `cmi.interactions.${n}.objectives.${n}.id`;
+
+/**
+ * Point in time at which the interaction was first made available to the student for student interaction and response
+ */
+export type CMIElementInteractionsNTime = `cmi.interactions.${n}.time`;
+
+/**
+ * Which type of interaction is recorded
+ */
+export type CMIElementInteractionsNType = `cmi.interactions.${n}.type`;
+
+/**
+ * Current number of correct responses being stored by the LMS for this interaction
+ */
+export type CMIElementInteractionsNCorrectResponsesCount = `cmi.interactions.${n}.correct_responses._count`;
+
+/**
+ * One correct response pattern for the interaction
+ */
+export type CMIElementInteractionsNCorrectResponsesNPattern = `cmi.interactions.${n}.correct_responses.${n}.pattern`;
+
+/**
+ * Weight given to the interaction relative to other interactions
+ */
+export type CMIElementInteractionsNWeighting = `cmi.interactions.${n}.weighting`;
+
+/**
+ * Data generated when a student responds to an interaction
+ */
+export type CMIElementInteractionsNStudentResponse = `cmi.interactions.${n}.student_response`;
+
+/**
+ * Judgment of the correctness of the learner response
+ */
+export type CMIElementInteractionsNResult = `cmi.interactions.${n}.result`;
+
+/**
+ * Time elapsed between the time the interaction was made available to the learner for response and the time of the first response
+ */
+export type CMIElementInteractionsNLatency = `cmi.interactions.${n}.latency`;
+
+/**
+ * The version of the data model supported by the LMS
+ */
+export type CMIElementVersion = 'cmi._version';

--- a/types/scorm-browser/1.2/CMIErrorCode.d.ts
+++ b/types/scorm-browser/1.2/CMIErrorCode.d.ts
@@ -1,0 +1,80 @@
+// Null errors
+
+/**
+ * No error
+ */
+export type CMIErrorCodeNoerror = '0';
+
+// General errors
+
+/**
+ * General exception
+ */
+export type CMIErrorCodeGeneralException = '101';
+
+// Syntax errors
+
+/**
+ * Invalid argument error
+ */
+export type CMIErrorCodeInvalidArgumentError = '201';
+
+/**
+ * Element cannot have children
+ */
+export type CMIErrorCodeElementCannotHaveChildren = '202';
+
+/**
+ * Element not an array. Cannot have count
+ */
+export type CMIErrorCodeElementNotAnArrayCannotHaveCount = '203';
+
+// LMS errors
+
+/**
+ * Not initialized
+ */
+export type CMIErrorCodeNotInitialized = '301';
+
+// Data model errors
+
+/**
+ * Not implemented error
+ */
+export type CMIErrorCodeNotImplementedError = '401';
+
+/**
+ * Invalid set value, element is a keyword
+ */
+export type CMIErrorCodeInvalidSetValueElementIsAKeyword = '402';
+
+/**
+ * Element is read only
+ */
+export type CMIErrorCodeElementIsReadOnly = '403';
+
+/**
+ * Element is write only
+ */
+export type CMIErrorCodeElementIsWriteOnly = '404';
+
+/**
+ * Incorrect data type
+ */
+export type CMIErrorCodeIncorrectDataType = '405';
+
+/**
+ * The CMIErrorCode data type is a three-digit number, represented as a string, that corresponds to one of the SCORM Run-Time error codes.
+ */
+export type CMIErrorCode =
+    | CMIErrorCodeNoerror
+    | CMIErrorCodeGeneralException
+    | CMIErrorCodeInvalidArgumentError
+    | CMIErrorCodeElementCannotHaveChildren
+    | CMIErrorCodeElementNotAnArrayCannotHaveCount
+    | CMIErrorCodeNotInitialized
+    | CMIErrorCodeNotImplementedError
+    | CMIErrorCodeInvalidSetValueElementIsAKeyword
+    | CMIErrorCodeElementIsReadOnly
+    | CMIErrorCodeElementIsWriteOnly
+    | CMIErrorCodeIncorrectDataType;

--- a/types/scorm-browser/1.2/CMIVocabulary.d.ts
+++ b/types/scorm-browser/1.2/CMIVocabulary.d.ts
@@ -1,0 +1,73 @@
+import { CMIDecimal } from './CMIDataTypes';
+
+/**
+ * A set vocabulary phrase. Three possible vocabulary values:
+ *
+ * - "browse": The student wants to preview the materials, but not necessarily challenge the SCO for a grade.
+ * - "normal": This indicates that the SCO should behave as designed for a student wanting to get credit for his learning.
+ * - "review": The student has already seen the material at least once and been graded.
+ *
+ * If an unrecognized or unanticipated lesson_mode is received, then **normal** is assumed by the SCO.
+ */
+export type CMIVocabularyMode = 'normal' | 'review' | 'browse';
+
+/**
+ * A set vocabulary phrase. Six possible vocabulary values:
+ *
+ * - "passed": Necessary number of objectives in the SCO were mastered, or the necessary score was achieved. Student is considered to have completed the SCO and passed.
+ * - "completed": The SCO may or may not be passed, but all the elements in the SCO were experienced by the student. The student is considered to have completed the SCO. For instance, passing may
+ * depend on a certain score known to the LMS system. The SCO knows the raw score but not whether that raw score was high enough to pass.
+ * - "failed": The SCO was not passed. All the SCO elements may or may not have been completed by the student. The student is considered to have completed the SCO and failed.
+ * - "incomplete": The SCO was begun but not finished.
+ * - "browsed": The student launched the SCO with a LMS mode of Browse on the initial attempt.
+ * - "not attempted": Incomplete implies that the student made an attempt to perform the SCO, but for some reason was unable to finish it. Not attempted means that the student did not even begin the
+ * SCO. Maybe he just read the table of contents, or the SCO abstract and decided he was not ready. Any algorithm within the SCO may be used to determine when the SCO moves from "not attempted" to
+ * "incomplete".
+ */
+export type CMIVocabularyStatus = 'passed' | 'completed' | 'failed' | 'incomplete' | 'browsed' | 'not attempted';
+
+/**
+ * A set vocabulary phrase. Three possible vocabulary values:
+ *
+ * - "time-out": This indicates the SCO ended because the SCO has determined an excessive amount of time has elapsed, or the max_time_allowed has been exceeded. The max_time_allowed can be found in
+ * the manifest (adlcp:maxtimeallowed for the item)
+ * - "suspend": This indicates the student leaves the SCO with the intent of returning to it later at the point where he/she left.
+ * - "logout": This indicates that the student logged out from within the SCO instead of returning to the LMS system to log out. This implies that the SCO passed control to the LMS system, and the
+ * LMS system automatically logged the student out of the course - after updating the appropriate data model elements.
+ * - "": The empty string vocabulary should be used to represent a normal exit state.
+ */
+export type CMIVocabularyExit = 'time-out' | 'suspend' | 'logout' | '';
+
+/**
+ * A set vocabulary phrase. Two possible vocabulary values:
+ * - "credit": This means that the student is taking the SCO for credit. The LMS system is telling the SCO that if the SCO sends data to the LMS system, the LMS system will credit it to the student.
+ * - "no-credit": This means that the student is taking the SCO for no-credit. His current credit if any (for instance a score of 80 and a status of passed) will not be changed by his performance in
+ * this SCO. The LMS system is telling the SCO that if the SCO sends data to the LMS system it will not change the student's accreditation.
+ */
+export type CMIVocabularyCredit = 'credit' | 'no-credit';
+
+/**
+ * A set vocabulary phrase. Three possible vocabulary values:
+ *
+ * - "ab-initio": This indicates it is the first time the student is entering the SCO. Because the student may have passed all of the objectives in an SCO by completing a pre-test, the lesson_status
+ * of not attempted is not a reliable indicator. That is, a SCO may be passed without the student having ever seen it.
+ * - "resume": This indicates that the student was in the SCO earlier. The student is resuming a suspended SCO.
+ * - "": The empty string should be used to represent an entry into the SCO that is neither an initial (ab-initio) nor a continuation from a suspended state (resume). A scenario that this might be
+ * used is if the SCO was already completed and then later it was loaded for review purposes. In this case it was neither an initial launch (ab-initio) nor a continuation from a suspended state
+ * (resume).
+ */
+export type CMIVocabularyEntry = 'ab-initio' | 'resume' | '';
+
+export type CMIVocabularyInteraction =
+    | 'true-false'
+    | 'choice'
+    | 'fill-in'
+    | 'numeric'
+    | 'likert'
+    | 'matching'
+    | 'performance'
+    | 'sequencing';
+
+export type CMIVocabularyResult = 'correct' | 'wrong' | 'unanticipated' | 'neutral' | CMIDecimal;
+
+export type CMIVocabularyTimeLimitAction = `${'exit' | 'continue'},${'message' | 'no message'}`;

--- a/types/scorm-browser/1.2/index.d.ts
+++ b/types/scorm-browser/1.2/index.d.ts
@@ -1,0 +1,591 @@
+import {
+    CMIBoolean,
+    CMIBlank,
+    CMIString255,
+    CMIIdentifier,
+    CMIDecimal,
+    CMITimeSpan,
+    CMIString4096,
+    CMIInteger,
+    CMISInteger,
+    CMITime,
+    CMIFeedback,
+} from './CMIDataTypes';
+import {
+    CMIElementComments,
+    CMIElementCommentsFromLMS,
+    CMIElementCoreChildren,
+    CMIElementCoreCredit,
+    CMIElementCoreEntry,
+    CMIElementCoreExit,
+    CMIElementCoreLessonLocation,
+    CMIElementCoreLessonMode,
+    CMIElementCoreLessonStatus,
+    CMIElementCoreScoreChildren,
+    CMIElementCoreScoreMax,
+    CMIElementCoreScoreMin,
+    CMIElementCoreScoreRaw,
+    CMIElementCoreSessionTime,
+    CMIElementCoreStudentId,
+    CMIElementCoreStudentName,
+    CMIElementCoreTotalTime,
+    CMIElementInteractionsChildren,
+    CMIElementInteractionsCount,
+    CMIElementInteractionsNCorrectResponsesCount,
+    CMIElementInteractionsNCorrectResponsesNPattern,
+    CMIElementInteractionsNID,
+    CMIElementInteractionsNLatency,
+    CMIElementInteractionsNObjectivesCount,
+    CMIElementInteractionsNResult,
+    CMIElementInteractionsNStudentResponse,
+    CMIElementInteractionsNTime,
+    CMIElementInteractionsNType,
+    CMIElementInteractionsNWeighting,
+    CMIElementLaunchData,
+    CMIElementObjectivesChildren,
+    CMIElementObjectivesCount,
+    CMIElementObjectivesNID,
+    CMIElementObjectivesNScoreChildren,
+    CMIElementObjectivesNScoreMax,
+    CMIElementObjectivesNScoreMin,
+    CMIElementObjectivesNScoreRaw,
+    CMIElementObjectivesNStatus,
+    CMIElementStudentDataChildren,
+    CMIElementStudentDataMasteryScore,
+    CMIElementStudentDataMaxTimeAllowed,
+    CMIElementStudentDataTimeLimitAction,
+    CMIElementStudentPreferenceAudio,
+    CMIElementStudentPreferenceChildren,
+    CMIElementStudentPreferenceLanguage,
+    CMIElementStudentPreferenceSpeed,
+    CMIElementStudentPreferenceText,
+    CMIElementSuspendData,
+    CMIElementVersion,
+} from './CMIElement';
+import { CMIErrorCode } from './CMIErrorCode';
+import {
+    CMIVocabularyCredit,
+    CMIVocabularyEntry,
+    CMIVocabularyExit,
+    CMIVocabularyInteraction,
+    CMIVocabularyMode,
+    CMIVocabularyResult,
+    CMIVocabularyStatus,
+    CMIVocabularyTimeLimitAction,
+} from './CMIVocabulary';
+
+export * from './CMIDataTypes';
+export * from './CMIElement';
+export * from './CMIErrorCode';
+export * from './CMIVocabulary';
+
+/**
+ * The Sharable Content Object Reference Model (SCORM) Version 1.2 Run-Time Environment
+ */
+export interface SCORM12 {
+    // Execution State
+
+    /**
+     * Begins a communication session with the LMS.
+     * @param param The “” parameter is required by all SCORM methods that don’t accept any other arguments.
+     */
+    LMSInitialize(param: CMIBlank): CMIBoolean;
+
+    /**
+     * Ends a communication session with the LMS.
+     * @param param The “” parameter is required by all SCORM methods that don’t accept any other arguments.
+     */
+    LMSFinish(param: CMIBlank): CMIBoolean;
+
+    // Data Transfer
+
+    /**
+     * The _children keyword is used to determine all of the elements in the core category that are supported by the LMS. If an element has no children, but is supported, an empty string is returned.
+     * If an element is not supported, an empty string is returned. A subsequent request for last error can verify that the element is not supported.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreChildren): CMIString255;
+
+    /**
+     * Unique alpha-numeric code / identifier that refers to a single user of the LMS system.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreStudentId): CMIIdentifier;
+
+    /**
+     * Normally, the official name used for the student on the course roster. A complete name, not just a first name.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreStudentName): CMIString255;
+
+    /**
+     * This corresponds to the SCO exit point passed to the LMS system the last time the student experienced the SCO. This provides one mechanism to let the student return to a SCO at the same place
+     * he left it earlier. In other words, this element can identify the student's exit point and that exit point can be used by the SCO as an entry point the next time the student runs the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreLessonLocation): CMIString255;
+
+    /**
+     * Indicates whether the student is being credited by the LMS system based on performance (pass/fail and score) in this SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreCredit): CMIVocabularyCredit;
+
+    /**
+     * This is the current student status as determined by the LMS system. Six status values are possible.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreLessonStatus): CMIVocabularyStatus;
+
+    /**
+     * Indication of whether the student has been in the SCO before.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreEntry): CMIVocabularyEntry;
+
+    /**
+     * The _children keyword is used to determine all of the elements in the core category that are supported by the LMS. If an element has no children, but is supported, an empty string is returned.
+     * If an element is not supported, an empty string is returned. A subsequent request for last error can verify that the element is not supported.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreScoreChildren): CMIString255;
+
+    /**
+     * Indication of the performance of the student during his last attempt on the SCO. This score may be determined and calculated in any manner that makes sense to the SCO designer. For instance,
+     * it could reflect the percentage of objectives complete, it could be the raw score on a multiple choice test, or it could indicate the number of correct first responses to embedded questions in
+     * a SCO.
+     *
+     * The cmi.core.score.raw must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreScoreRaw): CMIDecimal | CMIBlank;
+
+    /**
+     * The maximum score or total number that the student could have achieved.
+     *
+     * The cmi.core.score.max must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreScoreMax): CMIDecimal | CMIBlank;
+
+    /**
+     * The minimum score that the student could have achieved.
+     *
+     * The cmi.core.score.min must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreScoreMin): CMIDecimal | CMIBlank;
+
+    /**
+     * Accumulated time of all the student's sessions in the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreTotalTime): CMITimeSpan;
+
+    /**
+     * Identifies the SCO behavior desired after launch. Many SCOs have a single "behavior". Some SCOs, however, can present different amounts of information, or present information in different
+     * sequences, or present information reflecting  different training philosophies based on an instructor's or designer's decisions. Designers may enable SCOs to behave in a virtually unlimited
+     * number of ways. This standard supports the communication of three parameters that may result in different SCO behaviors.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCoreLessonMode): CMIVocabularyMode;
+
+    /**
+     * Unique information generated by the SCO during previous uses that is needed for the current use. This unique information is applicable to a launching SCO. Normally this is the element used
+     * by the SCO for restart information. This is normally data that is created by the SCO and stored by the LMS to pass back to the SCO the next time the SCO is run.
+     *
+     * The LMS must set aside a space for this group for each SCO for each student. It stores this data and returns it to the SCO when it is run again. The LMS shall retain this data as long as the
+     * student is in the course.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementSuspendData): CMIString4096;
+
+    /**
+     * Unique information generated at the SCO's creation that is needed for every use. Without this information, a SCO may not execute.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementLaunchData): CMIString4096;
+
+    /**
+     * Freeform feedback from the SCO. For example, the student may have the option of leaving comments at any point in the SCO, or they may be asked for comments at the end of the SCO. The comment
+     * may also have an indication of where or when in the SCO it was created. A location may be tagged and embedded in the comment.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementComments): CMIString4096;
+
+    /**
+     * This element represents comments that would come from the LMS. An example of how this might be used is in the form of instructor comments. These types of comments are directed at the student
+     * that the SCO may present to the student when appropriate.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementCommentsFromLMS): CMIString4096;
+
+    /**
+     * The _children keyword is used to determine all of the elements in the core category that are supported by the LMS. If an element has no children, but is supported, an empty string is returned.
+     * If an element is not supported, an empty string is returned. A subsequent request for last error can verify that the element is not supported.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementObjectivesChildren): CMIString255;
+
+    /**
+     * The _count keyword is used to determine the current number of records in the cmi.objectives list. The total number of entries is returned. If the SCO does not know the count of the
+     * cmi.objectives records, it can begin the current student count with 0. This would overwrite any information about objectives currently stored in the first index position. Overwriting or
+     * appending is a decision that is made by the SCO author when he/she creates the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementObjectivesCount): CMIInteger;
+
+    /**
+     * An internally, developer defined, SCO specific identifier for an objective.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementObjectivesNID): CMIIdentifier;
+
+    /**
+     * The _children keyword is used to determine all of the elements in the core category that are supported by the LMS. If an element has no children, but is supported, an empty string is returned.
+     * If an element is not supported, an empty string is returned. A subsequent request for last error can verify that the element is not supported.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementObjectivesNScoreChildren): CMIString255;
+
+    /**
+     * Numerical representation of student performance after each attempt on the objective. May be unprocessed raw score.
+     *
+     * The cmi.objectives.n.score.raw must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementObjectivesNScoreRaw): CMIDecimal | CMIBlank;
+
+    /**
+     * The maximum score or total number that the student could have achieved on the objective.
+     *
+     * The cmi.objectives.n.score.max must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementObjectivesNScoreMax): CMIDecimal | CMIBlank;
+
+    /**
+     * The minimum score that the student could have achieved on the objective.
+     *
+     * The cmi.objectives.n.score.min must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementObjectivesNScoreMin): CMIDecimal | CMIBlank;
+
+    /**
+     * The status of the SCO's objective obtained by the student after each attempt to master the SCO's objective. Only 6 possible vocabulary values: passed, completed, failed, incomplete, not
+     * attempted or browsed.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementObjectivesNStatus): CMIVocabularyStatus;
+
+    /**
+     * The _children keyword is used to determine all of the elements in the core category that are supported by the LMS. If an element has no children, but is supported, an empty string is returned.
+     * If an element is not supported, an empty string is returned. A subsequent request for last error can verify that the element is not supported.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementStudentDataChildren): CMIString255;
+
+    /**
+     * The passing score, as determined outside the SCO. When the SCO score is greater than or equal to the mastery score, the student is considered to have passed, or mastered the content. In some
+     * cases, the SCO does not know what this passing score is, because it is determined by the LMS system.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementStudentDataMasteryScore): CMIDecimal;
+
+    /**
+     * The amount of time the student is allowed to have in the current attempt on the SCO. See time_limit_action for the SCO's expected response to exceeding the limit.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementStudentDataMaxTimeAllowed): CMITimeSpan;
+
+    /**
+     * Tells the SCO what to do when the max_time_allowed is exceeded. There iare two arguments for this element:
+     *
+     * - What the SCO should do - exit or continue
+     * - What the student should see - message or no message
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementStudentDataTimeLimitAction): CMIVocabularyTimeLimitAction;
+
+    /**
+     * The _children keyword is used to determine all of the elements in the core category that are supported by the LMS. If an element has no children, but is supported, an empty string is returned.
+     * If an element is not supported, an empty string is returned. A subsequent request for last error can verify that the element is not supported.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementStudentPreferenceChildren): CMIString255;
+
+    /**
+     * Audio may be turned off, or its volume controlled. The element indicates whether the audio is turned off, or on.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementStudentPreferenceAudio): CMISInteger;
+
+    /**
+     * For SCOs with multi-lingual capability, this element should be used to identify in what language the information should be delivered.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementStudentPreferenceLanguage): CMIString255;
+
+    /**
+     * SCOs may sometimes be difficult to understand because of the pace. This element controls the pace of the content delivery.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementStudentPreferenceSpeed): CMISInteger;
+
+    /**
+     * In a SCO designed for audio, it may be possible to turn off the audio, and view the audio content in a text window. Or it may be possible to leave the audio on, and request that the text be
+     * presented simultaneously with the audio. Or it may be possible to make the text disappear so that only the audio and the screen graphics are available. This element defines whether the audio
+     * text appears in the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementStudentPreferenceText): CMISInteger;
+
+    /**
+     * The _children keyword is used to determine all of the elements in the core category that are supported by the LMS. If an element has no children, but is supported, an empty string is returned.
+     * If an element is not supported, an empty string is returned. A subsequent request for last error can verify that the element is not supported.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementInteractionsChildren): CMIString255;
+
+    /**
+     * The _count keyword is used to determine the current number of records in the cmi.interactions list. The total number of entries is returned. If the SCO does not know the count of the
+     * cmi.interactions records, it can begin the current student count with 0. This would overwrite any information about interactions currently stored in the first index position. Overwriting or
+     * appending is a decision that is made by the SCO author when he/she creates the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementInteractionsCount): CMIInteger;
+
+    /**
+     * The _count keyword is used to determine the current number of records in the cmi.interactions objective id list. The total number of entries is returned. If the SCO does not know the count of
+     * the cmi.interactions.n.objecives records, it can begin the current student count with 0. This would overwrite any information about objective ids currently stored in the first index position.
+     * Overwriting or appending is a decision that is made by the SCO author when he/she creates the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementInteractionsNObjectivesCount): CMIInteger;
+
+    /**
+     * The _count keyword is used to determine the current number of records in the cmi.interactions correct responses list. The total number of entries is returned. If the SCO does not know the
+     * count of the cmi.interactions.n.correct_responses records, it can begin the current student count with 0. This would overwrite any information about correct responses currently stored in the
+     * first index position. Overwriting or appending is a decision that is made by the SCO author when he/she creates the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementInteractionsNCorrectResponsesCount): CMIInteger;
+
+    /**
+     * The _version keyword is used to determine the version of the data model supported by the LMS.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSGetValue(element: CMIElementVersion): CMIString255;
+
+    /**
+     * This corresponds to the SCO exit point passed to the LMS system the last time the student experienced the SCO. This provides one mechanism to let the student return to a SCO at the same place
+     * he left it earlier. In other words, this element can identify the student's exit point and that exit point can be used by the SCO as an entry point the next time the student runs the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementCoreLessonLocation, value: CMIString255): CMIBoolean;
+
+    /**
+     * This is the current student status as determined by the LMS system. Six status values are possible.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementCoreLessonStatus, value: CMIVocabularyStatus): CMIBoolean;
+
+    /**
+     * Indication of the performance of the student during his last attempt on the SCO. This score may be determined and calculated in any manner that makes sense to the SCO designer. For instance,
+     * it could reflect the percentage of objectives complete, it could be the raw score on a multiple choice test, or it could indicate the number of correct first responses to embedded questions in
+     * a SCO.
+     *
+     * The cmi.core.score.raw must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementCoreScoreRaw, value: CMIDecimal | CMIBlank): CMIBoolean;
+
+    /**
+     * The maximum score or total number that the student could have achieved.
+     *
+     * The cmi.core.score.max must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementCoreScoreMax, value: CMIDecimal | CMIBlank): CMIBoolean;
+
+    /**
+     * The minimum score that the student could have achieved.
+     *
+     * The cmi.core.score.min must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementCoreScoreMin, value: CMIDecimal | CMIBlank): CMIBoolean;
+
+    /**
+     * An indication of how or why the student has left the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementCoreExit, value: CMIVocabularyExit): CMIBoolean;
+
+    /**
+     * This is the amount of time in hours, minutes and seconds that the student has spent in the SCO at the time they leave it. That is, this represents the time from beginning of the session to the
+     * end of a single use of the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementCoreSessionTime, value: CMITimeSpan): CMIBoolean;
+
+    /**
+     * Unique information generated by the SCO during previous uses that is needed for the current use. This unique information is applicable to a launching SCO. Normally this is the element used by
+     * the SCO for restart information. This is normally data that is created by the SCO and stored by the LMS to pass back to the SCO the next time the SCO is run.
+     *
+     * The LMS must set aside a space for this group for each SCO for each student. It stores this data and returns it to the SCO when it is run again. The LMS shall retain this data as long as the
+     * student is in the course.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementSuspendData, value: CMIString4096): CMIBoolean;
+
+    /**
+     * Freeform feedback from the SCO. For example, the student may have the option of leaving comments at any point in the SCO, or they may be asked for comments at the end of the SCO. The comment
+     * may also have an indication of where or when in the SCO it was created. A location may be tagged and embedded in the comment.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementComments, value: CMIString4096): CMIBoolean;
+
+    /**
+     * An internally, developer defined, SCO specific identifier for an objective.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementObjectivesNID, value: CMIIdentifier): CMIBoolean;
+
+    /**
+     * Numerical representation of student performance after each attempt on the objective. May be unprocessed raw score.
+     *
+     * The cmi.objectives.n.score.raw must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementObjectivesNScoreRaw, value: CMIDecimal | CMIBlank): CMIBoolean;
+
+    /**
+     * The maximum score or total number that the student could have achieved on the objective.
+     *
+     * The cmi.objectives.n.score.max must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementObjectivesNScoreMax, value: CMIDecimal | CMIBlank): CMIBoolean;
+
+    /**
+     * The minimum score that the student could have achieved on the objective.
+     *
+     * The cmi.objectives.n.score.min must be a normalized value between 0 and 100.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementObjectivesNScoreMin, value: CMIDecimal | CMIBlank): CMIBoolean;
+
+    /**
+     * The status of the SCO's objective obtained by the student after each attempt to master the SCO's objective. Only 6 possible vocabulary values: passed, completed, failed, incomplete, not
+     * attempted or browsed.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementObjectivesNStatus, value: CMIVocabularyStatus): CMIBoolean;
+
+    /**
+     * Audio may be turned off, or its volume controlled. The element indicates whether the audio is turned off, or on.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementStudentPreferenceAudio, value: CMISInteger): CMIBoolean;
+
+    /**
+     * For SCOs with multi-lingual capability, this element should be used to identify in what language the information should be delivered.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementStudentPreferenceLanguage, value: CMIString255): CMIBoolean;
+
+    /**
+     * SCOs may sometimes be difficult to understand because of the pace. This element controls the pace of the content delivery.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementStudentPreferenceSpeed, value: CMISInteger): CMIBoolean;
+
+    /**
+     * In a SCO designed for audio, it may be possible to turn off the audio, and view the audio content in a text window. Or it may be possible to leave the audio on, and request that the text be
+     * presented simultaneously with the audio. Or it may be possible to make the text disappear so that only the audio and the screen graphics are available. This element defines whether the audio
+     * text appears in the SCO.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementStudentPreferenceText, value: CMISInteger): CMIBoolean;
+
+    /**
+     * Unique identifier for an interaction.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementInteractionsNID, value: CMIIdentifier): CMIBoolean;
+
+    /**
+     * Identification of when the student interaction was completed.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementInteractionsNTime, value: CMITime): CMIBoolean;
+
+    /**
+     * Indication of which category of interaction is recorded. The type of interction determines how the interaction response should be interpreted. Eight possible question types are defined. They
+     * are not meant to be limiting. There are other types of questions. However, if one of these eight types is used, these are the identifiers that match those types.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementInteractionsNType, value: CMIVocabularyInteraction): CMIBoolean;
+
+    /**
+     * Description of possible student responses to the interaction. There may be more than one correct response, and some responses may be more correct than others.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementInteractionsNCorrectResponsesNPattern, value: CMIFeedback): CMIBoolean;
+
+    /**
+     * Interactions vary in importance. The weighting is a factor which is used to identify the relative importance of one interaction compared to another. For instance, if the first interaction has
+     * a weight of 15 and the second interaction has a weight of 25, then any combined score that reflects weighting would be more influenced by the second interaction.
+     *
+     * If all interactions are equal in importance, then each interaction has the same weight.
+     *
+     * A weight of 0 indicates that the interaction should not be counted in the weighted final score.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementInteractionsNWeighting, value: CMIDecimal): CMIBoolean;
+
+    /**
+     * Description of possible responses to the interaction. There may be more than one correct response, and some responses may be more correct than others.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementInteractionsNStudentResponse, value: CMIFeedback): CMIBoolean;
+
+    /**
+     * How the system judges the described response.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementInteractionsNResult, value: CMIVocabularyResult): CMIBoolean;
+
+    /**
+     * The time from the presentation of the stimulus to the completion of the measurable response.
+     */
+    // tslint:disable-next-line:unified-signatures
+    LMSSetValue(element: CMIElementInteractionsNLatency, value: CMITimeSpan): CMIBoolean;
+
+    /**
+     * Indicates to the LMS that all data should be persisted (not required).
+     * @param param The “” parameter is required by all SCORM methods that don’t accept any other arguments.
+     */
+    LMSCommit(param: CMIBlank): CMIBoolean;
+
+    // State Management
+
+    /**
+     * Returns the error code that resulted from the last API call.
+     */
+    LMSGetLastError(): CMIErrorCode;
+
+    /**
+     * Returns a short string describing the specified error code.
+     * @param errorCode The CMIErrorCode data type is a three-digit number, represented by a string, that corresponds to one of the SCORM Run-Time error codes.
+     */
+    LMSGetErrorString(errorCode: CMIErrorCode): string;
+
+    /**
+     * Returns detailed information about the last error that occurred.
+     * @param errorCode The CMIErrorCode data type is a three-digit number, represented by a string, that corresponds to one of the SCORM Run-Time error codes.
+     */
+    LMSGetDiagnostic(errorCode: CMIErrorCode): string;
+}

--- a/types/scorm-browser/index.d.ts
+++ b/types/scorm-browser/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for non-npm package scorm-browser 1.0
+// Project: http://xml.coverpages.org/SCORM-12-RunTimeEnv.pdf
+// Definitions by: Christian Cook <https://github.com/CookieCookson>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.3
+
+import { SCORM12 } from './1.2';
+
+export * from './1.2';
+
+declare global {
+    interface Window {
+        API?: SCORM12;
+    }
+}

--- a/types/scorm-browser/scorm-browser-tests.ts
+++ b/types/scorm-browser/scorm-browser-tests.ts
@@ -1,0 +1,133 @@
+import {
+    CMIBlank,
+    CMIBoolean,
+    CMIDecimal,
+    CMIFeedbackChoice,
+    CMIFeedbackLikert,
+    CMIFeedbackMatching,
+    CMIFeedbackNumeric,
+    CMIFeedbackTrueFalse,
+} from 'scorm-browser/1.2';
+
+if (window.API) {
+    // Data Types
+    const cmiBlank: CMIBlank = '';
+
+    const cmiBooleanTrue: CMIBoolean = 'true';
+    const cmiBooleanFalse: CMIBoolean = 'false';
+
+    const cmiDecimalNegative: CMIDecimal = '-4';
+    const cmiDecimalPositive: CMIDecimal = '4';
+    const cmiDecimalNegativeDecimal: CMIDecimal = '-4.4';
+
+    const cmiFeedbackTrueFalseBinaryFalse: CMIFeedbackTrueFalse = '0';
+    const cmiFeedbackTrueFalseBinaryTrue: CMIFeedbackTrueFalse = '1';
+    const cmiFeedbackTrueFalseCharFalse: CMIFeedbackTrueFalse = 'f';
+    const cmiFeedbackTrueFalseCharTrue: CMIFeedbackTrueFalse = 't';
+
+    const cmiFeedbackChoiceChar: CMIFeedbackChoice = 'a';
+    const cmiFeedbackChoiceCharDouble: CMIFeedbackChoice = 'a,b';
+    const cmiFeedbackChoiceCharMultiple: CMIFeedbackChoice = 'a,b,c';
+    const cmiFeedbackChoiceCharDoubleAll: CMIFeedbackChoice = '{a,b}';
+    const cmiFeedbackChoiceCharMultipleAll: CMIFeedbackChoice = '{a,b,c,d,e}';
+    const cmiFeedbackChoiceNum: CMIFeedbackChoice = '0';
+    const cmiFeedbackChoiceNumDouble: CMIFeedbackChoice = '0,1';
+    const cmiFeedbackChoiceNumMultiple: CMIFeedbackChoice = '0,1,2';
+    const cmiFeedbackChoiceNumDoubleAll: CMIFeedbackChoice = '{0,1}';
+    const cmiFeedbackChoiceNumMultipleAll: CMIFeedbackChoice = '{0,1,2,3,4}';
+
+    const cmiFeedbackNumericNegative: CMIFeedbackNumeric = '-4';
+    const cmiFeedbackNumericPositive: CMIFeedbackNumeric = '4';
+    const cmiFeedbackNumericNegativeDecimal: CMIFeedbackNumeric = '-4.4';
+
+    const cmiFeedbackLikertChar: CMIFeedbackLikert = 'a';
+    const cmiFeedbackLikertNum: CMIFeedbackLikert = '0';
+
+    const cmiFeedbackMatching: CMIFeedbackMatching = 'a.1,b.2,c.3';
+    const cmiFeedbackMatchingAll: CMIFeedbackMatching = '{a.1,b.2,c.3}';
+
+    const cmiTime = '00:00:00';
+    const cmiTimeDecimalSingle = '00:00:00.1';
+    const cmiTimeDecimalDouble = '00:00:00.12';
+
+    const cmiTimeSpan = '00:00:00';
+    const cmiTimeSpanDecimalSingle = '00:00:00.1';
+    const cmiTimeSpanDecimalDouble = '00:00:00.12';
+    const cmiTimeSpanManyHours = '1000:00:00';
+
+    // Methods
+    const initSuccess: string = window.API.LMSInitialize('');
+    const commitSuccess: string = window.API.LMSCommit('');
+    const finishSuccess: string = window.API.LMSFinish('');
+    const errorCode = window.API.LMSGetLastError();
+    const errorString: string = window.API.LMSGetErrorString(errorCode);
+    const diagnostic: string = window.API.LMSGetDiagnostic(errorCode);
+
+    const coreChildren: string = window.API.LMSGetValue('cmi.core._children');
+    const coreStudentID: string = window.API.LMSGetValue('cmi.core.student_id');
+    const coreStudentName: string = window.API.LMSGetValue('cmi.core.student_name');
+    const coreSCOLocation: string = window.API.LMSGetValue('cmi.core.lesson_location');
+    const creditFlag: string = window.API.LMSGetValue('cmi.core.credit');
+    const lessonStatus: string = window.API.LMSGetValue('cmi.core.lesson_status');
+    const entryStatus: string = window.API.LMSGetValue('cmi.core.entry');
+    const scoreChildren: string = window.API.LMSGetValue('cmi.core.score_children');
+    const scoreRaw: string = window.API.LMSGetValue('cmi.core.score.raw');
+    const scoreMax: string = window.API.LMSGetValue('cmi.core.score.max');
+    const scoreMin: string = window.API.LMSGetValue('cmi.core.score.min');
+    const totalTime: string = window.API.LMSGetValue('cmi.core.total_time');
+    const lessonMode: string = window.API.LMSGetValue('cmi.core.lesson_mode');
+    const suspendData: string = window.API.LMSGetValue('cmi.suspend_data');
+    const launchData: string = window.API.LMSGetValue('cmi.launch_data');
+    const comments: string = window.API.LMSGetValue('cmi.comments');
+    const commentsFromLMS: string = window.API.LMSGetValue('cmi.comments_from_lms');
+    const objChildren: string = window.API.LMSGetValue('cmi.objectives._children');
+    const totalObj: string = window.API.LMSGetValue('cmi.objectives._count');
+    const objID: string = window.API.LMSGetValue(`cmi.objectives.${0}.id`);
+    const objScoreChildren: string = window.API.LMSGetValue(`cmi.objectives.${(1).toString()}.score._children`);
+    const objScoreRaw: string = window.API.LMSGetValue(`cmi.objectives.${2}.score.raw`);
+    const objScoreMax: string = window.API.LMSGetValue(`cmi.objectives.${3}.score.max`);
+    const objStatus: string = window.API.LMSGetValue(`cmi.objectives.${5}.status`);
+    const studentDataChildren: string = window.API.LMSGetValue('cmi.student_data._children');
+    const masteryScore: string = window.API.LMSGetValue('cmi.student_data.mastery_score');
+    const maxTimeAllowed: string = window.API.LMSGetValue('cmi.student_data.max_time_allowed');
+    const timeLimitAction: string = window.API.LMSGetValue('cmi.student_data.time_limit_action');
+    const studentPreferenceChildren: string = window.API.LMSGetValue('cmi.student_preference._children');
+    const audioValue: string = window.API.LMSGetValue('cmi.student_preference.audio');
+    const languageValue: string = window.API.LMSGetValue('cmi.student_preference.language');
+    const speedValue: string = window.API.LMSGetValue('cmi.student_preference.speed');
+    const textValue: string = window.API.LMSGetValue('cmi.student_preference.text');
+    const interactionsChildren: string = window.API.LMSGetValue('cmi.interactions._children');
+    const interactionsCount: string = window.API.LMSGetValue('cmi.interactions._count');
+    const interactionObjectivesCount: string = window.API.LMSGetValue(`cmi.interactions.${0}.objectives._count`);
+    const interactionCorrectResponsesCount: string = window.API.LMSGetValue(
+        `cmi.interactions.${0}.correct_responses._count`,
+    );
+    const version = window.API.LMSGetValue('cmi._version');
+
+    window.API.LMSSetValue('cmi.core.lesson_location', 'my-location');
+    window.API.LMSSetValue('cmi.core.lesson_status', 'passed');
+    window.API.LMSSetValue('cmi.core.score.raw', `${50}`);
+    window.API.LMSSetValue('cmi.core.score.max', (100).toString());
+    window.API.LMSSetValue('cmi.core.score.min', '0');
+    window.API.LMSSetValue('cmi.core.exit', 'suspend');
+    window.API.LMSSetValue('cmi.core.session_time', `${(0).toString()}:0:0`);
+    window.API.LMSSetValue('cmi.suspend_data', JSON.stringify({ test: true }));
+    window.API.LMSSetValue('cmi.comments', 'hello world');
+    window.API.LMSSetValue(`cmi.objectives.${(0).toString()}.id`, 'Obj1');
+    window.API.LMSSetValue(`cmi.objectives.${1}.score.raw`, `${5}`);
+    window.API.LMSSetValue(`cmi.objectives.${2}.score.max`, `${100}`);
+    window.API.LMSSetValue(`cmi.objectives.${4}.status`, 'failed');
+    window.API.LMSSetValue('cmi.student_preference.audio', '100');
+    window.API.LMSSetValue('cmi.student_preference.language', 'English');
+    window.API.LMSSetValue('cmi.student_preference.speed', '-100');
+    window.API.LMSSetValue('cmi.student_preference.text', (1).toString());
+    window.API.LMSSetValue(`cmi.interactions.${0}.id`, 't-010-010');
+    window.API.LMSSetValue(`cmi.interactions.${0}.objectives.${0}.id`, 'objective-0');
+    window.API.LMSSetValue(`cmi.interactions.${0}.time`, '12:34:56.00');
+    window.API.LMSSetValue(`cmi.interactions.${0}.type`, 'true-false');
+    window.API.LMSSetValue(`cmi.interactions.${0}.correct_responses.${0}.pattern`, 't');
+    window.API.LMSSetValue(`cmi.interactions.${0}.weighting`, '1');
+    window.API.LMSSetValue(`cmi.interactions.${0}.student_response`, 'f');
+    window.API.LMSSetValue(`cmi.interactions.${0}.result`, 'wrong');
+    window.API.LMSSetValue(`cmi.interactions.${0}.latency`, '12:34:56.00');
+}

--- a/types/scorm-browser/tsconfig.json
+++ b/types/scorm-browser/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "scorm-browser-tests.ts"
+    ]
+}

--- a/types/scorm-browser/tslint.json
+++ b/types/scorm-browser/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Adding type definitions for probably one of the oldest and still most commonly used APIs of the elearning world - SCORM 1.2. All definitions have been implemented based on http://xml.coverpages.org/SCORM-12-RunTimeEnv.pdf. The SCORM `API` is exposed to the browser only when the content is run within a learning management system environment.

This PR does not include typings for other SCORM standards (SCORM 2004 1st/2nd/3rd/4th Edition).

# Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] ~~Create it with `dts-gen --dt`, not by basing it on an existing project.~~
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.