### PR TITLE
#55798 Add helperText property to carbon-components-react MultiSelectProps definition

### DIFF
--- a/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
+++ b/types/carbon-components-react/lib/components/MultiSelect/MultiSelect.d.ts
@@ -22,6 +22,7 @@ export interface MultiSelectProps<T extends ListBoxBaseItemType = string> extend
     direction?: VerticalDirection | undefined,
     disabled?: ListBoxProps["disabled"] | undefined,
     downshiftProps?: any, // TODO
+    helperText?: React.ReactNode | undefined,
     id: string,
     initialSelectedItems?: readonly T[] | undefined,
     items: readonly T[],


### PR DESCRIPTION
As it can be seen below, carbon-components-react MultiSelect implementation makes use of a helperText property. It is missing in the type definition.

https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/MultiSelect/MultiSelect.js

![image](https://user-images.githubusercontent.com/19869080/133452390-b0d71e7d-2ebf-4cbc-b121-75f99fe67d10.png)
