### PR TITLE
[react-tabs-redux] Add explicit types for Tabs#children

### DIFF
--- a/types/react-tabs-redux/Tabs.d.ts
+++ b/types/react-tabs-redux/Tabs.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 export interface TabsProps {
+    children?: React.ReactNode;
     name?: string | undefined;
     onChange?: ((selectedTab: string, name: string) => void) | undefined;
     handleSelect?: ((tab: string, name: string) => void) | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/patrik-piskay/react-tabs-redux/blob/4.0.0/src/components/Tabs.js#L143
