### PR TITLE
[@mdx-js/react] `components` accepts ComponentType not React nodes

### DIFF
--- a/types/mdx-js__react/index.d.ts
+++ b/types/mdx-js__react/index.d.ts
@@ -118,7 +118,7 @@ interface MDXProviderComponents {
     /**
      * Any other components we wish to define
      */
-    [key: string]: ReactNode;
+    [key: string]: ComponentType<any> | undefined;
 }
 
 type MDXProviderComponentsProp = MDXProviderComponents | ((components: MDXProviderComponents) => MDXProviderComponents);

--- a/types/mdx-js__react/mdx-js__react-tests.tsx
+++ b/types/mdx-js__react/mdx-js__react-tests.tsx
@@ -3,6 +3,7 @@ import { MDXProvider, useMDXComponents, withMDXComponents, InjectedMDXProviderPr
 import { renderToString } from 'react-dom/server';
 
 const H1: FC = props => <h1 style={{ color: 'tomato' }} {...props} />;
+const Time: FC = props => <time style={{ color: '#f0f'}} {...props} />;
 
 renderToString(
     <MDXProvider components={{ h1: H1 }}>
@@ -11,7 +12,7 @@ renderToString(
 );
 
 renderToString(
-    <MDXProvider components={c => ({ ...c, h1: H1 })}>
+    <MDXProvider components={c => ({ ...c, h1: H1, time: Time })}>
         <div />
     </MDXProvider>,
 );


### PR DESCRIPTION
Revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026.
Seems like a mistake that we expect component types for known components but nodes for unknown ones.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://mdxjs.com/advanced/components/#updating-the-mapping-object-during-application-runtime
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

