### PR TITLE
fix(dompurify): missing configuration option

### DIFF
--- a/types/dompurify/index.d.ts
+++ b/types/dompurify/index.d.ts
@@ -48,20 +48,23 @@ declare namespace DOMPurify {
         ADD_ATTR?: string[] | undefined;
         ADD_DATA_URI_TAGS?: string[] | undefined;
         ADD_TAGS?: string[] | undefined;
+        ADD_URI_SAFE_ATTR?: string[] | undefined;
         ALLOW_DATA_ATTR?: boolean | undefined;
+        ALLOW_UNKNOWN_PROTOCOLS?: boolean | undefined;
         ALLOWED_ATTR?: string[] | undefined;
         ALLOWED_TAGS?: string[] | undefined;
+        ALLOWED_URI_REGEXP?: RegExp | undefined;
         FORBID_ATTR?: string[] | undefined;
         FORBID_CONTENTS?: string[] | undefined;
         FORBID_TAGS?: string[] | undefined;
         FORCE_BODY?: boolean | undefined;
+        IN_PLACE?: boolean | undefined;
         KEEP_CONTENT?: boolean | undefined;
         /**
          * change the default namespace from HTML to something different
          */
         NAMESPACE?: string | undefined;
         PARSER_MEDIA_TYPE?: string | undefined;
-        RETURN_DOM?: boolean | undefined;
         RETURN_DOM_FRAGMENT?: boolean | undefined;
         /**
          * This defaults to `true` starting DOMPurify 2.2.0. Note that setting it to `false`
@@ -69,14 +72,20 @@ declare namespace DOMPurify {
          * supports Declarative Shadow: DOM https://web.dev/declarative-shadow-dom/
          */
         RETURN_DOM_IMPORT?: boolean | undefined;
+        RETURN_DOM?: boolean | undefined;
         RETURN_TRUSTED_TYPE?: boolean | undefined;
-        SANITIZE_DOM?: boolean | undefined;
-        WHOLE_DOCUMENT?: boolean | undefined;
-        ALLOWED_URI_REGEXP?: RegExp | undefined;
         SAFE_FOR_TEMPLATES?: boolean | undefined;
-        ALLOW_UNKNOWN_PROTOCOLS?: boolean | undefined;
-        USE_PROFILES?: false | { mathMl?: boolean | undefined; svg?: boolean | undefined; svgFilters?: boolean | undefined; html?: boolean | undefined } | undefined;
-        IN_PLACE?: boolean | undefined;
+        SANITIZE_DOM?: boolean | undefined;
+        USE_PROFILES?:
+            | false
+            | {
+                  mathMl?: boolean | undefined;
+                  svg?: boolean | undefined;
+                  svgFilters?: boolean | undefined;
+                  html?: boolean | undefined;
+              }
+            | undefined;
+        WHOLE_DOCUMENT?: boolean | undefined;
     }
 
     type HookName =

--- a/types/dompurify/test/dompurify-tests.ts
+++ b/types/dompurify/test/dompurify-tests.ts
@@ -1,59 +1,42 @@
 import DOMPurify = require('dompurify');
 
-DOMPurify.sanitize('<script>alert("hi")</script>'); // $ExpectType string
 DOMPurify.addHook('beforeSanitizeElements', (el, data, config) => undefined);
 
 // examples from the DOMPurify README
 const dirty = '<script>alert("hi")</script><p>Totally safe<p><p onerror="blowUp()">Totally not safe</p>';
-let str: string;
-let elem: HTMLElement;
 let frag: DocumentFragment;
 let trustedHtml: TrustedHTML;
-
-// allow only <b>
-str = DOMPurify.sanitize(dirty, { ALLOWED_TAGS: ['b'] });
-
-// allow only <b> and <q> with style attributes (for whatever reason)
-str = DOMPurify.sanitize(dirty, { ALLOWED_TAGS: ['b', 'q'], ALLOWED_ATTR: ['style'] });
 
 DOMPurify.sanitize('<div><b>preserve me</b></div><p><b>no not preserve me</b></p>', {
     FORBID_CONTENTS: ['p'],
     FORBID_TAGS: ['div', 'p'],
 });
 
-// leave all as it is but forbid <style>
-str = DOMPurify.sanitize(dirty, { FORBID_TAGS: ['style'] });
+DOMPurify.sanitize('<script>alert("hi")</script>'); // $ExpectType string
+DOMPurify.sanitize(dirty, { ADD_ATTR: ['my-attr'] }); // $ExpectType string
+DOMPurify.sanitize(dirty, { ADD_DATA_URI_TAGS: ['a', 'area'] }); // $ExpectType string
+DOMPurify.sanitize(dirty, { ADD_TAGS: ['my-tag'] }); // $ExpectType string
+DOMPurify.sanitize(dirty, { ADD_URI_SAFE_ATTR: ['my-attr'] }); // $ExpectType string
+DOMPurify.sanitize(dirty, { ALLOW_DATA_ATTR: false }); // $ExpectType string
+DOMPurify.sanitize(dirty, { ALLOWED_TAGS: ['b', 'q'], ALLOWED_ATTR: ['style'] }); // $ExpectType string
+DOMPurify.sanitize(dirty, { ALLOWED_TAGS: ['b'] }); // $ExpectType string
+DOMPurify.sanitize(dirty, { FORBID_ATTR: ['style'] }); // $ExpectType string
+DOMPurify.sanitize(dirty, { FORBID_TAGS: ['style'] }); // $ExpectType string
+DOMPurify.sanitize(dirty, { KEEP_CONTENT: false }); // $ExpectType string
+DOMPurify.sanitize(dirty, { NAMESPACE: 'http://www.w3.org/2000/svg' }); // $ExpectType string
+DOMPurify.sanitize(dirty, { PARSER_MEDIA_TYPE: 'text/html' }); // $ExpectType string
+DOMPurify.sanitize(dirty, { RETURN_DOM: false }); // $ExpectType string
+DOMPurify.sanitize(dirty, { SANITIZE_DOM: false }); // $ExpectType string
+DOMPurify.sanitize(dirty, { WHOLE_DOCUMENT: true }); // $ExpectType string
 
