### PR TITLE
[react-animate-on-scroll] Add explicit types for children

### DIFF
--- a/types/react-animate-on-scroll/index.d.ts
+++ b/types/react-animate-on-scroll/index.d.ts
@@ -9,6 +9,7 @@ import * as React from 'react';
 export interface ScrollAnimationProps {
     animateIn?: string | undefined;
     animateOut?: string | undefined;
+    children?: React.ReactNode;
     offset?: number | undefined;
     duration?: number | undefined;
     delay?: number | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/dbramwell/react-animate-on-scroll/blob/72341ad51c90bd95acd30f566bb30a129ca0237c/src/scroll-animation.js#L202
