### PR TITLE
Remove recharts from notNeededPackages.json

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -4190,10 +4190,6 @@
             "libraryName": "reapop",
             "asOfVersion": "3.0.0"
         },
-        "recharts": {
-            "libraryName": "recharts",
-            "asOfVersion": "2.0.0"
-        },
         "recoil": {
             "libraryName": "recoil",
             "asOfVersion": "0.0.9"


### PR DESCRIPTION
I don't think the publisher can publish old versions of a package while keeping the new version deprecated.

Followup to #55547