### PR TITLE
Add DOM to axios-curlirize dependencies

### DIFF
--- a/types/axios-curlirize/tsconfig.json
+++ b/types/axios-curlirize/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
It is (temporarily?) required by axios@0.22.