### PR TITLE
[calidation] Add explicit types for children

### DIFF
--- a/types/calidation/index.d.ts
+++ b/types/calidation/index.d.ts
@@ -148,6 +148,7 @@ export type CustomValidatorFunction<T extends object> = (
 ) => (value: T[keyof T]) => string | null;
 
 export interface ValidatorsProviderProps<T extends object> {
+    children?: React.ReactNode;
     validators: Record<string, CustomValidatorFunction<T>>;
 }
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/selbekk/calidation/blob/v1.16.2/src/ValidatorsContext.js#L51

