### PR TITLE
[react-vertical-timeline-component] Add explicit types for children

### DIFF
--- a/types/react-vertical-timeline-component/index.d.ts
+++ b/types/react-vertical-timeline-component/index.d.ts
@@ -9,11 +9,13 @@ import * as React from "react";
 
 export interface VerticalTimelineProps {
     animate?: boolean | undefined;
+    children?: React.ReactNode;
     className?: string | undefined;
     layout?: '1-column' | '2-columns' | undefined;
 }
 
 export interface VerticalTimelineElementProps {
+    children?: React.ReactNode;
     id?: string | undefined;
     className?: string | undefined;
     date?: string | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/stephane-monnot/react-vertical-timeline/tree/v3.0.2#usage
