### PR TITLE
[@types/prettier] Remove explicit undefined for CursorOptions optional fields

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -214,11 +214,11 @@ export interface Printer<T = any> {
     print(path: AstPath<T>, options: ParserOptions<T>, print: (path: AstPath<T>) => Doc): Doc;
     embed?:
         | ((
-              path: AstPath<T>,
-              print: (path: AstPath<T>) => Doc,
-              textToDoc: (text: string, options: Options) => Doc,
-              options: ParserOptions<T>,
-          ) => Doc | null)
+            path: AstPath<T>,
+            print: (path: AstPath<T>) => Doc,
+            textToDoc: (text: string, options: Options) => Doc,
+            options: ParserOptions<T>,
+        ) => Doc | null)
         | undefined;
     insertPragma?: ((text: string) => string) | undefined;
     /**
@@ -233,34 +233,34 @@ export interface Printer<T = any> {
     printComment?: ((commentPath: AstPath<T>, options: ParserOptions<T>) => Doc) | undefined;
     handleComments?:
         | {
-              ownLine?:
-                  | ((
+            ownLine?:
+                | ((
                         commentNode: any,
                         text: string,
                         options: ParserOptions<T>,
                         ast: T,
                         isLastComment: boolean,
                     ) => boolean)
-                  | undefined;
-              endOfLine?:
-                  | ((
+                | undefined;
+            endOfLine?:
+                | ((
                         commentNode: any,
                         text: string,
                         options: ParserOptions<T>,
                         ast: T,
                         isLastComment: boolean,
                     ) => boolean)
-                  | undefined;
-              remaining?:
-                  | ((
+                | undefined;
+            remaining?:
+                | ((
                         commentNode: any,
                         text: string,
                         options: ParserOptions<T>,
                         ast: T,
                         isLastComment: boolean,
                     ) => boolean)
-                  | undefined;
-          }
+                | undefined;
+        }
         | undefined;
 }
 

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -269,8 +269,8 @@ export interface CursorOptions extends Options {
      * Specify where the cursor is.
      */
     cursorOffset: number;
-    rangeStart?: never | undefined;
-    rangeEnd?: never | undefined;
+    rangeStart?: never;
+    rangeEnd?: never;
 }
 
 export interface CursorResult {

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -214,11 +214,11 @@ export interface Printer<T = any> {
     print(path: AstPath<T>, options: ParserOptions<T>, print: (path: AstPath<T>) => Doc): Doc;
     embed?:
         | ((
-            path: AstPath<T>,
-            print: (path: AstPath<T>) => Doc,
-            textToDoc: (text: string, options: Options) => Doc,
-            options: ParserOptions<T>,
-        ) => Doc | null)
+              path: AstPath<T>,
+              print: (path: AstPath<T>) => Doc,
+              textToDoc: (text: string, options: Options) => Doc,
+              options: ParserOptions<T>,
+          ) => Doc | null)
         | undefined;
     insertPragma?: ((text: string) => string) | undefined;
     /**
@@ -233,34 +233,34 @@ export interface Printer<T = any> {
     printComment?: ((commentPath: AstPath<T>, options: ParserOptions<T>) => Doc) | undefined;
     handleComments?:
         | {
-            ownLine?:
-                | ((
+              ownLine?:
+                  | ((
                         commentNode: any,
                         text: string,
                         options: ParserOptions<T>,
                         ast: T,
                         isLastComment: boolean,
                     ) => boolean)
-                | undefined;
-            endOfLine?:
-                | ((
+                  | undefined;
+              endOfLine?:
+                  | ((
                         commentNode: any,
                         text: string,
                         options: ParserOptions<T>,
                         ast: T,
                         isLastComment: boolean,
                     ) => boolean)
-                | undefined;
-            remaining?:
-                | ((
+                  | undefined;
+              remaining?:
+                  | ((
                         commentNode: any,
                         text: string,
                         options: ParserOptions<T>,
                         ast: T,
                         isLastComment: boolean,
                     ) => boolean)
-                | undefined;
-        }
+                  | undefined;
+          }
         | undefined;
 }
 

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -75,6 +75,10 @@ prettier.clearConfigCache();
 const currentSupportInfo = prettier.getSupportInfo();
 
 prettierStandalone.formatWithCursor(' 1', { cursorOffset: 2, parser: 'babel' });
+// $ExpectError
+prettierStandalone.formatWithCursor(' 1', { cursorOffset: 2, parser: 'babel', rangeStart: 2 });
+// $ExpectError
+prettierStandalone.formatWithCursor(' 1', { cursorOffset: 2, parser: 'babel', rangeEnd: 2 });
 
 prettierStandalone.format(' 1', { parser: 'babel' });
 prettierStandalone.check(' console.log(b)');


### PR DESCRIPTION
For turning on `exactOptionalPropertyTypes` [recommended](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) option [introduced](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#exact-optional-property-types) in TypeScript 4.4, `CursorOptions` interface's `rangeStart` and `rangeEnd` field typings lead to incorrect extension of `Options` interface.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.