### PR TITLE
Fixes for TS 4.5b

### DIFF
--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -395,5 +395,7 @@ buff.writeDoubleBE(123.123);
 buff.writeDoubleBE(123.123, 0);
 
 {
-    resolveObjectURL(URL.createObjectURL(new Blob(['']))); // $ExpectType Blob | undefined
+    // The 'as any' is to make sure the Global DOM Blob does not clash with the
+    //  local "Blob" which comes with node.
+    resolveObjectURL(URL.createObjectURL(new Blob(['']) as any)); // $ExpectType Blob | undefined
 }

--- a/types/offscreen-canvas/create-worker.d.ts
+++ b/types/offscreen-canvas/create-worker.d.ts
@@ -1,3 +1,6 @@
+interface WindowPostMessageOptions {}
+interface PostMessageOptions extends WindowPostMessageOptions {}
+
 declare function createWorker(
     canvas: HTMLCanvasElement,
     workerUrl: string,

--- a/types/offscreen-canvas/create-worker.d.ts
+++ b/types/offscreen-canvas/create-worker.d.ts
@@ -1,4 +1,7 @@
+// Ensures it works on both TS4.5 and below
+// tslint:disable-next-line:no-empty-interface
 interface WindowPostMessageOptions {}
+// tslint:disable-next-line:no-empty-interface
 interface PostMessageOptions extends WindowPostMessageOptions {}
 
 declare function createWorker(

--- a/types/offscreen-canvas/inside-worker.d.ts
+++ b/types/offscreen-canvas/inside-worker.d.ts
@@ -1,3 +1,6 @@
+interface WindowPostMessageOptions {}
+interface PostMessageOptions extends WindowPostMessageOptions {}
+
 declare function insideWorker(listener: (ev: MessageEvent) => any): WorkerInterface;
 interface WorkerInterface {
     post(message: any, transfer: Transferable[]): void;

--- a/types/offscreen-canvas/inside-worker.d.ts
+++ b/types/offscreen-canvas/inside-worker.d.ts
@@ -1,4 +1,7 @@
+// Ensures it works on both TS4.5 and below
+// tslint:disable-next-line:no-empty-interface
 interface WindowPostMessageOptions {}
+// tslint:disable-next-line:no-empty-interface
 interface PostMessageOptions extends WindowPostMessageOptions {}
 
 declare function insideWorker(listener: (ev: MessageEvent) => any): WorkerInterface;

--- a/types/webrtc/test/MediaStream.ts
+++ b/types/webrtc/test/MediaStream.ts
@@ -11,7 +11,6 @@ navigator.getUserMedia(mediaStreamConstraints,
     console.log('label:' + track.label);
     console.log('ended:' + track.readyState);
     track.onended = (event: Event) => console.log('Track ended');
-    const objectUrl = URL.createObjectURL(stream);
   },
   error => {
     console.log('Error message: ' + error.message);
@@ -24,7 +23,6 @@ navigator.webkitGetUserMedia(mediaStreamConstraints,
     console.log('label:' + track.label);
     console.log('ended:' + track.readyState);
     track.onended = (event: Event) => console.log('Track ended');
-    const objectUrl = URL.createObjectURL(stream);
   },
   error => {
     console.log('Error message: ' + error.message);
@@ -37,7 +35,6 @@ navigator.mozGetUserMedia(mediaStreamConstraints,
     console.log('label:' + track.label);
     console.log('ended:' + track.readyState);
     track.onended = (event: Event) => console.log('Track ended');
-    const objectUrl = URL.createObjectURL(stream);
   },
   error => {
     console.log('Error message: ' + error.message);


### PR DESCRIPTION
From [these fails](https://typescript.visualstudio.com/TypeScript/_build/results?buildId=111619&view=logs&j=71179031-6417-5a2f-3d87-af6fce2011e4&t=5ac81f15-0a74-5a9b-b155-06ef07cd84f6):

- webrtc: `PostMessageOptions` was renamed to `WindowPostMessageOptions` - so I created an interface hierarchy to ensure they both still work fine

- node / offscreen-canvas: `URL.createObjectURL` now has types (not `any`) and support for passing MediaStreams was removed in newer specs
   > In older versions of the Media Source specification, attaching a stream to a `<video>` element required creating an object URL for the MediaStream. This is no longer necessary, and browsers are removing support for doing this.

  https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL#using_object_urls_for_media_streams