### PR TITLE
[react-document-meta] Add explicit types for children

### DIFF
--- a/types/react-document-meta/index.d.ts
+++ b/types/react-document-meta/index.d.ts
@@ -7,6 +7,7 @@
 import * as React from 'react';
 
 export interface DocumentMetaProps {
+    children?: React.ReactNode;
     readonly title?: string | undefined;
     readonly description?: string | undefined;
     readonly canonical?: string | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/kodyl/react-document-meta/blob/v3.0.0-beta.5/lib/index.js#L184-L190
