### PR TITLE
[react-switch-case] Add explicit types for children

### DIFF
--- a/types/react-switch-case/index.d.ts
+++ b/types/react-switch-case/index.d.ts
@@ -6,10 +6,12 @@
 import * as React from 'react';
 
 export interface SwitchProps {
+    children?: React.ReactNode;
     condition: any;
 }
 
 interface CaseProps {
+    children?: React.ReactNode;
     value: any;
 }
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/AlexSergey/react-switch-case#step-3
