### PR TITLE
sinon: add return type to yield-like methods

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -100,27 +100,27 @@ declare namespace Sinon {
          * Useful if a function is called with more than one callback, and simply calling the first callback is not desired.
          * @param pos
          */
-        callArg(pos: number): void;
-        callArgOn(pos: number, obj: any, ...args: any[]): void;
+        callArg(pos: number): unknown[];
+        callArgOn(pos: number, obj: any, ...args: any[]): unknown[];
         /**
          * Like callArg, but with arguments.
          */
-        callArgWith(pos: number, ...args: any[]): void;
-        callArgOnWith(pos: number, obj: any, ...args: any[]): void;
+        callArgWith(pos: number, ...args: any[]): unknown[];
+        callArgOnWith(pos: number, obj: any, ...args: any[]): unknown[];
         /**
          * Invoke callbacks passed to the stub with the given arguments.
          * If the stub was never called with a function argument, yield throws an error.
          * Returns an Array with all callbacks return values in the order they were called, if no error is thrown.
          * Also aliased as invokeCallback.
          */
-        yield(...args: any[]): void;
-        yieldOn(obj: any, ...args: any[]): void;
+        yield(...args: any[]): unknown[];
+        yieldOn(obj: any, ...args: any[]): unknown[];
         /**
          * Invokes callbacks passed as a property of an object to the stub.
          * Like yield, yieldTo grabs the first matching argument, finds the callback and calls it with the (optional) arguments.
          */
-        yieldTo(property: string, ...args: any[]): void;
-        yieldToOn(property: string, obj: any, ...args: any[]): void;
+        yieldTo(property: string, ...args: any[]): unknown[];
+        yieldToOn(property: string, obj: any, ...args: any[]): unknown[];
     }
 
     interface SinonSpyCall<TArgs extends any[] = any[], TReturnValue = any>

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -535,15 +535,15 @@ function testSpy() {
     spy.threw();
     spy.threw("foo");
     spy.threw(new Error("foo"));
-    spy.callArg(1);
-    spy.callArgOn(1, instance);
-    spy.callArgOn(1, instance, "a", 2);
-    spy.callArgWith(1, "a", 2);
-    spy.callArgOnWith(1, instance, "a", 2);
-    spy.yield("a", 2);
-    spy.yieldOn(instance, "a", 2);
-    spy.yieldTo("prop", "a", 2);
-    spy.yieldToOn("prop", instance, "a", 2);
+    spy.callArg(1); // $ExpectType unknown[]
+    spy.callArgOn(1, instance); // $ExpectType unknown[]
+    spy.callArgOn(1, instance, "a", 2); // $ExpectType unknown[]
+    spy.callArgWith(1, "a", 2); // $ExpectType unknown[]
+    spy.callArgOnWith(1, instance, "a", 2); // $ExpectType unknown[]
+    spy.yield("a", 2); // $ExpectType unknown[]
+    spy.yieldOn(instance, "a", 2); // $ExpectType unknown[]
+    spy.yieldTo("prop", "a", 2); // $ExpectType unknown[]
+    spy.yieldToOn("prop", instance, "a", 2); // $ExpectType unknown[]
 
     let call = spy.firstCall;
     call = spy.secondCall;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://sinonjs.org/releases/latest/stubs/#stubyieldarg1-arg2-)

`yield` like methods return an array of callback results.

for example:

```ts
const stub = sinon.stub();

stub(() => 1);
stub(() => 2);

stub.yield(); // [1, 2]
```

has to be unknown since we've no idea what callback types were passed and when.