### PR TITLE
[react-custom-scroll] Add explicit types for children

### DIFF
--- a/types/react-custom-scroll/index.d.ts
+++ b/types/react-custom-scroll/index.d.ts
@@ -5,12 +5,13 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
-import { ComponentClass } from 'react';
+import { ComponentClass, ReactNode } from 'react';
 
 /**
  * Props for a CustomScroll component.
  */
 export interface CustomScrollProps {
+    children?: ReactNode;
     allowOuterScroll?: boolean | undefined;
     heightRelativeToParent?: string | undefined;
     flex?: number | string | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/rommguy/react-custom-scroll/blob/v4.3.0/src/main/customScroll.js#L399

