### PR TITLE
fix(node): disallow `undefined` as value in `URLSearchParams`

### DIFF
--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -148,6 +148,11 @@ import * as url from 'node:url';
 }
 
 {
+    // $ExpectError
+    new url.URLSearchParams({ foobar: undefined });
+}
+
+{
     let path: string = url.fileURLToPath('file://test');
     path = url.fileURLToPath(new url.URL('file://test'));
 }

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -684,7 +684,7 @@ declare module 'url' {
      * @since v7.5.0, v6.13.0
      */
     class URLSearchParams implements Iterable<[string, string]> {
-        constructor(init?: URLSearchParams | string | NodeJS.Dict<string | ReadonlyArray<string>> | Iterable<[string, string]> | ReadonlyArray<[string, string]>);
+        constructor(init?: URLSearchParams | string | Record<string, string | ReadonlyArray<string>> | Iterable<[string, string]> | ReadonlyArray<[string, string]>);
         /**
          * Append a new name-value pair to the query string.
          */

--- a/types/node/v14/test/url.ts
+++ b/types/node/v14/test/url.ts
@@ -142,6 +142,11 @@ import * as url from 'url';
 }
 
 {
+    // $ExpectError
+    new url.URLSearchParams({ foobar: undefined });
+}
+
+{
     let path: string = url.fileURLToPath('file://test');
     path = url.fileURLToPath(new url.URL('file://test'));
 }

--- a/types/node/v14/url.d.ts
+++ b/types/node/v14/url.d.ts
@@ -98,7 +98,7 @@ declare module 'url' {
     }
 
     class URLSearchParams implements Iterable<[string, string]> {
-        constructor(init?: URLSearchParams | string | NodeJS.Dict<string | ReadonlyArray<string>> | Iterable<[string, string]> | ReadonlyArray<[string, string]>);
+        constructor(init?: URLSearchParams | string | Record<string, string | ReadonlyArray<string>> | Iterable<[string, string]> | ReadonlyArray<[string, string]>);
         append(name: string, value: string): void;
         delete(name: string): void;
         entries(): IterableIterator<[string, string]>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

You're not supposed to provide `undefined` here as they are included when stringified.

```sh-session
$ node -p 'new URLSearchParams({ foobar: undefined }).toString()'
foobar=undefined
```

Also see https://github.com/whatwg/url/issues/427

Finally, this matches the DOM types which does not allow `undefined` here: https://github.com/microsoft/TypeScript/blob/4dde5cc4f16f8904f3f355637b41e4f89acf4e14/lib/lib.dom.d.ts#L14944

---

Note that passing an array like the types allow doesn't really work either

```js
const s1 = new URLSearchParams({ foobar: ['foo', 'bar'] });
const s2 = new URLSearchParams('foobar=foo&foobar=bar');

console.log(s1.getAll('foobar'), s2.getAll('foobar'));

// prints `[ 'foo,bar' ] [ 'foo', 'bar' ]` - i.e. the constructor only calls
// `.toString()` on the passed in array and enters a single value into the map
```

However, this behaviour is asserted on in tests, so maybe you actually want `'foo,bar'` as a single query param? Seems far-fetched, but I don't care about this since I don't use an array in my own code 🙈 