### PR TITLE
[@wordpress/components] Add explicit types for children

### DIFF
--- a/types/wordpress__components/panel/row.d.ts
+++ b/types/wordpress__components/panel/row.d.ts
@@ -1,7 +1,8 @@
-import { ComponentType } from 'react';
+import { ComponentType, ReactNode } from 'react';
 
 declare namespace PanelRow {
     interface Props {
+        children?: ReactNode;
         /**
          * The class that will be added with `components-panel__row`. to the
          * classes of the wrapper div. If no `className` is passed only

--- a/types/wordpress__components/slot-fill/context.d.ts
+++ b/types/wordpress__components/slot-fill/context.d.ts
@@ -1,5 +1,5 @@
 import { Component } from '@wordpress/element';
-import { ComponentType, Consumer as ContextConsumer } from 'react';
+import { ComponentType, Consumer as ContextConsumer, ReactNode } from 'react';
 
 export interface SlotFillContext {
     registerSlot(name: string, instance: Component): void;
@@ -12,7 +12,7 @@ export interface SlotFillContext {
     getFills(name: string, instance: Component): ReadonlyArray<Component & { occurrence?: number | undefined }>;
 }
 
-declare const SlotFillProvider: ComponentType;
+declare const SlotFillProvider: ComponentType<{ children?: ReactNode }>;
 
 export const Consumer: ContextConsumer<SlotFillContext>;
 

--- a/types/wordpress__components/snackbar/index.d.ts
+++ b/types/wordpress__components/snackbar/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from 'react';
+import { ComponentType, ReactNode } from 'react';
 
 import Notice from '../notice';
 
@@ -8,6 +8,7 @@ declare namespace Snackbar {
          * An array of `Notice.Action` objects.
          */
         actions?: readonly Notice.Action[] | undefined;
+        children?: ReactNode;
         className?: string | undefined;
         /**
          * Callback to be called when the snackbar is to be removed.


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.