### PR TITLE
[react-portal-tooltip] Add explicit types for children

### DIFF
--- a/types/react-portal-tooltip/lib/Card.d.ts
+++ b/types/react-portal-tooltip/lib/Card.d.ts
@@ -10,6 +10,7 @@ declare namespace Card {
     type Align = null | 'center' | 'right' | 'left';
 
     interface CardProps {
+        children?: React.ReactNode;
         position?: Position | undefined;
         arrow?: Arrow | undefined;
         align?: Align | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/romainberger/react-portal-tooltip/blob/v2.4.7/src/index.js#L355
