### PR TITLE
Replace deprecated SFCFactory with FunctionComponentFactory

### DIFF
--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -259,7 +259,7 @@ const functionComponentFactory: React.FunctionComponentFactory<SCProps> =
 const functionComponentFactoryElement: React.FunctionComponentElement<SCProps> =
     functionComponentFactory(props);
 
-const legacyStatelessComponentFactory: React.SFCFactory<SCProps> =
+const legacyStatelessComponentFactory: React.FunctionComponentFactory<SCProps> =
     React.createFactory(FunctionComponent);
 const legacyStatelessComponentFactoryElement: React.SFCElement<SCProps> =
     legacyStatelessComponentFactory(props);


### PR DESCRIPTION
`React.SFCFactory` was deprecated in favor of `React.FunctionComponentFactory`. By the time we remove the deprecated types, (hopefully) no published packages rely on that type anymore. 