### PR TITLE
[react-reconciler] Fix operator precedence issue in updateContainer

### DIFF
--- a/types/react-reconciler/index.d.ts
+++ b/types/react-reconciler/index.d.ts
@@ -955,7 +955,7 @@ declare namespace ReactReconciler {
             element: ReactNode,
             container: OpaqueRoot,
             parentComponent?: Component<any, any> | null,
-            callback?: () => void | null,
+            callback?: (() => void) | null,
         ): Lane;
 
         batchedEventUpdates<A, R>(fn: (a: A) => R, a: A): R;


### PR DESCRIPTION
The callback parameter is intended to be nullable, but as written it requires a callback that returns `void | null`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/facebook/react/blob/d3e0869324267dc62b50ee02f747f5f0a5f5c656/packages/react-reconciler/src/ReactFiberReconciler.new.js#L258>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
