### PR TITLE
[react-motion-slider] Add explicit types for children

### DIFF
--- a/types/react-motion-slider/index.d.ts
+++ b/types/react-motion-slider/index.d.ts
@@ -9,6 +9,7 @@ declare module "react-motion-slider" {
     import { OpaqueConfig } from "react-motion";
 
     export interface SliderProps {
+        children?: React.ReactNode;
         /**
          * Move to a slide by its key.
          */


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/souporserious/react-view-pager/tree/0.4.1

