### PR TITLE
Skia-Canvas: Add missing maxWidth option

### DIFF
--- a/types/skia-canvas/index.d.ts
+++ b/types/skia-canvas/index.d.ts
@@ -31,7 +31,7 @@ export class CanvasRenderingContext2D extends globalThis.CanvasRenderingContext2
     fontVariant: string;
     textTracking: number;
     textWrap: boolean;
-    measureText(text: string): TextMetrics;
+    measureText(text: string, maxWidth?: number): TextMetrics;
 }
 
 export interface TextMetrics extends globalThis.TextMetrics {


### PR DESCRIPTION
Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: [Docs](https://github.com/samizdatco/skia-canvas/tree/9e223e5252383cce8a98a5d6b1891ebe956d0c7e#measuretextstr-width) and [Code](https://github.com/samizdatco/skia-canvas/blob/9e223e5252383cce8a98a5d6b1891ebe956d0c7e/lib/index.js#L403)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
