### PR TITLE
@types/ember__debug - Update types of deprecation options

### DIFF
--- a/types/ember__debug/ember__debug-tests.ts
+++ b/types/ember__debug/ember__debug-tests.ts
@@ -80,14 +80,61 @@ deprecate('missing options', false); // $ExpectError
 deprecate('missing options body', true, {}); // $ExpectError
 deprecate('missing options id', true, { until: 'v4.0.0' }); // $ExpectError
 deprecate('missing options until', true, { id: 'some.deprecation' }); // $ExpectError
-deprecate('a valid deprecation without url', true, { id: 'some.deprecation', until: 'v4.0.0' }); // $ExpectType void
-deprecate('incorrect options url', true, { id: 'some.deprecation', until: 'v4.0.0', url: 123 }); // $ExpectError
-deprecate('a valid deprecation with url', true, { id: 'some.deprecation', until: 'v4.0.0', url: 'https://example.com/ember-deprecations-yo' }); // $ExpectType void
-deprecate('a valid deprecation without `for`', true, { id: 'some.deprecation', until: 'v4.0.0' }); // $ExpectType void
-deprecate('incorrect options `for`', true, { id: 'some.deprecation', until: 'v4.0.0', for: 123 }); // $ExpectError
-deprecate('a valid deprecation with `for`', true, { id: 'some.deprecation', until: 'v4.0.0', for: 'some.namespace' }); // $ExpectType void
-deprecate('a valid deprecation without `since`', true, { id: 'some.deprecation', until: 'v4.0.0' }); // $ExpectType void
-deprecate('incorrect options `since`', true, { id: 'some.deprecation', until: 'v4.0.0', since: 123 }); // $ExpectError
-deprecate('incorrect options `since`', true, { id: 'some.deprecation', until: 'v4.0.0', since: { wrongKey: 'some.version' } }); // $ExpectError
-deprecate('incorrect options `since`', true, { id: 'some.deprecation', until: 'v4.0.0', since: { available: 123 } }); // $ExpectError
-deprecate('a valid deprecation with `since`', true, { id: 'some.deprecation', until: 'v4.0.0', since: { enabled: 'some.version'} }); // $ExpectType void
+deprecate('a valid deprecation without url', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+}); // $ExpectType void
+deprecate('incorrect options url', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  url: 123,
+}); // $ExpectError
+deprecate('a valid deprecation with url', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  url: 'https://example.com/ember-deprecations-yo',
+}); // $ExpectType void
+deprecate('a valid deprecation without `for`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+}); // $ExpectType void
+deprecate('incorrect options `for`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  for: 123,
+}); // $ExpectError
+deprecate('a valid deprecation with `for`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  for: 'some.namespace',
+}); // $ExpectType void
+deprecate('a valid deprecation without `since`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+}); // $ExpectType void
+deprecate('incorrect options `since`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  since: 123,
+}); // $ExpectError
+deprecate('incorrect options `since`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  since: {
+    wrongKey: 'some.version',
+  },
+}); // $ExpectError
+deprecate('incorrect options `since`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  since: {
+    available: 123,
+  },
+}); // $ExpectError
+deprecate('a valid deprecation with `since`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  since: {
+    enabled: 'some.version',
+  },
+}); // $ExpectType void

--- a/types/ember__debug/ember__debug-tests.ts
+++ b/types/ember__debug/ember__debug-tests.ts
@@ -83,3 +83,11 @@ deprecate('missing options until', true, { id: 'some.deprecation' }); // $Expect
 deprecate('a valid deprecation without url', true, { id: 'some.deprecation', until: 'v4.0.0' }); // $ExpectType void
 deprecate('incorrect options url', true, { id: 'some.deprecation', until: 'v4.0.0', url: 123 }); // $ExpectError
 deprecate('a valid deprecation with url', true, { id: 'some.deprecation', until: 'v4.0.0', url: 'https://example.com/ember-deprecations-yo' }); // $ExpectType void
+deprecate('a valid deprecation without `for`', true, { id: 'some.deprecation', until: 'v4.0.0' }); // $ExpectType void
+deprecate('incorrect options `for`', true, { id: 'some.deprecation', until: 'v4.0.0', for: 123 }); // $ExpectError
+deprecate('a valid deprecation with `for`', true, { id: 'some.deprecation', until: 'v4.0.0', for: 'some.namespace' }); // $ExpectType void
+deprecate('a valid deprecation without `since`', true, { id: 'some.deprecation', until: 'v4.0.0' }); // $ExpectType void
+deprecate('incorrect options `since`', true, { id: 'some.deprecation', until: 'v4.0.0', since: 123 }); // $ExpectError
+deprecate('incorrect options `since`', true, { id: 'some.deprecation', until: 'v4.0.0', since: { wrongKey: 'some.version' } }); // $ExpectError
+deprecate('incorrect options `since`', true, { id: 'some.deprecation', until: 'v4.0.0', since: { available: 123 } }); // $ExpectError
+deprecate('a valid deprecation with `since`', true, { id: 'some.deprecation', until: 'v4.0.0', since: { enabled: 'some.version'} }); // $ExpectType void

