### PR TITLE
[sharp] Add types for 0.29.1 additions

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -453,7 +453,8 @@ declare namespace sharp {
         recomb(inputMatrix: Matrix3x3): Sharp;
 
         /**
-         * Transforms the image using brightness, saturation and hue rotation.
+         * Transforms the image using brightness, saturation, hue rotation and lightness.
+         * Brightness and lightness both operate on luminance, with the difference being that brightness is multiplicative whereas lightness is additive.
          * @param options describes the modulation
          * @returns A sharp instance that can be used to chain operations
          */
@@ -461,6 +462,7 @@ declare namespace sharp {
             brightness?: number | undefined;
             saturation?: number | undefined;
             hue?: number | undefined;
+            lightness?: number | undefined;
         }): Sharp;
 
         //#endregion
@@ -920,7 +922,7 @@ declare namespace sharp {
         quality?: number | undefined;
         /** use lossless compression (optional, default false) */
         lossless?: boolean | undefined;
-        /** CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest) (optional, default 5) */
+        /** CPU effort vs file size, 0 (slowest/smallest) to 9 (fastest/largest) (optional, default 5) */
         speed?: number | undefined;
         /** set to '4:4:4' to prevent chroma subsampling otherwise defaults to '4:2:0' chroma subsampling, requires libvips v8.11.0 (optional, default '4:2:0') */
         chromaSubsampling?: string;
@@ -933,7 +935,7 @@ declare namespace sharp {
         compression?: 'av1' | 'hevc' | undefined;
         /** use lossless compression (optional, default false) */
         lossless?: boolean | undefined;
-        /** CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest) (optional, default 5) */
+        /** CPU effort vs file size, 0 (slowest/smallest) to 9 (fastest/largest) (optional, default 5) */
         speed?: number | undefined;
     }
 

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -257,6 +257,7 @@ sharp('input.gif')
 
     .modulate({ brightness: 2 })
     .modulate({ hue: 180 })
+    .modulate({ lightness: 10 })
     .modulate({ brightness: 0.5, saturation: 0.5, hue: 90 });
 
 // From https://sharp.pixelplumbing.com/api-output#examples-9


### PR DESCRIPTION
This PR adds the new `lightness` option for the `modulate()` method, and updates the `speed` documentation forAVIF/HEIF encoding to allow for the new maximum of 9.

I'm a little unsure about versioning here: this change is only available in sharp `0.29.1` and up, but I don't think there's any way we can indicate that in definitelytyped unless sharp itself moves over to use >= 1.0.0 for semantic versioning - correct me if I'm wrong. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sharp.pixelplumbing.com/changelog#v0291---7th-september-2021
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

