### PR TITLE
serverless: add missing `getCredentials()` method for awsProvider

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -647,12 +647,17 @@ declare namespace Aws {
     interface Custom {
         [key: string]: any;
     }
+
+    interface Credentials {
+        [key: string]: any;
+    }
 }
 
 declare class Aws {
     constructor(serverless: Serverless, options: Serverless.Options);
 
     naming: { [key: string]: () => string };
+    getCredentials(): Aws.Credentials;
     getProviderName(): string;
     getRegion(): string;
     getServerlessDeploymentBucketName(): Promise<string>;

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -106,6 +106,9 @@ provider.request(
 // Test provider's 'getServerlessDeploymentBucketName'
 provider.getServerlessDeploymentBucketName().then(bucketName => {});
 
+// $ExpectType Credentials
+provider.getCredentials();
+
 // Test ApiGateway validator
 getHttp(
     {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Serverless source](https://github.com/serverless/serverless/blob/1107763df8fb07a40ec45529f77d99e5a0f6d4d6/lib/plugins/aws/provider.js#L1456)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This method have been existing in the Serverless source code for about 5 years and is useful when reusing credential information from plugins [like this](https://github.com/theBenForce/serverless-swagger-api/pull/44).