### PR TITLE
update(new-relic-browser): export as proper global script

### DIFF
--- a/types/new-relic-browser/index.d.ts
+++ b/types/new-relic-browser/index.d.ts
@@ -1,116 +1,120 @@
-// Type definitions for non-npm package NewRelicBrowser 0.1118
+// Type definitions for non-npm package NewRelicBrowser 0.1211
 // Project: https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api
-// Definitions by: Rene Hamburger <https://github.com/renehamburger>, Piotr Kubisa <https://github.com/piotrkubisa>
+// Definitions by: Rene Hamburger <https://github.com/renehamburger>
+//                 Piotr Kubisa <https://github.com/piotrkubisa>
+//                 Piotr Błażejewicz <https://github.com/piotrblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace NewRelic {
-    interface Browser {
-        /**
-         * Adds a unique name and ID to identify releases with multiple JavaScript bundles on the same page.
-         *
-         * @param releaseName A short description of the component; for example, the name of a project,
-         *  application, file, or library.
-         * @param releaseId The ID or version of this release; for example, a version number, build number
-         *   from your CI environment, GitHub SHA, GUID, or a hash of the contents. Since New Relic converts this
-         *   value into a string, you can also use null or undefined if necessary
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-release
-         */
-        addRelease(releaseName: string, releaseId: string): void;
+/**
+ * The browser and Single Page Application (SPA) APIs
+ * allow you to customize and extend your browser monitoring.
+ */
+declare namespace newrelic {
+    /**
+     * Adds a unique name and ID to identify releases with multiple JavaScript bundles on the same page.
+     *
+     * @param releaseName A short description of the component; for example, the name of a project,
+     *  application, file, or library.
+     * @param releaseId The ID or version of this release; for example, a version number, build number
+     *   from your CI environment, GitHub SHA, GUID, or a hash of the contents. Since New Relic converts this
+     *   value into a string, you can also use null or undefined if necessary
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-release
+     */
+    function addRelease(releaseName: string, releaseId: string): void;
 
-        /**
-         * Reports a Browser PageAction event to Insights along with a name and attributes.
-         *
-         * @param name Name or category of the action. Reports to Insights as the actionName attribute.
-         * @param attributes JSON object with one or more key/value pairs.
-         *   The key will report to Insights as its own PageAction attribute with the specified values.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
-         */
-        addPageAction(name: string, attributes: { [key: string]: string | number }): void;
+    /**
+     * Reports a Browser PageAction event to Insights along with a name and attributes.
+     *
+     * @param name Name or category of the action. Reports to Insights as the actionName attribute.
+     * @param attributes JSON object with one or more key/value pairs.
+     *   The key will report to Insights as its own PageAction attribute with the specified values.
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
+     */
+    function addPageAction(name: string, attributes: Record<string, SimpleType>): void;
 
-        /**
-         * Adds a JavaScript object with a custom name, start time, etc. to an in-progress session trace.
-         *
-         * @param eventObject If you are sending the same event object to New Relic Insights as a
-         *   PageAction, omit the TYPE attribute. If included, it will override the event type and cause the
-         *   PageAction event to be sent incorrectly. Instead, use the NAME attribute for event information.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-to-trace
-         */
-        addToTrace(eventObject: EventObject): void;
+    /**
+     * Adds a JavaScript object with a custom name, start time, etc. to an in-progress session trace.
+     *
+     * @param eventObject If you are sending the same event object to New Relic Insights as a
+     *   PageAction, omit the TYPE attribute. If included, it will override the event type and cause the
+     *   PageAction event to be sent incorrectly. Instead, use the NAME attribute for event information.
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-to-trace
+     */
+    function addToTrace(eventObject: EventObject): void;
 
-        /**
-         * Records an additional time point as "finished" in a session trace, and sends the event to Insights.
-         *
-         * @param timestamp Defaults to the current time of the call. If used, this marks the time that
-         *   the page is "finished" according to your own criteria.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/finished
-         */
-        finished(timestamp?: number): void;
+    /**
+     * Records an additional time point as "finished" in a session trace, and sends the event to Insights.
+     *
+     * @param timestamp Defaults to the current time of the call. If used, this marks the time that
+     *   the page is "finished" according to your own criteria.
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/finished
+     */
+    function finished(timestamp?: number): void;
 
-        /**
-         * Identifies a browser error without disrupting your app's operations.
-         *
-         * @param error Provide a meaningful error message that you can use when analyzing data on
-         *   New Relic Browser's JavaScript errors page.
-         * @param customAttributes An object containing name/value pairs representing custom attributes.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/notice-error
-         */
-        noticeError(error: Error | string, customAttributes?: { [key: string]: string | number }): void;
+    /**
+     * Identifies a browser error without disrupting your app's operations.
+     *
+     * @param error Provide a meaningful error message that you can use when analyzing data on
+     *   New Relic Browser's JavaScript errors page.
+     * @param customAttributes An object containing name/value pairs representing custom attributes.
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/notice-error
+     */
+    function noticeError(error: Error | string, customAttributes?: Record<string, SimpleType>): void;
 
-        /**
-         * Adds a user-defined attribute name and value to subsequent events on the page.
-         *
-         * @param name Name of the attribute. Appears as column in the PageView event.
-         *   It will also appear as a column in the PageAction event if you are using it.
-         * @param value Value of the attribute. Appears as the value in the named attribute column in the
-         *   PageView event. It will appear as a column in the PageAction event if you are using it. Custom attribute
-         *   values cannot be complex objects, only simple types such as strings and numbers.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-custom-attribute
-         */
-        setCustomAttribute(name: string, value: string | number): void;
+    /**
+     * Adds a user-defined attribute name and value to subsequent events on the page.
+     *
+     * @param name Name of the attribute. Appears as column in the PageView event.
+     *   It will also appear as a column in the PageAction event if you are using it.
+     * @param value Value of the attribute. Appears as the value in the named attribute column in the
+     *   PageView event. It will appear as a column in the PageAction event if you are using it. Custom attribute
+     *   values cannot be complex objects, only simple types such as strings and numbers.
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-custom-attribute
+     */
+    function setCustomAttribute(name: string, value: SimpleType): void;
 
-        /**
-         * Allows selective ignoring of known errors that the Browser agent captures.
-         *
-         * @param filterCallback The callback will be called with each error, so it is not
-         *   specific to one error. `err` will usually be an error object, but it can be other data types.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-error-handler
-         */
-        setErrorHandler(filterCallback: (err: any) => boolean): void;
+    /**
+     * Allows selective ignoring of known errors that the Browser agent captures.
+     *
+     * @param filterCallback The callback will be called with each error, so it is not
+     *   specific to one error. `err` will usually be an error object, but it can be other data types.
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-error-handler
+     */
+    function setErrorHandler(filterCallback: ErrorHandler): void;
 
-        /**
-         * Groups page views to help URL structure or to capture the URL's routing information.
-         *
-         * @param name Name of the page you want to use when viewing it in New Relic Browser or Insights.
-         * @param host Default is http://custom.transaction. Typically set host to your site's domain URI.
-         *   To further group these custom transactions, provide a custom host. Otherwise, the page views will be
-         *   assigned the default domain custom.transaction. Segments within the name must be explicitly added to
-         *   the Whitelist segments in your URL whitelist settings if they do not already appear.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-pageview-name
-         */
-        setPageViewName(name: string, host?: string): void;
+    /**
+     * Groups page views to help URL structure or to capture the URL's routing information.
+     *
+     * @param name Name of the page you want to use when viewing it in New Relic Browser or Insights.
+     * @param host Default is http://custom.transaction. Typically set host to your site's domain URI.
+     *   To further group these custom transactions, provide a custom host. Otherwise, the page views will be
+     *   assigned the default domain custom.transaction. Segments within the name must be explicitly added to
+     *   the Whitelist segments in your URL whitelist settings if they do not already appear.
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-pageview-name
+     */
+    function setPageViewName(name: string, host?: string): void;
 
-        /**
-         * Returns a new API object that is bound to the current SPA interaction.
-         *
-         * @returns This method returns an API object that is bound to a specific BrowserInteraction
-         *   event. Each time this method is called for the same BrowserInteraction, a new object is created, but it still
-         *   references the same interaction.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/interaction-browser-spa-api
-         */
-        interaction(): BrowserInteraction;
+    /**
+     * Returns a new API object that is bound to the current SPA interaction.
+     *
+     * @returns This method returns an API object that is bound to a specific BrowserInteraction
+     *   event. Each time this method is called for the same BrowserInteraction, a new object is created, but it still
+     *   references the same interaction.
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/interaction-browser-spa-api
+     */
+    function interaction(): BrowserInteraction;
 
-        /**
-         * Gives SPA routes more accurate names than default names. Monitors specific routes rather than by default
-         * grouping.
-         *
-         * @param name Current route name for the page. Route names passed to setCurrentRouteName() can
-         *   be any string, but they should represent a routing pattern rather than a specific resource. For example,
-         *   use /users/:id rather than /users/123. If null, exits out of the route change requirement and returns to
-         *   the default naming strategy.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-current-route-name
-         */
-        setCurrentRouteName(name: string | null): void;
-    }
+    /**
+     * Gives SPA routes more accurate names than default names. Monitors specific routes rather than by default
+     * grouping.
+     *
+     * @param name Current route name for the page. Route names passed to setCurrentRouteName() can
+     *   be any string, but they should represent a routing pattern rather than a specific resource. For example,
+     *   use /users/:id rather than /users/123. If null, exits out of the route change requirement and returns to
+     *   the default naming strategy.
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-current-route-name
+     */
+    function setCurrentRouteName(name: string | null): void;
 
     interface EventObject {
         /** Event name */
@@ -133,7 +137,7 @@ declare namespace NewRelic {
          * @returns This method returns the same API object created by interaction().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api
          */
-        actionText(value: string): BrowserInteraction;
+        actionText(value: string): this;
 
         /**
          * Times sub-components of a SPA interaction separately, including wait time and JS execution time.
@@ -146,7 +150,7 @@ declare namespace NewRelic {
          * @returns This method ends the async time. It calls (and times) the callback that was passed into createTracer().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-create-tracer
          */
-        createTracer(name: string, callback?: () => void): () => void;
+        createTracer(name: string, callback?: Callback): Wrapper;
 
         /**
          * Ends the New Relic SPA interaction at the current time.
@@ -154,7 +158,7 @@ declare namespace NewRelic {
          * @returns This method returns the same API object created by interaction().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-end
          */
-        end(): BrowserInteraction;
+        end(): this;
 
         /**
          * Stores values across the current SPA interaction asynchronously in New Relic Browser.
@@ -164,7 +168,8 @@ declare namespace NewRelic {
          * @returns This method returns the same API object created by interaction().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-get-context
          */
-        getContext(callback: (contextObject: any) => void): BrowserInteraction;
+        // tslint:disable-next-line:no-unnecessary-generics
+        getContext<T extends ContextObject = ContextObject>(callback: GetContextCallback<T>): this;
 
         /**
          * Overrides other SPA save() calls; ignores an interaction so it is not saved or sent to New Relic.
@@ -172,7 +177,7 @@ declare namespace NewRelic {
          * @returns This method returns the same API object created by interaction().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-ignore-browser
          */
-        ignore(): BrowserInteraction;
+        ignore(): this;
 
         /**
          * Adds custom attributes for SPA interactions to the end of an event. It is called when the interaction
@@ -182,7 +187,8 @@ declare namespace NewRelic {
          * @returns This method returns the same API object created by interaction().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-on-end
          */
-        onEnd(callback: (contextObject: any) => void): BrowserInteraction;
+        // tslint:disable-next-line:no-unnecessary-generics
+        onEnd<T extends ContextObject = ContextObject>(callback: GetContextCallback<T>): this;
 
         /**
          * Ensures a SPA browser interaction will be saved when it ends.
@@ -190,7 +196,7 @@ declare namespace NewRelic {
          * @returns This method returns the same API object created by interaction().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-save
          */
-        save(): BrowserInteraction;
+        save(): this;
 
         /**
          * Adds a custom SPA attribute only to the current interaction in New Relic Browser.
@@ -201,7 +207,7 @@ declare namespace NewRelic {
          * @returns This method returns the same API object created by interaction().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-attribute
          */
-        setAttribute(key: string, value: any): BrowserInteraction;
+        setAttribute(key: string, value: ComplexType): this;
 
         /**
          * Sets the name and trigger of a SPA's browser interaction that is not a route change or URL change.
@@ -212,9 +218,39 @@ declare namespace NewRelic {
          * @returns This method returns the same API object created by interaction().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-name
          */
-        setName(name: string, trigger?: string): BrowserInteraction;
+        setName(name: string, trigger?: string): this;
     }
-}
 
-declare const api: NewRelic.Browser;
-export = api;
+    interface ContextObject extends Record<string, any> {}
+
+    interface Callback {
+        (): void;
+    }
+
+    interface ErrorHandler {
+        (err: any): boolean;
+    }
+
+    interface GetContextCallback<T extends ContextObject = ContextObject> {
+        (contextObject: T): void;
+    }
+
+    interface Wrapper {
+        (): void;
+    }
+
+    type SimpleType = string | number;
+    type ComplexType = string | number | boolean | unknown;
+
+    interface Info {
+        agent: string;
+        applicationID: string;
+        beacon: string;
+        errorBeacon: string;
+        jsAttributes: Record<string, ComplexType>;
+        licenseKey: string;
+        sa: number;
+    }
+
+    const info: Info;
+}

