### PR TITLE
[react-stripe-elements] Add explicit types for children

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -34,8 +34,8 @@ export namespace ReactStripeElements {
         stripeAccount?: string | undefined;
     }
     type StripeProviderProps =
-        | { apiKey: string; stripe?: never | undefined } & StripeProviderOptions
-        | { apiKey?: never | undefined; stripe: stripe.Stripe | null } & StripeProviderOptions;
+        | { children?: React.ReactNode, apiKey: string; stripe?: never | undefined } & StripeProviderOptions
+        | { children?: React.ReactNode, apiKey?: never | undefined; stripe: stripe.Stripe | null } & StripeProviderOptions;
 
     interface StripeOverrideProps {
         /*
@@ -100,7 +100,7 @@ export namespace ReactStripeElements {
 
 export class StripeProvider extends React.Component<ReactStripeElements.StripeProviderProps> {}
 
-export class Elements extends React.Component<stripe.elements.ElementsCreateOptions> {}
+export class Elements extends React.Component<stripe.elements.ElementsCreateOptions & { children?: React.ReactNode }> {}
 
 export function injectStripe<P extends object>(
     WrappedComponent: React.ComponentType<P & ReactStripeElements.InjectedStripeProps>,


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/stripe-archive/react-stripe-elements/blob/v6.1.2/src/components/Provider.js#L8
https://github.com/stripe-archive/react-stripe-elements/blob/v6.1.2/src/components/Elements.js#L15
