### PR TITLE
fix(angular): remove obsolete `$compileProvider.preAssignBindingsEnabled()` method

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1429,16 +1429,6 @@ declare namespace angular {
         debugInfoEnabled(enabled: boolean): ICompileProvider;
 
         /**
-         * Call this method to enable/disable whether directive controllers are assigned bindings before calling the controller's constructor.
-         * If enabled (true), the compiler assigns the value of each of the bindings to the properties of the controller object before the constructor of this object is called.
-         * If disabled (false), the compiler calls the constructor first before assigning bindings.
-         * Defaults to false.
-         * See: https://docs.angularjs.org/api/ng/provider/$compileProvider#preAssignBindingsEnabled
-         */
-        preAssignBindingsEnabled(): boolean;
-        preAssignBindingsEnabled(enabled: boolean): ICompileProvider;
-
-        /**
          * Sets the number of times $onChanges hooks can trigger new changes before giving up and assuming that the model is unstable.
          * Increasing the TTL could have performance implications, so you should not change it without proper justification.
          * Default: 10.


### PR DESCRIPTION
The `$compileProvider.preAssignBindingsEnabled()` method has been removed from AngularJS since version 1.7.0 (see [angular.js@38f8c97][1]). The latest version (which the types are targeting) is v1.8.2, where the method is long gone.

This commit removes the method from the typings as well.

[1]: https://github.com/angular/angular.js/commit/38f8c97af74649ce224b6dd45f433cc665acfbfb

##
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/angular/angular.js/commit/38f8c97af74649ce224b6dd45f433cc665acfbfb
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
