### PR TITLE
[react-native-pull-to-refresh] Add explicit types for children

### DIFF
--- a/types/react-native-pull-to-refresh/index.d.ts
+++ b/types/react-native-pull-to-refresh/index.d.ts
@@ -6,6 +6,7 @@
 import * as React from 'react';
 
 export interface PTRViewProps {
+    children?: React.ReactNode;
     onRefresh?: (() => any) | undefined;
     delay?: number | undefined; // default O
     style?: object | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/moschan/react-native-pull-to-refresh/tree/v2.1.3#getting-started
