### PR TITLE
Fix incorrect typescript definition of `wavesurfer.regions.list`

### DIFF
--- a/types/wavesurfer.js/src/plugin/regions.d.ts
+++ b/types/wavesurfer.js/src/plugin/regions.d.ts
@@ -24,7 +24,7 @@ export default class RegionsPlugin extends Observer implements WaveSurferPlugin 
     getCurrentRegion(): Region | null;
     getRegionSnapToGridValue(value: number, params: RegionParams): number;
 
-    readonly list: Region[];
+    readonly list: {[key: string]: Region};
     readonly maxRegions: number[];
     readonly params: RegionsPluginParams;
     readonly regionsMinLength: number;

--- a/types/wavesurfer.js/src/plugin/regions.d.ts
+++ b/types/wavesurfer.js/src/plugin/regions.d.ts
@@ -24,7 +24,7 @@ export default class RegionsPlugin extends Observer implements WaveSurferPlugin 
     getCurrentRegion(): Region | null;
     getRegionSnapToGridValue(value: number, params: RegionParams): number;
 
-    readonly list: {[key: string]: Region};
+    readonly list: { [id: string]: Region };
     readonly maxRegions: number[];
     readonly params: RegionsPluginParams;
     readonly regionsMinLength: number;


### PR DESCRIPTION
Typescript definition of `wavesurfer.regions.list` is incorrect.
After logging `ws.regions.list`, it can be seen that the type should be {[key: string]: Region} instead of Region[].

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The definition of `ws.regions.list` is incorrect and as per my knowledge, it was never `Region[]` even in older versions.

https://github.com/katspaugh/wavesurfer.js/issues/2361

https://github.com/katspaugh/wavesurfer.js/blob/8ec83d2119a1c4ac27ae6a5f1e1ebbd5e67ba53f/src/plugin/regions/index.js#L147
