### PR TITLE
strftime: add `utc` method

### DIFF
--- a/types/strftime/index.d.ts
+++ b/types/strftime/index.d.ts
@@ -22,6 +22,12 @@ declare module "strftime" {
         export function timezone(offset: number | string): strftimeFunction;
 
         /**
+         * Sets the timezone to UTC.
+         * @return {strftimeFunction} A strftime function.
+         */
+        export function utc(): strftimeFunction;
+
+        /**
          * Locale formats.
          * @interface
          */

--- a/types/strftime/strftime-tests.ts
+++ b/types/strftime/strftime-tests.ts
@@ -33,3 +33,6 @@ var strftimePDT = strftime.timezone(-420);
 var strftimeCEST = strftime.timezone(120);
 strftimePDT('%B %d, %y %H:%M:%S', new Date(1307472705067));
 strftimeCEST('%F %T', new Date(1307472705067));
+
+var strftimeUTC = strftime.utc();
+strftimeUTC('%B %d, %y %H:%M:%S', new Date(1307472705067));


### PR DESCRIPTION
strftime 0.9.0 added the new `utc` method for setting the timezone to UTC in <https://github.com/samsonjs/strftime/commit/f36819ad992e0af4e7f2dfee9d8b0d50c47829cc>.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/samsonjs/strftime/commit/f36819ad992e0af4e7f2dfee9d8b0d50c47829cc>.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This method was added in 0.9.0, but there are already 0.9.x versions of `@types/strftime` without it; is the usual procedure in this case to just publish a new patch version even though it doesn't correspond with the version of `strftime` itself? Thank you very much!