### PR TITLE
ioredis: add missing .pubsub() method.

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -18,7 +18,7 @@
 //                 Michael Salaverry <https://github.com/barakplasma>
 //                 Hannes Van De Vreken <https://github.com/hannesvdvreken>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// Minimum TypeScript Version: 4.2
 
 /* =================== USAGE ===================
     import * as Redis from "ioredis";

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1164,6 +1164,11 @@ declare namespace IORedis {
 
         punsubscribe: OverloadedCommand<string, number>;
 
+        pubsub(subcommand: 'CHANNELS' | 'NUMSUB' | 'channels' | 'numsub', ...args: [...string[], Callback<string[]>]): void;
+        pubsub(subcommand: 'CHANNELS' | 'NUMSUB' | 'channels' | 'numsub', ...args: string[]): Promise<string[]>;
+        pubsub(subcommand: 'NUMPAT' | 'numpat', callback: Callback<number>): void;
+        pubsub(subcommand: 'NUMPAT' | 'numpat'): Promise<number>;
+
         publish(channel: string, message: string, callback: Callback<number>): void;
         publish(channel: string, message: string): Promise<number>;
 

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -289,6 +289,13 @@ redis.setBuffer('key', '100', 'NX', 'EX', 10, (err, data) => {});
 redis.exists('foo').then(result => result * 1);
 redis.exists('foo', (err, data) => data * 1);
 
+// Pubsub commands
+redis.pubsub("channels", (err, data) => {});
+redis.pubsub("channels", "one", (err, data) => {});
+redis.pubsub("channels", "one", "two", (err, data) => {});
+redis.pubsub("numsub", "one", "two", (err, data) => {});
+redis.pubsub("numpat", (err, data) => {});
+
 // Should support usage of Buffer
 redis.set(Buffer.from('key'), '100');
 redis.setBuffer(Buffer.from('key'), '100', 'NX', 'EX', 10);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

---

This PR should close this https://github.com/luin/ioredis/issues/1434

The **Minimum TypeScript Version** had to be bumped to `4.2` due to this signature:

```typescript
pubsub(subcommand: 'CHANNELS' | 'NUMSUB' | 'channels' | 'numsub', ...args: [...string[], Callback<string[]>]): void;
```
