### PR TITLE
Add build metadata type for BugsnagBuildReporterPlugin in webpack-bugsnag-plugins

### DIFF
--- a/types/webpack-bugsnag-plugins/index.d.ts
+++ b/types/webpack-bugsnag-plugins/index.d.ts
@@ -111,6 +111,17 @@ export interface BuildReporterBuild {
      * this option if you aren’t able to set an `appVersion` in your notifier.
      */
     autoAssignRelease?: boolean | undefined;
+
+    /**
+     * Key value pairs containing any custom build information that provides useful metadata about the build. e.g. build configuration parameters, versions of dependencies, reason for the build etc.
+     * The keys and values must be strings. Nested objects aren't supported.
+     * e.g.
+     * {
+     * "buildServer": "build1",
+     * "buildReason": "Releasing JIRA-1234"
+     * }
+     */
+    metadata?: Record<string, string> | undefined;
 }
 
 export interface BuildReporterOptions {

--- a/types/webpack-bugsnag-plugins/webpack-bugsnag-plugins-tests.ts
+++ b/types/webpack-bugsnag-plugins/webpack-bugsnag-plugins-tests.ts
@@ -39,6 +39,15 @@ new BugsnagBuildReporterPlugin({
     appVersion: "1.2.3"
 });
 
+// $ExpectType BugsnagBuildReporterPlugin
+new BugsnagBuildReporterPlugin({
+    apiKey: "123456789",
+    appVersion: "1.2.3",
+    metadata: {
+        foo: "bar"
+    }
+});
+
 /**
  * All possible options
  */
@@ -65,7 +74,10 @@ new BugsnagBuildReporterPlugin(
             revision: "123456789"
         },
         builderName: "whoami",
-        autoAssignRelease: false
+        autoAssignRelease: false,
+        metadata: {
+            foo: "bar"
+        }
     },
     {
         logLevel: "debug",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://bugsnagbuildapi.docs.apiary.io/#introduction/source-control>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
