### PR TITLE
update(concurrently): support for Chalk colors

### DIFF
--- a/types/concurrently/concurrently-tests.ts
+++ b/types/concurrently/concurrently-tests.ts
@@ -65,3 +65,19 @@ concurrently(['echo foo', 'npm:watch-*', { command: 'nodemon', name: 'server' }]
     // $ExpectType (reason: any) => void
     reason => {},
 );
+
+concurrently(['echo foo'], {
+    prefixColors: ['grey', 'red', 'black'],
+});
+
+concurrently(
+    [
+        {
+            command: 'echo foo',
+            prefixColor: 'red',
+        },
+    ],
+    {
+        prefixColors: ['red'],
+    },
+);

--- a/types/concurrently/index.d.ts
+++ b/types/concurrently/index.d.ts
@@ -1,10 +1,13 @@
-// Type definitions for concurrently 6.2
-// Project: https://github.com/kimmobrunfeldt/concurrently#readme
+// Type definitions for concurrently 6.3
+// Project: https://github.com/open-cli-tools/concurrently#readme
 // Definitions by: Michael B. <https://github.com/Blasz>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Ryan Ling <https://github.com/72636c>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 /// <reference types="node" />
+
+import { Color as ChalkColor } from 'chalk';
 
 declare function concurrently(
     commands: Array<concurrently.CommandObj | string>,
@@ -17,7 +20,7 @@ declare namespace concurrently {
         cwd?: Options['cwd'] | undefined;
         env?: NodeJS.ProcessEnv | undefined;
         name?: string | undefined;
-        prefixColor?: string | undefined;
+        prefixColor?: typeof ChalkColor | undefined;
     }
     interface ExitInfos {
         command: CommandObj;
@@ -51,6 +54,11 @@ declare namespace concurrently {
          * the prefix type to use when logging processes output.
          */
         prefix?: 'index' | 'pid' | 'time' | 'command' | 'name' | 'none' | string | undefined;
+        /**
+         * list of chalk colors to use on prefixes.
+         * If there are more commands than colors, the last color will be repeated.
+         */
+        prefixColors?: Array<typeof ChalkColor> | undefined;
         /** how many characters to show when prefixing with `command`. Default: `10` */
         prefixLength?: number | undefined;
         /** whether raw mode should be used, meaning strictly process output will be logged, without any prefixes, colouring or extra stuff. */

--- a/types/concurrently/package.json
+++ b/types/concurrently/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "chalk": "^4.1.0"
+    }
+}


### PR DESCRIPTION
v2.3 added support for Chalk's (direct dependency) colors. This change
reflect this adding typed colors support to new `prefixColors` options:

https://github.com/open-cli-tools/concurrently/pull/286/files

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.