### PR TITLE
[universalify] improve types to mantain type on arguments instead of just any -> any

### DIFF
--- a/types/universalify/index.d.ts
+++ b/types/universalify/index.d.ts
@@ -3,5 +3,126 @@
 // Definitions by: Richie Bendall <https://github.com/Richienb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export function fromCallback(fn: (callback: (err?: unknown) => void) => void): {
+    (): Promise<void>;
+    (callback: (err?: unknown) => void): void;
+};
+export function fromCallback<T1, TResult>(
+    fn: (arg1: T1, callback: (err: unknown, result: TResult) => void) => void,
+): {
+    (arg1: T1): Promise<TResult>;
+    (arg1: T1, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromCallback<T1>(fn: (arg1: T1, callback: (err?: unknown) => void) => void): {
+    (arg1: T1): Promise<void>;
+    (arg1: T1, cb: (err?: unknown) => void): void;
+};
+export function fromCallback<T1, T2, TResult>(
+    fn: (arg1: T1, arg2: T2, callback: (err: unknown, result: TResult) => void) => void,
+): {
+    (arg1: T1, arg2: T2): Promise<TResult>;
+    (arg1: T1, arg2: T2, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromCallback<T1, T2>(
+    fn: (arg1: T1, arg2: T2, callback: (err?: unknown) => void) => void,
+): {
+    (arg1: T1, arg2: T2): Promise<void>;
+    (arg1: T1, arg2: T2, cb: (err: unknown) => void): void;
+};
+export function fromCallback<T1, T2, T3, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: unknown, result: TResult) => void) => void,
+): {
+    (arg1: T1, arg2: T2, arg3: T3): Promise<TResult>;
+    (arg1: T1, arg2: T2, arg3: T3, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromCallback<T1, T2, T3>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: unknown) => void) => void,
+): {
+    (arg1: T1, arg2: T2, arg3: T3): Promise<void>;
+    (arg1: T1, arg2: T2, arg3: T3, cb: (err?: unknown) => void): void;
+};
+export function fromCallback<T1, T2, T3, T4, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: unknown, result: TResult) => void) => void,
+): {
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4): Promise<TResult>;
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromCallback<T1, T2, T3, T4>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: unknown) => void) => void,
+): {
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4): Promise<void>;
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, cb: (err?: unknown) => void): void;
+};
+export function fromCallback<T1, T2, T3, T4, T5, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: unknown, result: TResult) => void) => void,
+): {
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): Promise<TResult>;
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromCallback<T1, T2, T3, T4, T5>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: unknown) => void) => void,
+): {
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): Promise<void>;
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, cb: (err?: unknown) => void): void;
+};
 export function fromCallback(fn: (...args: any[]) => any): (...args: any[]) => Promise<any> | void;
+
+export function fromPromise<T1, TResult>(
+    fn: (arg1: T1) => Promise<TResult>,
+): {
+    (arg1: T1): Promise<TResult>;
+    (arg1: T1, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromPromise<T1>(fn: (arg1: T1) => Promise<void>): {
+    (arg1: T1): Promise<void>;
+    (arg1: T1, cb: (err?: unknown) => void): void;
+};
+export function fromPromise<T1, T2, TResult>(
+    fn: (arg1: T1, arg2: T2) => Promise<TResult>,
+): {
+    (arg1: T1, arg2: T2): Promise<TResult>;
+    (arg1: T1, arg2: T2, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromPromise<T1, T2>(
+    fn: (arg1: T1, arg2: T2) => Promise<void>,
+): {
+    (arg1: T1, arg2: T2): Promise<void>;
+    (arg1: T1, arg2: T2, cb: (err?: unknown) => void): void;
+};
+export function fromPromise<T1, T2, T3, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>,
+): {
+    (arg1: T1, arg2: T2, arg3: T3): Promise<TResult>;
+    (arg1: T1, arg2: T2, arg3: T3, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromPromise<T1, T2, T3>(
+    fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<void>,
+): {
+    (arg1: T1, arg2: T2, arg3: T3): Promise<void>;
+    (arg1: T1, arg2: T2, arg3: T3, cb: (err?: unknown) => void): void;
+};
+export function fromPromise<T1, T2, T3, T4, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>,
+): {
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4): Promise<TResult>;
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromPromise<T1, T2, T3, T4>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>,
+): {
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4): Promise<void>;
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, cb: (err?: unknown) => void): void;
+};
+export function fromPromise<T1, T2, T3, T4, T5, TResult>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5) => Promise<TResult>,
+): {
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5): Promise<TResult>;
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5, cb: (err: unknown, result: TResult) => void): void;
+};
+export function fromPromise<T1, T2, T3, T4, T5>(
+    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5) => Promise<void>,
+): {
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5): Promise<void>;
+    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5, cb: (err?: unknown) => void): void;
+};
 export function fromPromise(fn: (...args: any[]) => any): (...args: any[]) => Promise<any> | void;

