### PR TITLE
[react-power-tooltip] Add explicit types for children

### DIFF
--- a/types/react-power-tooltip/ToolTip.d.ts
+++ b/types/react-power-tooltip/ToolTip.d.ts
@@ -14,6 +14,7 @@ export type ArrowAlignType = "start" | "center" | "end";
 export type AnimationType = "fade" | "bounce";
 
 export interface TooltipProps {
+    children?: React.ReactNode;
     lineSeparated?: boolean | string | undefined;
     position?: PositionType | undefined;
     hoverBackground?: string | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/justinrhodes1/react-power-tooltip/tree/fb2df8120e0d64ed81c53fcaaef845157f1a9e0c#usage

