### PR TITLE
[react-scroll-sync] Add explicit types for children

### DIFF
--- a/types/react-scroll-sync/index.d.ts
+++ b/types/react-scroll-sync/index.d.ts
@@ -6,6 +6,7 @@
 import * as React from 'react';
 
 export interface ScrollSyncProps {
+    children?: React.ReactNode;
     onSync?(el: Element): void;
     proportional?: boolean | undefined;
     vertical?: boolean | undefined;
@@ -15,6 +16,7 @@ export interface ScrollSyncProps {
 
 export interface ScrollSyncPaneProps {
     attachTo?: HTMLElement | undefined;
+    children?: React.ReactNode;
     group?: string | undefined;
     enabled?: boolean | undefined;
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/okonet/react-scroll-sync/tree/v0.8.0#usage
