### PR TITLE
[fluent-react] LocalizationProvider#children requires a single element

### DIFF
--- a/types/fluent-react/fluent-react-tests.tsx
+++ b/types/fluent-react/fluent-react-tests.tsx
@@ -20,7 +20,7 @@ function* generateBundles(currentLocales: string[]) {
 
 ReactDOM.render(
   <LocalizationProvider bundles={generateBundles(['en-US'])}>
-    Content
+    <div />
   </LocalizationProvider>,
   document.getElementById('root')
 );

--- a/types/fluent-react/index.d.ts
+++ b/types/fluent-react/index.d.ts
@@ -24,6 +24,7 @@ export interface Context {
 }
 export interface LocalizationProviderProps {
   bundles: IterableIterator<FluentBundle>;
+  children: React.ReactElement;
   parseMarkup?: MarkupParser | undefined;
 }
 export class LocalizationProvider extends React.Component<LocalizationProviderProps> {


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/projectfluent/fluent.js/blob/fluent-react%400.8.5/fluent-react/src/provider.js#L67


