### PR TITLE
@ckeditor/ckeditor5-engine: Improvements to downcast/upcast events, TreeWalker

### DIFF
--- a/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
@@ -26,10 +26,22 @@ import {
     ViewDocument,
 } from "@ckeditor/ckeditor5-engine";
 import DowncastDispatcher from "@ckeditor/ckeditor5-engine/src/conversion/downcastdispatcher";
-import DowncastHelpers from "@ckeditor/ckeditor5-engine/src/conversion/downcasthelpers";
+import DowncastHelpers, {
+    clearAttributes,
+    convertCollapsedSelection,
+    convertRangeSelection,
+    insertText,
+    remove,
+    wrap,
+    insertElement,
+    insertUIElement,
+} from "@ckeditor/ckeditor5-engine/src/conversion/downcasthelpers";
 import Mapper from "@ckeditor/ckeditor5-engine/src/conversion/mapper";
 import UpcastDispatcher from "@ckeditor/ckeditor5-engine/src/conversion/upcastdispatcher";
-import UpcastHelpers from "@ckeditor/ckeditor5-engine/src/conversion/upcasthelpers";
+import UpcastHelpers, {
+    convertToModelFragment,
+    convertText,
+} from "@ckeditor/ckeditor5-engine/src/conversion/upcasthelpers";
 import Batch from "@ckeditor/ckeditor5-engine/src/model/batch";
 import DocumentFragment from "@ckeditor/ckeditor5-engine/src/model/documentfragment";
 import { Item } from "@ckeditor/ckeditor5-engine/src/model/item";
@@ -216,7 +228,39 @@ let upcastHelper: UpcastHelpers = conversion.for("upcast");
 upcastHelper = new UpcastHelpers([new UpcastDispatcher()]).add(() => {});
 // $ExpectError
 upcastHelper = new UpcastHelpers([new DowncastDispatcher()]);
