### PR TITLE
fix 'has or is using name ... but cannot be named' error in @types/react-transition-group

### DIFF
--- a/types/react-transition-group/Transition.d.ts
+++ b/types/react-transition-group/Transition.d.ts
@@ -137,7 +137,7 @@ interface BaseTransitionProps<RefElement extends undefined | HTMLElement> {
 export type TransitionStatus = typeof ENTERING | typeof ENTERED | typeof EXITING | typeof EXITED | typeof UNMOUNTED;
 export type TransitionChildren = ReactNode | ((status: TransitionStatus) => ReactNode);
 
-interface TimeoutProps<RefElement extends undefined | HTMLElement> extends BaseTransitionProps<RefElement> {
+export interface TimeoutProps<RefElement extends undefined | HTMLElement> extends BaseTransitionProps<RefElement> {
     /**
      * The duration of the transition, in milliseconds. Required unless addEndListener is provided.
      *
@@ -167,7 +167,7 @@ interface TimeoutProps<RefElement extends undefined | HTMLElement> extends BaseT
     addEndListener?: EndHandler<RefElement> | undefined;
 }
 
-interface EndListenerProps<Ref extends undefined | HTMLElement> extends BaseTransitionProps<Ref> {
+export interface EndListenerProps<Ref extends undefined | HTMLElement> extends BaseTransitionProps<Ref> {
     /**
      * The duration of the transition, in milliseconds. Required unless addEndListener is provided.
      *


### PR DESCRIPTION
- export `TimeoutProps` and `EndListenerProps`
- fixes error `Exported variable 'Foo' has or is using name 'TimeoutProps' from external module "foo/node_modules/@types/react-transition-group/Transition" but cannot be named`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/55802>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
