### PR TITLE
[@types/jquery] Fix for issue #52052 - add undefined to get() function

### DIFF
--- a/types/jquery.gridster/jquery.gridster-tests.ts
+++ b/types/jquery.gridster/jquery.gridster-tests.ts
@@ -19,7 +19,7 @@ var options: GridsterOptions = {
 
 var gridster: Gridster = $('.gridster ul').gridster(options).data('gridster');
 gridster.add_widget('<li class="new">The HTML of the widget...</li>', 2, 1);
-gridster.remove_widget($('gridster li').eq(3).get(0));
+gridster.remove_widget($('gridster li').eq(3).get(0)!);
 var json = gridster.serialize<SerializeData>();
 
 var coords: GridsterCoords = gridster.get_highest_occupied_cell();

--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -4526,9 +4526,9 @@ $( "*", document.body ).click(function( event ) {
 </html>
 ```
      */
-    get(index: number): TElement;
+    get(index: number): TElement | undefined;
     /**
-     * Retrieve the elements matched by the jQuery object.
+     * Retrieve the elements matched by the jQuery object. If the value of index is out of bounds — less than the negative number of elements or equal to or greater than the number of elements — it returns undefined.
      * @see \`{@link https://api.jquery.com/get/ }\`
      * @since 1.0
      * @example ​ ````Select all divs in the document and return the DOM Elements as an Array; then use the built-in reverse() method to reverse that array.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -23,6 +23,7 @@
 //                 Thomas Schulz <https://github.com/King2500>
 //                 Terry Mun <https://github.com/terrymun>
 //                 Martin Badin <https://github.com/martin-badin>
+//                 Chris Frewin <https://github.com/princefishthrower>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -6327,11 +6327,14 @@ function JQuery() {
         }
 
         function get() {
-            // $ExpectType HTMLElement
+            // $ExpectType HTMLElement | undefined
             $('p').get(0);
 
             // $ExpectType HTMLElement[]
             $('p').get();
+
+            // $ExpectType HTMLElement | undefined
+            $('nonExistentElement').get(0);
         }
 
         function index() {

--- a/types/jquery/test/example-tests.ts
+++ b/types/jquery/test/example-tests.ts
@@ -1943,7 +1943,9 @@ function examples() {
         $('*', document.body).click(function(event) {
             event.stopPropagation();
             var domElement = $(this).get(0);
-            $('span:first').text('Clicked on - ' + domElement.nodeName);
+            if (domElement) {
+                $('span:first').text('Clicked on - ' + domElement.nodeName);
+            }
         });
     }
 
@@ -3451,21 +3453,26 @@ function examples() {
 
     function map_1() {
         var mappedItems = $('li').map(function(index) {
-            var replacement: Element | null = $('<li>').text($(this).text()).get(0);
-            if (index === 0) {
-                // Make the first item all caps
-                $(replacement).text($(replacement).text().toUpperCase());
-            } else if (index === 1 || index === 3) {
-                // Delete the second and fourth items
-                replacement = null;
-            } else if (index === 2) {
-                // Make two of the third item and add some text
-                var _replacement = [replacement, $('<li>').get(0)];
-                $(_replacement[0]).append('<b> - A</b>');
-                $(_replacement[1]).append('Extra <b> - B</b>');
+            var replacement: Element | undefined = $('<li>').text($(this).text()).get(0);
+            if (replacement) {
+                if (index === 0) {
+                    // Make the first item all caps
+                    $(replacement).text($(replacement).text().toUpperCase());
+                } else if (index === 1 || index === 3) {
+                    // Delete the second and fourth items
+                    replacement = undefined;
+                } else if (index === 2) {
+                    // Make two of the third item and add some text
+                    var li = $('<li>').get(0);
+                    if (li) {
+                        var _replacement = [replacement, li];
+                        $(_replacement[0]).append('<b> - A</b>');
+                        $(_replacement[1]).append('Extra <b> - B</b>');
+                    }
+                }
             }
 
-            // Replacement will be a dom element, null,
+            // Replacement will be a dom element, undefined,
             // or an array of dom elements
             return replacement;
         });
@@ -3954,8 +3961,11 @@ function examples() {
 
     function parent_1() {
         $('*', document.body).each(function() {
-            var parentTag = $(this).parent().get(0).tagName;
-            $(this).prepend(document.createTextNode(parentTag + ' > '));
+            var parent = $(this).parent().get(0);
+            if (parent) {
+                var parentTag = parent.tagName;
+                $(this).prepend(document.createTextNode(parentTag + ' > '));
+            }
         });
     }
 

--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -21,7 +21,6 @@
 //                 Dick van den Brink <https://github.com/DickvdBrink>
 //                 Thomas Schulz <https://github.com/King2500>
 //                 Leonard Thieu <https://github.com/leonard-thieu>
-//                 Chris Frewin <https://github.com/princefishthrower>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /* *****************************************************************************
@@ -3357,7 +3356,7 @@ interface JQuery {
      * @param index A zero-based integer indicating which element to retrieve.
      * @see {@link https://api.jquery.com/get/#get-index}
      */
-    get(index: number): Element | undefined;
+    get(index: number): Element;
     /**
      * Retrieve the elements matched by the jQuery object.
      * @alias toArray

--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -21,6 +21,7 @@
 //                 Dick van den Brink <https://github.com/DickvdBrink>
 //                 Thomas Schulz <https://github.com/King2500>
 //                 Leonard Thieu <https://github.com/leonard-thieu>
+//                 Chris Frewin <https://github.com/princefishthrower>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /* *****************************************************************************
@@ -3356,7 +3357,7 @@ interface JQuery {
      * @param index A zero-based integer indicating which element to retrieve.
      * @see {@link https://api.jquery.com/get/#get-index}
      */
-    get(index: number): Element;
+    get(index: number): Element | undefined;
     /**
      * Retrieve the elements matched by the jQuery object.
      * @alias toArray

--- a/types/select2/select2-tests.ts
+++ b/types/select2/select2-tests.ts
@@ -778,8 +778,8 @@ const selectedData: Select2.OptionData[] = $("#mySelect2").select2("data");
 declare let select: HTMLSelectElement;
 const $select: JQuery<HTMLSelectElement> = $(select);
 
-select = $select.select2().get(0);
-select = $select.select2({tags: true}).get(0);
-select = $select.select2("open").get(0);
-select = $select.select2("close").get(0);
-select = $select.select2("destroy").get(0);
+select = $select.select2().get(0)!;
+select = $select.select2({tags: true}).get(0)!;
+select = $select.select2("open").get(0)!;
+select = $select.select2("close").get(0)!;
+select = $select.select2("destroy").get(0)!;


### PR DESCRIPTION
As the title states, this should solve the issue brought up here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52052

According to the jQuery docs for `get()`:

```
If the value of index is out of bounds — less than the negative number of elements or equal to or greater than the number of elements — it returns undefined.
```

So this typing change brings in that `undefined` case.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.jquery.com/get/#get-index
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
