### PR TITLE
Add node.js base64url encoding

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -176,7 +176,7 @@ declare module 'buffer' {
         /**
          * Raw data is stored in instances of the Buffer class.
          * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.
-         * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
+         * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'base64url'|'binary'(deprecated)|'hex'
          */
         interface BufferConstructor {
             /**

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -250,7 +250,7 @@ declare module 'crypto' {
      */
     function createHmac(algorithm: string, key: BinaryLike | KeyObject, options?: stream.TransformOptions): Hmac;
     // https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
-    type BinaryToTextEncoding = 'base64' | 'hex';
+    type BinaryToTextEncoding = 'base64' | 'base64url' | 'hex';
     type CharacterEncoding = 'utf8' | 'utf-8' | 'utf16le' | 'latin1';
     type LegacyCharacterEncoding = 'ascii' | 'binary' | 'ucs2' | 'ucs-2';
     type Encoding = BinaryToTextEncoding | CharacterEncoding | LegacyCharacterEncoding;
@@ -2160,7 +2160,7 @@ declare module 'crypto' {
             key: BinaryLike,
             curve: string,
             inputEncoding?: BinaryToTextEncoding,
-            outputEncoding?: 'latin1' | 'hex' | 'base64',
+            outputEncoding?: 'latin1' | 'hex' | 'base64' | 'base64url',
             format?: 'uncompressed' | 'compressed' | 'hybrid'
         ): Buffer | string;
         /**

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -14,6 +14,7 @@ import { Readable, Writable } from 'node:stream';
 
 const utf8Buffer = new Buffer('test');
 const base64Buffer = new Buffer('', 'base64');
+const base64UrlBuffer = new Buffer('', 'base64url');
 const octets: Uint8Array = new Uint8Array(123);
 const octetBuffer = new Buffer(octets);
 const sharedBuffer = new Buffer(octets.buffer);
@@ -106,6 +107,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const buf1: Buffer = Buffer.alloc(5);
     const buf2: Buffer = Buffer.alloc(5, 'a');
     const buf3: Buffer = Buffer.alloc(11, 'aGVsbG8gd29ybGQ=', 'base64');
+    const buf4: Buffer = Buffer.alloc(11, 'aGVsbG8gd29ybGQ', 'base64url');
 }
 // Class Method: Buffer.allocUnsafe(size)
 {

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -75,6 +75,12 @@ import { promisify } from 'node:util';
 }
 
 {
+    // update Hmac with base64url encoded string
+    const message = Buffer.from('message').toString('base64url');
+    crypto.createHmac('sha256', 'key').update(message, 'base64url').digest();
+}
+
+{
     // crypto_cipher_decipher_string_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText = 'This is the clear text.';

--- a/types/node/v14/crypto.d.ts
+++ b/types/node/v14/crypto.d.ts
@@ -140,7 +140,7 @@ declare module 'crypto' {
     function createHmac(algorithm: string, key: BinaryLike | KeyObject, options?: stream.TransformOptions): Hmac;
 
     // https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
-    type BinaryToTextEncoding = 'base64' | 'hex';
+    type BinaryToTextEncoding = 'base64' | 'base64url' | 'hex';
     type CharacterEncoding = 'utf8' | 'utf-8' | 'utf16le' | 'latin1';
     type LegacyCharacterEncoding = 'ascii' | 'binary' | 'ucs2' | 'ucs-2';
 
@@ -514,7 +514,7 @@ declare module 'crypto' {
             key: BinaryLike,
             curve: string,
             inputEncoding?: BinaryToTextEncoding,
-            outputEncoding?: 'latin1' | 'hex' | 'base64',
+            outputEncoding?: 'latin1' | 'hex' | 'base64' | 'base64url',
             format?: 'uncompressed' | 'compressed' | 'hybrid',
         ): Buffer | string;
         generateKeys(): Buffer;

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -71,14 +71,14 @@ declare var module: NodeModule;
 declare var exports: any;
 
 // Buffer class
-type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex";
+type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex";
 
 type WithImplicitCoercion<T> = T | { valueOf(): T };
 
 /**
  * Raw data is stored in instances of the Buffer class.
  * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.
- * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
+ * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'base64url'|'binary'(deprecated)|'hex'
  */
 declare class Buffer extends Uint8Array {
     /**
@@ -160,7 +160,7 @@ declare class Buffer extends Uint8Array {
     static isBuffer(obj: any): obj is Buffer;
     /**
      * Returns true if {encoding} is a valid encoding argument.
-     * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
+     * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'base64url'|'binary'(deprecated)|'hex'
      *
      * @param encoding string to test.
      */

--- a/types/node/v14/test/buffer.ts
+++ b/types/node/v14/test/buffer.ts
@@ -11,6 +11,7 @@ import {
 
 const utf8Buffer = new Buffer('test');
 const base64Buffer = new Buffer('', 'base64');
+const base64UrlBuffer = new Buffer('', 'base64url');
 const octets: Uint8Array = new Uint8Array(123);
 const octetBuffer = new Buffer(octets);
 const sharedBuffer = new Buffer(octets.buffer);
@@ -103,6 +104,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const buf1: Buffer = Buffer.alloc(5);
     const buf2: Buffer = Buffer.alloc(5, 'a');
     const buf3: Buffer = Buffer.alloc(11, 'aGVsbG8gd29ybGQ=', 'base64');
+    const buf4: Buffer = Buffer.alloc(11, 'aGVsbG8gd29ybGQ', 'base64url');
 }
 // Class Method: Buffer.allocUnsafe(size)
 {

--- a/types/node/v14/test/crypto.ts
+++ b/types/node/v14/test/crypto.ts
@@ -73,6 +73,12 @@ import { promisify } from 'util';
 }
 
 {
+    // update Hmac with base64url encoded string
+    const message = Buffer.from('message').toString('base64url');
+    crypto.createHmac('sha256', 'key').update(message, 'base64url').digest();
+}
+
+{
     // crypto_cipher_decipher_string_test
     const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
     const clearText = 'This is the clear text.';


### PR DESCRIPTION
Node 14.18.0 adds `base64url` encoding for Buffers etc.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v14.x/docs/api/buffer.html
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.