### PR TITLE
[react-native-calendars] Add explicit types for children

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -623,6 +623,7 @@ export type UpdateSource =
     | 'propUpdate';
 
 export interface CalendarProviderProps {
+    children?: React.ReactNode;
     /**
      * Initial date in 'yyyy-MM-dd' format. Default = Date()
      */


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/wix/react-native-calendars/blob/1.1266.0/src/expandableCalendar/Context/Provider.tsx#L169

