### PR TITLE
[react-sidebar] Add explicit types for children

### DIFF
--- a/types/react-sidebar/index.d.ts
+++ b/types/react-sidebar/index.d.ts
@@ -4,9 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { Component } from "react";
+import { Component, ReactNode } from "react";
 
 export interface SidebarProps {
+    children?: ReactNode;
     contentClassName?: string | undefined;
     defaultSidebarWidth?: number | undefined;
     docked?: boolean | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://www.npmjs.com/package/react-sidebar/v/3.0.2#getting-started

