### PR TITLE
[moxy/next-router-scroll] `withRouterScroll` receives a ComponentType

### DIFF
--- a/types/moxy__next-router-scroll/index.d.ts
+++ b/types/moxy__next-router-scroll/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for @moxy/next-router-scroll 2.2
 // Project: https://github.com/moxystudio/next-router-scroll#readme
-// Definitions by: Lee seung chan <https://github.com/me>
+// Definitions by: Lee seung chan <https://github.com/heozeop>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 export { default as RouterScrollProvider } from './RouterScrollProvider';
 export { default as useRouterScroll } from './use-router-scroll';

--- a/types/moxy__next-router-scroll/with-router-scroll.d.ts
+++ b/types/moxy__next-router-scroll/with-router-scroll.d.ts
@@ -1,4 +1,4 @@
-import { ForwardRefExoticComponent, ReactNode } from 'react';
+import { ForwardRefExoticComponent, ComponentType } from 'react';
 
 export default withRouterScroll;
-declare function withRouterScroll(WrappedComponent: ReactNode): ForwardRefExoticComponent<any>;
+declare function withRouterScroll(WrappedComponent: ComponentType): ForwardRefExoticComponent<any>;


### PR DESCRIPTION
Revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026
Change is already tested but only works due to `ReactNode` including `{}`:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/43f20db5ac423d1875c8c86b2ef633d3b9ba1de9/types/moxy__next-router-scroll/moxy__next-router-scroll-tests.tsx#L47-L53

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://github.com/moxystudio/next-router-scroll/tree/v2.2.0#withrouterscrollcomponent
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
