### PR TITLE
[react-helmet-visor] Add explicit types for children

### DIFF
--- a/types/react-helmet-with-visor/index.d.ts
+++ b/types/react-helmet-with-visor/index.d.ts
@@ -32,6 +32,7 @@ export interface HelmetProps {
     async?: boolean | undefined;
     base?: any;
     bodyAttributes?: BodyProps | undefined;
+    children?: React.ReactNode;
     defaultTitle?: string | undefined;
     defer?: boolean | undefined;
     encodeSpecialCharacters?: boolean | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/kokushkin/react-helmet-with-visor/blob/release/5.4.0/src/Helmet.js#L39-L42

