### PR TITLE
[rebass] Card implements CardProps not BoxKnownProps

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -68,7 +68,7 @@ export interface ButtonProps
 export const Button: React.FunctionComponent<ButtonProps>;
 
 export interface CardProps extends BoxKnownProps, Omit<React.HTMLProps<HTMLDivElement>, keyof BoxKnownProps> {}
-export const Card: React.FunctionComponent<BoxKnownProps>;
+export const Card: React.FunctionComponent<CardProps>;
 
 // tslint:disable-next-line no-empty-interface
 interface FlexKnownProps extends BoxKnownProps {}


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.