### PR TITLE
[react-css-collapse] Add explicit types for children

### DIFF
--- a/types/react-css-collapse/index.d.ts
+++ b/types/react-css-collapse/index.d.ts
@@ -6,6 +6,7 @@
 
 declare module 'react-css-collapse' {
   interface Props {
+    children?: React.ReactNode;
     isOpen: boolean;
     className?: string | null | undefined;
     onRest?: (() => void) | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/SparebankenVest/react-css-collapse/tree/v3.6.1#installation

