### PR TITLE
[react-router-redux] Add explicit types for ConnectedRouter#children

### DIFF
--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -23,6 +23,7 @@ import * as React from 'react';
 import { match } from 'react-router';
 
 export interface ConnectedRouterProps<State> {
+    children?: React.ReactNode;
     store?: Store<State> | undefined;
     history: History;
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://www.npmjs.com/package/react-router-redux/v/5.0.0-alpha.8#usage
