### PR TITLE
[react-router] Add explicit types for children

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -43,6 +43,7 @@ export {
 
 export interface BrowserRouterProps {
     basename?: string | undefined;
+    children?: React.ReactNode;
     getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined;
     forceRefresh?: boolean | undefined;
     keyLength?: number | undefined;
@@ -51,6 +52,7 @@ export class BrowserRouter extends React.Component<BrowserRouterProps, any> {}
 
 export interface HashRouterProps {
     basename?: string | undefined;
+    children?: React.ReactNode;
     getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined;
     hashType?: 'slash' | 'noslash' | 'hashbang' | undefined;
 }

--- a/types/react-router-native/index.d.ts
+++ b/types/react-router-native/index.d.ts
@@ -47,6 +47,7 @@ export interface LinkProps {
 export class Link extends React.Component<LinkProps> {}
 
 export interface NativeRouterProps {
+  children?: React.ReactNode;
   getUserConfirmation?: Function | undefined;
   keyLength?: number | undefined;
   initialEntries?: string[] | undefined;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -38,6 +38,7 @@ export interface RouterChildContext<Params extends { [K in keyof Params]?: strin
     };
 }
 export interface MemoryRouterProps {
+    children?: React.ReactNode;
     initialEntries?: H.LocationDescriptor[] | undefined;
     initialIndex?: number | undefined;
     getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void) | undefined;
@@ -102,6 +103,7 @@ export class Route<T extends {} = {}, Path extends string = string> extends Reac
 > {}
 
 export interface RouterProps {
+    children?: React.ReactNode;
     history: H.History;
 }
 export class Router extends React.Component<RouterProps, any> {}
@@ -113,6 +115,7 @@ export interface StaticRouterContext extends StaticContext {
 }
 export interface StaticRouterProps {
     basename?: string | undefined;
+    children?: React.ReactNode;
     location?: string | object | undefined;
     context?: StaticRouterContext | undefined;
 }

--- a/types/react-router/ts4.0/index.d.ts
+++ b/types/react-router/ts4.0/index.d.ts
@@ -13,6 +13,7 @@ export interface RouterChildContext<Params extends { [K in keyof Params]?: strin
     };
 }
 export interface MemoryRouterProps {
+    children?: React.ReactNode;
     initialEntries?: H.LocationDescriptor[];
     initialIndex?: number;
     getUserConfirmation?: (message: string, callback: (ok: boolean) => void) => void;
@@ -71,6 +72,7 @@ export interface RouteProps {
 export class Route<T extends RouteProps = RouteProps> extends React.Component<T, any> {}
 
 export interface RouterProps {
+    children?: React.ReactNode;
     history: H.History;
 }
 export class Router extends React.Component<RouterProps, any> {}
@@ -82,6 +84,7 @@ export interface StaticRouterContext extends StaticContext {
 }
 export interface StaticRouterProps {
     basename?: string;
+    children?: React.ReactNode;
     location?: string | object;
     context?: StaticRouterContext;
 }

--- a/types/react-router/v3/lib/Route.d.ts
+++ b/types/react-router/v3/lib/Route.d.ts
@@ -12,6 +12,7 @@ import {
 import { IndexRouteProps } from "react-router/lib/IndexRoute";
 
 export interface RouteProps<Props = any> extends IndexRouteProps<Props> {
+    children?: React.ReactNode;
     path?: RoutePattern | undefined;
 }
 

--- a/types/react-router/v3/lib/Router.d.ts
+++ b/types/react-router/v3/lib/Router.d.ts
@@ -13,6 +13,7 @@ import {
     Search
 } from "history";
 import { PlainRoute } from "react-router";
+import React = require("react");
 
 export interface Params {
     [key: string]: string;
@@ -76,6 +77,7 @@ export interface RouteComponentProps<P, R, ComponentProps = any, Q = any> {
 }
 
 export interface RouterProps extends ClassAttributes<any> {
+    children?: React.ReactNode;
     routes?: RouteConfig | undefined;
     history?: History | undefined;
     createElement?(component: RouteComponent, props: any): any;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://reactrouter.com/web/api/Router
https://reactrouter.com/native/api/NativeRouter
https://reactrouter.com/web/api/HashRouter/children-node
https://reactrouter.com/web/api/BrowserRouter/children-node
https://reactrouter.com/web/api/StaticRouter/children-node
https://reactrouter.com/web/api/MemoryRouter/children-node

