### PR TITLE
[react-portal] Children can only be a single element

### DIFF
--- a/types/react-portal/v3/index.d.ts
+++ b/types/react-portal/v3/index.d.ts
@@ -11,6 +11,7 @@ interface CallBackProps extends React.Props<any> {
 }
 
 interface ReactPortalProps {
+    children: React.ReactElement;
     isOpened?: boolean | undefined;
     openByClickOn?: React.ReactElement<CallBackProps> | undefined;
     closeOnEsc?: boolean | undefined;

--- a/types/react-portal/v3/react-portal-tests.tsx
+++ b/types/react-portal/v3/react-portal-tests.tsx
@@ -7,6 +7,9 @@ export default class App extends React.Component {
   render() {
     const button1 = <button>Open portal with pseudo modal</button>;
 
+    // $ExpectError
+    <Portal />;
+
     return (
       <div>
         <Portal
@@ -24,7 +27,6 @@ export default class App extends React.Component {
             <p>This react component is appended to the document body.</p>
           </PseudoModal>
         </Portal>
-        <Portal />
       </div>
     );
   }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/tajo/react-portal/tree/v3.2.0#children--reactelement
https://github.com/tajo/react-portal/blob/v3.2.0/lib/portal.js#L158
