### PR TITLE
Lodash debounce generic function fix

### DIFF
--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -391,7 +391,7 @@ declare module "../index" {
          * was never invoked.
          */
         flush(): ReturnType<T> | undefined;
-    }
+    };
     interface LoDashStatic {
         /**
          * Creates a debounced function that delays invoking func until after wait milliseconds have elapsed since

--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -368,18 +368,16 @@ declare module "../index" {
          */
         trailing?: boolean | undefined;
     }
-    interface DebouncedFunc<T extends (...args: any[]) => any> {
-        /**
-         * Call the original function, but applying the debounce rules.
-         *
-         * If the debounced function can be run immediately, this calls it and returns its return
-         * value.
-         *
-         * Otherwise, it returns the return value of the last invocation, or undefined if the debounced
-         * function was not invoked yet.
-         */
-        (...args: Parameters<T>): ReturnType<T> | undefined;
-
+    /**
+     * Call the original function, but applying the debounce rules.
+     *
+     * If the debounced function can be run immediately, this calls it and returns its return
+     * value.
+     *
+     * Otherwise, it returns the return value of the last invocation, or undefined if the debounced
+     * function was not invoked yet.
+     */
+    type DebouncedFunc<T extends (...args: any[]) => any> = (T | (() => undefined)) & {
         /**
          * Throw away any pending invocation of the debounced function.
          */

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3408,6 +3408,14 @@ fp.now(); // $ExpectType number
     _.chain(func).debounce(42, options); // $ExpectType FunctionChain<DebouncedFunc<(n: number, s: string) => boolean>>
     fp.debounce(42, func); // $ExpectType DebouncedFunc<(n: number, s: string) => boolean>
     fp.debounce(42)(func); // $ExpectType DebouncedFunc<(n: number, s: string) => boolean>
+
+    const generic_func = <T>(v: T): T => v;
+    const debounced_generic_func = _.debounce(generic_func, 0, { leading: true }); // $ExpectType DebouncedFunc<(<T>(v: T) => T)>
+    debounced_generic_func('string'); // $ExpectType "string" | undefined
+    debounced_generic_func(42); // $ExpectType 42 | undefined
+    debounced_generic_func({ a: 1, b: 2}); // $ExpectType { a: number; b: number; } | undefined
+    debounced_generic_func('string' as string); // $ExpectType string | undefined
+    debounced_generic_func(42 as number); // $ExpectType number | undefined
 }
 
 // _.defer


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes [https://lodash.com/docs/#debounce](https://lodash.com/docs/#debounce)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Hello, I found a bug in typescript declarations in lodash package. When passing generic function to `lodash.debounce` generic type is forced assigned to unknown. I think I found a solution, check out this example:  [https://tsplay.dev/wRJyLw](https://tsplay.dev/wRJyLw)
