### PR TITLE
prosemirror-model: Adds Schema.nodeType declaration

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -1380,6 +1380,10 @@ export class Schema<N extends string = any, M extends string = any> {
      * bound.
      */
     markFromJSON(json: { [key: string]: any }): Mark<Schema<N, M>>;
+    /**
+     * Get schema's node type by name. This method uses `schema.nodes` internally
+     */
+    nodeType(name: string): ProsemirrorNode<Schema<N, M>>;
 }
 export interface DOMOutputSpecArray {
     0: string;

--- a/types/prosemirror-model/prosemirror-model-tests.ts
+++ b/types/prosemirror-model/prosemirror-model-tests.ts
@@ -119,3 +119,12 @@ const fragmentTests = () => {
     // $ExpectType string
     const textBetweenSeparatorAndNullLeafArgs = prosemirrorFragment.textBetween(1, 2, 'separator', null);
 };
+
+const schemaTests = () => {
+    const nodeSpec: model.NodeSpec = { content: 'text*' };
+    const schema = new model.Schema({ nodes: { foo: nodeSpec } });
+
+    // get node type by name
+    // $ExpectType ProsemirrorNode<Schema<"foo", any>>
+    schema.nodeType('foo');
+};


### PR DESCRIPTION
method has been there a long time and is used e.g. when resolving Nodes from JSON documents.
Not having this method typed introduces unnecessary hurdles when implementing custom parsers

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-model/blob/master/src/schema.js#L565
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.