### PR TITLE
[react-stack-grid] Add explicit types for children

### DIFF
--- a/types/react-stack-grid/index.d.ts
+++ b/types/react-stack-grid/index.d.ts
@@ -13,6 +13,7 @@ export interface Grid {
     updateLayout: () => void;
 }
 export interface StackGridProps {
+    children?: React.ReactNode;
     columnWidth: number | string;
     className?: string | undefined;
     style?: React.CSSProperties | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://www.npmjs.com/package/react-stack-grid/v/0.7.1#quick-example
