### PR TITLE
[react-leaflet-sidebarv2] Add explicit types for children

### DIFF
--- a/types/react-leaflet-sidebarv2/index.d.ts
+++ b/types/react-leaflet-sidebarv2/index.d.ts
@@ -11,6 +11,7 @@ type Anchor = 'top' | 'bottom';
 type Position = 'left' | 'right';
 
 interface TabProps {
+  children?: React.ReactNode;
   id: string;
   header: string;
   icon: Icon;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/condense/react-leaflet-sidebarv2/blob/fff64ab00d04eeb9a07177a32e83eda5b0e9b15d/src/Sidebar.js#L38
