### PR TITLE
[fix] remove nul.d.ts file

### DIFF
--- a/types/barnard59-base/barnard59-base-tests.ts
+++ b/types/barnard59-base/barnard59-base-tests.ts
@@ -10,7 +10,9 @@ import {
     limit,
     map,
     nul,
-    offset, stdout, toString,
+    offset,
+    stdout,
+    toString,
 } from 'barnard59-base';
 import { object as concatObject } from 'barnard59-base/concat';
 import forEach from 'barnard59-base/forEach';
@@ -19,19 +21,23 @@ import { Readable, Duplex, Writable, Transform } from 'readable-stream';
 import Pipeline from 'barnard59-core/lib/Pipeline';
 
 function testCombine() {
+    // prettier-ignore
     const a: stream.Readable = <any> {};
+    // prettier-ignore
     const b: stream.Readable = <any> {};
+    // prettier-ignore
     const c: stream.Writable = <any> {};
 
     const combinedDuplex: stream.Duplex = combine([a, b, c]);
     const combineSingle: stream.Readable = combine([a]);
 
     const combinedWithOpts: stream.Duplex = combine([a, b, c], {
-        allowHalfOpen: true
+        allowHalfOpen: true,
     });
 }
 
 function testConcat() {
+    // prettier-ignore
     const streams: stream[] = <any> {};
 
     let concatenated: Readable;
@@ -46,7 +52,7 @@ function testFilter() {
         bar: string;
     }
 
-    const filtered: stream.Transform = filter<Foo>(function(chunk) {
+    const filtered: stream.Transform = filter<Foo>(function filterFunc(chunk) {
         return chunk.bar === this.variables.get('baz');
     });
 }
@@ -56,6 +62,7 @@ function testFlatten() {
 }
 
 function testForEach() {
+    // prettier-ignore
     const pipeline: Pipeline = <any> {};
 
     let loop: Duplex = forEach(pipeline);
@@ -64,12 +71,12 @@ function testForEach() {
 
 function testGlob() {
     let globbed: Readable = glob({
-        pattern: 'foo/**/bar'
+        pattern: 'foo/**/bar',
     });
 
     globbed = glob({
         pattern: '*.foo',
-        absolute: true
+        absolute: true,
     });
 }
 
@@ -86,14 +93,13 @@ function testMap() {
     interface Foo {
         bar: number;
     }
-
-    const mapped: stream.Transform = map<Foo, number>(function(chunk, _) {
+    const mapped: stream.Transform = map<Foo, number>(function mapFunc(chunk, _) {
         const baz: number = this.variables.get('baz');
 
         return chunk.bar * baz;
     });
 
-    const lazyMapped: stream.Transform = map<Foo, number>(async function(chunk, _) {
+    const lazyMapped: stream.Transform = map<Foo, number>(async function mapFunc(chunk, _) {
         const baz: number = this.variables.get('baz');
 
         return chunk.bar * baz;

--- a/types/barnard59-base/combine.d.ts
+++ b/types/barnard59-base/combine.d.ts
@@ -2,6 +2,9 @@ import * as stream from 'stream';
 
 type FirstOrDuplex<First, T extends stream[]> = T[1] extends never ? stream.Duplex : First;
 
-export default function combine<T extends stream>(streams: [T] | stream[], options?: stream.DuplexOptions): FirstOrDuplex<T, typeof streams>;
+export default function combine<T extends stream>(
+    streams: [T] | stream[],
+    options?: stream.DuplexOptions,
+): FirstOrDuplex<T, typeof streams>;
 
 export {};

--- a/types/barnard59-base/index.d.ts
+++ b/types/barnard59-base/index.d.ts
@@ -3,6 +3,10 @@
 // Definitions by: Tomasz Pluskiewicz <https://github.com/tpluscode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
+import { Writable } from 'stream';
+
 export { default as combine } from './combine';
 export { default as concat, object as concatObject } from './concat';
 export { default as filter } from './filter';
@@ -11,7 +15,7 @@ export { default as glob } from './glob';
 export { parse as jsonParse, stringify as jsonStringify } from './json';
 export { default as limit } from './limit';
 export { default as map } from './map';
-export { default as nul } from './nul';
+export function nul(): Writable;
 export { default as offset } from './offset';
 export { default as stdout } from './stdout';
 export { default as toString } from './toString';

--- a/types/barnard59-base/index.d.ts
+++ b/types/barnard59-base/index.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="node" />
 
-import { Writable } from 'stream';
+import { Writable } from 'readable-stream';
 
 export { default as combine } from './combine';
 export { default as concat, object as concatObject } from './concat';

--- a/types/barnard59-base/map.d.ts
+++ b/types/barnard59-base/map.d.ts
@@ -2,4 +2,7 @@ import * as stream from 'stream';
 import { Context } from 'barnard59-core';
 
 // tslint:disable-next-line:no-unnecessary-generics
-export default function map<From, To>(cb: (this: Context, chunk: From, encoding: string) => Promise<To> | To): stream.Transform;
+export default function map<From, To>(
+    // tslint:disable-next-line:no-unnecessary-generics
+    cb: (this: Context, chunk: From, encoding: string) => Promise<To> | To,
+): stream.Transform;

--- a/types/barnard59-base/nul.d.ts
+++ b/types/barnard59-base/nul.d.ts
@@ -1,3 +1,0 @@
-import { Writable } from 'readable-stream';
-
-export default function nul(): Writable;


### PR DESCRIPTION
- remove file
- move definition to index file

Temporary fix for Windows OS, for git failing to work
properly with reserved filename in usual scenarios.

Closes #55700

- [x] Use a meaningful title for the pull request. Include the name of the package modified.