### PR TITLE
[redux-first-router] precise `RouteThunk`, `Bag`, `kind`, `notFoundPath` & `Query`

### DIFF
--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -33,6 +33,7 @@ export type ConfirmLeave = (state: object, action: object) => Nullable<string>;
 export type RouteThunk<TState = any> = (
     dispatch: Dispatch<any>,
     getState: StateGetter<TState>,
+    bag: Bag,
 ) => any | Promise<any>;
 
 export type RouteObject<TKeys = {}, TState = any> = TKeys & {
@@ -207,7 +208,7 @@ export interface NavigatorsConfig<TKeys = {}, TState = any> {
 
 export interface Bag {
     action: ReceivedAction | Action;
-    extra: any;
+    extra?: any | undefined;
 }
 
 export interface Options<TKeys = {}, TState = any> {

--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -13,13 +13,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import {
-    Dispatch,
-    Store,
-    Reducer,
-    Middleware,
-    StoreEnhancer
-} from 'redux';
+import { Dispatch, Store, Reducer, Middleware, StoreEnhancer } from 'redux';
 import { History } from 'history';
 
 export type Nullable<T> = T | null | undefined;
@@ -147,25 +141,14 @@ export interface HistoryLocation {
 
 export type HistoryAction = string;
 
-export type Listener = (
-    location: HistoryLocation,
-    action: HistoryAction
-) => void;
+export type Listener = (location: HistoryLocation, action: HistoryAction) => void;
 
 export type ScrollBehavior = object;
 
 export interface Router<TState = any> {
-    getStateForActionOriginal(
-        action: object,
-        state: Nullable<TState>
-    ): Nullable<TState>;
-    getStateForAction(
-        action: object,
-        state: Nullable<TState>
-    ): Nullable<TState>;
-    getPathAndParamsForState(
-        state: TState
-    ): { path: Nullable<string>; params: Nullable<Params> };
+    getStateForActionOriginal(action: object, state: Nullable<TState>): Nullable<TState>;
+    getStateForAction(action: object, state: Nullable<TState>): Nullable<TState>;
+    getPathAndParamsForState(state: TState): { path: Nullable<string>; params: Nullable<Params> };
     getActionForPathAndParams(path: string): Nullable<object>;
 }
 
@@ -193,17 +176,17 @@ export interface NavigatorsConfig<TKeys = {}, TState = any> {
         navigators: Navigators<TState>,
         action: object, // TODO check this
         navigationAction: Nullable<NavigationAction>,
-        route: Nullable<Route<TKeys, TState>>
+        route: Nullable<Route<TKeys, TState>>,
     ): object;
     navigationToAction(
         navigators: Navigators<TState>,
         store: Store<TState>,
         routesMap: RoutesMap<TKeys, TState>,
-        action: object
+        action: object,
     ): {
-            action: object;
-            navigationAction: Nullable<NavigationAction>;
-        };
+        action: object;
+        navigationAction: Nullable<NavigationAction>;
+    };
 }
 
 export interface Bag {
@@ -324,7 +307,7 @@ export const NOT_FOUND: '@@redux-first-router/NOT_FOUND';
 export function actionToPath<TKeys = {}, TState = any>(
     action: ReceivedAction,
     routesMap: RoutesMap<TKeys, TState>,
-    querySerializer?: QuerySerializer
+    querySerializer?: QuerySerializer,
 ): string;
 
 export function back(): void;
@@ -339,12 +322,12 @@ export function connectRoutes<TKeys = {}, TState = any>(
     routesMap: RoutesMap<TKeys, TState>,
     options?: Options<TKeys, TState>,
 ): {
-        reducer: Reducer<LocationState<TKeys, TState>>;
-        middleware: Middleware;
-        thunk(store: Store<TState>): Promise<Nullable<RouteThunk<TState>>>;
-        enhancer: StoreEnhancer;
-        initialDispatch?(): void;
-    };
+    reducer: Reducer<LocationState<TKeys, TState>>;
+    middleware: Middleware;
+    thunk(store: Store<TState>): Promise<Nullable<RouteThunk<TState>>>;
+    enhancer: StoreEnhancer;
+    initialDispatch?(): void;
+};
 
 export function go(n: number): void;
 
@@ -359,7 +342,7 @@ export function nextPath(): string | void;
 export function pathToAction<TKeys = {}, TState = any>(
     pathname: string,
     routesMap: RoutesMap<TKeys, TState>,
-    querySerializer?: QuerySerializer
+    querySerializer?: QuerySerializer,
 ): ReceivedAction;
 
 export function prevPath(): string | void;

--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -249,7 +249,7 @@ export interface Options<TKeys = {}, TState = any> {
      *  or if you manually call dispatch(redirect({ type: NOT_FOUND })), where NOT_FOUND is an export from this package.
      *  The type in actions and state will be NOT_FOUND, which you can use to show a 404 page.
      */
-    notFoundPath?: string | undefined;
+    notFoundPath?: string | undefined | null;
     /**
      * Whether or not window.scrollTo(0, 0) should be run on route changes so the user starts each page at the top.
      */

--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -303,7 +303,7 @@ export interface Options<TKeys = {}, TState = any> {
 }
 
 export interface Query {
-    [key: string]: string | undefined;
+    [key: string]: string | any;
 }
 
 export interface Params {

--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -90,6 +90,8 @@ export interface Location {
     search?: string | undefined;
 }
 
+export type LocationKind = 'load' | 'back' | 'next' | 'pop' | 'stealth' | 'push' | 'replace' | 'redirect';
+
 export interface LocationState<TKeys = {}, TState = any> {
     pathname: string;
     type: string;
@@ -97,7 +99,7 @@ export interface LocationState<TKeys = {}, TState = any> {
     query?: Query | undefined;
     search?: string | undefined;
     prev: Location;
-    kind: Nullable<string>;
+    kind: Nullable<LocationKind>;
     history: Nullable<HistoryData>;
     routesMap: RoutesMap<TKeys, TState>;
     hasSSR?: boolean | undefined;
@@ -106,7 +108,7 @@ export interface LocationState<TKeys = {}, TState = any> {
 export interface ActionMetaLocation {
     current: Location;
     prev: Location;
-    kind: Nullable<string>;
+    kind: Nullable<LocationKind>;
     history: Nullable<HistoryData>;
 }
 

--- a/types/redux-first-router/redux-first-router-tests.ts
+++ b/types/redux-first-router/redux-first-router-tests.ts
@@ -127,6 +127,12 @@ const action: ReduxFirstRouterAction = {
 };
 redirect(action); // $ExpectType Action
 
+const secondAction: ReduxFirstRouterAction = {
+    type: 'PAGE',
+    query: { foo: 'bar' }
+};
+redirect(action); // $ExpectType Action
+
 // $ExpectType Store<CombinedState<State>, AnyAction> || Store<EmptyObject & State, AnyAction>
 store;
 

--- a/types/redux-first-router/redux-first-router-tests.ts
+++ b/types/redux-first-router/redux-first-router-tests.ts
@@ -13,7 +13,7 @@ import {
     Navigators,
     NavigationAction,
     Nullable,
-    Route
+    Route,
 } from 'redux-first-router';
 import {
     createStore,
@@ -24,7 +24,7 @@ import {
     StoreEnhancerStoreCreator,
     combineReducers,
     AnyAction,
-    Store
+    Store,
 } from 'redux';
 import { History } from 'history';
 
@@ -43,7 +43,7 @@ const routesMap: RoutesMap<Keys, State> = {
     HOME: '/',
     ADMIN: {
         path: '/admin',
-        role: 'admin'
+        role: 'admin',
     },
     STATUS: {
         path: '/status',
@@ -51,8 +51,8 @@ const routesMap: RoutesMap<Keys, State> = {
         thunk: (dispatch, getState) => {
             dispatch; // $ExpectType Dispatch<any>
             getState; // $ExpectType StateGetter<State>
-        }
-    }
+        },
+    },
 };
 
 const { reducer, middleware, enhancer, initialDispatch, thunk } = connectRoutes(routesMap, {
@@ -76,28 +76,25 @@ const { reducer, middleware, enhancer, initialDispatch, thunk } = connectRoutes(
         parse: params => {
             params; // $ExpectType string
             return {};
-        }
+        },
     },
     notFoundPath: 'not-found',
     scrollTop: true,
     restoreScroll: (history: History) => {
         return {};
     },
-    onBeforeChange: (dispatch: Dispatch, getState: StateGetter<State>, bag: Bag) => { },
-    onAfterChange: (dispatch: Dispatch, getState: StateGetter<State>, bag: Bag) => { },
-    onBackNext: (dispatch: Dispatch, getState: StateGetter<State>, bag: Bag) => { },
-    displayConfirmLeave: (message: string, callback: (unblock: boolean) => void) => { },
-    createHistory: (options?: any) => history
+    onBeforeChange: (dispatch: Dispatch, getState: StateGetter<State>, bag: Bag) => {},
+    onAfterChange: (dispatch: Dispatch, getState: StateGetter<State>, bag: Bag) => {},
+    onBackNext: (dispatch: Dispatch, getState: StateGetter<State>, bag: Bag) => {},
+    displayConfirmLeave: (message: string, callback: (unblock: boolean) => void) => {},
+    createHistory: (options?: any) => history,
 });
 
 const dumbMiddleware: Middleware = store => next => action => next(action);
 
 const composedMiddleware = applyMiddleware(middleware, dumbMiddleware);
 
-const storeEnhancer = compose(
-    enhancer,
-    composedMiddleware
-);
+const storeEnhancer = compose(enhancer, composedMiddleware);
 
 const combined = combineReducers<State>({ location: reducer });
 
@@ -110,26 +107,26 @@ thunk(store).then(t => {
 
 const receivedAction: ReceivedAction = {
     type: 'HOME',
-    payload: {}
+    payload: {},
 };
 actionToPath(receivedAction, routesMap); // $ExpectType string
 pathToAction('/', routesMap); // $ExpectType ReceivedAction
 
 const querySerializer: QuerySerializer = {
     stringify: params => '',
-    parse: queryString => ({})
+    parse: queryString => ({}),
 };
 actionToPath(receivedAction, routesMap, querySerializer); // $ExpectType string
 pathToAction('/', routesMap, querySerializer); // $ExpectType ReceivedAction
 
 const action: ReduxFirstRouterAction = {
-    type: 'HOME'
+    type: 'HOME',
 };
 redirect(action); // $ExpectType Action
 
 const secondAction: ReduxFirstRouterAction = {
     type: 'PAGE',
-    query: { foo: 'bar' }
+    query: { foo: 'bar' },
 };
 redirect(action); // $ExpectType Action
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - kind: string -> 'load' | 'back' | 'next' | 'pop' | 'stealth’ | 'push' | 'replace' | 'redirect'
     * docs: https://github.com/faceyspacey/redux-first-router/blob/c1bb1df83d4e1dced78b72d67e487c3eebb2ddb0/docs/reducer.md#reducer
     * tests: https://github.com/faceyspacey/redux-first-router/blob/c1bb1df83d4e1dced78b72d67e487c3eebb2ddb0/__tests__/__snapshots__/connectRoutes.js.snap
    * From `history` (push, pop & replace)
    * From browser (back & next)
    * From `React Navigation` (stealth)
https://github.com/faceyspacey/redux-first-router/blob/c1bb1df83d4e1dced78b72d67e487c3eebb2ddb0/src/connectRoutes.js#L478
    * From `redux-first-router` (load & redirect)
https://github.com/faceyspacey/redux-first-router/blob/c1bb1df83d4e1dced78b72d67e487c3eebb2ddb0/src/pure-utils/isRedirectAction.js#L8
   - notFound path also `null` -> https://github.com/faceyspacey/redux-first-router/blob/c1bb1df83d4e1dced78b72d67e487c3eebb2ddb0/docs/connectRoutes.md#options
Allows having the path not change on a 404
  - Missing `bag` argument in Options `thunk` property + `extra` should possibly be undefined -> https://github.com/faceyspacey/redux-first-router/blob/c1bb1df83d4e1dced78b72d67e487c3eebb2ddb0/docs/connectRoutes.md#parameters
  - Allow `any` in `Query` interface object values
To support any serialisation strategy using `querySerializer` option of `connectRoutes`
-> https://github.com/faceyspacey/redux-first-router/blob/c1bb1df83d4e1dced78b72d67e487c3eebb2ddb0/docs/connectRoutes.md#options
https://github.com/faceyspacey/redux-first-router/blob/c1bb1df83d4e1dced78b72d67e487c3eebb2ddb0/docs/query-strings.md


