### PR TITLE
[react-hammerjs] Add explicit types for children 

### DIFF
--- a/types/react-hammerjs/index.d.ts
+++ b/types/react-hammerjs/index.d.ts
@@ -16,6 +16,7 @@ type HammerOptionsWithRecognizers = Omit<HammerOptions, "recognizers"> & {
 
 declare namespace ReactHammer {
     interface ReactHammerProps {
+        children: React.ReactElement;
         direction?:
             | "DIRECTION_NONE"
             | "DIRECTION_LEFT"

--- a/types/react-hammerjs/v0/index.d.ts
+++ b/types/react-hammerjs/v0/index.d.ts
@@ -15,6 +15,7 @@ type HammerOptionsWithRecognizers = Omit<HammerOptions, 'recognizers'> & {
 
 declare namespace ReactHammer {
     interface ReactHammerProps {
+        children: React.ReactElement;
         direction?: number | undefined;
         options?: HammerOptionsWithRecognizers | undefined;
         recognizeWith?: { [gesture: string]: Recognizer | string } | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/JedWatson/react-hammerjs/blob/v0.5.0/src/Hammer.js#L131