### PR TITLE
@ckeditor/ckeditor5-utils several fixes

### DIFF
--- a/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
@@ -53,6 +53,7 @@ import {
     isInsideSurrogatePair,
     isLowSurrogateHalf,
 } from '@ckeditor/ckeditor5-utils/src/unicode';
+import version from '@ckeditor/ckeditor5-utils/src/version';
 
 declare const document: Document;
 declare let emitter: Emitter;
@@ -343,8 +344,12 @@ source4.add({ hidden: false });
 
 // utils/comparearrays ========================================================
 
+// $ExpectType number | ArrayRelation
 compareArrays([0, 2], [0, 2, 1]);
+// $ExpectType number | ArrayRelation
 compareArrays(['abc', 0], ['abc', 0, 3]);
+// $ExpectType number | ArrayRelation
+compareArrays(['abc', 0] as const, ['abc', 0, 3] as const);
 
 // utils/config ===============================================================
 
@@ -483,12 +488,27 @@ fastDiff(str, '2ab').forEach(change => {
     }
 });
 
+// $ExpectType (InsertChange | DeleteChange)[]
+fastDiff([''], [''], () => true);
+// $ExpectType (InsertChange | DeleteChange)[]
+fastDiff([''], [''], null);
+// $ExpectType Change[]
+fastDiff([''], [''], () => true, true);
+// $ExpectType (InsertChange | DeleteChange)[]
+fastDiff([''], [''], null, false);
+
 // utils/first ================================================================
 
-const collection = [11, 22];
-const iterator = collection[Symbol.iterator]();
-
-first(iterator);
+// $ExpectType number | null
+first([11, 12]);
+// $ExpectType string | number | null
+first(['f', 12]);
+// $ExpectType null
+first([]);
+// $ExpectType number | null
+first(new Set([4]));
+// $ExpectType [string, number] | null
+first(new Map([['foo', 4]]));
 
 // utils/focustracker =========================================================
 
@@ -539,25 +559,25 @@ keystrokes.destroy();
 // utils/locale ===============================================================
 
 new Locale();
-new Locale({ uiLanguage: "en" });
-new Locale({ contentLanguage: "en" });
-new Locale({ uiLanguage: "en", contentLanguage: "en" });
+new Locale({ uiLanguage: 'en' });
+new Locale({ contentLanguage: 'en' });
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' });
 // $ExpectType string
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).contentLanguage;
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).contentLanguage;
 // $ExpectType string
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).uiLanguage;
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).uiLanguage;
 // $ExpectType string
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).uiLanguageDirection;
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).uiLanguageDirection;
 // $ExpectType string
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).contentLanguageDirection;
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("Label");
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("Created file '%0' in %1ms.", ["fileName", "100"]);
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("Created file in %1ms.", 5);
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", "");
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", [5]);
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", [5, ""]);
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).contentLanguageDirection;
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).t('Label');
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).t("Created file '%0' in %1ms.", ['fileName', '100']);
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).t('Created file in %1ms.', 5);
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).t('', '');
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).t('', [5]);
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).t('', [5, '']);
 // $ExpectError
-new Locale({ uiLanguage: "en", contentLanguage: "en" }).t("", false);
+new Locale({ uiLanguage: 'en', contentLanguage: 'en' }).t('', false);
 
 // utils/mapsequal ============================================================
 
@@ -602,8 +622,14 @@ function* getGenerator() {
     yield 22;
     yield 33;
 }
-
+// $ExpectType 11 | 22 | 33 | null
 nth(2, getGenerator());
+// $ExpectType null
+nth(2, []);
+// $ExpectType number | null
+nth(2, [5]);
+// $ExpectType 5 | null
+nth(2, [5] as const);
 
 // utils/objecttomap ==========================================================
 
@@ -673,7 +699,8 @@ num = priorities.get('normal');
 
 const fn1 = spy();
 fn1();
-bool = fn1.called;
+// $ExpectType true | undefined
+fn1.called;
 
 // utils/tomap
 
@@ -690,6 +717,27 @@ add('pl', {
     OK: 'OK',
     'Cancel [context: reject]': 'Anuluj',
 });