--- a/types/new-relic-browser/index.d.ts
+++ b/types/new-relic-browser/index.d.ts
@@ -30,7 +30,7 @@ declare namespace newrelic {
      *   The key will report to Insights as its own PageAction attribute with the specified values.
      * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
      */
-    function addPageAction(name: string, attributes: Record<string, SimpleType>): void;
+    function addPageAction(name: string, attributes?: Record<string, SimpleType>): void;
 
     /**
      * Adds a JavaScript object with a custom name, start time, etc. to an in-progress session trace.

--- a/types/new-relic-browser/index.d.ts
+++ b/types/new-relic-browser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package NewRelicBrowser 0.1211
+// Type definitions for non-npm package NewRelicBrowser 0.1212
 // Project: https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api
 // Definitions by: Rene Hamburger <https://github.com/renehamburger>
 //                 Piotr Kubisa <https://github.com/piotrkubisa>

--- a/types/new-relic-browser/new-relic-browser-tests.ts
+++ b/types/new-relic-browser/new-relic-browser-tests.ts
@@ -1,6 +1,5 @@
-import newrelic = require('new-relic-browser');
-
-// The following tests are largely taken straight from the examples at https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api
+// The following tests are largely taken straight from the examples
+// at https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api
 
 // --- NewRelic.Browser methods ----------------------------------------------
 
@@ -17,11 +16,11 @@ newrelic.addToTrace({
     start: 1417044274239,
     end: 1417044274252,
     origin: 'Origin of event',
-    type: 'What type of event was this'
+    type: 'What type of event was this',
 });
 newrelic.addToTrace({
     name: 'Event Name',
-    start: 1417044274239
+    start: 1417044274239,
 });
 
 // finished()
@@ -35,14 +34,14 @@ try {
 }
 newrelic.noticeError(new Error('bar'));
 newrelic.noticeError('bar');
-newrelic.noticeError('bar', { foo: 'bar', baz: 1});
+newrelic.noticeError('bar', { foo: 'bar', baz: 1 });
 
 // setCustomAttribute()
 newrelic.setCustomAttribute('nodeId', '123');
 newrelic.setCustomAttribute('nodeId', 123);
 
 // setErrorHandler()
-newrelic.setErrorHandler((err) => {
+newrelic.setErrorHandler(err => {
     if (err.message !== 'foo') {
         return true;
     } else {
@@ -60,40 +59,53 @@ newrelic.setCurrentRouteName(null);
 // --- NewRelic.BrowserInteraction methods -----------------------------------
 
 // actionText()
-newrelic
-    .interaction()
-    .actionText('Create Subscription');
+newrelic.interaction().actionText('Create Subscription');
 
 // createTracer()
-newrelic
-    .interaction()
-    .createTracer('customSegment', () => { })();
+newrelic.interaction().createTracer('customSegment', () => {})();
 
 // end()
 newrelic.interaction().end();
 
+interface ProductContext {
+    productId: number;
+}
 // getContext(), setAttribute()
 const interaction = newrelic.interaction();
+interaction.getContext<ProductContext>(ctx => {
+    if (ctx.productId) {
+        interaction.setAttribute('productId', ctx.productId);
+    }
+});
+interaction.getContext((ctx: ProductContext) => {
+    if (ctx.productId) {
+        interaction.setAttribute('productId', ctx.productId);
+    }
+});
+
 interaction.getContext(ctx => {
     if (ctx.productId) {
         interaction.setAttribute('productId', ctx.productId);
     }
 });
 
+interface MyAppContext {
+    totalChartLoadTime: number;
+    chartLoadCount: number;
+}
+
 // ignore()
 newrelic.interaction().ignore();
 
 // onEnd(), setAttribute()
-newrelic.interaction().onEnd(ctx => {
-    interaction.setAttribute(
-        'averageChartLoadTime',
-        ctx.totalChartLoadTime / ctx.chartLoadCount
-    );
+newrelic.interaction().onEnd((ctx: MyAppContext) => {
+    interaction.setAttribute('averageChartLoadTime', ctx.totalChartLoadTime / ctx.chartLoadCount);
+});
+
+newrelic.interaction().onEnd<MyAppContext>(ctx => {
+    interaction.setAttribute('averageChartLoadTime', ctx.totalChartLoadTime / ctx.chartLoadCount);
 });
 
 // setName(), setAttribute(), save()
-newrelic.interaction()
-    .setName('loadNextPage')
-    .setAttribute('username', 'userName')
-    .setAttribute('userId', 123)
-    .save();
+newrelic.interaction().setName('loadNextPage').setAttribute('username', 'userName').setAttribute('userId', 123).save();
+newrelic.interaction().setName('createSubscription');


### PR DESCRIPTION
This should fix issues dicussed here:
https://discuss.newrelic.com/t/typescript-for-browser-agent/35942/7

https://discuss.newrelic.com/t/typescript-for-browser-agent/35942/14

- export for global script consumption
- minor changes
- version bump


There is no module here, this is a global script, accessed like e.g.
Google AdWords script. We just expose interface to be consumed as global
script. Just by adding `@types/new-relic-browser`, should fix TS
problesm. Becuase this is non-NPM browser, there is no automatic types
resolution support, so no need to support "import " or "require" to help
with TS problems as well.


Used as (or via tsconfig):

```ts
/// <reference types="new-relic-browser" />
import { Component, OnInit } from '@angular/core';

```ts
ngOnInit(): void {
  newrelic.addToTrace({
    name: 'Event Name',
    start: 1417044274239,
    end: 1417044274252,
    origin: 'Origin of event',
    type: 'What type of event was this',
  });
  newrelic.addToTrace({
    name: 'Event Name',
    start: 1417044274239,
  });
}
```

how to configure via tsconfig:
```json
{
  "extends": "./tsconfig.json",
  "compilerOptions": {
    "outDir": "./out-tsc/app",
    "types": ["new-relic-browser"]
  },
  "files": [
    "src/main.ts",
    "src/polyfills.ts"
  ],
  "include": [
    "src/**/*.d.ts"
  ]
}
```

![image](https://user-images.githubusercontent.com/14539/134394900-d6542822-5f88-462a-adb3-59c6096d59c7.png)

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
