### PR TITLE
[fundamental-react] Add explicit types for children

### DIFF
--- a/types/fundamental-react/fundamental-react-tests.tsx
+++ b/types/fundamental-react/fundamental-react-tests.tsx
@@ -1655,11 +1655,9 @@ const selects = (
         <Select placeholder='Select' options={[
             {text: "List Item 1", key: "1"},
             {text: "List Item 2", key: "2"}
-        ]} selectedKey={"2"}>
-        </Select>
+        ]} selectedKey={"2"} />
 
-        <Select compact validationState={{state: 'warning', text: 'Validated'}}>
-        </Select>
+        <Select compact validationState={{state: 'warning', text: 'Validated'}} />
     </div>
 );
 

--- a/types/fundamental-react/lib/List/List.d.ts
+++ b/types/fundamental-react/lib/List/List.d.ts
@@ -16,10 +16,12 @@ export type ListProps = {
 } & React.HTMLAttributes<HTMLAnchorElement>;
 
 export interface ListFooterProps {
+    children?: React.ReactNode;
     className?: string | undefined;
 }
 
 export interface ListHeaderProps {
+    children?: React.ReactNode;
     className?: string | undefined;
 }
 
@@ -29,12 +31,14 @@ export interface ListIconProps {
 }
 
 export interface ListItemProps {
+    children?: React.ReactNode;
     className?: string | undefined;
     selected?: boolean | undefined;
     onClick?: ((...args: any[]) => any) | undefined;
 }
 
 export interface ListTextProps {
+    children?: React.ReactNode;
     className?: string | undefined;
     noWrap?: boolean | undefined;
     secondary?: boolean | undefined;

--- a/types/fundamental-react/lib/MessageStrip/MessageStrip.d.ts
+++ b/types/fundamental-react/lib/MessageStrip/MessageStrip.d.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 export interface MessageStripProps {
     buttonProps?: any;
+    children?: React.ReactNode;
     className?: string | undefined;
     disableStyles?: boolean | undefined;
     dismissible?: boolean | undefined;

--- a/types/fundamental-react/lib/Switch/Switch.d.ts
+++ b/types/fundamental-react/lib/Switch/Switch.d.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 export interface SwitchProps {
     checked?: boolean | undefined;
+    children?: React.ReactNode;
     className?: string | undefined;
     compact?: boolean | undefined;
     disabled?: boolean | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/SAP/fundamental-react/blob/v0.13.0/src/Select/Select.js#L222-L226

