### PR TITLE
[@types/express] [@types/express-serve-static-core] Express array of request handler fix

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -212,3 +212,13 @@ app.get<{}, any, any, {}, { foo: boolean }>('/locals', (req, res, next) => {
     res.locals.bar; // $ExpectError
     res.send({ foo: 'ok' }); // $ExpectType Response<any, { foo: boolean; }, number>
 });
+
+// Request handlers can be an array
+app.get("/", [
+    (req, res) => {
+        res.send("hello world");
+    },
+    (req, res) => {
+        res.send("hello world again");
+    },
+]);

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -8,6 +8,7 @@
 //                 Jose Luis Leon <https://github.com/JoseLion>
 //                 David Stephens <https://github.com/dwrss>
 //                 Shin Ando <https://github.com/andoshin11>
+//                 Chris Frewin <https://github.com/princefishthrower>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -125,6 +126,21 @@ export interface IRouterMatcher<
     T,
     Method extends 'all' | 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' = any
 > {
+    // Array of RequestHandlers
+    <
+        Route extends string,
+        P = RouteParameters<Route>,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        Locals extends Record<string, any> = Record<string, any>
+    >(
+        // tslint:disable-next-line no-unnecessary-generics (it's used as the default type parameter for P)
+        path: Route,
+        // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
+        handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>>
+    ): T;
+    // Comma separated list of RequestHandlers
     <
         Route extends string,
         P = RouteParameters<Route>,
@@ -138,6 +154,21 @@ export interface IRouterMatcher<
         // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
         ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>>
     ): T;
+    // Array of RequestHandlers
+    <
+        Path extends string,
+        P = RouteParameters<Path>,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        Locals extends Record<string, any> = Record<string, any>
+    >(
+        // tslint:disable-next-line no-unnecessary-generics (it's used as the default type parameter for P)
+        path: Path,
+        // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
+        handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery, Locals>>
+    ): T;
+    // Comma separated list of RequestHandlers
     <
         Path extends string,
         P = RouteParameters<Path>,
@@ -151,6 +182,19 @@ export interface IRouterMatcher<
         // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
         ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery, Locals>>
     ): T;
+    // Array of RequestHandlers
+    <
+        P = ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        Locals extends Record<string, any> = Record<string, any>
+    >(
+        path: PathParams,
+        // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
+        handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>>
+    ): T;
+    // Comma separated list of RequestHandlers
     <
         P = ParamsDictionary,
         ResBody = any,
@@ -162,6 +206,19 @@ export interface IRouterMatcher<
         // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
         ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>>
     ): T;
+    // Array of RequestHandlers
+    <
+        P = ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        Locals extends Record<string, any> = Record<string, any>
+    >(
+        path: PathParams,
+        // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
+        handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery, Locals>>
+    ): T;
+    // Comma separated list of RequestHandlers
     <
         P = ParamsDictionary,
         ResBody = any,

--- a/types/express-serve-static-core/ts4.0/index.d.ts
+++ b/types/express-serve-static-core/ts4.0/index.d.ts
@@ -82,6 +82,19 @@ export interface IRouterMatcher<
     T,
     Method extends 'all' | 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' = any
     > {
+    // Array of RequestHandler
+    <
+        P = ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        Locals extends Record<string, any> = Record<string, any>
+        >(
+        path: PathParams,
+        // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
+        handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>>
+    ): T;
+    // Comma separated list of RequestHandlers
     <
         P = ParamsDictionary,
         ResBody = any,
@@ -93,6 +106,19 @@ export interface IRouterMatcher<
         // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
         ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals>>
     ): T;
+    // Array of RequestHandler
+    <
+        P = ParamsDictionary,
+        ResBody = any,
+        ReqBody = any,
+        ReqQuery = ParsedQs,
+        Locals extends Record<string, any> = Record<string, any>
+        >(
+        path: PathParams,
+        // tslint:disable-next-line no-unnecessary-generics (This generic is meant to be passed explicitly.)
+        handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery, Locals>>
+    ): T;
+    // Comma separated list of RequestHandlers
     <
         P = ParamsDictionary,
         ResBody = any,

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -37,9 +37,20 @@ namespace express_tests {
         next(err);
     });
 
+    // handler can be a single RequestHandler:
     app.get('/', (req, res) => {
         res.send('hello world');
     });
+
+    // ...or an array of RequestHandler
+    app.get("/", [
+        (req, res) => {
+            res.send("hello world");
+        },
+        (req, res) => {
+            res.send("hello world again");
+        },
+    ]);
 
     // Accept json app-wide or on one endpoint.
     app.use(express.json({ limit: '200kb' }));

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -4,6 +4,7 @@
 //                 China Medical University Hospital <https://github.com/CMUH>
 //                 Puneet Arora <https://github.com/puneetar>
 //                 Dylan Frankland <https://github.com/dfrankland>
+//                 Chris Frewin <https://github.com/princefishthrower>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /* =================== USAGE ===================


### PR DESCRIPTION
As the title suggests, this should be a fix for the issue raised here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/51337

The issue was the spread on `handlers` in the typings of `IRouterMatcher`.  This allows for infinitely comma-separated `RequestHandler`s, but _not_ a single array of them. For each of the typing overrides in `IRouterMatcher` that made use of the spread on handlers, i.e. `...handlers:`, I made an _additional_ override without the spread operator in the typings, i.e. just `handlers:`.

As the Express docs state,

```
Callback functions; can be:
- A middleware function.
- A series of middleware functions (separated by commas).
- An array of middleware functions.
- A combination of all of the above.
```

This pull request fixes that third point.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://expressjs.com/en/4x/api.html#app.get
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

One final issue however, I noticed even before starting my pull request one of the $ExpectError doesn't work, just this single one:

```typescript
// Params defaults to typed object
router.get('/:foo', req => {
    req.params.foo; // $ExpectType string
    req.params[0]; // $ExpectError <-- this one
});
```

But if I remove `$ExpectError`, it fails for TypeScript 4.5. Any ideas here? Seems like this error was already 'allowed' into the express typings from before.

My new definitions introduce no new errors.