### PR TITLE
[react-animated-modal] Add explicit types for children

### DIFF
--- a/types/react-animated-modal/index.d.ts
+++ b/types/react-animated-modal/index.d.ts
@@ -48,6 +48,7 @@ export type AnimationTypes =
     | "flash";
 
 export interface ModalProps {
+    children?: React.ReactNode;
     closemodal: () => void;
     visible: boolean;
     /** @default 'flipInX' */


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/morfsys/react-animated-modal/blob/1.1.0/src/index.js#L115
