### PR TITLE
[react-native-modalbox] Add explicit types for children

### DIFF
--- a/types/react-native-modalbox/index.d.ts
+++ b/types/react-native-modalbox/index.d.ts
@@ -8,6 +8,8 @@ import * as React from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
 
 export interface ModalProps {
+    children?: React.ReactNode;
+
     /**
      * Checks if the modal is open
      *


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/maxs15/react-native-modalbox/blob/v1.4.2/index.js#L428
