### PR TITLE
[atom] Use inline documentation for types in `grammar-registry.d.ts`

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -1255,10 +1255,10 @@ function testGrammarRegistry() {
     // Event Subscription
     subscription = registry.onDidAddGrammar(grammar => grammar.name);
     subscription = registry.onDidUpdateGrammar(grammar => grammar.name);
-    subscription = registry.onDidRemoveGrammar(grammar => grammar.name);
 
     // Managing Grammars
     grammars = registry.getGrammars();
+    grammars = registry.getGrammars({ includeTreeSitter: true });
 
     let potentialGrammar = registry.grammarForScopeName('scope.test');
     if (potentialGrammar) grammar = potentialGrammar;
@@ -1286,6 +1286,9 @@ function testGrammarRegistry() {
             if (error) error.name;
         }
     });
+
+    bool = registry.assignGrammar(buffer, grammar);
+    str = registry.getAssignedLanguageId(buffer);
 }
 
 // Gutter =====================================================================

--- a/types/atom/src/grammar-registry.d.ts
+++ b/types/atom/src/grammar-registry.d.ts
@@ -1,7 +1,7 @@
 import { Disposable, Grammar, GrammarToken, TextBuffer } from '../index';
 
 type SyntaxNode = any;
-interface InjectionPoint = {
+interface InjectionPoint {
     type: string;
     language: (node: SyntaxNode) => string;
     content: (node: SyntaxNode) => SyntaxNode | SyntaxNode[];

--- a/types/atom/src/grammar-registry.d.ts
+++ b/types/atom/src/grammar-registry.d.ts
@@ -1,11 +1,11 @@
 import { Disposable, Grammar, GrammarToken, TextBuffer } from '../index';
 
 type SyntaxNode = any;
-type InjectionPoint = {
+interface InjectionPoint = {
     type: string;
     language: (node: SyntaxNode) => string;
     content: (node: SyntaxNode) => SyntaxNode | SyntaxNode[];
-}
+};
 
 /** Registry containing one or more grammars. */
 export interface GrammarRegistry {

--- a/types/atom/src/grammar-registry.d.ts
+++ b/types/atom/src/grammar-registry.d.ts
@@ -5,7 +5,7 @@ interface InjectionPoint {
     type: string;
     language: (node: SyntaxNode) => string;
     content: (node: SyntaxNode) => SyntaxNode | SyntaxNode[];
-};
+}
 
 /** Registry containing one or more grammars. */
 export interface GrammarRegistry {

--- a/types/atom/src/grammar-registry.d.ts
+++ b/types/atom/src/grammar-registry.d.ts
@@ -1,5 +1,12 @@
 import { Disposable, Grammar, GrammarToken, TextBuffer } from '../index';
 
+type SyntaxNode = any;
+type InjectionPoint = {
+    type: string;
+    language: (node: SyntaxNode) => string;
+    content: (node: SyntaxNode) => SyntaxNode | SyntaxNode[];
+}
+
 /** Registry containing one or more grammars. */
 export interface GrammarRegistry {
     // Event Subscription
@@ -18,19 +25,16 @@ export interface GrammarRegistry {
      */
     onDidUpdateGrammar(callback: (grammar: Grammar) => void): Disposable;
 
-    /**
-     *  Invoke the given callback when a grammar is removed from the registry.
-     *  @param callback The callback to be invoked whenever a grammar is removed.
-     *  @return A Disposable on which `.dispose()` can be called to unsubscribe.
-     */
-    onDidRemoveGrammar(callback: (grammar: Grammar) => void): Disposable;
-
     // Managing Grammars
     /**
      *  Get all the grammars in this registry.
+     *  @param [params]
+     *  @param [params.includeTreeSitter] Whether to include
+     *  [Tree-sitter](https://github.blog/2018-10-31-atoms-new-parsing-system/)
+     *  grammars
      *  @return A non-empty array of Grammar instances.
      */
-    getGrammars(): Grammar[];
+    getGrammars(params?: { includeTreeSitter?: boolean }): Grammar[];
 
     /**
      *  Get a grammar with the given scope name.
@@ -66,14 +70,16 @@ export interface GrammarRegistry {
     /**
      *  Read a grammar synchronously but don't add it to the registry.
      *  @param grammarPath The absolute file path to a grammar.
-     *  @return The newly loaded Grammar.
+     *  @return A Grammar.
      */
     readGrammarSync(grammarPath: string): Grammar;
 
     /**
      *  Read a grammar asynchronously but don't add it to the registry.
      *  @param grammarPath The absolute file path to the grammar.
-     *  @param callback The function to be invoked once the Grammar has been read in.
+     *  @param callback The function to call when read with the following arguments:
+     *      - error: An error or null
+     *      - grammar: A grammar if an error has not occurred
      */
     readGrammar(grammarPath: string, callback: (error: Error | null, grammar?: Grammar) => void): void;
 
@@ -121,6 +127,22 @@ export interface GrammarRegistry {
     assignLanguageMode(buffer: TextBuffer, languageId: string): boolean;
 
     /**
+     *  Force a TextBuffer to use a different grammar than the one that would otherwise
+     *  be selected for it.
+     *  @param buffer The buffer whose grammar will be set.
+     *  @param grammar The desired Grammar
+     *  @return Returns a boolean that indicates whether the assignment was successful
+     */
+    assignGrammar(buffer: TextBuffer, grammar: Grammar): boolean;
+
+    /**
+     *  Get the `languageId` that has been explicity assigned to the given buffer, if
+     *  any.
+     *  @return Returns a string id of the language
+     */
+    getAssignedLanguageId(buffer: TextBuffer): string;
+
+    /**
      *  Remove any language mode override that has been set for the given TextBuffer.
      *  This will assign to the buffer the best language mode available.
      */
@@ -144,4 +166,20 @@ export interface GrammarRegistry {
      *  @param contents A string of text for that file path.
      */
     getGrammarScore(grammar: Grammar, filePath: string, contents: string): number;
+
+    /**
+     *  Specify a type of syntax node that may embed other languages
+     *  @param grammarId The string id of the parent language
+     *  @param injectionPoint An object with the following keys:
+     *  @param injectionPoint.type The string type of syntax node that may embed
+     *  other languages
+     *  @param injectionPoint.language A function that is called with syntax nodes
+     *  of the specified type and returns a string that will be tested against
+     *  other grammars' injectionRegex in order to determine what language should
+     *  be embedded.
+     *  @param injectionPoint.content A function that is called with syntax nodes
+     *  of the specified type and returns another syntax node or array of syntax
+     *  nodes that contain the embedded source code.
+     */
+    addInjectionPoint(grammarId: string, injectionPoint: InjectionPoint): Disposable;
 }

--- a/types/atom/src/grammar-registry.d.ts
+++ b/types/atom/src/grammar-registry.d.ts
@@ -1,6 +1,6 @@
 import { Disposable, Grammar, GrammarToken, TextBuffer } from '../index';
 
-interface SyntaxNode {}
+type SyntaxNode = {}
 interface InjectionPoint {
     type: string;
     language: (node: SyntaxNode) => string;

--- a/types/atom/src/grammar-registry.d.ts
+++ b/types/atom/src/grammar-registry.d.ts
@@ -1,6 +1,6 @@
 import { Disposable, Grammar, GrammarToken, TextBuffer } from '../index';
 
-type SyntaxNode = any;
+interface SyntaxNode {}
 interface InjectionPoint {
     type: string;
     language: (node: SyntaxNode) => string;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/atom/atom/blob/v1.40.0/src/grammar-registry.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (Doesn't apply here)

#### Details

Fixes the problem mentioned here: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/56297

> The docs for `GrammarRegistry` point to https://github.com/atom/first-mate/blob/v7.4.1/src/grammar-registry.coffee instead of https://github.com/atom/atom/blob/v1.40.0/src/grammar-registry.js
>
> (Issue in docs repo: https://github.com/atom/flight-manual.atom.io/issues/736)
> (Types: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/atom/src/grammar-registry.d.ts)
> (Code: https://github.com/atom/atom/blob/v1.40.0/src/grammar-registry.js)
>
> Unfortunately, the types for Atom seem to be based on what the docs say instead of what the code says (understandable).

__I didn't remove undocumented methods or add deprecated methods for now.__ (Although if it should be otherwise let me know.)
Sometimes the docs and the code don't match up. When that happens I explain in the commit

### <s>Blocked</s>

- [x] https://github.com/microsoft/DefinitelyTyped-tools/pull/333