### PR TITLE
update power-assert types to include type assertions used in node's assert

### DIFF
--- a/types/power-assert/index.d.ts
+++ b/types/power-assert/index.d.ts
@@ -23,12 +23,14 @@ declare namespace assert {
         generatedMessage: boolean;
 
         constructor(options?: {
+            // tslint:disable-next-line:no-redundant-undefined
             message?: string | undefined;
             actual?: unknown;
             expected?: unknown;
+            // tslint:disable-next-line:no-redundant-undefined
             operator?: string | undefined;
-            // tslint:disable-next-line:ban-types
-            stackStartFunction?: Function | undefined
+            // tslint:disable-next-line:no-redundant-undefined
+            stackStartFunction?: () => void | undefined
         });
     }
 
@@ -44,22 +46,20 @@ declare namespace assert {
     function notDeepStrictEqual(actual: unknown, expected: unknown, message?: string): void;
     const throws: {
         (block: () => unknown, message?: string): void;
-        (block: () => unknown, error: (new () => object), message?: string): void;
-        (block: () => unknown, error: RegExp, message?: string): void;
-        (block: () => unknown, error: (err: unknown) => boolean, message?: string): void;
+        (block: () => unknown, error: (new () => object) | RegExp | ((err: unknown) => boolean), message?: string): void;
     };
     const doesNotThrow: {
         (block: () => unknown, message?: string): void;
-        (block: () => unknown, error: (new () => object), message?: string): void;
-        (block: () => unknown, error: RegExp, message?: string): void;
-        (block: () => unknown, error: (err: any) => boolean, message?: string): void;
+        (block: () => unknown, error: (new () => object) | RegExp | ((err: any) => boolean), message?: string): void;
     };
     function ifError(value: unknown): asserts value is null | undefined;
 
     const strict: typeof assert;
 
     interface Options {
+        // tslint:disable-next-line:no-redundant-undefined
         assertion?: empower.Options | undefined;
+        // tslint:disable-next-line:no-redundant-undefined
         output?: powerAssertFormatter.Options | undefined;
     }
 

--- a/types/power-assert/index.d.ts
+++ b/types/power-assert/index.d.ts
@@ -1,61 +1,67 @@
-// Type definitions for power-assert 1.5.3
+// Type definitions for power-assert 1.5
 // Project: https://github.com/twada/power-assert
 // Definitions by: vvakame <https://github.com/vvakame>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
 
 // copy from assert external module in node.d.ts
 
-/// <reference types="empower" />
-/// <reference types="power-assert-formatter" />
-
 import * as empower from "empower";
+import * as powerAssertFormatter from "power-assert-formatter";
 
 export = assert;
 export as namespace assert;
 
-declare function assert(value: any, message?: string): void;
+declare function assert(value: unknown, message?: string): asserts value;
 declare namespace assert {
-    export class AssertionError implements Error {
+    class AssertionError implements Error {
         name: string;
         message: string;
-        actual: any;
-        expected: any;
+        actual: unknown;
+        expected: unknown;
         operator: string;
         generatedMessage: boolean;
 
-        constructor(options?: { message?: string | undefined; actual?: any; expected?: any; operator?: string | undefined; stackStartFunction?: Function | undefined });
+        constructor(options?: {
+            message?: string | undefined;
+            actual?: unknown;
+            expected?: unknown;
+            operator?: string | undefined;
+            // tslint:disable-next-line:ban-types
+            stackStartFunction?: Function | undefined
+        });
     }
 
-    export function fail(actual?: any, expected?: any, message?: string, operator?: string): never;
-    export function ok(value: any, message?: string): void;
-    export function equal(actual: any, expected: any, message?: string): void;
-    export function notEqual(actual: any, expected: any, message?: string): void;
-    export function deepEqual(actual: any, expected: any, message?: string): void;
-    export function notDeepEqual(acutal: any, expected: any, message?: string): void;
-    export function strictEqual(actual: any, expected: any, message?: string): void;
-    export function notStrictEqual(actual: any, expected: any, message?: string): void;
-    export function deepStrictEqual(actual: any, expected: any, message?: string): void;
-    export function notDeepStrictEqual(actual: any, expected: any, message?: string): void;
-    export var throws: {
-        (block: Function, message?: string): void;
-        (block: Function, error: Function, message?: string): void;
-        (block: Function, error: RegExp, message?: string): void;
-        (block: Function, error: (err: any) => boolean, message?: string): void;
+    function fail(actual?: unknown, expected?: unknown, message?: string, operator?: string): never;
+    function ok(value: unknown, message?: string): asserts value;
+    function equal(actual: unknown, expected: unknown, message?: string): void;
+    function notEqual(actual: unknown, expected: unknown, message?: string): void;
+    function deepEqual(actual: unknown, expected: unknown, message?: string): void;
+    function notDeepEqual(actual: unknown, expected: unknown, message?: string): void;
+    function strictEqual<T>(actual: unknown, expected: T, message?: string): asserts actual is T;
+    function notStrictEqual(actual: unknown, expected: unknown, message?: string): void;
+    function deepStrictEqual(actual: unknown, expected: unknown, message?: string): void;
+    function notDeepStrictEqual(actual: unknown, expected: unknown, message?: string): void;
+    const throws: {
+        (block: () => unknown, message?: string): void;
+        (block: () => unknown, error: (new () => object), message?: string): void;
+        (block: () => unknown, error: RegExp, message?: string): void;
+        (block: () => unknown, error: (err: unknown) => boolean, message?: string): void;
     };
-    export var doesNotThrow: {
-        (block: Function, message?: string): void;
-        (block: Function, error: Function, message?: string): void;
-        (block: Function, error: RegExp, message?: string): void;
-        (block: Function, error: (err: any) => boolean, message?: string): void;
+    const doesNotThrow: {
+        (block: () => unknown, message?: string): void;
+        (block: () => unknown, error: (new () => object), message?: string): void;
+        (block: () => unknown, error: RegExp, message?: string): void;
+        (block: () => unknown, error: (err: any) => boolean, message?: string): void;
     };
-    export function ifError(value: any): void;
+    function ifError(value: unknown): asserts value is null | undefined;
 
-    export const strict: typeof assert;
+    const strict: typeof assert;
 
-    export interface Options {
+    interface Options {
         assertion?: empower.Options | undefined;
         output?: powerAssertFormatter.Options | undefined;
     }
 
-    export function customize(options: Options): typeof assert;
+    function customize(options: Options): typeof assert;
 }

--- a/types/power-assert/power-assert-tests.ts
+++ b/types/power-assert/power-assert-tests.ts
@@ -6,6 +6,11 @@ assert.deepEqual({x: {y: 3}}, {x: {y: 3}}, "DEEP WENT DERP");
 
 assert.equal(3, "3", "uses == comparator");
 
+const maybeString: string | null = null;
+assert.ok(maybeString);
+// $ExpectType string
+maybeString;
+
 assert.notStrictEqual(2, "2", "uses === comparator");
 
 assert.deepStrictEqual([{a:1}], [{a:1}], "uses === comparator");
@@ -13,17 +18,16 @@ assert.deepStrictEqual([{a:1}], [{a:1}], "uses === comparator");
 assert.notDeepStrictEqual([{a:1}], [{a:1}], "uses === comparator");
 
 assert.throws(() => {
-    throw "a hammer at your face";
+    throw new Error("a hammer at your face");
 }, "DODGED IT");
 
 assert.doesNotThrow(() => {
     if (!!false) {
-        throw "a hammer at your face";
+        throw new Error("a hammer at your face");
     }
 }, "What the...*crunch*");
 
-
-var customizedAssert1 = assert.customize({
+const customizedAssert1: typeof assert = assert.customize({
     output: {
         maxDepth: 2
     }
@@ -38,17 +42,16 @@ customizedAssert1.equal(3, "3", "uses == comparator");
 customizedAssert1.notStrictEqual(2, "2", "uses === comparator");
 
 customizedAssert1.throws(() => {
-    throw "a hammer at your face";
+    throw new Error("a hammer at your face");
 }, "DODGED IT");
 
 customizedAssert1.doesNotThrow(() => {
     if (!!false) {
-        throw "a hammer at your face";
+        throw new Error("a hammer at your face");
     }
 }, "What the...*crunch*");
 
-
-var customizedAssert2 = assert.customize({
+const customizedAssert2 = assert.customize({
     assertion: {
         destructive: false,
         modifyMessageOnRethrow: true,
@@ -86,7 +89,12 @@ var customizedAssert2 = assert.customize({
 
 (): typeof assert => assert.strict;
 
-declare const set: Set<0>;
+declare const set: Set<number>;
 assert(set.size === 0);
 set.add(0);
-assert(set.size === 1);
+// size has been asserted to be 0
+assert(set.size === 1); // $ExpectError
+
+declare const set2: Set<0>;
+set2.add(0);
+assert(set2.size === 1);

--- a/types/power-assert/power-assert-tests.ts
+++ b/types/power-assert/power-assert-tests.ts
@@ -13,9 +13,9 @@ maybeString;
 
 assert.notStrictEqual(2, "2", "uses === comparator");
 
-assert.deepStrictEqual([{a:1}], [{a:1}], "uses === comparator");
+assert.deepStrictEqual([{a: 1}], [{a: 1}], "uses === comparator");
 
-assert.notDeepStrictEqual([{a:1}], [{a:1}], "uses === comparator");
+assert.notDeepStrictEqual([{a: 1}], [{a: 1}], "uses === comparator");
 
 assert.throws(() => {
     throw new Error("a hammer at your face");

--- a/types/power-assert/tslint.json
+++ b/types/power-assert/tslint.json
@@ -1,8 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-redundant-undefined": false,
-        "unified-signatures": false,
-        "whitespace": false
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/power-assert/tslint.json
+++ b/types/power-assert/tslint.json
@@ -1,14 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "ban-types": false,
-        "dt-header": false,
-        "no-consecutive-blank-lines": false,
-        "no-reference-import": false,
-        "no-string-throw": false,
-        "no-var-keyword": false,
-        "prefer-const": false,
-        "strict-export-declare-modifiers": false,
+        "no-redundant-undefined": false,
         "unified-signatures": false,
         "whitespace": false
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/assert.d.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


This primarily leverages `asserts` and `unknown` similar to how node's assert module does.
Allowing for type narrowing through assertions.
In addition this re-enables a number of dtslint rules which were previously disabled, and resolves the associated issues.