### PR TITLE
[react-svg-pan-zoom] Add explicit types for ReactSwipe#children

### DIFF
--- a/types/react-svg-pan-zoom/index.d.ts
+++ b/types/react-svg-pan-zoom/index.d.ts
@@ -143,6 +143,7 @@ export interface OptionalProps {
 }
 
 export interface RequiredProps {
+    children: React.ReactElement;
     // width of the viewer displayed on screen
     width: number;
     // height of the viewer displayed on screen
@@ -174,6 +175,7 @@ export interface UncontrolledExtraOptionalProps {
 }
 
 export interface UncontrolledRequiredProps {
+    children: React.ReactElement;
     // width of the viewer displayed on screen
     width: number;
     // height of the viewer displayed on screen

--- a/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
+++ b/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
@@ -114,6 +114,7 @@ class MyViewer extends React.Component {
       <UncontrolledReactSVGPanZoom
         width={200} height={400}
       >
+        <svg />
       </UncontrolledReactSVGPanZoom>
     );
   }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/chrvadala/react-svg-pan-zoom/blob/v3.3.0/src/viewer.js#L603-L623
