### PR TITLE
deep-extend: Allow only object as parameter of `deepExtend`

### DIFF
--- a/types/deep-extend/deep-extend-tests.ts
+++ b/types/deep-extend/deep-extend-tests.ts
@@ -1,32 +1,36 @@
 import * as deepExtend from 'deep-extend';
 const obj1 = {
-  a: 1,
-  b: 2,
-  d: {
     a: 1,
-    b: [true],
-    c: { test1: 123, test2: 321 }
-  },
-  f: 5,
-  g: 123,
-  i: 321,
-  j: [1, 2]
+    b: 2,
+    d: {
+        a: 1,
+        b: [true],
+        c: { test1: 123, test2: 321 },
+    },
+    f: 5,
+    g: 123,
+    i: 321,
+    j: [1, 2],
 };
 const obj2 = {
-  b: 3,
-  c: 5,
-  d: {
-    b: { first: 'one', second: 'two' },
-    c: { test2: 222 }
-  },
-  e: { one: 1, two: 2 },
-  f: [42],
-  g() {},
-  h: /abc/g,
-  i: null,
-  j: [3, 4]
+    b: 3,
+    c: 5,
+    d: {
+        b: { first: 'one', second: 'two' },
+        c: { test2: 222 },
+    },
+    e: { one: 1, two: 2 },
+    f: [42],
+    g() {},
+    h: /abc/g,
+    i: null,
+    j: [3, 4],
 };
 
 deepExtend(obj1, obj2);
-deepExtend(obj1, obj2, {ccc: 3});
-deepExtend(obj1, obj2, {ccc: 3}, {ddd: 4});
+deepExtend(obj1, obj2, { ccc: 3 });
+deepExtend(obj1, obj2, { ccc: 3 }, { ddd: 4 });
+deepExtend(obj1, obj1, obj1, obj1, obj1, obj1); // More than 5 arguments
+
+deepExtend({ a: 1 }, { b: true }); // $ExpectType { a: number; } & { b: boolean; }
+deepExtend({ a: 1 }, 1); // $ExpectError

--- a/types/deep-extend/index.d.ts
+++ b/types/deep-extend/index.d.ts
@@ -4,9 +4,18 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** Recursive object extending. */
-declare function deepExtend<T, U>(target: T, source: U): T & U;
-declare function deepExtend<T, U, V>(target: T, source1: U, source2: V): T & U & V;
-declare function deepExtend<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
-declare function deepExtend(target: any, ...sources: any[]): any;
+declare function deepExtend<T extends object, U extends object>(target: T, source: U): T & U;
+declare function deepExtend<T extends object, U extends object, V extends object>(
+    target: T,
+    source1: U,
+    source2: V,
+): T & U & V;
+declare function deepExtend<T extends object, U extends object, V extends object, W extends object>(
+    target: T,
+    source1: U,
+    source2: V,
+    source3: W,
+): T & U & V & W;
+declare function deepExtend(target: object, ...sources: object[]): object;
 declare namespace deepExtend {}
 export = deepExtend;

--- a/types/deep-extend/tsconfig.json
+++ b/types/deep-extend/tsconfig.json
@@ -4,10 +4,7 @@
         "lib": [
             "es6"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
+        "strict": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/unclechu/node-deep-extend
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Current type definition of `deep-extend` allows any type of parameter.

```typescript
deepExtend(1, 2, 3)
```

however it actually accepts only objects. This PR makes the parameters of types accept only objects. And more tests are added for the change.