### PR TITLE
[prettier] Update types to support version 2.4

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -153,9 +153,13 @@ export interface RequiredOptions extends doc.printer.Options {
      */
     arrowParens: 'avoid' | 'always';
     /**
-     * The plugin API is in a beta state.
+     * Provide ability to support new languages to prettier.
      */
     plugins: Array<string | Plugin>;
+    /**
+     * Specify plugin directory paths to search for plugins if not installed in the same `node_modules` where prettier is located.
+     */
+    pluginSearchDirs: string[];
     /**
      * How to handle whitespaces in HTML.
      * @default 'css'

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -98,7 +98,7 @@ export interface RequiredOptions extends doc.printer.Options {
      */
     bracketSpacing: boolean;
     /**
-     * Put the > of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line instead of being
+     * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line instead of being
      * alone on the next line (does not apply to self closing elements).
      * @default false
      */

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prettier 2.3
+// Type definitions for prettier 2.4
 // Project: https://github.com/prettier/prettier, https://prettier.io
 // Definitions by: Ika <https://github.com/ikatyang>,
 //                 Ifiok Jr. <https://github.com/ifiokjr>,
@@ -98,8 +98,15 @@ export interface RequiredOptions extends doc.printer.Options {
      */
     bracketSpacing: boolean;
     /**
+     * Put the > of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line instead of being
+     * alone on the next line (does not apply to self closing elements).
+     * @default false
+     */
+    bracketSameLine: boolean;
+    /**
      * Put the `>` of a multi-line JSX element at the end of the last line instead of being alone on the next line.
      * @default false
+     * @deprecated use bracketSameLine instead
      */
     jsxBracketSameLine: boolean;
     /**
@@ -201,12 +208,14 @@ export interface Parser<T = any> {
 
 export interface Printer<T = any> {
     print(path: AstPath<T>, options: ParserOptions<T>, print: (path: AstPath<T>) => Doc): Doc;
-    embed?: ((
-        path: AstPath<T>,
-        print: (path: AstPath<T>) => Doc,
-        textToDoc: (text: string, options: Options) => Doc,
-        options: ParserOptions<T>,
-    ) => Doc | null) | undefined;
+    embed?:
+        | ((
+              path: AstPath<T>,
+              print: (path: AstPath<T>) => Doc,
+              textToDoc: (text: string, options: Options) => Doc,
+              options: ParserOptions<T>,
+          ) => Doc | null)
+        | undefined;
     insertPragma?: ((text: string) => string) | undefined;
     /**
      * @returns `null` if you want to remove this node
@@ -218,29 +227,37 @@ export interface Printer<T = any> {
     canAttachComment?: ((node: T) => boolean) | undefined;
     willPrintOwnComments?: ((path: AstPath<T>) => boolean) | undefined;
     printComment?: ((commentPath: AstPath<T>, options: ParserOptions<T>) => Doc) | undefined;
-    handleComments?: {
-        ownLine?: ((
-            commentNode: any,
-            text: string,
-            options: ParserOptions<T>,
-            ast: T,
-            isLastComment: boolean,
-        ) => boolean) | undefined;
-        endOfLine?: ((
-            commentNode: any,
-            text: string,
-            options: ParserOptions<T>,
-            ast: T,
-            isLastComment: boolean,
-        ) => boolean) | undefined;
-        remaining?: ((
-            commentNode: any,
-            text: string,
-            options: ParserOptions<T>,
-            ast: T,
-            isLastComment: boolean,
-        ) => boolean) | undefined;
-    } | undefined;
+    handleComments?:
+        | {
+              ownLine?:
+                  | ((
+                        commentNode: any,
+                        text: string,
+                        options: ParserOptions<T>,
+                        ast: T,
+                        isLastComment: boolean,
+                    ) => boolean)
+                  | undefined;
+              endOfLine?:
+                  | ((
+                        commentNode: any,
+                        text: string,
+                        options: ParserOptions<T>,
+                        ast: T,
+                        isLastComment: boolean,
+                    ) => boolean)
+                  | undefined;
+              remaining?:
+                  | ((
+                        commentNode: any,
+                        text: string,
+                        options: ParserOptions<T>,
+                        ast: T,
+                        isLastComment: boolean,
+                    ) => boolean)
+                  | undefined;
+          }
+        | undefined;
 }
 
 export interface CursorOptions extends Options {

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -231,3 +231,15 @@ const plugin: prettier.Plugin<PluginAST> = {
 };
 
 prettier.format('a line!', { parser: 'lines', plugins: [plugin] });
+
+prettier.format('pluginSearchDir is empty', {
+    pluginSearchDirs: [],
+});
+
+prettier.format('pluginSearchDir is not empty', {
+    pluginSearchDirs: ['/a', '/b'],
+});
+
+prettier.format('pluginSearchDir is not empty and mixed with weird stuff', {
+    pluginSearchDirs: ['c', 'd', ''],
+});

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -226,7 +226,7 @@ const plugin: prettier.Plugin<PluginAST> = {
             since: '1.0.0',
             type: 'path',
             category: 'Test',
-        }
+        },
     },
 };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://prettier.io/blog/2021/09/09/2.4.0.html#replace-jsxbracketsameline-option-with-bracketsameline-option-11006httpsgithubcomprettierprettierpull11006-by-kurtztechhttpsgithubcomkurtztech
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

This PR adds an option to use `bracketSameLine` instead of the `jsxBracketSameLine` that is deprecated in `prettier-2.4.0`.

- Link to the release note that reflects this change: https://prettier.io/blog/2021/09/09/2.4.0.html#replace-jsxbracketsameline-option-with-bracketsameline-option-11006httpsgithubcomprettierprettierpull11006-by-kurtztechhttpsgithubcomkurtztech
- Link to the new option added: https://prettier.io/docs/en/options.html#bracket-line
- Link to the now deprecated option:  https://prettier.io/docs/en/options.html#deprecated-jsx-brackets

Additional changes in files indentation have been made after running `npm run prettier -- --write ./types/prettier/*.ts`
