### PR TITLE
[react-body-classname] Add explicit types for children

### DIFF
--- a/types/react-body-classname/index.d.ts
+++ b/types/react-body-classname/index.d.ts
@@ -8,7 +8,7 @@ import * as React from "react";
 
 export = BodyClassName;
 
-declare class BodyClassName extends React.Component<{ className: string }> {
+declare class BodyClassName extends React.Component<{ children?: React.ReactElement, className: string }> {
     static canUseDOM: boolean;
     static displayName: string;
     static peek(): any;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/iest/react-body-classname/blob/v1.1.1/index.js#L20-L24
