### PR TITLE
Default Backbone CombinedModelConstructorOptions E parameter to lenient

### DIFF
--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -241,7 +241,12 @@ function test_collection() {
     books.set([{ title: 'Title 0', author: 'Johan' }]);
     books.reset();
 
-    const book1: Book = new Book({ title: 'Title 1', author: 'Mike' });
+    const book1: Book = new Book({ title: 'Title 1', author: 'Mike' }, {
+        // We sneak in an arbitrary option to check that
+        // `CombinedModelSetOptions` no longer breaks pre-1.4.4 code
+        // (see #55764 and #46513).
+        testOption: 'banana',
+    });
     books.add(book1);
 
     // Test adding sort option to add.

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -212,7 +212,7 @@ declare namespace Backbone {
      * E - Extensions to the model constructor options. You can accept additional constructor options
      * by listing them in the E parameter.
      */
-    class Model<T extends ObjectHash = any, S = ModelSetOptions, E = {}> extends ModelBase implements Events {
+    class Model<T extends ObjectHash = any, S = ModelSetOptions, E = any> extends ModelBase implements Events {
         /**
          * Do not use, prefer TypeScript's extend functionality.
          */


### PR DESCRIPTION
#46513 by @khasanovbi, which I reviewed myself and which ended up being released as `@types/backbone@1.4.4`, added the ability to strictly type the `options` argument that can be passed to the `Backbone.Model` constructor (among other things). While this was undeniably an improvement, I already [predicted](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46513#discussion_r465083548) at the time that it would be a breaking change. Apparently, I did not realize at the time that the break could be avoided by defaulting the `E` type parameter to `any` instead of `{}`.

Today, I finally upgraded past `@types/backbone@1.4.4` in one of my projects and the breaking change bit me. Making the change I'm proposing here eliminated about a whole page of TS error messages.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46513#discussion_r465083548
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. *it doesn't*
