### PR TITLE
[react-wait] Add explicit types for children

### DIFF
--- a/types/react-wait/index.d.ts
+++ b/types/react-wait/index.d.ts
@@ -5,11 +5,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { ComponentType, FunctionComponent } from 'react';
+import { ComponentType, FunctionComponent, ReactNode } from 'react';
 
-export const Waiter: FunctionComponent;
+export const Waiter: FunctionComponent<{ children?: ReactNode }>;
 
 export interface WaitingContextWaitProps {
+    children?: ReactNode;
     fallback: JSX.Element;
 }
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/f/react-wait/blob/e2ad40672815dd54c8fe4ec8e7320ce842ece6ad/src/index.js#L8
