### PR TITLE
shopify-buy: changed 'sortBy' to 'sortKey' in Query interface

### DIFF
--- a/types/shopify-buy/index.d.ts
+++ b/types/shopify-buy/index.d.ts
@@ -115,7 +115,7 @@ declare namespace ShopifyBuy {
          * as their  community guidelines
          */
         query: string;
-        sortBy: string;
+        sortKey: string;
         after?: string | undefined;
         before?: string | undefined;
         first?: number | undefined;


### PR DESCRIPTION
Spotted this one while trying to do something like `client.product.fetchQuery({query: "", sortBy: "TITLE"})` and it had no effect.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Shopify/js-buy-sdk/blob/28c85805ee21bdebf9611da6b92c39858b15dc0a/src/product-resource.js#L98
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.