### PR TITLE
[fixed-data-table-2] Add explicit types for children

### DIFF
--- a/types/fixed-data-table-2/index.d.ts
+++ b/types/fixed-data-table-2/index.d.ts
@@ -81,6 +81,8 @@ export type TableRowEventHandler = (event: React.SyntheticEvent<Table>, rowIndex
  *   vertically or horizontally.
  */
 export interface TableProps extends React.ClassAttributes<Table> {
+    children?: React.ReactNode;
+
     /**
      * Pixel width of table. If all columns do not fit,
      * a horizontal scrollbar will appear.


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.
