### PR TITLE
Update react-native AppState interface

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -41,6 +41,7 @@
 //                 Alexey Molchan <https://github.com/alexeymolchan>
 //                 Alex Brazier <https://github.com/alexbrazier>
 //                 Arafat Zahan <https://github.com/kuasha420>
+//                 Brett Lindsay <https://github.com/bdlindsay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -7416,7 +7417,7 @@ export interface AppStateStatic {
 
     /**
      * @deprecated Use the `remove()` method on the event subscription returned by `addEventListener()`.
-     * 
+     *
      * Remove a handler by passing the change event type and the handler
      */
     removeEventListener(type: AppStateEvent, listener: (state: AppStateStatus) => void): void;

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7406,12 +7406,20 @@ export type AppStateStatus = 'active' | 'background' | 'inactive' | 'unknown' | 
 
 export interface AppStateStatic {
     currentState: AppStateStatus;
+    isAvailable: boolean;
 
     /**
      * Add a handler to AppState changes by listening to the change event
      * type and providing the handler
      */
-    addEventListener(type: AppStateEvent, listener: (state: AppStateStatus) => void): EmitterSubscription;
+    addEventListener(type: AppStateEvent, listener: (state: AppStateStatus) => void): NativeEventSubscription;
+
+    /**
+     * @deprecated Use the `remove()` method on the event subscription returned by `addEventListener()`.
+     * 
+     * Remove a handler by passing the change event type and the handler
+     */
+    removeEventListener(type: AppStateEvent, listener: (state: AppStateStatus) => void): void;
 }
 
 /**

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -520,6 +520,7 @@ appState = 'extension';
 const AppStateExample = () => {
     const appState = React.useRef(AppState.currentState);
     const [appStateVisible, setAppStateVisible] = React.useState(appState.current);
+    const appStateIsAvailable = AppState.isAvailable;
 
     React.useEffect(() => {
       const subscription = AppState.addEventListener("change", nextAppState => {
@@ -543,6 +544,7 @@ const AppStateExample = () => {
     return (
       <View style={styles.container}>
         <Text>Current state is: {appStateVisible}</Text>
+        <Text>Available: {appStateIsAvailable}</Text>
       </View>
     );
   };


### PR DESCRIPTION
Many of the properties/functions on EmitterSubscription do not exist on the subscription returned by this function in react native 0.65.1. Updated to reflect an extra property on AppState and changed to a narrower return type for `addEventListener`. `removeEventListener` is also re-added because it still exists on the type but is deprecated via the react-native docs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/appstate#methods
 