+add(
+    'pl',
+    {
+        OK: 'OK',
+        'Cancel [context: reject]': 'Anuluj',
+    },
+    n => n - 1,
+);
+add(
+    'pl',
+    {
+        OK: 'OK',
+        'Cancel [context: reject]': 'Anuluj',
+    },
+    n => !!n,
+);
+
+// $ExpectType number | boolean
+window.CKEDITOR_TRANSLATIONS.en.getPluralForm(4);
+// $ExpectType Record<string, string>
+window.CKEDITOR_TRANSLATIONS.en.dictionary;
 
 // utils/uid ==================================================================
 
@@ -744,6 +792,18 @@ options = {
 };
 
 // utils/toArray ==============================================================
-let myArrayOfOneNumber: [number] = toArray(5);
-myArrayOfOneNumber = toArray([5]);
-const myArrayOfThreeNumbers: number[] = toArray([1, 2, 3]);
+// $ExpectType number[]
+toArray(5);
+// $ExpectType number[]
+toArray([1, 2, 3]);
+// $ExpectType readonly [0]
+toArray([0] as const);
+// $ExpectType 5[]
+toArray(5 as const);
+
+// utils/version
+
+// $ExpectType "28.0.0"
+window.CKEDITOR_VERSION;
+// $ExpectType "28.0.0"
+version;

--- a/types/ckeditor__ckeditor5-utils/src/comparearrays.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/comparearrays.d.ts
@@ -4,12 +4,13 @@
  * a flag specifying the relation is returned. Flags are negative numbers, so whenever a number >= 0 is returned
  * it means that arrays differ.
  *
- *  compareArrays( [ 0, 2 ], [ 0, 2 ] );		// 'same'
- *  compareArrays( [ 0, 2 ], [ 0, 2, 1 ] );		// 'prefix'
- *  compareArrays( [ 0, 2 ], [ 0 ] );			// 'extension'
- *  compareArrays( [ 0, 2 ], [ 1, 2 ] );		// 0
- *  compareArrays( [ 0, 2 ], [ 0, 1 ] );		// 1
- *
+ *  compareArrays( [ 0, 2 ], [ 0, 2 ] );  // 'same'
+ *  compareArrays( [ 0, 2 ], [ 0, 2, 1 ] );  // 'prefix'
+ *  compareArrays( [ 0, 2 ], [ 0 ] );   // 'extension'
+ *  compareArrays( [ 0, 2 ], [ 1, 2 ] );  // 0
+ *  compareArrays( [ 0, 2 ], [ 0, 1 ] );  // 1
  */
-export default function compareArrays<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): number | ArrayRelation;
-export type ArrayRelation = "extension" | "same" | "prefix";
+export default function compareArrays<T>(a: T[], b: T[]): ArrayRelation | number;
+export default function compareArrays<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): ArrayRelation | number;
+
+export type ArrayRelation = 'extension' | 'same' | 'prefix';

