### PR TITLE
Fix some hellosign-sdk typings

### DIFF
--- a/types/hellosign-sdk/hellosign-sdk-tests.ts
+++ b/types/hellosign-sdk/hellosign-sdk-tests.ts
@@ -58,18 +58,12 @@ const signatureRequestDownloadable = async (data: EventResponse) => {
 
     const { ...metadata } = data.signature_request.metadata;
 
-    const filePath = await new Promise<string>((resolve, reject) => {
-        hsClient.signatureRequest.download(
-            data.signature_request.signature_request_id,
-            { file_type: 'pdf' },
-            (err, response) => {
-                if (err) reject(err);
-                const file = fs.createWriteStream('TEST');
-                response.pipe(file);
-                resolve('TEST');
-            },
-        );
-    });
+    const fileStream = await hsClient.signatureRequest.download(
+        data.signature_request.signature_request_id,
+        { file_type: 'pdf' },
+    );
+    const file = fs.createWriteStream('TEST');
+    fileStream.pipe(file);
 
     const signatures = data.signature_request.signatures;
     let sigA;

--- a/types/hellosign-sdk/hellosign-sdk-tests.ts
+++ b/types/hellosign-sdk/hellosign-sdk-tests.ts
@@ -58,10 +58,9 @@ const signatureRequestDownloadable = async (data: EventResponse) => {
 
     const { ...metadata } = data.signature_request.metadata;
 
-    const fileStream = await hsClient.signatureRequest.download(
-        data.signature_request.signature_request_id,
-        { file_type: 'pdf' },
-    );
+    const fileStream = await hsClient.signatureRequest.download(data.signature_request.signature_request_id, {
+        file_type: 'pdf',
+    });
     const file = fs.createWriteStream('TEST');
     fileStream.pipe(file);
 
@@ -231,7 +230,7 @@ export const sendSigningRequestWithTemplates = async (pdfFilePath: string) => {
                 role: 'Signer',
             },
         ],
-        template_id: "test template id",
+        template_id: 'test template id',
         metadata,
     });
     const signatures = data.signature_request.signatures;

--- a/types/hellosign-sdk/index.d.ts
+++ b/types/hellosign-sdk/index.d.ts
@@ -251,8 +251,7 @@ declare namespace HelloSign {
                 get_url?: boolean,
                 get_data_uri?: boolean,
             },
-            callback: (err: Error, response: IncomingMessage) => void,
-        ): void;
+        ): Promise<IncomingMessage>;
         cancel(requestId: string): Promise<any>;
         removeAccess(requestId: string): Promise<any>;
         createEmbedded(options: SignatureRequestRequestOptions): Promise<SignatureRequestResponse>;

