### PR TITLE
[react] update Key type to support bigint

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -127,7 +127,7 @@ declare namespace React {
 
     type ComponentState = any;
 
-    type Key = string | number;
+    type Key = string | number | bigint;
 
     /**
      * @internal You shouldn't need to use this type since you never see these attributes

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -44,6 +44,8 @@ const testCases = [
     <input accept="video/*" capture />,
     <input accept="audio/*" capture />,
 
+    // switch to `BigInt(17)` once we've upgraded to es2020 and TypeScript >= 3.8 minimum
+    <div key={17 as unknown as bigint} />,
     <div role="dialog" />,
     <div role="none presentation" />,
     <svg role="treeitem" />,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
     _According to the docs on [Lists and Keys](https://reactjs.org/docs/lists-and-keys.html), they recommend that you use strings as keys, probably because they are trying to discourage using the array index as the key. However, numbers work fine and are an accepted key type in this package, and bigints work fine too, so I'm adding `bigint` to the accepted key types._
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
    _This PR does not include a version bump and does not include any breaking changes for the supported TypeScript versions._