### PR TITLE
[`fs-extra`] Fix the `options` parameter on various methods to allow accepting string (encoding) instead of an options object

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -1,29 +1,29 @@
-import * as fs from "fs-extra";
+import * as fs from 'fs-extra';
 
 const len = 2;
-const src = "";
-const dest = "";
-const file = "";
-const dir = "";
-const path = "";
-const data = "";
+const src = '';
+const dest = '';
+const file = '';
+const dir = '';
+const path = '';
+const data = '';
 const uid = 0;
 const gid = 0;
 const fd = 0;
 const modeNum = 0;
-const modeStr = "";
+const modeStr = '';
 const object = {};
-const errorCallback = (err: Error) => { };
-const noParamCallback: fs.NoParamCallback = (err) => {};
+const errorCallback = (err: Error) => {};
+const noParamCallback: fs.NoParamCallback = err => {};
 const ensureNum = 0o700;
 const ensureObj: fs.EnsureOptions = {
-   mode: 0o700
+    mode: 0o700,
 };
 const readOptions: fs.ReadOptions = {
-    reviver: {}
+    reviver: {},
 };
 const writeOptions: fs.WriteOptions = {
-    replacer: {}
+    replacer: {},
 };
 
 fs.moveSync(src, dest, {});
@@ -48,24 +48,24 @@ fs.copy(src, dest, { overwrite: true }).then(() => {
 });
 fs.copy(src, dest, errorCallback);
 fs.copy(src, dest, { filter: (src: string, dest: string) => false }, errorCallback);
