### PR TITLE
[react-instantsearch-core] Export StateResultsProvided

### DIFF
--- a/types/react-instantsearch-native/index.d.ts
+++ b/types/react-instantsearch-native/index.d.ts
@@ -41,6 +41,6 @@ export { connectScrollTo } from 'react-instantsearch-core';
 export { connectSearchBox } from 'react-instantsearch-core';
 export { connectRelevantSort } from 'react-instantsearch-core';
 export { connectSortBy } from 'react-instantsearch-core';
-export { connectStateResults } from 'react-instantsearch-core';
+export { connectStateResults, StateResultsProvided } from 'react-instantsearch-core';
 export { connectStats } from 'react-instantsearch-core';
 export { connectToggleRefinement } from 'react-instantsearch-core';

--- a/types/react-instantsearch-native/react-instantsearch-native-tests.tsx
+++ b/types/react-instantsearch-native/react-instantsearch-native-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { SearchBox, Hits } from "react-instantsearch-dom";
-import { InstantSearch, Index, connectStateResults } from 'react-instantsearch-native';
+import { InstantSearch, Index, connectStateResults, StateResultsProvided } from 'react-instantsearch-native';
 import { values } from 'lodash';
 
 // https://community.algolia.com/react-instantsearch/guide/Conditional_display.html
@@ -41,7 +41,7 @@ const App2 = () => (
 );
 
 const IndexResults = connectStateResults(
-  ({ searchState, searchResults, children }) =>
+  ({ searchState, searchResults, children }: React.PropsWithChildren<StateResultsProvided>) =>
     searchResults && searchResults.nbHits !== 0 ? (
       children as React.ReactElement
     ) : (
@@ -52,7 +52,7 @@ const IndexResults = connectStateResults(
     )
 );
 
-const AllResults = connectStateResults(({ allSearchResults, children }) => {
+const AllResults = connectStateResults(({ allSearchResults, children }: React.PropsWithChildren<StateResultsProvided>) => {
   const hasResults =
     allSearchResults &&
       values(allSearchResults).some(results => results.nbHits > 0);

--- a/types/react-instantsearch/react-instantsearch-tests.tsx
+++ b/types/react-instantsearch/react-instantsearch-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { connectMenu, connectRefinementList, connectStateResults, SearchState } from "react-instantsearch/connectors";
+import { connectMenu, connectRefinementList, connectStateResults, SearchState, StateResultsProvided } from "react-instantsearch/connectors";
 import { InstantSearch, SearchBox, Index, Hits, Highlight, Menu } from "react-instantsearch/dom";
 import { values } from 'lodash';
 
@@ -296,7 +296,7 @@ import { values } from 'lodash';
   );
 
   const IndexResults = connectStateResults(
-    ({ searchState, searchResults, children }) =>
+    ({ searchState, searchResults, children }: React.PropsWithChildren<StateResultsProvided>) =>
       searchResults && searchResults.nbHits !== 0 ? (
         children as React.ReactElement
       ) : (
@@ -307,7 +307,7 @@ import { values } from 'lodash';
       )
   );
 
-  const AllResults = connectStateResults(({ allSearchResults, children }) => {
+  const AllResults = connectStateResults(({ allSearchResults, children }: React.PropsWithChildren<StateResultsProvided>) => {
     const hasResults =
       allSearchResults &&
         values(allSearchResults).some(results => results.nbHits > 0);


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.