### PR TITLE
Update dns2 to match v2.0 and add UDP & TCP server types

### DIFF
--- a/types/dns2/dns2-tests.ts
+++ b/types/dns2/dns2-tests.ts
@@ -12,22 +12,25 @@ const dns = new DNS();
 
 const { Packet } = DNS;
 
-const server = DNS.createServer((request, send, rinfo) => {
-  const response = Packet.createResponseFromRequest(request);
-  const [ question ] = request.questions;
-  const { name } = question;
-  response.answers.push({
-    name,
-    type: Packet.TYPE.A,
-    class: Packet.CLASS.IN,
-    ttl: 300,
-    address: '8.8.8.8'
-  });
-  send(response);
+const server = DNS.createServer({
+  udp: true,
+  handle: (request, send, rinfo) => {
+    const response = Packet.createResponseFromRequest(request);
+    const [ question ] = request.questions;
+    const { name } = question;
+    response.answers.push({
+      name,
+      type: Packet.TYPE.A,
+      class: Packet.CLASS.IN,
+      ttl: 300,
+      address: '8.8.8.8'
+    });
+    send(response);
+  }
 });
 
 server.on('request', (request, response, rinfo) => {
   console.log(request.header.id, request.questions[0]);
 });
 
-server.listen(5333);
+server.listen({ udp: 5333 });

--- a/types/dns2/dns2-tests.ts
+++ b/types/dns2/dns2-tests.ts
@@ -34,3 +34,17 @@ server.on('request', (request, response, rinfo) => {
 });
 
 server.listen({ udp: 5333 });
+
+const udpServer = new DNS.UDPServer((request, send, rinfo) => {
+  const response = Packet.createResponseFromRequest(request);
+  send(response);
+});
+
+udpServer.listen(5353, "127.0.0.1");
+
+const tcpServer = DNS.createTCPServer((request, send, rinfo) => {
+  const response = Packet.createResponseFromRequest(request);
+  send(response);
+});
+
+tcpServer.listen(5454, "127.0.0.1");

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -72,6 +72,12 @@ declare namespace DNS {
         ttl: number;
         address: string;
     }
+
+    type DnsHandler = (
+        request: DnsRequest,
+        sendResponse: (response: DnsResponse) => void,
+        remoteInfo: udp.RemoteInfo,
+    ) => void;
 }
 
 declare class DnsServer extends EventEmitter {
@@ -90,19 +96,30 @@ declare class DnsServer extends EventEmitter {
     close(): Promise<void>;
 }
 
+declare class UdpDnsServer extends udp.Socket {
+    constructor(callback?: DNS.DnsHandler);
+    listen(port: number, address: string): Promise<void>;
+}
+
+declare class TcpDnsServer extends net.Server {
+    constructor(callback?: DNS.DnsHandler);
+}
+
 declare class DNS {
     static createServer(options: {
         udp?: boolean,
         tcp?: boolean,
         doh?: boolean,
-        handle: (
-            request: DNS.DnsRequest,
-            sendResponse: (response: DNS.DnsResponse) => void,
-            remoteInfo: udp.RemoteInfo,
-        ) => void
+        handle: DNS.DnsHandler
     }): DnsServer;
 
     static Packet: typeof Packet;
+
+    static createUDPServer: (...options: ConstructorParameters<typeof UdpDnsServer>) => UdpDnsServer;
+    static UDPServer: typeof UdpDnsServer;
+
+    static createTCPServer: (...options: ConstructorParameters<typeof TcpDnsServer>) => TcpDnsServer;
+    static TCPServer: typeof TcpDnsServer;
 
     resolveA(domain: string, clientIp?: string): Promise<DNS.DnsResponse>;
     resolveAAAA(domain: string): Promise<DNS.DnsResponse>;

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for dns2 1.4
+// Type definitions for dns2 2.0
 // Project: https://github.com/song940/node-dns#readme
 // Definitions by: Tim Perry <https://github.com/pimterry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -7,6 +7,7 @@
 
 import * as net from 'net';
 import * as udp from 'dgram';
+import { EventEmitter } from 'events';
 
 declare class Packet {
     static TYPE: {
@@ -73,14 +74,33 @@ declare namespace DNS {
     }
 }
 
+declare class DnsServer extends EventEmitter {
+    addresses(): {
+        udp?: net.AddressInfo;
+        tcp?: net.AddressInfo;
+        doh?: net.AddressInfo;
+    };
+
+    listen(ports: {
+        udp?: number,
+        tcp?: number,
+        doh?: number
+    }): Promise<void>;
+
+    close(): Promise<void>;
+}
+
 declare class DNS {
-    static createServer(
-        callback: (
+    static createServer(options: {
+        udp?: boolean,
+        tcp?: boolean,
+        doh?: boolean,
+        handle: (
             request: DNS.DnsRequest,
             sendResponse: (response: DNS.DnsResponse) => void,
             remoteInfo: udp.RemoteInfo,
-        ) => void,
-    ): net.Server;
+        ) => void
+    }): DnsServer;
 
     static Packet: typeof Packet;
 


### PR DESCRIPTION
Only updated for the breaking changes for now and a couple of the core servers types, not all the APIs available, but it's enough to make the types usable for V2.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - See examples at https://www.npmjs.com/package/dns2 for general `createServer` v2 usage
  - UDP & TCP servers are exported as part of the API [here](https://github.com/song940/node-dns/blob/master/index.js#L81-L82) and defined [here](https://github.com/song940/node-dns/blob/master/server/udp.js) & [here](https://github.com/song940/node-dns/blob/master/server/tcp.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
