### PR TITLE
xtend: More strict argument types

### DIFF
--- a/types/xtend/index.d.ts
+++ b/types/xtend/index.d.ts
@@ -4,12 +4,30 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Xtend {
-    <T, U>(target: T, source: U): T & U;
-    <T, U, V>(target: T, source1: U, source2: V): T & U & V;
-    <T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
-    <T, U, V, W, Q>(target: T, source1: U, source2: V, source3: W, source4: Q): T & U & V & W & Q;
-    <T, U, V, W, Q, R>(target: T, source1: U, source2: V, source3: W, source4: Q, source5: R): T & U & V & W & Q & R;
-    (target: any, ...sources: any[]): any;
+    <T extends object, U extends object>(target: T, source: U): T & U;
+    <T extends object, U extends object, V extends object>(target: T, source1: U, source2: V): T & U & V;
+    <T extends object, U extends object, V extends object, W extends object>(
+        target: T,
+        source1: U,
+        source2: V,
+        source3: W,
+    ): T & U & V & W;
+    <T extends object, U extends object, V extends object, W extends object, Q extends object>(
+        target: T,
+        source1: U,
+        source2: V,
+        source3: W,
+        source4: Q,
+    ): T & U & V & W & Q;
+    <T extends object, U extends object, V extends object, W extends object, Q extends object, R extends object>(
+        target: T,
+        source1: U,
+        source2: V,
+        source3: W,
+        source4: Q,
+        source5: R,
+    ): T & U & V & W & Q & R;
+    (target: object, ...sources: object[]): object;
 }
 declare const xtend: Xtend;
 export = xtend;

--- a/types/xtend/index.d.ts
+++ b/types/xtend/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for xtend 4.0.1
+// Type definitions for xtend 4.0
 // Project: https://github.com/Raynos/xtend
-// Definitions by: rhysd <https://rhysd.github.io>
+// Definitions by: rhysd <https://github.com/rhysd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Xtend {

--- a/types/xtend/tslint.json
+++ b/types/xtend/tslint.json
@@ -1,9 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "dt-header": false,
-        "no-consecutive-blank-lines": false,
-        "no-padding": false,
-        "trim-file": false
-    }
-}
+{ "extends": "dtslint/dt.json" }

--- a/types/xtend/xtend-tests.ts
+++ b/types/xtend/xtend-tests.ts
@@ -1,78 +1,77 @@
-import xtend = require("xtend");
+import xtend = require('xtend');
 
 interface Target {
-  hellow: string;
+    hellow: string;
 }
-
 interface Source1 {
-  source1: string;
+    source1: string;
 }
-
-interface Result extends Target, Source1 {
-
-}
-
 interface Source2 {
-  source2: string;
+    source2: string;
 }
-
-interface Result2 extends Result, Source2 {
-
-}
-
 interface Source3 {
-  source3: string;
+    source3: string;
 }
-
-interface Result3 extends Result2, Source3 {
-
-}
-
 interface Source4 {
-  source4: string;
+    source4: string;
 }
-
-interface Result4 extends Result3, Source4 {
-
-}
-
 interface Source5 {
-  source5: string;
+    source5: string;
 }
 
-interface Result5 extends Result4, Source5 {
+type Result1 = Target & Source1;
+type Result2 = Result1 & Source2;
+type Result3 = Result2 & Source3;
+type Result4 = Result3 & Source4;
+type Result5 = Result4 & Source5;
 
-}
-
-function assign1(): Result {
-  return xtend({hellow: "world"}, {source1: "U"});
+function assign1(): Result1 {
+    return xtend({ hellow: 'world' }, { source1: 'U' });
 }
 
 function assign2(): Result2 {
-  return xtend({hellow: "world"}, {source1: "U"}, {source2: "V"});
+    return xtend({ hellow: 'world' }, { source1: 'U' }, { source2: 'V' });
 }
 
 function assign3(): Result3 {
-  return xtend({hellow: "world"}, {source1: "U"}, {source2: "V"}, {source3: "W"});
+    return xtend({ hellow: 'world' }, { source1: 'U' }, { source2: 'V' }, { source3: 'W' });
 }
 
 function assign4(): Result4 {
-  return xtend({hellow: "world"}, {source1: "U"}, {source2: "V"}, {source3: "W"}, {source4: "Q"});
+    return xtend({ hellow: 'world' }, { source1: 'U' }, { source2: 'V' }, { source3: 'W' }, { source4: 'Q' });
 }
 
 function assign5(): Result5 {
-  return xtend({hellow: "world"}, {source1: "U"}, {source2: "V"}, {source3: "W"}, {source4: "Q"}, {source5: "R"});
+    return xtend(
+        { hellow: 'world' },
+        { source1: 'U' },
+        { source2: 'V' },
+        { source3: 'W' },
+        { source4: 'Q' },
+        { source5: 'R' },
+    );
 }
 
-function assign() {
-  return xtend({hellow: "world"}, {source1: "U"}, {source2: "V"}, {source3: "W"}, {source4: "Q"}, {source5: "R"}, {
-    hellow: "hellow",
-    source1: "source1",
-    source2: "source2",
-    source3: "source3",
-    source4: "source4",
-    source5: "source5",
-    generic: "any"
-  });
+function assign(): object {
+    return xtend(
+        { hellow: 'world' },
+        { source1: 'U' },
+        { source2: 'V' },
+        { source3: 'W' },
+        { source4: 'Q' },
+        { source5: 'R' },
+        {
+            hellow: 'hellow',
+            source1: 'source1',
+            source2: 'source2',
+            source3: 'source3',
+            source4: 'source4',
+            source5: 'source5',
+            generic: 'any',
+        },
+    );
 }
 
+xtend(1, 2, 3); // $ExpectError
+xtend({}, 1); // $ExpectError
+xtend({}, {}, {}, {}, {}, 1); // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Raynos/xtend
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This is similar to #56168. `xtend` allows only objects as parameters but currently the type definition allows any type as arguments.

This PR stricts them to objects, add more test cases and fix some dtslint errors which enables all dtslint rules now.
