### PR TITLE
[relay-runtime] - v12 & update RelayOperationTracker

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -7,22 +7,22 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import ConnectionInterface from "./lib/handlers/connection/ConnectionInterface";
+import ConnectionInterface from './lib/handlers/connection/ConnectionInterface';
 export { ConnectionInterface };
-export { ConnectionMetadata } from "./lib/handlers/connection/ConnectionHandler";
-export { EdgeRecord, PageInfo } from "./lib/handlers/connection/ConnectionInterface";
+export { ConnectionMetadata } from './lib/handlers/connection/ConnectionHandler';
+export { EdgeRecord, PageInfo } from './lib/handlers/connection/ConnectionInterface';
 export {
     DeclarativeMutationConfig,
     MutationTypes,
     RangeBehaviors,
     RangeOperations,
-} from "./lib/mutations/RelayDeclarativeMutationConfig";
+} from './lib/mutations/RelayDeclarativeMutationConfig';
 export {
     MutationTypes as MutationType,
     RangeOperations as RangeOperation,
-} from "./lib/mutations/RelayDeclarativeMutationConfig";
-export { OptimisticMutationConfig } from "./lib/mutations/applyOptimisticMutation";
-export { MutationConfig, MutationParameters } from "./lib/mutations/commitMutation";
+} from './lib/mutations/RelayDeclarativeMutationConfig';
+export { OptimisticMutationConfig } from './lib/mutations/applyOptimisticMutation';
+export { MutationConfig, MutationParameters } from './lib/mutations/commitMutation';
 export {
     ExecuteFunction,
     FetchFunction,
@@ -40,8 +40,8 @@ export {
     SubscribeFunction,
     Uploadable,
     UploadableMap,
-} from "./lib/network/RelayNetworkTypes";
-export { ObservableFromValue, Observer, Subscribable, Subscription } from "./lib/network/RelayObservable";
+} from './lib/network/RelayNetworkTypes';
+export { ObservableFromValue, Observer, Subscribable, Subscription } from './lib/network/RelayObservable';
 export {
     GraphQLTaggedNode,
     graphql,
@@ -50,10 +50,10 @@ export {
     getPaginationFragment,
     getRefetchableFragment,
     getRequest,
-} from "./lib/query/RelayModernGraphQLTag";
-export { isClientID, generateClientID, generateUniqueClientID } from "./lib/store/ClientID";
-export { TaskScheduler } from "./lib/store/RelayModernQueryExecutor";
-export { RecordState } from "./lib/store/RelayRecordState";
+} from './lib/query/RelayModernGraphQLTag';
+export { isClientID, generateClientID, generateUniqueClientID } from './lib/store/ClientID';
+export { TaskScheduler } from './lib/store/RelayModernQueryExecutor';
+export { RecordState } from './lib/store/RelayRecordState';
 export {
     Environment as IEnvironment,
     FragmentMap,
@@ -89,8 +89,8 @@ export {
     SingularReaderSelector,
     Snapshot,
     StoreUpdater,
-} from "./lib/store/RelayStoreTypes";
-export { GraphQLSubscriptionConfig } from "./lib/subscription/requestSubscription";
+} from './lib/store/RelayStoreTypes';
+export { GraphQLSubscriptionConfig } from './lib/subscription/requestSubscription';
 export {
     NormalizationArgument,
     NormalizationDefer,
@@ -105,8 +105,8 @@ export {
     NormalizationSelection,
     NormalizationSplitOperation,
     NormalizationStream,
-} from "./lib/util/NormalizationNode";
-export { NormalizationOperation } from "./lib/util/NormalizationNode";
+} from './lib/util/NormalizationNode';
+export { NormalizationOperation } from './lib/util/NormalizationNode';
 export {
     ReaderArgument,
     ReaderArgumentDefinition,
@@ -124,19 +124,19 @@ export {
     ReaderScalarField,
     ReaderSelection,
     RequiredFieldAction,
-} from "./lib/util/ReaderNode";
-export { ConcreteRequest, GeneratedNode, RequestParameters } from "./lib/util/RelayConcreteNode";
-export * from "./lib/util/RelayRuntimeTypes";
+} from './lib/util/ReaderNode';
+export { ConcreteRequest, GeneratedNode, RequestParameters } from './lib/util/RelayConcreteNode';
+export * from './lib/util/RelayRuntimeTypes';
 
 // Core API
