### PR TITLE
Add typing for qsConfig method to url-assembler

### DIFF
--- a/types/url-assembler/index.d.ts
+++ b/types/url-assembler/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for url-assembler 2.1.0
 // Project: https://github.com/Floby/node-url-assembler
 // Definitions by: Wolfgang Faust <https://github.com/wolfgang42>
+//                 Alice Pote <https://github.com/alicewriteswrongs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 import * as qs from 'qs';
 

--- a/types/url-assembler/index.d.ts
+++ b/types/url-assembler/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for url-assembler 2.1.0
+// Type definitions for url-assembler 2.1
 // Project: https://github.com/Floby/node-url-assembler
 // Definitions by: Wolfgang Faust <https://github.com/wolfgang42>
 //                 Alice Pote <https://github.com/alicewriteswrongs>

--- a/types/url-assembler/index.d.ts
+++ b/types/url-assembler/index.d.ts
@@ -9,9 +9,9 @@ interface UrlAssembler {
     prefix(subPath: string): UrlAssembler;
     segment(subPathTemplate: string): UrlAssembler;
     param(key: string, value: string, strict?: boolean): UrlAssembler;
-    param(params: {[s: string]: any}, strict?: boolean): UrlAssembler;
+    param(params: { [s: string]: any }, strict?: boolean): UrlAssembler;
     query(key: string, value: any): UrlAssembler;
-    query(params: {[s: string]: any}): UrlAssembler;
+    query(params: { [s: string]: any }): UrlAssembler;
     toString(): string;
     valueOf(): string;
     toJSON(): string;

--- a/types/url-assembler/index.d.ts
+++ b/types/url-assembler/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/Floby/node-url-assembler
 // Definitions by: Wolfgang Faust <https://github.com/wolfgang42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import * as qs from 'qs';
 
 interface UrlAssembler {
     template(template: string): UrlAssembler;
@@ -14,6 +15,7 @@ interface UrlAssembler {
     toString(): string;
     valueOf(): string;
     toJSON(): string;
+    qsConfig(config: qs.IStringifyOptions): UrlAssembler;
 }
 
 interface UrlAssemblerConstructor {

--- a/types/url-assembler/index.d.ts
+++ b/types/url-assembler/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for url-assembler 1.2
+// Type definitions for url-assembler 2.1.0
 // Project: https://github.com/Floby/node-url-assembler
 // Definitions by: Wolfgang Faust <https://github.com/wolfgang42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/url-assembler/url-assembler-tests.ts
+++ b/types/url-assembler/url-assembler-tests.ts
@@ -5,3 +5,9 @@ const f = new UrlAssembler('https://foo/bar/');
 function printUrl(u: UrlAssembler) {
     return u.toJSON();
 }
+
+function checkQSConfig(u: UrlAssembler) {
+    return u.qsConfig({
+        sort: (a: string, b: string) => a.localeCompare(b),
+    });
+}

--- a/types/url-assembler/url-assembler-tests.ts
+++ b/types/url-assembler/url-assembler-tests.ts
@@ -43,7 +43,7 @@ function checkQSConfig(u: UrlAssembler) {
         // $ExpectError
         sort: false,
         // $ExpectError
-        serializeDate: (d: Date) => d.toString(),
+        serializeDate: (s: string) => s,
         // $ExpectError
         format: 'RFC1111',
         // $ExpectError

--- a/types/url-assembler/url-assembler-tests.ts
+++ b/types/url-assembler/url-assembler-tests.ts
@@ -7,7 +7,54 @@ function printUrl(u: UrlAssembler) {
 }
 
 function checkQSConfig(u: UrlAssembler) {
-    return u.qsConfig({
+    u.qsConfig({
+        delimiter: "#",
+        strictNullHandling: true,
+        skipNulls: true,
+        encode: true,
+        filter: [1, 2, 3],
+        arrayFormat: 'indices',
+        indices: true,
         sort: (a: string, b: string) => a.localeCompare(b),
+        serializeDate: (d: Date) => d.toString(),
+        format: 'RFC1738',
+        encodeValuesOnly: true,
+        addQueryPrefix: true,
+        allowDots: true,
+        charset: 'utf-8',
+        charsetSentinel: true,
+    });
+
+    u.qsConfig({
+        // $ExpectError
+        delimiter: true
+        // $ExpectError
+        strictNullHandling: "boop",
+        // $ExpectError
+        skipNulls: "boop",
+        // $ExpectError
+        encode: "encode",
+        // $ExpectError
+        filter: true,
+        // $ExpectError
+        arrayFormat: 'uncool',
+        // $ExpectError
+        indices: "true",
+        // $ExpectError
+        sort: false
+        // $ExpectError
+        serializeDate: (d: Date) => d.toString(),
+        // $ExpectError
+        format: 'RFC1111',
+        // $ExpectError
+        encodeValuesOnly: "values",
+        // $ExpectError
+        addQueryPrefix: "yes please",
+        // $ExpectError
+        allowDots: "no dots",
+        // $ExpectError
+        charset: 'UtF-eight',
+        // $ExpectError
+        charsetSentinel: "sentinel?",
     });
 }

--- a/types/url-assembler/url-assembler-tests.ts
+++ b/types/url-assembler/url-assembler-tests.ts
@@ -8,7 +8,7 @@ function printUrl(u: UrlAssembler) {
 
 function checkQSConfig(u: UrlAssembler) {
     u.qsConfig({
-        delimiter: "#",
+        delimiter: '#',
         strictNullHandling: true,
         skipNulls: true,
         encode: true,
@@ -27,34 +27,34 @@ function checkQSConfig(u: UrlAssembler) {
 
     u.qsConfig({
         // $ExpectError
-        delimiter: true
+        delimiter: true,
         // $ExpectError
-        strictNullHandling: "boop",
+        strictNullHandling: 'boop',
         // $ExpectError
-        skipNulls: "boop",
+        skipNulls: 'boop',
         // $ExpectError
-        encode: "encode",
+        encode: 'encode',
         // $ExpectError
         filter: true,
         // $ExpectError
         arrayFormat: 'uncool',
         // $ExpectError
-        indices: "true",
+        indices: 'true',
         // $ExpectError
-        sort: false
+        sort: false,
         // $ExpectError
         serializeDate: (d: Date) => d.toString(),
         // $ExpectError
         format: 'RFC1111',
         // $ExpectError
-        encodeValuesOnly: "values",
+        encodeValuesOnly: 'values',
         // $ExpectError
-        addQueryPrefix: "yes please",
+        addQueryPrefix: 'yes please',
         // $ExpectError
-        allowDots: "no dots",
+        allowDots: 'no dots',
         // $ExpectError
         charset: 'UtF-eight',
         // $ExpectError
-        charsetSentinel: "sentinel?",
+        charsetSentinel: 'sentinel?',
     });
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Floby/node-url-assembler/blob/master/lib/url-assembler-factory.js#L65>>