### PR TITLE
[@hippy/react] Add explicit types for children

### DIFF
--- a/types/hippy__react/index.d.ts
+++ b/types/hippy__react/index.d.ts
@@ -1092,6 +1092,8 @@ interface ViewProps extends LayoutableProps, ClickableProps, TouchableProps {
      */
     accessible?: boolean;
 
+    children?: React.ReactNode;
+
     /**
      * Views that are only used to layout their children or otherwise don't draw anything may be
      * automatically removed from the native hierarchy as an optimization.


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.


https://github.com/Tencent/Hippy/blob/2.7.6/packages/hippy-react/src/components/view.tsx#L68-L75
