### PR TITLE
[node-ipc] fix: add type to IPC.of

### DIFF
--- a/types/node-ipc/index.d.ts
+++ b/types/node-ipc/index.d.ts
@@ -143,10 +143,10 @@ declare namespace NodeIPC {
          */
         serveNet(host: string, port: number, callback?: () => void): void;
         /**
-         * This is where socket connection refrences will be stored when connecting to them as a client via the ipc.connectTo
+         * This is where socket connection references will be stored when connecting to them as a client via the ipc.connectTo
          * or iupc.connectToNet. They will be stored based on the ID used to create them, eg : ipc.of.mySocket
          */
-        of: any;
+        of: Record<string, Client>;
         /**
          * This is a refrence to the server created by ipc.serve or ipc.serveNet
          */


### PR DESCRIPTION
This isn't a new change, the code has been like this for 6+ years. For some reason this field was set as `any` though.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/RIAEvangelist/node-ipc/blob/a2f4c6136201a531bb26f3159d2194cc14244fb9/services/IPC.js#L251
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

