### PR TITLE
[webpack-env] Fix definition for __webpack_chunk_load__

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -305,9 +305,8 @@ declare var __webpack_require__: any;
  * The internal chunk loading function
  *
  * @param chunkId The id for the chunk to load.
- * @param callback A callback function called once the chunk is loaded.
  */
-declare var __webpack_chunk_load__: (chunkId: any, callback: (require: __WebpackModuleApi.RequireLambda) => void) => void;
+declare var __webpack_chunk_load__: (chunkId: any) => Promise<any>;
 
 /**
  * Access to the internal object of all modules.

--- a/types/webpack-env/webpack-env-tests.ts
+++ b/types/webpack-env/webpack-env-tests.ts
@@ -19,6 +19,10 @@ require(['./someModule', './otherModule'], (someModule: SomeModule, otherModule:
 
 });
 
+async function testChunkLoad(): Promise<void> {
+    const module = await __webpack_chunk_load__("./someModule");
+}
+
 // check if HMR is enabled
 if(module.hot) {
     // accept update of dependency without a callback


### PR DESCRIPTION
The API changed to a promise-based one in 2015(!): https://github.com/webpack/webpack/commit/2245c4acca9c028b2b55c5cd7f1a933da605187a

It looks like `__WebpackModuleApi.RequireLambda` and friends are now unused. I didn't delete them because I wasn't sure whether this was intended to be a public API.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack/commit/2245c4acca9c028b2b55c5cd7f1a933da605187a
