### PR TITLE
[@types/detox] Adding Android attributes to getAttributes()

### DIFF
--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -925,7 +925,7 @@ declare global {
             /**
              * length: The length of the text element (character count). (Android Only)
              */
-            length: number
+            length: number;
         }
 
         type DataNetwork = 'wifi' | '3g' | '4g' | 'lte' | 'lte-a' | 'lte+';

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -7,6 +7,7 @@
 //                 Max Komarychev <https://github.com/maxkomarychev>
 //                 Dor Ben Baruch <https://github.com/Dor256>
 //                 dkrk <https://github.com/grgr-dkrk>
+//                 Chris Frewin <https://github.com/princefishthrower>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 declare global {
     const device: Detox.Device;
@@ -630,7 +631,7 @@ declare global {
              * jestExpect(multipleMatchedElements.elements.length).toBe(5);
              * jestExpect(multipleMatchedElements.elements[0].identifier).toBe('FirstElement');
              */
-            getAttributes(): Promise<AttributesOfIOS>;
+            getAttributes(): Promise<AttributesOfIOS | AttributesOfAndroid>;
         }
 
         type Direction = 'left' | 'right' | 'up' | 'down';
@@ -801,7 +802,9 @@ declare global {
             left: number;
             bottom: number;
         }
-        interface AttributesOfIOS {
+
+        // Shared iOS and Android Attributes
+        interface SharedAttributes {
             /**
              * the text value of the element
              */
@@ -811,78 +814,118 @@ declare global {
              */
             label: string;
             /**
-             * the value of the element (matches `accessibilityValue`)
-             */
-            value: string;
-            /**
              * the placeholder text value of the element
              */
             placeholder: string;
-            /**
-             * the identifier of the element (matches `accessibilityIdentifier`)
-             */
-            identifier: string;
             /**
              * whether or not the element is enabled for user interaction
              */
             enabled: boolean;
             /**
-             * the activation point of the element, in element coordinate space
+             * the identifier of the element (matches `accessibilityIdentifier`)
              */
-            activationPoint: Point;
-            /**
-             * the activation point of the element, in normalized percentage ([0.0, 1.0])
-             */
-            normalizedActivationPoint: Point;
-            /**
-             * whether the element is hittable at the activation point
-             */
-            hittable: boolean;
+            identifier: string;
             /**
              * whether the element is visible at the activation point
              */
             visible: boolean;
             /**
-             * the frame of the element, in screen coordinate space
+             * the value of the element (matches `accessibilityValue`)
+             */
+            value: string;
+        }
+
+        // iOS Specific Attributes
+        interface AttributesOfIOS extends SharedAttributes {
+            /**
+             * the activation point of the element, in element coordinate space (iOS Only)
+             */
+            activationPoint: Point;
+            /**
+             * the activation point of the element, in normalized percentage ([0.0, 1.0]) (iOS Only)
+             */
+            normalizedActivationPoint: Point;
+            /**
+             * whether the element is hittable at the activation point (iOS Only)
+             */
+            hittable: boolean;
+            /**
+             * the frame of the element, in screen coordinate space (iOS Only)
              */
             frame: AttributeIOSFrame;
             /**
-             * the frame of the element, in container coordinate space
+             * the frame of the element, in container coordinate space (iOS Only)
              */
             elementFrame: AttributeIOSFrame;
             /**
-             * the bounds of the element, in element coordinate space
+             * the bounds of the element, in element coordinate space (iOS Only)
              */
             elementBounds: AttributeIOSFrame;
             /**
-             * the safe area insets of the element, in element coordinate space
+             * the safe area insets of the element, in element coordinate space (iOS Only)
              */
             safeAreaInsets: AttributeIOSInsets;
             /**
-             * the safe area bounds of the element, in element coordinate space
+             * the safe area bounds of the element, in element coordinate space (iOS Only)
              */
             elementSafeBounds: AttributeIOSFrame;
             /**
-             * the date of the element (in case the element is a date picker)
+             * the date of the element (in case the element is a date picker) (iOS Only)
              */
             date: string;
             /**
-             * the normalized slider position (in case the element is a slider)
+             * the normalized slider position (in case the element is a slider) (iOS Only)
              */
             normalizedSliderPosition: number;
             /**
-             * the content offset (in case the element is a scroll view)
+             * the content offset (in case the element is a scroll view) (iOS Only)
              */
             contentOffset: number;
             /**
-             * the content inset (in case the element is a scroll view)
+             * the content inset (in case the element is a scroll view) (iOS Only)
              */
             contentInset: number;
             /**
-             * the adjusted content inset (in case the element is a scroll view)
+             * the adjusted content inset (in case the element is a scroll view) (iOS Only)
              */
             adjustedContentInset: number;
             layer: string;
+        }
+
+        // Android Specific Attributes
+        interface AttributesOfAndroid extends SharedAttributes {
+            /**
+             * The OS visibility type associated with the element: visible, invisible or gone. (Android Only)
+             */
+            visibility: 'visible' | 'invisible' | 'gone';
+            /**
+             * width: Width of the element, in pixels. (Android Only)
+             */
+            width: number;
+            /**
+             * height: Height of the element, in pixels. (Android Only)
+             */
+            height: number;
+            /**
+             * elevation: Elevation of the element. (Android Only)
+             */
+            elevation: number;
+            /**
+             * alpha: Alpha value for the element. (Android Only)
+             */
+            alpha: number;
+            /**
+             * focused: Whether the element is the one currently in focus. (Android Only)
+             */
+            focused: number;
+            /**
+             * textSize: The text size for the text element. (Android Only)
+             */
+            textSize: number;
+            /**
+             * length: The length of the text element (character count). (Android Only)
+             */
+            length: number
         }
 
         type DataNetwork = 'wifi' | '3g' | '4g' | 'lte' | 'lte-a' | 'lte+';

--- a/types/detox/test/detox-global-tests.ts
+++ b/types/detox/test/detox-global-tests.ts
@@ -45,7 +45,6 @@ describe('Test', () => {
         await element(by.type('UIPickerView')).setColumnToValue(1, '6');
         await element(by.id('datePicker')).setDatePickerDate('2019-02-06T05:10:00-08:00', 'ISO8601');
         await element(by.id('slider')).adjustSliderToPosition(0.75);
-        await element(by.id('element')).getAttributes();
         await waitFor(element(by.id('element')))
             .toBeVisible()
             .withTimeout(2000);
@@ -66,6 +65,33 @@ describe('Test', () => {
         } finally {
             detox.trace.endSection('Turn off notifications');
         }
+
+        // type as AttributesOfAndroid
+        const androidAttributes = await element(by.id('element')).getAttributes() as Detox.AttributesOfAndroid;
+
+        // Shared properties should be available
+        androidAttributes.text;
+        androidAttributes.label;
+
+        // As well as Android properties
+        androidAttributes.width;
+        androidAttributes.height;
+
+        // $ExpectError
+        androidAttributes.activationPoint;
+
+        // type as AttributesOfIOS
+        const iOSAttributes = await element(by.id('element')).getAttributes() as Detox.AttributesOfIOS;
+
+        // Shared properties should be available
+        iOSAttributes.text;
+        iOSAttributes.label;
+
+        // As well as iOS properties
+        iOSAttributes.activationPoint;
+
+        // $ExpectError
+        iOSAttributes.width;
 
         /**
          * Expectations


### PR DESCRIPTION
As the title states, this pull request brings in the Android types for getAttributes. I saw the iOS ones were there but not the Android ones. As far as I can tell, I've followed the [detox docs for `getAttributes`](https://github.com/wix/Detox/blob/master/docs/APIRef.ActionsOnElement.md#getAttributes) exactly.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wix/Detox/blob/master/docs/APIRef.ActionsOnElement.md#getAttributes
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.