### PR TITLE
[error-cause] Make ponyfill types values

### DIFF
--- a/types/error-cause/Error.d.ts
+++ b/types/error-cause/Error.d.ts
@@ -1,11 +1,9 @@
-import { BaseError, BaseErrorConstructor } from './base/Error';
+import BaseError from './base/Error';
 
-interface Error extends BaseError {
+declare class Error extends BaseError {
+    constructor(reason?: string, options?: { cause?: unknown });
+
     cause: unknown;
 }
 
-interface ErrorConstructor extends BaseErrorConstructor {
-    new (reason: string, options?: { cause?: unknown }): Error;
-}
-
-export default ErrorConstructor;
+export default Error;

--- a/types/error-cause/Error.d.ts
+++ b/types/error-cause/Error.d.ts
@@ -1,0 +1,11 @@
+import { BaseError, BaseErrorConstructor } from './base/Error';
+
+interface Error extends BaseError {
+    cause: unknown;
+}
+
+interface ErrorConstructor extends BaseErrorConstructor {
+    new (reason: string, options?: { cause?: unknown }): Error;
+}
+
+export default ErrorConstructor;

--- a/types/error-cause/EvalError.d.ts
+++ b/types/error-cause/EvalError.d.ts
@@ -1,11 +1,9 @@
-import { BaseEvalError, BaseEvalErrorConstructor } from './base/EvalError';
+import BaseEvalError from './base/EvalError';
 
-interface EvalError extends BaseEvalError {
+declare class EvalError extends BaseEvalError {
+    constructor(reason?: string, options?: { cause?: unknown });
+
     cause: unknown;
 }
 
-interface EvalErrorConstructor extends BaseEvalErrorConstructor {
-    new (reason: string, options?: { cause?: unknown }): EvalError;
-}
-
-export default EvalErrorConstructor;
+export default EvalError;

--- a/types/error-cause/EvalError.d.ts
+++ b/types/error-cause/EvalError.d.ts
@@ -1,0 +1,11 @@
+import { BaseEvalError, BaseEvalErrorConstructor } from './base/EvalError';
+
+interface EvalError extends BaseEvalError {
+    cause: unknown;
+}
+
+interface EvalErrorConstructor extends BaseEvalErrorConstructor {
+    new (reason: string, options?: { cause?: unknown }): EvalError;
+}
+
+export default EvalErrorConstructor;

--- a/types/error-cause/RangeError.d.ts
+++ b/types/error-cause/RangeError.d.ts
@@ -1,11 +1,9 @@
-import { BaseRangeError, BaseRangeErrorConstructor } from './base/RangeError';
+import BaseRangeError from './base/RangeError';
 
-interface RangeError extends BaseRangeError {
+declare class RangeError extends BaseRangeError {
+    constructor(reason?: string, options?: { cause?: unknown });
+
     cause: unknown;
 }
 
-interface RangeErrorConstructor extends BaseRangeErrorConstructor {
-    new (reason: string, options?: { cause?: unknown }): RangeError;
-}
-
-export default RangeErrorConstructor;
+export default RangeError;

--- a/types/error-cause/RangeError.d.ts
+++ b/types/error-cause/RangeError.d.ts
@@ -1,0 +1,11 @@
+import { BaseRangeError, BaseRangeErrorConstructor } from './base/RangeError';
+
+interface RangeError extends BaseRangeError {
+    cause: unknown;
+}
+
+interface RangeErrorConstructor extends BaseRangeErrorConstructor {
+    new (reason: string, options?: { cause?: unknown }): RangeError;
+}
+
+export default RangeErrorConstructor;

--- a/types/error-cause/ReferenceError.d.ts
+++ b/types/error-cause/ReferenceError.d.ts
@@ -1,11 +1,9 @@
-import { BaseReferenceError, BaseReferenceErrorConstructor } from './base/ReferenceError';
+import BaseReferenceError from './base/ReferenceError';
 
-interface ReferenceError extends BaseReferenceError {
+declare class ReferenceError extends BaseReferenceError {
+    constructor(reason?: string, options?: { cause?: unknown });
+
     cause: unknown;
 }
 
-interface ReferenceErrorConstructor extends BaseReferenceErrorConstructor {
-    new (reason: string, options?: { cause?: unknown }): ReferenceError;
-}
-
-export default ReferenceErrorConstructor;
+export default ReferenceError;

--- a/types/error-cause/ReferenceError.d.ts
+++ b/types/error-cause/ReferenceError.d.ts
@@ -1,0 +1,11 @@
+import { BaseReferenceError, BaseReferenceErrorConstructor } from './base/ReferenceError';
+
+interface ReferenceError extends BaseReferenceError {
+    cause: unknown;
+}
+
+interface ReferenceErrorConstructor extends BaseReferenceErrorConstructor {
+    new (reason: string, options?: { cause?: unknown }): ReferenceError;
+}
+
+export default ReferenceErrorConstructor;

--- a/types/error-cause/SyntaxError.d.ts
+++ b/types/error-cause/SyntaxError.d.ts
@@ -1,0 +1,11 @@
+import { BaseSyntaxError, BaseSyntaxErrorConstructor } from './base/SyntaxError';
+
+interface SyntaxError extends BaseSyntaxError {
+    cause: unknown;
+}
+
+interface SyntaxErrorConstructor extends BaseSyntaxErrorConstructor {
+    new (reason: string, options?: { cause?: unknown }): SyntaxError;
+}
+
+export default SyntaxErrorConstructor;

--- a/types/error-cause/SyntaxError.d.ts
+++ b/types/error-cause/SyntaxError.d.ts
@@ -1,11 +1,9 @@
-import { BaseSyntaxError, BaseSyntaxErrorConstructor } from './base/SyntaxError';
+import BaseSyntaxError from './base/SyntaxError';
 
-interface SyntaxError extends BaseSyntaxError {
+declare class SyntaxError extends BaseSyntaxError {
+    constructor(reason?: string, options?: { cause?: unknown });
+
     cause: unknown;
 }
 
-interface SyntaxErrorConstructor extends BaseSyntaxErrorConstructor {
-    new (reason: string, options?: { cause?: unknown }): SyntaxError;
-}
-
-export default SyntaxErrorConstructor;
+export default SyntaxError;

--- a/types/error-cause/TypeError.d.ts
+++ b/types/error-cause/TypeError.d.ts
@@ -1,0 +1,11 @@
+import { BaseTypeError, BaseTypeErrorConstructor } from './base/TypeError';
+
+interface TypeError extends BaseTypeError {
+    cause: unknown;
+}
+
+interface TypeErrorConstructor extends BaseTypeErrorConstructor {
+    new (reason: string, options?: { cause?: unknown }): TypeError;
+}
+
+export default TypeErrorConstructor;

--- a/types/error-cause/TypeError.d.ts
+++ b/types/error-cause/TypeError.d.ts
@@ -1,11 +1,9 @@
-import { BaseTypeError, BaseTypeErrorConstructor } from './base/TypeError';
+import BaseTypeError from './base/TypeError';
 
-interface TypeError extends BaseTypeError {
+declare class TypeError extends BaseTypeError {
+    constructor(reason?: string, options?: { cause?: unknown });
+
     cause: unknown;
 }
 
-interface TypeErrorConstructor extends BaseTypeErrorConstructor {
-    new (reason: string, options?: { cause?: unknown }): TypeError;
-}
-
-export default TypeErrorConstructor;
+export default TypeError;

--- a/types/error-cause/URIError.d.ts
+++ b/types/error-cause/URIError.d.ts
@@ -1,0 +1,11 @@
+import { BaseURIError, BaseURIErrorConstructor } from './base/URIError';
+
+interface URIError extends BaseURIError {
+    cause: unknown;
+}
+
+interface URIErrorConstructor extends BaseURIErrorConstructor {
+    new (reason: string, options?: { cause?: unknown }): URIError;
+}
+
+export default URIErrorConstructor;

--- a/types/error-cause/URIError.d.ts
+++ b/types/error-cause/URIError.d.ts
@@ -1,11 +1,9 @@
-import { BaseURIError, BaseURIErrorConstructor } from './base/URIError';
+import BaseURIError from './base/URIError';
 
-interface URIError extends BaseURIError {
+declare class URIError extends BaseURIError {
+    constructor(reason?: string, options?: { cause?: unknown });
+
     cause: unknown;
 }
 
-interface URIErrorConstructor extends BaseURIErrorConstructor {
-    new (reason: string, options?: { cause?: unknown }): URIError;
-}
-
-export default URIErrorConstructor;
+export default URIError;

--- a/types/error-cause/auto.d.ts
+++ b/types/error-cause/auto.d.ts
@@ -1,0 +1,7 @@
+interface Error {
+    cause: unknown;
+}
+
+interface ErrorConstructor {
+    new (reason: string, options?: { cause?: unknown }): Error;
+}

--- a/types/error-cause/base/Error.d.ts
+++ b/types/error-cause/base/Error.d.ts
@@ -1,0 +1,4 @@
+type BaseError = Error;
+type BaseErrorConstructor = ErrorConstructor;
+
+export { BaseError, BaseErrorConstructor };

--- a/types/error-cause/base/Error.d.ts
+++ b/types/error-cause/base/Error.d.ts
@@ -1,4 +1,3 @@
-type BaseError = Error;
-type BaseErrorConstructor = ErrorConstructor;
+declare const BaseError: ErrorConstructor;
 
-export { BaseError, BaseErrorConstructor };
+export default BaseError;

--- a/types/error-cause/base/EvalError.d.ts
+++ b/types/error-cause/base/EvalError.d.ts
@@ -1,0 +1,4 @@
+type BaseEvalError = EvalError;
+type BaseEvalErrorConstructor = EvalErrorConstructor;
+
+export { BaseEvalError, BaseEvalErrorConstructor };

--- a/types/error-cause/base/EvalError.d.ts
+++ b/types/error-cause/base/EvalError.d.ts
@@ -1,4 +1,3 @@
-type BaseEvalError = EvalError;
-type BaseEvalErrorConstructor = EvalErrorConstructor;
+declare const BaseEvalError: EvalErrorConstructor;
 
-export { BaseEvalError, BaseEvalErrorConstructor };
+export default BaseEvalError;

--- a/types/error-cause/base/RangeError.d.ts
+++ b/types/error-cause/base/RangeError.d.ts
@@ -1,0 +1,4 @@
+type BaseRangeError = RangeError;
+type BaseRangeErrorConstructor = RangeErrorConstructor;
+
+export { BaseRangeError, BaseRangeErrorConstructor };

--- a/types/error-cause/base/RangeError.d.ts
+++ b/types/error-cause/base/RangeError.d.ts
@@ -1,4 +1,3 @@
-type BaseRangeError = RangeError;
-type BaseRangeErrorConstructor = RangeErrorConstructor;
+declare const BaseRangeError: RangeErrorConstructor;
 
-export { BaseRangeError, BaseRangeErrorConstructor };
+export default BaseRangeError;

--- a/types/error-cause/base/ReferenceError.d.ts
+++ b/types/error-cause/base/ReferenceError.d.ts
@@ -1,4 +1,3 @@
-type BaseReferenceError = ReferenceError;
-type BaseReferenceErrorConstructor = ReferenceErrorConstructor;
+declare const BaseReferenceError: ReferenceErrorConstructor;
 
-export { BaseReferenceError, BaseReferenceErrorConstructor };
+export default BaseReferenceError;

--- a/types/error-cause/base/ReferenceError.d.ts
+++ b/types/error-cause/base/ReferenceError.d.ts
@@ -1,0 +1,4 @@
+type BaseReferenceError = ReferenceError;
+type BaseReferenceErrorConstructor = ReferenceErrorConstructor;
+
+export { BaseReferenceError, BaseReferenceErrorConstructor };

--- a/types/error-cause/base/SyntaxError.d.ts
+++ b/types/error-cause/base/SyntaxError.d.ts
@@ -1,4 +1,3 @@
-type BaseSyntaxError = SyntaxError;
-type BaseSyntaxErrorConstructor = SyntaxErrorConstructor;
+declare const BaseSyntaxError: SyntaxErrorConstructor;
 
-export { BaseSyntaxError, BaseSyntaxErrorConstructor };
+export default BaseSyntaxError;

--- a/types/error-cause/base/SyntaxError.d.ts
+++ b/types/error-cause/base/SyntaxError.d.ts
@@ -1,0 +1,4 @@
+type BaseSyntaxError = SyntaxError;
+type BaseSyntaxErrorConstructor = SyntaxErrorConstructor;
+
+export { BaseSyntaxError, BaseSyntaxErrorConstructor };

--- a/types/error-cause/base/TypeError.d.ts
+++ b/types/error-cause/base/TypeError.d.ts
@@ -1,0 +1,4 @@
+type BaseTypeError = TypeError;
+type BaseTypeErrorConstructor = TypeErrorConstructor;
+
+export { BaseTypeError, BaseTypeErrorConstructor };

--- a/types/error-cause/base/TypeError.d.ts
+++ b/types/error-cause/base/TypeError.d.ts
@@ -1,4 +1,3 @@
-type BaseTypeError = TypeError;
-type BaseTypeErrorConstructor = TypeErrorConstructor;
+declare const BaseTypeError: TypeErrorConstructor;
 
-export { BaseTypeError, BaseTypeErrorConstructor };
+export default BaseTypeError;

--- a/types/error-cause/base/URIError.d.ts
+++ b/types/error-cause/base/URIError.d.ts
@@ -1,4 +1,3 @@
-type BaseURIError = URIError;
-type BaseURIErrorConstructor = URIErrorConstructor;
+declare const BaseURIError: URIErrorConstructor;
 
-export { BaseURIError, BaseURIErrorConstructor };
+export default BaseURIError;

--- a/types/error-cause/base/URIError.d.ts
+++ b/types/error-cause/base/URIError.d.ts
@@ -1,0 +1,4 @@
+type BaseURIError = URIError;
+type BaseURIErrorConstructor = URIErrorConstructor;
+
+export { BaseURIError, BaseURIErrorConstructor };

--- a/types/error-cause/index.d.ts
+++ b/types/error-cause/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for error-cause 1.0
 // Project: https://github.com/es-shims/error-cause
-// Definitions by: Conrad Buck <https://github.com/conartist6>
+// Definitions by: Conrad Buck <https://github.com/conartist6>, Jordan Harband <https://github.com/ljharb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 type ErrorTypes = [

--- a/types/error-cause/index.d.ts
+++ b/types/error-cause/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for error-cause 1.0
+// Project: https://github.com/es-shims/error-cause
+// Definitions by: Conrad Buck <https://github.com/conartist6>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type ErrorTypes = [
+    'Error',
+    'AggregateError',
+    'EvalError',
+    'RangeError',
+    'ReferenceError',
+    'SyntaxError',
+    'TypeError',
+    'URIError',
+];
+
+export default ErrorTypes;

--- a/types/error-cause/test/Error.test.ts
+++ b/types/error-cause/test/Error.test.ts
@@ -1,0 +1,16 @@
+import Error from 'error-cause/Error';
+
+declare const Ø: any;
+
+// $ExpectType Error
+new (Ø as Error)();
+// $ExpectType Error
+new (Ø as Error)('reason');
+// $ExpectType Error
+new (Ø as Error)('reason', {});
+// $ExpectType Error
+new (Ø as Error)('reason', { cause: null });
+// $ExpectType Error
+new (Ø as Error)('reason', { cause: 'stupidity' });
+// $ExpectType Error
+new (Ø as Error)('reason', { cause: Ø as Error });

--- a/types/error-cause/test/Error.test.ts
+++ b/types/error-cause/test/Error.test.ts
@@ -1,16 +1,14 @@
 import Error from 'error-cause/Error';
 
-declare const Ø: any;
-
 // $ExpectType Error
-new (Ø as Error)();
+new Error();
 // $ExpectType Error
-new (Ø as Error)('reason');
+new Error('reason');
 // $ExpectType Error
-new (Ø as Error)('reason', {});
+new Error('reason', {});
 // $ExpectType Error
-new (Ø as Error)('reason', { cause: null });
+new Error('reason', { cause: null });
 // $ExpectType Error
-new (Ø as Error)('reason', { cause: 'stupidity' });
+new Error('reason', { cause: 'stupidity' });
 // $ExpectType Error
-new (Ø as Error)('reason', { cause: Ø as Error });
+new Error('reason', { cause: new Error() });

--- a/types/error-cause/test/EvalError.test.ts
+++ b/types/error-cause/test/EvalError.test.ts
@@ -1,16 +1,14 @@
 import EvalError from 'error-cause/EvalError';
 
-declare const Ø: any;
-
 // $ExpectType EvalError
-new (Ø as EvalError)();
+new EvalError();
 // $ExpectType EvalError
-new (Ø as EvalError)('reason');
+new EvalError('reason');
 // $ExpectType EvalError
-new (Ø as EvalError)('reason', {});
+new EvalError('reason', {});
 // $ExpectType EvalError
-new (Ø as EvalError)('reason', { cause: null });
+new EvalError('reason', { cause: null });
 // $ExpectType EvalError
-new (Ø as EvalError)('reason', { cause: 'stupidity' });
+new EvalError('reason', { cause: 'stupidity' });
 // $ExpectType EvalError
-new (Ø as EvalError)('reason', { cause: Ø as Error });
+new EvalError('reason', { cause: new EvalError() });

--- a/types/error-cause/test/EvalError.test.ts
+++ b/types/error-cause/test/EvalError.test.ts
@@ -1,0 +1,16 @@
+import EvalError from 'error-cause/EvalError';
+
+declare const Ø: any;
+
+// $ExpectType EvalError
+new (Ø as EvalError)();
+// $ExpectType EvalError
+new (Ø as EvalError)('reason');
+// $ExpectType EvalError
+new (Ø as EvalError)('reason', {});
+// $ExpectType EvalError
+new (Ø as EvalError)('reason', { cause: null });
+// $ExpectType EvalError
+new (Ø as EvalError)('reason', { cause: 'stupidity' });
+// $ExpectType EvalError
+new (Ø as EvalError)('reason', { cause: Ø as Error });

--- a/types/error-cause/test/RangeError.test.ts
+++ b/types/error-cause/test/RangeError.test.ts
@@ -1,16 +1,14 @@
 import RangeError from 'error-cause/RangeError';
 
-declare const Ø: any;
-
 // $ExpectType RangeError
-new (Ø as RangeError)();
+new RangeError();
 // $ExpectType RangeError
-new (Ø as RangeError)('reason');
+new RangeError('reason');
 // $ExpectType RangeError
-new (Ø as RangeError)('reason', {});
+new RangeError('reason', {});
 // $ExpectType RangeError
-new (Ø as RangeError)('reason', { cause: null });
+new RangeError('reason', { cause: null });
 // $ExpectType RangeError
-new (Ø as RangeError)('reason', { cause: 'stupidity' });
+new RangeError('reason', { cause: 'stupidity' });
 // $ExpectType RangeError
-new (Ø as RangeError)('reason', { cause: Ø as Error });
+new RangeError('reason', { cause: new RangeError() });

--- a/types/error-cause/test/RangeError.test.ts
+++ b/types/error-cause/test/RangeError.test.ts
@@ -1,0 +1,16 @@
+import RangeError from 'error-cause/RangeError';
+
+declare const Ø: any;
+
+// $ExpectType RangeError
+new (Ø as RangeError)();
+// $ExpectType RangeError
+new (Ø as RangeError)('reason');
+// $ExpectType RangeError
+new (Ø as RangeError)('reason', {});
+// $ExpectType RangeError
+new (Ø as RangeError)('reason', { cause: null });
+// $ExpectType RangeError
+new (Ø as RangeError)('reason', { cause: 'stupidity' });
+// $ExpectType RangeError
+new (Ø as RangeError)('reason', { cause: Ø as Error });

--- a/types/error-cause/test/ReferenceError.test.ts
+++ b/types/error-cause/test/ReferenceError.test.ts
@@ -1,16 +1,14 @@
 import ReferenceError from 'error-cause/ReferenceError';
 
-declare const Ø: any;
-
 // $ExpectType ReferenceError
-new (Ø as ReferenceError)();
+new ReferenceError();
 // $ExpectType ReferenceError
-new (Ø as ReferenceError)('reason');
+new ReferenceError('reason');
 // $ExpectType ReferenceError
-new (Ø as ReferenceError)('reason', {});
+new ReferenceError('reason', {});
 // $ExpectType ReferenceError
-new (Ø as ReferenceError)('reason', { cause: null });
+new ReferenceError('reason', { cause: null });
 // $ExpectType ReferenceError
-new (Ø as ReferenceError)('reason', { cause: 'stupidity' });
+new ReferenceError('reason', { cause: 'stupidity' });
 // $ExpectType ReferenceError
-new (Ø as ReferenceError)('reason', { cause: Ø as Error });
+new ReferenceError('reason', { cause: new ReferenceError() });

--- a/types/error-cause/test/ReferenceError.test.ts
+++ b/types/error-cause/test/ReferenceError.test.ts
@@ -1,0 +1,16 @@
+import ReferenceError from 'error-cause/ReferenceError';
+
+declare const Ø: any;
+
+// $ExpectType ReferenceError
+new (Ø as ReferenceError)();
+// $ExpectType ReferenceError
+new (Ø as ReferenceError)('reason');
+// $ExpectType ReferenceError
+new (Ø as ReferenceError)('reason', {});
+// $ExpectType ReferenceError
+new (Ø as ReferenceError)('reason', { cause: null });
+// $ExpectType ReferenceError
+new (Ø as ReferenceError)('reason', { cause: 'stupidity' });
+// $ExpectType ReferenceError
+new (Ø as ReferenceError)('reason', { cause: Ø as Error });

--- a/types/error-cause/test/SyntaxError.test.ts
+++ b/types/error-cause/test/SyntaxError.test.ts
@@ -1,16 +1,14 @@
 import SyntaxError from 'error-cause/SyntaxError';
 
-declare const Ø: any;
-
 // $ExpectType SyntaxError
-new (Ø as SyntaxError)();
+new SyntaxError();
 // $ExpectType SyntaxError
-new (Ø as SyntaxError)('reason');
+new SyntaxError('reason');
 // $ExpectType SyntaxError
-new (Ø as SyntaxError)('reason', {});
+new SyntaxError('reason', {});
 // $ExpectType SyntaxError
-new (Ø as SyntaxError)('reason', { cause: null });
+new SyntaxError('reason', { cause: null });
 // $ExpectType SyntaxError
-new (Ø as SyntaxError)('reason', { cause: 'stupidity' });
+new SyntaxError('reason', { cause: 'stupidity' });
 // $ExpectType SyntaxError
-new (Ø as SyntaxError)('reason', { cause: Ø as Error });
+new SyntaxError('reason', { cause: new SyntaxError() });

--- a/types/error-cause/test/SyntaxError.test.ts
+++ b/types/error-cause/test/SyntaxError.test.ts
@@ -1,0 +1,16 @@
+import SyntaxError from 'error-cause/SyntaxError';
+
+declare const Ø: any;
+
+// $ExpectType SyntaxError
+new (Ø as SyntaxError)();
+// $ExpectType SyntaxError
+new (Ø as SyntaxError)('reason');
+// $ExpectType SyntaxError
+new (Ø as SyntaxError)('reason', {});
+// $ExpectType SyntaxError
+new (Ø as SyntaxError)('reason', { cause: null });
+// $ExpectType SyntaxError
+new (Ø as SyntaxError)('reason', { cause: 'stupidity' });
+// $ExpectType SyntaxError
+new (Ø as SyntaxError)('reason', { cause: Ø as Error });

--- a/types/error-cause/test/TypeError.test.ts
+++ b/types/error-cause/test/TypeError.test.ts
@@ -1,16 +1,14 @@
 import TypeError from 'error-cause/TypeError';
 
-declare const Ø: any;
-
 // $ExpectType TypeError
-new (Ø as TypeError)();
+new TypeError();
 // $ExpectType TypeError
-new (Ø as TypeError)('reason');
+new TypeError('reason');
 // $ExpectType TypeError
-new (Ø as TypeError)('reason', {});
+new TypeError('reason', {});
 // $ExpectType TypeError
-new (Ø as TypeError)('reason', { cause: null });
+new TypeError('reason', { cause: null });
 // $ExpectType TypeError
-new (Ø as TypeError)('reason', { cause: 'stupidity' });
+new TypeError('reason', { cause: 'stupidity' });
 // $ExpectType TypeError
-new (Ø as TypeError)('reason', { cause: Ø as Error });
+new TypeError('reason', { cause: new TypeError() });

--- a/types/error-cause/test/TypeError.test.ts
+++ b/types/error-cause/test/TypeError.test.ts
@@ -1,0 +1,16 @@
+import TypeError from 'error-cause/TypeError';
+
+declare const Ø: any;
+
+// $ExpectType TypeError
+new (Ø as TypeError)();
+// $ExpectType TypeError
+new (Ø as TypeError)('reason');
+// $ExpectType TypeError
+new (Ø as TypeError)('reason', {});
+// $ExpectType TypeError
+new (Ø as TypeError)('reason', { cause: null });
+// $ExpectType TypeError
+new (Ø as TypeError)('reason', { cause: 'stupidity' });
+// $ExpectType TypeError
+new (Ø as TypeError)('reason', { cause: Ø as Error });

--- a/types/error-cause/test/URIError.test.ts
+++ b/types/error-cause/test/URIError.test.ts
@@ -1,0 +1,16 @@
+import URIError from 'error-cause/URIError';
+
+declare const Ø: any;
+
+// $ExpectType URIError
+new (Ø as URIError)();
+// $ExpectType URIError
+new (Ø as URIError)('reason');
+// $ExpectType URIError
+new (Ø as URIError)('reason', {});
+// $ExpectType URIError
+new (Ø as URIError)('reason', { cause: null });
+// $ExpectType URIError
+new (Ø as URIError)('reason', { cause: 'stupidity' });
+// $ExpectType URIError
+new (Ø as URIError)('reason', { cause: Ø as Error });

--- a/types/error-cause/test/URIError.test.ts
+++ b/types/error-cause/test/URIError.test.ts
@@ -1,16 +1,14 @@
 import URIError from 'error-cause/URIError';
 
-declare const Ø: any;
-
 // $ExpectType URIError
-new (Ø as URIError)();
+new URIError();
 // $ExpectType URIError
-new (Ø as URIError)('reason');
+new URIError('reason');
 // $ExpectType URIError
-new (Ø as URIError)('reason', {});
+new URIError('reason', {});
 // $ExpectType URIError
-new (Ø as URIError)('reason', { cause: null });
+new URIError('reason', { cause: null });
 // $ExpectType URIError
-new (Ø as URIError)('reason', { cause: 'stupidity' });
+new URIError('reason', { cause: 'stupidity' });
 // $ExpectType URIError
-new (Ø as URIError)('reason', { cause: Ø as Error });
+new URIError('reason', { cause: new URIError() });

--- a/types/error-cause/test/auto.test.ts
+++ b/types/error-cause/test/auto.test.ts
@@ -1,0 +1,16 @@
+import 'error-cause/auto';
+
+declare const Ø: any;
+
+// $ExpectType Error
+new Error();
+// $ExpectType Error
+new Error('reason');
+// $ExpectType Error
+new Error('reason', {});
+// $ExpectType Error
+new Error('reason', { cause: null });
+// $ExpectType Error
+new Error('reason', { cause: 'stupidity' });
+// $ExpectType Error
+new Error('reason', { cause: Ø as Error });

--- a/types/error-cause/test/index.test.ts
+++ b/types/error-cause/test/index.test.ts
@@ -1,0 +1,6 @@
+import ErrorTypes from 'error-cause';
+
+declare const Ø: any;
+
+// $ExpectType "Error"
+(Ø as ErrorTypes)[0];

--- a/types/error-cause/tsconfig.json
+++ b/types/error-cause/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "index.d.ts",
+        "test/auto.test.ts",
+        "test/Error.test.ts",
+        "test/EvalError.test.ts",
+        "test/RangeError.test.ts",
+        "test/ReferenceError.test.ts",
+        "test/SyntaxError.test.ts",
+        "test/TypeError.test.ts",
+        "test/URIError.test.ts",
+        "test/index.test.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": true,
+        "types": [],
+        "lib": ["es6"],
+        "baseUrl": "../",
+        "typeRoots": ["../"]
+    }
+}

--- a/types/error-cause/tslint.json
+++ b/types/error-cause/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

I am fixing a bug in an existing definition and its tests.

My previous definitions contained a critical mistake: types were exported, but did not declare any values which had those types. This is appropriate in the `auto` module where we are merely declaring that a core type which is already declared to be the type of `global.Error`, but when we are exporting types for new classes we must define the values that have our types.

Since we wouldn't support interface merging anyway (it only works in files with no imports and no exports), I've switched the defs over to just declare classes.