### PR TITLE
[react-svg-inline] `component` accepts an ElementType not ReactNode

### DIFF
--- a/types/react-svg-inline/index.d.ts
+++ b/types/react-svg-inline/index.d.ts
@@ -11,7 +11,7 @@ declare namespace svgInline {
         svg: string;
         className?: string | undefined;
         classSuffix?: string | undefined;
-        component?: React.ReactNode | undefined;
+        component?: React.ElementType | undefined;
         fill?: string | undefined;
         cleanup?: boolean | Array<"title" | "desc" | "comment" | "defs" | "width" | "height" | "fill" | "sketchMSShapeGroup" | "sketchMSPage" | "sketchMSLayerGroup"> | undefined;
         cleanupExceptions?: Array<"title" | "desc" | "comment" | "defs" | "width" | "height" | "fill" | "sketchMSShapeGroup" | "sketchMSPage" | "sketchMSLayerGroup"> | undefined;


### PR DESCRIPTION
Revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026
Change is already tested but only works due to `ReactNode` including `{}`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://github.com/MoOx/react-svg-inline/tree/2.1.1#component
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

