### PR TITLE
[react-native-tab-navigator] Add explicit types for children

### DIFF
--- a/types/react-native-tab-navigator/index.d.ts
+++ b/types/react-native-tab-navigator/index.d.ts
@@ -8,6 +8,8 @@ import * as React from 'react';
 import { ViewStyle, TextStyle } from 'react-native';
 
 export interface TabNavigatorProps {
+    children?: React.ReactNode;
+
     /**
      * Define for rendered scene
      */
@@ -41,6 +43,8 @@ interface TabNavigatorItemProps {
      * Text for Item badge
      */
     badgeText?: string | number | undefined;
+
+    children?: React.ReactNode;
 
     /**
      * Return whether the item is selected


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/ptomasroos/react-native-tab-navigator/tree/5004fa9f78ef5a59c83d43a8eb6205563e28c795#usage
