### PR TITLE
[ink-box] Add explicit types for children

### DIFF
--- a/types/ink-box/index.d.ts
+++ b/types/ink-box/index.d.ts
@@ -24,6 +24,7 @@ interface BoxProps {
         horizontal?: string | undefined;
         vertical?: string | undefined;
     } | undefined;
+    children?: React.ReactNode;
     dimBorder?: boolean | undefined;
     padding?: Spacing | undefined;
     margin?: Spacing | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/sindresorhus/ink-box/blob/v1.0.0/index.js#L13-L16

