### PR TITLE
sinon: add promise types

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1654,7 +1654,7 @@ declare namespace Sinon {
 
     type SinonPromise<T> = Promise<T> & {
         status: 'pending'|'resolved'|'rejected';
-        resolve(val: unknown): Promise<void>;
+        resolve(val: unknown): Promise<T>;
         reject(reason: unknown): Promise<void>;
         resolvedValue?: T;
         rejectedValue?: unknown;

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1652,6 +1652,14 @@ declare namespace Sinon {
         ): SinonStubbedInstance<TType>;
     }
 
+    type SinonPromise<T> = Promise<T> & {
+        status: 'pending'|'resolved'|'rejected';
+        resolve(val: unknown): Promise<void>;
+        reject(reason: unknown): Promise<void>;
+        resolvedValue?: T;
+        rejectedValue?: unknown;
+    };
+
     interface SinonApi {
         expectation: SinonExpectationStatic;
 
@@ -1686,6 +1694,10 @@ declare namespace Sinon {
          * on a format of your choosing, such as "{ id: 42 }"
          */
         setFormatter: (customFormatter: (...args: any[]) => string) => void;
+
+        promise<T = unknown>(
+            executor?: (resolve: (value: T) => void, reject: (reason?: unknown) => void) => void
+        ): SinonPromise<T>;
     }
 
     type SinonStatic = SinonSandbox & SinonApi;

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -716,7 +716,7 @@ async function testPromises() {
     promise.status; // $ExpectType "pending" | "resolved" | "rejected"
 
     const typedPromise = sinon.promise<number>();
-    await typedPromise.resolve(111);
+    await typedPromise.resolve(111); // $ExpectType number
     typedPromise.resolvedValue; // $ExpectType number | undefined
     typedPromise.rejectedValue; // $ExpectType unknown
 

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -708,3 +708,22 @@ function testAddBehavior() {
 function testSetFormatter() {
     sinon.setFormatter((...args) => JSON.stringify(args));
 }
+
+async function testPromises() {
+    const promise = sinon.promise();
+    await promise.resolve(123);
+    await promise.reject('foo');
+    promise.status; // $ExpectType "pending" | "resolved" | "rejected"
+
+    const typedPromise = sinon.promise<number>();
+    await typedPromise.resolve(111);
+    typedPromise.resolvedValue; // $ExpectType number | undefined
+    typedPromise.rejectedValue; // $ExpectType unknown
+
+    const executor = sinon.promise<string>((resolve) => {
+        resolve('abc');
+    });
+    const executor2 = sinon.promise<string>((resolve, reject) => {
+        reject('some error');
+    });
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/v11.1.2/promises/

sinon at some point introduced `sinon.promise()`
