### PR TITLE
fix(react): Default FocusEvent#relatedTarget to Element

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1193,9 +1193,9 @@ declare namespace React {
         isPrimary: boolean;
     }
 
-    interface FocusEvent<T = Element> extends SyntheticEvent<T, NativeFocusEvent> {
-        relatedTarget: EventTarget | null;
-        target: EventTarget & T;
+    interface FocusEvent<Target = Element, RelatedTarget = Element> extends SyntheticEvent<Target, NativeFocusEvent> {
+        relatedTarget: (EventTarget & RelatedTarget) | null;
+        target: EventTarget & Target;
     }
 
     interface FormEvent<T = Element> extends SyntheticEvent<T> {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -499,6 +499,22 @@ const htmlAttr: React.HTMLProps<HTMLElement> = {
     onAnimationStart: event => {
         const currentTarget: EventTarget & HTMLElement = event.currentTarget;
     },
+    onBlur: (event: React.FocusEvent) => {
+        const {
+            // $ExpectType (EventTarget & Element) | null
+            relatedTarget,
+            // $ExpectType EventTarget & Element
+            target
+        } = event;
+    },
+    onFocus: (event: React.FocusEvent) => {
+        const {
+            // $ExpectType (EventTarget & Element) | null
+            relatedTarget,
+            // $ExpectType EventTarget & Element
+            target
+        } = event;
+    },
     dangerouslySetInnerHTML: {
         __html: "<strong>STRONG</strong>"
     },

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1191,9 +1191,9 @@ declare namespace React {
         isPrimary: boolean;
     }
 
-    interface FocusEvent<T = Element> extends SyntheticEvent<T, NativeFocusEvent> {
-        relatedTarget: EventTarget | null;
-        target: EventTarget & T;
+    interface FocusEvent<Target = Element, RelatedTarget = Element> extends SyntheticEvent<Target, NativeFocusEvent> {
+        relatedTarget: (EventTarget & RelatedTarget) | null;
+        target: EventTarget & Target;
     }
 
     // tslint:disable-next-line:no-empty-interface

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -494,6 +494,22 @@ const htmlAttr: React.HTMLProps<HTMLElement> = {
     onAnimationStart: event => {
         const currentTarget: EventTarget & HTMLElement = event.currentTarget;
     },
+    onBlur: (event: React.FocusEvent) => {
+        const {
+            // $ExpectType (EventTarget & Element) | null
+            relatedTarget,
+            // $ExpectType EventTarget & Element
+            target
+        } = event;
+    },
+    onFocus: (event: React.FocusEvent) => {
+        const {
+            // $ExpectType (EventTarget & Element) | null
+            relatedTarget,
+            // $ExpectType EventTarget & Element
+            target
+        } = event;
+    },
     dangerouslySetInnerHTML: {
         __html: "<strong>STRONG</strong>"
     },


### PR DESCRIPTION
The `relatedTarget` of a FocusEvent is the `target` of its related `FocusEvent` so the types of `relatedTarget` and `target` should match.

Note that by spec `relatedTarget` can be as abstract as `EventTarget` but so can the `target`. I'd argue that if we make the practical concession for `target` we should make the same one for `relatedTarget`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/relatedTarget
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