--- a/types/hellosign-sdk/index.d.ts
+++ b/types/hellosign-sdk/index.d.ts
@@ -180,7 +180,7 @@ declare namespace HelloSign {
     }
     interface SignatureRequestRequestOptions<Metadata = GenericObject> {
         test_mode?: number | undefined;
-        clientId: string;
+        clientId?: string;
         files?: string[] | undefined;
         title?: string | undefined;
         subject?: string | undefined;

--- a/types/hellosign-sdk/index.d.ts
+++ b/types/hellosign-sdk/index.d.ts
@@ -49,17 +49,17 @@ declare namespace HelloSign {
 
     type HelloSignOptions =
         | {
-            key: string;
-        }
+              key: string;
+          }
         | {
-            username: string;
-            password: string;
-        }
+              username: string;
+              password: string;
+          }
         | {
-            key: string;
-            client_id: string;
-            client_secret: string;
-        };
+              key: string;
+              client_id: string;
+              client_secret: string;
+          };
 
     interface BaseAccount {
         account_id: string;
@@ -137,14 +137,16 @@ declare namespace HelloSign {
         details_url: string;
         cc_email_addresses: string | string[];
         signing_redirect_url: string;
-        custom_fields?: Array<{
-            name: string;
-            type: 'text' | 'checkbox';
-            value: string;
-            required: boolean;
-            api_id: string;
-            editor: string;
-        }> | undefined;
+        custom_fields?:
+            | Array<{
+                  name: string;
+                  type: 'text' | 'checkbox';
+                  value: string;
+                  required: boolean;
+                  api_id: string;
+                  editor: string;
+              }>
+            | undefined;
         response_data: Array<{
             api_id: string;
             signature_id: string;
@@ -167,16 +169,17 @@ declare namespace HelloSign {
         signer: number;
         name?: string | undefined;
         validation_type?:
-        | 'numbers_only'
-        | 'letters_only'
-        | 'phone_number'
-        | 'bank_routing_number'
-        | 'bank_account_number'
-        | 'email_address'
-        | 'zip_code'
-        | 'social_security_number'
-        | 'employer_identification_number'
-        | 'custom_regex' | undefined;
+            | 'numbers_only'
+            | 'letters_only'
+            | 'phone_number'
+            | 'bank_routing_number'
+            | 'bank_account_number'
+            | 'email_address'
+            | 'zip_code'
+            | 'social_security_number'
+            | 'employer_identification_number'
+            | 'custom_regex'
+            | undefined;
     }
     interface SignatureRequestRequestOptions<Metadata = GenericObject> {
         test_mode?: number | undefined;
@@ -195,18 +198,22 @@ declare namespace HelloSign {
             pin?: string | undefined;
             sms_phone_number?: string | undefined;
         }>;
-        attachments?: Array<{
-            name?: string | undefined;
-            instructions?: string | undefined;
-            signer_index?: string | undefined;
-            required?: boolean | undefined;
-        }> | undefined;
-        custom_fields?: Array<{
-            name: string;
-            value: string;
-            editor?: string | undefined;
-            required?: boolean | undefined;
-        }> | undefined;
+        attachments?:
+            | Array<{
+                  name?: string | undefined;
+                  instructions?: string | undefined;
+                  signer_index?: string | undefined;
+                  required?: boolean | undefined;
+              }>
+            | undefined;
+        custom_fields?:
+            | Array<{
+                  name: string;
+                  value: string;
+                  editor?: string | undefined;
+                  required?: boolean | undefined;
+              }>
+            | undefined;
         cc_email_addresses?: string[] | undefined;
         use_text_tags?: number | undefined;
         hide_text_tags?: number | undefined;
@@ -214,22 +221,26 @@ declare namespace HelloSign {
         allow_decline?: number | undefined;
         allow_reassign?: number | undefined;
         form_fields_per_document?: FormField[][] | undefined;
-        signing_options?: {
-            draw?: boolean | undefined;
-            type?: boolean | undefined;
-            upload?: boolean | undefined;
-            phone?: boolean | undefined;
-            default: string;
-        } | undefined;
-        field_options?: {
-            date_format:
-            | 'MM / DD / YYYY'
-            | 'MM - DD - YYYY'
-            | 'DD / MM / YYYY'
-            | 'DD - MM - YYYY'
-            | 'YYYY / MM / DD'
-            | 'YYYY - MM - DD';
-        } | undefined;
+        signing_options?:
+            | {
+                  draw?: boolean | undefined;
+                  type?: boolean | undefined;
+                  upload?: boolean | undefined;
+                  phone?: boolean | undefined;
+                  default: string;
+              }
+            | undefined;
+        field_options?:
+            | {
+                  date_format:
+                      | 'MM / DD / YYYY'
+                      | 'MM - DD - YYYY'
+                      | 'DD / MM / YYYY'
+                      | 'DD - MM - YYYY'
+                      | 'YYYY / MM / DD'
+                      | 'YYYY - MM - DD';
+              }
+            | undefined;
     }
     interface SignatureRequestResponse {
         signature_request: SignatureRequest;
@@ -247,9 +258,9 @@ declare namespace HelloSign {
         download(
             requestId: string,
             options: {
-                file_type: string,
-                get_url?: boolean,
-                get_data_uri?: boolean,
+                file_type: string;
+                get_url?: boolean;
+                get_data_uri?: boolean;
             },
         ): Promise<IncomingMessage>;
         cancel(requestId: string): Promise<any>;
@@ -281,10 +292,12 @@ declare namespace HelloSign {
         skip_subject_message?: any;
         force_signer_roles?: any;
         force_subject_message?: any;
-        editor_options?: {
-            allow_edit_signers?: boolean | undefined;
-            allow_edit_documents?: boolean | undefined;
-        } | undefined;
+        editor_options?:
+            | {
+                  allow_edit_signers?: boolean | undefined;
+                  allow_edit_documents?: boolean | undefined;
+              }
+            | undefined;
     }
     interface EmbeddedModule {
         getSignUrl(signatureId: string): Promise<EmbeddedResponse>;
@@ -415,7 +428,7 @@ declare namespace HelloSign {
             is_embedded: boolean;
             can_edit: boolean;
             is_locked: boolean;
-        }> { }
+        }> {}
     interface TemplateResponse {
         template: Template;
     }
@@ -446,23 +459,29 @@ declare namespace HelloSign {
         type: string;
         subject?: string | undefined;
         message?: string | undefined;
-        signers?: Array<{
-            email_address?: string | undefined;
-            name?: string | undefined;
-            order?: number | undefined;
-        }> | undefined;
-        attachments?: Array<{
-            name?: string | undefined;
-            instructions?: string | undefined;
-            signer_index?: string | undefined;
-            required?: boolean | undefined;
-        }> | undefined;
-        custom_fields?: Array<{
-            name: string;
-            value: string;
-            editor?: string | undefined;
-            required?: boolean | undefined;
-        }> | undefined;
+        signers?:
+            | Array<{
+                  email_address?: string | undefined;
+                  name?: string | undefined;
+                  order?: number | undefined;
+              }>
+            | undefined;
+        attachments?:
+            | Array<{
+                  name?: string | undefined;
+                  instructions?: string | undefined;
+                  signer_index?: string | undefined;
+                  required?: boolean | undefined;
+              }>
+            | undefined;
+        custom_fields?:
+            | Array<{
+                  name: string;
+                  value: string;
+                  editor?: string | undefined;
+                  required?: boolean | undefined;
+              }>
+            | undefined;
         cc_email_addresses?: string[] | undefined;
         signing_redirect_url?: string | undefined;
         requesting_redirect_url?: string | undefined;
@@ -472,22 +491,26 @@ declare namespace HelloSign {
         metadata?: GenericObject<Metadata> | undefined;
         allow_decline?: number | undefined;
         form_fields_per_document?: FormField[][] | undefined;
-        signing_options?: {
-            draw?: boolean | undefined;
-            type?: boolean | undefined;
-            upload?: boolean | undefined;
-            phone?: boolean | undefined;
-            default: string;
-        } | undefined;
-        field_options?: {
-            date_format:
-            | 'MM / DD / YYYY'
-            | 'MM - DD - YYYY'
-            | 'DD / MM / YYYY'
-            | 'DD - MM - YYYY'
-            | 'YYYY / MM / DD'
-            | 'YYYY - MM - DD';
-        } | undefined;
+        signing_options?:
+            | {
+                  draw?: boolean | undefined;
+                  type?: boolean | undefined;
+                  upload?: boolean | undefined;
+                  phone?: boolean | undefined;
+                  default: string;
+              }
+            | undefined;
+        field_options?:
+            | {
+                  date_format:
+                      | 'MM / DD / YYYY'
+                      | 'MM - DD - YYYY'
+                      | 'DD / MM / YYYY'
+                      | 'DD - MM - YYYY'
+                      | 'YYYY / MM / DD'
+                      | 'YYYY - MM - DD';
+              }
+            | undefined;
         is_for_embedded_signing?: number | undefined;
     }
     interface UnclaimedDraftModule {
@@ -579,14 +602,18 @@ declare namespace HelloSign {
         domain?: string | undefined;
         callback_url?: string | undefined;
         custom_logo_file?: any;
-        oauth?: {
-            callback_url: string;
-            scopes: string;
-        } | undefined;
+        oauth?:
+            | {
+                  callback_url: string;
+                  scopes: string;
+              }
+            | undefined;
         white_labeling_options?: any[] | undefined;
-        options?: {
-            can_insert_everywhere?: boolean | undefined;
-        } | undefined;
+        options?:
+            | {
+                  can_insert_everywhere?: boolean | undefined;
+              }
+            | undefined;
     }
     interface ApiAppModule {
         get(clientId: string): Promise<ApiAppResponse>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - See that `client_id` is optional in hellosign's api [here](https://app.hellosign.com/api/reference#send_signature_request)
  - I modified the `SignatureRequestModule.download` type as all the other methods of `SignatureRequestModule` are typed with Promise. I think it's better to be consistent
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
