### PR TITLE
[gestalt] Add explicit types for children

### DIFF
--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -520,6 +520,8 @@ export interface DropdownProps {
 }
 
 export interface DropdownItemProps {
+    children?: React.ReactNode;
+
     onSelect: AbstractEventHandler<
         React.FocusEvent<HTMLInputElement>,
         {
@@ -1635,6 +1637,7 @@ export interface TypeaheadProps {
  * https://gestalt.netlify.app/Upsell
  */
 export interface UpsellProps {
+    children?: React.ReactElement;
     message: string;
     dismissButton?:
         | {


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/pinterest/gestalt/blob/v34.3.4/packages/gestalt/src/DropdownItem.js#L9
https://github.com/pinterest/gestalt/blob/v34.3.4/packages/gestalt/src/Upsell.js#L25

