### PR TITLE
[mongoose-delete] Add missing `updateOne` methods

### DIFF
--- a/types/mongoose-delete/index.d.ts
+++ b/types/mongoose-delete/index.d.ts
@@ -20,6 +20,7 @@ declare namespace MongooseDelete {
         | 'findOne'
         | 'findOneAndUpdate'
         | 'update'
+        | 'updateOne'
         | 'updateMany'
         | 'aggregate';
     interface SoftDeleteModel<T extends Omit<mongoose.Document, 'delete'>, QueryHelpers = {}>
@@ -48,6 +49,10 @@ declare namespace MongooseDelete {
         updateDeleted: typeof mongoose.Model.update;
         /** Update all documents including deleted */
         updateWithDeleted: typeof mongoose.Model.update;
+        /** Update One only deleted documents */
+        updateOneDeleted: typeof mongoose.Model.updateOne;
+        /** Update One all documents including deleted */
+        updateOneWithDeleted: typeof mongoose.Model.updateOne;
         /** Update Many only deleted documents */
         updateManyDeleted: typeof mongoose.Model.updateMany;
         /** Update Many all documents including deleted */

--- a/types/mongoose-delete/mongoose-delete-tests.ts
+++ b/types/mongoose-delete/mongoose-delete-tests.ts
@@ -98,6 +98,8 @@ Pet.findOneAndUpdateDeleted({ age: 10 }, { name: 'Fluffy' });
 Pet.findOneAndUpdateWithDeleted({ age: 10 }, { name: 'Fluffy' });
 Pet.updateDeleted({ age: 10 }, { name: 'Fluffy' });
 Pet.updateWithDeleted({ age: 10 }, { name: 'Fluffy' });
+Pet.updateOneDeleted({ age: 10 }, { name: 'Fluffy' });
+Pet.updateOneWithDeleted({ age: 10 }, { name: 'Fluffy' });
 Pet.updateManyDeleted({ age: 10 }, { name: 'Fluffy' });
 Pet.updateManyWithDeleted({ age: 10 }, { name: 'Fluffy' });
 Pet.aggregateDeleted([{ $match: { age: 10 } }]);


### PR DESCRIPTION
Add missing `updateOne` methods to `mongoose-delete`

### Docs

https://github.com/dsanel/mongoose-delete#method-overridden

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
