### PR TITLE
[react-portal] Remove usage of deprecated React.Props

### DIFF
--- a/types/react-portal/index.d.ts
+++ b/types/react-portal/index.d.ts
@@ -7,7 +7,7 @@
 
 import * as React from "react";
 
-export interface PortalProps extends React.Props<any> {
+export interface PortalProps {
     children: React.ReactNode;
     node?: Element | null | undefined;
 }
@@ -21,7 +21,7 @@ export interface PortalFunctionParams {
     isOpen: boolean;
 }
 
-export interface PortalWithStateProps extends React.Props<any> {
+export interface PortalWithStateProps {
     children: (params: PortalFunctionParams) => React.ReactNode;
     node?: Element | null | undefined;
     defaultOpen?: boolean | undefined;


### PR DESCRIPTION
Revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026
Change is already tested but only works due to `ReactNode` including `{}`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- ~[ ]~ Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

