### PR TITLE
[@types/better-sqlite3] Add generics for return types, improve bind return type. Overhaul parameters and their typings

### DIFF
--- a/types/better-sqlite3/better-sqlite3-tests.ts
+++ b/types/better-sqlite3/better-sqlite3-tests.ts
@@ -90,9 +90,10 @@ stmtWithNamedBind.bind({ name: 'bob', age: 20, id: BigInt(1234) }).all();
 const fullyTypedStmt = db.prepare<{ age: number }, { name: string }, [string]>(
     'SELECT name FROM test WHERE age = @age',
 );
-// $ExpectType { name: string; }
+
+// $ExpectType StrictDict<{ name: string; }>
 fullyTypedStmt.get({ age: 42 })!;
-// $ExpectType { name: string; }[]
+// $ExpectType StrictDict<{ name: string; }>[]
 fullyTypedStmt.all({ age: 42 });
 // $ExpectType string
 fullyTypedStmt.pluck(true).get({ age: 42 })!;

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -122,7 +122,7 @@ declare namespace BetterSqlite3 {
 
         prepare<
             BindParameters extends any[] | {} = any[],
-            Row extends Dict = Dict,
+            Row extends object = object,
             RowTypes extends any[] | {} = any[],
         >(
             source: string,
@@ -200,7 +200,7 @@ declare namespace Database {
     type SqliteError = typeof SqliteError;
     type Statement<
         BindParameters extends any[] | {} = any[],
-        Row extends BetterSqlite3.Dict = BetterSqlite3.Dict,
+        Row extends object = object,
         RowTypes extends any[] | {} = any[],
     > = BindParameters extends any[]
         ? BetterSqlite3.NormalStatement<BindParameters, Row, RowTypes>

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -13,11 +13,8 @@ type VariableArgFunction = (...params: any[]) => any;
 type ArgumentTypes<F extends VariableArgFunction> = F extends (...args: infer A) => any ? A : never;
 
 declare namespace BetterSqlite3 {
-    interface Dict {
-        [key: string]: any;
-    }
     interface NamespacedDict {
-        [key: string]: Dict;
+        [key: string]: object;
     }
 
     interface Statement<BindParameters extends any[]> {
@@ -36,7 +33,7 @@ declare namespace BetterSqlite3 {
         safeIntegers(toggleState?: boolean): this;
     }
 
-    interface NormalStatement<BindParameters extends any[], Row extends Dict, RowTypes extends any[] | {}>
+    interface NormalStatement<BindParameters extends any[], Row extends object, RowTypes extends any[] | {}>
         extends Statement<BindParameters> {
         get(...params: BindParameters): Row | undefined;
         all(...params: BindParameters): Row[];
@@ -50,7 +47,7 @@ declare namespace BetterSqlite3 {
         bind(...params: BindParameters): NormalStatement<[], Row, RowTypes>;
     }
 
-    interface PluckedStatement<BindParameters extends any[], Row extends Dict, RowTypes extends any[] | {}>
+    interface PluckedStatement<BindParameters extends any[], Row extends object, RowTypes extends any[] | {}>
         extends Statement<BindParameters> {
         get(...params: BindParameters): (RowTypes extends any[] ? RowTypes[0] : RowTypes) | undefined;
         all(...params: BindParameters): RowTypes extends any[] ? Array<RowTypes[0]> : RowTypes[];
@@ -64,7 +61,7 @@ declare namespace BetterSqlite3 {
         bind(...params: BindParameters): PluckedStatement<[], Row, RowTypes>;
     }
 
-    interface ExpandedStatement<BindParameters extends any[], Row extends Dict, RowTypes extends any[] | {}>
+    interface ExpandedStatement<BindParameters extends any[], Row extends object, RowTypes extends any[] | {}>
         extends Statement<BindParameters> {
         get(...params: BindParameters): NamespacedDict | undefined;
         all(...params: BindParameters): NamespacedDict[];
@@ -78,7 +75,7 @@ declare namespace BetterSqlite3 {
         bind(...params: BindParameters): ExpandedStatement<[], Row, RowTypes>;
     }
 
-    interface RawStatement<BindParameters extends any[], Row extends Dict, RowTypes extends any[] | {}>
+    interface RawStatement<BindParameters extends any[], Row extends object, RowTypes extends any[] | {}>
         extends Statement<BindParameters> {
         get(...params: BindParameters): (RowTypes extends any[] ? RowTypes : [RowTypes, {}]) | undefined;
         all(...params: BindParameters): RowTypes extends any[] ? RowTypes[] : Array<[RowTypes, {}]>;


### PR DESCRIPTION
This PR adds support for specifying return types using generics. Of course, this doesn't cover everything (ex: you do `stmt.pluck()` and then `stmt.get()` as two different calls), but should be useful in 99% of actual use cases (**pluck**, **expand**, **raw** all change return types and support chaining). As well as that, **bind**'s return type is now the same statement however with correct parameters for later calls (**get**, **all** etc won't ask for parameters after **bind**, which is exactly how the API docs say).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
 Return types check with [pluck](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#plucktogglestate---this), [expand](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#expandtogglestate---this) and [raw](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#rawtogglestate---this). After [bind](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#bindbindparameters---this) usage changes
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
