### PR TITLE
[logrotate-stream] size can be a number

### DIFF
--- a/types/logrotate-stream/index.d.ts
+++ b/types/logrotate-stream/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for logrotate-stream 0.2.5
+// Type definitions for logrotate-stream 0.2.8
 // Project: https://github.com/dstokes/logrotate-stream
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/logrotate-stream/index.d.ts
+++ b/types/logrotate-stream/index.d.ts
@@ -21,7 +21,7 @@ declare namespace logrotateStream {
         /**
          * The max file size of a log before rotation occurs. Supports 1024, 1k, 1m, 1g
          */
-        size: string;
+        size: string | number;
         /**
          * The number of rotated log files to keep (including the primary log file). Additional logs are deleted no rotation.
          */

--- a/types/logrotate-stream/logrotate-stream-tests.ts
+++ b/types/logrotate-stream/logrotate-stream-tests.ts
@@ -2,6 +2,12 @@
 import stream = require("stream");
 import rotateStream = require("logrotate-stream");
 
+var q: stream.Writable = rotateStream({
+    file: "mylogfile.log",
+    size: 100,
+    keep: 3
+});
+
 var s: stream.Writable = rotateStream({
     file: "mylogfile.log",
     size: "1m",


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See https://github.com/dstokes/logrotate-stream/blob/0cae68e5a9327ac44b9e70adbffe246ac3ee964b/test/logrotate-stream.js#L58