### PR TITLE
[react-swipe] Add explicit types for ReactSwipe#children

### DIFF
--- a/types/react-swipe/index.d.ts
+++ b/types/react-swipe/index.d.ts
@@ -24,6 +24,7 @@ declare namespace ReactSwipe {
     }
 
     interface Props {
+        children?: React.ReactNode;
         id?: string | undefined;
         swipeOptions?: SwipeOptions | undefined;
         childCount?: number | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://www.npmjs.com/package/react-swipe/v/6.0.4#examples
