### PR TITLE
[react-native-material-menu] Add explicit types for children

### DIFF
--- a/types/react-native-material-menu/index.d.ts
+++ b/types/react-native-material-menu/index.d.ts
@@ -8,7 +8,7 @@ import { StyleProp, TextStyle, TextProps, ViewStyle } from 'react-native';
 
 export interface MenuProps {
     button?: ReactElement | undefined;
-    children?: React.ReactNode;
+    children?: ReactNode;
     testID?: string | undefined;
     style?: StyleProp<ViewStyle> | undefined;
     onHidden?: (() => void) | undefined;

--- a/types/react-native-material-menu/index.d.ts
+++ b/types/react-native-material-menu/index.d.ts
@@ -3,17 +3,19 @@
 // Definitions by: hyun <https://github.com/KoreanThinker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ComponentClass, ReactElement, Component } from 'react';
+import { ComponentClass, ReactElement, Component, ReactNode } from 'react';
 import { StyleProp, TextStyle, TextProps, ViewStyle } from 'react-native';
 
 export interface MenuProps {
     button?: ReactElement | undefined;
+    children?: React.ReactNode;
     testID?: string | undefined;
     style?: StyleProp<ViewStyle> | undefined;
     onHidden?: (() => void) | undefined;
     animationDuration?: number | undefined;
 }
 export interface MenuItemProps {
+    children?: ReactNode;
     disabled?: boolean | undefined;
     testID?: string | undefined;
     disabledTextColor?: string | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/mxck/react-native-material-menu/blob/v1.0.0/src/Menu.js#L194-L226
https://github.com/mxck/react-native-material-menu/blob/v1.0.0/src/MenuItem.js#L20-L51

