### PR TITLE
[react-helmet] toComponent returns an ReactElement instead of ReactComponent

### DIFF
--- a/types/react-helmet-with-visor/index.d.ts
+++ b/types/react-helmet-with-visor/index.d.ts
@@ -70,7 +70,7 @@ export interface HelmetData {
 
 export interface HelmetDatum {
     toString(): string;
-    toComponent(): React.Component<any>;
+    toComponent(): React.ReactElement<any>;
 }
 
 export interface HelmetHTMLBodyDatum {

--- a/types/react-helmet-with-visor/index.d.ts
+++ b/types/react-helmet-with-visor/index.d.ts
@@ -70,7 +70,7 @@ export interface HelmetData {
 
 export interface HelmetDatum {
     toString(): string;
-    toComponent(): React.ReactElement<any>;
+    toComponent(): React.ReactElement;
 }
 
 export interface HelmetHTMLBodyDatum {

--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -91,7 +91,7 @@ export interface HelmetData {
 
 export interface HelmetDatum {
     toString(): string;
-    toComponent(): React.ReactElement<any>;
+    toComponent(): React.ReactElement;
 }
 
 export interface HelmetHTMLBodyDatum {

--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -91,7 +91,7 @@ export interface HelmetData {
 
 export interface HelmetDatum {
     toString(): string;
-    toComponent(): React.Component<any>;
+    toComponent(): React.ReactElement<any>;
 }
 
 export interface HelmetHTMLBodyDatum {

--- a/types/react-helmet/v4/index.d.ts
+++ b/types/react-helmet/v4/index.d.ts
@@ -39,7 +39,7 @@ declare namespace ReactHelmet {
 
     interface HelmetDatum {
         toString(): string;
-        toComponent(): React.ReactElement<any>;
+        toComponent(): React.ReactElement;
     }
 }
 

--- a/types/react-helmet/v4/index.d.ts
+++ b/types/react-helmet/v4/index.d.ts
@@ -39,7 +39,7 @@ declare namespace ReactHelmet {
 
     interface HelmetDatum {
         toString(): string;
-        toComponent(): React.Component<any>;
+        toComponent(): React.ReactElement<any>;
     }
 }
 

--- a/types/react-helmet/v5/index.d.ts
+++ b/types/react-helmet/v5/index.d.ts
@@ -74,7 +74,7 @@ export interface HelmetData {
 
 export interface HelmetDatum {
     toString(): string;
-    toComponent(): React.Component<any>;
+    toComponent(): React.ReactElement<any>;
 }
 
 export interface HelmetHTMLBodyDatum {

--- a/types/react-helmet/v5/index.d.ts
+++ b/types/react-helmet/v5/index.d.ts
@@ -74,7 +74,7 @@ export interface HelmetData {
 
 export interface HelmetDatum {
     toString(): string;
-    toComponent(): React.ReactElement<any>;
+    toComponent(): React.ReactElement;
 }
 
 export interface HelmetHTMLBodyDatum {


### PR DESCRIPTION
Revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026
Change is already tested but only works due to `ReactNode` including `{}`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://github.com/nfl/react-helmet/tree/6.1.0#as-react-components
   - https://github.com/nfl/react-helmet/tree/5.2.0#as-react-components
   - https://github.com/nfl/react-helmet/tree/4.0.0#as-react-components
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

