### PR TITLE
Adding Brotli Option to koa-static-server

### DIFF
--- a/types/koa-static-server/index.d.ts
+++ b/types/koa-static-server/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-static-server 1.5.2
+// Type definitions for koa-static-server 1.5
 // Project: https://github.com/pkoretic/koa-static-server
 // Definitions by: wulunyi <https://github.com/wulunyi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/koa-static-server/index.d.ts
+++ b/types/koa-static-server/index.d.ts
@@ -51,6 +51,10 @@ declare namespace KoaStaticServer {
      * Try to serve the gzipped version of a file automatically when gzip is supported by a client and if the requested
      */
     gzip?: boolean | undefined;
+    /**
+     * Try to serve the brotli version of a file automatically when brotli is supported by a client and in the requested
+     */
+    brotli?: boolean | undefined;
     index?: string | undefined;
   }
 }

--- a/types/koa-static-server/index.d.ts
+++ b/types/koa-static-server/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-static-server 1.3
+// Type definitions for koa-static-server 1.5.2
 // Project: https://github.com/pkoretic/koa-static-server
 // Definitions by: wulunyi <https://github.com/wulunyi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/koa-static-server/koa-static-server-tests.ts
+++ b/types/koa-static-server/koa-static-server-tests.ts
@@ -3,6 +3,6 @@ import serve = require("koa-static-server");
 
 const app = new Koa();
 
-app.use(serve({rootDir: 'web'}));
+app.use(serve({rootDir: 'web', brotli: true}));
 
 app.listen(80);


### PR DESCRIPTION
koa-static-server type shape is different than the current implementation. The current implementation uses koa-send to support sending files. koa-send receives all the options from koa-static-server. koa-send receives Brotli as an option. 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [X] Provide a URL to documentation or source code that provides context for the suggested changes:
  Package Dependency on [koa-send](https://github.com/pkoretic/koa-static-server/blob/891ade4d6f7773d9eb7d3c25442f4a8e17e309e8/index.js#L103)
 Package package.json dependency [version](https://github.com/pkoretic/koa-static-server/blob/891ade4d6f7773d9eb7d3c25442f4a8e17e309e8/package.json#L21)
[koa-send definitions](https://github.com/pkoretic/koa-static-server/blob/891ade4d6f7773d9eb7d3c25442f4a8e17e309e8/package.json#L21)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

