### PR TITLE
Corrected type of Settings.rowId

### DIFF
--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1386,7 +1386,7 @@ declare namespace DataTables {
         /**
          * Data property name that DataTables will use to set <tr> element DOM IDs. Since: 1.10.8
          */
-        rowId?: string | undefined;
+        rowId?: string | (data: any) => string | undefined;
 
         /**
          * Allow the table to reduce in height when a limited number of rows are shown. Since: 1.10


### PR DESCRIPTION
Though not documented on the DataTables.net website (except in a comment,) the rowId can be a function that computes the row ID, rather than the name of a property from which to draw the row ID.

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [na ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ na] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatables.net/reference/option/rowId

