### PR TITLE
[react-imgpro] ProcessImage takes no children

### DIFF
--- a/types/react-imgpro/react-imgpro-tests.tsx
+++ b/types/react-imgpro/react-imgpro-tests.tsx
@@ -15,11 +15,7 @@ class Test extends React.Component<any> {
                 storage={true}
                 scale={false}
                 onProcessFinish={() => console.log("onProcessFinish")}
-            >
-                <div className="one"/>
-                <div className="two"/>
-                <div className="three"/>
-            </ProcessImage>
+            />
         );
     }
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/nitin42/react-imgpro/blob/1.3.11/src/components/ProcessImage.js#L150
