### PR TITLE
[@types/fluxible-router] Add missing prop types for NavLink component

### DIFF
--- a/types/fluxible-router/index.d.ts
+++ b/types/fluxible-router/index.d.ts
@@ -29,4 +29,12 @@ export class NavLinkProps {
     preserveScrollPosition?: boolean | undefined;
     className?: string | undefined;
     type?: string | undefined;
+    activeClass?: string;
+    activeElement?: string;
+    followLink?: boolean;
+    stopPropagation?: boolean;
+    replaceState?: boolean;
+    validate?: boolean;
+    navParams?: object;
+    queryParams?: object;
 }


### PR DESCRIPTION
There are some prop types missing in the `NavLink` interface for `fluxible-router`.

Here are the prop types definitions in the official [repo](https://github.com/yahoo/fluxible/blob/master/packages/fluxible-router/src/createNavLinkComponent.js#L360).

This PR adds these missing props as conditional properties.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/yahoo/fluxible/blob/master/packages/fluxible-router/src/createNavLinkComponent.js#L360
