### PR TITLE
[react-gamepad] Add explicit types for children

### DIFF
--- a/types/react-gamepad/index.d.ts
+++ b/types/react-gamepad/index.d.ts
@@ -43,6 +43,8 @@ export interface Layout {
 }
 
 export interface Props {
+    children: React.ReactElement;
+
     /**
      * The index of the gamepad to use, from 0 to 4 Default: 0
      */

--- a/types/react-gamepad/test/four-players-tests.tsx
+++ b/types/react-gamepad/test/four-players-tests.tsx
@@ -116,11 +116,9 @@ class PlayerCube extends React.Component<Props, State> {
                 onDisconnect={this.disconnectHandler.bind(this)}
                 onAxisChange={this.axisChangeHandler.bind(this)}
             >
-                {this.state.connected && (
-                    <div id={`player${this.props.playerIndex}`} style={this.getPlayerStyle()}>
-                        {this.props.playerIndex}
-                    </div>
-                )}
+                <div hidden={!this.state.connected} id={`player${this.props.playerIndex}`} style={this.getPlayerStyle()}>
+                    {this.props.playerIndex}
+                </div>
             </Gamepad>
         );
     }

--- a/types/react-gamepad/test/readme-tests.tsx
+++ b/types/react-gamepad/test/readme-tests.tsx
@@ -37,7 +37,9 @@ class App extends React.Component {
                 onDisconnect={this.disconnectHandler}
                 onButtonChange={this.buttonChangeHandler}
                 onAxisChange={this.axisChangeHandler}
-            />
+            >
+                <React.Fragment />
+            </Gamepad>
         );
     }
 }
@@ -74,4 +76,6 @@ console.log(<App />);
     onDown={() => {}}
     onLeft={() => {}}
     onRight={() => {}}
-/>;
+>
+    <React.Fragment />
+</Gamepad>;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/SBRK/react-gamepad/blob/master/src/Gamepad.js#L238

