### PR TITLE
add `originalId` to `Column`

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -237,6 +237,7 @@ export interface UseTableHooks<D extends object> extends Record<string, any> {
 
 export interface UseTableColumnOptions<D extends object> {
     id?: IdType<D> | undefined;
+    originalId?: IdType<D> | undefined;
     Header?: Renderer<HeaderProps<D>> | undefined;
     Footer?: Renderer<FooterProps<D>> | undefined;
     width?: number | string | undefined;


### PR DESCRIPTION

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
-  [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
