### PR TITLE
[react-image-magnifiers] Add explicit types for children

### DIFF
--- a/types/react-image-magnifiers/index.d.ts
+++ b/types/react-image-magnifiers/index.d.ts
@@ -105,6 +105,7 @@ export interface SideBySideMagnifierProps extends CommonProps {
 export const SideBySideMagnifier: React.ComponentType<SideBySideMagnifierProps>;
 
 export interface MagnifierContainerProps {
+    children?: React.ReactNode;
     style?: string | undefined;
     className?: string | undefined;
     autoInPlace?: boolean | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/AdamRisberg/react-image-magnifiers/blob/1.3.2/src/MagnifierContainer.js#L190

