### PR TITLE
Fix `$expectType` to `$ExpectType` for type check by dtslint

### DIFF
--- a/types/gl-texture2d/gl-texture2d-tests.ts
+++ b/types/gl-texture2d/gl-texture2d-tests.ts
@@ -84,5 +84,5 @@ texture.handle;
 // $ExpectType number
 texture.format;
 
-// $expectType number
+// $ExpectType number
 texture.type;

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -750,7 +750,7 @@ new mapboxgl.FullscreenControl(null);
 new mapboxgl.FullscreenControl({});
 new mapboxgl.FullscreenControl({ container: document.querySelector('body') });
 
-// $expectType boolean
+// $ExpectType boolean
 map.hasControl(attributionControl);
 
 declare var lnglat: mapboxgl.LngLat;

--- a/types/mapbox-gl/v1/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/v1/mapbox-gl-tests.ts
@@ -694,7 +694,7 @@ new mapboxgl.FullscreenControl(null);
 new mapboxgl.FullscreenControl({});
 new mapboxgl.FullscreenControl({ container: document.querySelector('body') });
 
-// $expectType boolean
+// $ExpectType boolean
 map.hasControl(attributionControl);
 
 declare var lnglat: mapboxgl.LngLat;

--- a/types/nonogram-solver/nonogram-solver-tests.ts
+++ b/types/nonogram-solver/nonogram-solver-tests.ts
@@ -4,7 +4,7 @@ const { status, puzzle } = solve('input.json');
 
 puzzle; // $ExpectType Puzzle
 puzzle.columnHints; // $ExpectType number[][]
-puzzle.isFinished; // $expectType boolean
-puzzle.svg; // $expectType string
+puzzle.isFinished; // $ExpectType boolean
+puzzle.svg; // $ExpectType string
 
 status; // $ExpectType State


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/dtslint#write-tests
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

While making #56168, I noticed that some other modules mistake `$ExpectType` with `$expectType`. It is case sensitive. dtslint ignores `$expectType` and no type check is performed actually. I grepped `./types` and fixed all `$expectType` with correct `$ExpectType`.