### PR TITLE
[react-native-flip-card] Add explicit types for children

### DIFF
--- a/types/react-native-flip-card/index.d.ts
+++ b/types/react-native-flip-card/index.d.ts
@@ -15,6 +15,7 @@ import {
 
 // FlipCard
 export interface FlipCardProps {
+  children?: ReactNode[];
   style?: StyleProp<ViewStyle> | undefined;
   flip?: boolean | undefined;
   friction?: number | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/moschan/react-native-flip-card/blob/v3.4.1/lib/FlipCard.js#L210-L213

