### PR TITLE
[react-helmet] Add explicit types for children

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -38,6 +38,7 @@ export interface HelmetProps {
     async?: boolean | undefined;
     base?: any;
     bodyAttributes?: BodyProps | undefined;
+    children?: React.ReactNode;
     defaultTitle?: string | undefined;
     defer?: boolean | undefined;
     encodeSpecialCharacters?: boolean | undefined;

--- a/types/react-helmet/v5/index.d.ts
+++ b/types/react-helmet/v5/index.d.ts
@@ -37,6 +37,7 @@ export interface HelmetProps {
     async?: boolean | undefined;
     base?: any;
     bodyAttributes?: BodyProps | undefined;
+    children?: React.ReactNode;
     defaultTitle?: string | undefined;
     defer?: boolean | undefined;
     encodeSpecialCharacters?: boolean | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/nfl/react-helmet/blob/5.2.0/src/Helmet.js#L36-L39
https://github.com/nfl/react-helmet/blob/6.1.0/src/Helmet.js#L36-L39