-// leave all as it is but forbid style attributes
-str = DOMPurify.sanitize(dirty, { FORBID_ATTR: ['style'] });
-
-// extend the existing array of allowed tags
-str = DOMPurify.sanitize(dirty, { ADD_TAGS: ['my-tag'] });
-
-// extend the existing array of attributes
-str = DOMPurify.sanitize(dirty, { ADD_ATTR: ['my-attr'] });
-
-// extend the existing array of tags that can use Data URIs
-
-str = DOMPurify.sanitize(dirty, { ADD_DATA_URI_TAGS: ['a', 'area'] });
-
-// prohibit HTML5 data attributes (default is true)
-str = DOMPurify.sanitize(dirty, { ALLOW_DATA_ATTR: false });
-
-str = DOMPurify.sanitize(dirty, { NAMESPACE: 'http://www.w3.org/2000/svg' });
-
-str = DOMPurify.sanitize(dirty, { PARSER_MEDIA_TYPE: 'text/html' });
-
-// return a DOM HTMLBodyElement instead of an HTML string (default is false)
-str = DOMPurify.sanitize(dirty, { RETURN_DOM: false });
-elem = DOMPurify.sanitize(dirty, { RETURN_DOM: true });
-elem = DOMPurify.sanitize(dirty, { RETURN_DOM: true, RETURN_DOM_FRAGMENT: false });
+DOMPurify.sanitize(dirty, { RETURN_DOM: true }); // $ExpectType HTMLElement
+DOMPurify.sanitize(dirty, { RETURN_DOM: true, RETURN_DOM_FRAGMENT: false }); // $ExpectType HTMLElement
 
 // return a DOM DocumentFragment instead of an HTML string (default is false)
-str = DOMPurify.sanitize(dirty, { RETURN_DOM_FRAGMENT: false });
-frag = DOMPurify.sanitize(dirty, { RETURN_DOM_FRAGMENT: true });
-frag = DOMPurify.sanitize(dirty, { RETURN_DOM_FRAGMENT: true, RETURN_DOM: false });
-frag = DOMPurify.sanitize(dirty, { RETURN_DOM_FRAGMENT: true, RETURN_DOM: true });
+DOMPurify.sanitize(dirty, { RETURN_DOM_FRAGMENT: false }); // $ExpectType string
+DOMPurify.sanitize(dirty, { RETURN_DOM_FRAGMENT: true }); // $ExpectType DocumentFragment
+DOMPurify.sanitize(dirty, { RETURN_DOM_FRAGMENT: true, RETURN_DOM: false }); // $ExpectType DocumentFragment
+DOMPurify.sanitize(dirty, { RETURN_DOM_FRAGMENT: true, RETURN_DOM: true }); // $ExpectType DocumentFragment
 
 // return a DOM DocumentFragment instead of an HTML string (default is false)
 // also import it into the current document (default is false).
@@ -63,15 +46,6 @@ frag = DOMPurify.sanitize(dirty, { RETURN_DOM_FRAGMENT: true, RETURN_DOM_IMPORT:
 
 // return a TrustHTML type instead of a HTML string
 trustedHtml = DOMPurify.sanitize(dirty, { RETURN_TRUSTED_TYPE: true });
-
-// return entire document including <html> tags (default is false)
-str = DOMPurify.sanitize(dirty, { WHOLE_DOCUMENT: true });
-
-// disable DOM Clobbering protection on output (default is true, handle with care!)
-str = DOMPurify.sanitize(dirty, { SANITIZE_DOM: false });
-
-// discard an element's content when the element is removed (default is true)
-str = DOMPurify.sanitize(dirty, { KEEP_CONTENT: false });
 
 // test createDOMPurify factory that accepts custom window (very helpful for nodejs)
 const createDOMPurify = DOMPurify;


### PR DESCRIPTION
- `ADD_URI_SAFE_ATTR`
https://github.com/cure53/DOMPurify/blob/f7fa358c3c4747993fcf3977915639cd32fd8aab/src/purify.js#L375
- sort options in config for better devex
- sort and cleanup tests grouping by similar area and outcome, testing
  with TSLint expectations

Thanks!

/cc @nicroto

Fixes #56019

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).