### PR TITLE
[react-jsonschema-form] Add explicit types for children

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -26,6 +26,7 @@ declare module 'react-jsonschema-form' {
     };
 
     export interface FormProps<T> {
+        children?: React.ReactNode;
         /** Form schema */
         schema: JSONSchema6;
         /** If true, disabled prop is passed down to each field on the form */


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/rjsf-team/react-jsonschema-form/blob/1.x/src/components/Form.js#L309-L366