--- a/types/ember__debug/ember__debug-tests.ts
+++ b/types/ember__debug/ember__debug-tests.ts
@@ -80,61 +80,84 @@ deprecate('missing options', false); // $ExpectError
 deprecate('missing options body', true, {}); // $ExpectError
 deprecate('missing options id', true, { until: 'v4.0.0' }); // $ExpectError
 deprecate('missing options until', true, { id: 'some.deprecation' }); // $ExpectError
-deprecate('a valid deprecation without url', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
-}); // $ExpectType void
-deprecate('incorrect options url', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
-  url: 123,
-}); // $ExpectError
-deprecate('a valid deprecation with url', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
-  url: 'https://example.com/ember-deprecations-yo',
-}); // $ExpectType void
-deprecate('a valid deprecation without `for`', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
-}); // $ExpectType void
-deprecate('incorrect options `for`', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
-  for: 123,
-}); // $ExpectError
-deprecate('a valid deprecation with `for`', true, {
+deprecate('a valid deprecation without `url`', true, { // $ExpectType void
   id: 'some.deprecation',
   until: 'v4.0.0',
   for: 'some.namespace',
-}); // $ExpectType void
-deprecate('a valid deprecation without `since`', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
-}); // $ExpectType void
-deprecate('incorrect options `since`', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
-  since: 123,
-}); // $ExpectError
-deprecate('incorrect options `since`', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
-  since: {
-    wrongKey: 'some.version',
-  },
-}); // $ExpectError
-deprecate('incorrect options `since`', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
-  since: {
-    available: 123,
-  },
-}); // $ExpectError
-deprecate('a valid deprecation with `since`', true, {
-  id: 'some.deprecation',
-  until: 'v4.0.0',
   since: {
     enabled: 'some.version',
   },
-}); // $ExpectType void
+});
+deprecate('incorrect options `url`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  url: 123, // $ExpectError
+  for: 'some.namespace',
+  since: {
+    enabled: 'some.version',
+  },
+});
+deprecate('a valid deprecation with `url`', true, { // $ExpectType void
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  url: 'https://example.com/ember-deprecations-yo',
+  for: 'some.namespace',
+  since: {
+    enabled: 'some.version',
+  },
+});
+deprecate('a valid deprecation with `for`', true, { // $ExpectType void
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  for: 'some.namespace',
+  since: {
+    enabled: 'some.version',
+  },
+});
+deprecate('incorrect options `for`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  for: 123, // $ExpectError
+  since: {
+    enabled: 'some.version',
+  },
+});
+deprecate('a valid deprecation with `since`', true, { // $ExpectType void
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  for: 'some.namespace',
+  since: {
+    available: 'some.version',
+  },
+});
+deprecate('a valid deprecation with `since`', true, { // $ExpectType void
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  for: 'some.namespace',
+  since: {
+    available: 'some.version',
+    enabled: 'some.version',
+  },
+});
+deprecate('incorrect options `since`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  for: 'some.namespace',
+  since: 123, // $ExpectError
+});
+deprecate('incorrect options `since`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  for: 'some.namespace',
+  since: {
+    wrongKey: 'some.version', // $ExpectError
+  },
+});
+deprecate('incorrect options `since`', true, {
+  id: 'some.deprecation',
+  until: 'v4.0.0',
+  for: 'some.namespace',
+  since: {
+    available: 123, // $ExpectError
+  },
+});

--- a/types/ember__debug/index.d.ts
+++ b/types/ember__debug/index.d.ts
@@ -87,5 +87,13 @@ export function deprecate(
          * An optional url to the transition guide on the emberjs.com website.
          */
         url?: string | undefined;
+        /**
+         * A namespace for the deprecation, usually the package name.
+         */
+        for?: string;
+        /**
+         * Describes when the deprecation became available and enabled.
+         */
+        since?: Partial<Record<'available' | 'enabled', string>>;
     },
 ): void;

--- a/types/ember__debug/index.d.ts
+++ b/types/ember__debug/index.d.ts
@@ -90,10 +90,10 @@ export function deprecate(
         /**
          * A namespace for the deprecation, usually the package name.
          */
-        for?: string;
+        for: string;
         /**
          * Describes when the deprecation became available and enabled.
          */
-        since?: Partial<Record<'available' | 'enabled', string>>;
+        since: Partial<Record<'available' | 'enabled', string>>;
     },
 ): void;


### PR DESCRIPTION
Types inspired from the latest stable version of Ember.js currently available:
https://github.com/emberjs/ember.js/blob/v3.28.1/packages/@ember/debug/lib/deprecate.ts#L13-L21

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/blob/v3.28.1/packages/@ember/debug/lib/deprecate.ts#L13-L21
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