--- a/types/universalify/index.d.ts
+++ b/types/universalify/index.d.ts
@@ -2,127 +2,18 @@
 // Project: https://github.com/RyanZim/universalify#readme
 // Definitions by: Richie Bendall <https://github.com/Richienb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.0
 
-export function fromCallback(fn: (callback: (err?: unknown) => void) => void): {
-    (): Promise<void>;
-    (callback: (err?: unknown) => void): void;
-};
-export function fromCallback<T1, TResult>(
-    fn: (arg1: T1, callback: (err: unknown, result: TResult) => void) => void,
+export function fromCallback<Arguments extends readonly unknown[], Err, Value>(
+    fn: (...arguments_: [...Arguments, (error: Err, value: Value) => void]) => void,
 ): {
-    (arg1: T1): Promise<TResult>;
-    (arg1: T1, cb: (err: unknown, result: TResult) => void): void;
+    (...arguments: Arguments): Promise<Value>;
+    (...arguments: [...Arguments, (error: Err, value: Value) => void]): void;
 };
-export function fromCallback<T1>(fn: (arg1: T1, callback: (err?: unknown) => void) => void): {
-    (arg1: T1): Promise<void>;
-    (arg1: T1, cb: (err?: unknown) => void): void;
-};
-export function fromCallback<T1, T2, TResult>(
-    fn: (arg1: T1, arg2: T2, callback: (err: unknown, result: TResult) => void) => void,
-): {
-    (arg1: T1, arg2: T2): Promise<TResult>;
-    (arg1: T1, arg2: T2, cb: (err: unknown, result: TResult) => void): void;
-};
-export function fromCallback<T1, T2>(
-    fn: (arg1: T1, arg2: T2, callback: (err?: unknown) => void) => void,
-): {
-    (arg1: T1, arg2: T2): Promise<void>;
-    (arg1: T1, arg2: T2, cb: (err: unknown) => void): void;
-};
-export function fromCallback<T1, T2, T3, TResult>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: unknown, result: TResult) => void) => void,
-): {
-    (arg1: T1, arg2: T2, arg3: T3): Promise<TResult>;
-    (arg1: T1, arg2: T2, arg3: T3, cb: (err: unknown, result: TResult) => void): void;
-};
-export function fromCallback<T1, T2, T3>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: unknown) => void) => void,
-): {
-    (arg1: T1, arg2: T2, arg3: T3): Promise<void>;
-    (arg1: T1, arg2: T2, arg3: T3, cb: (err?: unknown) => void): void;
-};
-export function fromCallback<T1, T2, T3, T4, TResult>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: unknown, result: TResult) => void) => void,
-): {
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4): Promise<TResult>;
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, cb: (err: unknown, result: TResult) => void): void;
-};
-export function fromCallback<T1, T2, T3, T4>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: unknown) => void) => void,
-): {
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4): Promise<void>;
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, cb: (err?: unknown) => void): void;
-};
-export function fromCallback<T1, T2, T3, T4, T5, TResult>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: unknown, result: TResult) => void) => void,
-): {
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): Promise<TResult>;
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, cb: (err: unknown, result: TResult) => void): void;
-};
-export function fromCallback<T1, T2, T3, T4, T5>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: unknown) => void) => void,
-): {
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): Promise<void>;
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, cb: (err?: unknown) => void): void;
-};
-export function fromCallback(fn: (...args: any[]) => any): (...args: any[]) => Promise<any> | void;
 
