### PR TITLE
fix(markdown-it): correct core rule return type

### DIFF
--- a/types/markdown-it/lib/index.d.ts
+++ b/types/markdown-it/lib/index.d.ts
@@ -1,13 +1,11 @@
-import utils = require('./common/utils');
-import helpers = require('./helpers');
-import State = require('./rules_core/state_core');
-import Renderer = require('./renderer');
-import ParserCore = require('./parser_core');
-import ParserBlock = require('./parser_block');
-import ParserInline = require('./parser_inline');
-
 import LinkifyIt = require('linkify-it');
 
+import utils = require('./common/utils');
+import helpers = require('./helpers');
+import ParserBlock = require('./parser_block');
+import ParserCore = require('./parser_core');
+import ParserInline = require('./parser_inline');
+import Renderer = require('./renderer');
 import Token = require('./token');
 
 declare namespace MarkdownIt {

--- a/types/markdown-it/lib/parser_block.d.ts
+++ b/types/markdown-it/lib/parser_block.d.ts
@@ -1,7 +1,7 @@
 import MarkdownIt = require('.');
 import Ruler = require('./ruler');
-import Token = require('./token');
 import StateBlock = require('./rules_block/state_block');
+import Token = require('./token');
 
 declare namespace ParserBlock {
     type RuleBlock = (state: StateBlock, startLine: number, endLine: number, silent: boolean) => boolean;

--- a/types/markdown-it/lib/parser_core.d.ts
+++ b/types/markdown-it/lib/parser_core.d.ts
@@ -1,10 +1,8 @@
-import MarkdownIt = require('.');
 import Ruler = require('./ruler');
-import Token = require('./token');
 import StateCore = require('./rules_core/state_core');
 
 declare namespace Core {
-    type RuleCore = (state: StateCore) => boolean;
+    type RuleCore = (state: StateCore) => void;
 }
 
 declare class Core {

--- a/types/markdown-it/lib/ruler.d.ts
+++ b/types/markdown-it/lib/ruler.d.ts
@@ -1,5 +1,3 @@
-import StateCore = require('./rules_core/state_core');
-
 declare namespace Ruler {
     interface RuleOptions {
         /**

--- a/types/markdown-it/markdown-it-tests.ts
+++ b/types/markdown-it/markdown-it-tests.ts
@@ -1,9 +1,8 @@
-import MarkdownIt = require('markdown-it');
-import MarkdownIt1 = require('markdown-it/index');
-import MarkdownIt2 = require('markdown-it/lib');
-import MarkdownIt3 = require('markdown-it/lib/index');
-
 import LinkifyIt = require('linkify-it');
+import MarkdownIt = require('markdown-it');
+import MarkdownIt1 = require('markdown-it');
+import MarkdownIt2 = require('markdown-it/lib');
+import MarkdownIt3 = require('markdown-it/lib');
 
 // sstub highlight-js interaction
 declare const hljs: {
@@ -85,6 +84,7 @@ declare const plugin1: any;
 declare const plugin2: any;
 declare const plugin3: any;
 declare const opts: any;
+
 let md: MarkdownIt;
 {
     md = MarkdownIt().use(plugin1).use(plugin2, opts).use(plugin3);

--- a/types/markdown-it/test/common/utils.ts
+++ b/types/markdown-it/test/common/utils.ts
@@ -1,8 +1,7 @@
-import utils = require('markdown-it/lib/common/utils');
-
 import entities = require('markdown-it/lib/common/entities');
 import htmlBlocks = require('markdown-it/lib/common/html_blocks');
 import htmlRE = require('markdown-it/lib/common/html_re');
+import utils = require('markdown-it/lib/common/utils');
 import StateBlock = require('markdown-it/lib/rules_block/state_block');
 import StateInline = require('markdown-it/lib/rules_inline/state_inline');
 

--- a/types/markdown-it/test/index.ts
+++ b/types/markdown-it/test/index.ts
@@ -1,9 +1,9 @@
+import LinkifyIt = require('linkify-it');
 import MarkdownIt = require('markdown-it/lib');
-import ParserInline = require('markdown-it/lib/parser_inline');
 import ParserBlock = require('markdown-it/lib/parser_block');
 import ParserCore = require('markdown-it/lib/parser_core');
+import ParserInline = require('markdown-it/lib/parser_inline');
 import Renderer = require('markdown-it/lib/renderer');
-import LinkifyIt = require('linkify-it');
 
 {
     const md = new MarkdownIt();

--- a/types/markdown-it/test/parser_block.ts
+++ b/types/markdown-it/test/parser_block.ts
@@ -1,7 +1,7 @@
 import MarkdownIt = require('markdown-it/lib');
-import Token = require('markdown-it/lib/token');
-import StateBlock = require('markdown-it/lib/rules_block/state_block');
 import ParserBlock = require('markdown-it/lib/parser_block');
+import StateBlock = require('markdown-it/lib/rules_block/state_block');
+import Token = require('markdown-it/lib/token');
 
 const md = new MarkdownIt();
 const tokens: Token[] = [];

--- a/types/markdown-it/test/parser_core.ts
+++ b/types/markdown-it/test/parser_core.ts
@@ -1,7 +1,6 @@
 import MarkdownIt = require('markdown-it/lib');
-import Token = require('markdown-it/lib/token');
-import StateCore = require('markdown-it/lib/rules_core/state_core');
 import ParserCore = require('markdown-it/lib/parser_core');
+import StateCore = require('markdown-it/lib/rules_core/state_core');
 
 const md = new MarkdownIt();
 const state: StateCore = new md.core.State('# Foobar', md, {});

--- a/types/markdown-it/test/parser_inline.ts
+++ b/types/markdown-it/test/parser_inline.ts
@@ -1,7 +1,7 @@
 import MarkdownIt = require('markdown-it/lib');
-import Token = require('markdown-it/lib/token');
-import StateInline = require('markdown-it/lib/rules_inline/state_inline');
 import ParserInline = require('markdown-it/lib/parser_inline');
+import StateInline = require('markdown-it/lib/rules_inline/state_inline');
+import Token = require('markdown-it/lib/token');
 
 const md = new MarkdownIt();
 const tokens: Token[] = [];

--- a/types/markdown-it/test/ruler.ts
+++ b/types/markdown-it/test/ruler.ts
@@ -1,5 +1,5 @@
 import MarkdownIt = require('markdown-it');
-import Ruler = require('markdown-it/lib/ruler');
+import StateCore = require('markdown-it/lib/rules_core/state_core');
 
 const md = new MarkdownIt();
 
@@ -30,7 +30,12 @@ md.core.ruler.enableOnly('image');
 md.core.ruler.disable(['link', 'image']);
 md.core.ruler.disable('link');
 
+declare const state: StateCore;
 const coreRules = md.core.ruler.getRules('');
+coreRules.forEach(rule => {
+    rule(state);
+});
+
 const terminatorRules = md.block.ruler.getRules('blockquote');
 
 md.core.ruler.push('foobar', state => false, { alt: ['foo', 'bar'] });

--- a/types/markdown-it/tslint.json
+++ b/types/markdown-it/tslint.json
@@ -3,7 +3,6 @@
     "rules": {
         "array-type": false,
         "comment-format": false,
-        "no-duplicate-variable": false,
         "object-literal-shorthand": false,
         "prefer-const": false,
         "prefer-template": false,


### PR DESCRIPTION
- void, not predicate
- minor fixes, sorting imports and removing unused imports (dead code)
- minor TSLint improvement
- 
https://github.com/markdown-it/markdown-it/blob/6e2de08a0b03d3d0dcc524b89710ce05f83a0283/lib/parser_core.js#L40-L53

/cc @Lemmingh

Thanks!

Fixes #56245

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).