### PR TITLE
[react-sparklines] Add explicit types for children

### DIFF
--- a/types/react-sparklines/index.d.ts
+++ b/types/react-sparklines/index.d.ts
@@ -12,6 +12,7 @@ export interface Point {
 }
 
 export interface SparklinesProps {
+    children?: React.ReactNode;
     data?: number[] | undefined;
     limit?: number | undefined;
     width?: number | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://www.npmjs.com/package/react-sparklines/v/1.7.0#basic-sparkline
