### PR TITLE
Fix return type of `lodash.chain(nullableString).groupBy`

### DIFF
--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -980,7 +980,7 @@ declare module "../index" {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<string>): ObjectChain<Dictionary<string>>;
+        groupBy(iteratee?: ValueIteratee<string>): ObjectChain<Dictionary<string[]>>;
     }
     interface CollectionChain<T> {
         /**

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -23,6 +23,7 @@ const dictionaryIterator = (value: AbcObject, key: string, collection: _.Diction
 const numericDictionaryIterator = (value: AbcObject, key: string, collection: _.NumericDictionary<AbcObject>) => true;
 const valueIterator = (value: AbcObject) => true;
 const stringIterator = (value: string) => "";
+const nullableString: string | null = anything;
 
 // Wrapped array shortcut methods
 _([1, 2, 3, 4]).pop(); // $ExpectType number | undefined
@@ -2543,6 +2544,7 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
     _.chain(dictionary).groupBy(valueIterator); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
     _.chain(dictionary).groupBy(""); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
     _.chain(dictionary).groupBy({ a: 42 }); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(nullableString).groupBy(); // $ExpectType ObjectChain<Dictionary<string[]>>
 
     fp.groupBy(valueIterator, list); // $ExpectType Dictionary<AbcObject[]>
     fp.groupBy(valueIterator)(list); // $ExpectType Dictionary<AbcObject[]>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

`_.groupBy(x, f)` and `_.chain(x).groupBy(f).value()` should be (and are) equivalent, but this code fails to compile:

``` 
const s: string | undefined = '' as any;
let r = _.groupBy(s);
r = _.chain(s).groupBy().value();
```

With error:
```
Type 'Dictionary<string>' is not assignable to type 'Dictionary<string[]>'.
  Type 'string' is not assignable to type 'string[]'. ts(2322)
```

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

It doesn't - it fixes a bug on an existing type definition.

