### PR TITLE
@wordpress/blocks: allow Partial BlockConfiguration as 2nd arg when 1st arg is metadata.

### DIFF
--- a/types/wordpress__blocks/api/registration.d.ts
+++ b/types/wordpress__blocks/api/registration.d.ts
@@ -124,7 +124,7 @@ export function registerBlockStyle(blockName: string, styleVariation: BlockStyle
  */
 export function registerBlockType<TAttributes extends Record<string, any> = {}>(
     metadata: BlockConfiguration<TAttributes>,
-    settings?: BlockConfiguration<TAttributes>,
+    settings?: Partial<BlockConfiguration<TAttributes>>,
 ): Block<TAttributes> | undefined;
 export function registerBlockType<TAttributes extends Record<string, any> = {}>(
     name: string,

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -369,7 +369,7 @@ blocks.registerBlockType<{ foo: string }>('my/foo', {
     category: 'common',
 });
 
-// Register with block.json metadata
+// Register with block.json metadata and no client-side settings.
 // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/
 blocks.registerBlockType({
     apiVersion: 2,
@@ -427,6 +427,67 @@ blocks.registerBlockType({
     editorStyle: 'file:./build/index.css',
     style: 'file:./build/style.css',
 });
+
+// Register with block.json metadata and additional client-side settings.
+blocks.registerBlockType(
+    {
+        apiVersion: 2,
+        name: 'my-plugin/notice',
+        title: 'Notice',
+        category: 'text',
+        parent: ['core/group'],
+        icon: 'star-half',
+        description: 'Shows warning, error or success notices…',
+        keywords: ['alert', 'message'],
+        version: '1.0.3',
+        textdomain: 'my-plugin',
+        attributes: {
+            message: {
+                type: 'string',
+                source: 'html',
+                selector: '.message',
+            },
+        },
+        providesContext: {
+            'my-plugin/message': 'message',
+        },
+        usesContext: ['groupId'],
+        supports: {
+            align: true,
+        },
+        styles: [
+            { name: 'default', label: 'Default', isDefault: true },
+            { name: 'other', label: 'Other' },
+        ],
+        example: {
+            attributes: {
+                message: 'This is a notice!',
+            },
+            innerBlocks: [
+                {
+                    name: 'core/paragraph',
+                    attributes: {
+                        content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis.',
+                    },
+                    innerBlocks: [
+                        {
+                            name: 'core/paragraph',
+                            attributes: {
+                                content:
+                                    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis.',
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        editorScript: 'file:./build/index.js',
+        script: 'file:./build/script.js',
+        editorStyle: 'file:./build/index.css',
+        style: 'file:./build/style.css',
+    },
+    { edit: () => null, save: () => null }
+);
 
 // $ExpectType void
 blocks.setDefaultBlockName('my/foo');


### PR DESCRIPTION
## Description

Follow-up to #55245.

The following should work (as seen in the [official documentation](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#javascript-client-side)), but currently, the 2nd arg is considered invalid:

```ts
import { registerBlockType } from '@wordpress/blocks'
import edit from './edit'

const metadata = {
	apiVersion: 2,
	name: 'foo/bar',
	category: 'widgets',
	attributes: {},
	example: {},
	title: 'Block title',
	textdomain: 'foo',
	script: 'file:./script.js',
	editorScript: 'file:./editor-script.js',
}

registerBlockType(metadata, { edit })
```

The problem is that the 2nd arg, while optional, still requires all the same props if present, whereas with the new signature, it shouldn't require any.

This PR fixes that issue by adding a `Partial` around the 2nd arg in the signature that accepts a metadata object as the first argument.

## Checklists

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#javascript-client-side
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
