### PR TITLE
fix(svgo:loadConfig): correct method signature

### DIFF
--- a/types/svgo/index.d.ts
+++ b/types/svgo/index.d.ts
@@ -778,3 +778,4 @@ export function optimize(svgString: string | Buffer, options?: OptimizeOptions):
  * You can also specify relative or absolute path and customize current working directory.
  */
 export function loadConfig(configFile: string, cwd?: string): Promise<OptimizeOptions>;
+export function loadConfig(): Promise<OptimizeOptions | null>;

--- a/types/svgo/svgo-tests.ts
+++ b/types/svgo/svgo-tests.ts
@@ -461,3 +461,12 @@ optimize('', { plugins: extendDefaultPlugins(plugins) });
 loadConfig('foo.js');
 // $ExpectType Promise<OptimizeOptions>
 loadConfig('foo.js', '/home/user');
+
+(async () => {
+    const config = await loadConfig();
+    if (!config) {
+        config; // $ExpectType null
+        return;
+    }
+    config; // $ExpectType OptimizeOptions
+})();


### PR DESCRIPTION
`loadConfig` accepts no parameters, to just be used as config resolver
by consuming tooling (the hosting code could not be aware about svgo
configuration details):
https://github.com/svg/svgo#loadconfig

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).