### PR TITLE
[sharp] Constrain output `channels` property to 1-4 range

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -1160,7 +1160,7 @@ declare namespace sharp {
         size: number;
         width: number;
         height: number;
-        channels: number;
+        channels: 1 | 2 | 3 | 4;
         /** indicating if premultiplication was used */
         premultiplied: boolean;
         /** Only defined when using a crop strategy */

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -384,3 +384,18 @@ sharp('16bpc.png')
         console.log((size / width / height / channels) * 8);
         console.log(new Uint16Array(data.buffer));
     });
+
+// Output channels are constrained from 1-4, can be used as raw input
+sharp(input)
+    .toBuffer({ resolveWithObject: true })
+    .then(result => {
+        const newImg = sharp(result.data, {
+            raw: {
+                channels: result.info.channels,
+                width: result.info.width,
+                height: result.info.height,
+            },
+        });
+
+        return newImg.toBuffer();
+    });


### PR DESCRIPTION
The `channels` property on `OutputInfo` was typed as `number`, which is a bit annoying when you want to use it for the `raw` property when constructing or composing images. This change sets it to `1 | 2 | 3 | 4`, which means you can pass it on to these constructors/methods without having to type cast it yourself (`channels as 1 | 2 | 3 | 4`)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sharp.pixelplumbing.com/api-output
