### PR TITLE
[react-instantsearch-core] Add explicit types for children

### DIFF
--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -32,6 +32,7 @@ export interface InstantSearchProps {
 export class InstantSearch extends React.Component<InstantSearchProps> {}
 
 export interface IndexProps {
+  children?: React.ReactNode;
   indexName: string;
   indexId?: string | undefined;
 }

--- a/types/react-instantsearch-core/index.d.ts
+++ b/types/react-instantsearch-core/index.d.ts
@@ -12,6 +12,7 @@ import { SearchParameters } from 'algoliasearch-helper';
 
 // Core
 export interface InstantSearchProps {
+  children?: React.ReactNode;
   searchClient: any;
   indexName: string;
   createURL?: ((...args: any[]) => any) | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/algolia/react-instantsearch/blob/v6.11.0/packages/react-instantsearch-core/src/widgets/Index.tsx#L121
https://github.com/algolia/algolia/react-instantsearch@v6.11.0/packages/react-instantsearch-core/src/widgets/InstantSearch.tsx#L304