### PR TITLE
[react-breadcrumbs-dynamic] Add explicit types for children

### DIFF
--- a/types/react-breadcrumbs-dynamic/index.d.ts
+++ b/types/react-breadcrumbs-dynamic/index.d.ts
@@ -13,6 +13,7 @@ export class Breadcrumbs extends React.Component<BreadcrumbsProps> {}
 export class BreadcrumbsItem extends React.Component<BreadcrumbsItemProps> {}
 
 export interface BreadcrumbsProviderProps {
+  children?: React.ReactNode;
   shouldBreadcrumbsUpdate?: ((...args: any[]) => any) | undefined;
 }
 
@@ -28,5 +29,6 @@ export interface BreadcrumbsProps {
 }
 
 export interface BreadcrumbsItemProps {
+  children?: React.ReactNode;
   to: string;
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.



https://github.com/oklas/react-breadcrumbs-dynamic#adding-items-to-breadcrumbs

