### PR TITLE
Add support for forwardedFor in Auth0 passwordGrant

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -189,6 +189,12 @@ auth.tokens
         // Handle the error.
     });
 
+// Password Grant
+auth.passwordGrant({username: 'username', password: 'password'}).then((response: auth0.TokenResponse) => { console.log(response); });
+auth.passwordGrant({username: 'username', password: 'password'}, (err, response: auth0.TokenResponse) => { console.log(response); });
+auth.passwordGrant({username: 'username', password: 'password'}, { forwardedFor: '12.34.56.78' }).then((response: auth0.TokenResponse) => { console.log(response); });
+auth.passwordGrant({username: 'username', password: 'password'}, { forwardedFor: '12.34.56.78' }, (err, response: auth0.TokenResponse) => { console.log(response); });
+
 // Get management client access token
 management
     .getAccessToken()

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -670,6 +670,10 @@ export interface PasswordGrantOptions {
     audience?: string | undefined;
 }
 
+export interface PasswordGrantAdditionalOptions {
+    forwardedFor?: string;
+}
+
 export interface AuthorizationCodeGrantOptions {
     code: string;
     redirect_uri: string;
@@ -1118,7 +1122,9 @@ export class AuthenticationClient {
     ): void;
 
     passwordGrant(options: PasswordGrantOptions): Promise<TokenResponse>;
+    passwordGrant(options: PasswordGrantOptions, additionalOptions: PasswordGrantAdditionalOptions): Promise<TokenResponse>;
     passwordGrant(options: PasswordGrantOptions, cb: (err: Error, response: TokenResponse) => void): void;
+    passwordGrant(options: PasswordGrantOptions, additionalOptions: PasswordGrantAdditionalOptions, cb: (err: Error, response: TokenResponse) => void): void;
 
     refreshToken(options: AuthenticationClientRefreshTokenOptions): Promise<TokenResponse>;
     refreshToken(
@@ -1499,7 +1505,9 @@ export class OAuthAuthenticator {
     constructor(options: OAuthClientOptions);
 
     passwordGrant(options: PasswordGrantOptions): Promise<SignInToken>;
+    passwordGrant(options: PasswordGrantOptions, additionalOptions: PasswordGrantAdditionalOptions): Promise<SignInToken>;
     passwordGrant(options: PasswordGrantOptions, cb: (err: Error, response: SignInToken) => void): void;
+    passwordGrant(options: PasswordGrantOptions, additionalOptions: PasswordGrantAdditionalOptions, cb: (err: Error, response: SignInToken) => void): void;
 
     signIn(data: SignInOptions): Promise<SignInToken>;
     signIn(data: SignInOptions, cb: (err: Error, data: SignInToken) => void): void;


### PR DESCRIPTION
Adds support for forwardedFor when using `passwordGrant`.

Closes: #49503

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.github.io/node-auth0/module-auth.OAuthAuthenticator.html#passwordGrant and https://github.com/auth0/node-auth0/pull/661


