### PR TITLE
fix(markdown-it): remove highlight-js direct dependency

### DIFF
--- a/types/markdown-it/markdown-it-tests.ts
+++ b/types/markdown-it/markdown-it-tests.ts
@@ -3,8 +3,19 @@ import MarkdownIt1 = require('markdown-it/index');
 import MarkdownIt2 = require('markdown-it/lib');
 import MarkdownIt3 = require('markdown-it/lib/index');
 
-import hljs = require('highlight.js');
 import LinkifyIt = require('linkify-it');
+
+// sstub highlight-js interaction
+declare const hljs: {
+    highlight: (
+        codeOrlanguageName: string,
+        optionsOrCode: string,
+        ignoreIllegals?: boolean,
+    ) => {
+        value: string;
+    };
+    getLanguage: (languageName: string) => string | undefined;
+};
 
 {
     // check exports
@@ -52,7 +63,7 @@ import LinkifyIt = require('linkify-it');
         linkify: false,
         typographer: false,
         quotes: '“”‘’',
-        highlight: function(str: string, lang: string): string {
+        highlight: (str: string, lang: string): string => {
             return '';
         },
     });
@@ -64,7 +75,7 @@ import LinkifyIt = require('linkify-it');
         linkify: false,
         typographer: false,
         quotes: '“”‘’',
-        highlight: function(str: string, lang: string): string {
+        highlight: (str: string, lang: string): string => {
             return '';
         },
     });
@@ -74,16 +85,14 @@ declare const plugin1: any;
 declare const plugin2: any;
 declare const plugin3: any;
 declare const opts: any;
+let md: MarkdownIt;
 {
-    var md = MarkdownIt()
-        .use(plugin1)
-        .use(plugin2, opts)
-        .use(plugin3);
+    md = MarkdownIt().use(plugin1).use(plugin2, opts).use(plugin3);
 }
 
 {
-    var md = MarkdownIt({
-        highlight: function(str, lang) {
+    md = MarkdownIt({
+        highlight: (str, lang) => {
             if (lang && hljs.getLanguage(lang)) {
                 try {
                     return hljs.highlight(lang, str, true).value;
@@ -94,9 +103,10 @@ declare const opts: any;
         },
     });
 }
+
 {
-    var md = MarkdownIt({
-        highlight: function(str, lang) {
+    md = MarkdownIt({
+        highlight: (str, lang) => {
             if (lang && hljs.getLanguage(lang)) {
                 try {
                     return '<pre class="hljs"><code>' + hljs.highlight(lang, str, true).value + '</code></pre>';
@@ -114,10 +124,7 @@ declare const opts: any;
 }
 
 {
-    let md = MarkdownIt()
-        .disable(['link', 'image'])
-        .enable(['link'])
-        .enable('image');
+    md = MarkdownIt().disable(['link', 'image']).enable(['link']).enable('image');
 
     md = MarkdownIt({
         html: true,
@@ -130,10 +137,10 @@ declare const opts: any;
     let md = MarkdownIt();
     let state = new md.inline.State('text `code`', md, {}, []);
     md.inline.tokenize(state);
-    let hasNull = false
+    let hasNull = false;
     for (let i of state.tokens_meta) {
         if (i === null) {
-            hasNull = true
+            hasNull = true;
         }
     }
 }

--- a/types/markdown-it/package.json
+++ b/types/markdown-it/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "highlight.js": "^10.7.2"
-    }
-}

--- a/types/markdown-it/test/index.ts
+++ b/types/markdown-it/test/index.ts
@@ -56,7 +56,7 @@ import LinkifyIt = require('linkify-it');
         linkify: false,
         typographer: false,
         quotes: '\u201c\u201d\u2018\u2019' /* “”‘’ */,
-        highlight: function(str, lang, attrs) { return ""; },
+        highlight: (str, lang, attrs) => "",
     };
 }
 

--- a/types/markdown-it/tslint.json
+++ b/types/markdown-it/tslint.json
@@ -4,12 +4,9 @@
         "array-type": false,
         "comment-format": false,
         "no-duplicate-variable": false,
-        "no-var-keyword": false,
         "object-literal-shorthand": false,
-        "only-arrow-functions": false,
         "prefer-const": false,
         "prefer-template": false,
-        "semicolon": false,
         "unified-signatures": false
     }
 }


### PR DESCRIPTION
highlight-js is dev type dependency and is external to core features and
there is no dependency (imports) in package itself.

This change reflects this removing depndency on highlight.js from
markdown-it types.

minor: linter improvements

https://github.com/markdown-it/markdown-it/blob/master/package.json#L39-L45

/cc @Lemmingh

Fixes #56187

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).