### PR TITLE
[react-masonry-layout] Add explicit types for children

### DIFF
--- a/types/react-masonry-layout/index.d.ts
+++ b/types/react-masonry-layout/index.d.ts
@@ -24,6 +24,8 @@ declare namespace ReactMasonryLayoutExport {
     }
 
     interface MasonryLayoutProps {
+        children: React.ReactElement[];
+
         id: string;
 
         /**


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/scarletsky/react-masonry-layout/blob/master/src/components/MasonryLayout.jsx#L15

