### PR TITLE
[react-native-drawer-layout] `renderNavigation` takes a render callback not ReactNode

### DIFF
--- a/types/react-native-drawer-layout/index.d.ts
+++ b/types/react-native-drawer-layout/index.d.ts
@@ -81,7 +81,7 @@ export interface DrawerLayoutProperties extends ViewProps {
   /**
    * The navigation view that will be rendered to the side of the screen and can be pulled in.
    */
-  renderNavigationView: React.ReactNode;
+  renderNavigationView: () => React.ReactNode;
   /**
    * Make the drawer take the entire screen and draw the background of the status bar to allow it
    * to open over the status bar. It will only have an effect on API 21+.


### PR DESCRIPTION
Revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026
Change is already tested but only works due to `ReactNode` including `{}`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://github.com/rnc-archive/react-native-drawer-layout/blob/v1.3.2/src/DrawerLayout.js#L34
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
