### PR TITLE
[react-bootstrap-typeahead] Add explicit types for children

### DIFF
--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -146,6 +146,8 @@ export interface TypeaheadProps<T extends TypeaheadModel> {
     /* Whether or not filtering should be case-sensitive. */
     caseSensitive?: boolean | undefined;
 
+    children?: React.ReactNode | ((props: any) => React.ReactNode);
+
     /* Displays a button to clear the input when there are selections. */
     clearButton?: boolean | undefined;
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/ericgio/react-bootstrap-typeahead/blob/v5.1.4/src/components/Typeahead.js#L154-L197

