### PR TITLE
Superagent: Use Record for links property

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -114,7 +114,7 @@ declare namespace request {
         header: any;
         headers: any;
         info: boolean;
-        links: object;
+        links: Record<string, string>;
         noContent: boolean;
         notAcceptable: boolean;
         notFound: boolean;


### PR DESCRIPTION
The `links` property is currently typed as `object` making it annoying to use. It should be `Record<string, string>`:

https://github.com/visionmedia/superagent/blob/3c9c0f7feef61328131ae43b06e628bce1c20c17/src/utils.js#L40
