### PR TITLE
react-map-gl: Added string to width and height on ViewportProps for use with 'vw', …

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -128,8 +128,8 @@ export interface MapControllerOptions {
 }
 
 export interface ViewportProps {
-    width: number;
-    height: number;
+    width: number | string;
+    height: number | string;
     latitude: number;
     longitude: number;
     zoom: number;

--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -172,6 +172,19 @@ class MyMap extends React.Component<{}, State> {
                 >
                     Jump to Null Point
                 </button>
+                <button
+                    onClick={() => {
+                        this.setState(prevState => ({
+                            viewport: {
+                                ...prevState.viewport,
+                                width: '100vw',
+                                height: '100vh',
+                            },
+                        }));
+                    }}
+                >
+                    Make map width and height of viewport
+                </button>
             </div>
         );
     }


### PR DESCRIPTION
…'vw' and '%'.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/visgl/react-map-gl/blob/6.1-release/src/components/static-map.js#L64 and https://github.com/visgl/react-map-gl/blob/6.1-release/src/components/static-map.js#L64
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
