### PR TITLE
[react-redux] Add explicit types for Provider#children

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -30,7 +30,8 @@ import {
     ComponentType,
     StatelessComponent,
     Context,
-    NamedExoticComponent
+    NamedExoticComponent,
+    ReactNode
 } from 'react';
 
 import {
@@ -483,6 +484,7 @@ export interface ProviderProps<A extends Action = AnyAction> {
      * Provider. Initial value doesn't matter, as it is overwritten with the internal state of Provider.
      */
     context?: Context<ReactReduxContextValue> | undefined;
+    children?: ReactNode;
 }
 
 /**

--- a/types/react-redux/v6/index.d.ts
+++ b/types/react-redux/v6/index.d.ts
@@ -31,7 +31,8 @@ import {
     Component,
     ComponentClass,
     ComponentType,
-    StatelessComponent
+    StatelessComponent,
+    ReactNode
 } from 'react';
 
 import {
@@ -398,6 +399,7 @@ export interface ProviderProps<A extends Action = AnyAction> {
      * The single Redux store in your application.
      */
     store: Store<any, A>;
+    children?: ReactNode;
 }
 
 /**


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/reduxjs/react-redux/blob/v7.2.5/src/components/Provider.js#L45
https://github.com/reduxjs/react-redux/blob/v6.0.1/src/components/Provider.js#L81

