### PR TITLE
Fix ResourceType definitions

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10919,11 +10919,11 @@ declare namespace chrome.declarativeNetRequest {
         IMAGE = "image",
         FONT = "font",
         OBJECT = "object",
-        XML_HTTP_REQUEST = "xmlhttprequest",
+        XMLHTTPREQUEST = "xmlhttprequest",
         PING = "ping",
         CSP_REPORT = "csp_report",
         MEDIA = "media",
-        WEB_SOCKET = "websocket",
+        WEBSOCKET = "websocket",
         OTHER = "other"
     }
 


### PR DESCRIPTION
XMLHTTPREQUEST and WEBSOCKET are defined without underscores in the Chrome API.
https://source.chromium.org/chromium/chromium/src/+/main:out/Debug/gen/extensions/common/api/web_request.h;drc=15bd1e3799da3c56f3039e703f04666cb5861f5d;l=48 https://source.chromium.org/chromium/chromium/src/+/main:out/Debug/gen/extensions/common/api/web_request.h;drc=15bd1e3799da3c56f3039e703f04666cb5861f5d;l=52

The current definitions are not working and evaluate as "undefined" when used in Chrome.
