### PR TITLE
brainhubeu__react-carousel : Modify breakpoints definition to match Carousel API definition

### DIFF
--- a/types/brainhubeu__react-carousel/brainhubeu__react-carousel-tests.tsx
+++ b/types/brainhubeu__react-carousel/brainhubeu__react-carousel-tests.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from 'react';
 import Carousel, {
     Dots,
     slidesToShowPlugin,
@@ -10,7 +10,7 @@ import Carousel, {
     slidesToScrollPlugin,
     arrowsPlugin,
     fastSwipePlugin,
-} from "@brainhubeu/react-carousel";
+} from '@brainhubeu/react-carousel';
 
 interface MyCarouselProps {
     value: number;
@@ -24,41 +24,38 @@ interface MyCarouselState {
 class MyCarousel extends React.Component<MyCarouselProps, MyCarouselState> {
     state = {
         value: 0,
-        slides: [
-            <img key={1} alt="img-2"/>,
-            <img key={2} alt="img-2"/>,
-            <img key={3} alt="img-3"/>,
-        ],
+        slides: [<img key={1} alt="img-2" />, <img key={2} alt="img-2" />, <img key={3} alt="img-3" />],
     };
 
     handleChange = (value: number) => {
-        this.setState({value});
+        this.setState({ value });
     }
 
     render() {
-        const {value, slides} = this.state;
+        const { value, slides } = this.state;
 
         return (
             <>
                 <Carousel
-                    plugins={['infinite',
+                    plugins={[
+                        'infinite',
                         {
                             resolve: slidesToShowPlugin,
                             options: {
                                 numberOfSlides: 3,
-                            }
+                            },
                         },
                         {
                             resolve: slidesToScrollPlugin,
                             options: {
                                 numberOfSlides: 3,
-                            }
+                            },
                         },
                         {
                             resolve: infinitePlugin,
                             options: {
                                 numberOfInfiniteClones: 1,
-                            }
+                            },
                         },
                         {
                             resolve: clickToChangePlugin,
@@ -67,8 +64,8 @@ class MyCarousel extends React.Component<MyCarouselProps, MyCarouselState> {
                             resolve: autoplayPlugin,
                             options: {
                                 interval: 2000,
-                                direction: 'left'
-                            }
+                                direction: 'left',
+                            },
                         },
                         {
                             resolve: rtlPlugin,
@@ -84,11 +81,11 @@ class MyCarousel extends React.Component<MyCarouselProps, MyCarouselState> {
                                 arrowRight: <button>{'>>'}</button>,
                                 arrowRightDisabled: <button>{'>'}</button>,
                                 addArrowClickHandler: true,
-                            }
+                            },
                         },
                         {
                             resolve: fastSwipePlugin,
-                        }
+                        },
                     ]}
                     animationSpeed={2000}
                     draggable
@@ -97,10 +94,29 @@ class MyCarousel extends React.Component<MyCarouselProps, MyCarouselState> {
                     offset={50}
                     slides={slides}
                     value={value}
+                    breakpoints={{
+                        900: {
+                            animationSpeed: 2000,
+                            draggable: true,
+                            itemWidth: 100,
+                            onChange: this.handleChange,
+                            offset: 50,
+                            slides,
+                            value,
+                            plugins: [
+                                {
+                                    resolve: slidesToShowPlugin,
+                                    options: {
+                                        numberOfSlides: 2,
+                                    },
+                                },
+                            ],
+                        },
+                    }}
                 >
-                    <img alt="image-1"/>
-                    <img alt="image-2"/>
-                    <img alt="image-3"/>
+                    <img alt="image-1" />
+                    <img alt="image-2" />
+                    <img alt="image-3" />
                 </Carousel>
                 <Dots
                     number={slides.length}

--- a/types/brainhubeu__react-carousel/index.d.ts
+++ b/types/brainhubeu__react-carousel/index.d.ts
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
+import * as React from 'react';
 export type ImgProps = React.ReactComponentElement<'img'>;
 
 export interface DotsProps {
@@ -18,12 +18,19 @@ export interface DotsProps {
     className?: string | undefined;
 }
 
-export class Dots extends React.Component<DotsProps> {
-}
+export class Dots extends React.Component<DotsProps> {}
 
 export type PluginStrategy = (originalValue: number, previousValue: number) => number;
 
-export type CarouselPluginFunc = ({ options, carouselProps, refs }: { options?: any, carouselProps: CarouselProps, refs: Record<string, React.RefObject<HTMLElement>>}) => {
+export type CarouselPluginFunc = ({
+    options,
+    carouselProps,
+    refs,
+}: {
+    options?: any;
+    carouselProps: CarouselProps;
+    refs: Record<string, React.RefObject<HTMLElement>>;
+}) => {
     plugin?: (() => void) | undefined;
     beforeCarouselItems?: (() => JSX.Element) | undefined;
     afterCarouselItems?: (() => JSX.Element) | undefined;
@@ -40,6 +47,10 @@ export interface CarouselPluginTypes {
     options?: any;
 }
 
+export interface CarouselBreakpoints {
+    [breakpointNumber: number]: Pick<CarouselProps, Exclude<keyof CarouselProps, 'breakpoints'>>;
+}
+
 export interface CarouselProps {
     itemWidth?: number | undefined;
     value?: number | undefined;
@@ -49,12 +60,11 @@ export interface CarouselProps {
     draggable?: boolean | undefined;
     animationSpeed?: number | undefined;
     className?: string | undefined;
-    breakpoints?: Pick<CarouselProps, Exclude<keyof CarouselProps, "breakpoints" | "plugins">> | undefined;
-    plugins?: Array<string|CarouselPluginTypes> | undefined;
+    breakpoints?: CarouselBreakpoints | undefined;
+    plugins?: Array<string | CarouselPluginTypes> | undefined;
 }
 
-export default class extends React.Component<CarouselProps> {
-}
+export default class extends React.Component<CarouselProps> {}
 
 export const slidesToShowPlugin: CarouselPluginFunc;
 export const infinitePlugin: CarouselPluginFunc;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [https://brainhubeu.github.io/react-carousel/docs/examples/responsive](https://brainhubeu.github.io/react-carousel/docs/examples/responsive)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. => This not bring a new definition