### PR TITLE
[react-native] Add explicit types for children

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1001,6 +1001,8 @@ export interface TextProps extends TextPropsIOS, TextPropsAndroid, Accessibility
      */
     allowFontScaling?: boolean | undefined;
 
+    children?: React.ReactNode | undefined;
+
     /**
      * This can be one of the following values:
      *
@@ -2475,6 +2477,7 @@ export interface ViewProps
         GestureResponderHandlers,
         Touchable,
         AccessibilityProps {
+    children?: React.ReactNode | undefined;
     /**
      * This defines how far a touch event can start away from the view.
      * Typical interface guidelines recommend touch targets that are at least
@@ -2747,6 +2750,8 @@ export class InputAccessoryView extends React.Component<InputAccessoryViewProps>
 
 export interface InputAccessoryViewProps {
     backgroundColor?: ColorValue | undefined;
+
+    children?: React.ReactNode;
 
     /**
      * An ID which is used to associate this InputAccessoryView to specified TextInput(s).
@@ -5196,6 +5201,8 @@ export interface TouchableWithoutFeedbackProps
     extends TouchableWithoutFeedbackPropsIOS,
         TouchableWithoutFeedbackPropsAndroid,
         AccessibilityProps {
+    children?: React.ReactNode;
+
     /**
      * Delay in ms, from onPressIn, before onLongPress is called.
      */

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -43,6 +43,7 @@
 //                 Arafat Zahan <https://github.com/kuasha420>
 //                 Pedro Hernández <https://github.com/phvillegas>
 //                 Brett Lindsay <https://github.com/bdlindsay>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1002,7 +1002,7 @@ export interface TextProps extends TextPropsIOS, TextPropsAndroid, Accessibility
      */
     allowFontScaling?: boolean | undefined;
 
-    children?: React.ReactNode | undefined;
+    children?: React.ReactNode;
 
     /**
      * This can be one of the following values:
@@ -2478,7 +2478,7 @@ export interface ViewProps
         GestureResponderHandlers,
         Touchable,
         AccessibilityProps {
-    children?: React.ReactNode | undefined;
+    children?: React.ReactNode;
     /**
      * This defines how far a touch event can start away from the view.
      * Typical interface guidelines recommend touch targets that are at least

--- a/types/react-native/v0.63/index.d.ts
+++ b/types/react-native/v0.63/index.d.ts
@@ -983,6 +983,8 @@ export interface TextProps extends TextPropsIOS, TextPropsAndroid, Accessibility
      */
     allowFontScaling?: boolean;
 
+    children?: React.ReactNode;
+
     /**
      * This can be one of the following values:
      *
@@ -2442,6 +2444,7 @@ export interface ViewProps
         GestureResponderHandlers,
         Touchable,
         AccessibilityProps {
+    children?: React.ReactNode | undefined;
     /**
      * This defines how far a touch event can start away from the view.
      * Typical interface guidelines recommend touch targets that are at least
@@ -2714,6 +2717,8 @@ export class InputAccessoryView extends React.Component<InputAccessoryViewProps>
 
 export interface InputAccessoryViewProps {
     backgroundColor?: ColorValue;
+
+    children?: React.ReactNode;
 
     /**
      * An ID which is used to associate this InputAccessoryView to specified TextInput(s).
@@ -5157,6 +5162,8 @@ export interface TouchableWithoutFeedbackProps
     extends TouchableWithoutFeedbackPropsIOS,
         TouchableWithoutFeedbackPropsAndroid,
         AccessibilityProps {
+    children?: React.ReactNode;
+
     /**
      * Delay in ms, from onPressIn, before onLongPress is called.
      */
@@ -9330,6 +9337,7 @@ export interface ARTGroupProps extends ARTNodeMixin {
 }
 
 export interface ARTClippingRectangleProps extends ARTNodeMixin {
+    children?: React.ReactNode;
     width?: number;
     height?: number;
 }
@@ -9355,6 +9363,7 @@ export interface ARTTextProps extends ARTRenderableMixin {
 }
 
 export interface ARTSurfaceProps {
+    children?: React.ReactNode;
     style?: StyleProp<ViewStyle>;
     width: number;
     height: number;

--- a/types/react-native/v0.63/index.d.ts
+++ b/types/react-native/v0.63/index.d.ts
@@ -2444,7 +2444,7 @@ export interface ViewProps
         GestureResponderHandlers,
         Touchable,
         AccessibilityProps {
-    children?: React.ReactNode | undefined;
+    children?: React.ReactNode;
     /**
      * This defines how far a touch event can start away from the view.
      * Typical interface guidelines recommend touch targets that are at least

--- a/types/react-native/v0.64/index.d.ts
+++ b/types/react-native/v0.64/index.d.ts
@@ -991,6 +991,8 @@ export interface TextProps extends TextPropsIOS, TextPropsAndroid, Accessibility
      */
     allowFontScaling?: boolean | undefined;
 
+    children?: React.ReactNode;
+
     /**
      * This can be one of the following values:
      *
@@ -2460,6 +2462,8 @@ export interface ViewProps
         GestureResponderHandlers,
         Touchable,
         AccessibilityProps {
+    children?: React.ReactNode;
+
     /**
      * This defines how far a touch event can start away from the view.
      * Typical interface guidelines recommend touch targets that are at least
@@ -2732,6 +2736,8 @@ export class InputAccessoryView extends React.Component<InputAccessoryViewProps>
 
 export interface InputAccessoryViewProps {
     backgroundColor?: ColorValue | undefined;
+
+    children?: React.ReactNode;
 
     /**
      * An ID which is used to associate this InputAccessoryView to specified TextInput(s).
@@ -5173,6 +5179,8 @@ export interface TouchableWithoutFeedbackProps
     extends TouchableWithoutFeedbackPropsIOS,
         TouchableWithoutFeedbackPropsAndroid,
         AccessibilityProps {
+    children?: React.ReactNode;
+
     /**
      * Delay in ms, from onPressIn, before onLongPress is called.
      */


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/facebook/react-native/blob/v0.64.2/Libraries/Text/TextProps.js#L72
