### PR TITLE
progressbar.js: change container from SVGPathElement to HTMLElement

### DIFF
--- a/types/progressbar.js/shape.d.ts
+++ b/types/progressbar.js/shape.d.ts
@@ -7,7 +7,7 @@ declare class Shape {
      * @param [opts] - Options for path drawing.
      * @see {@link https://progressbarjs.readthedocs.io/en/latest/api/shape/#new-shapecontainer-options}
      */
-    constructor(container: SVGPathElement | string | null, opts?: PathDrawingOptions);
+    constructor(container: HTMLElement | string | null, opts?: PathDrawingOptions);
     /**
      * Reference to SVG element where progress bar is drawn.
      */


### PR DESCRIPTION
The container is usually a HTMLDivElement. The docs say…
> container Element where SVG is added. Query string or element.
> For example '#container' or document.getElementById('#container')

The examples – eg https://jsfiddle.net/kimmobrunfeldt/72tkyn40/ – also show `DIV#container`.

---

Initially typed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46181. @peterblazejewicz do you have time to have a look at this?

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---


