### PR TITLE
[react-copy-to-clipboard] Add explicit types for children

### DIFF
--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -21,6 +21,7 @@ declare namespace CopyToClipboard {
     }
 
     interface Props {
+        children?: React.ReactNode;
         text: string;
         onCopy?(text: string, result: boolean): void;
         options?: Options | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/nkbt/react-copy-to-clipboard/tree/v5.0.4#usage
