### PR TITLE
[react] Host children accept readonly array

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -232,7 +232,7 @@ declare namespace React {
     type ReactText = string | number;
     type ReactChild = ReactElement | ReactText;
 
-    interface ReactNodeArray extends Array<ReactNode> {}
+    interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
     type ReactFragment = {} | ReactNodeArray;
     type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;
 


### PR DESCRIPTION
In preparation of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026.

readonly arrays are currently only accepted because `ReactNode` includes `{}`. Readonly arrays is covered by https://github.com/DefinitelyTyped/DefinitelyTyped/blob/684c905d533f1a4f5a62edf9011d5eca5a9458a6/types/react/test/tsx.tsx#L461-L469

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
   - https://codesandbox.io/s/readonly-children-array-ittqz
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
