### PR TITLE
update(picomatch): v2.3 and minor fixes

### DIFF
--- a/types/picomatch/index.d.ts
+++ b/types/picomatch/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for picomatch 2.2
+// Type definitions for picomatch 2.3
 // Project: https://github.com/micromatch/picomatch
 // Definitions by: Patrick <https://github.com/p-kuen>
 //                 Daniel Tschinder <https://github.com/danez>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.0
 
 import picomatch = require('./lib/picomatch');
 

--- a/types/picomatch/lib/constants.d.ts
+++ b/types/picomatch/lib/constants.d.ts
@@ -15,6 +15,7 @@ declare const POSIX_CHARS: {
     STAR: string;
     START_ANCHOR: string;
 };
+
 /**
  * Windows glob regex
  */
@@ -30,11 +31,8 @@ declare const WINDOWS_CHARS: {
     QMARK_NO_DOT: string;
     START_ANCHOR: string;
     END_ANCHOR: string;
-    DOT_LITERAL: string;
-    PLUS_LITERAL: string;
-    QMARK_LITERAL: string;
-    ONE_CHAR: string;
-};
+} & typeof POSIX_CHARS;
+
 /**
  * POSIX Bracket Regex
  */

--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -21,7 +21,7 @@ import scanImport = require('./scan');
  * @return Returns a matcher function.
  * @api public
  */
-declare function picomatch<T extends true | false>(
+declare function picomatch<T extends true | false = false>(
     glob: picomatch.Glob,
     options?: picomatch.PicomatchOptions,
     returnState?: T,
@@ -96,7 +96,7 @@ declare namespace picomatch {
         /**
          * Regex flags to use in the generated regex. If defined, the `nocase` option will be overridden.
          */
-        flags?: boolean | undefined;
+        flags?: string | undefined;
         /**
          * Custom function for formatting the returned string. This is useful for removing leading slashes, converting Windows paths to Posix paths, etc.
          */
@@ -243,7 +243,9 @@ declare namespace picomatch {
         returnState?: boolean,
     ): ReturnType<typeof compileRe>;
 
-    function toRegex(source: string | RegExp, options?: { flags?: string | undefined; nocase?: boolean | undefined; debug?: boolean | undefined }): RegExp;
+    type ToRegexOptions = Pick<PicomatchOptions, 'flags' | 'nocase' | 'debug'>;
+
+    function toRegex(source: string | RegExp, options?: ToRegexOptions): RegExp;
 
     const constants: typeof constantsImport;
 }

--- a/types/picomatch/picomatch-tests.ts
+++ b/types/picomatch/picomatch-tests.ts
@@ -1,8 +1,9 @@
 import pm = require('picomatch');
-import { Matcher, PicomatchOptions } from 'picomatch';
 
+new RegExp(/a/);
 // main function
 const isMatch = pm('*.!(*a)');
+isMatch('abcd');
 
 // main function with state
 const isMatch2 = pm('*.!(*a)', {}, true);
@@ -36,15 +37,24 @@ pm.scan('!./foo/*.js');
 const state = pm.parse('*.js');
 pm.compileRe(state);
 pm.toRegex(state.output);
+pm.toRegex(state.output, {
+    debug: true,
+    flags: 'g',
+    nocase: true,
+});
 
 pm.scan('!./foo/*.js', { tokens: true });
 
 pm.makeRe('foo/*.js').test('foo/bar.js');
 pm.makeRe('foo/{01..25}/bar', {
     expandRange(a, b) {
-      return `(<fill-range output>)`;
-    }
+        return `(<fill-range output>)`;
+    },
 });
 
-const isMatchWithIgnore = pm('*.!(*a)', {ignore: 'single-string'});
-const isMatchWithMultipleIgnores = pm('*.!(*a)', {ignore: ['many', 'strings']});
+const isMatchWithIgnore = pm('*.!(*a)', { ignore: 'single-string' });
+const isMatchWithMultipleIgnores = pm('*.!(*a)', { ignore: ['many', 'strings'] });
+
+const picoConstansts = pm.constants.globChars(true /* is windows */);
+picoConstansts.SLASH_LITERAL; // $ExpectType string
+picoConstansts.DOT_LITERAL; // $ExpectType string


### PR DESCRIPTION
- `picomatch` generic for `returnState` defaults to `false` now
- options `flag` is a string, not a boolean, it's used in RegExp
  constructor (I'll amned upstream docs in separate PR)
- move `toRegex` options into type (sutype of options)
- Windows constats are a merge with Posix settings, reflected in
  defintion to avoid duplication
- minor style change (prettier)
- version bump
- maintainer added

https://github.com/micromatch/picomatch/blob/4a510d7fd7a3037efaf54786e5fe2b553cdc657a/lib/constants.js#L50
https://github.com/micromatch/picomatch/blob/56083efda08c68b5123ba29c55a9f22e0d830b51/lib/picomatch.js#L324
https://github.com/micromatch/picomatch/blob/master/lib/picomatch.js#L32

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.