### PR TITLE
[busboy] Update from version 0.2 to 0.3

### DIFF
--- a/types/busboy/busboy-tests.ts
+++ b/types/busboy/busboy-tests.ts
@@ -4,20 +4,20 @@ import * as util from 'util';
 
 function serverFn(req: http.IncomingMessage, res: http.ServerResponse) {
   if (req.method === 'POST') {
-    var busboy = new Busboy({ headers: req.headers });
-    busboy.on('file', function(fieldname, file, filename, encoding, mimetype) {
-      console.log('File [' + fieldname + ']: filename: ' + filename + ', encoding: ' + encoding + ', mimetype: ' + mimetype);
-      file.on('data', function(data: Buffer) {
-        console.log('File [' + fieldname + '] got ' + data.length + ' bytes');
+    const busboy = new Busboy({ headers: req.headers });
+    busboy.on('file', (fieldname, file, filename, encoding, mimetype) => {
+      console.log(`File [${fieldname}]: filename: ${filename}, encoding: ${encoding}, mimetype: ${mimetype}`);
+      file.on('data', (data: Buffer) => {
+        console.log(`File [${fieldname}] got ${data.length} bytes`);
       });
-      file.on('end', function() {
-        console.log('File [' + fieldname + '] Finished');
+      file.on('end', () => {
+        console.log(`File [${fieldname}] Finished`);
       });
     });
-    busboy.on('field', function(fieldname, val, fieldnameTruncated, valTruncated, encoding, mimetype) {
-      console.log('Field [' + fieldname + ']: value: ' + util.inspect(val));
+    busboy.on('field', (fieldname, val, fieldnameTruncated, valTruncated, encoding, mimetype) => {
+      console.log(`Field [${fieldname}]: value: ${util.inspect(val)}`);
     });
-    busboy.on('finish', function() {
+    busboy.on('finish', () => {
       console.log('Done parsing form!');
       res.writeHead(303, { Connection: 'close', Location: '/' });
       res.end();
@@ -25,12 +25,12 @@ function serverFn(req: http.IncomingMessage, res: http.ServerResponse) {
     req.pipe(busboy);
   } else if (req.method === 'GET') {
     res.writeHead(200, { Connection: 'close' });
-    res.end('<html><head></head><body>\
-               <form method="POST" enctype="multipart/form-data">\
-                <input type="text" name="textfield"><br />\
-                <input type="file" name="filefield"><br />\
-                <input type="submit">\
-              </form>\
-            </body></html>');
+    res.end(`<html><head></head><body>
+               <form method="POST" enctype="multipart/form-data">
+                <input type="text" name="textfield"><br />
+                <input type="file" name="filefield"><br />
+                <input type="submit">
+              </form>
+            </body></html>`);
   }
 }

--- a/types/busboy/index.d.ts
+++ b/types/busboy/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for busboy v0.2.13
+// Type definitions for busboy 0.3
 // Project: https://www.npmjs.com/package/busboy
 // Definitions by: Jacob Baskin <https://github.com/jacobbaskin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,7 +6,13 @@
 
 import { Readable, Writable } from 'stream';
 
-declare namespace busboy {
+export as namespace Busboy;
+export = Busboy;
+
+declare class Busboy extends Writable implements Busboy.Busboy {
+    constructor(options: Busboy.BusboyConfig);
+}
+declare namespace Busboy {
     interface Options {
         headers: any;
     }
@@ -44,17 +50,7 @@ declare namespace busboy {
                filename: string,
                encoding: string,
                mimetype: string) => void): this;
-        on(event: 'finish', callback: () => void): this;
-        on(event: 'partsLimit', callback: () => void): this;
-        on(event: 'filesLimit', callback: () => void): this;
-        on(event: 'fieldsLimit', callback: () => void): this;
-        on(event: string, listener: Function): this;
-    }
-
-    interface BusboyConstructor {
-        new (options: BusboyConfig): Busboy;
+        on(event: 'finish' | 'partsLimit' | 'fielsLimit' | 'fieldsLimit', callback: () => void): this;
+        on(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 }
-
-declare const temp: busboy.BusboyConstructor;
-export = temp;

--- a/types/busboy/index.d.ts
+++ b/types/busboy/index.d.ts
@@ -56,7 +56,5 @@ declare namespace busboy {
     }
 }
 
-declare module 'busboy' {
-    const temp: busboy.BusboyConstructor;
-    export = temp;
-}
+declare const temp: busboy.BusboyConstructor;
+export = temp;

--- a/types/busboy/index.d.ts
+++ b/types/busboy/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
-import {Readable, Writable} from 'stream';
+import { Readable, Writable } from 'stream';
 
 declare namespace busboy {
     interface Options {

--- a/types/busboy/index.d.ts
+++ b/types/busboy/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
+import {Readable, Writable} from 'stream';
+
 declare namespace busboy {
     interface Options {
         headers: any;
@@ -26,7 +28,7 @@ declare namespace busboy {
         } | undefined;
     }
 
-    interface Busboy extends NodeJS.WritableStream {
+    interface Busboy extends Writable {
         on(event: 'field',
            listener: (
                fieldname: string,
@@ -38,7 +40,7 @@ declare namespace busboy {
         on(event: 'file',
            listener: (
                fieldname: string,
-               file: NodeJS.ReadableStream,
+               file: Readable,
                filename: string,
                encoding: string,
                mimetype: string) => void): this;

--- a/types/busboy/tslint.json
+++ b/types/busboy/tslint.json
@@ -1,14 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "ban-types": false,
-        "dt-header": false,
-        "no-declare-current-package": false,
-        "no-single-declare-module": false,
-        "no-var-keyword": false,
-        "only-arrow-functions": false,
-        "prefer-const": false,
-        "prefer-template": false,
-        "unified-signatures": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Hei,

I updated the busboy definitions for the version 0.3.

It now uses `stream.Writable` and `stream.Readable` instead of `NodeJS.WritableStream` and `NodeJS.ReadableStream`.

[Commit of the main change between version 0.2 and 0.3](https://github.com/mscdex/busboy/commit/db9b25f2b88fd4689d78d74b1fdc9de7f10d5f3d).

`stream.Readable` and `stream.Writable` implement `NodeJS.ReadableStream` and `NodeJS.WritableStream` respectively, so it should not introduce a breaking change in the definitions.

I also struggled to make the tests pass since the last update many years ago.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.




