### PR TITLE
[react-phone-number-input] Add the missing countryCallingCodeEditable prop to PhoneInputProps

### DIFF
--- a/types/react-phone-number-input/index.d.ts
+++ b/types/react-phone-number-input/index.d.ts
@@ -265,6 +265,12 @@ export interface PhoneInputProps extends Omit<React.InputHTMLAttributes<string>,
      * set `useNationalFormatForDefaultCountryValue` property to `true`.
      */
     useNationalFormatForDefaultCountryValue?: boolean;
+    /**
+     * If set to false, and international is true, then users won't be able
+     * to erase the "country calling part" of a phone number in the <input/>.
+     * @default true
+     */
+    countryCallingCodeEditable?: boolean;
 }
 
 export default class PhoneInput extends React.Component<PhoneInputProps, object> {}

--- a/types/react-phone-number-input/test/react-phone-number-input.tsx
+++ b/types/react-phone-number-input/test/react-phone-number-input.tsx
@@ -95,3 +95,14 @@ const test3 = (
         flagComponent={(props: {country: string, flagUrl: string}) => <span>country: {props.country}, flagUrl: {props.flagUrl}</span>}
     />
 );
+
+const test4 = (
+    <PhoneInput
+        value="+12345678901"
+        onChange={(value: string) => {
+            console.log(value);
+        }}
+        international
+        countryCallingCodeEditable={false}
+    />
+);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://catamphetamine.gitlab.io/react-phone-number-input/docs/index.html#phoneinputwithcountry
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
