### PR TITLE
[cavy] Ref callback is called with an instance not the React node

### DIFF
--- a/types/cavy/index.d.ts
+++ b/types/cavy/index.d.ts
@@ -10,9 +10,7 @@ import * as React from 'react';
 // Turn off automatic exporting by exporting {}.
 export {};
 
-type RefCallback = (element: React.ReactNode | null) => void;
-
-type TestHookGeneratorWithRefCallback = (label: string, ref?: RefCallback) => RefCallback;
+type TestHookGeneratorWithRefCallback = (label: string, ref?: React.RefCallback<any>) => React.RefCallback<any>;
 
 type TestHookGeneratorWithRefObject = (label: string, ref?: React.RefObject<any>) => React.RefObject<any>;
 


### PR DESCRIPTION
Revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026
Basically just replaces the custom `RefCallback` with the built-in type from `@types/react`. I doubt the callback actually provided a `ReactNode`. The previous behavior probably only worked because `ReactNode` includes `{}`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

