### PR TITLE
fix mapbox-gl: missing Expression for line-cap

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -2339,7 +2339,7 @@ declare namespace mapboxgl {
     }
 
     export interface LineLayout extends Layout {
-        'line-cap'?: 'butt' | 'round' | 'square' | undefined;
+        'line-cap'?: 'butt' | 'round' | 'square' | Expression | undefined;
         'line-join'?: 'bevel' | 'round' | 'miter' | Expression | undefined;
         'line-miter-limit'?: number | Expression | undefined;
         'line-round-limit'?: number | Expression | undefined;


### PR DESCRIPTION
fix mapbox-gl: missing Expression for line-cap