### PR TITLE
[THREE]: Minor fix: Update to parameter type in WebGLRenderLists.d.ts 

### DIFF
--- a/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -60,5 +60,5 @@ export class WebGLRenderLists {
     constructor(properties: WebGLProperties);
 
     dispose(): void;
-    get(scene: Scene, camera: Camera): WebGLRenderList;
+    get(scene: Scene, renderCallDepth: number): WebGLRenderList;
 }


### PR DESCRIPTION
The second parameter of WebGLRenderLists.get() should be a number indicating the render call depth.
Three.js source line here: https://github.com/mrdoob/three.js/blob/68b5f4f0cc279b6b7c61205aeda72b995a3642f5/src/renderers/webgl/WebGLRenderLists.js#L205


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

