### PR TITLE
feat(node-zendesk): add requester field to create ticket

### DIFF
--- a/types/node-zendesk/index.d.ts
+++ b/types/node-zendesk/index.d.ts
@@ -488,6 +488,7 @@ export namespace Tickets {
         status?: Status | null | undefined;
         recipient?: string | null | undefined;
         requester_id?: ZendeskID | undefined;
+        requester?: Requests.RequesterAnonymous | undefined;
         submitter_id?: ZendeskID | null | undefined;
         assignee_id?: ZendeskID | null | undefined;
         organization_id?: number | null | undefined;

--- a/types/node-zendesk/node-zendesk-tests.ts
+++ b/types/node-zendesk/node-zendesk-tests.ts
@@ -99,6 +99,7 @@ client.tickets.create({ ticket: { comment: {
   uploads: [token]
 } } }, zendeskCallback);
 client.tickets.create({ ticket: { comment: {} } }).then(zendeskCallback);
+client.tickets.create({ ticket: { comment: {}, requester: { name: "" } } }).then(zendeskCallback);
 client.tickets.createMany({ tickets: [{ comment: {} }] }, zendeskCallback);
 client.tickets.createMany({ tickets: [{ comment: {} }] }).then(zendeskCallback);
 client.tickets.update(123, { ticket: {} }, zendeskCallback);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.zendesk.com/documentation/ticketing/managing-tickets/creating-and-updating-tickets/#creating-a-ticket-with-a-new-requester
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

I'm right now using `node-zendesk` with a `@ts-ignore` because this type definition doesn't reflect the possibility to provide a `requester` parameter. Can confirm it works and the `node-zendesk` package allows for this parameter.