### PR TITLE
[react-burger-menu] Add explicit types for children

### DIFF
--- a/types/react-burger-menu/index.d.ts
+++ b/types/react-burger-menu/index.d.ts
@@ -32,6 +32,7 @@ export interface Props {
     bodyClassName?: string | undefined;
     burgerBarClassName?: string | undefined;
     burgerButtonClassName?: string | undefined;
+    children?: React.ReactNode;
     className?: string | undefined;
     crossButtonClassName?: string | undefined;
     crossClassName?: string | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/negomi/react-burger-menu/tree/v2.8.0#usage

