### PR TITLE
[react-grid-layout] Add explicit types for children

### DIFF
--- a/types/react-grid-layout/index.d.ts
+++ b/types/react-grid-layout/index.d.ts
@@ -277,6 +277,8 @@ declare namespace ReactGridLayout {
     }
 
     interface ReactGridLayoutProps extends CoreProps {
+        children?: React.ReactNode;
+
         /**
          * Number of columns in this layout.
          */
@@ -321,6 +323,8 @@ declare namespace ReactGridLayout {
          * Breakpoint names are arbitrary but must match in the cols and layouts objects.
          */
         breakpoints?: { [P: string]: number } | undefined;
+
+        children?: React.ReactNode;
 
         /**
          * Number of cols. This is a breakpoint -> cols map, e.g. `{lg: 12, md: 10, ...}`.


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/react-grid-layout/react-grid-layout/tree/1.1.1#usage
https://github.com/react-grid-layout/react-grid-layout/tree/1.1.1#responsive-usage
