### PR TITLE
[react-albus] Add explicit types for children

### DIFF
--- a/types/react-albus/index.d.ts
+++ b/types/react-albus/index.d.ts
@@ -43,11 +43,12 @@ export const Wizard: React.ComponentType<WizardProps>;
 
 export type WizardContextRenderProps =
     | { render?: ((wizard: WizardContext) => React.ReactNode) | undefined }
-    | { children: (wizard: WizardContext) => React.ReactNode };
+    | { children: ((wizard: WizardContext) => React.ReactNode) | React.ReactNode };
 
 export const WithWizard: React.ComponentType<WizardContextRenderProps>;
 
 export interface StepsProps {
+    children: NonNullable<React.ReactNode>;
     step?: StepObject | undefined;
 }
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/americanexpress/react-albus/blob/v2.0.0/src/utils/renderCallback.js#L16-L21
