### PR TITLE
[Meteor] Added createIndex type and marked _ensureIndex as deprecated

### DIFF
--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -203,11 +203,7 @@ declare module Mongo {
             fetch?: string[] | undefined;
             transform?: Fn | undefined;
         }): boolean;
-        createIndex(index: { [key: string]: number | string } | string, options?: {
-            name?: String | undefined;
-            sparse?: Boolean | undefined;
-            unique?: Boolean | undefined;
-        }): void;
+        createIndex(index: { [key: string]: number | string } | string, options?: any): void;
         deny<Fn extends Transform<T> = undefined>(options: {
             insert?: ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean) | undefined;
             update?:

--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -203,6 +203,11 @@ declare module Mongo {
             fetch?: string[] | undefined;
             transform?: Fn | undefined;
         }): boolean;
+        createIndex(index: { [key: string]: number | string } | string, options?: {
+            name?: String | undefined;
+            sparse?: Boolean | undefined;
+            unique?: Boolean | undefined;
+        }): void;
         deny<Fn extends Transform<T> = undefined>(options: {
             insert?: ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean) | undefined;
             update?:
@@ -301,6 +306,7 @@ declare module Mongo {
             numberAffected?: number | undefined;
             insertedId?: string | undefined;
         };
+        /** @deprecated */
         _ensureIndex(keys: { [key: string]: number | string } | string, options?: { [key: string]: any }): void;
         _dropIndex(keys: { [key: string]: number | string } | string): void;
     }

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -1,4 +1,4 @@
-import { Collection as MongoCollection, Db as MongoDb, MongoClient } from 'mongodb';
+import { Collection as MongoCollection, Db as MongoDb, IndexOptions, MongoClient } from 'mongodb';
 import { Meteor } from 'meteor/meteor';
 
 declare module 'meteor/mongo' {
@@ -212,11 +212,7 @@ declare module 'meteor/mongo' {
                 fetch?: string[] | undefined;
                 transform?: Fn | undefined;
             }): boolean;
-            createIndex(index: { [key: string]: number | string } | string, options?: {
-                name?: String | undefined;
-                sparse?: Boolean | undefined;
-                unique?: Boolean | undefined;
-            }): void;
+            createIndex(index: { [key: string]: number | string } | string, options?: IndexOptions): void;
             deny<Fn extends Transform<T> = undefined>(options: {
                 insert?: ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean) | undefined;
                 update?:

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -212,6 +212,11 @@ declare module 'meteor/mongo' {
                 fetch?: string[] | undefined;
                 transform?: Fn | undefined;
             }): boolean;
+            createIndex(index: { [key: string]: number | string } | string, options?: {
+                name?: String | undefined;
+                sparse?: Boolean | undefined;
+                unique?: Boolean | undefined;
+            }): void;
             deny<Fn extends Transform<T> = undefined>(options: {
                 insert?: ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean) | undefined;
                 update?:
@@ -315,6 +320,7 @@ declare module 'meteor/mongo' {
                 numberAffected?: number | undefined;
                 insertedId?: string | undefined;
             };
+            /** @deprecated */
             _ensureIndex(keys: { [key: string]: number | string } | string, options?: { [key: string]: any }): void;
             _dropIndex(keys: { [key: string]: number | string } | string): void;
         }

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -391,7 +391,7 @@ namespace MeteorTests {
         * From Collections, createIndex section
     */
 
-    Posts.createIndex('title');
+    Posts.createIndex({ title: 1 });
 
     /**
      * From Collections, cursor.forEach section

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -388,6 +388,12 @@ namespace MeteorTests {
     });
 
     /**
+        * From Collections, createIndex section
+    */
+
+    Posts.createIndex('title');
+
+    /**
      * From Collections, cursor.forEach section
      */
     var topPosts = Posts.find({}, { sort: { score: -1 }, limit: 5 }) as Mongo.Cursor<PostDAO | iPost>;

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -406,7 +406,7 @@ namespace MeteorTests {
      * From Collections, createIndex section
      */
 
-    Posts.createIndex('title');
+    Posts.createIndex({ title: 1 });
 
     /**
      * From Collections, cursor.forEach section

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -403,6 +403,12 @@ namespace MeteorTests {
     });
 
     /**
+     * From Collections, createIndex section
+     */
+
+    Posts.createIndex('title');
+
+    /**
      * From Collections, cursor.forEach section
      */
     var topPosts = Posts.find({}, { sort: { score: -1 }, limit: 5 }) as Mongo.Cursor<PostDAO | iPost>;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/changelog.html#v2420210915
https://docs.meteor.com/api/collections.html#Mongo-Collection-createIndex
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.