### PR TITLE
[@bandagedbd/bdapi] add `Plugin` interface and make `BdApi` object global

### DIFF
--- a/types/bandagedbd__bdapi/bandagedbd__bdapi-tests.ts
+++ b/types/bandagedbd__bdapi/bandagedbd__bdapi-tests.ts
@@ -1,6 +1,8 @@
-import { BdApi } from '@bandagedbd/bdapi';
-
 BdApi.React; // $ExpectType typeof React
 BdApi.ReactDOM.render; // $ExpectType Renderer
 BdApi.alert('foo', 'bar'); // $ExpectType void
 BdApi.showToast('hello', { timeout: 2000 }); // $ExpectType void
+
+// https://github.com/BetterDiscord/BetterDiscord/wiki/Creating-Plugins#bdapi
+window.BdApi;
+global.BdApi;

--- a/types/bandagedbd__bdapi/bandagedbd__bdapi-tests.ts
+++ b/types/bandagedbd__bdapi/bandagedbd__bdapi-tests.ts
@@ -6,3 +6,7 @@ BdApi.showToast('hello', { timeout: 2000 }); // $ExpectType void
 // https://github.com/BetterDiscord/BetterDiscord/wiki/Creating-Plugins#bdapi
 window.BdApi;
 global.BdApi;
+
+// lodash is available globally in the discord app
+_;
+window._;

--- a/types/bandagedbd__bdapi/index.d.ts
+++ b/types/bandagedbd__bdapi/index.d.ts
@@ -9,6 +9,8 @@ import * as ReactInstance from 'react';
 import * as ReactDOMInstance from 'react-dom';
 import * as _ from 'lodash';
 
+export {};
+
 declare global {
     const BdApi: typeof BdApiModule;
     const _: typeof _;
@@ -181,7 +183,7 @@ export interface ConfirmationModalOptions {
 /**
  * The following functions are available as a part of each `AddonAPI` object from `BdApi`.
  */
-export class AddonAPI {
+declare class AddonAPI {
     /**
      * String representing the resolved location of the user's addon folder.
      */
@@ -226,7 +228,7 @@ export class AddonAPI {
     getAll(): void;
 }
 
-export namespace BdApiModule {
+declare namespace BdApiModule {
     /**
      * The React module being used inside Discord.
      */

--- a/types/bandagedbd__bdapi/index.d.ts
+++ b/types/bandagedbd__bdapi/index.d.ts
@@ -17,6 +17,78 @@ declare global {
 }
 
 /**
+ * Plugins must have a default export of a class that implements this interface
+ * @see https://github.com/BetterDiscord/BetterDiscord/wiki/Creating-Plugins
+ */
+export interface BdPlugin {
+    /**
+     * The name for the plugin to be displayed to the user in the plugins page and for internal settings to use.
+     *
+     * Note: This is no longer required if it is included in the meta.
+     * @returns the name for the plugin.
+     */
+    getName?(): string;
+
+    /**
+     * The description of the plugin shown in the plugins page.
+     *
+     * Note: This is no longer required if it is included in the meta.
+     * @returns the description of the plugin.
+     */
+    getDescription?(): string;
+
+    /**
+     * The version of the plugin displayed in the plugins page.
+     *
+     * Note: This is no longer required if it is included in the meta.
+     * @returns the version of the plugin.
+     */
+    getVersion?(): string;
+
+    /**
+     * The author string for the plugin displayed in the plugins page.
+     *
+     * Note: This is no longer required if it is included in the meta.
+     * @returns the author of the plugin.
+     */
+    getAuthor?(): string;
+
+    /**
+     * Called when the plugin is enabled or when it is loaded and was previously reloaded (such as discord start or reload).
+     */
+    start(): void;
+
+    /**
+     * Called when the plugin is disabled.
+     */
+    stop(): void;
+
+    /**
+     * Called when the user clicks on the settings button for the plugin. If this function is not implemented the button is not shown.
+     *
+     * Note: The button will be disabled if the plugin is disabled to avoid errors with not-started plugins.
+     */
+    getSettingsPanel?(): string;
+
+    /**
+     * Called when the plugin is loaded regardless of if it is enabled or disabled.
+     */
+    load?(): void;
+
+    /**
+     * Called on every mutation that occurs on the document. For more information on observers and mutations take a look at
+     * [MDN's documentation](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver).
+     * @param e The mutation that occurred.
+     */
+    observer?(e: MutationRecord): void;
+
+    /**
+     * Called every time the user navigates such as changing channel, changing servers, changing to friends list, etc.
+     */
+    onSwitch?(): void;
+}
+
+/**
  * Function with no arguments and no return value that may be called to revert changes made by `monkeyPatch` method, restoring (unpatching) original method.
  */
 export type CancelPatch = () => void;

--- a/types/bandagedbd__bdapi/index.d.ts
+++ b/types/bandagedbd__bdapi/index.d.ts
@@ -8,7 +8,13 @@
 import * as ReactInstance from 'react';
 import * as ReactDOMInstance from 'react-dom';
 
-export const BdApi: typeof BdApiModule;
+declare global {
+    const BdApi: typeof BdApiModule;
+    interface Window {
+        BdApi: typeof BdApiModule;
+    }
+    const global: Window;
+}
 
 /**
  * Function with no arguments and no return value that may be called to revert changes made by `monkeyPatch` method, restoring (unpatching) original method.

--- a/types/bandagedbd__bdapi/index.d.ts
+++ b/types/bandagedbd__bdapi/index.d.ts
@@ -7,11 +7,14 @@
 
 import * as ReactInstance from 'react';
 import * as ReactDOMInstance from 'react-dom';
+import * as _ from 'lodash';
 
 declare global {
     const BdApi: typeof BdApiModule;
+    const _: typeof _;
     interface Window {
         BdApi: typeof BdApiModule;
+        _: typeof _;
     }
     const global: Window;
 }


### PR DESCRIPTION
- added `Plugin` interface that all BetterDiscord plugins must implement
- made `BdApi` object global since BetterDiscord adds it to the `window`/`global` object. it can't be imported from `@bandagedbd/bdapi` at runtime because that package doesn't exist

see documentation below for more info

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://github.com/BetterDiscord/BetterDiscord/wiki/Creating-Plugins#bdapi
    - https://github.com/BetterDiscord/BetterDiscord/wiki/Creating-Plugins#required-functions