### PR TITLE
[reactable] Add explicit types for children

### DIFF
--- a/types/reactable/index.d.ts
+++ b/types/reactable/index.d.ts
@@ -18,6 +18,7 @@ export type SortDirection = 'asc' | 'desc';
 export type FilterMethodType = (text: string) => void;
 
 export interface TableComponentProperties<T> {
+    children?: React.ReactNode;
     data?: T[] | undefined;
     className?: string | undefined;
     columns?: ColumnsType[] | undefined;
@@ -36,16 +37,19 @@ export interface TableComponentProperties<T> {
 }
 
 export interface ThProperties {
+    children?: React.ReactNode;
     column: string;
     className?: string | undefined;
 }
 
 export interface TrProperties<T> {
+    children?: React.ReactNode;
     data?: T | undefined;
     className?: string | undefined;
 }
 
 export interface TdProperties {
+    children?: React.ReactNode;
     column: string;
     value?: any;
     data?: any;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/abdulrahman-khankan/reactable/tree/0.14.1#customizing-columns
