### PR TITLE
[react-motion-ui-pack] Add explicit types for children

### DIFF
--- a/types/react-motion-ui-pack/index.d.ts
+++ b/types/react-motion-ui-pack/index.d.ts
@@ -9,6 +9,7 @@ import * as motion from 'react-motion';
 
 declare namespace Transition {
     interface TransitionProps {
+        children?: React.ReactNode;
         component?: string | boolean | React.ReactElement | undefined;
         runOnMount?: boolean | undefined;
         appear?: motion.Style | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/souporserious/react-motion-ui-pack/tree/0.10.3#example

