### PR TITLE
[react-onsenui] Add explicit types for children

### DIFF
--- a/types/react-onsenui/index.d.ts
+++ b/types/react-onsenui/index.d.ts
@@ -479,6 +479,7 @@ export class ListHeader extends Component<{
 }, any> {}
 
 export class ListItem extends Component<{
+    children?: React.ReactNode;
     modifier?: string | undefined,
     tappable?: boolean | undefined,
     tapBackgroundColor?: string | undefined,


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.