### PR TITLE
[chec/commerce.js] Remove checkout.protect() method from definitions

### DIFF
--- a/types/chec__commerce.js/features/checkout.d.ts
+++ b/types/chec__commerce.js/features/checkout.d.ts
@@ -99,6 +99,7 @@ export interface CheckGiftcardResponse {
 export class Checkout {
     constructor(commerce: Commerce);
 
+    /** @deprecated */
     protect(token: string): Promise<any>;
     generateToken(identifier: string, data: object): Promise<CheckoutToken>;
     generateTokenFrom(type: IdentifierType, identifier: string): Promise<CheckoutToken>;


### PR DESCRIPTION
This method is removed upstream, see https://github.com/chec/commerce.js/pull/190

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
