### PR TITLE
[react-highlight] Add Explicit types for children

### DIFF
--- a/types/react-highlight/index.d.ts
+++ b/types/react-highlight/index.d.ts
@@ -10,6 +10,7 @@ import * as React from 'react';
  * Props for a Highlight component.
  */
 export interface HighlightProps {
+    children?: React.ReactNode;
     /**
      * Language name to use as a class to signal type to highlight.js.
      */


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/akiran/react-highlight#syntax-highlighting-of-single-code-snippet
