### PR TITLE
[calidation] Ensure only render props are accepted as children of FormValidation

### DIFF
--- a/types/calidation/index.d.ts
+++ b/types/calidation/index.d.ts
@@ -136,7 +136,7 @@ export interface ValidationProps<T extends object> {
 
 export class Validation<T extends object> extends React.Component<ValidationProps<T>> {}
 
-export interface FormValidationProps<T extends object> extends FormProps<T>, ValidationProps<T> {
+export interface FormValidationProps<T extends object> extends Omit<FormProps<T>, 'children'>, ValidationProps<T> {
     children: (context: ValidationContext<T>) => React.ReactNode;
 }
 


### PR DESCRIPTION
Revealed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026
Unlikely that an intersection of `ReactNode & () => ReactNode` was intended. Previous tests only pass because `ReactNode` includes `{}`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

