### PR TITLE
[react-typist] Add explicit types for Typist#children

### DIFF
--- a/types/react-typist/index.d.ts
+++ b/types/react-typist/index.d.ts
@@ -36,6 +36,7 @@ export namespace Typist {
 }
 
 export interface TypistProps {
+    children?: React.ReactNode;
     className?: string | undefined;
     avgTypingDelay?: number | undefined;
     stdTypingDelay?: number | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/jstejada/react-typist/blob/v2.0.5/src/Typist.jsx#L14
