### PR TITLE
[@types/react-table] Allow table to accept readonly arrays for column and data options

### DIFF
--- a/types/react-table/Readme.md
+++ b/types/react-table/Readme.md
@@ -2,6 +2,11 @@
 
 ## Changelog
 
+### 2021-09-17 (@types/react-table 7.7.3, react-table 7.7.0)
+
+The definition of `useTableOptions` was updated to accept readonly arrays  as columns and data. See [the Pull Request for these changes](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55833).
+
+
 ### 2020-04-09 (@types/react-table 7.0.14, react-table 7.0.4)
 
 A number of breaking changes related to changing `Column<D>` from `interface` to `type` and making the columns types stricter overall. For more information and migration guide see [the Pull Request for these changes](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43714).

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -166,8 +166,8 @@ export function useTable<D extends object = {}>(
  * NOTE: To use custom options, use "Interface Merging" to add the custom options
  */
 export type UseTableOptions<D extends object> = {
-    columns: Array<Column<D>>;
-    data: D[];
+    columns: ReadonlyArray<Column<D>>;
+    data: readonly D[];
 } & Partial<{
     initialState: Partial<TableState<D>>;
     stateReducer: (newState: TableState<D>, action: ActionType, previousState: TableState<D>, instance?: TableInstance<D>) => TableState<D>;

--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -315,7 +315,7 @@ function fuzzyTextFilterFn<T extends object>(rows: Array<Row<T>>, id: IdType<T>,
 fuzzyTextFilterFn.autoRemove = (val: any) => !val;
 
 interface Table<T extends object> {
-    columns: Array<Column<T>>;
+    columns: ReadonlyArray<Column<T>>;
     data: T[];
     updateMyData?: any;
     skipPageReset?: boolean | undefined;
@@ -597,7 +597,7 @@ const Component = (props: {}) => {
         { firstName: 'surprise', lastName: 'zinc', age: 23, visits: 7, progress: 48, status: 'single' },
         { firstName: 'riddle', lastName: 'information', age: 2, visits: 63, progress: 3, status: 'complicated' },
     ];
-    const columns: Array<Column<Data>> = [
+    const columns: ReadonlyArray<Column<Data>> = [
         {
             id: 'selection',
             // The header can use the table's getToggleAllRowsSelectedProps method
@@ -692,7 +692,7 @@ const Component = (props: {}) => {
     ];
 
     // mostly the same as above but minus the grouping
-    const columns2: Array<Column<Data>> = [
+    const columns2: ReadonlyArray<Column<Data>> = [
         {
             Header: 'First Name',
             accessor: 'firstName',


### PR DESCRIPTION
Right now the following code does not typecheck

```tsx
const columns = [] as const
const data = [] as const

useTable({ columns, data })
```
because the typings require that `columns` and `data` be mutable.

The solution is to make these fields accept readonly arrays, per https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes.
> function sum(nums: number[]): number: **Use ReadonlyArray if a function does not write to its parameters.**

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
