### PR TITLE
[react-calendar-timeline] Add explicit types for children

### DIFF
--- a/types/react-calendar-timeline/index.d.ts
+++ b/types/react-calendar-timeline/index.d.ts
@@ -194,6 +194,7 @@ declare module 'react-calendar-timeline' {
         CustomItem extends TimelineItemBase<any> = TimelineItemBase<number>,
         CustomGroup extends TimelineGroupBase = TimelineGroupBase
     > {
+        children?: React.ReactNode;
         groups: CustomGroup[];
         items: CustomItem[];
         keys?: TimelineKeys | undefined;
@@ -287,6 +288,7 @@ declare module 'react-calendar-timeline' {
     export class CursorMarker extends React.Component<CursorMarkerProps> {}
 
     export interface TimelineHeadersProps {
+        children?: React.ReactNode;
         style?: React.CSSProperties | undefined;
         className?: string | undefined;
         calendarHeaderStyle?: React.CSSProperties | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/namespace-ee/react-calendar-timeline/tree/0.26.7#overview

