### PR TITLE
CSON only exports a Singleton instance

### DIFF
--- a/types/cson/cson-tests.ts
+++ b/types/cson/cson-tests.ts
@@ -1,4 +1,4 @@
-import cson = require('cson');
+import cson from 'cson';
 
 let data: string = cson.stringify({ hello: 'world' });
 

--- a/types/cson/cson-tests.ts
+++ b/types/cson/cson-tests.ts
@@ -1,4 +1,4 @@
-import cson from 'cson';
+import cson = require('cson');
 
 let data: string = cson.stringify({ hello: 'world' });
 

--- a/types/cson/index.d.ts
+++ b/types/cson/index.d.ts
@@ -33,4 +33,4 @@ declare class CSON {
 
 declare const _default: CSON;
 
-export default _default;
+export = _default;

--- a/types/cson/index.d.ts
+++ b/types/cson/index.d.ts
@@ -3,28 +3,34 @@
 // Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Create Strings
-export function stringify(data: any, opts?: object, indent?: any): string;
-export function createCSONString(data: any, opts?: object, next?: any): string;
-export function createJSONString(data: any, opts?: object, next?: any): string;
-export function createString(data: any, opts?: object, next?: any): string;
+declare class CSON {
+    // Create Strings
+    stringify(data: any, opts?: object, indent?: any): string;
+    createCSONString(data: any, opts?: object, next?: any): string;
+    createJSONString(data: any, opts?: object, next?: any): string;
+    createString(data: any, opts?: object, next?: any): string;
 
-// Parse Strings
-export function parse(data: string, opts?: object, next?: any): any;
-export function parseCSONString(data: string, opts?: object, next?: any): any;
-export function parseJSONString(data: string, opts?: object, next?: any): any;
-export function parseCSString(data: string, opts?: object, next?: any): any;
-export function parseJSString(data: string, opts?: object, next?: any): any;
-export function parseString(data: string, opts?: object, next?: any): any;
+    // Parse Strings
+    parse(data: string, opts?: object, next?: any): any;
+    parseCSONString(data: string, opts?: object, next?: any): any;
+    parseJSONString(data: string, opts?: object, next?: any): any;
+    parseCSString(data: string, opts?: object, next?: any): any;
+    parseJSString(data: string, opts?: object, next?: any): any;
+    parseString(data: string, opts?: object, next?: any): any;
 
-// Parse Files
-export function load(filePath: string, opts?: object, next?: any): any;
-export function parseCSONFile(filePath: string, opts?: object, next?: any): any;
-export function parseJSONFile(filePath: string, opts?: object, next?: any): any;
-export function parseCSFile(filePath: string, opts?: object, next?: any): any;
-export function parseJSFile(filePath: string, opts?: object, next?: any): any;
+    // Parse Files
+    load(filePath: string, opts?: object, next?: any): any;
+    parseCSONFile(filePath: string, opts?: object, next?: any): any;
+    parseJSONFile(filePath: string, opts?: object, next?: any): any;
+    parseCSFile(filePath: string, opts?: object, next?: any): any;
+    parseJSFile(filePath: string, opts?: object, next?: any): any;
 
-// Require Files
-export function requireCSFile(filePath: string, opts?: object, next?: any): any;
-export function requireJSFile(filePath: string, opts?: object, next?: any): any;
-export function requireFile(filePath: string, opts?: object, next?: any): any;
+    // Require Files
+    requireCSFile(filePath: string, opts?: object, next?: any): any;
+    requireJSFile(filePath: string, opts?: object, next?: any): any;
+    requireFile(filePath: string, opts?: object, next?: any): any;
+}
+
+declare const _default: CSON;
+
+export default _default;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bevry/cson/blob/master/source/index.coffee#L552
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. Nope, definition already pointing to the latest version.

-----------------

Instead of declaring named exports, this change declares the default exported singleton, as intended by the lib code: https://github.com/bevry/cson/blob/master/source/index.coffee#L552

BTW: trying to import a function as a named export will cause the operation to crash.