### PR TITLE
Add optional "hd" parameter for jaredhanson/passport-google-oauth2

### DIFF
--- a/types/passport-google-oauth20/index.d.ts
+++ b/types/passport-google-oauth20/index.d.ts
@@ -46,6 +46,7 @@ export interface Profile extends passport.Profile {
         email: string;
         email_verified: boolean;
         locale: string;
+        hd?: string;
     };
 }
 


### PR DESCRIPTION
https://github.com/jaredhanson/passport-google-oauth2

https://developers.google.com/identity/protocols/oauth2/openid-connect
> `hd` - The hosted G Suite domain of the user. Provided only if the user belongs to a hosted domain.
