### PR TITLE
Add WebRTC types that were removed with TS 4.4

### DIFF
--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -11,6 +11,62 @@
 
 /// <reference path='MediaStream.d.ts' />
 
+// https://www.w3.org/TR/webrtc/#idl-def-rtcerrordetailtype
+type RTCErrorDetailType =
+    | 'data-channel-failure'
+    | 'dtls-failure'
+    | 'fingerprint-failure'
+    | 'hardware-encoder-error'
+    | 'hardware-encoder-not-available'
+    | 'sctp-failure'
+    | 'sdp-syntax-error';
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcerror
+interface RTCError extends DOMException {
+    readonly errorDetail: RTCErrorDetailType;
+    readonly httpRequestStatusCode: number | null;
+    readonly receivedAlert: number | null;
+    readonly sctpCauseCode: number | null;
+    readonly sdpLineNumber: number | null;
+    readonly sentAlert: number | null;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcerrorinit
+interface RTCErrorInit {
+    errorDetail: RTCErrorDetailType;
+    httpRequestStatusCode?: number | undefined;
+    receivedAlert?: number | undefined;
+    sctpCauseCode?: number | undefined;
+    sdpLineNumber?: number | undefined;
+    sentAlert?: number | undefined;
+}
+
+declare var RTCError: {
+    prototype: RTCError;
+    new (init: RTCErrorInit, message?: string): RTCError;
+};
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcerrorevent
+interface RTCErrorEvent extends Event {
+    readonly error: RTCError;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcerroreventinit
+interface RTCErrorEventInit extends EventInit {
+    error: RTCError;
+}
+
+declare var RTCErrorEvent: {
+    prototype: RTCErrorEvent;
+    new (type: string, eventInitDict: RTCErrorEventInit): RTCErrorEvent;
+};
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicecandidatepair
+interface RTCIceCandidatePair {
+    local?: RTCIceCandidate | undefined;
+    remote?: RTCIceCandidate | undefined;
+}
+
 // https://www.w3.org/TR/webrtc/#idl-def-rtcofferansweroptions
 interface RTCOfferAnswerOptions {
     voiceActivityDetection?: boolean | undefined; // default = true
@@ -27,20 +83,32 @@ interface RTCAnswerOptions extends RTCOfferAnswerOptions {
 
 // https://www.w3.org/TR/webrtc/#idl-def-rtciceserver
 interface RTCIceServer {
-    //urls: string | string[];
-    credentialType?: RTCIceCredentialType | undefined; // default = 'password'
+    credential?: string | undefined;
+    credentialType?: RTCIceCredentialType | undefined;
+    urls: string | string[];
+    username?: string | undefined;
 }
 
 // https://www.w3.org/TR/webrtc/#idl-def-rtciceparameters
 interface RTCIceParameters {
-    //usernameFragment: string;
-    //password: string;
+    iceLite?: boolean | undefined;
+    password?: string | undefined;
+    usernameFragment?: string | undefined;
+}
+
+// https://www.w3.org/TR/webrtc/#idl-def-rtcicerole
+type RTCIceRole = 'controlled' | 'controlling' | 'unknown';
+
+interface RTCIceTransportEventMap {
+    "gatheringstatechange": Event;
+    "selectedcandidatepairchange": Event;
+    "statechange": Event;
 }
 
 // https://www.w3.org/TR/webrtc/#idl-def-rtcicetransport
 type IceTransportEventHandler = ((this: RTCIceTransport, ev: Event) => any) | null;
-interface RTCIceTransport {
-    //readonly role: RTCIceRole;
+interface RTCIceTransport extends EventTarget {
+    readonly role: RTCIceRole;
     //readonly component: RTCIceComponent;
     //readonly state: RTCIceTransportState;
     readonly gatheringState: RTCIceGatheringState;
@@ -48,18 +116,33 @@ interface RTCIceTransport {
     getRemoteCandidates(): RTCIceCandidate[];
     getLocalParameters(): RTCIceParameters | null;
     getRemoteParameters(): RTCIceParameters | null;
+    getSelectedCandidatePair(): RTCIceCandidatePair | null;
     onstatechange: IceTransportEventHandler;
     ongatheringstatechange: IceTransportEventHandler;
     onselectedcandidatepairchange: IceTransportEventHandler;
+    addEventListener<K extends keyof RTCIceTransportEventMap>(type: K, listener: (this: RTCIceTransport, ev: RTCIceTransportEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof RTCIceTransportEventMap>(type: K, listener: (this: RTCIceTransport, ev: RTCIceTransportEventMap[K]) => any, options: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
+interface RTCDtlsTransportEventMap {
+    "error": RTCErrorEvent;
+    "statechange": Event;
 }
 
 // https://www.w3.org/TR/webrtc/#idl-def-rtcdtlstransport
-type DtlsTransportEventHandler = ((this: RTCDtlsTransport, ev: Event) => any) | null;
-interface RTCDtlsTransport {
-    readonly transport: RTCIceTransport;
-    //readonly state: RTCDtlsTransportState;
+type DtlsTransportEventHandler<E extends Event> = ((this: RTCDtlsTransport, ev: E) => any) | null;
+interface RTCDtlsTransport extends EventTarget {
+    readonly iceTransport: RTCIceTransport;
+    readonly state: RTCDtlsTransportState;
     getRemoteCertificates(): ArrayBuffer[];
-    onstatechange: DtlsTransportEventHandler;
+    onerror: DtlsTransportEventHandler<RTCErrorEvent>;
+    onstatechange: DtlsTransportEventHandler<Event>;
+    addEventListener<K extends keyof RTCDtlsTransportEventMap>(type: K, listener: (this: RTCDtlsTransport, ev: RTCDtlsTransportEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof RTCDtlsTransportEventMap>(type: K, listener: (this: RTCDtlsTransport, ev: RTCDtlsTransportEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 // https://www.w3.org/TR/webrtc/#idl-def-rtcrtpcodeccapability

--- a/types/webrtc/test/RTCPeerConnection.ts
+++ b/types/webrtc/test/RTCPeerConnection.ts
@@ -92,3 +92,34 @@ pc.getStats(
     (report: RTCStatsReport) => console.log('got report'),
     (error: DOMException) => console.log(error.message)
 ).then(() => console.log('getStats complete'));
+
+// RTCError
+const error = new RTCError({
+    errorDetail: 'dtls-failure',
+    httpRequestStatusCode: 400,
+    receivedAlert: 1,
+    sctpCauseCode: 1,
+    sdpLineNumber: 1,
+    sentAlert: 1,
+});
+
+// RPCDtlsTransport
+const dtlsTransport = pc.sctp!.transport;
+dtlsTransport.onerror = ev => console.log(ev.error.errorDetail);
+dtlsTransport.onstatechange = ev => console.log(ev.type);
+dtlsTransport.addEventListener('error', ev => console.log(ev.error.errorDetail));
+dtlsTransport.addEventListener('statechange', ev => console.log(ev.type));
+console.log(dtlsTransport.state);
+
+// RPCIceTransport
+const iceTransport = dtlsTransport.iceTransport;
+iceTransport.onstatechange = ev => console.log(ev.type);
+iceTransport.ongatheringstatechange = ev => console.log(ev.type);
+iceTransport.onselectedcandidatepairchange = ev => console.log(ev.type);
+iceTransport.addEventListener('statechange', ev => console.log(ev.type));
+iceTransport.addEventListener('ongatheringstatechange', ev => console.log(ev.type));
+iceTransport.addEventListener('onselectedcandidatepairchange', ev => console.log(ev.type));
+console.log(iceTransport.role);
+console.log(iceTransport.gatheringState);
+console.log(iceTransport.getSelectedCandidatePair()!.local);
+console.log(iceTransport.getSelectedCandidatePair()!.remote);


### PR DESCRIPTION
TypeScript 4.4 removed a few WebRTC types because of lacking browser support. There is still some code out there using those APIs. This adds them to `@types/webrtc`:

- RTCError
- RTCErrorEvent
- RTCIceCandidatePair
- Some members of RTCIceServer
- Some members of RTCIceParameters
- Some members of RTCIceTransport
- Some members of RTCDtlsTransport

Changing an existing definition:
- URL to documentation or source code which provides context for the suggested changes: [TS 4.4 type removals](https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1029#issuecomment-869224737)