-export function fromPromise<T1, TResult>(
-    fn: (arg1: T1) => Promise<TResult>,
+export function fromPromise<Arguments extends readonly unknown[], Value>(
+    fn: (...arguments_: [...Arguments]) => Promise<Value>,
 ): {
-    (arg1: T1): Promise<TResult>;
-    (arg1: T1, cb: (err: unknown, result: TResult) => void): void;
+    (...arguments: Arguments): Promise<Value>;
+    (...arguments: [...Arguments, (error: unknown, value: Value) => void]): void;
 };
-export function fromPromise<T1>(fn: (arg1: T1) => Promise<void>): {
-    (arg1: T1): Promise<void>;
-    (arg1: T1, cb: (err?: unknown) => void): void;
-};
-export function fromPromise<T1, T2, TResult>(
-    fn: (arg1: T1, arg2: T2) => Promise<TResult>,
-): {
-    (arg1: T1, arg2: T2): Promise<TResult>;
-    (arg1: T1, arg2: T2, cb: (err: unknown, result: TResult) => void): void;
-};
-export function fromPromise<T1, T2>(
-    fn: (arg1: T1, arg2: T2) => Promise<void>,
-): {
-    (arg1: T1, arg2: T2): Promise<void>;
-    (arg1: T1, arg2: T2, cb: (err?: unknown) => void): void;
-};
-export function fromPromise<T1, T2, T3, TResult>(
-    fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>,
-): {
-    (arg1: T1, arg2: T2, arg3: T3): Promise<TResult>;
-    (arg1: T1, arg2: T2, arg3: T3, cb: (err: unknown, result: TResult) => void): void;
-};
-export function fromPromise<T1, T2, T3>(
-    fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<void>,
-): {
-    (arg1: T1, arg2: T2, arg3: T3): Promise<void>;
-    (arg1: T1, arg2: T2, arg3: T3, cb: (err?: unknown) => void): void;
-};
-export function fromPromise<T1, T2, T3, T4, TResult>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>,
-): {
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4): Promise<TResult>;
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, cb: (err: unknown, result: TResult) => void): void;
-};
-export function fromPromise<T1, T2, T3, T4>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>,
-): {
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4): Promise<void>;
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, cb: (err?: unknown) => void): void;
-};
-export function fromPromise<T1, T2, T3, T4, T5, TResult>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5) => Promise<TResult>,
-): {
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5): Promise<TResult>;
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5, cb: (err: unknown, result: TResult) => void): void;
-};
-export function fromPromise<T1, T2, T3, T4, T5>(
-    fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5) => Promise<void>,
-): {
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5): Promise<void>;
-    (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg: T5, cb: (err?: unknown) => void): void;
-};
-export function fromPromise(fn: (...args: any[]) => any): (...args: any[]) => Promise<any> | void;

--- a/types/universalify/index.d.ts
+++ b/types/universalify/index.d.ts
@@ -11,9 +11,9 @@ export function fromCallback<Arguments extends readonly unknown[], ErrorValue, R
     (...arguments_: [...Arguments, (error: ErrorValue, value: ReturnValue) => void]): void;
 };
 
