### PR TITLE
[react-smooth-scrollbar] Add explicit types for children

### DIFF
--- a/types/react-smooth-scrollbar/index.d.ts
+++ b/types/react-smooth-scrollbar/index.d.ts
@@ -10,6 +10,7 @@ import { ScrollbarOptions, ScrollStatus } from "smooth-scrollbar/interfaces";
 
 declare namespace Scrollbar {
     interface ScrollbarProps extends Partial<ScrollbarOptions> {
+        children?: React.ReactNode;
         /**
          * Pipe to scrollbar.addListener()
          */


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://www.npmjs.com/package/react-smooth-scrollbar/v/8.0.6#usage
