### PR TITLE
[codemirror] Add missing lookAhead method to StringStream type

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1655,7 +1655,7 @@ declare namespace CodeMirror {
          * Returns the content of the line n lines ahead in the stream without
          * advancing it. Will return undefined if not found.
          */
-        lookAhead(n: number): string;
+        lookAhead(n: number): string | undefined;
     }
 
     /**

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1650,6 +1650,12 @@ declare namespace CodeMirror {
          * Get the string between the start of the current token and the current stream position.
          */
         current(): string;
+
+        /**
+         * Returns the content of the line n lines ahead in the stream without
+         * advancing it. Will return undefined if not found.
+         */
+        lookAhead(n: number): string;
     }
 
     /**

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -4,7 +4,7 @@ const myCodeMirror: CodeMirror.Editor = CodeMirror(document.body);
 
 const myCodeMirror2: CodeMirror.Editor = CodeMirror(document.body, {
     value: 'function myScript(){return 100;}\n',
-    mode: {name: 'javascript', json: true},
+    mode: { name: 'javascript', json: true },
     extraKeys: {
         Enter: cm => {
             console.log('save');
@@ -77,6 +77,7 @@ htmlElement2.remove();
 CodeMirror.commands.newlineAndIndent(myCodeMirror);
 
 const stringStream = new CodeMirror.StringStream('var myEditor;');
+stringStream.lookAhead(1);
 
 // Call a method from the CodeMirror.Doc interface to confirm a CodeMirror.Editor extends it
 myCodeMirror.getCursor();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [stringstream.js](https://codemirror.net/1/js/stringstream.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

