### PR TITLE
[rrc] Add explicit types for children

### DIFF
--- a/types/rrc/index.d.ts
+++ b/types/rrc/index.d.ts
@@ -10,6 +10,7 @@ import { RouteProps, RouteComponentProps, match as MatchObject } from "react-rou
 
 export interface ScrollIntoViewProps {
     alignToTop?: boolean | undefined;
+    children?: React.ReactNode;
     id: string;
 }
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/pshrmn/rrc/blob/b6d903dc97043f0503f9eef934d40d778fcf17a6/src/ScrollIntoView.js#L12