-upcastHelper = upcastHelper.add(() => {});
+upcastHelper = upcastHelper.add((dispatcher) => {
+    dispatcher.on("element:p", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "element:p"
+        data; // $ExpectType UpcastConversionData<Element & { name: "p"; }>
+        conversionApi; // $ExpectType UpcastConversionApi
+        const { modelCursor, modelRange, viewItem } = data;
+        modelCursor; // $ExpectType Position
+        modelRange; // $ExpectType Range
+        viewItem; // $ExpectType Element & { name: "p"; }
+    });
+    dispatcher.on("element", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "element"
+        data; // $ExpectType UpcastConversionData<Element>
+        conversionApi; // $ExpectType UpcastConversionApi
+    });
+    dispatcher.on("text", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "text"
+        data; // $ExpectType UpcastConversionData<Text>
+        conversionApi; // $ExpectType UpcastConversionApi
+    });
+    dispatcher.on("documentFragment", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "documentFragment"
+        data; // $ExpectType UpcastConversionData<DocumentFragment>
+        conversionApi; // $ExpectType UpcastConversionApi
+    });
+    dispatcher.on("element", convertToModelFragment());
+    dispatcher.on("element:p", convertToModelFragment());
+    dispatcher.on("documentFragment", convertToModelFragment());
+    dispatcher.on("text", convertText());
+    dispatcher.on("viewCleanup", (evt, data) => {
+        data; // $ExpectType Element | DocumentFragment
+    });
+});
 upcastHelper.attributeToAttribute({
     view: "foo",
     model: "bar",
@@ -230,7 +274,108 @@ upcastHelper.attributeToAttribute({
 let downcastHelper: DowncastHelpers = conversion.for("downcast");
 downcastHelper = conversion.for("dataDowncast");
 downcastHelper = conversion.for("editingDowncast");
-downcastHelper = downcastHelper.add(() => {});
+downcastHelper = downcastHelper.add((dispatcher) => {
+    dispatcher.on("insert:paragraph", (evt, data, { consumable, mapper, writer, dispatcher, schema }) => {
+        evt.name; // $ExpectType "insert:paragraph"
+        data; // $ExpectType { item: Element & { name: "paragraph"; }; range: Range; }
+        schema; // $ExpectType Schema
+        writer; // $ExpectType DowncastWriter
+        dispatcher; // $ExpectType DowncastDispatcher<{}>
+        mapper; // $ExpectType Mapper
+        consumable; // ExpectType ModelConsumable
+
+        const viewElement = mapper.toViewElement(data.item);
+        if (viewElement) {
+            writer.addClass("img-class", viewElement);
+        }
+    });
+    dispatcher.on(
+        "insert:myElem",
+        insertElement((modelItem, { writer }) => {
+            modelItem; // $ExpectType Element
+            const text = writer.createText("myText");
+            return writer.createAttributeElement("myElem", { myAttr: "my-" + modelItem.getAttribute("myAttr") });
+        }),
+    );
+    dispatcher.on("insert:$text", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "insert:$text"
+        data; // $ExpectType { item: TextProxy; range: Range; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("insert:$text", insertText());
+    dispatcher.on("insert", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "insert"
+        data; // $ExpectType { item: TextProxy | Element; range: Range; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("attribute:bold", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "attribute:bold"
+        // $ExpectType { item: Element; range: Range; attributeKey: "bold"; attributeOldValue: any; attributeNewValue: any; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("attribute:bold", wrap((modelAttributeValue, conversionApi) => {
+        modelAttributeValue; // $ExpectType any
+        conversionApi; // $ExpectType DowncastConversionApi<any>
+        const { writer } = conversionApi;
+        return writer.createAttributeElement("strong");
+    }));
+    dispatcher.on("attribute:bold:$text", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "attribute:bold:$text"
+        // $ExpectType { item: DocumentSelection | TextProxy; range: Range; attributeKey: "bold"; attributeOldValue: any; attributeNewValue: any; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("attribute", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "attribute"
+        // $ExpectType { item: Element; range: Range; attributeKey: string; attributeOldValue: any; attributeNewValue: any; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("selection", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "selection"
+        data; // $ExpectType { selection: Selection; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("selection", clearAttributes());
+    dispatcher.on("selection", convertRangeSelection());
+    dispatcher.on("selection", convertCollapsedSelection());
+    dispatcher.on("remove", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "remove"
+        data; // $ExpectType { position: Position; length: number; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("remove", remove());
+    dispatcher.on("removeMarker:mention", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "removeMarker:mention"
+        data; // $ExpectType { markerName: "mention"; markerRange: Range; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("removeMarker", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "removeMarker"
+        data; // $ExpectType { markerName: string; markerRange: Range; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("addMarker:mention", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "addMarker:mention"
+        // $ExpectType { item?: Selection | undefined; range?: Range | undefined; markerName: "mention"; markerRange: Range; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on(
+        "addMarker:mention",
+        insertUIElement((data, { writer }) => {
+            const name = `${data.markerName}:${data.isOpening ? "start" : "end"}`;
+            return writer.createUIElement(name);
+        }),
+    );
+    dispatcher.on("addMarker", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "addMarker"
+        // $ExpectType { item?: Selection | undefined; range?: Range | undefined; markerName: string; markerRange: Range; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+});
 downcastHelper.attributeToAttribute({
     model: "foo",
     view: "bar",

--- a/types/ckeditor__ckeditor5-engine/src/conversion/conversion.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/conversion.d.ts
@@ -7,9 +7,9 @@ import UpcastDispatcher from "./upcastdispatcher";
 import UpcastHelpers from "./upcasthelpers";
 
 export interface ConverterDefinition {
-    converterPriority: PriorityString;
+    converterPriority?: PriorityString;
     model: any;
-    upcastAlso: MatcherPattern | MatcherPattern[];
+    upcastAlso?: MatcherPattern | MatcherPattern[];
     view: ElementDefinition | Record<string, any>;
 }
 
@@ -28,5 +28,5 @@ export default class Conversion {
     elementToElement(definition: ConverterDefinition): void;
     for(groupName: 'dataDowncast' | 'editingDowncast' | 'downcast'): DowncastHelpers;
     for(groupName: 'upcast'): UpcastHelpers;
-    for(groupName: string): DowncastHelpers | UpcastHelpers;
+    for(groupName: 'upcast' | 'downcast' | 'dataDowncast' | 'editingDowncast'): UpcastHelpers | DowncastHelpers;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/conversionhelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/conversionhelpers.d.ts
@@ -5,5 +5,5 @@ import UpcastHelpers from "./upcasthelpers";
 
 export default abstract class ConversionHelpers<T extends DowncastHelpers | UpcastHelpers> {
     constructor(dispatchers: T extends DowncastHelpers ? DowncastDispatcher[] : UpcastDispatcher[]);
-    add(conversionHelper: (...args: any[]) => any): T;
+    add(conversionHelper: (dispatcher: T extends DowncastHelpers ? DowncastDispatcher : UpcastDispatcher) => void): this;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
@@ -5,6 +5,8 @@ import Position from "../model/position";
 import Range from "../model/range";
 import Schema from "../model/schema";
 import Selection from "../model/selection";
+import TextProxy from "../model/textproxy";
+import DocumentSelection from "../model/documentselection";
 import DowncastWriter from "../view/downcastwriter";
 import Mapper from "./mapper";
 import ModelConsumable from "../conversion/modelconsumable";
@@ -12,6 +14,83 @@ import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/sr
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import DomEventData from "../view/observer/domeventdata";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+
+export interface DowncastEventDataTypes {
+    attribute: {
+        item: Element;
+        range: Range;
+        attributeKey: string;
+        attributeOldValue: any;
+        attributeNewValue: any;
+    };
+    remove: {
+        position: Position;
+        length: number;
+    };
+    insert: {
+        item: Element | TextProxy;
+        range: Range;
+    };
+    selection: {
+        selection: Selection;
+    };
+    removeMarker: {
+        markerName: string;
+        markerRange: Range;
+    };
+    addMarker: {
+        item?: Selection;
+        range?: Range;
+        markerName: string;
+        markerRange: Range;
+    };
+}
+
+export type DowncastEventArgs<K extends string, T = {}> = K extends keyof DowncastEventDataTypes
+    ? [DowncastEventDataTypes[K], DowncastConversionApi<T>]
+    : K extends `attribute:${infer N}:$text`
+    ? [
+          {
+              item: DocumentSelection | TextProxy;
+              range: Range;
+              attributeKey: N;
+              attributeOldValue: any;
+              attributeNewValue: any;
+          },
+          DowncastConversionApi<T>,
+      ]
+    : K extends `attribute:${infer N}`
+    ? [
+          {
+              item: Element;
+              range: Range;
+              attributeKey: N;
+              attributeOldValue: any;
+              attributeNewValue: any;
+          },
+          DowncastConversionApi<T>,
+      ]
+    : K extends "insert:$text"
+    ? [{ item: TextProxy; range: Range }, DowncastConversionApi<T>]
+    : K extends `insert:${infer N}`
+    ? [{ item: Element & { name: N }; range: Range }, DowncastConversionApi<T>]
+    : K extends `removeMarker:${infer N}`
+    ? [{ markerName: N; markerRange: Range }, DowncastConversionApi<T>]
+    : K extends `addMarker:${infer N}`
+    ? [
+          {
+              item?: Selection;
+              range?: Range;
+              markerName: N;
+              markerRange: Range;
+          },
+          DowncastConversionApi<T>,
+      ]
+    : K extends `${infer NS}:${string}`
+    ? NS extends keyof DowncastEventDataTypes
+        ? [DowncastEventDataTypes[NS], DowncastConversionApi<T>]
+        : any[]
+    : any[];
 
 export interface DowncastConversionApi<T = any> {
     consumable: ModelConsumable;
@@ -22,9 +101,14 @@ export interface DowncastConversionApi<T = any> {
     writer: DowncastWriter;
 }
 
-export default class DowncastDispatcher<T = {}> implements Emitter {
-    conversionApi: DowncastConversionApi<T>;
+export type DowncastDispatcherCallback<N extends string = string, T = {}, S extends Emitter = Emitter> = (
+    info: EventInfo<S, N>,
+    ...args: DowncastEventArgs<N, T>
+) => void;
+
+export default class DowncastDispatcher<T = {}> {
     constructor(conversionApi: Partial<DowncastConversionApi<T>>);
+    conversionApi: DowncastConversionApi<T>;
     convertAttribute(range: Range, key: string, oldValue: any, newValue: any, writer: DowncastWriter): void;
     convertChanges(differ: Differ, markers: MarkerCollection, writer: DowncastWriter): void;
     convertInsert(range: Range, writer: DowncastWriter): void;
@@ -34,25 +118,30 @@ export default class DowncastDispatcher<T = {}> implements Emitter {
     convertSelection(selection: Selection, markers: MarkerCollection, writer: DowncastWriter): void;
     reconvertElement(element: Element, writer: DowncastWriter): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: DowncastDispatcherCallback<N, T>,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: DowncastDispatcherCallback<N, T>,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: DowncastDispatcherCallback<N, T>): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: DowncastDispatcherCallback<N, T, S>,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: DowncastDispatcherCallback<N, T, S>,
+    ): void;
+    fire<N extends string>(eventOrInfo: N | EventInfo, ...args: DowncastEventArgs<N, T>): any;
+
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/downcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/downcasthelpers.d.ts
@@ -1,10 +1,15 @@
 import AttributeElement from "../view/attributeelement";
 import DowncastWriter from "../view/downcastwriter";
 import ConversionHelpers from "./conversionhelpers";
-import { DowncastConversionApi } from "./downcastdispatcher";
+import DowncastDispatcher, {
+    DowncastConversionApi,
+    DowncastDispatcherCallback,
+    DowncastEventDataTypes,
+} from "./downcastdispatcher";
 import { ElementDefinition } from "../view/elementdefinition";
-import Element from "../model/element";
+import ModelElement from "../model/element";
 import ContainerElement from "../view/containerelement";
+import Element from "../view/element";
 import UIElement from "../view/uielement";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
@@ -15,17 +20,33 @@ export interface HighlightDescriptor {
     priority?: number | undefined;
 }
 
-export function clearAttributes(): (...arg: any[]) => any;
-export function convertCollapsedSelection(): (...arg: any[]) => any;
-export function convertRangeSelection(): (...arg: any[]) => any;
+export function clearAttributes(): DowncastDispatcherCallback<"selection">;
+export function convertCollapsedSelection(): DowncastDispatcherCallback<"selection">;
+export function convertRangeSelection(): DowncastDispatcherCallback<"selection">;
 export function createViewElementFromHighlightDescriptor(
     writer: DowncastWriter,
     descriptor: HighlightDescriptor,
 ): AttributeElement;
-export function insertText(): (...arg: any[]) => any;
-export function remove(): (...arg: any[]) => any;
+export function insertText(): DowncastDispatcherCallback<"insert:$text">;
+export function remove(): DowncastDispatcherCallback<"remove">;
+export function wrap(
+    elementCreator: (modelAttributeValue: any, conversionApi: DowncastConversionApi) => Element | void | null,
+): DowncastDispatcherCallback<`attribute:${string}:$text` | `attribute:${string}`>;
+export function insertElement(
+    elementCreator: (modelItem: ModelElement, conversionApi: DowncastConversionApi) => Element | void | null,
+): DowncastDispatcherCallback<"insert" | `insert:${string}`>;
+export function insertUIElement(
+    elementOrElementCreator:
+        | UIElement
+        | ((
+              data: DowncastEventDataTypes["addMarker"] & { isOpening: boolean },
+              conversionApi: DowncastConversionApi,
+          ) => UIElement | void | null),
+): DowncastDispatcherCallback<"addMarker" | `addMarker:${string}`>;
 
 export default class DowncastHelpers extends ConversionHelpers<DowncastHelpers> {
+    add(conversionHelper: (dispatcher: DowncastDispatcher) => void): this;
+
     attributeToAttribute(config?: {
         model: string | { key: string; values: string[]; name?: string | undefined };
         view:
@@ -38,32 +59,32 @@ export default class DowncastHelpers extends ConversionHelpers<DowncastHelpers> 
                   value: string | string[] | Record<string, string>;
               });
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
     attributeToElement(config?: {
         model: string | { key: string; values: string[]; name?: string | undefined };
         view: string | ElementDefinition | ((value: string, api: DowncastConversionApi) => AttributeElement);
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
     elementToElement(config?: {
         model: string;
         view: ElementDefinition | ((element: Element, api: DowncastConversionApi) => ContainerElement);
         triggerBy?: { attributes: string[]; children: string[] } | undefined;
-    }): DowncastHelpers;
+    }): this;
     markerToData(config?: {
         model: string;
         view?: ((markerName: string, api: DowncastConversionApi) => { group: string; name: string }) | undefined;
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
     markerToElement(config?: {
         model: string;
         view:
             | ElementDefinition
             | ((data: { [key: string]: any; isOpening: boolean }, api: DowncastConversionApi) => UIElement);
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
     markerToHighlight(config?: {
         model: string;
         view: HighlightDescriptor | ((data: any, api: DowncastConversionApi) => HighlightDescriptor);
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/modelconsumable.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/modelconsumable.d.ts
@@ -1,10 +1,11 @@
+import DocumentSelection from "../model/documentselection";
 import { Item } from "../model/item";
 import Range from "../model/range";
 import Selection from "../model/selection";
 
 export default class ModelConsumable {
-    add(item: Item | Selection | Range, type: string): void;
-    consume(item: Item | Selection | Range, type: string): boolean;
-    revert(item: Item | Selection | Range, type: string): null | boolean;
-    test(item: Item | Selection | Range, type: string): null | boolean;
+    add(item: Item | Selection | DocumentSelection | Range, type: string): void;
+    consume(item: Item | Selection | DocumentSelection | Range, type: string): boolean;
+    revert(item: Item | Selection | DocumentSelection | Range, type: string): null | boolean;
+    test(item: Item | Selection | DocumentSelection | Range, type: string): null | boolean;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
@@ -2,19 +2,23 @@ import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/sr
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Element from "../model/element";
+import ViewText from "../view/text";
+import ViewElement from "../view/element";
+import ViewDocumentFragment from "../view/documentfragment";
 import Node from "../model/node";
 import Position from "../model/position";
 import Range from "../model/range";
 import Schema, { SchemaContextDefinition } from "../model/schema";
 import Writer from "../model/writer";
-import { Item } from "../view/item";
-import DomEventData from "../view/observer/domeventdata";
+import { Item } from "../model/item";
 import ViewConsumable from "./viewconsumable";
 
-export interface UpcastConversionData {
+export type ViewItem = ViewElement | ViewText | ViewDocumentFragment;
+
+export interface UpcastConversionData<T extends ViewItem = ViewItem> {
     modelCursor: Position;
     modelRange: Range;
-    viewItem: Item;
+    viewItem: T;
 }
 
 export interface UpcastConversionApi {
@@ -24,14 +28,14 @@ export interface UpcastConversionApi {
     writer: Writer;
 
     convertChildren(
-        viewItem: Item,
+        viewItem: ViewItem,
         positionOrElement: Position | Element,
     ): {
         modelRange: Range;
         modelCursor: Position;
     };
     convertItem(
-        viewItem: Item,
+        viewItem: ViewItem,
         modelCursor: Position,
     ): {
         modelRange: Range;
@@ -46,33 +50,60 @@ export interface UpcastConversionApi {
         position: Position;
         cursorParent: Element;
     };
-    updateConversionResult(element: Element, data: UpcastConversionData, conversionApi: UpcastConversionApi): void;
+    updateConversionResult(element: Element, data: UpcastConversionData): void;
 }
 
-export default class UpcastDispatcher implements Emitter {
-    conversionApi: UpcastConversionApi;
-    constructor(conversionApi?: Partial<UpcastConversionApi>);
-    convert(viewItem: Item, writer: Writer, context?: SchemaContextDefinition): DocumentFragment;
+export interface UpcastEventDataTypes {
+    element: UpcastConversionData<ViewElement>;
+    text: UpcastConversionData<ViewText>;
+    documentFragment: UpcastConversionData<ViewDocumentFragment>;
+}
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+export type UpcastEventArgs<K extends string = string> = K extends keyof UpcastEventDataTypes
+    ? [UpcastEventDataTypes[K], UpcastConversionApi]
+    : K extends "viewCleanup"
+    ? [ViewDocumentFragment | ViewElement]
+    : K extends `element:${infer N}`
+    ? [UpcastConversionData<ViewElement & { name: N; }>, UpcastConversionApi]
+    : K extends `${infer NS}:${string}`
+    ? NS extends keyof UpcastEventDataTypes
+        ? [UpcastEventDataTypes[NS], UpcastConversionApi]
+        : any[]
+    : any[];
+
+export type UpcastDispatcherCallback<N extends string, S extends Emitter = Emitter> = (
+    info: EventInfo<S, N>,
+    ...args: UpcastEventArgs<N>
+) => void;
+
+export default class UpcastDispatcher {
+    constructor(conversionApi?: Partial<UpcastConversionApi>);
+    conversionApi: UpcastConversionApi;
+    convert(viewItem: ViewItem, writer: Writer, context?: SchemaContextDefinition): ViewDocumentFragment;
+
+    on<N extends string>(
+        event: N,
+        callback: UpcastDispatcherCallback<N>,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: UpcastDispatcherCallback<N>,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: UpcastDispatcherCallback<N>): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: UpcastDispatcherCallback<N, S>,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: UpcastDispatcherCallback<N, S>,
+    ): void;
+    fire<N extends string>(eventOrInfo: N | EventInfo, ...args: UpcastEventArgs<N>): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
@@ -2,7 +2,7 @@ import Element from "../view/element";
 import ModelElement from "../model/element";
 import { MatcherPattern } from "../view/matcher";
 import ConversionHelpers from "./conversionhelpers";
-import { UpcastConversionApi } from "./upcastdispatcher";
+import { UpcastConversionApi, UpcastDispatcherCallback } from "./upcastdispatcher";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
 export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
@@ -12,28 +12,57 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
             | {
                   key: string;
                   name?: string | undefined;
-                  value?: RegExp | string | ((value: any) => boolean) | { styles: Record<string, string | RegExp> } | undefined;
+                  value?:
+                      | RegExp
+                      | string
+                      | ((value: any) => boolean)
+                      | { styles: Record<string, string | RegExp> }
+                      | undefined;
+              }
+            | { name: string; styles: Record<string, string | RegExp> };
+
+        model:
+            | string
+            | { key: string; value: string | ((el: Element, api: UpcastConversionApi) => string) }
+            | {
+                  key: "srcset";
+                  value:
+                      | {
+                            data: string | undefined;
+                            width?: string;
+                        }
+                      | ((
+                            el: Element,
+                            api: UpcastConversionApi,
+                        ) => {
+                            data: string | undefined;
+                            width?: string;
+                        });
               };
 
-        model: string | { key: string; value: string | ((el: Element, api: UpcastConversionApi) => string) };
-
         converterPriority?: PriorityString | number | undefined;
-    }): UpcastHelpers;
+    }): this;
     dataToMarker(config?: {
         view: string;
         model?: ((name: string, api: UpcastConversionApi) => string) | undefined;
         converterPriority?: PriorityString | number | undefined;
-    }): UpcastHelpers;
+    }): this;
     elementToAttribute(config?: {
         view: MatcherPattern;
         model:
             | string
             | { key: string; value: string | ((viewElement: Element, api: UpcastConversionApi) => string | null) };
         converterPriority?: PriorityString | number | undefined;
-    }): UpcastHelpers;
+    }): this;
     elementToElement(config?: {
         view?: MatcherPattern | undefined;
-        model: string | ModelElement | ((el: Element, api: UpcastConversionApi) => ModelElement);
+        model: string | ModelElement | ((el: Element, api: UpcastConversionApi) => ModelElement | null);
         converterPriority?: PriorityString | number | undefined;
-    }): UpcastHelpers;
+    }): this;
 }
+
+export function convertToModelFragment(): UpcastDispatcherCallback<
+    "element" | `element:${string}` | "documentFragment"
+>;
+
+export function convertText(): UpcastDispatcherCallback<"text">;

--- a/types/ckeditor__ckeditor5-engine/src/model/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/range.d.ts
@@ -9,10 +9,12 @@ import { Marker } from "./markercollection";
 import Node from "./node";
 import RootElement from "./rootelement";
 import Position from "./position";
-import TreeWalker, { TreeWalkerDirection, TreeWalkerValue } from "./treewalker";
+import TreeWalker, { TreeWalkerValue, TreeWalkerOptions } from "./treewalker";
 import Selection from "./selection";
 import Text from "./text";
 import Operation from "./operation/operation";
+
+export type RangeTreeWalkerOptions = Partial<Omit<TreeWalkerOptions, "boundaries">>;
 
 export default class Range implements Iterable<TreeWalkerValue> {
     readonly end: Position;
@@ -31,32 +33,13 @@ export default class Range implements Iterable<TreeWalkerValue> {
     getContainedElement(): Element | null;
     getDifference(otherRange: Range): Range[];
     getIntersection(otherRange: Range): Range | null;
-    getItems(options?: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
-        startPosition: Position;
-    }): Generator<Item>;
+    getItems(options?: RangeTreeWalkerOptions): Generator<Item>;
     getJoined(otherRange: Range, loose?: boolean): Range | null;
     getMinimalFlatRanges(): Range[];
-    getPositions(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
-        startPosition: Position;
-    }): Generator<Position>;
+    getPositions(options?: RangeTreeWalkerOptions): Generator<Position>;
     getTransformedByOperation(operation: Operation): Range[];
     getTransformedByOperations(operations: Iterable<Operation>): Range[];
-    getWalker(options?: {
-        startPosition?: Position | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
-    }): TreeWalker;
+    getWalker(options?: RangeTreeWalkerOptions): TreeWalker;
     is(type: "position" | "model:position"): this is Position | LivePosition;
     is(type: "livePosition" | "model:livePosition"): this is LivePosition;
     is(type: "range" | "model:range"): this is Range | LiveRange;

--- a/types/ckeditor__ckeditor5-engine/src/model/treewalker.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/treewalker.d.ts
@@ -1,18 +1,45 @@
-import { Item } from "./item";
+import Element from "./element";
 import Position from "./position";
 import Range from "./range";
+import TextProxy from "./textproxy";
 
 export type TreeWalkerValueType = "elementStart" | "elementEnd" | "character" | "text";
 
-export interface TreeWalkerValue {
-    item: Item;
-    length: number;
-    nextPosition: Position;
-    previousPosition: Position;
-    type: TreeWalkerValueType;
-}
+export type TreeWalkerValue =
+    | {
+          item: TextProxy;
+          length: number;
+          nextPosition: Position;
+          previousPosition: Position;
+          type: "character" | "text";
+      }
+    | {
+          item: Element;
+          length: number;
+          nextPosition: Position;
+          previousPosition: Position;
+          type: "elementStart" | "elementEnd";
+      };
 
 export type TreeWalkerDirection = "forward" | "backward";
+
+export type TreeWalkerOptions =
+    | {
+          boundaries: Range;
+          direction?: TreeWalkerDirection | undefined;
+          ignoreElementEnd?: boolean | undefined;
+          shallow?: boolean | undefined;
+          singleCharacters?: boolean | undefined;
+          startPosition?: Position | undefined;
+      }
+    | {
+          boundaries?: Range | undefined;
+          direction?: TreeWalkerDirection | undefined;
+          ignoreElementEnd?: boolean | undefined;
+          shallow?: boolean | undefined;
+          singleCharacters?: boolean | undefined;
+          startPosition: Position;
+      };
 
 export default class TreeWalker implements Iterable<TreeWalkerValue> {
     readonly boundaries: Range;
@@ -22,14 +49,7 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
     readonly shallow: boolean;
     readonly singleCharacters: boolean;
 
-    constructor(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
-        startPosition: Position;
-    });
+    constructor(options: TreeWalkerOptions);
     [Symbol.iterator](): Iterator<TreeWalkerValue>;
     skip(skip: (value: TreeWalkerValue) => boolean): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/writer.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/writer.d.ts
@@ -83,8 +83,15 @@ export default class Writer {
     removeSelectionAttribute(keyOrIterableOfKeys: string | string[]): void;
     rename(element: Element, newName: string): void;
     restoreSelectionGravity(uid: string): void;
-    setAttribute(key: string, value: string | number | boolean, itemOrRange: Item | Range): void;
-    setAttributes(attributes: Record<string, string | number | boolean>, itemOrRange: Item | Range): void;
+    setAttribute(
+        key: string,
+        value: string | number | boolean | Record<string, string | number | boolean>,
+        itemOrRange: Item | Range,
+    ): void;
+    setAttributes(
+        attributes: Record<string, string | number | boolean | Record<string, string | number | boolean>>,
+        itemOrRange: Item | Range,
+    ): void;
     setSelection(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",

--- a/types/ckeditor__ckeditor5-engine/src/view/element.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/element.d.ts
@@ -1,6 +1,7 @@
 import Document from "./document";
 import Node from "./node";
 import StylesMap from "./stylesmap";
+import { Item } from "./item";
 
 export default abstract class Element extends Node {
     readonly childCount: number;
@@ -17,13 +18,16 @@ export default abstract class Element extends Node {
 
     findAncestor(
         patterns:
+            | ((
+                  element: Element,
+              ) => boolean)
             | string
             | RegExp
             | {
                   attributes?: Record<string, string | RegExp | boolean> | undefined;
                   classes?: string | RegExp | Array<string | RegExp> | undefined;
                   name?: string | RegExp | undefined;
-                  styles: Record<string, string>;
+                  styles?: Record<string, string>;
               },
     ): Element | null;
     getAttribute(key: string): string | undefined;

--- a/types/ckeditor__ckeditor5-engine/src/view/matcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/matcher.d.ts
@@ -26,7 +26,7 @@ export default class Matcher {
 }
 
 export type MatcherPattern =
-    | ((element: Element) => void | {
+    | ((element: Element) => void | null | {
           name?: boolean | undefined;
           attribute?: string[] | undefined;
           classes?: string[] | undefined;

--- a/types/ckeditor__ckeditor5-engine/src/view/observer/domeventobserver.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/observer/domeventobserver.d.ts
@@ -4,6 +4,5 @@ export default abstract class DomEventObserver extends Observer {
     readonly domEventType: string | string[];
     useCapture: boolean;
 
-    fire(eventType: string, domEvent: Event, additionalData?: any): void;
     abstract onDomEvent(event: UIEvent | ClipboardEvent): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/observer/observer.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/observer/observer.d.ts
@@ -1,5 +1,9 @@
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Document from "../document";
 import View from "../view";
+import DomEventData from "./domeventdata";
 
 export default abstract class Observer {
     readonly document: Document;
@@ -12,4 +16,37 @@ export default abstract class Observer {
     disable(): void;
     enable(): void;
     observe(domElement: HTMLElement, name?: string): void;
+
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S | Node | Window,
+        event: N,
+        callback: (info: EventInfo<S, N>, domEvt: Event, ...rest: any[]) => void,
+        options?: {
+            useCapture?: boolean | undefined;
+            usePassive?: boolean | undefined;
+            priority?: number | PriorityString | undefined;
+        },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: Node | Window | S,
+        event?: N,
+        callback?: (info: EventInfo<S, N>, data: Event, ...rest: any[]) => void,
+    ): void;
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<Emitter, N>, domEvt: Event, ...rest: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<Emitter, N>, domEvt: Event, ...rest: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(
+        event: N,
+        callback?: (info: EventInfo<Emitter, N>, domEvt: Event, ...rest: any[]) => void,
+    ): void;
+    fire<N extends string>(eventOrInfo: N | EventInfo<Emitter, N>, domEvt: Event, ...rest: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/treewalker.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/treewalker.d.ts
@@ -1,16 +1,25 @@
+import Element from "./element";
 import Position from "./position";
-import { Item } from "./item";
 import Range from "./range";
+import TextProxy from "./textproxy";
 
 export type TreeWalkerValueType = "elementStart" | "elementEnd" | "text";
 
-export interface TreeWalkerValue {
-    item: Item;
-    length: number | undefined;
-    nextPosition: Position;
-    previousPosition: Position;
-    type: TreeWalkerValueType;
-}
+export type TreeWalkerValue =
+    | {
+          item: TextProxy;
+          length: number;
+          nextPosition: Position;
+          previousPosition: Position;
+          type: "text";
+      }
+    | {
+          item: Element;
+          length: number;
+          nextPosition: Position;
+          previousPosition: Position;
+          type: "elementStart" | "elementEnd";
+      };
 
 export type TreeWalkerDirection = "forward" | "backward";
 

--- a/types/ckeditor__ckeditor5-engine/v27/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/ckeditor__ckeditor5-engine-tests.ts
@@ -26,10 +26,22 @@ import {
     ViewDocument,
 } from "@ckeditor/ckeditor5-engine";
 import DowncastDispatcher from "@ckeditor/ckeditor5-engine/src/conversion/downcastdispatcher";
-import DowncastHelpers from "@ckeditor/ckeditor5-engine/src/conversion/downcasthelpers";
+import DowncastHelpers, {
+    clearAttributes,
+    convertCollapsedSelection,
+    convertRangeSelection,
+    insertText,
+    remove,
+    wrap,
+    insertElement,
+    insertUIElement,
+} from "@ckeditor/ckeditor5-engine/src/conversion/downcasthelpers";
 import Mapper from "@ckeditor/ckeditor5-engine/src/conversion/mapper";
 import UpcastDispatcher from "@ckeditor/ckeditor5-engine/src/conversion/upcastdispatcher";
-import UpcastHelpers from "@ckeditor/ckeditor5-engine/src/conversion/upcasthelpers";
+import UpcastHelpers, {
+    convertToModelFragment,
+    convertText,
+} from "@ckeditor/ckeditor5-engine/src/conversion/upcasthelpers";
 import Batch from "@ckeditor/ckeditor5-engine/src/model/batch";
 import DocumentFragment from "@ckeditor/ckeditor5-engine/src/model/documentfragment";
 import { Item } from "@ckeditor/ckeditor5-engine/src/model/item";
@@ -216,7 +228,39 @@ let upcastHelper: UpcastHelpers = conversion.for("upcast");
 upcastHelper = new UpcastHelpers([new UpcastDispatcher()]).add(() => {});
 // $ExpectError
 upcastHelper = new UpcastHelpers([new DowncastDispatcher()]);
-upcastHelper = upcastHelper.add(() => {});
+upcastHelper = upcastHelper.add((dispatcher) => {
+    dispatcher.on("element:p", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "element:p"
+        data; // $ExpectType UpcastConversionData<Element & { name: "p"; }>
+        conversionApi; // $ExpectType UpcastConversionApi
+        const { modelCursor, modelRange, viewItem } = data;
+        modelCursor; // $ExpectType Position
+        modelRange; // $ExpectType Range
+        viewItem; // $ExpectType Element & { name: "p"; }
+    });
+    dispatcher.on("element", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "element"
+        data; // $ExpectType UpcastConversionData<Element>
+        conversionApi; // $ExpectType UpcastConversionApi
+    });
+    dispatcher.on("text", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "text"
+        data; // $ExpectType UpcastConversionData<Text>
+        conversionApi; // $ExpectType UpcastConversionApi
+    });
+    dispatcher.on("documentFragment", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "documentFragment"
+        data; // $ExpectType UpcastConversionData<DocumentFragment>
+        conversionApi; // $ExpectType UpcastConversionApi
+    });
+    dispatcher.on("element", convertToModelFragment());
+    dispatcher.on("element:p", convertToModelFragment());
+    dispatcher.on("documentFragment", convertToModelFragment());
+    dispatcher.on("text", convertText());
+    dispatcher.on("viewCleanup", (evt, data) => {
+        data; // $ExpectType Element | DocumentFragment
+    });
+});
 upcastHelper.attributeToAttribute({
     view: "foo",
     model: "bar",
@@ -230,7 +274,108 @@ upcastHelper.attributeToAttribute({
 let downcastHelper: DowncastHelpers = conversion.for("downcast");
 downcastHelper = conversion.for("dataDowncast");
 downcastHelper = conversion.for("editingDowncast");
-downcastHelper = downcastHelper.add(() => {});
+downcastHelper = downcastHelper.add((dispatcher) => {
+    dispatcher.on("insert:paragraph", (evt, data, { consumable, mapper, writer, dispatcher, schema }) => {
+        evt.name; // $ExpectType "insert:paragraph"
+        data; // $ExpectType { item: Element & { name: "paragraph"; }; range: Range; }
+        schema; // $ExpectType Schema
+        writer; // $ExpectType DowncastWriter
+        dispatcher; // $ExpectType DowncastDispatcher<{}>
+        mapper; // $ExpectType Mapper
+        consumable; // ExpectType ModelConsumable
+
+        const viewElement = mapper.toViewElement(data.item);
+        if (viewElement) {
+            writer.addClass("img-class", viewElement);
+        }
+    });
+    dispatcher.on(
+        "insert:myElem",
+        insertElement((modelItem, { writer }) => {
+            modelItem; // $ExpectType Element
+            const text = writer.createText("myText");
+            return writer.createAttributeElement("myElem", { myAttr: "my-" + modelItem.getAttribute("myAttr") });
+        }),
+    );
+    dispatcher.on("insert:$text", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "insert:$text"
+        data; // $ExpectType { item: TextProxy; range: Range; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("insert:$text", insertText());
+    dispatcher.on("insert", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "insert"
+        data; // $ExpectType { item: TextProxy | Element; range: Range; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("attribute:bold", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "attribute:bold"
+        // $ExpectType { item: Element; range: Range; attributeKey: "bold"; attributeOldValue: any; attributeNewValue: any; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("attribute:bold", wrap((modelAttributeValue, conversionApi) => {
+        modelAttributeValue; // $ExpectType any
+        conversionApi; // $ExpectType DowncastConversionApi<any>
+        const { writer } = conversionApi;
+        return writer.createAttributeElement("strong");
+    }));
+    dispatcher.on("attribute:bold:$text", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "attribute:bold:$text"
+        // $ExpectType { item: DocumentSelection | TextProxy; range: Range; attributeKey: "bold"; attributeOldValue: any; attributeNewValue: any; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("attribute", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "attribute"
+        // $ExpectType { item: Element; range: Range; attributeKey: string; attributeOldValue: any; attributeNewValue: any; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("selection", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "selection"
+        data; // $ExpectType { selection: Selection; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("selection", clearAttributes());
+    dispatcher.on("selection", convertRangeSelection());
+    dispatcher.on("selection", convertCollapsedSelection());
+    dispatcher.on("remove", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "remove"
+        data; // $ExpectType { position: Position; length: number; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("remove", remove());
+    dispatcher.on("removeMarker:mention", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "removeMarker:mention"
+        data; // $ExpectType { markerName: "mention"; markerRange: Range; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("removeMarker", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "removeMarker"
+        data; // $ExpectType { markerName: string; markerRange: Range; }
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on("addMarker:mention", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "addMarker:mention"
+        // $ExpectType { item?: Selection | undefined; range?: Range | undefined; markerName: "mention"; markerRange: Range; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+    dispatcher.on(
+        "addMarker:mention",
+        insertUIElement((data, { writer }) => {
+            const name = `${data.markerName}:${data.isOpening ? "start" : "end"}`;
+            return writer.createUIElement(name);
+        }),
+    );
+    dispatcher.on("addMarker", (evt, data, conversionApi) => {
+        evt.name; // $ExpectType "addMarker"
+        // $ExpectType { item?: Selection | undefined; range?: Range | undefined; markerName: string; markerRange: Range; }
+        data;
+        conversionApi; // $ExpectType DowncastConversionApi<{}>
+    });
+});
 downcastHelper.attributeToAttribute({
     model: "foo",
     view: "bar",

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/conversion.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/conversion.d.ts
@@ -7,9 +7,9 @@ import UpcastDispatcher from "./upcastdispatcher";
 import UpcastHelpers from "./upcasthelpers";
 
 export interface ConverterDefinition {
-    converterPriority: PriorityString;
+    converterPriority?: PriorityString;
     model: any;
-    upcastAlso: MatcherPattern | MatcherPattern[];
+    upcastAlso?: MatcherPattern | MatcherPattern[];
     view: ElementDefinition | Record<string, any>;
 }
 
@@ -28,7 +28,7 @@ export default class Conversion {
     }): void;
     attributeToElement(definition: ConverterDefinition): void;
     elementToElement(definition: ConverterDefinition): void;
-    for(groupName: "dataDowncast" | "editingDowncast" | "downcast"): DowncastHelpers;
-    for(groupName: "upcast"): UpcastHelpers;
-    for(groupName: string): DowncastHelpers | UpcastHelpers;
+    for(groupName: 'dataDowncast' | 'editingDowncast' | 'downcast'): DowncastHelpers;
+    for(groupName: 'upcast'): UpcastHelpers;
+    for(groupName: 'upcast' | 'downcast' | 'dataDowncast' | 'editingDowncast'): UpcastHelpers | DowncastHelpers;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/conversionhelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/conversionhelpers.d.ts
@@ -5,5 +5,5 @@ import UpcastHelpers from "./upcasthelpers";
 
 export default abstract class ConversionHelpers<T extends DowncastHelpers | UpcastHelpers> {
     constructor(dispatchers: T extends DowncastHelpers ? DowncastDispatcher[] : UpcastDispatcher[]);
-    add(conversionHelper: (...args: any[]) => any): T;
+    add(conversionHelper: (dispatcher: T extends DowncastHelpers ? DowncastDispatcher : UpcastDispatcher) => void): this;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcastdispatcher.d.ts
@@ -5,6 +5,8 @@ import Position from "../model/position";
 import Range from "../model/range";
 import Schema from "../model/schema";
 import Selection from "../model/selection";
+import TextProxy from "../model/textproxy";
+import DocumentSelection from "../model/documentselection";
 import DowncastWriter from "../view/downcastwriter";
 import Mapper from "./mapper";
 import ModelConsumable from "../conversion/modelconsumable";
@@ -12,6 +14,83 @@ import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/sr
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import DomEventData from "../view/observer/domeventdata";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
+
+export interface DowncastEventDataTypes {
+    attribute: {
+        item: Element;
+        range: Range;
+        attributeKey: string;
+        attributeOldValue: any;
+        attributeNewValue: any;
+    };
+    remove: {
+        position: Position;
+        length: number;
+    };
+    insert: {
+        item: Element | TextProxy;
+        range: Range;
+    };
+    selection: {
+        selection: Selection;
+    };
+    removeMarker: {
+        markerName: string;
+        markerRange: Range;
+    };
+    addMarker: {
+        item?: Selection;
+        range?: Range;
+        markerName: string;
+        markerRange: Range;
+    };
+}
+
+export type DowncastEventArgs<K extends string, T = {}> = K extends keyof DowncastEventDataTypes
+    ? [DowncastEventDataTypes[K], DowncastConversionApi<T>]
+    : K extends `attribute:${infer N}:$text`
+    ? [
+          {
+              item: DocumentSelection | TextProxy;
+              range: Range;
+              attributeKey: N;
+              attributeOldValue: any;
+              attributeNewValue: any;
+          },
+          DowncastConversionApi<T>,
+      ]
+    : K extends `attribute:${infer N}`
+    ? [
+          {
+              item: Element;
+              range: Range;
+              attributeKey: N;
+              attributeOldValue: any;
+              attributeNewValue: any;
+          },
+          DowncastConversionApi<T>,
+      ]
+    : K extends "insert:$text"
+    ? [{ item: TextProxy; range: Range }, DowncastConversionApi<T>]
+    : K extends `insert:${infer N}`
+    ? [{ item: Element & { name: N }; range: Range }, DowncastConversionApi<T>]
+    : K extends `removeMarker:${infer N}`
+    ? [{ markerName: N; markerRange: Range }, DowncastConversionApi<T>]
+    : K extends `addMarker:${infer N}`
+    ? [
+          {
+              item?: Selection;
+              range?: Range;
+              markerName: N;
+              markerRange: Range;
+          },
+          DowncastConversionApi<T>,
+      ]
+    : K extends `${infer NS}:${string}`
+    ? NS extends keyof DowncastEventDataTypes
+        ? [DowncastEventDataTypes[NS], DowncastConversionApi<T>]
+        : any[]
+    : any[];
 
 export interface DowncastConversionApi<T = any> {
     consumable: ModelConsumable;
@@ -22,9 +101,14 @@ export interface DowncastConversionApi<T = any> {
     writer: DowncastWriter;
 }
 
-export default class DowncastDispatcher<T = {}> implements Emitter {
-    conversionApi: DowncastConversionApi<T>;
+export type DowncastDispatcherCallback<N extends string = string, T = {}, S extends Emitter = Emitter> = (
+    info: EventInfo<S, N>,
+    ...args: DowncastEventArgs<N, T>
+) => void;
+
+export default class DowncastDispatcher<T = {}> {
     constructor(conversionApi: Partial<DowncastConversionApi<T>>);
+    conversionApi: DowncastConversionApi<T>;
     convertAttribute(range: Range, key: string, oldValue: any, newValue: any, writer: DowncastWriter): void;
     convertChanges(differ: Differ, markers: MarkerCollection, writer: DowncastWriter): void;
     convertInsert(range: Range, writer: DowncastWriter): void;
@@ -34,25 +118,30 @@ export default class DowncastDispatcher<T = {}> implements Emitter {
     convertSelection(selection: Selection, markers: MarkerCollection, writer: DowncastWriter): void;
     reconvertElement(element: Element, writer: DowncastWriter): void;
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+    on<N extends string>(
+        event: N,
+        callback: DowncastDispatcherCallback<N, T>,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: DowncastDispatcherCallback<N, T>,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: DowncastDispatcherCallback<N, T>): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: DowncastDispatcherCallback<N, T, S>,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: DowncastDispatcherCallback<N, T, S>,
+    ): void;
+    fire<N extends string>(eventOrInfo: N | EventInfo, ...args: DowncastEventArgs<N, T>): any;
+
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/downcasthelpers.d.ts
@@ -1,10 +1,15 @@
 import AttributeElement from "../view/attributeelement";
 import DowncastWriter from "../view/downcastwriter";
 import ConversionHelpers from "./conversionhelpers";
-import { DowncastConversionApi } from "./downcastdispatcher";
+import DowncastDispatcher, {
+    DowncastConversionApi,
+    DowncastDispatcherCallback,
+    DowncastEventDataTypes,
+} from "./downcastdispatcher";
 import { ElementDefinition } from "../view/elementdefinition";
-import Element from "../model/element";
+import ModelElement from "../model/element";
 import ContainerElement from "../view/containerelement";
+import Element from "../view/element";
 import UIElement from "../view/uielement";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
@@ -15,17 +20,33 @@ export interface HighlightDescriptor {
     priority?: number | undefined;
 }
 
-export function clearAttributes(): (...arg: any[]) => any;
-export function convertCollapsedSelection(): (...arg: any[]) => any;
-export function convertRangeSelection(): (...arg: any[]) => any;
+export function clearAttributes(): DowncastDispatcherCallback<"selection">;
+export function convertCollapsedSelection(): DowncastDispatcherCallback<"selection">;
+export function convertRangeSelection(): DowncastDispatcherCallback<"selection">;
 export function createViewElementFromHighlightDescriptor(
     writer: DowncastWriter,
     descriptor: HighlightDescriptor,
 ): AttributeElement;
-export function insertText(): (...arg: any[]) => any;
-export function remove(): (...arg: any[]) => any;
+export function insertText(): DowncastDispatcherCallback<"insert:$text">;
+export function remove(): DowncastDispatcherCallback<"remove">;
+export function wrap(
+    elementCreator: (modelAttributeValue: any, conversionApi: DowncastConversionApi) => Element | void | null,
+): DowncastDispatcherCallback<`attribute:${string}:$text` | `attribute:${string}`>;
+export function insertElement(
+    elementCreator: (modelItem: ModelElement, conversionApi: DowncastConversionApi) => Element | void | null,
+): DowncastDispatcherCallback<"insert" | `insert:${string}`>;
+export function insertUIElement(
+    elementOrElementCreator:
+        | UIElement
+        | ((
+              data: DowncastEventDataTypes["addMarker"] & { isOpening: boolean },
+              conversionApi: DowncastConversionApi,
+          ) => UIElement | void | null),
+): DowncastDispatcherCallback<"addMarker" | `addMarker:${string}`>;
 
 export default class DowncastHelpers extends ConversionHelpers<DowncastHelpers> {
+    add(conversionHelper: (dispatcher: DowncastDispatcher) => void): this;
+
     attributeToAttribute(config?: {
         model: string | { key: string; values: string[]; name?: string | undefined };
         view:
@@ -38,32 +59,32 @@ export default class DowncastHelpers extends ConversionHelpers<DowncastHelpers> 
                   value: string | string[] | Record<string, string>;
               });
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
     attributeToElement(config?: {
         model: string | { key: string; values: string[]; name?: string | undefined };
         view: string | ElementDefinition | ((value: string, api: DowncastConversionApi) => AttributeElement);
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
     elementToElement(config?: {
         model: string;
         view: ElementDefinition | ((element: Element, api: DowncastConversionApi) => ContainerElement);
         triggerBy?: { attributes: string[]; children: string[] } | undefined;
-    }): DowncastHelpers;
+    }): this;
     markerToData(config?: {
         model: string;
         view?: ((markerName: string, api: DowncastConversionApi) => { group: string; name: string }) | undefined;
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
     markerToElement(config?: {
         model: string;
         view:
             | ElementDefinition
             | ((data: { [key: string]: any; isOpening: boolean }, api: DowncastConversionApi) => UIElement);
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
     markerToHighlight(config?: {
         model: string;
         view: HighlightDescriptor | ((data: any, api: DowncastConversionApi) => HighlightDescriptor);
         converterPriority?: PriorityString | number | undefined;
-    }): DowncastHelpers;
+    }): this;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/modelconsumable.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/modelconsumable.d.ts
@@ -1,10 +1,11 @@
+import DocumentSelection from "../model/documentselection";
 import { Item } from "../model/item";
 import Range from "../model/range";
 import Selection from "../model/selection";
 
 export default class ModelConsumable {
-    add(item: Item | Selection | Range, type: string): void;
-    consume(item: Item | Selection | Range, type: string): boolean;
-    revert(item: Item | Selection | Range, type: string): null | boolean;
-    test(item: Item | Selection | Range, type: string): null | boolean;
+    add(item: Item | Selection | DocumentSelection | Range, type: string): void;
+    consume(item: Item | Selection | DocumentSelection | Range, type: string): boolean;
+    revert(item: Item | Selection | DocumentSelection | Range, type: string): null | boolean;
+    test(item: Item | Selection | DocumentSelection | Range, type: string): null | boolean;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcastdispatcher.d.ts
@@ -2,19 +2,23 @@ import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/sr
 import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Element from "../model/element";
+import ViewText from "../view/text";
+import ViewElement from "../view/element";
+import ViewDocumentFragment from "../view/documentfragment";
 import Node from "../model/node";
 import Position from "../model/position";
 import Range from "../model/range";
 import Schema, { SchemaContextDefinition } from "../model/schema";
 import Writer from "../model/writer";
-import { Item } from "../view/item";
-import DomEventData from "../view/observer/domeventdata";
+import { Item } from "../model/item";
 import ViewConsumable from "./viewconsumable";
 
-export interface UpcastConversionData {
+export type ViewItem = ViewElement | ViewText | ViewDocumentFragment;
+
+export interface UpcastConversionData<T extends ViewItem = ViewItem> {
     modelCursor: Position;
     modelRange: Range;
-    viewItem: Item;
+    viewItem: T;
 }
 
 export interface UpcastConversionApi {
@@ -24,14 +28,14 @@ export interface UpcastConversionApi {
     writer: Writer;
 
     convertChildren(
-        viewItem: Item,
+        viewItem: ViewItem,
         positionOrElement: Position | Element,
     ): {
         modelRange: Range;
         modelCursor: Position;
     };
     convertItem(
-        viewItem: Item,
+        viewItem: ViewItem,
         modelCursor: Position,
     ): {
         modelRange: Range;
@@ -46,33 +50,60 @@ export interface UpcastConversionApi {
         position: Position;
         cursorParent: Element;
     };
-    updateConversionResult(element: Element, data: UpcastConversionData, conversionApi: UpcastConversionApi): void;
+    updateConversionResult(element: Element, data: UpcastConversionData): void;
 }
 
-export default class UpcastDispatcher implements Emitter {
-    conversionApi: UpcastConversionApi;
-    constructor(conversionApi?: Partial<UpcastConversionApi>);
-    convert(viewItem: Item, writer: Writer, context?: SchemaContextDefinition): DocumentFragment;
+export interface UpcastEventDataTypes {
+    element: UpcastConversionData<ViewElement>;
+    text: UpcastConversionData<ViewText>;
+    documentFragment: UpcastConversionData<ViewDocumentFragment>;
+}
 
-    on: (
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
-    ) => void;
-    once(
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority: PriorityString | number },
+export type UpcastEventArgs<K extends string = string> = K extends keyof UpcastEventDataTypes
+    ? [UpcastEventDataTypes[K], UpcastConversionApi]
+    : K extends "viewCleanup"
+    ? [ViewDocumentFragment | ViewElement]
+    : K extends `element:${infer N}`
+    ? [UpcastConversionData<ViewElement & { name: N; }>, UpcastConversionApi]
+    : K extends `${infer NS}:${string}`
+    ? NS extends keyof UpcastEventDataTypes
+        ? [UpcastEventDataTypes[NS], UpcastConversionApi]
+        : any[]
+    : any[];
+
+export type UpcastDispatcherCallback<N extends string, S extends Emitter = Emitter> = (
+    info: EventInfo<S, N>,
+    ...args: UpcastEventArgs<N>
+) => void;
+
+export default class UpcastDispatcher {
+    constructor(conversionApi?: Partial<UpcastConversionApi>);
+    conversionApi: UpcastConversionApi;
+    convert(viewItem: ViewItem, writer: Writer, context?: SchemaContextDefinition): ViewDocumentFragment;
+
+    on<N extends string>(
+        event: N,
+        callback: UpcastDispatcherCallback<N>,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    off(event: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    listenTo(
-        emitter: Emitter,
-        event: string,
-        callback: (info: EventInfo, data: DomEventData) => void,
-        options?: { priority?: PriorityString | number | undefined },
+    once<N extends string>(
+        event: N,
+        callback: UpcastDispatcherCallback<N>,
+        options?: { priority?: number | PriorityString | undefined },
     ): void;
-    stopListening(emitter?: Emitter, event?: string, callback?: (info: EventInfo, data: DomEventData) => void): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): any;
+    off<N extends string>(event: N, callback?: UpcastDispatcherCallback<N>): void;
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S,
+        event: N,
+        callback: UpcastDispatcherCallback<N, S>,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: S,
+        event?: N,
+        callback?: UpcastDispatcherCallback<N, S>,
+    ): void;
+    fire<N extends string>(eventOrInfo: N | EventInfo, ...args: UpcastEventArgs<N>): any;
     delegate(...events: string[]): EmitterMixinDelegateChain;
     stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/conversion/upcasthelpers.d.ts
@@ -2,7 +2,7 @@ import Element from "../view/element";
 import ModelElement from "../model/element";
 import { MatcherPattern } from "../view/matcher";
 import ConversionHelpers from "./conversionhelpers";
-import { UpcastConversionApi } from "./upcastdispatcher";
+import { UpcastConversionApi, UpcastDispatcherCallback } from "./upcastdispatcher";
 import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 
 export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
@@ -12,28 +12,57 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
             | {
                   key: string;
                   name?: string | undefined;
-                  value?: RegExp | string | ((value: any) => boolean) | { styles: Record<string, string | RegExp> } | undefined;
+                  value?:
+                      | RegExp
+                      | string
+                      | ((value: any) => boolean)
+                      | { styles: Record<string, string | RegExp> }
+                      | undefined;
+              }
+            | { name: string; styles: Record<string, string | RegExp> };
+
+        model:
+            | string
+            | { key: string; value: string | ((el: Element, api: UpcastConversionApi) => string) }
+            | {
+                  key: "srcset";
+                  value:
+                      | {
+                            data: string | undefined;
+                            width?: string;
+                        }
+                      | ((
+                            el: Element,
+                            api: UpcastConversionApi,
+                        ) => {
+                            data: string | undefined;
+                            width?: string;
+                        });
               };
 
-        model: string | { key: string; value: string | ((el: Element, api: UpcastConversionApi) => string) };
-
         converterPriority?: PriorityString | number | undefined;
-    }): UpcastHelpers;
+    }): this;
     dataToMarker(config?: {
         view: string;
         model?: ((name: string, api: UpcastConversionApi) => string) | undefined;
         converterPriority?: PriorityString | number | undefined;
-    }): UpcastHelpers;
+    }): this;
     elementToAttribute(config?: {
         view: MatcherPattern;
         model:
             | string
             | { key: string; value: string | ((viewElement: Element, api: UpcastConversionApi) => string | null) };
         converterPriority?: PriorityString | number | undefined;
-    }): UpcastHelpers;
+    }): this;
     elementToElement(config?: {
         view?: MatcherPattern | undefined;
-        model: string | ModelElement | ((el: Element, api: UpcastConversionApi) => ModelElement);
+        model: string | ModelElement | ((el: Element, api: UpcastConversionApi) => ModelElement | null);
         converterPriority?: PriorityString | number | undefined;
-    }): UpcastHelpers;
+    }): this;
 }
+
+export function convertToModelFragment(): UpcastDispatcherCallback<
+    "element" | `element:${string}` | "documentFragment"
+>;
+
+export function convertText(): UpcastDispatcherCallback<"text">;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/range.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/range.d.ts
@@ -9,10 +9,12 @@ import { Marker } from "./markercollection";
 import Node from "./node";
 import RootElement from "./rootelement";
 import Position from "./position";
-import TreeWalker, { TreeWalkerDirection, TreeWalkerValue } from "./treewalker";
+import TreeWalker, { TreeWalkerValue, TreeWalkerOptions } from "./treewalker";
 import Selection from "./selection";
 import Text from "./text";
 import Operation from "./operation/operation";
+
+export type RangeTreeWalkerOptions = Partial<Omit<TreeWalkerOptions, "boundaries">>;
 
 export default class Range implements Iterable<TreeWalkerValue> {
     readonly end: Position;
@@ -31,32 +33,13 @@ export default class Range implements Iterable<TreeWalkerValue> {
     getContainedElement(): Element | null;
     getDifference(otherRange: Range): Range[];
     getIntersection(otherRange: Range): Range | null;
-    getItems(options?: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
-        startPosition: Position;
-    }): Generator<Item>;
+    getItems(options?: RangeTreeWalkerOptions): Generator<Item>;
     getJoined(otherRange: Range, loose?: boolean): Range | null;
     getMinimalFlatRanges(): Range[];
-    getPositions(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
-        startPosition: Position;
-    }): Generator<Position>;
+    getPositions(options?: RangeTreeWalkerOptions): Generator<Position>;
     getTransformedByOperation(operation: Operation): Range[];
     getTransformedByOperations(operations: Iterable<Operation>): Range[];
-    getWalker(options?: {
-        startPosition?: Position | undefined;
-        singleCharacters?: boolean | undefined;
-        shallow?: boolean | undefined;
-        ignoreElementEnd?: boolean | undefined;
-    }): TreeWalker;
+    getWalker(options?: RangeTreeWalkerOptions): TreeWalker;
     is(type: "position" | "model:position"): this is Position | LivePosition;
     is(type: "livePosition" | "model:livePosition"): this is LivePosition;
     is(type: "range" | "model:range"): this is Range | LiveRange;

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/treewalker.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/treewalker.d.ts
@@ -1,18 +1,45 @@
-import { Item } from "./item";
+import Element from "./element";
 import Position from "./position";
 import Range from "./range";
+import TextProxy from "./textproxy";
 
 export type TreeWalkerValueType = "elementStart" | "elementEnd" | "character" | "text";
 
-export interface TreeWalkerValue {
-    item: Item;
-    length: number;
-    nextPosition: Position;
-    previousPosition: Position;
-    type: TreeWalkerValueType;
-}
+export type TreeWalkerValue =
+    | {
+          item: TextProxy;
+          length: number;
+          nextPosition: Position;
+          previousPosition: Position;
+          type: "character" | "text";
+      }
+    | {
+          item: Element;
+          length: number;
+          nextPosition: Position;
+          previousPosition: Position;
+          type: "elementStart" | "elementEnd";
+      };
 
 export type TreeWalkerDirection = "forward" | "backward";
+
+export type TreeWalkerOptions =
+    | {
+          boundaries: Range;
+          direction?: TreeWalkerDirection | undefined;
+          ignoreElementEnd?: boolean | undefined;
+          shallow?: boolean | undefined;
+          singleCharacters?: boolean | undefined;
+          startPosition?: Position | undefined;
+      }
+    | {
+          boundaries?: Range | undefined;
+          direction?: TreeWalkerDirection | undefined;
+          ignoreElementEnd?: boolean | undefined;
+          shallow?: boolean | undefined;
+          singleCharacters?: boolean | undefined;
+          startPosition: Position;
+      };
 
 export default class TreeWalker implements Iterable<TreeWalkerValue> {
     readonly boundaries: Range;
@@ -22,14 +49,7 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
     readonly shallow: boolean;
     readonly singleCharacters: boolean;
 
-    constructor(options: {
-        boundaries?: Range | undefined;
-        direction?: TreeWalkerDirection | undefined;
-        ignoreElementEnd?: boolean | undefined;
-        shallow?: boolean | undefined;
-        singleCharacters?: boolean | undefined;
-        startPosition: Position;
-    });
+    constructor(options: TreeWalkerOptions);
     [Symbol.iterator](): Iterator<TreeWalkerValue>;
     skip(skip: (value: TreeWalkerValue) => boolean): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/model/writer.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/model/writer.d.ts
@@ -83,8 +83,15 @@ export default class Writer {
     removeSelectionAttribute(keyOrIterableOfKeys: string | string[]): void;
     rename(element: Element, newName: string): void;
     restoreSelectionGravity(uid: string): void;
-    setAttribute(key: string, value: string | number | boolean, itemOrRange: Item | Range): void;
-    setAttributes(attributes: Record<string, string | number | boolean>, itemOrRange: Item | Range): void;
+    setAttribute(
+        key: string,
+        value: string | number | boolean | Record<string, string | number | boolean>,
+        itemOrRange: Item | Range,
+    ): void;
+    setAttributes(
+        attributes: Record<string, string | number | boolean | Record<string, string | number | boolean>>,
+        itemOrRange: Item | Range,
+    ): void;
     setSelection(
         selectable: Selectable,
         placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/element.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/element.d.ts
@@ -1,6 +1,7 @@
 import Document from "./document";
 import Node from "./node";
 import StylesMap from "./stylesmap";
+import { Item } from "./item";
 
 export default abstract class Element extends Node {
     readonly childCount: number;
@@ -17,13 +18,16 @@ export default abstract class Element extends Node {
 
     findAncestor(
         patterns:
+            | ((
+                  element: Element,
+              ) => boolean)
             | string
             | RegExp
             | {
                   attributes?: Record<string, string | RegExp | boolean> | undefined;
                   classes?: string | RegExp | Array<string | RegExp> | undefined;
                   name?: string | RegExp | undefined;
-                  styles: Record<string, string>;
+                  styles?: Record<string, string>;
               },
     ): Element | null;
     getAttribute(key: string): string | undefined;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/matcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/matcher.d.ts
@@ -26,7 +26,7 @@ export default class Matcher {
 }
 
 export type MatcherPattern =
-    | ((element: Element) => void | {
+    | ((element: Element) => void | null | {
           name?: boolean | undefined;
           attribute?: string[] | undefined;
           classes?: string[] | undefined;

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/observer/domeventobserver.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/observer/domeventobserver.d.ts
@@ -4,6 +4,5 @@ export default abstract class DomEventObserver extends Observer {
     readonly domEventType: string | string[];
     useCapture: boolean;
 
-    fire(eventType: string, domEvent: Event, additionalData?: any): void;
     abstract onDomEvent(event: UIEvent | ClipboardEvent): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/observer/observer.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/observer/observer.d.ts
@@ -1,5 +1,9 @@
+import { Emitter, EmitterMixinDelegateChain } from "@ckeditor/ckeditor5-utils/src/emittermixin";
+import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
+import { PriorityString } from "@ckeditor/ckeditor5-utils/src/priorities";
 import Document from "../document";
 import View from "../view";
+import DomEventData from "./domeventdata";
 
 export default abstract class Observer {
     readonly document: Document;
@@ -12,4 +16,37 @@ export default abstract class Observer {
     disable(): void;
     enable(): void;
     observe(domElement: HTMLElement, name?: string): void;
+
+    listenTo<S extends Emitter, N extends string>(
+        emitter: S | Node | Window,
+        event: N,
+        callback: (info: EventInfo<S, N>, domEvt: Event, ...rest: any[]) => void,
+        options?: {
+            useCapture?: boolean | undefined;
+            usePassive?: boolean | undefined;
+            priority?: number | PriorityString | undefined;
+        },
+    ): void;
+    stopListening<S extends Emitter, N extends string>(
+        emitter?: Node | Window | S,
+        event?: N,
+        callback?: (info: EventInfo<S, N>, data: Event, ...rest: any[]) => void,
+    ): void;
+    on<N extends string>(
+        event: N,
+        callback: (info: EventInfo<Emitter, N>, domEvt: Event, ...rest: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<N extends string>(
+        event: N,
+        callback: (info: EventInfo<Emitter, N>, domEvt: Event, ...rest: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<N extends string>(
+        event: N,
+        callback?: (info: EventInfo<Emitter, N>, domEvt: Event, ...rest: any[]) => void,
+    ): void;
+    fire<N extends string>(eventOrInfo: N | EventInfo<Emitter, N>, domEvt: Event, ...rest: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/v27/src/view/treewalker.d.ts
+++ b/types/ckeditor__ckeditor5-engine/v27/src/view/treewalker.d.ts
@@ -1,16 +1,25 @@
+import Element from "./element";
 import Position from "./position";
-import { Item } from "./item";
 import Range from "./range";
+import TextProxy from "./textproxy";
 
 export type TreeWalkerValueType = "elementStart" | "elementEnd" | "text";
 
-export interface TreeWalkerValue {
-    item: Item;
-    length: number | undefined;
-    nextPosition: Position;
-    previousPosition: Position;
-    type: TreeWalkerValueType;
-}
+export type TreeWalkerValue =
+    | {
+          item: TextProxy;
+          length: number;
+          nextPosition: Position;
+          previousPosition: Position;
+          type: "text";
+      }
+    | {
+          item: Element;
+          length: number;
+          nextPosition: Position;
+          previousPosition: Position;
+          type: "elementStart" | "elementEnd";
+      };
 
 export type TreeWalkerDirection = "forward" | "backward";
 


### PR DESCRIPTION
- Make chainable downcast + upcast methods return `this`
- Type downcast + upcast dispatcher callbacks based on event name ([DowncastDispatcher events](https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_conversion_downcastdispatcher-DowncastDispatcher.html#events), [UpcastDispatcher events](https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_conversion_upcastdispatcher-UpcastDispatcher.html#events))
- Make TreeWalker constructor more exactly convey required options ([reference](https://github.com/ckeditor/ckeditor5/blob/55df6c0496c78a497cf66b64d3ad62ab9be71b17/packages/ckeditor5-engine/src/model/treewalker.js#L44-L54))
- Support passing objects as the value to model writer setAttribute ([reference](https://github.com/ckeditor/ckeditor5/blob/55df6c0496c78a497cf66b64d3ad62ab9be71b17/packages/ckeditor5-engine/src/model/writer.js#L361-L369))
- view Element.findAncestor: should accept the same pattern types as `Matcher.add`, which can be a function; also styles
  property should not be required if passing an object ([reference](https://github.com/ckeditor/ckeditor5/blob/55df6c0496c78a497cf66b64d3ad62ab9be71b17/packages/ckeditor5-engine/src/view/matcher.js#L35-L71))
- view Matcher: allow null return for pattern argument

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - [DowncastDispatcher events](https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_conversion_downcastdispatcher-DowncastDispatcher.html#events)
    - [UpcastDispatcher events](https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_conversion_upcastdispatcher-UpcastDispatcher.html#events)
    - [TreeWalker constructor](https://github.com/ckeditor/ckeditor5/blob/55df6c0496c78a497cf66b64d3ad62ab9be71b17/packages/ckeditor5-engine/src/model/treewalker.js#L44-L54)
    - [model Writer.setAttribute](https://github.com/ckeditor/ckeditor5/blob/55df6c0496c78a497cf66b64d3ad62ab9be71b17/packages/ckeditor5-engine/src/model/writer.js#L361-L369)
    - [Matcher.add](https://github.com/ckeditor/ckeditor5/blob/55df6c0496c78a497cf66b64d3ad62ab9be71b17/packages/ckeditor5-engine/src/view/matcher.js#L35-L71)
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ (N/A)
