### PR TITLE
[react-modal] Add explicit types for children

### DIFF
--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -52,6 +52,8 @@ declare namespace ReactModal {
     }
 
     interface Props {
+        children?: React.ReactNode;
+
         /* Boolean describing if the modal should be shown or not. Defaults to false. */
         isOpen: boolean;
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/reactjs/react-modal/blob/v3.12.1/src/components/ModalPortal.js#L59

