### PR TITLE
[react-native-modals] Add explicit types for children

### DIFF
--- a/types/react-native-modals/index.d.ts
+++ b/types/react-native-modals/index.d.ts
@@ -25,6 +25,7 @@ export interface DragEvent {
 }
 
 export interface ModalContentProps {
+    children?: React.ReactNode;
     style?: StyleProp<ViewStyle> | undefined;
 }
 
@@ -40,6 +41,7 @@ export interface BackdropProps {
 
 export interface ModalFooterProps {
     bordered?: boolean | undefined;
+    children?: React.ReactNode;
     style?: StyleProp<ViewStyle> | undefined;
 }
 
@@ -63,6 +65,7 @@ export interface ModalTitleProps {
 }
 
 export interface ModalProps {
+    children?: React.ReactNode;
     visible: boolean;
     width?: number | undefined;
     height?: number | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/jacklam718/react-native-modals/tree/v0.19.10#usage---modal-action
