### PR TITLE
chrome-remote-interface: use devtools-protocol@0.0.927104

### DIFF
--- a/types/chrome-remote-interface/package.json
+++ b/types/chrome-remote-interface/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "devtools-protocol": ">=0.0.894172"
+        "devtools-protocol": "0.0.927104"
     }
 }


### PR DESCRIPTION
Newer versions remove the interface that this package depends on.