### PR TITLE
[react-native-table-component] Add explicit types for children

### DIFF
--- a/types/react-native-table-component/index.d.ts
+++ b/types/react-native-table-component/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: David Cole <https://github.com/davidcole1340>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Component, ReactChildren } from 'react';
+import { Component, ReactChildren, ReactNode } from 'react';
 import { TextStyle, ViewStyle } from 'react-native';
 
 // cell.js
@@ -70,6 +70,7 @@ export class Rows extends Component<RowsProps> {}
 // table.js
 
 export interface TableProps {
+  children?: ReactNode;
   style?: ViewStyle | undefined;
   borderStyle?: ViewStyle | undefined;
 }
@@ -79,6 +80,7 @@ export class Table extends Component<TableProps> {
 }
 
 export interface TableWrapperProps {
+  children?: ReactNode;
   style?: ViewStyle | undefined;
   borderStyle?: ViewStyle | undefined;
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/Gil2015/react-native-table-component/tree/7f64bb9f3a280158fb8d753e9370cab48d7591ff#examples

