### PR TITLE
[react-native-svg-charts] Add explicit types for children

### DIFF
--- a/types/react-native-svg-charts/index.d.ts
+++ b/types/react-native-svg-charts/index.d.ts
@@ -35,6 +35,7 @@ export type OrderFunction = (series: Series<any, any>) => number[];
 
 export interface ChartProps<T> {
     data: T[];
+    children?: React.ReactNode;
     style?: StyleProp<ViewStyle> | undefined;
     animate?: boolean | undefined;
     animationDuration?: number | undefined;

--- a/types/react-native-svg-charts/react-native-svg-charts-tests.tsx
+++ b/types/react-native-svg-charts/react-native-svg-charts-tests.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 import { View } from 'react-native';
-import { Defs, LinearGradient, Stop } from 'react-native-svg';
+import { LinearGradientProps, Stop } from 'react-native-svg';
 import { StackedAreaChart, StackedBarChart, XAxis, Grid, Decorators } from 'react-native-svg-charts';
 import { curveNatural } from 'd3-shape';
 import { scaleTime } from 'd3-scale';
+
+// Inlined https://github.com/react-native-svg/react-native-svg/pull/1652
+declare const Defs: React.ComponentClass<{ children?: React.ReactNode }>;
+declare const LinearGradient: React.ComponentClass<React.PropsWithChildren<LinearGradientProps>>;
 
 interface Data {
     time: number;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/JesperLekland/react-native-svg-charts/tree/v.5.0.0#common-props