-export { default as Environment } from "./lib/store/RelayModernEnvironment";
-export { RelayNetwork as Network } from "./lib/network/RelayNetwork";
-export { RelayObservable as Observable } from "./lib/network/RelayObservable";
-import QueryResponseCache from "./lib/network/RelayQueryResponseCache";
+export { default as Environment } from './lib/store/RelayModernEnvironment';
+export { RelayNetwork as Network } from './lib/network/RelayNetwork';
+export { RelayObservable as Observable } from './lib/network/RelayObservable';
+import QueryResponseCache from './lib/network/RelayQueryResponseCache';
 export { QueryResponseCache };
-export { RelayRecordSource as RecordSource } from "./lib/store/RelayRecordSource";
-export { RelayModernRecord as Record } from "./lib/store/RelayModernRecord";
-export { default as Store } from "./lib/store/RelayModernStore";
+export { RelayRecordSource as RecordSource } from './lib/store/RelayRecordSource';
+export { RelayModernRecord as Record } from './lib/store/RelayModernRecord';
+export { default as Store } from './lib/store/RelayModernStore';
 
 export {
     areEqualSelectors,
@@ -152,8 +152,8 @@ export {
     getVariablesFromFragment,
     getVariablesFromPluralFragment,
     getVariablesFromSingularFragment,
-} from "./lib/store/RelayModernSelector";
-export { createOperationDescriptor, createRequestDescriptor } from "./lib/store/RelayModernOperationDescriptor";
+} from './lib/store/RelayModernSelector';
+export { createOperationDescriptor, createRequestDescriptor } from './lib/store/RelayModernOperationDescriptor';
 export {
     getStorageKey,
     getModuleComponentKey,
@@ -166,40 +166,40 @@ export {
     ROOT_ID,
     ROOT_TYPE,
     TYPENAME_KEY,
-} from "./lib/store/RelayStoreUtils";
-export { createFragmentSpecResolver } from "./lib/store/createFragmentSpecResolver";
-export { readInlineData } from "./lib/store/readInlineData";
+} from './lib/store/RelayStoreUtils';
+export { createFragmentSpecResolver } from './lib/store/createFragmentSpecResolver';
+export { readInlineData } from './lib/store/readInlineData';
 
 // Extensions
-export { RelayDefaultHandlerProvider as DefaultHandlerProvider } from "./lib/handlers/RelayDefaultHandlerProvider";
+export { RelayDefaultHandlerProvider as DefaultHandlerProvider } from './lib/handlers/RelayDefaultHandlerProvider';
 
-import getDefaultMissingFieldHandlers from "./lib/handlers/getRelayDefaultMissingFieldHandlers";
+import getDefaultMissingFieldHandlers from './lib/handlers/getRelayDefaultMissingFieldHandlers';
 export { getDefaultMissingFieldHandlers };
-import * as ConnectionHandler from "./lib/handlers/connection/ConnectionHandler";
+import * as ConnectionHandler from './lib/handlers/connection/ConnectionHandler';
 export { ConnectionHandler };
 
 // Helpers (can be implemented via the above API)
