### PR TITLE
[react-bootstrap] Add explicit types for children

### DIFF
--- a/types/react-bootstrap/lib/MediaBody.d.ts
+++ b/types/react-bootstrap/lib/MediaBody.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 declare namespace MediaBody {
     export interface MediaBodyProps extends React.ClassAttributes<MediaBody> {
+        children?: React.ReactNode;
         componentClass?: React.ReactType | undefined;
     }
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://react-bootstrap-v3.netlify.app/layout/media/

