### PR TITLE
@types/carbon-components-react - add missing props for Slider component

### DIFF
--- a/types/carbon-components-react/lib/components/Slider/Slider.d.ts
+++ b/types/carbon-components-react/lib/components/Slider/Slider.d.ts
@@ -7,8 +7,10 @@ export interface SliderOnChangeArg {
 
 export interface SliderProps extends Omit<ReactDivAttr, "onChange"> {
     ariaLabelInput?: string | undefined,
+    disabled?: boolean | undefined;
     formatLabel?(value: SliderProps["value"], minOrMaxLabel: string): string,
     hideTextInput?: boolean | undefined,
+    invalid?: boolean | undefined;
     inputType?: ReactInputAttr["type"] | undefined,
     labelText?: React.ReactNode | undefined,
     light?: boolean | undefined,


### PR DESCRIPTION
This PR adds missing props for the Slider component that are documented in the [Carbon Design System React docs](https://react.carbondesignsystem.com/?path=/docs/components-slider--default#component-api).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.carbondesignsystem.com/?path=/docs/components-slider--default#component-api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.