-export { applyOptimisticMutation } from "./lib/mutations/applyOptimisticMutation";
-export { commitLocalUpdate } from "./lib/mutations/commitLocalUpdate";
-export { commitMutation } from "./lib/mutations/commitMutation";
-export { fetchQuery } from "./lib/query/fetchQuery";
-export { fetchQuery_DEPRECATED } from "./lib/query/fetchQuery_DEPRECATED";
-export { isRelayModernEnvironment } from "./lib/store/isRelayModernEnvironment";
-export { requestSubscription } from "./lib/subscription/requestSubscription";
+export { applyOptimisticMutation } from './lib/mutations/applyOptimisticMutation';
+export { commitLocalUpdate } from './lib/mutations/commitLocalUpdate';
+export { commitMutation } from './lib/mutations/commitMutation';
+export { fetchQuery } from './lib/query/fetchQuery';
+export { fetchQuery_DEPRECATED } from './lib/query/fetchQuery_DEPRECATED';
+export { isRelayModernEnvironment } from './lib/store/isRelayModernEnvironment';
+export { requestSubscription } from './lib/subscription/requestSubscription';
 
 // Utilities
-export { RelayProfiler } from "./lib/util/RelayProfiler";
-export { default as getRelayHandleKey } from "./lib/util/getRelayHandleKey";
-export { default as getRequestIdentifier } from "./lib/util/getRequestIdentifier";
-export { default as getFragmentIdentifier } from "./lib/util/getFragmentIdentifier";
+export { RelayProfiler } from './lib/util/RelayProfiler';
+export { default as getRelayHandleKey } from './lib/util/getRelayHandleKey';
+export { default as getRequestIdentifier } from './lib/util/getRequestIdentifier';
+export { default as getFragmentIdentifier } from './lib/util/getFragmentIdentifier';
 
 // INTERNAL-ONLY
-export { RelayConcreteNode } from "./lib/util/RelayConcreteNode";
-export { RelayFeatureFlags } from "./lib/util/RelayFeatureFlags";
-export { default as deepFreeze } from "./lib/util/deepFreeze";
-export { default as isPromise } from "./lib/util/isPromise";
+export { RelayConcreteNode } from './lib/util/RelayConcreteNode';
+export { RelayFeatureFlags } from './lib/util/RelayFeatureFlags';
+export { default as deepFreeze } from './lib/util/deepFreeze';
+export { default as isPromise } from './lib/util/isPromise';
 
