### PR TITLE
Added type definitions for zipcode-to-timezone

### DIFF
--- a/types/zipcode-to-timezone/index.d.ts
+++ b/types/zipcode-to-timezone/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for zipcode-to-timezone 0.0
+// Project: https://github.com/DoubleDor/node-zipcode-to-timezone#readme
+// Definitions by: Paul Oldridge <https://github.com/poldridge>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function lookup(zipCode: string | number): string | null;

--- a/types/zipcode-to-timezone/tsconfig.json
+++ b/types/zipcode-to-timezone/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "zipcode-to-timezone-tests.ts"
+    ]
+}

--- a/types/zipcode-to-timezone/tslint.json
+++ b/types/zipcode-to-timezone/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/zipcode-to-timezone/zipcode-to-timezone-tests.ts
+++ b/types/zipcode-to-timezone/zipcode-to-timezone-tests.ts
@@ -1,0 +1,13 @@
+import { lookup } from "zipcode-to-timezone";
+
+// $ExpectType string | null
+const stringLookup = lookup("10001");
+
+// $ExpectType string | null
+const numberLookup = lookup(10001);
+
+// $ExpectError
+const noArg = lookup();
+
+// $ExpectError
+const wrongType = lookup([]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
