### PR TITLE
feat: support `BigUint64Array`, `BigInt64Array`, and `GenericArray`

### DIFF
--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -41,11 +41,6 @@ declare namespace ndarray {
         length: number;
     }
 
-    interface Indexible<T> {
-        [x: number]: T;
-        length: number;
-    }
-
     type Data<T = any> = T extends number
         ? GenericArray<T> | T[] | TypedArray
         : T extends bigint
@@ -63,7 +58,7 @@ declare namespace ndarray {
         | Float32Array
         | Float64Array;
 
-    type Value<D extends Data> = D extends GenericArray<infer T> | Indexible<infer T> ? T : never;
+    type Value<D extends Data> = D extends GenericArray<infer T> | Record<number, infer T> ? T : never;
 
     type DataType<D extends Data = Data> = D extends Int8Array
         ? 'int8'

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -5,6 +5,7 @@
 //                 Axel Bocciarelli <https://github.com/axelboc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
+/// <reference lib="esnext.bigint" />
 
 declare function ndarray<D extends ndarray.Data = ndarray.Data<number>>(
     data: D,

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -14,7 +14,7 @@ declare function ndarray<D extends ndarray.Data = ndarray.Data<number>>(
 ): ndarray.NdArray<D>;
 
 declare namespace ndarray {
-    interface NdArray<D extends Data = Data<number>> {
+    interface NdArray<D extends Data = Data<number, TypedArray>> {
         data: D;
         shape: number[];
         stride: number[];
@@ -33,8 +33,9 @@ declare namespace ndarray {
         pick(...args: Array<number | null>): NdArray<D>;
         T: NdArray<D>;
     }
-
-    type Data<T = any> = T[] | TypedArray;
+    type Data<Scalar = any, T extends { [x: number]: unknown } = TypedArray | BigUint64Array | BigInt64Array> =
+        | Scalar[]
+        | T;
     type TypedArray =
         | Int8Array
         | Int16Array
@@ -45,10 +46,9 @@ declare namespace ndarray {
         | Uint32Array
         | Float32Array
         | Float64Array;
+    type Value<D extends Data> = D[number];
 
-    type Value<D extends Data> = D extends Array<infer T> ? T : number;
-
-    type DataType<D extends Data = Data> = D extends Int8Array
+    type DataType<D extends Data> = D extends Int8Array
         ? 'int8'
         : D extends Int16Array
         ? 'int16'
@@ -66,6 +66,10 @@ declare namespace ndarray {
         ? 'float32'
         : D extends Float64Array
         ? 'float64'
+        : D extends BigInt64Array
+        ? 'bigint64'
+        : D extends BigUint64Array
+        ? 'biguint64'
         : 'array';
 }
 

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -35,11 +35,22 @@ declare namespace ndarray {
         T: NdArray<D>;
     }
 
+    interface GenericArray<T> {
+        get(idx: number): T;
+        set(idx: number, value: T): void;
+        length: number;
+    }
+
+    interface Indexible<T> {
+        [x: number]: T;
+        length: number;
+    }
+
     type Data<T = any> = T extends number
-        ? T[] | TypedArray
+        ? GenericArray<T> | T[] | TypedArray
         : T extends bigint
-        ? T[] | BigInt64Array | BigUint64Array
-        : T[];
+        ? GenericArray<T> | T[] | BigInt64Array | BigUint64Array
+        : GenericArray<T> | T[];
 
     type TypedArray =
         | Int8Array
@@ -52,7 +63,7 @@ declare namespace ndarray {
         | Float32Array
         | Float64Array;
 
-    type Value<D extends Data> = D[number];
+    type Value<D extends Data> = D extends GenericArray<infer T> | Indexible<infer T> ? T : never;
 
     type DataType<D extends Data = Data> = D extends Int8Array
         ? 'int8'
@@ -76,6 +87,8 @@ declare namespace ndarray {
         ? 'bigint64'
         : D extends BigUint64Array
         ? 'biguint64'
+        : D extends GenericArray<unknown>
+        ? 'generic'
         : 'array';
 }
 

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -5,7 +5,6 @@
 //                 Axel Bocciarelli <https://github.com/axelboc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
-/// <reference lib="esnext.bigint" />
 
 declare function ndarray<D extends ndarray.Data = ndarray.Data<number>>(
     data: D,
@@ -41,10 +40,13 @@ declare namespace ndarray {
         length: number;
     }
 
+    type MaybeBigInt64Array = InstanceType<typeof globalThis extends { BigInt64Array: infer T } ? T : never>;
+    type MaybeBigUint64Array = InstanceType<typeof globalThis extends { BigUint64Array: infer T } ? T : never>;
+
     type Data<T = any> = T extends number
         ? GenericArray<T> | T[] | TypedArray
         : T extends bigint
-        ? GenericArray<T> | T[] | BigInt64Array | BigUint64Array
+        ? GenericArray<T> | T[] | MaybeBigInt64Array | MaybeBigUint64Array
         : GenericArray<T> | T[];
 
     type TypedArray =
@@ -78,9 +80,9 @@ declare namespace ndarray {
         ? 'float32'
         : D extends Float64Array
         ? 'float64'
-        : D extends BigInt64Array
+        : D extends MaybeBigInt64Array
         ? 'bigint64'
-        : D extends BigUint64Array
+        : D extends MaybeBigUint64Array
         ? 'biguint64'
         : D extends GenericArray<unknown>
         ? 'generic'

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -34,7 +34,15 @@ declare namespace ndarray {
         pick(...args: Array<number | null>): NdArray<D>;
         T: NdArray<D>;
     }
-    type Data<T = any> = T extends bigint ? T[] | TypedArray | BigInt64Array | BigUint64Array : T[] | TypedArray;
+
+    type Data<T = any> = T extends number
+        ? T[] | TypedArray
+        : T extends bigint
+        ? T[] | BigInt64Array | BigUint64Array
+        : T extends bigint | number
+        ? T[] | TypedArray | BigInt64Array | BigUint64Array
+        : T[];
+
     type TypedArray =
         | Int8Array
         | Int16Array
@@ -45,6 +53,7 @@ declare namespace ndarray {
         | Uint32Array
         | Float32Array
         | Float64Array;
+
     type Value<D extends Data> = D[number];
 
     type DataType<D extends Data = Data> = D extends Int8Array

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -39,8 +39,6 @@ declare namespace ndarray {
         ? T[] | TypedArray
         : T extends bigint
         ? T[] | BigInt64Array | BigUint64Array
-        : T extends bigint | number
-        ? T[] | TypedArray | BigInt64Array | BigUint64Array
         : T[];
 
     type TypedArray =

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -49,7 +49,7 @@ declare namespace ndarray {
         | Float64Array;
     type Value<D extends Data> = D[number];
 
-    type DataType<D extends Data> = D extends Int8Array
+    type DataType<D extends Data = Data> = D extends Int8Array
         ? 'int8'
         : D extends Int16Array
         ? 'int16'

--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -15,7 +15,7 @@ declare function ndarray<D extends ndarray.Data = ndarray.Data<number>>(
 ): ndarray.NdArray<D>;
 
 declare namespace ndarray {
-    interface NdArray<D extends Data = Data<number, TypedArray>> {
+    interface NdArray<D extends Data = Data<number>> {
         data: D;
         shape: number[];
         stride: number[];
@@ -34,9 +34,7 @@ declare namespace ndarray {
         pick(...args: Array<number | null>): NdArray<D>;
         T: NdArray<D>;
     }
-    type Data<Scalar = any, T extends { [x: number]: unknown } = TypedArray | BigUint64Array | BigInt64Array> =
-        | Scalar[]
-        | T;
+    type Data<T = any> = T extends bigint ? T[] | TypedArray | BigInt64Array | BigUint64Array : T[] | TypedArray;
     type TypedArray =
         | Int8Array
         | Int16Array

--- a/types/ndarray/ndarray-tests.ts
+++ b/types/ndarray/ndarray-tests.ts
@@ -65,8 +65,15 @@ function getTypedArrayOrNumberArray(arr: ndarray.NdArray<ndarray.Data<number>>):
 }
 
 function getBigIntTypedArrayOrBigIntArray(arr: ndarray.NdArray<ndarray.Data<bigint>>): {
-    data: BigUint64Array | BigInt64Array | bigint[];
+    data: BigUint64Array | BigInt64Array | Array<bigint>;
     scalar: bigint;
+} {
+    return { data: arr.data, scalar: arr.get(0) };
+}
+
+function getBigIntOrNumeric(arr: ndarray.NdArray<ndarray.Data<number | bigint>>): {
+    data: number[] | ndarray.TypedArray | BigUint64Array | BigInt64Array | Array<bigint>;
+    scalar: number | bigint;
 } {
     return { data: arr.data, scalar: arr.get(0) };
 }

--- a/types/ndarray/ndarray-tests.ts
+++ b/types/ndarray/ndarray-tests.ts
@@ -58,26 +58,38 @@ function getFirstValue(arr: ndarray.NdArray): number {
 }
 
 function getTypedArrayOrNumberArray(arr: ndarray.NdArray<ndarray.Data<number>>): {
-    data: ndarray.TypedArray | number[];
+    data: ndarray.GenericArray<number> | ndarray.TypedArray | number[];
     scalar: number;
 } {
     return { data: arr.data, scalar: arr.get(0) };
 }
 
 function getBigIntTypedArrayOrBigIntArray(arr: ndarray.NdArray<ndarray.Data<bigint>>): {
-    data: BigUint64Array | BigInt64Array | Array<bigint>;
+    data: ndarray.GenericArray<bigint> | BigUint64Array | BigInt64Array | Array<bigint>;
     scalar: bigint;
 } {
     return { data: arr.data, scalar: arr.get(0) };
 }
 
 function getBigIntOrNumeric(arr: ndarray.NdArray<ndarray.Data<number | bigint>>): {
-    data: number[] | ndarray.TypedArray | BigUint64Array | BigInt64Array | Array<bigint>;
+    data: ndarray.GenericArray<number> | ndarray.GenericArray<bigint> | number[] | ndarray.TypedArray | BigUint64Array | BigInt64Array | Array<bigint>;
     scalar: number | bigint;
 } {
     return { data: arr.data, scalar: arr.get(0) };
 }
 
-function infersStringOnly(arr: ndarray.NdArray<ndarray.Data<string>>): { data: string[]; scalar: string } {
+function infersStringOnly(arr: ndarray.NdArray<ndarray.Data<string>>): { data: ndarray.GenericArray<string> | string[]; scalar: string } {
     return { data: arr.data, scalar: arr.get(0) };
+}
+
+function genericDtype(arr: ndarray.NdArray<ndarray.GenericArray<any>>): 'generic' {
+    return arr.dtype;
+}
+
+function bigintDtype(arr: ndarray.NdArray<ndarray.Data<bigint>>): 'generic' | 'array' | 'bigint64' | 'biguint64' {
+    return arr.dtype;
+}
+
+function stringDtype(arr: ndarray.NdArray<ndarray.Data<string>>): 'generic' | 'array' {
+    return arr.dtype;
 }

--- a/types/ndarray/ndarray-tests.ts
+++ b/types/ndarray/ndarray-tests.ts
@@ -57,10 +57,20 @@ function getFirstValue(arr: ndarray.NdArray): number {
     return arr.get(0);
 }
 
-function getFirstValueMaybeBigInt(arr: ndarray.NdArray<ndarray.Data<bigint>>): bigint | number {
-    return arr.get(0);
+function getTypedArrayOrNumberArray(arr: ndarray.NdArray<ndarray.Data<number>>): {
+    data: ndarray.TypedArray | number[];
+    scalar: number;
+} {
+    return { data: arr.data, scalar: arr.get(0) };
 }
 
-function getFirstValueBigInt(arr: ndarray.NdArray<BigInt64Array>): bigint {
-    return arr.get(0);
+function getBigIntTypedArrayOrBigIntArray(arr: ndarray.NdArray<ndarray.Data<bigint>>): {
+    data: BigUint64Array | BigInt64Array | bigint[];
+    scalar: bigint;
+} {
+    return { data: arr.data, scalar: arr.get(0) };
+}
+
+function infersStringOnly(arr: ndarray.NdArray<ndarray.Data<string>>): { data: string[]; scalar: string } {
+    return { data: arr.data, scalar: arr.get(0) };
 }

--- a/types/ndarray/ndarray-tests.ts
+++ b/types/ndarray/ndarray-tests.ts
@@ -56,3 +56,11 @@ console.log(typeof firstVal === 'string' ? firstVal.length : firstVal.valueOf())
 function getFirstValue(arr: ndarray.NdArray): number {
     return arr.get(0);
 }
+
+function getFirstValueMaybeBigInt(arr: ndarray.NdArray<ndarray.Data<number, BigInt64Array>>): bigint | number {
+    return arr.get(0);
+}
+
+function getFirstValueBigInt(arr: ndarray.NdArray<BigInt64Array>): bigint {
+    return arr.get(0);
+}

--- a/types/ndarray/ndarray-tests.ts
+++ b/types/ndarray/ndarray-tests.ts
@@ -57,7 +57,7 @@ function getFirstValue(arr: ndarray.NdArray): number {
     return arr.get(0);
 }
 
-function getFirstValueMaybeBigInt(arr: ndarray.NdArray<ndarray.Data<number, BigInt64Array>>): bigint | number {
+function getFirstValueMaybeBigInt(arr: ndarray.NdArray<ndarray.Data<bigint>>): bigint | number {
     return arr.get(0);
 }
 

--- a/types/ndarray/ndarray-tests.ts
+++ b/types/ndarray/ndarray-tests.ts
@@ -1,3 +1,4 @@
+/// <reference lib="esnext.bigint" />
 import ndarray = require('ndarray');
 
 const data1 = new Int32Array(2 * 2 * 2 + 10);

--- a/types/ndarray/tsconfig.json
+++ b/types/ndarray/tsconfig.json
@@ -3,7 +3,8 @@
         "module": "commonjs",
         "lib": [
             "es6",
-            "dom"
+            "dom",
+            "esnext.bigint"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/ndarray/tsconfig.json
+++ b/types/ndarray/tsconfig.json
@@ -3,8 +3,7 @@
         "module": "commonjs",
         "lib": [
             "es6",
-            "dom",
-            "esnext.bigint"
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/numjs/numjs-tests.ts
+++ b/types/numjs/numjs-tests.ts
@@ -17,9 +17,9 @@ arr.transpose(1, 0, 2);
 // array([[[ 0, 1, 2]],
 //        [[ 3, 4, 5]]])
 
-const b = nj.array([2, 3, 4]);
+const b = nj.array([2, 3, 4] as number[]);
 
-const c = nj.uint8([1, 2, 3]);
+const c = nj.uint8([1, 2, 3] as number[]);
 
 const d = nj.array<number[]>([[2], [3, 4]]);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/scijs/ndarray#arraydtype
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

`ndarray` supports `BigInt64` and `BigUint64` data (see link above). This PR adds support for these typed arrays but preserves the default the top-level signature `ndarray.Ndarray` when the type parameters of `Data` aren't defined.

