### PR TITLE
[react-native-popup-dialog] Add explicit types for children

### DIFF
--- a/types/react-native-popup-dialog/index.d.ts
+++ b/types/react-native-popup-dialog/index.d.ts
@@ -14,11 +14,13 @@ export type OverlayPointerEventTypes = 'auto' | 'none';
 export type SlideFromTypes = 'top' | 'bottom' | 'left' | 'right';
 
 export interface DialogContentProps {
+    children?: React.ReactNode;
     style?: StyleProp<ViewStyle> | undefined;
 }
 
 export interface DialogFooterProps {
     bordered?: boolean | undefined;
+    children?: React.ReactNode;
     style?: StyleProp<ViewStyle> | undefined;
 }
 
@@ -53,6 +55,7 @@ export interface OverlayProps {
 }
 
 export interface DialogProps {
+    children?: React.ReactNode;
     dialogTitle?: any;
     width?: number | undefined;
     height?: number | undefined;


### PR DESCRIPTION

We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/jacklam718/react-native-modals/blob/v0.16.6/README.md#basic-usage
