### PR TITLE
update(cypress-dotenv): expicit/implicit configuration support

### DIFF
--- a/types/cypress-dotenv/cypress-dotenv-tests.ts
+++ b/types/cypress-dotenv/cypress-dotenv-tests.ts
@@ -1,15 +1,38 @@
 import dotenvPlugin = require('cypress-dotenv');
 
-dotenvPlugin({});
-
-dotenvPlugin({}, { path: '.env' });
-
-dotenvPlugin({}, { path: '.env' }, false);
+const cypressConfigExample = {
+    baseUrl: 'http://example.com',
+    env: {},
+    viewportWidth: 800,
+    viewportHeight: 600,
+};
 
 interface CypressConfiguration {
     baseUrl: string;
     port: number;
 }
 
-// $ExpectType CypressConfiguration
-dotenvPlugin<CypressConfiguration>({ baseUrl: 'http://example.com', port: 80 }, { path: '.env' }, false);
+dotenvPlugin({});
+
+dotenvPlugin(cypressConfigExample, { path: '.env' });
+
+dotenvPlugin({}, { path: '.env' }, false);
+
+// takes explicit configuration type
+
+// $ExpectType EnhancedConfig<CypressConfiguration>
+let enhancedConfig = dotenvPlugin<CypressConfiguration>(
+    { baseUrl: 'http://example.com', port: 80 },
+    { path: '.env' },
+    false,
+);
+enhancedConfig.baseUrl; // $ExpectType string
+enhancedConfig.port; // $ExpectType number
+enhancedConfig.env?.BASE_URL;
+
+// takes implicit configuration types
+// $ExpectType EnhancedConfig<{ baseUrl: string; port: number; }>
+enhancedConfig = dotenvPlugin({ baseUrl: 'http://example.com', port: 80 }, { path: '.env' });
+enhancedConfig.baseUrl; // $ExpectType string
+enhancedConfig.port; // $ExpectType number
+const url = enhancedConfig.env?.BASE_URL as string;

--- a/types/cypress-dotenv/index.d.ts
+++ b/types/cypress-dotenv/index.d.ts
@@ -1,10 +1,25 @@
-// Type definitions for cypress-dotenv 1.2
+// Type definitions for cypress-dotenv 2.0
 // Project: https://github.com/morficus/cypress-dotenv
 // Definitions by: Daiki Ojima <https://github.com/daikiojm>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 import { DotenvConfigOptions } from 'dotenv';
 
-declare function dotenvPlugin<T = any>(cypressConfig: T, dotEnvConfig?: DotenvConfigOptions, all?: boolean): T;
+// Cypress type
+interface CypressConfig {
+    [key: string]: any;
+}
+
+type EnhancedConfig<T extends CypressConfig> = T & {
+    env?: {
+        [key: string]: unknown;
+    };
+};
+
+declare function dotenvPlugin<T extends CypressConfig>(
+    cypressConfig: T,
+    dotEnvConfig?: DotenvConfigOptions,
+    all?: boolean,
+): EnhancedConfig<T>;
 
 export = dotenvPlugin;


### PR DESCRIPTION
- version 2 bump
- maintainer added
- implicit and explicit type support for Cypress configuration
- return enhanced config based on input and env vars
- `env` as optional to count for eary return

https://github.com/morficus/cypress-dotenv/blob/master/index.js

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x[ Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).