### PR TITLE
[muicss] Add explicit types for Tabs#children

### DIFF
--- a/types/muicss/react.d.ts
+++ b/types/muicss/react.d.ts
@@ -122,6 +122,7 @@ export interface SelectProps extends DivProps {
 }
 
 export interface TabProps {
+    children?: React.ReactNode;
     value?: any;
     label?: React.ReactNode | undefined;
     onActive?: ((tab: Tab) => void) | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/muicss/mui/blob/0.9.43/src/react/tabs.jsx#L80-L83