-import * as fetchQueryInternal from "./lib/query/fetchQueryInternal";
+import * as fetchQueryInternal from './lib/query/fetchQueryInternal';
 
 interface Internal {
     fetchQuery: typeof fetchQueryInternal.fetchQuery;
@@ -215,11 +215,11 @@ export const __internal: Internal;
  */
 
 export interface _RefType<Ref extends string> {
-    " $refType": Ref;
+    ' $refType': Ref;
 }
 
 export interface _FragmentRefs<Refs extends string> {
-    " $fragmentRefs": FragmentRefs<Refs>;
+    ' $fragmentRefs': FragmentRefs<Refs>;
 }
 
 // This is used in the actual artifacts to define the various fragment references a container holds.

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for relay-runtime 11.0
+// Type definitions for relay-runtime 12.0
 // Project: https://github.com/facebook/relay, https://facebook.github.io/relay
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 Stephen Pittman <https://github.com/Stephen2>
@@ -7,22 +7,22 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-import ConnectionInterface from './lib/handlers/connection/ConnectionInterface';
+import ConnectionInterface from "./lib/handlers/connection/ConnectionInterface";
 export { ConnectionInterface };
-export { ConnectionMetadata } from './lib/handlers/connection/ConnectionHandler';
-export { EdgeRecord, PageInfo } from './lib/handlers/connection/ConnectionInterface';
+export { ConnectionMetadata } from "./lib/handlers/connection/ConnectionHandler";
+export { EdgeRecord, PageInfo } from "./lib/handlers/connection/ConnectionInterface";
 export {
     DeclarativeMutationConfig,
     MutationTypes,
     RangeBehaviors,
     RangeOperations,
-} from './lib/mutations/RelayDeclarativeMutationConfig';
+} from "./lib/mutations/RelayDeclarativeMutationConfig";
 export {
     MutationTypes as MutationType,
     RangeOperations as RangeOperation,
-} from './lib/mutations/RelayDeclarativeMutationConfig';
-export { OptimisticMutationConfig } from './lib/mutations/applyOptimisticMutation';
-export { MutationConfig, MutationParameters } from './lib/mutations/commitMutation';
+} from "./lib/mutations/RelayDeclarativeMutationConfig";
+export { OptimisticMutationConfig } from "./lib/mutations/applyOptimisticMutation";
+export { MutationConfig, MutationParameters } from "./lib/mutations/commitMutation";
 export {
     ExecuteFunction,
     FetchFunction,
@@ -40,8 +40,8 @@ export {
     SubscribeFunction,
     Uploadable,
     UploadableMap,
-} from './lib/network/RelayNetworkTypes';
-export { ObservableFromValue, Observer, Subscribable, Subscription } from './lib/network/RelayObservable';
+} from "./lib/network/RelayNetworkTypes";
+export { ObservableFromValue, Observer, Subscribable, Subscription } from "./lib/network/RelayObservable";
 export {
     GraphQLTaggedNode,
     graphql,
@@ -50,10 +50,10 @@ export {
     getPaginationFragment,
     getRefetchableFragment,
     getRequest,
-} from './lib/query/RelayModernGraphQLTag';
-export { isClientID, generateClientID, generateUniqueClientID } from './lib/store/ClientID';
-export { TaskScheduler } from './lib/store/RelayModernQueryExecutor';
-export { RecordState } from './lib/store/RelayRecordState';
+} from "./lib/query/RelayModernGraphQLTag";
+export { isClientID, generateClientID, generateUniqueClientID } from "./lib/store/ClientID";
+export { TaskScheduler } from "./lib/store/RelayModernQueryExecutor";
+export { RecordState } from "./lib/store/RelayRecordState";
 export {
     Environment as IEnvironment,
     FragmentMap,
@@ -89,8 +89,8 @@ export {
     SingularReaderSelector,
     Snapshot,
     StoreUpdater,
-} from './lib/store/RelayStoreTypes';
-export { GraphQLSubscriptionConfig } from './lib/subscription/requestSubscription';
+} from "./lib/store/RelayStoreTypes";
+export { GraphQLSubscriptionConfig } from "./lib/subscription/requestSubscription";
 export {
     NormalizationArgument,
     NormalizationDefer,
@@ -105,8 +105,8 @@ export {
     NormalizationSelection,
     NormalizationSplitOperation,
     NormalizationStream,
-} from './lib/util/NormalizationNode';
-export { NormalizationOperation } from './lib/util/NormalizationNode';
+} from "./lib/util/NormalizationNode";
+export { NormalizationOperation } from "./lib/util/NormalizationNode";
 export {
     ReaderArgument,
     ReaderArgumentDefinition,
@@ -124,19 +124,19 @@ export {
     ReaderScalarField,
     ReaderSelection,
     RequiredFieldAction,
-} from './lib/util/ReaderNode';
-export { ConcreteRequest, GeneratedNode, RequestParameters } from './lib/util/RelayConcreteNode';
-export * from './lib/util/RelayRuntimeTypes';
+} from "./lib/util/ReaderNode";
+export { ConcreteRequest, GeneratedNode, RequestParameters } from "./lib/util/RelayConcreteNode";
+export * from "./lib/util/RelayRuntimeTypes";
 
 // Core API
-export { default as Environment } from './lib/store/RelayModernEnvironment';
-export { RelayNetwork as Network } from './lib/network/RelayNetwork';
-export { RelayObservable as Observable } from './lib/network/RelayObservable';
-import QueryResponseCache from './lib/network/RelayQueryResponseCache';
+export { default as Environment } from "./lib/store/RelayModernEnvironment";
+export { RelayNetwork as Network } from "./lib/network/RelayNetwork";
+export { RelayObservable as Observable } from "./lib/network/RelayObservable";
+import QueryResponseCache from "./lib/network/RelayQueryResponseCache";
 export { QueryResponseCache };
