### PR TITLE
[ioredis] allow .scan(cursor: number | string) in Commands interface

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1196,6 +1196,8 @@ declare namespace IORedis {
         quit(callback: Callback<Ok>): void;
         quit(): Promise<Ok>;
 
+        scan(cursor: number | string): Promise<[string, string[]]>;
+
         scan(cursor: number | string, matchOption: 'match' | 'MATCH', pattern: string): Promise<[string, string[]]>;
         scan(
             cursor: number | string,

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -446,6 +446,14 @@ Redis.Command.setReplyTransformer('get', (result: any) => {
     return result;
 });
 
+redis.scan(0).then(([nextCursor, keys]) => {
+    // nextCursor is always a string
+    if (nextCursor === '0') {
+        // keys is always an array of strings and it might be empty
+        return keys.map(key => key.trim());
+    }
+});
+
 redis.scan(0, 'match', '*foo*', 'count', 20).then(([nextCursor, keys]) => {
     // nextCursor is always a string
     if (nextCursor === '0') {


### PR DESCRIPTION
This overload definition unexpectedly got removed in this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43906

<img width="794" alt="截圖 2021-09-30 上午1 50 05" src="https://user-images.githubusercontent.com/3382565/135322232-7d244d97-f0c3-4e47-92d9-72f34d90b4e6.png">

see diff here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43906/files#diff-5e75fb9ee60770865b5e5de5ca019b1e6f85b53b8d39ec060938fb0f20a96a7bL664

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43906/files#diff-5e75fb9ee60770865b5e5de5ca019b1e6f85b53b8d39ec060938fb0f20a96a7bL664
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
