### PR TITLE
[react-native-drawer] Add explicit types for children

### DIFF
--- a/types/react-native-drawer/index.d.ts
+++ b/types/react-native-drawer/index.d.ts
@@ -54,6 +54,8 @@ export type TweenFunctions = 'linear' |
 export interface DrawerProperties {
     // Important
 
+    children?: React.ReactNode;
+
     /**
      * Menu component
      */


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/root-two/react-native-drawer/blob/v2.5.1/index.js#L44