--- a/types/ckeditor__ckeditor5-utils/src/fastdiff.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/fastdiff.d.ts
@@ -1,14 +1,4 @@
-export interface DeleteChange {
-    index: number;
-    type: "delete";
-    howMany: number;
-}
-
-export interface InsertChange {
-    index: number;
-    type: "insert";
-    values: string[];
-}
+import { Change } from './diff';
 
 /**
  * Finds positions of the first and last change in the given string/array and generates a set of changes:
@@ -32,7 +22,7 @@ export interface InsertChange {
  * should be passed as a third parameter:
  *
  *    fastDiff( [ { value: 1 }, { value: 2 } ], [ { value: 1 }, { value: 3 } ], ( a, b ) => {
- *        return a.value === b.value;
+ *      return a.value === b.value;
  *    } );
  *    // [ { index: 1, type: 'insert', values: [ { value: 3 } ] }, { index: 2, type: 'delete', howMany: 1 } ]
  *
@@ -43,11 +33,11 @@ export interface InsertChange {
  *    const changes = fastDiff( input, output );
  *
  *    changes.forEach( change => {
- *        if ( change.type == 'insert' ) {
- *            input = input.substring( 0, change.index ) + change.values.join( '' ) + input.substring( change.index );
- *        } else if ( change.type == 'delete' ) {
- *            input = input.substring( 0, change.index ) + input.substring( change.index + change.howMany );
- *        }
+ *      if ( change.type == 'insert' ) {
+ *        input = input.substring( 0, change.index ) + change.values.join( '' ) + input.substring( change.index );
+ *      } else if ( change.type == 'delete' ) {
+ *        input = input.substring( 0, change.index ) + input.substring( change.index + change.howMany );
+ *      }
  *    } );
  *
  *    // input equals output now
@@ -59,11 +49,11 @@ export interface InsertChange {
  *    const changes = fastDiff( input, output );
  *
  *    changes.forEach( change => {
- *        if ( change.type == 'insert' ) {
- *            input = input.slice( 0, change.index ).concat( change.values, input.slice( change.index ) );
- *        } else if ( change.type == 'delete' ) {
- *            input = input.slice( 0, change.index ).concat( input.slice( change.index + change.howMany ) );
- *        }
+ *      if ( change.type == 'insert' ) {
+ *        input = input.slice( 0, change.index ).concat( change.values, input.slice( change.index ) );
+ *      } else if ( change.type == 'delete' ) {
+ *        input = input.slice( 0, change.index ).concat( input.slice( change.index + change.howMany ) );
+ *      }
  *    } );
  *
  *    // input equals output now
@@ -85,36 +75,33 @@ export interface InsertChange {
  *    fastDiff( a, b );
  *    diffToChanges( diff( a, b ) );
  *
- *
- *    // Both calls will return the same results (grouped changes format).
- *    fastDiff( a, b );
- *    diffToChanges( diff( a, b ) );
- *
  *    // Again, both calls will return the same results (atomic changes format).
  *    fastDiff( a, b, null, true );
  *    diff( a, b );
+ *
  */
 export default function fastDiff(
-    oldText: string | string[],
-    newText: string | string[],
-    /**
-     * Optional function used to compare array values, by default === (strict equal operator) is used.
-     */
-    cmp?: (a: string, b: string) => boolean,
-    /**
-     * Whether an array of inset|delete|equal operations should be returned instead of changes set. This makes this function compatible with diff()
-     */
-    atomicChanges?: boolean,
-): Array<DeleteChange | InsertChange>;
-export default function fastDiff<T = unknown>(
-    oldText: T[],
-    newText: T[],
-    /**
-     * Optional function used to compare array values, by default === (strict equal operator) is used.
-     */
-    cmp: (a: T, b: T) => boolean,
-    /**
-     * Whether an array of inset|delete|equal operations should be returned instead of changes set. This makes this function compatible with diff()
-     */
-    atomicChanges?: boolean,
-): Array<DeleteChange | InsertChange>;
+    a: string | string[],
+    b: string | string[],
+    cmp: null | ((a: string, b: string) => boolean),
+    atomicChanges: true,
+): Change[];
+
+export default function fastDiff(
+    a: string | string[],
+    b: string | string[],
+    cmp?: null | ((a: string, b: string) => boolean),
+    atomicChanges?: false,
+): Array<InsertChange | DeleteChange>;
+
+export interface DeleteChange {
+    index: number;
+    type: 'delete';
+    howMany: number;
+}
+
+export interface InsertChange {
+    index: number;
+    type: 'insert';
+    values: string[];
+}

--- a/types/ckeditor__ckeditor5-utils/src/first.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/first.d.ts
@@ -1,4 +1,4 @@
 /**
  * Returns first item of the given `iterable`.
  */
-export default function first<T>(iterable: Iterable<T>): T;
+export default function first<T>(iterable: Iterable<T>): T | null;

--- a/types/ckeditor__ckeditor5-utils/src/language.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/language.d.ts
@@ -1,1 +1,4 @@
-export function getLanguageDirection(languageCode: string): "rtl" | "ltr";
+/**
+ * Helps determine whether a language text direction is LTR or RTL.
+ */
+export function getLanguageDirection(languageCode: string): 'ltr' | 'rtl';

--- a/types/ckeditor__ckeditor5-utils/src/nth.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/nth.d.ts
@@ -7,4 +7,4 @@
  * guide to learn differences between these interfaces.
  *
  */
