### PR TITLE
[react-panelgroup] Add explicit types for children

### DIFF
--- a/types/react-panelgroup/index.d.ts
+++ b/types/react-panelgroup/index.d.ts
@@ -17,6 +17,7 @@ export interface PanelWidth {
 }
 
 export interface PropTypes {
+    children?: React.ReactNode;
     spacing?: number | undefined;
     borderColor?: string | undefined;
     panelColor?: string | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.