### PR TITLE
fix(node): throwIfNoEntry only on statSync/lstatSync

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -904,42 +904,42 @@ declare module 'fs' {
         ): Promise<BigIntStats>;
         function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
     }
-    export interface StatSyncFn<TDescriptor = PathLike> extends Function {
-        (path: TDescriptor, options?: undefined): Stats;
+    export interface StatSyncFn extends Function {
+        (path: PathLike, options?: undefined): Stats;
         (
-            path: TDescriptor,
-            options?: StatOptions & {
+            path: PathLike,
+            options?: StatSyncOptions & {
                 bigint?: false | undefined;
                 throwIfNoEntry: false;
             }
         ): Stats | undefined;
         (
-            path: TDescriptor,
-            options: StatOptions & {
+            path: PathLike,
+            options: StatSyncOptions & {
                 bigint: true;
                 throwIfNoEntry: false;
             }
         ): BigIntStats | undefined;
         (
-            path: TDescriptor,
-            options?: StatOptions & {
+            path: PathLike,
+            options?: StatSyncOptions & {
                 bigint?: false | undefined;
             }
         ): Stats;
         (
-            path: TDescriptor,
-            options: StatOptions & {
+            path: PathLike,
+            options: StatSyncOptions & {
                 bigint: true;
             }
         ): BigIntStats;
         (
-            path: TDescriptor,
-            options: StatOptions & {
+            path: PathLike,
+            options: StatSyncOptions & {
                 bigint: boolean;
                 throwIfNoEntry?: false | undefined;
             }
         ): Stats | BigIntStats;
-        (path: TDescriptor, options?: StatOptions): Stats | BigIntStats | undefined;
+        (path: PathLike, options?: StatSyncOptions): Stats | BigIntStats | undefined;
     }
     /**
      * Synchronous stat(2) - Get file status.
@@ -993,7 +993,20 @@ declare module 'fs' {
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    export const fstatSync: StatSyncFn<number>;
+    export function fstatSync(
+        fd: number,
+        options?: StatOptions & {
+            bigint?: false | undefined;
+        }
+    ): Stats;
+    export function fstatSync(
+        fd: number,
+        options: StatOptions & {
+            bigint: true;
+        }
+    ): BigIntStats;
+    export function fstatSync(fd: number, options?: StatOptions): Stats | BigIntStats;
+
     /**
      * Retrieves the `fs.Stats` for the symbolic link referred to by the path.
      * The callback gets two arguments `(err, stats)` where `stats` is a `fs.Stats` object. `lstat()` is identical to `stat()`, except that if `path` is a symbolic
@@ -3654,6 +3667,8 @@ declare module 'fs' {
     }
     export interface StatOptions {
         bigint?: boolean | undefined;
+    }
+    export interface StatSyncOptions extends StatOptions {
         throwIfNoEntry?: boolean | undefined;
     }
     export interface CopyOptions {

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -516,7 +516,6 @@ async function testStat(
 
     fs.statSync(path, { throwIfNoEntry: false }); // $ExpectType Stats | undefined
     fs.lstatSync(path, { throwIfNoEntry: false }); // $ExpectType Stats | undefined
-    fs.fstatSync(fd, { throwIfNoEntry: false }); // $ExpectType Stats | undefined
 
     fs.statSync(path, {}); // $ExpectType Stats
     fs.lstatSync(path, {}); // $ExpectType Stats
@@ -532,15 +531,14 @@ async function testStat(
 
     fs.statSync(path, { bigint: true, throwIfNoEntry: false }); // $ExpectType BigIntStats | undefined
     fs.lstatSync(path, { bigint: true, throwIfNoEntry: false }); // $ExpectType BigIntStats | undefined
-    fs.fstatSync(fd, { bigint: true, throwIfNoEntry: false }); // $ExpectType BigIntStats | undefined
 
     fs.statSync(path, bigIntMaybeTrue); // $ExpectType Stats | BigIntStats | undefined
     fs.lstatSync(path, bigIntMaybeTrue); // $ExpectType Stats | BigIntStats | undefined
-    fs.fstatSync(fd, bigIntMaybeTrue); // $ExpectType Stats | BigIntStats | undefined
+    fs.fstatSync(fd, bigIntMaybeTrue); // $ExpectType Stats | BigIntStats
 
     fs.statSync(path, opts); // $ExpectType Stats | BigIntStats | undefined
     fs.lstatSync(path, opts); // $ExpectType Stats | BigIntStats | undefined
-    fs.fstatSync(fd, opts); // $ExpectType Stats | BigIntStats | undefined
+    fs.fstatSync(fd, opts); // $ExpectType Stats | BigIntStats
 
     // Promisify mode
     util.promisify(fs.stat)(path); // $ExpectType Promise<Stats>


### PR DESCRIPTION
- https://nodejs.org/dist/latest-v16.x/docs/api/fs.html says only `statSync` and `lstatSync` accept `throwIfNoEntry`
- when this field was added to `StatOptions`, this also affected `promises.stat` and other functions that don't actually accept it.
- made `StatSyncFn` not generic, as `fstatSync` shouldn't use it, so users always use `PathLike`.
- added `StatSyncOptions`. used only within `StatSyncFn`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v16.x/docs/api/fs.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
