### PR TITLE
[react-native-vector-icons] Change color types to include opaque colors

### DIFF
--- a/types/react-native-vector-icons/Icon.d.ts
+++ b/types/react-native-vector-icons/Icon.d.ts
@@ -30,7 +30,7 @@ export interface IconProps extends TextProps {
    * Color of the icon
    *
    */
-  color?: ColorValue | undefined;
+  color?: ColorValue | number | undefined;
 }
 
 export interface IconButtonProps extends IconProps, TouchableHighlightProps, TouchableNativeFeedbackProps {
@@ -40,7 +40,7 @@ export interface IconButtonProps extends IconProps, TouchableHighlightProps, Tou
    *
    * @default 'white'
    */
-  color?: ColorValue | undefined;
+  color?: ColorValue | number | undefined;
 
   /**
    * Border radius of the button
@@ -70,7 +70,7 @@ export interface IconButtonProps extends IconProps, TouchableHighlightProps, Tou
    *
    * @default '#007AFF'
    */
-  backgroundColor?: ColorValue | undefined;
+  backgroundColor?: ColorValue | number | undefined;
 }
 
 export type ImageSource = any;
@@ -109,7 +109,7 @@ export interface ToolbarAndroidProps extends ReactNativeToolbarAndroidProps {
    *
    * @default 'black'
    */
-  iconColor: string;
+  iconColor: ColorValue | number;
 }
 
 export interface TabBarItemIOSProps extends TabBarIOSItemProps {
@@ -138,7 +138,7 @@ export interface TabBarItemIOSProps extends TabBarIOSItemProps {
    * Color of the icon
    *
    */
-  iconColor?: ColorValue | undefined;
+  iconColor?: ColorValue | number | undefined;
 
   /**
    * Color of the selected icon.
@@ -153,12 +153,12 @@ export class Icon extends React.Component<IconProps, any> {
   static getImageSource(
     name: string,
     size?: number,
-    color?: ColorValue,
+    color?: ColorValue | number,
   ): Promise<ImageSource>;
   static getImageSourceSync(
     name: string,
     size?: number,
-    color?: ColorValue,
+    color?: ColorValue | number,
   ): ImageSource;
   static getRawGlyphMap(): { [name: string]: number };
   static loadFont(

--- a/types/react-native-vector-icons/Icon.d.ts
+++ b/types/react-native-vector-icons/Icon.d.ts
@@ -6,7 +6,8 @@ import {
   TouchableHighlightProps,
   TouchableNativeFeedbackProps,
   TabBarIOSItemProps,
-  ToolbarAndroidProps as ReactNativeToolbarAndroidProps
+  ToolbarAndroidProps as ReactNativeToolbarAndroidProps,
+  ColorValue
 } from 'react-native';
 
 export interface IconProps extends TextProps {
@@ -29,7 +30,7 @@ export interface IconProps extends TextProps {
    * Color of the icon
    *
    */
-  color?: string | undefined;
+  color?: ColorValue | undefined;
 }
 
 export interface IconButtonProps extends IconProps, TouchableHighlightProps, TouchableNativeFeedbackProps {
@@ -39,7 +40,7 @@ export interface IconButtonProps extends IconProps, TouchableHighlightProps, Tou
    *
    * @default 'white'
    */
-  color?: string | undefined;
+  color?: ColorValue | undefined;
 
   /**
    * Border radius of the button
@@ -69,7 +70,7 @@ export interface IconButtonProps extends IconProps, TouchableHighlightProps, Tou
    *
    * @default '#007AFF'
    */
-  backgroundColor?: string | undefined;
+  backgroundColor?: ColorValue | undefined;
 }
 
 export type ImageSource = any;
@@ -137,7 +138,7 @@ export interface TabBarItemIOSProps extends TabBarIOSItemProps {
    * Color of the icon
    *
    */
-  iconColor?: string | undefined;
+  iconColor?: ColorValue | undefined;
 
   /**
    * Color of the selected icon.
@@ -152,12 +153,12 @@ export class Icon extends React.Component<IconProps, any> {
   static getImageSource(
     name: string,
     size?: number,
-    color?: string,
+    color?: ColorValue,
   ): Promise<ImageSource>;
   static getImageSourceSync(
     name: string,
     size?: number,
-    color?: string,
+    color?: ColorValue,
   ): ImageSource;
   static getRawGlyphMap(): { [name: string]: number };
   static loadFont(

--- a/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
+++ b/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
@@ -125,7 +125,7 @@ class OpaqueColorTest extends React.Component {
   }
 
   render() {
-    const opaqueColor = PlatformColor(Platform.OS == "ios" ? "systemBlue" : "?android:attr/colorBackground");
+    const opaqueColor = PlatformColor(Platform.OS === "ios" ? "systemBlue" : "?android:attr/colorBackground");
 
     return (
       <View>

--- a/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
+++ b/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, Text, TabBarIOS } from 'react-native';
+import { View, Text, TabBarIOS, PlatformColor, Platform } from 'react-native';
 import { createIconSet } from 'react-native-vector-icons';
 import AntDesign from 'react-native-vector-icons/AntDesign';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
@@ -114,6 +114,33 @@ class TestCustomIcon extends React.Component {
             Hello CustomIcon!
           </Text>
         </CustomIcon.Button>
+      </View>
+    );
+  }
+}
+
+class OpaqueColorTest extends React.Component {
+  handleButton() {
+    console.log("You pressed me");
+  }
+
+  render() {
+    const opaqueColor = PlatformColor(Platform.OS == "ios" ? "systemBlue" : "?android:attr/colorBackground");
+
+    return (
+      <View>
+        {/* Normal Icon */}
+        <AntDesign size={10} color={opaqueColor} name="user" />
+        <MaterialIcon size={30} color={opaqueColor} name="exit" />
+        <FontAwesome5Icon size={10} color={opaqueColor} name="handshake" />
+        <FontAwesome5Icon size={10} color={opaqueColor} name="handshake" solid />
+        <FontAwesome5ProIcon size={10} color={opaqueColor} name="parachute-box" light={true} solid={false} />
+        <Fontisto color={opaqueColor} size={10} name="fontisto" />
+
+        {/* Icon button  */}
+        <FontAwesomeIcon.Button backgroundColor={opaqueColor} name="facebook" onPress={() => this.handleButton()}>
+          <Text style={{fontFamily: "Arial", fontSize: 15}}>Login with Facebook</Text>
+        </FontAwesomeIcon.Button>
       </View>
     );
   }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/oblador/react-native-vector-icons/pull/574
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.