### PR TITLE
doctrine: fix `FunctionType` result

### DIFF
--- a/types/doctrine/doctrine-tests.ts
+++ b/types/doctrine/doctrine-tests.ts
@@ -33,3 +33,17 @@ tags.forEach((tag) => {
 });
 
 string = doctrine.unwrapComment(string);
+
+const func: doctrine.type.FunctionType = {
+    type: 'FunctionType',
+    this: {
+        type: 'UndefinedLiteral',
+    },
+    new: {
+        type: 'UndefinedLiteral',
+    },
+    params: [],
+    result: {
+        type: 'UndefinedLiteral',
+    },
+};

--- a/types/doctrine/index.d.ts
+++ b/types/doctrine/index.d.ts
@@ -111,7 +111,7 @@ export module type {
     type: 'FunctionType';
     'this': Type;
     'new': Type, params: Type[];
-    result: Type[]
+    result: Type;
   }
   export interface NameExpression { type: 'NameExpression', name: string }
   export interface NonNullableType {


### PR DESCRIPTION
`doctrine.type.FunctionType`'s `result` property was incorrectly typed as returning an array of `Type`s, when in practice it was returning a single value.

This isn't clearly documented in the doctrine code itself but is visible in a test at <https://github.com/eslint/doctrine/blob/0e8eba7f80b89cc8185541dda4e90c961d1d3553/test/parse.js#L2089-L2095>.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/eslint/doctrine/blob/0e8eba7f80b89cc8185541dda4e90c961d1d3553/test/parse.js#L2089-L2095>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.