### PR TITLE
[react-mdl] Add explicit types for children

### DIFF
--- a/types/react-mdl/index.d.ts
+++ b/types/react-mdl/index.d.ts
@@ -618,5 +618,5 @@ declare namespace __ReactMDL {
     }
     class Tooltip extends __MDLComponent<TooltipProps> { }
 
-    class MDLComponent extends React.Component<{ recursive?: boolean | undefined }> { }
+    class MDLComponent extends React.Component<{ children: React.ReactElement; recursive?: boolean | undefined }> { }
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/tleunen/react-mdl/blob/v1.7.2/src/utils/MDLComponent.js#L14

