### PR TITLE
[react-resizeable] Add explicit types for children

### DIFF
--- a/types/react-resizable/index.d.ts
+++ b/types/react-resizable/index.d.ts
@@ -34,6 +34,7 @@ export interface ResizeCallbackData {
 }
 
 export interface ResizableProps {
+    children?: React.ReactNode;
     className?: string | undefined;
     width: number;
     height: number;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/react-grid-layout/react-resizable/tree/v1.7.5#props