-fs.copy(src, dest,
+fs.copy(
+    src,
+    dest,
     {
         overwrite: true,
         preserveTimestamps: true,
-        filter: (src: string, dest: string) => Promise.resolve(false)
+        filter: (src: string, dest: string) => Promise.resolve(false),
     },
-    errorCallback
+    errorCallback,
 );
 
 fs.copySync(src, dest);
 fs.copySync(src, dest, { filter: (src: string, dest: string) => false });
-fs.copySync(src, dest,
-    {
-        overwrite: true,
-        preserveTimestamps: true,
-        filter: (src: string, dest: string) => false
-    }
-);
+fs.copySync(src, dest, {
+    overwrite: true,
+    preserveTimestamps: true,
+    filter: (src: string, dest: string) => false,
+});
 
 fs.createFile(file).then(() => {
     // stub
@@ -83,11 +83,11 @@ fs.mkdir(dir, modeNum).then(() => {
 });
 fs.mkdir(dir, modeNum, errorCallback);
 fs.mkdirSync(dir, modeNum);
-fs.mkdir(dir, {mode: modeNum}).then(() => {
+fs.mkdir(dir, { mode: modeNum }).then(() => {
     // stub
 });
-fs.mkdir(dir, {mode: modeNum}, errorCallback);
-fs.mkdirSync(dir, {mode: modeNum});
+fs.mkdir(dir, { mode: modeNum }, errorCallback);
+fs.mkdirSync(dir, { mode: modeNum });
 
 fs.mkdirs(dir).then(() => {
     // stub
@@ -103,17 +103,61 @@ fs.mkdirpSync(dir);
 fs.outputFile(file, data).then(() => {
     // stub
 });
+fs.outputFile(file, data, 'utf-8').then(() => {
+    // stub
+});
+fs.outputFile(file, data, { encoding: 'utf-8' }).then(() => {
+    // stub
+});
+fs.outputFile(file, data, 'foo').then(() => {
+    // stub
+});
+fs.outputFile(file, data, { encoding: 'foo' }).then(() => {
+    // stub
+});
 fs.outputFile(file, data, errorCallback);
+fs.outputFile(file, data, 'utf-8', errorCallback);
+fs.outputFile(file, data, 'foo', errorCallback);
+fs.outputFile(file, data, { encoding: 'utf-8' }, errorCallback);
+fs.outputFile(file, data, { encoding: 'foo' }, errorCallback);
 fs.outputFileSync(file, data);
+fs.outputFileSync(file, data, 'utf-8');
+fs.outputFileSync(file, data, 'foo');
+fs.outputFileSync(file, data, { encoding: 'utf-8' });
+fs.outputFileSync(file, data, { encoding: 'foo' });
 
 fs.outputJson(file, data, {
-    spaces: 2
+    spaces: 2,
 }).then(() => {
     // stub
 });
 fs.outputJson(file, data, {
-    spaces: 2
-}, errorCallback);
+    encoding: 'utf-8',
+    spaces: 2,
+}).then(() => {
+    // stub
+});
+fs.outputJson(file, data, 'utf-8').then(() => {
+    // stub
+});
+fs.outputJson(
+    file,
+    data,
+    {
+        spaces: 2,
+    },
+    errorCallback,
+);
+fs.outputJson(
+    file,
+    data,
+    {
+        encoding: 'utf-8',
+        spaces: 2,
+    },
+    errorCallback,
+);
+fs.outputJson(file, data, 'utf-8', errorCallback);
 fs.outputJSON(file, data, errorCallback);
 fs.outputJSON(file, data).then(() => {
     // stub
@@ -121,28 +165,46 @@ fs.outputJSON(file, data).then(() => {
 
 fs.outputJsonSync(file, data);
 fs.outputJSONSync(file, data);
+fs.outputJsonSync(file, data, 'utf-8');
+fs.outputJSONSync(file, data, 'utf-8');
+fs.outputJsonSync(file, data, { encoding: 'utf-8' });
+fs.outputJSONSync(file, data, { encoding: 'utf-8' });
 
 fs.readJson(file).then(() => {
+    // stub
+});
+fs.readJson(file, 'utf-8').then(() => {
     // stub
 });
 
 fs.readJson(file, readOptions).then(() => {
     // stub
 });
-fs.readJson(file, (error: Error, jsonObject: any) => { });
-fs.readJson(file, readOptions, (error: Error, jsonObject: any) => { });
-fs.readJSON(file, (error: Error, jsonObject: any) => { });
-fs.readJSON(file, readOptions, (error: Error, jsonObject: any) => { });
+fs.readJson(file, { encoding: 'utf-8' }).then(() => {
+    // stub
+});
+fs.readJson(file, (error: Error, jsonObject: any) => {});
+fs.readJson(file, readOptions, (error: Error, jsonObject: any) => {});
+fs.readJson(file, 'utf-8', (error: Error, jsonObject: any) => {});
+fs.readJson(file, { encoding: 'utf-8' }, (error: Error, jsonObject: any) => {});
+fs.readJSON(file, (error: Error, jsonObject: any) => {});
+fs.readJSON(file, readOptions, (error: Error, jsonObject: any) => {});
+fs.readJSON(file, 'utf-8', (error: Error, jsonObject: any) => {});
+fs.readJSON(file, { encoding: 'utf-8' }, (error: Error, jsonObject: any) => {});
 
 fs.readJsonSync(file, readOptions);
 fs.readJSONSync(file, readOptions);
+fs.readJsonSync(file, 'utf-8');
+fs.readJSONSync(file, 'utf-8');
+fs.readJsonSync(file, { encoding: 'utf-8' });
+fs.readJSONSync(file, { encoding: 'utf-8' });
 
 fs.remove(dir, errorCallback);
 fs.remove(dir).then(() => {
     // stub
 });
 // @ts-expect-error map can't be called as it passes a number for the second argument instead of a callback.
-["file/to/remove"].map(fs.remove);
+['file/to/remove'].map(fs.remove);
 
 // @ts-expect-error promise should not be returned when callback is provided.
 // tslint:disable-next-line:no-void-expression
@@ -159,16 +221,39 @@ fs.writeJSON(file, object).then(() => {
 });
 fs.writeJson(file, object, errorCallback);
 fs.writeJson(file, object, writeOptions, errorCallback);
+fs.writeJson(file, object, 'utf-8', errorCallback);
+fs.writeJson(file, object, { encoding: 'utf-8' }, errorCallback);
 fs.writeJSON(file, object, errorCallback);
 fs.writeJSON(file, object, writeOptions, errorCallback);
+fs.writeJSON(file, object, 'utf-8', errorCallback);
+fs.writeJSON(file, object, { encoding: 'utf-8' }, errorCallback);
 fs.writeJson(file, object, writeOptions).then(() => {
+    // stub
+});
+fs.writeJson(file, object, writeOptions).then(() => {
+    // stub
+});
+fs.writeJson(file, object, 'utf-8').then(() => {
+    // stub
+});
+fs.writeJson(file, object, { encoding: 'utf-8' }).then(() => {
     // stub
 });
 fs.writeJSON(file, object, writeOptions).then(() => {
     // stub
 });
+fs.writeJSON(file, object, 'utf-8').then(() => {
+    // stub
+});
+fs.writeJSON(file, object, { encoding: 'utf-8' }).then(() => {
+    // stub
+});
 fs.writeJsonSync(file, object, writeOptions);
+fs.writeJsonSync(file, object, 'utf-8');
+fs.writeJsonSync(file, object, { encoding: 'utf-8' });
 fs.writeJSONSync(file, object, writeOptions);
+fs.writeJSONSync(file, object, 'utf-8');
+fs.writeJSONSync(file, object, { encoding: 'utf-8' });
 
 fs.ensureDir(path).then(() => {
     // stub
@@ -201,10 +286,10 @@ fs.createLink(path, path).then(() => {
 fs.createLink(path, path, errorCallback);
 fs.ensureLinkSync(path, path);
 fs.createLinkSync(path, path);
-fs.ensureSymlink(path, path, "file").then(() => {
+fs.ensureSymlink(path, path, 'file').then(() => {
     // stub
 });
-fs.ensureSymlink(path, path, "junction").then(() => {
+fs.ensureSymlink(path, path, 'junction').then(() => {
     // stub
 });
 fs.ensureSymlink(path, path, errorCallback);
@@ -220,7 +305,7 @@ fs.emptydirSync(path);
 fs.pathExists(path).then((_exist: boolean) => {
     // stub
 });
-fs.pathExists(path, (_err: Error, _exists: boolean) => { });
+fs.pathExists(path, (_err: Error, _exists: boolean) => {});
 const x: boolean = fs.pathExistsSync(path);
 
 fs.rename(src, dest, errorCallback);
@@ -248,16 +333,16 @@ fs.lchmodSync(path, modeStr);
 fs.statSync(path);
 fs.lstatSync(path);
 
-fs.read(0, Buffer.from(""), 0, 0, null).then(x => {
+fs.read(0, Buffer.from(''), 0, 0, null).then(x => {
     const a = x.buffer;
     const b = x.bytesRead;
 });
 
-fs.write(0, Buffer.from(""), 0, 0, null).then(x => {
+fs.write(0, Buffer.from(''), 0, 0, null).then(x => {
     const a = x.buffer;
     const b = x.bytesWritten;
 });
-fs.write(0, Buffer.from("")).then(x => {
+fs.write(0, Buffer.from('')).then(x => {
     const a = x.buffer;
     const b = x.bytesWritten;
 });
@@ -268,27 +353,34 @@ const writevTest = async (buffs: NodeJS.ArrayBufferView[], position: number) => 
 };
 
 // $ExpectType Promise<void>
-fs.writeFile("foo.txt", "i am foo", { encoding: "utf-8" });
+fs.writeFile('foo.txt', 'i am foo', 'utf-8');
+// $ExpectType Promise<void>
+fs.writeFile('foo.txt', 'i am foo', { encoding: 'utf-8' });
 
 // $ExpectType Promise<string>
-fs.mkdtemp("foo");
+fs.mkdtemp('foo');
 
-fs.copyFile("src", "dest").then();
-fs.copyFile("src", "dest", fs.constants.COPYFILE_EXCL).then();
-fs.copyFile("src", "dest", errorCallback);
+fs.copyFile('src', 'dest').then();
+fs.copyFile('src', 'dest', fs.constants.COPYFILE_EXCL).then();
+fs.copyFile('src', 'dest', errorCallback);
 
-fs.createSymlink("src", "dest", "dir").then();
-fs.createSymlink("src", "dest", "file").then();
-fs.createSymlink("src", "dest", "junction", errorCallback);
+fs.createSymlink('src', 'dest', 'dir').then();
+fs.createSymlink('src', 'dest', 'file').then();
+fs.createSymlink('src', 'dest', 'junction', errorCallback);
 
 const openDirTest = async (path: string, opts: fs.OpenDirOptions) => {
     await fs.opendir(path); // $ExpectType Dir
     await fs.opendir(path, opts); // $ExpectType Dir
 };
 
-fs.readdir("src").then((files: string[]) => {});
-fs.readdir("src", "buffer").then((files: Buffer[]) => {});
-fs.readdir("src", {withFileTypes: true}).then((files: fs.Dirent[]) => {});
+fs.readdir('src').then((files: string[]) => {});
+fs.readdir('src', 'buffer').then((files: Buffer[]) => {});
+fs.readdir('src', { encoding: 'buffer' }).then((files: Buffer[]) => {});
+fs.readdir('src', { withFileTypes: true }).then((files: fs.Dirent[]) => {});
+fs.readdir('src', 'utf-8').then((files: string[]) => {});
+fs.readdir('src', { encoding: 'utf-8' }).then((files: string[]) => {});
+fs.readdir('src', 'foo').then((files: string[]) => {});
+fs.readdir('src', { encoding: 'foo' }).then((files: string[]) => {});
 
 // $ExpectType void
 fs.realpath('src', (err, resolved) => {
@@ -297,12 +389,18 @@ fs.realpath('src', (err, resolved) => {
 });
 // $ExpectType Promise<string>
 fs.realpath.native('src');
+// $ExpectType Promise<string>
+fs.realpath.native('src', 'utf-8');
 // $ExpectType Promise<Buffer>
 fs.realpath.native('src', 'buffer');
+// $ExpectType Promise<string>
+fs.realpath.native('src', 'foo');
 // $ExpectType Promise<string>
 fs.realpath.native('src', { encoding: 'utf-8' });
 // $ExpectType Promise<Buffer>
 fs.realpath.native('src', { encoding: 'buffer' });
+// $ExpectType Promise<string>
+fs.realpath.native('src', { encoding: 'foo' });
 // $ExpectType Promise<string>
 fs.realpath.native('src', { encoding: null });
 

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -14,11 +14,11 @@
 
 /// <reference types="node" />
 
-import * as fs from "fs";
+import * as fs from 'fs';
 import Stats = fs.Stats;
 import PathLike = fs.PathLike;
 
-export * from "fs";
+export * from 'fs';
 
 export function copy(src: string, dest: string, options?: CopyOptions): Promise<void>;
 export function copy(src: string, dest: string, callback: (err: Error) => void): void;
@@ -54,43 +54,80 @@ export function mkdirp(dir: string, callback: (err: Error) => void): void;
 export function mkdirsSync(dir: string): void;
 export function mkdirpSync(dir: string): void;
 
-export function outputFile(file: string, data: any, options?: WriteFileOptions | string): Promise<void>;
+export function outputFile(
+    file: string,
+    data: any,
+    options?: WriteFileOptions | BufferEncoding | string,
+): Promise<void>;
 export function outputFile(file: string, data: any, callback: (err: Error) => void): void;
-export function outputFile(file: string, data: any, options: WriteFileOptions | string, callback: (err: Error) => void): void;
-export function outputFileSync(file: string, data: any, options?: WriteFileOptions | string): void;
+export function outputFile(
+    file: string,
+    data: any,
+    options: WriteFileOptions | string,
+    callback: (err: Error) => void,
+): void;
+export function outputFileSync(file: string, data: any, options?: WriteFileOptions | BufferEncoding | string): void;
 
-export function readJson(file: string, options?: ReadOptions): Promise<any>;
+export function readJson(file: string, options?: ReadOptions | BufferEncoding | string): Promise<any>;
 export function readJson(file: string, callback: (err: Error, jsonObject: any) => void): void;
-export function readJson(file: string, options: ReadOptions, callback: (err: Error, jsonObject: any) => void): void;
-export function readJSON(file: string, options?: ReadOptions): Promise<any>;
+export function readJson(
+    file: string,
+    options: ReadOptions | BufferEncoding | string,
+    callback: (err: Error, jsonObject: any) => void,
+): void;
+export function readJSON(file: string, options?: ReadOptions | BufferEncoding | string): Promise<any>;
 export function readJSON(file: string, callback: (err: Error, jsonObject: any) => void): void;
-export function readJSON(file: string, options: ReadOptions, callback: (err: Error, jsonObject: any) => void): void;
+export function readJSON(
+    file: string,
+    options: ReadOptions | BufferEncoding | string,
+    callback: (err: Error, jsonObject: any) => void,
+): void;
 
-export function readJsonSync(file: string, options?: ReadOptions): any;
-export function readJSONSync(file: string, options?: ReadOptions): any;
+export function readJsonSync(file: string, options?: ReadOptions | BufferEncoding | string): any;
+export function readJSONSync(file: string, options?: ReadOptions | BufferEncoding | string): any;
 
 export function remove(dir: string, callback: (err: Error) => void): void;
 export function remove(dir: string, callback?: (err: Error) => void): Promise<void>;
 export function removeSync(dir: string): void;
 
-export function outputJSON(file: string, data: any, options?: WriteOptions): Promise<void>;
-export function outputJSON(file: string, data: any, options: WriteOptions, callback: (err: Error) => void): void;
+export function outputJSON(file: string, data: any, options?: WriteOptions | BufferEncoding | string): Promise<void>;
+export function outputJSON(
+    file: string,
+    data: any,
+    options: WriteOptions | BufferEncoding | string,
+    callback: (err: Error) => void,
+): void;
 export function outputJSON(file: string, data: any, callback: (err: Error) => void): void;
-export function outputJson(file: string, data: any, options?: WriteOptions): Promise<void>;
-export function outputJson(file: string, data: any, options: WriteOptions, callback: (err: Error) => void): void;
+export function outputJson(file: string, data: any, options?: WriteOptions | BufferEncoding | string): Promise<void>;
+export function outputJson(
+    file: string,
+    data: any,
+    options: WriteOptions | BufferEncoding | string,
+    callback: (err: Error) => void,
+): void;
 export function outputJson(file: string, data: any, callback: (err: Error) => void): void;
-export function outputJsonSync(file: string, data: any, options?: WriteOptions): void;
-export function outputJSONSync(file: string, data: any, options?: WriteOptions): void;
+export function outputJsonSync(file: string, data: any, options?: WriteOptions | BufferEncoding | string): void;
+export function outputJSONSync(file: string, data: any, options?: WriteOptions | BufferEncoding | string): void;
 
-export function writeJSON(file: string, object: any, options?: WriteOptions): Promise<void>;
+export function writeJSON(file: string, object: any, options?: WriteOptions | BufferEncoding | string): Promise<void>;
 export function writeJSON(file: string, object: any, callback: (err: Error) => void): void;
-export function writeJSON(file: string, object: any, options: WriteOptions, callback: (err: Error) => void): void;
-export function writeJson(file: string, object: any, options?: WriteOptions): Promise<void>;
+export function writeJSON(
+    file: string,
+    object: any,
+    options: WriteOptions | BufferEncoding | string,
+    callback: (err: Error) => void,
+): void;
+export function writeJson(file: string, object: any, options?: WriteOptions | BufferEncoding | string): Promise<void>;
 export function writeJson(file: string, object: any, callback: (err: Error) => void): void;
-export function writeJson(file: string, object: any, options: WriteOptions, callback: (err: Error) => void): void;
+export function writeJson(
+    file: string,
+    object: any,
+    options: WriteOptions | BufferEncoding | string,
+    callback: (err: Error) => void,
+): void;
 
-export function writeJsonSync(file: string, object: any, options?: WriteOptions): void;
-export function writeJSONSync(file: string, object: any, options?: WriteOptions): void;
+export function writeJsonSync(file: string, object: any, options?: WriteOptions | BufferEncoding | string): void;
+export function writeJSONSync(file: string, object: any, options?: WriteOptions | BufferEncoding | string): void;
 
 export function ensureFile(path: string): Promise<void>;
 export function ensureFile(path: string, callback: (err: Error) => void): void;
@@ -127,10 +164,29 @@ export function access(path: PathLike, callback: (err: NodeJS.ErrnoException) =>
 export function access(path: PathLike, mode: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function access(path: PathLike, mode?: number): Promise<void>;
 
-export function appendFile(file: PathLike | number, data: any, options: { encoding?: string | undefined; mode?: number | string | undefined; flag?: string | undefined; },
-    callback: (err: NodeJS.ErrnoException) => void): void;
+export function appendFile(
+    file: PathLike | number,
+    data: any,
+    options: {
+        encoding?: BufferEncoding | string | undefined;
+        mode?: number | string | undefined;
+        flag?: string | undefined;
+    },
+    callback: (err: NodeJS.ErrnoException) => void,
+): void;
 export function appendFile(file: PathLike | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
-export function appendFile(file: PathLike | number, data: any, options?: { encoding?: string | undefined; mode?: number | string | undefined; flag?: string | undefined; }): Promise<void>;
+export function appendFile(
+    file: PathLike | number,
+    data: any,
+    options?:
+        | {
+              encoding?: BufferEncoding | string | undefined;
+              mode?: number | string | undefined;
+              flag?: string | undefined;
+          }
+        | BufferEncoding
+        | string,
+): Promise<void>;
 
 export function chmod(path: PathLike, mode: Mode, callback: (err: NodeJS.ErrnoException) => void): void;
 export function chmod(path: PathLike, mode: Mode): Promise<void>;
@@ -185,12 +241,25 @@ export function mkdir(path: PathLike, callback: (err: NodeJS.ErrnoException) => 
  *
  * @param callback No arguments other than a possible exception are given to the completion callback.
  */
-export function mkdir(path: PathLike, options: Mode | fs.MakeDirectoryOptions | null, callback: (err: NodeJS.ErrnoException) => void): void;
+export function mkdir(
+    path: PathLike,
+    options: Mode | fs.MakeDirectoryOptions | null,
+    callback: (err: NodeJS.ErrnoException) => void,
+): void;
 export function mkdir(path: PathLike, options?: Mode | fs.MakeDirectoryOptions | null): Promise<void>;
 export function mkdirSync(path: PathLike, options?: Mode | fs.MakeDirectoryOptions | null): void;
 
-export function open(path: PathLike, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
-export function open(path: PathLike, flags: string | number, mode: Mode, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
+export function open(
+    path: PathLike,
+    flags: string | number,
+    callback: (err: NodeJS.ErrnoException, fd: number) => void,
+): void;
+export function open(
+    path: PathLike,
+    flags: string | number,
+    mode: Mode,
+    callback: (err: NodeJS.ErrnoException, fd: number) => void,
+): void;
 export function open(path: PathLike, flags: string | number, mode?: Mode | null): Promise<number>;
 
 export function opendir(path: string, cb: (err: NodeJS.ErrnoException | null, dir: fs.Dir) => void): void;
@@ -201,41 +270,85 @@ export function opendir(
 ): void;
 export function opendir(path: string, options?: fs.OpenDirOptions): Promise<fs.Dir>;
 
-export function read<TBuffer extends ArrayBufferView>(fd: number, buffer: TBuffer, offset: number, length: number, position: number | null,
-    callback: (err: NodeJS.ErrnoException, bytesRead: number, buffer: TBuffer) => void): void;
-export function read<TBuffer extends ArrayBufferView>(fd: number, buffer: TBuffer, offset: number, length: number, position: number | null): Promise<{ bytesRead: number, buffer: TBuffer }>;
+export function read<TBuffer extends ArrayBufferView>(
+    fd: number,
+    buffer: TBuffer,
+    offset: number,
+    length: number,
+    position: number | null,
+    callback: (err: NodeJS.ErrnoException, bytesRead: number, buffer: TBuffer) => void,
+): void;
+export function read<TBuffer extends ArrayBufferView>(
+    fd: number,
+    buffer: TBuffer,
+    offset: number,
+    length: number,
+    position: number | null,
+): Promise<{ bytesRead: number; buffer: TBuffer }>;
 
 export function readFile(file: PathLike | number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(file: PathLike | number, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
 export function readFile(
     file: PathLike | number,
-    options: { flag?: string | undefined; } | { encoding: string; flag?: string | undefined; },
-    callback: (err: NodeJS.ErrnoException, data: Buffer) => void
+    encoding: BufferEncoding | string,
+    callback: (err: NodeJS.ErrnoException, data: string) => void,
 ): void;
-export function readFile(file: PathLike | number, options: { flag?: string | undefined; } | { encoding: string; flag?: string | undefined; }): Promise<string>;
+export function readFile(
+    file: PathLike | number,
+    options: { flag?: string | undefined } | { encoding: BufferEncoding | string; flag?: string | undefined },
+    callback: (err: NodeJS.ErrnoException, data: Buffer) => void,
+): void;
+export function readFile(
+    file: PathLike | number,
+    options: { flag?: string | undefined } | { encoding: BufferEncoding | string; flag?: string | undefined },
+): Promise<string>;
 // tslint:disable-next-line:unified-signatures
-export function readFile(file: PathLike | number, encoding: string): Promise<string>;
+export function readFile(file: PathLike | number, encoding: BufferEncoding | string): Promise<string>;
 export function readFile(file: PathLike | number): Promise<Buffer>;
 
 export function readdir(path: PathLike, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
-export function readdir(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false | undefined } | BufferEncoding | null): Promise<string[]>;
-export function readdir(path: PathLike, options: "buffer" | { encoding: "buffer"; withFileTypes?: false | undefined }): Promise<Buffer[]>;
-export function readdir(path: PathLike, options?: { encoding?: string | null | undefined; withFileTypes?: false | undefined }): Promise<string[] | Buffer[]>;
-export function readdir(path: PathLike, options: { encoding?: string | null | undefined; withFileTypes: true }): Promise<fs.Dirent[]>;
+export function readdir(
+    path: PathLike,
+    options: 'buffer' | { encoding: 'buffer'; withFileTypes?: false | undefined },
+): Promise<Buffer[]>;
+export function readdir(
+    path: PathLike,
+    options?:
+        | { encoding: BufferEncoding | string | null; withFileTypes?: false | undefined }
+        | BufferEncoding
+        | string
+        | null,
+): Promise<string[]>;
+export function readdir(
+    path: PathLike,
+    options?: { encoding?: BufferEncoding | string | null | undefined; withFileTypes?: false | undefined },
+): Promise<string[] | Buffer[]>;
+export function readdir(
+    path: PathLike,
+    options: { encoding?: BufferEncoding | string | null | undefined; withFileTypes: true },
+): Promise<fs.Dirent[]>;
 
 export function readlink(path: PathLike, callback: (err: NodeJS.ErrnoException, linkString: string) => any): void;
 export function readlink(path: PathLike): Promise<string>;
 
 export function realpath(path: PathLike, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
-export function realpath(path: PathLike, cache: { [path: string]: string }, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => any): void;
+export function realpath(
+    path: PathLike,
+    cache: { [path: string]: string },
+    callback: (err: NodeJS.ErrnoException, resolvedPath: string) => any,
+): void;
 export function realpath(path: PathLike, cache?: { [path: string]: string }): Promise<string>;
 
 /* tslint:disable:unified-signatures */
 export namespace realpath {
     const native: {
-        (path: PathLike, options: { encoding: BufferEncoding | null } | BufferEncoding | undefined | null): Promise<string>;
-        (path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
-        (path: PathLike, options: { encoding: BufferEncoding | null } | string | undefined | null): Promise<string | Buffer>;
+        (path: PathLike, options: { encoding: 'buffer' } | 'buffer'): Promise<Buffer>;
+        (
+            path: PathLike,
+            options: { encoding: BufferEncoding | string | null } | BufferEncoding | string | undefined | null,
+        ): Promise<string>;
+        (path: PathLike, options: { encoding: BufferEncoding | string | null } | string | undefined | null): Promise<
+            string | Buffer
+        >;
         (path: PathLike): Promise<string>;
     } & typeof fs.realpath.native;
 }
@@ -250,7 +363,15 @@ export function rename(oldPath: PathLike, newPath: PathLike): Promise<void>;
  *
  * Only available in node >= v14.14.0
  */
-export function rm(path: PathLike, options?: { force?: boolean | undefined, maxRetries?: number | undefined, recursive?: boolean | undefined, retryDelay?: number | undefined }): Promise<void>;
+export function rm(
+    path: PathLike,
+    options?: {
+        force?: boolean | undefined;
+        maxRetries?: number | undefined;
+        recursive?: boolean | undefined;
+        retryDelay?: number | undefined;
+    },
+): Promise<void>;
 
 /**
  * Asynchronous rmdir - removes the directory specified in {path}
@@ -263,7 +384,12 @@ export function rmdir(path: PathLike, options?: fs.RmDirOptions): Promise<void>;
 export function stat(path: PathLike, callback: (err: NodeJS.ErrnoException, stats: Stats) => any): void;
 export function stat(path: PathLike): Promise<Stats>;
 
-export function symlink(target: PathLike, path: PathLike, type: SymlinkType | undefined, callback: (err: NodeJS.ErrnoException) => void): void;
+export function symlink(
+    target: PathLike,
+    path: PathLike,
+    type: SymlinkType | undefined,
+    callback: (err: NodeJS.ErrnoException) => void,
+): void;
 export function symlink(target: PathLike, path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 export function symlink(target: PathLike, path: PathLike, type?: SymlinkType): Promise<void>;
 
@@ -279,31 +405,87 @@ export function truncate(path: PathLike, len?: number): Promise<void>;
 export function unlink(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 export function unlink(path: PathLike): Promise<void>;
 
-export function utimes(path: PathLike, atime: number, mtime: number, callback: (err: NodeJS.ErrnoException) => void): void;
+export function utimes(
+    path: PathLike,
+    atime: number,
+    mtime: number,
+    callback: (err: NodeJS.ErrnoException) => void,
+): void;
 export function utimes(path: PathLike, atime: Date, mtime: Date, callback: (err: NodeJS.ErrnoException) => void): void;
 export function utimes(path: PathLike, atime: number, mtime: number): Promise<void>;
 export function utimes(path: PathLike, atime: Date, mtime: Date): Promise<void>;
 
 export function write<TBuffer extends ArrayBufferView>(
-    fd: number, buffer: TBuffer, offset: number, length: number, position: number | null,
-    callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void
+    fd: number,
+    buffer: TBuffer,
+    offset: number,
+    length: number,
+    position: number | null,
+    callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void,
 ): void;
 export function write<TBuffer extends ArrayBufferView>(
-    fd: number, buffer: TBuffer, offset: number, length: number,
-    callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void
+    fd: number,
+    buffer: TBuffer,
+    offset: number,
+    length: number,
+    callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void,
 ): void;
-export function write(fd: number, data: any, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
-export function write(fd: number, data: any, offset: number, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
-export function write(fd: number, data: any, offset: number, encoding: string, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
-export function write<TBuffer extends ArrayBufferView>(fd: number, buffer: TBuffer, offset?: number, length?: number, position?: number | null): Promise<{ bytesWritten: number, buffer: TBuffer }>;
-export function write(fd: number, data: any, offset?: number, encoding?: string): Promise<{ bytesWritten: number, buffer: string }>;
+export function write(
+    fd: number,
+    data: any,
+    callback: (err: NodeJS.ErrnoException, written: number, str: string) => void,
+): void;
+export function write(
+    fd: number,
+    data: any,
+    offset: number,
+    callback: (err: NodeJS.ErrnoException, written: number, str: string) => void,
+): void;
+export function write(
+    fd: number,
+    data: any,
+    offset: number,
+    encoding: BufferEncoding | string,
+    callback: (err: NodeJS.ErrnoException, written: number, str: string) => void,
+): void;
+export function write<TBuffer extends ArrayBufferView>(
+    fd: number,
+    buffer: TBuffer,
+    offset?: number,
+    length?: number,
+    position?: number | null,
+): Promise<{ bytesWritten: number; buffer: TBuffer }>;
+export function write(
+    fd: number,
+    data: any,
+    offset?: number,
+    encoding?: BufferEncoding | string,
+): Promise<{ bytesWritten: number; buffer: string }>;
 
 export function writeFile(file: PathLike | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
-export function writeFile(file: PathLike | number, data: any, options?: WriteFileOptions | string): Promise<void>;
-export function writeFile(file: PathLike | number, data: any, options: WriteFileOptions | string, callback: (err: NodeJS.ErrnoException) => void): void;
+export function writeFile(
+    file: PathLike | number,
+    data: any,
+    options?: WriteFileOptions | BufferEncoding | string,
+): Promise<void>;
+export function writeFile(
+    file: PathLike | number,
+    data: any,
+    options: WriteFileOptions | BufferEncoding | string,
+    callback: (err: NodeJS.ErrnoException) => void,
+): void;
 
-export function writev(fd: number, buffers: NodeJS.ArrayBufferView[], position: number, cb: (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => void): void;
-export function writev(fd: number, buffers: NodeJS.ArrayBufferView[], cb: (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => void): void;
+export function writev(
+    fd: number,
+    buffers: NodeJS.ArrayBufferView[],
+    position: number,
+    cb: (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => void,
+): void;
+export function writev(
+    fd: number,
+    buffers: NodeJS.ArrayBufferView[],
+    cb: (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => void,
+): void;
 export function writev(fd: number, buffers: NodeJS.ArrayBufferView[], position?: number): Promise<WritevResult>;
 
 /**
@@ -326,7 +508,7 @@ export interface PathEntryStream {
 export type CopyFilterSync = (src: string, dest: string) => boolean;
 export type CopyFilterAsync = (src: string, dest: string) => Promise<boolean>;
 
-export type SymlinkType = "dir" | "file" | "junction";
+export type SymlinkType = 'dir' | 'file' | 'junction';
 
 export type Mode = string | number;
 
@@ -358,12 +540,12 @@ export interface ReadOptions {
     throws?: boolean | undefined;
     fs?: object | undefined;
     reviver?: any;
-    encoding?: string | undefined;
+    encoding?: BufferEncoding | string | undefined;
     flag?: string | undefined;
 }
 
 export interface WriteFileOptions {
-    encoding?: string | null | undefined;
+    encoding?: BufferEncoding | string | null | undefined;
     flag?: string | undefined;
     mode?: number | undefined;
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/jprichardson/node-fs-extra/blob/master/docs/readJson.md
  - https://github.com/jprichardson/node-fs-extra/blob/master/docs/readJson-sync.md
  - (and basically all the others)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

Note: I ran `npm run prettier -- --write types/fs-extra/**/*.ts` on the modified files, which caused a lot of style changes to happen. lmk if there's something I can do to help with reviews