### PR TITLE
[react-scrollspy] Add explicit types for children

### DIFF
--- a/types/react-scrollspy/index.d.ts
+++ b/types/react-scrollspy/index.d.ts
@@ -7,6 +7,8 @@
 import * as React from 'react';
 
 export interface ScrollspyProps {
+    children?: React.ReactNode;
+
     // Array of target element IDs
     items: ReadonlyArray<string>;
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/makotot/react-scrollspy/tree/3.3.9#usage

