### PR TITLE
[react-form] Add explicit types for children

### DIFF
--- a/types/react-form/v1/index.d.ts
+++ b/types/react-form/v1/index.d.ts
@@ -238,6 +238,7 @@ export interface TextProps extends InputAttrs {
 export const Text: React.SFC<TextProps>;
 
 export interface RadioGroupProps {
+    children?: React.ReactNode;
     field?: FormInputProps['field'] | undefined;
     showErrors?: FormInputProps['showErrors'] | undefined;
     errorBefore?: FormInputProps['errorBefore'] | undefined;

--- a/types/react-form/v2/index.d.ts
+++ b/types/react-form/v2/index.d.ts
@@ -108,7 +108,7 @@ export class Form
     render(): RenderReturn;
 }
 
-export const NestedForm: React.StatelessComponent<FieldProps>;
+export const NestedForm: React.FunctionComponent<FieldProps>;
 
 export function FormField(component: React.ComponentType<any>): React.ComponentClass<any>;
 
@@ -129,6 +129,7 @@ export interface FieldApi {
 }
 
 export interface FieldProps {
+    children?: React.ReactNode;
     field?: string | string[] | React.ReactText[] | Array<(string | React.ReactText[])> | undefined;
     showErrors?: boolean | undefined;
     errorBefore?: boolean | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/tannerlinsley/react-form/blob/v1.3.0/src/formInputs/radioGroup.js#L22-L37

