### PR TITLE
Fix parse-torrent missing infoHash

### DIFF
--- a/types/parse-torrent/index.d.ts
+++ b/types/parse-torrent/index.d.ts
@@ -12,8 +12,8 @@ declare const ParseTorrent: ParseTorrent.ParseTorrent;
 
 declare namespace ParseTorrent {
     interface ParseTorrent {
-        (torrent: string): MagnetUri.Instance;
-        (torrent: Buffer): MagnetUri.Instance | ParseTorrentFile.Instance;
+        (torrent: string): MagnetUri.Instance & {infoHash: string};
+        (torrent: Buffer): (MagnetUri.Instance | ParseTorrentFile.Instance) & {infoHash: string};
         (torrent: Instance | MagnetUri.Instance | ParseTorrentFile.Instance): Instance;
 
         toMagnetURI: typeof MagnetUri.encode;

--- a/types/parse-torrent/parse-torrent-tests.ts
+++ b/types/parse-torrent/parse-torrent-tests.ts
@@ -2,10 +2,12 @@ import parseTorrent = require('parse-torrent');
 import * as fs from 'fs';
 
 // info hash (as a hex string)
+// $ExpectType { infoHash: string }
 parseTorrent('d2474e86c95b19b8bcfdb92bc12c9d44667cfa36');
 // { infoHash: 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36' }
 
 // info hash (as a Buffer)
+// $ExpectType { infoHash: string }
 parseTorrent(new Buffer('d2474e86c95b19b8bcfdb92bc12c9d44667cfa36', 'hex'));
 // { infoHash: 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36' }
 


### PR DESCRIPTION
From the parse-torrent docs: "The only property that is guaranteed to be present is infoHash."

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
There are no working tests.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changes to an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/parse-torrent
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
