### PR TITLE
[react and friends] Update tests that would crash at runtime due to object-like children being passed to host components

### DIFF
--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -3024,7 +3024,7 @@ const ChipExampleSimple = () => (
     <Chip><Avatar size={32} color={blue300} backgroundColor={indigo900}>UI</Avatar> Avatar</Chip>
     <Chip style={styles.chip}>Styled</Chip>
     <Chip containerElement="span">String Container</Chip>
-    <Chip containerElement={() => {}}>ReactNode Container</Chip>
+    <Chip containerElement={<div />}>ReactNode Container</Chip>
   </div>
 );
 

--- a/types/reach__router/reach__router-tests.tsx
+++ b/types/reach__router/reach__router-tests.tsx
@@ -37,7 +37,7 @@ const UseLocationCheck = (props: RouteComponentProps) => {
         <div>
             Pathname: {pathname}
             Search: {search}
-            State: {state}
+            State: {JSON.stringify(state)}
             Hash: {hash}
             key: {key}
         </div>

--- a/types/react-frame-component/react-frame-component-tests.tsx
+++ b/types/react-frame-component/react-frame-component-tests.tsx
@@ -3,7 +3,7 @@ import Frame, { FrameContextConsumer, useFrame } from 'react-frame-component';
 
 function UseFrameHook() {
   const { document, window } = useFrame();
-  return <span>{window?.location}{document?.documentURI}</span>;
+  return <span>{window?.location?.toString()}{document?.documentURI}</span>;
 }
 
 <div>

--- a/types/react-is/test/react-is-tests.tsx
+++ b/types/react-is/test/react-is-tests.tsx
@@ -50,9 +50,9 @@ ReactIs.isValidElementType(MemoComponent);
 const ThemeContext = React.createContext('blue');
 
 ReactIs.isContextConsumer(<ThemeContext.Consumer children={StatelessComponent} />); // true
-ReactIs.isContextProvider(<ThemeContext.Provider children={StatelessComponent} value='black' />); // true
+ReactIs.isContextProvider(<ThemeContext.Provider children={<StatelessComponent />} value='black' />); // true
 ReactIs.typeOf(<ThemeContext.Consumer children={StatelessComponent} />) === ReactIs.ContextConsumer; // true
-ReactIs.typeOf(<ThemeContext.Provider children={StatelessComponent} value='black' />) === ReactIs.ContextProvider; // true
+ReactIs.typeOf(<ThemeContext.Provider children={<StatelessComponent />} value='black' />) === ReactIs.ContextProvider; // true
 
 // Element
 ReactIs.isElement(<div />); // true
@@ -94,5 +94,5 @@ ReactIs.isMemo(MemoComponent); // true
 ReactIs.typeOf(MemoComponent) === ReactIs.Memo; // true
 
 // Suspense
-ReactIs.isForwardRef(<React.Suspense fallback={StatelessComponent} />); // true
-ReactIs.typeOf(<React.Suspense fallback={StatelessComponent} />) === ReactIs.Suspense; // true
+ReactIs.isForwardRef(<React.Suspense fallback={<StatelessComponent />} />); // true
+ReactIs.typeOf(<React.Suspense fallback={<StatelessComponent />} />) === ReactIs.Suspense; // true

--- a/types/react-native/test/stylesheet-flatten.tsx
+++ b/types/react-native/test/stylesheet-flatten.tsx
@@ -10,7 +10,7 @@ export function App(props: Props) {
 
     return (
         <View style={[styles.container, props.style]}>
-            <Text>{backgroundColor}</Text>
+            <Text>{String(backgroundColor)}</Text>
         </View>
     );
 }

--- a/types/react-native/v0.63/test/stylesheet-flatten.tsx
+++ b/types/react-native/v0.63/test/stylesheet-flatten.tsx
@@ -10,7 +10,7 @@ export function App(props: Props) {
 
     return (
         <View style={[styles.container, props.style]}>
-            <Text>{backgroundColor}</Text>
+            <Text>{String(backgroundColor)}</Text>
         </View>
     );
 }

--- a/types/react-native/v0.64/test/stylesheet-flatten.tsx
+++ b/types/react-native/v0.64/test/stylesheet-flatten.tsx
@@ -10,7 +10,7 @@ export function App(props: Props) {
 
     return (
         <View style={[styles.container, props.style]}>
-            <Text>{backgroundColor}</Text>
+            <Text>{String(backgroundColor)}</Text>
         </View>
     );
 }

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -707,7 +707,7 @@ requestSubscription(
 ReactRelayContext.Consumer.prototype;
 ReactRelayContext.Provider.prototype;
 
-const MyRelayContextProvider: React.FunctionComponent = children => {
+const MyRelayContextProvider: React.FunctionComponent = ({children}) => {
     return (
         <ReactRelayContext.Provider
             value={{

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -5,7 +5,7 @@ import { Transition, CSSTransition, TransitionGroup, SwitchTransition, Transitio
 
 interface ContainerProps {
     theme: string;
-    children?: Element[] | undefined;
+    children?: React.ReactElement[] | undefined;
 }
 
 const Container: React.StatelessComponent<ContainerProps> = (props: ContainerProps) => {

--- a/types/react-ultimate-pagination/react-ultimate-pagination-tests.tsx
+++ b/types/react-ultimate-pagination/react-ultimate-pagination-tests.tsx
@@ -42,7 +42,7 @@ function LastPageLink(props: PaginationComponentProps) {
   return <button onClick={props.onClick} disabled={props.isDisabled}>Last</button>;
 }
 
-function Wrapper(props: { children: React.ReactChildren }) {
+function Wrapper(props: { children: React.ReactNode }) {
   return <div>{props.children}</div>;
 }
 

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -878,7 +878,7 @@ const sfc: React.SFC<any> = Memoized2;
 const propsWithChildren: React.PropsWithChildren<Props> = {
     hello: "world",
     foo: 42,
-    children: functionComponent,
+    children: React.createElement(functionComponent),
 };
 
 type UnionProps =

--- a/types/reactour/reactour-tests.tsx
+++ b/types/reactour/reactour-tests.tsx
@@ -152,7 +152,7 @@ class CustomTour extends React.Component<{}, { isTourOpen: boolean }> {
                     CustomHelper={({ current, content, totalSteps, gotoStep, close }: CustomHelperProps) => (
                         <main className="CustomHelper__wrapper">
                             <div className="CustomHelper__content">
-                                {content}
+                                {typeof content !== 'function' && content}
                                 <Controls
                                     data-tour-elem="controls"
                                     className="CustomHelper__controls"

--- a/types/relay-test-utils/relay-test-utils-tests.tsx
+++ b/types/relay-test-utils/relay-test-utils-tests.tsx
@@ -26,7 +26,7 @@ function TestQueryRenderer() {
             environment={environment}
             query={graphql``}
             render={({ error, props }) => {
-                if (error) return <div>{error}</div>;
+                if (error) return <div>{String(error)}</div>;
 
                 if (props) return <TestFragment {...props} />;
 

--- a/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
+++ b/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
@@ -105,7 +105,7 @@ RT.registerFormatType('foo', {
         myFoo: 'data-my-foo',
     },
     edit(props) {
-        return <span data-is-active={props.isActive}>{props.value}</span>;
+        return <span data-is-active={props.isActive}>{props.value.text}</span>;
     },
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Just updates to broken test that were revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026. All affected tests passed object-likes (`{}`) to `children` of host components which would throw at runtime. Due to `ReactNode` including `{}` these runtime crashes aren't caught by the type-checker (yet).