### PR TITLE
Add types for meteor/percolate:migrations

### DIFF
--- a/types/meteor-percolate-migrations/index.d.ts
+++ b/types/meteor-percolate-migrations/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for non-npm package Atmosphere package percolate:migrations 1.0
+// Project: https://github.com/percolatestudio/meteor-migrations/
+// Definitions by: Stepan Yurtsiv <https://github.com/yurtsiv>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.7
+
+// tslint:disable-next-line no-single-declare-module
+declare module 'meteor/percolate:migrations' {
+  interface MigrationSpec {
+    down?(): void;
+    name?: string;
+    up(): void;
+    version: number;
+  }
+
+  interface LoggerOptions {
+    level: 'info' | 'warn' | 'error' | 'debug';
+    message: string;
+    tag: 'Migrations';
+  }
+
+  interface Config {
+    collectionName?: string;
+    log?: boolean;
+    logger?: ((options: LoggerOptions) => void) | null;
+    logIfLatest?: boolean;
+  }
+
+  interface MigrationsT {
+    add(spec: MigrationSpec): void;
+    config(c: Config): void;
+    getVersion(): number;
+    migrateTo(version: number | string): void;
+    start(): void;
+    unlock(): void;
+  }
+
+  const Migrations: MigrationsT;
+}

--- a/types/meteor-percolate-migrations/index.d.ts
+++ b/types/meteor-percolate-migrations/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/percolatestudio/meteor-migrations/
 // Definitions by: Stepan Yurtsiv <https://github.com/yurtsiv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
 
 // tslint:disable-next-line no-single-declare-module
 declare module 'meteor/percolate:migrations' {

--- a/types/meteor-percolate-migrations/index.d.ts
+++ b/types/meteor-percolate-migrations/index.d.ts
@@ -25,7 +25,7 @@ declare module 'meteor/percolate:migrations' {
     logIfLatest?: boolean;
   }
 
-  interface MigrationsT {
+  interface MigrationsPublicApi {
     add(spec: MigrationSpec): void;
     config(c: Config): void;
     getVersion(): number;
@@ -34,5 +34,5 @@ declare module 'meteor/percolate:migrations' {
     unlock(): void;
   }
 
-  const Migrations: MigrationsT;
+  const Migrations: MigrationsPublicApi;
 }

--- a/types/meteor-percolate-migrations/meteor-percolate-migrations-tests.ts
+++ b/types/meteor-percolate-migrations/meteor-percolate-migrations-tests.ts
@@ -1,0 +1,95 @@
+import { LoggerOptions, Migrations } from 'meteor/percolate:migrations';
+
+// $ExpectType void
+Migrations.add({
+  version: 1,
+  up() {}
+});
+
+// $ExpectType void
+Migrations.add({
+  version: 1,
+  name: 'More pandas',
+  up() {}
+});
+
+// $ExpectType void
+Migrations.add({
+  version: 2,
+  name: 'Less pandas',
+  up() {},
+  down() {}
+});
+
+// $ExpectError
+Migrations.add({});
+
+// $ExpectError
+Migrations.add({
+  version: 1
+});
+
+// $ExpectError
+Migrations.add({
+  up() {}
+});
+
+function logger(options: LoggerOptions) {
+  // $ExpectType "info" | "warn" | "error" | "debug"
+  options.level;
+  // $ExpectType string
+  options.message;
+  // $ExpectType "Migrations"
+  options.tag;
+}
+
+// $ExpectType void
+Migrations.config({
+  collectionName: 'pandas',
+  log: true,
+  logger,
+  logIfLatest: true
+});
+
+// $ExpectType void
+Migrations.config({
+  log: true,
+  logger,
+  logIfLatest: true
+});
+
+// $ExpectType void
+Migrations.config({
+  logger,
+  logIfLatest: true,
+});
+
+// $ExpectType void
+Migrations.config({logIfLatest: true});
+
+// $ExpectType void
+Migrations.config({});
+
+// $ExpectType void
+Migrations.config({ logger: null });
+
+// $ExpectError
+Migrations.config();
+
+// $ExpectType number
+Migrations.getVersion();
+
+// $ExpectType void
+Migrations.migrateTo(1);
+
+// $ExpectType void
+Migrations.migrateTo('latest');
+
+// $ExpectType void
+Migrations.migrateTo('3,rerun');
+
+// $ExpectType void
+Migrations.start();
+
+// $ExpectType void
+Migrations.unlock();

--- a/types/meteor-percolate-migrations/tsconfig.json
+++ b/types/meteor-percolate-migrations/tsconfig.json
@@ -1,25 +1,23 @@
 {
-   "compilerOptions":{
-      "module":"commonjs",
-      "lib":[
-         "es6"
-      ],
-      "noImplicitAny":true,
-      "noImplicitThis":true,
-      "strictNullChecks":true,
-      "strictFunctionTypes":true,
-      "baseUrl":"../",
-      "typeRoots":[
-         "../"
-      ],
-      "types":[
-         
-      ],
-      "noEmit":true,
-      "forceConsistentCasingInFileNames":true
-   },
-   "files":[
-      "index.d.ts",
-      "meteor-percolate-migrations-tests.ts"
-   ]
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "meteor-percolate-migrations-tests.ts"
+    ]
 }

--- a/types/meteor-percolate-migrations/tsconfig.json
+++ b/types/meteor-percolate-migrations/tsconfig.json
@@ -1,0 +1,25 @@
+{
+   "compilerOptions":{
+      "module":"commonjs",
+      "lib":[
+         "es6"
+      ],
+      "noImplicitAny":true,
+      "noImplicitThis":true,
+      "strictNullChecks":true,
+      "strictFunctionTypes":true,
+      "baseUrl":"../",
+      "typeRoots":[
+         "../"
+      ],
+      "types":[
+         
+      ],
+      "noEmit":true,
+      "forceConsistentCasingInFileNames":true
+   },
+   "files":[
+      "index.d.ts",
+      "meteor-percolate-migrations-tests.ts"
+   ]
+}

--- a/types/meteor-percolate-migrations/tslint.json
+++ b/types/meteor-percolate-migrations/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
