### PR TITLE
fix(openseadragon): correct type of addControl

### DIFF
--- a/types/openseadragon/index.d.ts
+++ b/types/openseadragon/index.d.ts
@@ -463,7 +463,7 @@ declare namespace OpenSeadragon {
     class ControlDock {
         constructor(options: object);
 
-        addControl(element: Control, controlOptions: TControlOptions): void;
+        addControl(element: string | Element, controlOptions: TControlOptions): void;
         areControlsEnabled(): boolean;
         clearControls(): ControlDock;
         removeControl(element: Control): ControlDock;

--- a/types/openseadragon/openseadragon-tests.ts
+++ b/types/openseadragon/openseadragon-tests.ts
@@ -1,4 +1,4 @@
-import OpenSeadragon, { Viewport, Drawer, MouseTracker, IIIFTileSource } from 'openseadragon';
+import OpenSeadragon, { Viewport, Drawer, MouseTracker, IIIFTileSource, Button, ControlAnchor } from 'openseadragon';
 
 const viewer = OpenSeadragon({ id: 'viewerid' });
 
@@ -13,6 +13,12 @@ viewer.addHandler('full-screen', event => {
 viewer.addSimpleImage({ url: '2003rosen1799/0001q.jpg' });
 
 viewer.addTiledImage({ tileSource: '2003rosen1799/0001q.jpg' });
+
+const button = new Button({});
+
+viewer.addControl(button.element, {
+    anchor: ControlAnchor.TOP_LEFT,
+});
 
 const viewport = new Viewport({ margins: {} });
 


### PR DESCRIPTION
The `addControl` method of OpenSeadragon's `ControlDock` does not get a `Control` as its first argument, it gets a type that should be defined as `Element | string`.

See in the source code the function call [here](https://github.com/openseadragon/openseadragon/blob/master/src/controldock.js#L97). 

The type `Element | string` is the right type of the argument to the call to `getElement`, see [line 98](https://github.com/openseadragon/openseadragon/blob/master/src/controldock.js#L98). Then the function converts that element to a `Control` in line 144 [here](https://github.com/openseadragon/openseadragon/blob/master/src/controldock.js#L144).

If we see invokations of that function, for example in `viewer.js`, we see that `pagingControl` [here](https://github.com/openseadragon/openseadragon/blob/master/src/viewer.js#L1708) is an element, and is then passed to the function as the first argument in line 1711 [here](https://github.com/openseadragon/openseadragon/blob/master/src/viewer.js#L1711).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/openseadragon/openseadragon/blob/master/src/controldock.js#L97
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
