### PR TITLE
[chec/commerce.js] Update cart line item responses to match API responses

### DIFF
--- a/types/chec__commerce.js/types/line-item.d.ts
+++ b/types/chec__commerce.js/types/line-item.d.ts
@@ -1,5 +1,6 @@
 import { Price } from './price';
 import { SelectedVariant } from './selected-variant';
+import { Variant } from './variant';
 
 export interface LineItem {
     id: string;
@@ -7,9 +8,12 @@ export interface LineItem {
     quantity: number;
     product_id: string;
     product_name: string;
+    product_meta: any;
     sku: string;
+    permalink: string;
     media: any; // todo
-    variants: SelectedVariant[];
+    selected_options: SelectedVariant[];
+    variant?: Variant;
     price: Price;
     line_total: Price;
 }

--- a/types/chec__commerce.js/types/selected-variant.d.ts
+++ b/types/chec__commerce.js/types/selected-variant.d.ts
@@ -1,8 +1,8 @@
 import { Price } from './price';
 
 export interface SelectedVariant {
-    variant_id: string;
-    variant_name: string;
+    group_id: string;
+    group_name: string;
     option_id: string;
     option_name: string;
     price: Price;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://commercejs.com/docs/api/#add-item-to-cart
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

I can't see a good way of adding tests for the response structure from our API. In this case the LineItem type is not used in requests or the public API of the Commerce.js library anywhere, so I haven't added any tests for it.