### PR TITLE
eslint: require fix for suggestions

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -443,6 +443,10 @@ rule = {
                         return [ruleFixer.insertTextAfter(AST, "foo"), ruleFixer.insertTextAfter(TOKEN, "foo")];
                     },
                 },
+                {
+                    desc: "foo",
+                    fix: ruleFixer => null
+                }
             ],
         });
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -597,14 +597,22 @@ export namespace Rule {
         report(descriptor: ReportDescriptor): void;
     }
 
-    interface ReportDescriptorOptionsBase {
-        data?: { [key: string]: string } | undefined;
+    type ReportFixer = ((fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[]);
 
-        fix?: null | ((fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[]) | undefined;
+    interface ReportDescriptorOptionsBase {
+        data?: { [key: string]: string };
+
+        fix?: null | ReportFixer;
+    }
+
+    interface SuggestionReportOptions {
+        data?: { [key: string]: string };
+
+        fix: ReportFixer;
     }
 
     type SuggestionDescriptorMessage = { desc: string } | { messageId: string };
-    type SuggestionReportDescriptor = SuggestionDescriptorMessage & ReportDescriptorOptionsBase;
+    type SuggestionReportDescriptor = SuggestionDescriptorMessage & SuggestionReportOptions;
 
     interface ReportDescriptorOptions extends ReportDescriptorOptionsBase {
         suggest?: SuggestionReportDescriptor[] | null | undefined;

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -597,7 +597,7 @@ export namespace Rule {
         report(descriptor: ReportDescriptor): void;
     }
 
-    type ReportFixer = ((fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[]);
+    type ReportFixer = (fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[];
 
     interface ReportDescriptorOptionsBase {
         data?: { [key: string]: string };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions

---

When providing a suggestion in eslint, a fixer _must_ exist. It cannot be `undefined` or `null`, so our current types are incorrect by reusing the report base.

I could've probably used something like `Required<T>` or similar to re-use the base but i figured its more readable just having two interfaces.

I've also removed a redundant `undefined` (surprisingly the `no-redundant-undefined` rule hasn't been complaining about this).
