### PR TITLE
[react-no-ssr] Add explicit types for children

### DIFF
--- a/types/react-no-ssr/index.d.ts
+++ b/types/react-no-ssr/index.d.ts
@@ -7,5 +7,6 @@
 import * as React from 'react';
 
 export default class NoSSR extends React.Component<{
+    children?: React.ReactNode;
     onSSR?: React.ReactChild | undefined;
 }> {}


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/kadirahq/react-no-ssr/tree/v1.1.0#render-a-component-on-ssr