-export { RelayRecordSource as RecordSource } from './lib/store/RelayRecordSource';
-export { RelayModernRecord as Record } from './lib/store/RelayModernRecord';
-export { default as Store } from './lib/store/RelayModernStore';
+export { RelayRecordSource as RecordSource } from "./lib/store/RelayRecordSource";
+export { RelayModernRecord as Record } from "./lib/store/RelayModernRecord";
+export { default as Store } from "./lib/store/RelayModernStore";
 
 export {
     areEqualSelectors,
@@ -152,8 +152,8 @@ export {
     getVariablesFromFragment,
     getVariablesFromPluralFragment,
     getVariablesFromSingularFragment,
-} from './lib/store/RelayModernSelector';
-export { createOperationDescriptor, createRequestDescriptor } from './lib/store/RelayModernOperationDescriptor';
+} from "./lib/store/RelayModernSelector";
+export { createOperationDescriptor, createRequestDescriptor } from "./lib/store/RelayModernOperationDescriptor";
 export {
     getStorageKey,
     getModuleComponentKey,
@@ -166,40 +166,40 @@ export {
     ROOT_ID,
     ROOT_TYPE,
     TYPENAME_KEY,
-} from './lib/store/RelayStoreUtils';
-export { createFragmentSpecResolver } from './lib/store/createFragmentSpecResolver';
-export { readInlineData } from './lib/store/readInlineData';
+} from "./lib/store/RelayStoreUtils";
+export { createFragmentSpecResolver } from "./lib/store/createFragmentSpecResolver";
+export { readInlineData } from "./lib/store/readInlineData";
 
 // Extensions
-export { RelayDefaultHandlerProvider as DefaultHandlerProvider } from './lib/handlers/RelayDefaultHandlerProvider';
+export { RelayDefaultHandlerProvider as DefaultHandlerProvider } from "./lib/handlers/RelayDefaultHandlerProvider";
 
-import getDefaultMissingFieldHandlers from './lib/handlers/getRelayDefaultMissingFieldHandlers';
+import getDefaultMissingFieldHandlers from "./lib/handlers/getRelayDefaultMissingFieldHandlers";
 export { getDefaultMissingFieldHandlers };
-import * as ConnectionHandler from './lib/handlers/connection/ConnectionHandler';
+import * as ConnectionHandler from "./lib/handlers/connection/ConnectionHandler";
 export { ConnectionHandler };
 
 // Helpers (can be implemented via the above API)
-export { applyOptimisticMutation } from './lib/mutations/applyOptimisticMutation';
-export { commitLocalUpdate } from './lib/mutations/commitLocalUpdate';
-export { commitMutation } from './lib/mutations/commitMutation';
-export { fetchQuery } from './lib/query/fetchQuery';
-export { fetchQuery_DEPRECATED } from './lib/query/fetchQuery_DEPRECATED';
-export { isRelayModernEnvironment } from './lib/store/isRelayModernEnvironment';
-export { requestSubscription } from './lib/subscription/requestSubscription';
+export { applyOptimisticMutation } from "./lib/mutations/applyOptimisticMutation";
+export { commitLocalUpdate } from "./lib/mutations/commitLocalUpdate";
+export { commitMutation } from "./lib/mutations/commitMutation";
+export { fetchQuery } from "./lib/query/fetchQuery";
+export { fetchQuery_DEPRECATED } from "./lib/query/fetchQuery_DEPRECATED";
+export { isRelayModernEnvironment } from "./lib/store/isRelayModernEnvironment";
+export { requestSubscription } from "./lib/subscription/requestSubscription";
 
 // Utilities
