### PR TITLE
[reactabular-table] Add explicit types for children

### DIFF
--- a/types/reactabular-table/index.d.ts
+++ b/types/reactabular-table/index.d.ts
@@ -65,6 +65,7 @@ export type CellFormatter = (value: any, props: {
 }) => string | JSX.Element;
 
 export interface ProviderProps {
+    children?: React.ReactNode;
     columns: Column[];
     className?: string | undefined;
     renderers?: Renderers | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/reactabular/reactabular/tree/v8.14.0/packages/reactabular-table#tableprovider

