### PR TITLE
Relay-runtime: Support union discrimination in getLinkedRecord

### DIFF
--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -329,7 +329,8 @@ export interface RecordProxy<T = {}> {
     // If a parent type is provided, provide the child type
     getLinkedRecord<K extends keyof T>(name: K, args?: Variables | null): RecordProxy<NonNullable<T[K]>>;
     // If a __typename is provided, pick that union member
-    getLinkedRecord<H extends string, K extends keyof T = keyof T>(name: K, args?: Variables | null): RecordProxy<Extract<NonNullable<T[K]>, {__typename: H}>>
+    // tslint:disable-next-line:no-unnecessary-generics
+    getLinkedRecord<H extends string, K extends keyof T = keyof T>(name: K, args?: Variables | null): RecordProxy<Extract<NonNullable<T[K]>, {__typename: H}>>;
     // If a hint is provided, the return value is guaranteed to be the hint type
     getLinkedRecord<H = never>(
         name: string,

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -328,6 +328,8 @@ export interface RecordProxy<T = {}> {
     getDataID(): DataID;
     // If a parent type is provided, provide the child type
     getLinkedRecord<K extends keyof T>(name: K, args?: Variables | null): RecordProxy<NonNullable<T[K]>>;
+    // If a __typename is provided, pick that union member
+    getLinkedRecord<H extends string, K extends keyof T = keyof T>(name: K, args?: Variables | null): RecordProxy<Extract<NonNullable<T[K]>, {__typename: H}>>
     // If a hint is provided, the return value is guaranteed to be the hint type
     getLinkedRecord<H = never>(
         name: string,


### PR DESCRIPTION
This adds an additional overload to the `getLinkedRecord` generic.
Before, if the type wasn't strict enough, you had to add an entire object as a hint.
This isn't easy to do if you want a discriminated member from a union (ie pick 1 part of a GraphQLInterface)

```ts
// OLD WAY
type Unproxy<T> = T extends RecordProxy<infer U> ? U : T
const _name = fruit.getLinkedRecord('name')
const name = _name as RecordProxy<Extract<Unproxy<typeof _name>, {__typename: 'Apple'}>>

// NEW WAY
const name = fruit.getLinkedRecord<'Apple'>('name')
```

[See it live in the TS Playground](https://www.typescriptlang.org/play?ssl=15&ssc=1&pln=16&pc=1#code/KYDwDg9gTgLgBASwHY2FAZgQwMbDgNUygUwCMAbYAZzgG8AoOJuAbSUwFtgAuOKmYkgDmAXV6YkATwDc9AL716yVBhx4A8uQAmAJWDZoWgApQIISQB4AKnAC8dOQD46jZkOAwAMsgDWwXfqGFgDScKCoSFo0fpIQ6HBWjgAU7Fy8wQA0cERCVAD8vITEZJQ0AD5wSACu5OQAlLyaAQZQxqbmFgByEEidNeQlwNYswSKOjq5M7l6+-notWhYAEnaVwABuaMmTzEypPHwCyEIZO7s5+YVEJBTUcBXVtae7DaxLImEgEVGsSBtoHzycCa80MJjMknulX6cEa2lBrXBHSWEwUShQaCwuDgCLaEOsq1oThcu2m3iQfmaQVC4WAkWiwFi8USKU4B0y2SguQKBGug3K0Nqr1xSMs3V6-UGw1G4x2ZNmVNay0+3xo-EEJzgNK+dJ+MTiCVW+uZyX26SyFx5RRupShj3qvBF7UsAFEvlAcDAuj0+rUpVYRmMsrQAPohmCSMB0tm8JZOCakjzkym45X2P6bKDbXa7M2HDXPHNMS1XYq3AX2wtMV4sd4q3U0Nj-KCAnGBRHOu0wx3tvHI1GKCNRuAAMSgVQQ8HsDF2UGAmC0PXIkLzSR2M6LcDnC6XkLDQ+jaTgACIAIJgMCUY9nZjbxdIZdhKi8Y8AWQkAC8JJhr7s5FD1xvJg713OB90jQ8DmPAAhb92F-TcQIfSE6RfWD2HgnZ-zKQDNy3ed70fcCozzY8AFIIBgAALNAEKYBQXjgeRFBY+gAHo2ISJYXWBTwABE4AAdVPABNegDzgABVJAwGdaxnHsGxaXpYF4V7UULGQdA0Ck5wgUk2EEnoSh4AgbQxwnKdBXIbIaAkSFMBoEF1LkizJwmAwkH4MCzK0PiECobBiA4ZBMFQLROjZVZfLcmAADp5QpOZeySAByfZUrqehPO83z-MC4LQvCyKuFWEM8oCoKEBC9hiqixzVMVPtXXdT0LGk2T8QPA1yu0fKqpqsL-BK4BHGDYjIN4VLz0vYBUvjRQOK4njOhdQShNE4yPDgdBx0nVZ7Vs7IpCOp18Vijyem8rRKsK2rhqi+xdsshKkwVVNpovShUuSdK2UyxbOJ0F0AHFgYAZXBgBJdROgSF1wascHsqu+AtLQOcIsena9vixKUxSv6uABnL4Co5QHtKp7cdemYkqaixaDzWhdpfIwIA4LhjzkJw0oyrKtvgUwYAiWKDphBr7NOlyIRRryhcoiIoe0qBMZG1ZhdFmn8eShY+f+rLSa3RW6SWCmsap42RbpWLaeTXWgiZmM6FZk92c54Bud5om5sN1GrYifq7qGi28HsTWbe1t76Y+mbvt+-nWKAA)
