### PR TITLE
[numeral] Add `numeral.formats` type definition

### DIFF
--- a/types/numeral/index.d.ts
+++ b/types/numeral/index.d.ts
@@ -24,6 +24,17 @@ declare namespace numeral {
      * Object with all loaded locales
      */
     const locales: NumeralJSLocales;
+
+    /**
+     * Object with all loaded formats
+     */
+    const formats: NumeralJSFormats;
+
+    /**
+     * Object with utility functions
+     */
+    const _: NumeralJSUtils;
+
     /**
      * This function sets the current locale.  If no arguments are passed in,
      * it will simply return the current global locale key.
@@ -57,8 +68,8 @@ declare namespace numeral {
     function register(
         what: RegisterType,
         key: string,
-        value: NumeralJSLocale | NumeralJsFormat,
-    ): NumeralJSLocale | NumeralJsFormat;
+        value: NumeralJSLocale | NumeralJSFormat,
+    ): NumeralJSLocale | NumeralJSFormat;
 
     function validate(value: any, culture: any): boolean;
 
@@ -113,13 +124,22 @@ declare namespace numeral {
     type RoundingFunction = (value: number) => number;
 
     // http://numeraljs.com/#custom-formats
-    interface NumeralJsFormat {
+    interface NumeralJSFormat {
         regexps: {
             format: RegExp;
             unformat: RegExp;
         };
         format: (value: any, format: string, roundingFunction: RoundingFunction) => string;
         unformat: (value: string) => number;
+    }
+
+    interface NumeralJSFormats {
+        [id: string]: NumeralJSFormat;
+    }
+
+    interface NumeralJSUtils {
+        numberToFormat: (value: number, format: string, roundingFunction?: RoundingFunction) => string;
+        stringToNumber: (string: string) => number;
     }
 
     type RegisterType = 'format' | 'locale';

--- a/types/numeral/test/numeral-tests-cjs.ts
+++ b/types/numeral/test/numeral-tests-cjs.ts
@@ -110,3 +110,12 @@ numeral.isNumeral(1000);
 
 numeral(null).value(); // $ExpectType number | null
 numeral(null).value() || 0; // $ExpectType number
+
+// dict of configurations
+numeral.formats.currency;
+numeral.locales.fr;
+
+// Numeral utilities
+numeral._.numberToFormat(1000, '0,0');
+numeral._.numberToFormat(1000, '0,0', (value: number) => value / 3);
+numeral._.stringToNumber('1.32k');

--- a/types/numeral/test/numeral-tests-global.ts
+++ b/types/numeral/test/numeral-tests-global.ts
@@ -107,3 +107,12 @@ numeral.isNumeral(1000);
 
 numeral(null).value(); // $ExpectType number | null
 numeral(null).value() || 0; // $ExpectType number
+
+// dict of configurations
+numeral.formats.currency;
+numeral.locales.fr;
+
+// Numeral utilities
+numeral._.numberToFormat(1000, '0,0');
+numeral._.numberToFormat(1000, '0,0', (value: number) => value / 3);
+numeral._.stringToNumber('1.32k');


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/adamwdraper/Numeral-js/blob/master/src/numeral.js#L413
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (same version, not new)