### PR TITLE
[aws-lambda] Add metadata field with partitionKeys to Firehose transformation result

### DIFF
--- a/types/aws-lambda/test/kinesis-tests.ts
+++ b/types/aws-lambda/test/kinesis-tests.ts
@@ -51,6 +51,11 @@ const firehoseHandler: FirehoseTransformationHandler = async (event, context, ca
                 recordId: event.records[0].recordId,
                 result: 'Ok' as FirehoseRecordTransformationStatus,
                 data: 'eyJmb28iOiJiYXIifQ==',
+                metadata: {
+                    partitionKeys: {
+                        testPart: 'test1'
+                    }
+                }
             },
         ],
     };

--- a/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
+++ b/types/aws-lambda/trigger/kinesis-firehose-transformation.d.ts
@@ -34,11 +34,16 @@ export interface FirehoseRecordMetadata {
 
 export type FirehoseRecordTransformationStatus = 'Ok' | 'Dropped' | 'ProcessingFailed';
 
+export interface FirehoseTransformationMetadata {
+    partitionKeys: { [name: string]: string };
+}
+
 export interface FirehoseTransformationResultRecord {
     recordId: string;
     result: FirehoseRecordTransformationStatus;
     /** Encode in Base64 */
     data: string;
+    metadata?: FirehoseTransformationMetadata;
 }
 
 export interface FirehoseTransformationResult {


### PR DESCRIPTION
This PR adds the `metadata` field to AWS Firehose transformation result records that is required to use the new dynamic partitioning feature with partition keys set by the transformer Lambda.

Documentation:
https://docs.aws.amazon.com/firehose/latest/dev/dynamic-partitioning.html

Blog/announcement:
https://aws.amazon.com/blogs/big-data/kinesis-data-firehose-now-supports-dynamic-partitioning-to-amazon-s3/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.