### PR TITLE
Fix types of limitToCountries, lineGradient in apple-mapkit-js-browser

### DIFF
--- a/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
+++ b/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
@@ -81,14 +81,14 @@ filter = mapkit.PointOfInterestFilter.filterExcludingAllCategories;
 const filterIncludes: boolean = filter.includesCategory(mapkit.PointOfInterestCategory.Airport);
 const filterExcludes: boolean = filter.excludesCategory(mapkit.PointOfInterestCategory.Airport);
 
-const search = new mapkit.PointsOfInterestSearch();
-const searchRegion: mapkit.CoordinateRegion = search.region;
-const searchCenter: mapkit.Coordinate = search.center;
-const searchPointOfInterestFilter: mapkit.PointOfInterestFilter = search.pointOfInterestFilter;
-const searchLanguage: string = search.language;
-const searchMaxRadius: number = search.MaxRadius;
-const searchResult: number = search.search({});
-const searchCancel: boolean = search.cancel(0);
+const poiSearch = new mapkit.PointsOfInterestSearch();
+const searchRegion: mapkit.CoordinateRegion = poiSearch.region;
+const searchCenter: mapkit.Coordinate = poiSearch.center;
+const searchPointOfInterestFilter: mapkit.PointOfInterestFilter = poiSearch.pointOfInterestFilter;
+const searchLanguage: string = poiSearch.language;
+const searchMaxRadius: number = poiSearch.MaxRadius;
+const searchResult: number = poiSearch.search({});
+const searchCancel: boolean = poiSearch.cancel(0);
 
 const pointOfInterestSearchOptions: mapkit.PointsOfInterestSearchOptions = {
     language: '',
@@ -132,3 +132,9 @@ let newCameraZoomRange = new mapkit.CameraZoomRange(0, 0);
 newCameraZoomRange = new mapkit.CameraZoomRange({ minCameraDistance: 0, maxCameraDistance: 0 });
 const minCameraDistance: number = newCameraZoomRange.minCameraDistance;
 const maxCameraDistance: number = newCameraZoomRange.maxCameraDistance;
+
+// Check that limitToCountries accepts a string
+const search = new mapkit.Search({ limitToCountries: 'us,mx' });
+
+// Check that all StyleConstructorOptions are optional
+const style = new mapkit.Style({});

--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -1608,7 +1608,7 @@ declare namespace mapkit {
         /**
          * The gradient to apply along the line.
          */
-        lineGradient: LineGradient;
+        lineGradient?: LineGradient | undefined;
     }
 
     /**
@@ -1886,7 +1886,7 @@ declare namespace mapkit {
         /**
          * A string that constrains search results to within the provided countries.
          */
-        limitToCountries?: boolean | undefined;
+        limitToCountries?: string | undefined;
         /**
          * A Boolean value that indicates whether the search results should include points of interest.
          */


### PR DESCRIPTION
Fixing `StyleConstructorOptions['lineGradient']` to be optional.
https://developer.apple.com/documentation/mapkitjs/styleconstructoroptions

Fixing `SearchConstructorOptions['limitToCountries']` to be a string instead of boolean. https://developer.apple.com/documentation/mapkitjs/searchconstructoroptions

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: (Above)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
