### PR TITLE
add(new-relic-source-map-webpack-plugin): new definition

### DIFF
--- a/types/edx__new-relic-source-map-webpack-plugin/edx__new-relic-source-map-webpack-plugin-tests.ts
+++ b/types/edx__new-relic-source-map-webpack-plugin/edx__new-relic-source-map-webpack-plugin-tests.ts
@@ -1,0 +1,20 @@
+import NewRelicSourceMapPlugin = require('@edx/new-relic-source-map-webpack-plugin');
+import webpack = require('webpack');
+
+const config: webpack.Configuration = {
+    plugins: [
+        new NewRelicSourceMapPlugin({
+            applicationId: 'YOUR NEW RELIC APP ID',
+            apiKey: process.env.NEW_RELIC_ADMIN_KEY!,
+            staticAssetUrl: 'http://examplecdn.com',
+            noop: typeof process.env.NEW_RELIC_ADMIN_KEY === 'undefined',
+            errorCallback: (error: Error) => {},
+            extensionRegex: /\.js$/,
+            releaseId: '12345',
+            releaseName: 'test-release',
+            staticAssetUrlBuilder: (url, publicPath, file) => {
+                return '/computed/path/here';
+            },
+        }),
+    ],
+};

--- a/types/edx__new-relic-source-map-webpack-plugin/index.d.ts
+++ b/types/edx__new-relic-source-map-webpack-plugin/index.d.ts
@@ -1,0 +1,72 @@
+// Type definitions for @edx/new-relic-source-map-webpack-plugin 1.0
+// Project: https://github.com/edx/new-relic-source-map-webpack-plugin#readme
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import webpack = require('webpack');
+
+declare class NewRelicPlugin {
+    constructor(options?: NewRelicPlugin.Options);
+    apply(compiler: webpack.Compiler): void;
+}
+
+declare namespace NewRelicPlugin {
+    interface Options {
+        /**
+         * applicationId
+         * @link {https://docs.newrelic.com/docs/browser/browser-monitoring/configuration/browser-license-key-app-id/}
+         */
+        applicationId: string;
+        /**
+         * API Key
+         * @link {https://docs.newrelic.com/docs/apis/rest-api-v2/requirements/api-keys}
+         */
+        apiKey: string;
+        /**
+         * the domain your production assets are served from.
+         * Written as a complete url.
+         * Example: "examplecdn.com"
+         */
+        staticAssetUrl: string;
+        /**
+         * A function for building the production url your js file is built from.
+         * Will be called for every javascript file with four arguments: staticAssetUrl,
+         * the public path from your webpack config, the filename, and the webpack stats instance.
+         * Defaults to `${removeLastCharIfSlash(url)}${removeLastCharIfSlash(publicPath)}/${file}`
+         */
+        staticAssetUrlBuilder?: StaticAssetUrlBuilder | undefined;
+        /**
+         * a regex used to find js files
+         * @default /\.js$/
+         */
+        extensionRegex?: RegExp | undefined;
+        /**
+         * Control boolean that decides whether or not to run the plugin.
+         * Set to true for builds where you don't want to upload assets to new relic.
+         */
+        noop?: boolean | undefined;
+        /**
+         * unique identifier for the release name
+         */
+        releaseName?: string | null | undefined;
+        /**
+         * unique version for the release identifier
+         */
+        releaseId?: string | null | undefined;
+        /**
+         *  A function for error callback.
+         * Default is: 'console.warn(`New Relic sourcemap upload error: ${err}`)'
+         */
+        errorCallback?: ErrorCallback | undefined;
+    }
+
+    interface StaticAssetUrlBuilder {
+        (url: string, publicPath: 'auto' | string, file: string): string;
+    }
+
+    interface ErrorCallback {
+        (err: Error): void;
+    }
+}
+
+export = NewRelicPlugin;

--- a/types/edx__new-relic-source-map-webpack-plugin/package.json
+++ b/types/edx__new-relic-source-map-webpack-plugin/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "tapable": "^2.2.1",
+        "webpack": "^5.50.0"
+    }
+}

--- a/types/edx__new-relic-source-map-webpack-plugin/tsconfig.json
+++ b/types/edx__new-relic-source-map-webpack-plugin/tsconfig.json
@@ -1,0 +1,34 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths":{
+            "@edx/new-relic-source-map-webpack-plugin": [
+                "edx__new-relic-source-map-webpack-plugin"
+            ],
+            "webpack": [
+                "webpack/v4"
+            ],
+            "tapable": [
+                "tapable/v1"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "edx__new-relic-source-map-webpack-plugin-tests.ts"
+    ]
+}

--- a/types/edx__new-relic-source-map-webpack-plugin/tslint.json
+++ b/types/edx__new-relic-source-map-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
New declaration types:
- https://github.com/edx/new-relic-source-map-webpack-plugin

/cc @adamstankiewicz

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.