-export function fromPromise<Arguments extends readonly unknown[], Value>(
-    fn: (...arguments_: [...Arguments]) => Promise<Value>,
+export function fromPromise<Arguments extends readonly unknown[], ReturnValue>(
+    fn: (...arguments_: [...Arguments]) => Promise<ReturnValue>,
 ): {
-    (...arguments_: Arguments): Promise<Value>;
-    (...arguments_: [...Arguments, (error: unknown, value: Value) => void]): void;
+    (...arguments_: Arguments): Promise<ReturnValue>;
+    (...arguments_: [...Arguments, (error: unknown, value: ReturnValue) => void]): void;
 };

--- a/types/universalify/index.d.ts
+++ b/types/universalify/index.d.ts
@@ -7,13 +7,13 @@
 export function fromCallback<Arguments extends readonly unknown[], Err, Value>(
     fn: (...arguments_: [...Arguments, (error: Err, value: Value) => void]) => void,
 ): {
-    (...arguments: Arguments): Promise<Value>;
-    (...arguments: [...Arguments, (error: Err, value: Value) => void]): void;
+    (...arguments_: Arguments): Promise<Value>;
+    (...arguments_: [...Arguments, (error: Err, value: Value) => void]): void;
 };
 
 export function fromPromise<Arguments extends readonly unknown[], Value>(
     fn: (...arguments_: [...Arguments]) => Promise<Value>,
 ): {
-    (...arguments: Arguments): Promise<Value>;
-    (...arguments: [...Arguments, (error: unknown, value: Value) => void]): void;
+    (...arguments_: Arguments): Promise<Value>;
+    (...arguments_: [...Arguments, (error: unknown, value: Value) => void]): void;
 };

--- a/types/universalify/index.d.ts
+++ b/types/universalify/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.0
 
-export function fromCallback<Arguments extends readonly unknown[], Err, Value>(
-    fn: (...arguments_: [...Arguments, (error: Err, value: Value) => void]) => void,
+export function fromCallback<Arguments extends readonly unknown[], ErrorValue, ReturnValue>(
+    fn: (...arguments_: [...Arguments, (error: ErrorValue, value: ReturnValue) => void]) => void,
 ): {
-    (...arguments_: Arguments): Promise<Value>;
-    (...arguments_: [...Arguments, (error: Err, value: Value) => void]): void;
+    (...arguments_: Arguments): Promise<ReturnValue>;
+    (...arguments_: [...Arguments, (error: ErrorValue, value: ReturnValue) => void]): void;
 };
 
 export function fromPromise<Arguments extends readonly unknown[], Value>(

--- a/types/universalify/universalify-tests.ts
+++ b/types/universalify/universalify-tests.ts
@@ -1,16 +1,16 @@
 import universalify = require('universalify');
 
 declare const cb1: (p1: number, cb: (err: Error, data: string) => void) => void;
-universalify.fromCallback(cb1); // $ExpectType { (p1: number): Promise<string>; (arguments_0: number, arguments_1: (error: Error, value: string) => void): void; }
+universalify.fromCallback(cb1); // $ExpectType { (p1: number): Promise<string>; (arguments__0: number, arguments__1: (error: Error, value: string) => void): void; }
 
 declare const p1: (p1: number) => Promise<string>;
-universalify.fromPromise(p1); // $ExpectType { (p1: number): Promise<string>; (arguments_0: number, arguments_1: (error: unknown, value: string) => void): void; }
+universalify.fromPromise(p1); // $ExpectType { (p1: number): Promise<string>; (arguments__0: number, arguments__1: (error: unknown, value: string) => void): void; }
 
 declare const cb2: (p1: number, p2: number, cb: (err: Error, data: string) => void) => void;
-universalify.fromCallback(cb2); // $ExpectType { (p1: number, p2: number): Promise<string>; (arguments_0: number, arguments_1: number, arguments_2: (error: Error, value: string) => void): void; }
+universalify.fromCallback(cb2); // $ExpectType { (p1: number, p2: number): Promise<string>; (arguments__0: number, arguments__1: number, arguments__2: (error: Error, value: string) => void): void; }
 
 declare const p2: (p1: number, p2: number) => Promise<string>;
-universalify.fromPromise(p2); // $ExpectType { (p1: number, p2: number): Promise<string>; (arguments_0: number, arguments_1: number, arguments_2: (error: unknown, value: string) => void): void; }
+universalify.fromPromise(p2); // $ExpectType { (p1: number, p2: number): Promise<string>; (arguments__0: number, arguments__1: number, arguments__2: (error: unknown, value: string) => void): void; }
 
 declare const cb3: (p1: number, p2: number, p3: number, cb: (err: Error, data: string) => void) => void;
 universalify.fromCallback(cb3)(1, 2, 3); // $ExpectType Promise<string>

--- a/types/universalify/universalify-tests.ts
+++ b/types/universalify/universalify-tests.ts
@@ -1,19 +1,16 @@
 import universalify = require('universalify');
 
-universalify.fromCallback(() => {}); // $ExpectType { (): Promise<void>; (callback: (err?: unknown) => void): void; }
-universalify.fromPromise(async () => {}); // $ExpectType { (arg1: unknown): Promise<void>; (arg1: unknown, cb: (err: unknown, result: void) => void): void; }
-
 declare const cb1: (p1: number, cb: (err: Error, data: string) => void) => void;
-universalify.fromCallback(cb1); // $ExpectType { (arg1: number): Promise<string>; (arg1: number, cb: (err: unknown, result: string) => void): void; }
+universalify.fromCallback(cb1); // $ExpectType { (p1: number): Promise<string>; (arguments_0: number, arguments_1: (error: Error, value: string) => void): void; }
 
 declare const p1: (p1: number) => Promise<string>;
-universalify.fromPromise(p1); // $ExpectType { (arg1: number): Promise<string>; (arg1: number, cb: (err: unknown, result: string) => void): void; }
+universalify.fromPromise(p1); // $ExpectType { (p1: number): Promise<string>; (arguments_0: number, arguments_1: (error: unknown, value: string) => void): void; }
 
 declare const cb2: (p1: number, p2: number, cb: (err: Error, data: string) => void) => void;
-universalify.fromCallback(cb2); // $ExpectType { (arg1: number, arg2: number): Promise<string>; (arg1: number, arg2: number, cb: (err: unknown, result: string) => void): void; }
+universalify.fromCallback(cb2); // $ExpectType { (p1: number, p2: number): Promise<string>; (arguments_0: number, arguments_1: number, arguments_2: (error: Error, value: string) => void): void; }
 
 declare const p2: (p1: number, p2: number) => Promise<string>;
-universalify.fromPromise(p2); // $ExpectType { (arg1: number, arg2: number): Promise<string>; (arg1: number, arg2: number, cb: (err: unknown, result: string) => void): void; }
+universalify.fromPromise(p2); // $ExpectType { (p1: number, p2: number): Promise<string>; (arguments_0: number, arguments_1: number, arguments_2: (error: unknown, value: string) => void): void; }
 
 declare const cb3: (p1: number, p2: number, p3: number, cb: (err: Error, data: string) => void) => void;
 universalify.fromCallback(cb3)(1, 2, 3); // $ExpectType Promise<string>

--- a/types/universalify/universalify-tests.ts
+++ b/types/universalify/universalify-tests.ts
@@ -1,4 +1,47 @@
-import universalify = require("universalify");
+import universalify = require('universalify');
 
-universalify.fromCallback(() => { }); // $ExpectType (...args: any[]) => void | Promise<any>
-universalify.fromPromise(() => { }); // $ExpectType (...args: any[]) => void | Promise<any>
+universalify.fromCallback(() => {}); // $ExpectType { (): Promise<void>; (callback: (err?: unknown) => void): void; }
+universalify.fromPromise(async () => {}); // $ExpectType { (arg1: unknown): Promise<void>; (arg1: unknown, cb: (err: unknown, result: void) => void): void; }
+
+declare const cb1: (p1: number, cb: (err: Error, data: string) => void) => void;
+universalify.fromCallback(cb1); // $ExpectType { (arg1: number): Promise<string>; (arg1: number, cb: (err: unknown, result: string) => void): void; }
+
+declare const p1: (p1: number) => Promise<string>;
+universalify.fromPromise(p1); // $ExpectType { (arg1: number): Promise<string>; (arg1: number, cb: (err: unknown, result: string) => void): void; }
+
+declare const cb2: (p1: number, p2: number, cb: (err: Error, data: string) => void) => void;
+universalify.fromCallback(cb2); // $ExpectType { (arg1: number, arg2: number): Promise<string>; (arg1: number, arg2: number, cb: (err: unknown, result: string) => void): void; }
+
+declare const p2: (p1: number, p2: number) => Promise<string>;
+universalify.fromPromise(p2); // $ExpectType { (arg1: number, arg2: number): Promise<string>; (arg1: number, arg2: number, cb: (err: unknown, result: string) => void): void; }
+
+declare const cb3: (p1: number, p2: number, p3: number, cb: (err: Error, data: string) => void) => void;
+universalify.fromCallback(cb3)(1, 2, 3); // $ExpectType Promise<string>
+
+declare const p3: (p1: number, p2: number, p3: number) => Promise<string>;
+universalify.fromPromise(p3)(1, 2, 3, (err, data) => {
+    data; // $ExpectType string
+});
+
+declare const cb4: (p1: number, p2: number, p3: number, p4: number, cb: (err: Error, data: string) => void) => void;
+universalify.fromCallback(cb4)(1, 2, 3, 4); // $ExpectType Promise<string>
+
+declare const p4: (p1: number, p2: number, p3: number, p4: number) => Promise<string>;
+universalify.fromPromise(p4)(1, 2, 3, 4, (err, data) => {
+    data; // $ExpectType string
+});
+
+declare const cb5: (
+    p1: number,
+    p2: number,
+    p3: number,
+    p4: number,
+    p5: number,
+    cb: (err: Error, data: string) => void,
+) => void;
+universalify.fromCallback(cb5)(1, 2, 3, 4, 5); // $ExpectType Promise<string>
+
+declare const p5: (p1: number, p2: number, p3: number, p4: number, p5: number) => Promise<string>;
+universalify.fromPromise(p5)(1, 2, 3, 4, 5, (err, data) => {
+    data; // $ExpectType string
+});

--- a/types/universalify/universalify-tests.ts
+++ b/types/universalify/universalify-tests.ts
@@ -23,25 +23,25 @@ universalify.fromPromise(p3)(1, 2, 3, (err, data) => {
     data; // $ExpectType string
 });
 
-declare const cb4: (p1: number, p2: number, p3: number, p4: number, cb: (err: Error, data: string) => void) => void;
-universalify.fromCallback(cb4)(1, 2, 3, 4); // $ExpectType Promise<string>
+declare const cb4: (p1: number, p2: boolean, p3: number, p4: number, cb: (err: Error, data: string) => void) => void;
+universalify.fromCallback(cb4)(1, true, 3, 4); // $ExpectType Promise<string>
 
-declare const p4: (p1: number, p2: number, p3: number, p4: number) => Promise<string>;
-universalify.fromPromise(p4)(1, 2, 3, 4, (err, data) => {
+declare const p4: (p1: number, p2: boolean, p3: number, p4: number) => Promise<string>;
+universalify.fromPromise(p4)(1, false, 3, 4, (err, data) => {
     data; // $ExpectType string
 });
 
 declare const cb5: (
     p1: number,
     p2: number,
-    p3: number,
-    p4: number,
+    p3: boolean,
+    p4: string[],
     p5: number,
     cb: (err: Error, data: string) => void,
 ) => void;
-universalify.fromCallback(cb5)(1, 2, 3, 4, 5); // $ExpectType Promise<string>
+universalify.fromCallback(cb5)(1, 2, true, ['hi'], 5); // $ExpectType Promise<string>
 
-declare const p5: (p1: number, p2: number, p3: number, p4: number, p5: number) => Promise<string>;
-universalify.fromPromise(p5)(1, 2, 3, 4, 5, (err, data) => {
+declare const p5: (p1: number, p2: number, p3: boolean, p4: string[], p5: number) => Promise<string>;
+universalify.fromPromise(p5)(1, 2, false, [], 5, (err, data) => {
     data; // $ExpectType string
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/universalify/index.d.ts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The context is the types itself, which right now they are just

```typescript
export function fromCallback(fn: (...args: any[]) => any): (...args: any[]) => Promise<any> | void;
export function fromPromise(fn: (...args: any[]) => any): (...args: any[]) => Promise<any> | void;
```

Which means that any function passed through it will lose all the type information (it will be converted to a function that takes any and returns any). This changes that, using a similar technique that @types/node does on the `promisify` function inside the `util` library. It works up to 5 arguments, and then it gets to the previous default. This should be enough for most cases (since promisify is also limited to 5 arguments)