### PR TITLE
[react-responsive] Use built-in ElementType in favor of custom union

### DIFF
--- a/types/react-responsive/index.d.ts
+++ b/types/react-responsive/index.d.ts
@@ -75,7 +75,7 @@ export interface MediaQueryFeatures extends MediaQueryMatchers {
 export interface MediaQueryAllQueryable extends MediaQueryFeatures, MediaQueryTypes {}
 
 export interface MediaQueryProps extends MediaQueryAllQueryable {
-    component?: string | React.SFC<any> | React.ClassType<any, any, any> | React.ComponentClass<any> | undefined;
+    component?: React.ElementType | undefined;
     query?: string | undefined;
     style?: React.CSSProperties | undefined;
     className?: string | undefined;

--- a/types/react-responsive/react-responsive-tests.tsx
+++ b/types/react-responsive/react-responsive-tests.tsx
@@ -43,7 +43,7 @@ class QueryTests extends React.Component {
     }
 }
 
-const ChildrenPropTest: React.SFC = ({ children }) => <MediaQuery minWidth={992} children={children} />;
+const ChildrenPropTest: React.FC<React.PropsWithChildren<{}>> = ({ children }) => <MediaQuery minWidth={992} children={children} />;
 
 class PropsTests extends React.Component {
     render() {

--- a/types/react-responsive/v1/index.d.ts
+++ b/types/react-responsive/v1/index.d.ts
@@ -55,6 +55,7 @@ declare namespace MediaQuery {
         tty?: boolean | undefined;
         tv?: boolean | undefined;
         embossed?: boolean | undefined;
+        children?: React.ReactNode;
     }
 }
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/contra/react-responsive/tree/v1.1.5#using-properties
