### PR TITLE
[react-tracking] Add explicit `children` to TrackingComponent

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -24,7 +24,7 @@ export interface TrackingHook<P = {}> extends TrackingProp<P> {
     /**
      * This component will pass any tracking data as context to tracking calls made in any components within its subtree.
      */
-    Track: TrackingComponent;
+    Track: TrackingComponent<P>;
 }
 
 type Falsy = false | null | undefined | "";
@@ -116,7 +116,7 @@ export interface Track<T = any, P = any, S = any> {
 /**
  * This component will pass any tracking data as context to tracking calls made in any components within its subtree.
  */
-export type TrackingComponent = React.FC<React.PropsWithChildren<{}>>;
+export type TrackingComponent<P = {}> = React.FC<React.PropsWithChildren<P>>;
 
 export const track: Track;
 export default track;

--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -116,7 +116,7 @@ export interface Track<T = any, P = any, S = any> {
 /**
  * This component will pass any tracking data as context to tracking calls made in any components within its subtree.
  */
-export type TrackingComponent<P = {}> = React.FC<React.PropsWithChildren<P>>;
+export type TrackingComponent<P = {}> = React.FC<React.PropsWithChildren<{}>>;
 
 export const track: Track;
 export default track;

--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -24,7 +24,7 @@ export interface TrackingHook<P = {}> extends TrackingProp<P> {
     /**
      * This component will pass any tracking data as context to tracking calls made in any components within its subtree.
      */
-    Track: TrackingComponent<P>;
+    Track: TrackingComponent;
 }
 
 type Falsy = false | null | undefined | "";
@@ -116,7 +116,7 @@ export interface Track<T = any, P = any, S = any> {
 /**
  * This component will pass any tracking data as context to tracking calls made in any components within its subtree.
  */
-export type TrackingComponent<P = {}> = React.FC;
+export type TrackingComponent = React.FC<React.PropsWithChildren<{}>>;
 
 export const track: Track;
 export default track;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.