### PR TITLE
d3: add tickSubdivide type to Axis and allow null comparator for pie.sort

### DIFF
--- a/types/d3/v3/d3-tests.ts
+++ b/types/d3/v3/d3-tests.ts
@@ -700,7 +700,8 @@ function panAndZoom() {
         .scale(y)
         .orient("left")
         .ticks(5)
-        .tickSize(-width);
+        .tickSize(-width)
+        .tickSubdivide(true);
 
     var zoom = d3.behavior.zoom()
         .x(x)

--- a/types/d3/v3/index.d.ts
+++ b/types/d3/v3/index.d.ts
@@ -3131,6 +3131,7 @@ declare namespace d3 {
             value(accessor: (datum: T, index: number) => number): Pie<T>;
 
             sort(): (a: T, b: T) => number;
+            sort(comparator: null): Pie<T>;
             sort(comparator: (a: T, b: T) => number): Pie<T>;
 
             startAngle(): number | ((data: T[], index: number) => number);

--- a/types/d3/v3/index.d.ts
+++ b/types/d3/v3/index.d.ts
@@ -2582,6 +2582,8 @@ declare namespace d3 {
             tickFormat(): (t: any , index : number) => string;
             tickFormat(format: (t: any , index : number) => string): Axis;
             tickFormat(format: string): Axis;
+
+            tickSubdivide(...args: any[]): Axis;
         }
 
         export function brush(): Brush<any, number, number>;


### PR DESCRIPTION
Relevant code from v3.5.17 of d3
- tickSubdivide: https://github.com/d3/d3/blob/9cc9a875e636a1dcf36cc1e07bdf77e1ad6e2c74/d3.js#L9066-L9068
- pie.sort allows null comparator: https://github.com/d3/d3/blob/9cc9a875e636a1dcf36cc1e07bdf77e1ad6e2c74/d3.js#L6638-L6640

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: urls above
