### PR TITLE
update(mini-css-extract-plugin): 2.4 update

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mini-css-extract-plugin 2.3
+// Type definitions for mini-css-extract-plugin 2.4
 // Project: https://github.com/webpack-contrib/mini-css-extract-plugin
 // Definitions by: JounQin <https://github.com/JounQin>
 //                 Katsuya Hino <https://github.com/dobogo>
@@ -6,9 +6,9 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 James Garbutt <https://github.com/43081j>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
 
 /// <reference types="node" />
+
 import { Configuration, Compiler } from 'webpack';
 
 /**
@@ -49,7 +49,7 @@ declare namespace MiniCssExtractPlugin {
         /**
          * Enable the experimental importModule approach instead of using child compilers. This uses less memory and is faster.
          * @link https://github.com/webpack-contrib/mini-css-extract-plugin#experimentaluseimportmodule
-         * @default false
+         * @default undefined
          */
         experimentalUseImportModule?: boolean | undefined;
         /**

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -118,6 +118,9 @@ configuration = {
         new MiniCssExtractPlugin({
             experimentalUseImportModule: false,
         }),
+        new MiniCssExtractPlugin({
+            experimentalUseImportModule: undefined,
+        }),
     ],
 };
 


### PR DESCRIPTION
- explicit undefined support for `experimentalUseImportModule` option
  with JSDoc update

  https://github.com/webpack-contrib/mini-css-extract-plugin/compare/v2.3.0...v2.4.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).