### PR TITLE
gaussian - Fixed some type mismatch

### DIFF
--- a/types/gaussian/index.d.ts
+++ b/types/gaussian/index.d.ts
@@ -40,27 +40,27 @@ declare namespace gaussian {
          * returns the product distribution of this and the given
          * distribution; equivalent to scale(d) when d is a constant
          */
-        mul(x: number | Gaussian): number;
+        mul(x: number | Gaussian): Gaussian;
         /**
          * returns the quotient distribution of this and the given
          * distribution; equivalent to scale(1/d) when d is a constant
          */
-        div(x: number | Gaussian): number;
+        div(x: number | Gaussian): Gaussian;
         /**
          * returns the result of adding this and the given
          * distribution's means and variances
          */
-        add(x: Gaussian): number;
+        add(x: Gaussian): Gaussian;
         /**
          * returns the result of subtracting this and the given
          * distribution's means and variances
          */
-        sub(x: Gaussian): number;
+        sub(x: Gaussian): Gaussian;
         /**
          * returns the result of scaling this distribution by the
          * given constant
          */
-        scale(x: number): number;
+        scale(x: number): Gaussian;
         /**
          * generates given number of samples of the distribution
          */


### PR DESCRIPTION
The functions `scale`, `sub`, `add`, `div` and `mul` return a `Gaussian`, not a `number`.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/errcw/gaussian/blob/3a4f5f179288c736baaa283f513f2fc7a7ff0be1/lib/gaussian.js#L90
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