-export { RelayProfiler } from './lib/util/RelayProfiler';
-export { default as getRelayHandleKey } from './lib/util/getRelayHandleKey';
-export { default as getRequestIdentifier } from './lib/util/getRequestIdentifier';
-export { default as getFragmentIdentifier } from './lib/util/getFragmentIdentifier';
+export { RelayProfiler } from "./lib/util/RelayProfiler";
+export { default as getRelayHandleKey } from "./lib/util/getRelayHandleKey";
+export { default as getRequestIdentifier } from "./lib/util/getRequestIdentifier";
+export { default as getFragmentIdentifier } from "./lib/util/getFragmentIdentifier";
 
 // INTERNAL-ONLY
-export { RelayConcreteNode } from './lib/util/RelayConcreteNode';
-export { RelayFeatureFlags } from './lib/util/RelayFeatureFlags';
-export { default as deepFreeze } from './lib/util/deepFreeze';
-export { default as isPromise } from './lib/util/isPromise';
+export { RelayConcreteNode } from "./lib/util/RelayConcreteNode";
+export { RelayFeatureFlags } from "./lib/util/RelayFeatureFlags";
+export { default as deepFreeze } from "./lib/util/deepFreeze";
+export { default as isPromise } from "./lib/util/isPromise";
 
-import * as fetchQueryInternal from './lib/query/fetchQueryInternal';
+import * as fetchQueryInternal from "./lib/query/fetchQueryInternal";
 
 interface Internal {
     fetchQuery: typeof fetchQueryInternal.fetchQuery;
@@ -215,11 +215,11 @@ export const __internal: Internal;
  */
 
 export interface _RefType<Ref extends string> {
-    ' $refType': Ref;
+    " $refType": Ref;
 }
 
 export interface _FragmentRefs<Refs extends string> {
-    ' $fragmentRefs': FragmentRefs<Refs>;
+    " $fragmentRefs": FragmentRefs<Refs>;
 }
 
 // This is used in the actual artifacts to define the various fragment references a container holds.

--- a/types/relay-runtime/lib/store/RelayOperationTracker.d.ts
+++ b/types/relay-runtime/lib/store/RelayOperationTracker.d.ts
@@ -1,4 +1,4 @@
-import { RequestDescriptor } from "./RelayStoreTypes";
+import { RequestDescriptor } from './RelayStoreTypes';
 
 export class RelayOperationTracker {
     /**

--- a/types/relay-runtime/lib/store/RelayOperationTracker.d.ts
+++ b/types/relay-runtime/lib/store/RelayOperationTracker.d.ts
@@ -1,4 +1,4 @@
-import { RequestDescriptor } from './RelayStoreTypes';
+import { RequestDescriptor } from "./RelayStoreTypes";
 
 export class RelayOperationTracker {
     /**
@@ -15,5 +15,10 @@ export class RelayOperationTracker {
 
     _resolveOwnerResolvers(owner: RequestDescriptor): void;
 
-    getPromiseForPendingOperationsAffectingOwner(owner: RequestDescriptor): Promise<void> | null;
+    getPendingOperationsAffectingOwner(
+        owner: RequestDescriptor,
+    ): {
+        promise: Promise<void>;
+        pendingOperations: ReadonlyArray<RequestDescriptor>;
+    };
 }

--- a/types/relay-runtime/lib/store/RelayOperationTracker.d.ts
+++ b/types/relay-runtime/lib/store/RelayOperationTracker.d.ts
@@ -20,5 +20,5 @@ export class RelayOperationTracker {
     ): {
         promise: Promise<void>;
         pendingOperations: ReadonlyArray<RequestDescriptor>;
-    };
+    } | null;
 }


### PR DESCRIPTION
This PR update [RelayOperationTracker](https://github.com/facebook/relay/blob/v12.0.0/packages/relay-runtime/store/RelayOperationTracker.js#L154-L159)

```js
 getPendingOperationsAffectingOwner(
    owner: RequestDescriptor,
  ): {|
    promise: Promise<void>,
    pendingOperations: $ReadOnlyArray<RequestDescriptor>,
  |} | null {
  ...
};


```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.