-export default function nth<T>(index: number, iterable: Iterable<T>): T;
+export default function nth<T>(index: number, iterable: Iterable<T>): T | null;

--- a/types/ckeditor__ckeditor5-utils/src/spy.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/spy.d.ts
@@ -4,8 +4,10 @@
  * The following are the present features:
  *
  * * spy.called: property set to `true` if the function has been called at least once.
- *
  */
-declare const spy: { (): { (): void; called: boolean } };
+type Spy = () => {
+    called?: true | undefined;
+} & (() => void);
 
+declare const spy: Spy;
 export default spy;

--- a/types/ckeditor__ckeditor5-utils/src/toarray.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/toarray.d.ts
@@ -1,7 +1,7 @@
 /**
  * Transforms any value to an array. If the provided value is already an array, it is returned unchanged.
- *
  */
-type Return<T> = T extends any[] ? T : [T];
-export default function toArray<T>(arg: T): Return<T>;
-export {};
+declare function toArray<T extends readonly any[]>(data: T): T;
+declare function toArray<T extends any[]>(data: T): T;
+declare function toArray<T extends any>(data: T): T[];
+export default toArray;

--- a/types/ckeditor__ckeditor5-utils/src/translation-service.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/translation-service.d.ts
@@ -1,5 +1,11 @@
-export interface GetPluralForm {
-    (n: number): boolean | number;
+declare global {
+    var CKEDITOR_TRANSLATIONS: Record<
+        string,
+        {
+            getPluralForm: (n: number) => number | boolean;
+            dictionary: Record<string, string>;
+        }
+    >;
 }
 
 /**
@@ -12,74 +18,73 @@ export interface GetPluralForm {
  * Since the editor displays only the message string, the message ID can be found either in the source code or in the
  * built translations for another language.
  *
- *  add( 'pl', {
- *   'Cancel': 'Anuluj',
- *   'IMAGE': 'obraz', // Note that the `IMAGE` comes from the message ID, while the string can be `image`.
- *  } );
+ *    add( 'pl', {
+ *      'Cancel': 'Anuluj',
+ *      'IMAGE': 'obraz', // Note that the `IMAGE` comes from the message ID, while the string can be `image`.
+ *    } );
  *
  * If the message is supposed to support various plural forms, make sure to provide an array with the singular form and all plural forms:
  *
- *  add( 'pl', {
- *    'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
- *   } );
+ *    add( 'pl', {
+ *       'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
+ *     } );
  *
  * You should also specify the third argument (the `getPluralForm()` function) that will be used to determine the plural form if no
  * language file was loaded for that language. All language files coming from CKEditor 5 sources will have this option set, so
  * these plural form rules will be reused by other translations added to the registered languages. The `getPluralForm()` function
  * can return either a Boolean or a number.
  *
- *   add( 'en', {
- *    // ... Translations.
- *   }, n => n !== 1 );
- *   add( 'pl', {
- *    // ... Translations.
- *   }, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
+ *     add( 'en', {
+ *       // ... Translations.
+ *     }, n => n !== 1 );
+ *     add( 'pl', {
+ *       // ... Translations.
+ *     }, n => n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2 );
  *
  * All translations extend the global `window.CKEDITOR_TRANSLATIONS` object. An example of this object can be found below:
  *
- *   {
- *    pl: {
- *    dictionary: {
- *    	'Cancel': 'Anuluj',
- *    	'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
- *    },
- *    // A function that returns the plural form index.
- *    getPluralForm: n => n !==1
- *   }
- *   // Other languages.
- *  }
+ *     {
+ *       pl: {
+ *        dictionary: {
+ *          'Cancel': 'Anuluj',
+ *          'Add space': [ 'Dodaj spację', 'Dodaj %0 spacje', 'Dodaj %0 spacji' ]
+ *        },
+ *        // A function that returns the plural form index.
+ *        getPluralForm: n => n !==1
+ *      }
+ *      // Other languages.
+ *    }
  *
  * If you cannot import this function from this module (e.g. because you use a CKEditor 5 build), you can
  * still add translations by extending the global `window.CKEDITOR_TRANSLATIONS` object by using a function like
  * the one below:
  *
- *  function addTranslations( language, translations, getPluralForm ) {
- *   if ( !window.CKEDITOR_TRANSLATIONS ) {
- *    window.CKEDITOR_TRANSLATIONS = {};
- *   }
- *   if ( !window.CKEDITOR_TRANSLATIONS[ language ] ) {
- *    window.CKEDITOR_TRANSLATIONS[ language ] = {};
- *   }
+ *    function addTranslations( language, translations, getPluralForm ) {
+ *      if ( !window.CKEDITOR_TRANSLATIONS ) {
+ *        window.CKEDITOR_TRANSLATIONS = {};
+ *      }
+ *      if ( !window.CKEDITOR_TRANSLATIONS[ language ] ) {
+ *        window.CKEDITOR_TRANSLATIONS[ language ] = {};
+ *      }
  *
- *   const languageTranslations = window.CKEDITOR_TRANSLATIONS[ language ];
+ *      const languageTranslations = window.CKEDITOR_TRANSLATIONS[ language ];
  *
- *    languageTranslations.dictionary = languageTranslations.dictionary || {};
- *    languageTranslations.getPluralForm = getPluralForm || languageTranslations.getPluralForm;
+ *       languageTranslations.dictionary = languageTranslations.dictionary || {};
+ *       languageTranslations.getPluralForm = getPluralForm || languageTranslations.getPluralForm;
  *
- *   // Extend the dictionary for the given language.
- *   Object.assign( languageTranslations.dictionary, translations );
- *  }
- *
- * For each message ID the value should be either a translation or an array of translations if the message should support plural forms.
+ *      // Extend the dictionary for the given language.
+ *      Object.assign( languageTranslations.dictionary, translations );
+ *    }
  */
 export function add(
     language: string,
     translations: Record<string, string | string[]>,
-    getPluralForm?: GetPluralForm,
+    getPluralForm?: (n: number) => number | boolean,
 ): void;
 
 /**
- * The internationalization message interface. A message that implements this interface can be passed to the t() function to be translated to the target UI language.
+ * The internationalization message interface. A message that implements this interface can be passed to the `t()` function
+ * to be translated to the target UI language.
  */
 export interface Message {
     id?: string;

--- a/types/ckeditor__ckeditor5-utils/src/version.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/version.d.ts
@@ -1,2 +1,7 @@
-declare const version: "27.0.0";
+declare const version = '28.0.0';
 export default version;
+declare global {
+    interface Window {
+        CKEDITOR_VERSION: typeof version;
+    }
+}


### PR DESCRIPTION
* Allow `compareArrays` to accept readonly arrays.
* `fastDiff` have different return values depending on its fourth parameter. https://github.com/ckeditor/ckeditor5/blob/afca810c9aa64c4f7aecba04929658ca1b7a9365/packages/ckeditor5-utils/src/fastdiff.js#L10-L96
* `first` may return `null`. https://github.com/ckeditor/ckeditor5/blob/afca810c9aa64c4f7aecba04929658ca1b7a9365/packages/ckeditor5-utils/src/first.js#L19
* `nth` may return `null`. https://github.com/ckeditor/ckeditor5/blob/afca810c9aa64c4f7aecba04929658ca1b7a9365/packages/ckeditor5-utils/src/nth.js#L30
* Redefined `spy` cause if the `called` attribute is present, it can only be `true`. https://github.com/ckeditor/ckeditor5/blob/afca810c9aa64c4f7aecba04929658ca1b7a9365/packages/ckeditor5-utils/src/spy.js#L21
* Allow `toArray` to handle readonly arrays.
* `translation-service` defines a property in the global `window` object. https://github.com/ckeditor/ckeditor5/blob/afca810c9aa64c4f7aecba04929658ca1b7a9365/packages/ckeditor5-utils/src/translation-service.js#L15
* `version` was outdated, and defined a property in the global `window`. https://github.com/ckeditor/ckeditor5/blob/afca810c9aa64c4f7aecba04929658ca1b7a9365/packages/ckeditor5-utils/src/version.js#L156

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.