### PR TITLE
Add iterator TNext type for TS 4.5

### DIFF
--- a/types/es-get-iterator/es-get-iterator-tests.ts
+++ b/types/es-get-iterator/es-get-iterator-tests.ts
@@ -18,10 +18,10 @@ getIterator(new Map<symbol, unknown>());
 // $ExpectType Iterator<boolean, any, undefined>
 getIterator(new Set<boolean>());
 
-// $ExpectType Iterator<"foo" | "bar", void, unknown>
+// $ExpectType Iterator<"foo" | "bar", void, unknown> || Iterator<"foo" | "bar", void, any>
 getIterator((function*() { yield "foo"; yield "bar"; })());
 
-// $ExpectType Iterator<0 | 1, number, unknown>
+// $ExpectType Iterator<0 | 1, number, unknown> || Iterator<0 | 1, number, any>
 getIterator((function*() { yield 0; yield 1; return 2; })());
 
 declare const ARGUMENTS: IArguments;


### PR DESCRIPTION
The TNext type of IIFEs is `any` by default in Typescript 4.5, not `unknown` as it was before. That's because Typescript has different defaults for TNext depending on whether there's a contextual type or not, and IIFEs are now contextually typed in TS 4.5.

This is inconsistent and I'm not sure why it is this way, but it's minor enough to document it in es-get-iterator's tests without fixing it in TS.