### PR TITLE
[react-motion] Add types for StaggeredMotion#children render prop

### DIFF
--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -134,6 +134,7 @@ export class TransitionMotion extends Component<TransitionProps> { }
 
 
 interface StaggeredMotionProps {
+    children: (interpolatedStyles: any) => React.ReactElement;
     /**
      * Default styles
      */

--- a/types/react-motion/react-motion-tests.tsx
+++ b/types/react-motion/react-motion-tests.tsx
@@ -69,6 +69,7 @@ class StaggeredTest extends React.Component {
             <StaggeredMotion defaultStyles={[{ h: 0 }, { h: 0 }, { h: 0 }]}
                 styles={this.getStyles.bind(this)}
                 >
+                    {() => <div />}
             </StaggeredMotion>
         )
     }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/chenglou/react-motion/blob/v0.5.2/src/StaggeredMotion.js#L40
