### PR TITLE
[react-slick] Add explicit types for children

### DIFF
--- a/types/react-slick/index.d.ts
+++ b/types/react-slick/index.d.ts
@@ -42,6 +42,7 @@ export interface Settings {
     beforeChange?(currentSlide: number, nextSlide: number): void;
     centerMode?: boolean | undefined;
     centerPadding?: string | undefined;
+    children?: React.ReactNode;
     className?: string | undefined;
     cssEase?: string | undefined;
     customPaging?(index: number): JSX.Element;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/akiran/react-slick/tree/0.28.0#example
