### PR TITLE
Allow addAttributeCheck callback to also return undefined for default call to checkAttribute on the attribute name.

### DIFF
--- a/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
@@ -153,6 +153,11 @@ model.change(writer => {
 
 model.document.createRoot();
 model.schema.register("paragraph", { inheritAllFrom: "$block" });
+model.schema.addAttributeCheck(context => {
+    if (context.endsWith("paragraph")) {
+        return true;
+    }
+});
 
 const view: View = new View(new StylesProcessor());
 view.change(writer => {

--- a/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
@@ -13,7 +13,7 @@ import Selection from "./selection";
 import Writer from "./writer";
 
 export default class Schema implements Emitter, Observable {
-    addAttributeCheck(callback: (context: SchemaContext, name: string) => boolean): void;
+    addAttributeCheck(callback: (context: SchemaContext, name: string) => boolean | undefined): void;
     addChildCheck(callback: (context: SchemaContext, item: SchemaCompiledItemDefinition) => boolean): void;
     checkAttribute(context: SchemaContextDefinition, attributeName: string): boolean;
     checkAttributeInSelection(selection: Selection | DocumentSelection, attribute: string): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
@@ -13,7 +13,7 @@ import Selection from "./selection";
 import Writer from "./writer";
 
 export default class Schema implements Emitter, Observable {
-    addAttributeCheck(callback: (context: SchemaContext, name: string) => boolean | undefined): void;
+    addAttributeCheck(callback: (context: SchemaContext, name: string) => any): void;
     addChildCheck(callback: (context: SchemaContext, item: SchemaCompiledItemDefinition) => boolean): void;
     checkAttribute(context: SchemaContextDefinition, attributeName: string): boolean;
     checkAttributeInSelection(selection: Selection | DocumentSelection, attribute: string): boolean;


### PR DESCRIPTION
In CKEDITOR 5 documentation:  https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_model_schema-Schema.html#function-addAttributeCheck

It is not required that a `boolean` is returned. This `boolean` result informs the pipeline to override the `checkAttribute` call on context. In the code examples, if `undefined` is returned, then the `checkAttribute` result is used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

