### PR TITLE
[react-beautiful-dnd] Add explicit types for children

### DIFF
--- a/types/react-beautiful-dnd/v10/index.d.ts
+++ b/types/react-beautiful-dnd/v10/index.d.ts
@@ -87,6 +87,7 @@ export interface DropResult extends DragUpdate {
 }
 
 export interface DragDropContextProps {
+    children?: React.ReactNode;
     onBeforeDragStart?(initial: DragStart): void;
     onDragStart?(initial: DragStart, provided: ResponderProvided): void;
     onDragUpdate?(initial: DragUpdate, provided: ResponderProvided): void;

--- a/types/react-beautiful-dnd/v11/index.d.ts
+++ b/types/react-beautiful-dnd/v11/index.d.ts
@@ -84,6 +84,7 @@ export interface DropResult extends DragUpdate {
 }
 
 export interface DragDropContextProps {
+    children?: React.ReactNode;
     onBeforeCapture?(before: BeforeCapture): void;
     onBeforeDragStart?(initial: DragStart): void;
     onDragStart?(initial: DragStart, provided: ResponderProvided): void;

--- a/types/react-beautiful-dnd/v12/index.d.ts
+++ b/types/react-beautiful-dnd/v12/index.d.ts
@@ -557,6 +557,7 @@ export type Sensor = (api: SensorAPI) => void;
  */
 
 export interface DragDropContextProps {
+    children?: React.ReactNode;
     onBeforeCapture?(before: BeforeCapture): void;
     onBeforeDragStart?(initial: DragStart): void;
     onDragStart?(initial: DragStart, provided: ResponderProvided): void;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/atlassian/react-beautiful-dnd/blob/v11.0.5/src/view/drag-drop-context/drag-drop-context.jsx#L11
https://github.com/atlassian/react-beautiful-dnd/blob/v12.2.0/src/view/drag-drop-context/drag-drop-context.jsx#L12
https://github.com/atlassian/react-beautiful-dnd/blob/v10.1.1/src/view/drag-drop-context/drag-drop-context.jsx#L49

