### PR TITLE
[react-native] Add missing button props

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5155,31 +5155,6 @@ interface TouchableMixin {
     touchableGetHitSlop(): Insets;
 }
 
-export interface TouchableWithoutFeedbackPropsIOS {
-    /**
-     * *(Apple TV only)* TV preferred focus (see documentation for the View component).
-     *
-     * @platform ios
-     */
-    hasTVPreferredFocus?: boolean | undefined;
-
-    /**
-     * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
-     *
-     * enabled: If true, parallax effects are enabled.  Defaults to true.
-     * shiftDistanceX: Defaults to 2.0.
-     * shiftDistanceY: Defaults to 2.0.
-     * tiltAngle: Defaults to 0.05.
-     * magnification: Defaults to 1.0.
-     * pressMagnification: Defaults to 1.0.
-     * pressDuration: Defaults to 0.3.
-     * pressDelay: Defaults to 0.0.
-     *
-     * @platform ios
-     */
-    tvParallaxProperties?: TVParallaxProperties | undefined;
-}
-
 export interface TouchableWithoutFeedbackPropsAndroid {
     /**
      * If true, doesn't play a system sound on touch.
@@ -5193,8 +5168,7 @@ export interface TouchableWithoutFeedbackPropsAndroid {
  * @see https://reactnative.dev/docs/touchablewithoutfeedback#props
  */
 export interface TouchableWithoutFeedbackProps
-    extends TouchableWithoutFeedbackPropsIOS,
-        TouchableWithoutFeedbackPropsAndroid,
+    extends TouchableWithoutFeedbackPropsAndroid,
         AccessibilityProps {
     /**
      * Delay in ms, from onPressIn, before onLongPress is called.
@@ -5345,12 +5319,28 @@ export class TouchableHighlight extends TouchableHighlightBase {}
 /**
  * @see https://reactnative.dev/docs/touchableopacity#props
  */
-export interface TouchableOpacityProps extends TouchableWithoutFeedbackProps {
+export interface TouchableOpacityProps extends TouchableWithoutFeedbackProps, TVProps {
     /**
      * Determines what the opacity of the wrapped view should be when touch is active.
      * Defaults to 0.2
      */
     activeOpacity?: number | undefined;
+
+    /**
+     * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
+     *
+     * enabled: If true, parallax effects are enabled.  Defaults to true.
+     * shiftDistanceX: Defaults to 2.0.
+     * shiftDistanceY: Defaults to 2.0.
+     * tiltAngle: Defaults to 0.05.
+     * magnification: Defaults to 1.0.
+     * pressMagnification: Defaults to 1.0.
+     * pressDuration: Defaults to 0.3.
+     * pressDelay: Defaults to 0.0.
+     *
+     * @platform ios
+     */
+    tvParallaxProperties?: TVParallaxProperties | undefined;
 }
 
 /**
@@ -5393,6 +5383,13 @@ type BackgroundPropType = RippleBackgroundPropType | ThemeAttributeBackgroundPro
 
 interface TVProps {
     /**
+     * *(Apple TV only)* TV preferred focus (see documentation for the View component).
+     *
+     * @platform ios
+     */
+    hasTVPreferredFocus?: boolean | undefined;
+
+    /**
      * Designates the next view to receive focus when the user navigates down. See the Android documentation.
      *
      * @platform android
@@ -5429,7 +5426,7 @@ interface TVProps {
 }
 
 /**
- * @see https://reactnative.dev/docs/touchableopacity#props
+ * @see https://reactnative.dev/docs/touchablenativefeedback#props
  */
 export interface TouchableNativeFeedbackProps extends TouchableWithoutFeedbackProps, TVProps {
     /**
@@ -7581,7 +7578,6 @@ export interface BackHandlerStatic {
 }
 export interface ButtonProps
     extends Omit<AccessibilityProps, 'accessibilityRole' | 'accessibilityValue'>,
-        Pick<TouchableWithoutFeedbackPropsIOS, 'hasTVPreferredFocus'>,
         TouchableWithoutFeedbackPropsAndroid,
         TVProps {
     /**

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5394,35 +5394,35 @@ type BackgroundPropType = RippleBackgroundPropType | ThemeAttributeBackgroundPro
 interface TVProps {
     /**
      * Designates the next view to receive focus when the user navigates down. See the Android documentation.
-     * 
+     *
      * @platform android
      */
     nextFocusDown?: number | undefined;
 
     /**
      * Designates the next view to receive focus when the user navigates forward. See the Android documentation.
-     * 
+     *
      * @platform android
      */
     nextFocusForward?: number | undefined;
 
     /**
      * Designates the next view to receive focus when the user navigates left. See the Android documentation.
-     * 
+     *
      * @platform android
      */
     nextFocusLeft?: number | undefined;
 
     /**
      * Designates the next view to receive focus when the user navigates right. See the Android documentation.
-     * 
+     *
      * @platform android
      */
     nextFocusRight?: number | undefined;
 
     /**
      * Designates the next view to receive focus when the user navigates up. See the Android documentation.
-     * 
+     *
      * @platform android
      */
     nextFocusUp?: number | undefined;
@@ -7579,9 +7579,9 @@ export interface BackHandlerStatic {
     addEventListener(eventName: BackPressEventName, handler: () => boolean | null | undefined): NativeEventSubscription;
     removeEventListener(eventName: BackPressEventName, handler: () => boolean | null | undefined): void;
 }
-export interface ButtonProps 
-    extends Omit<AccessibilityProps, 'accessibilityRole' | 'accessibilityValue'>, 
-        Pick<TouchableWithoutFeedbackPropsIOS, "hasTVPreferredFocus">, 
+export interface ButtonProps
+    extends Omit<AccessibilityProps, 'accessibilityRole' | 'accessibilityValue'>,
+        Pick<TouchableWithoutFeedbackPropsIOS, 'hasTVPreferredFocus'>,
         TouchableWithoutFeedbackPropsAndroid,
         TVProps {
     /**

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5391,10 +5391,47 @@ interface ThemeAttributeBackgroundPropType extends BaseBackgroundPropType {
 
 type BackgroundPropType = RippleBackgroundPropType | ThemeAttributeBackgroundPropType;
 
+interface TVProps {
+    /**
+     * Designates the next view to receive focus when the user navigates down. See the Android documentation.
+     * 
+     * @platform android
+     */
+    nextFocusDown?: number | undefined;
+
+    /**
+     * Designates the next view to receive focus when the user navigates forward. See the Android documentation.
+     * 
+     * @platform android
+     */
+    nextFocusForward?: number | undefined;
+
+    /**
+     * Designates the next view to receive focus when the user navigates left. See the Android documentation.
+     * 
+     * @platform android
+     */
+    nextFocusLeft?: number | undefined;
+
+    /**
+     * Designates the next view to receive focus when the user navigates right. See the Android documentation.
+     * 
+     * @platform android
+     */
+    nextFocusRight?: number | undefined;
+
+    /**
+     * Designates the next view to receive focus when the user navigates up. See the Android documentation.
+     * 
+     * @platform android
+     */
+    nextFocusUp?: number | undefined;
+}
+
 /**
  * @see https://reactnative.dev/docs/touchableopacity#props
  */
-export interface TouchableNativeFeedbackProps extends TouchableWithoutFeedbackProps {
+export interface TouchableNativeFeedbackProps extends TouchableWithoutFeedbackProps, TVProps {
     /**
      * Determines the type of background drawable that's going to be used to display feedback.
      * It takes an object with type property and extra data depending on the type.
@@ -7542,19 +7579,35 @@ export interface BackHandlerStatic {
     addEventListener(eventName: BackPressEventName, handler: () => boolean | null | undefined): NativeEventSubscription;
     removeEventListener(eventName: BackPressEventName, handler: () => boolean | null | undefined): void;
 }
-
-export interface ButtonProps {
+export interface ButtonProps 
+    extends Omit<AccessibilityProps, 'accessibilityRole' | 'accessibilityValue'>, 
+        Pick<TouchableWithoutFeedbackPropsIOS, "hasTVPreferredFocus">, 
+        TouchableWithoutFeedbackPropsAndroid,
+        TVProps {
+    /**
+     * Text to display inside the button. On Android the given title will be converted to the uppercased form.
+     */
     title: string;
+
+    /**
+     * Handler to be called when the user taps the button.
+     */
     onPress: (ev: NativeSyntheticEvent<NativeTouchEvent>) => void;
+
+    /**
+     * Color of the text (iOS), or background color of the button (Android).
+     */
     color?: ColorValue | undefined;
-    accessibilityLabel?: string | undefined;
+
+    /**
+     * If true, disable all interactions for this component.
+     */
     disabled?: boolean | undefined;
 
     /**
      * Used to locate this button in end-to-end tests.
      */
     testID?: string | undefined;
-    accessibilityState?: AccessibilityState | undefined;
 }
 
 export class Button extends React.Component<ButtonProps> {}

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5155,6 +5155,8 @@ interface TouchableMixin {
     touchableGetHitSlop(): Insets;
 }
 
+export interface TouchableWithoutFeedbackPropsIOS {}
+
 export interface TouchableWithoutFeedbackPropsAndroid {
     /**
      * If true, doesn't play a system sound on touch.
@@ -5168,7 +5170,8 @@ export interface TouchableWithoutFeedbackPropsAndroid {
  * @see https://reactnative.dev/docs/touchablewithoutfeedback#props
  */
 export interface TouchableWithoutFeedbackProps
-    extends TouchableWithoutFeedbackPropsAndroid,
+    extends TouchableWithoutFeedbackPropsIOS,
+        TouchableWithoutFeedbackPropsAndroid,
         AccessibilityProps {
     /**
      * Delay in ms, from onPressIn, before onLongPress is called.
@@ -5338,7 +5341,7 @@ export interface TouchableOpacityProps extends TouchableWithoutFeedbackProps, TV
      * pressDuration: Defaults to 0.3.
      * pressDelay: Defaults to 0.0.
      *
-     * @platform ios
+     * @platform android
      */
     tvParallaxProperties?: TVParallaxProperties | undefined;
 }
@@ -7576,34 +7579,32 @@ export interface BackHandlerStatic {
     addEventListener(eventName: BackPressEventName, handler: () => boolean | null | undefined): NativeEventSubscription;
     removeEventListener(eventName: BackPressEventName, handler: () => boolean | null | undefined): void;
 }
+
 export interface ButtonProps
-    extends Pick<AccessibilityProps, 'accessibilityState' | 'accessibilityLabel'>,
-        TouchableWithoutFeedbackPropsAndroid,
-        TVProps {
+    extends Pick<
+        TouchableNativeFeedbackProps & TouchableOpacityProps,
+        | "accessibilityLabel"
+        | "accessibilityState"
+        | "hasTVPreferredFocus"
+        | "nextFocusDown"
+        | "nextFocusForward"
+        | "nextFocusLeft"
+        | "nextFocusRight"
+        | "nextFocusUp"
+        | "testID"
+        | "disabled"
+        | "onPress"
+        | "touchSoundDisabled"
+    > {
     /**
      * Text to display inside the button. On Android the given title will be converted to the uppercased form.
      */
     title: string;
 
     /**
-     * Handler to be called when the user taps the button.
-     */
-    onPress: (ev: NativeSyntheticEvent<NativeTouchEvent>) => void;
-
-    /**
      * Color of the text (iOS), or background color of the button (Android).
      */
     color?: ColorValue | undefined;
-
-    /**
-     * If true, disable all interactions for this component.
-     */
-    disabled?: boolean | undefined;
-
-    /**
-     * Used to locate this button in end-to-end tests.
-     */
-    testID?: string | undefined;
 }
 
 export class Button extends React.Component<ButtonProps> {}

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7577,7 +7577,7 @@ export interface BackHandlerStatic {
     removeEventListener(eventName: BackPressEventName, handler: () => boolean | null | undefined): void;
 }
 export interface ButtonProps
-    extends Omit<AccessibilityProps, 'accessibilityRole' | 'accessibilityValue'>,
+    extends Pick<AccessibilityProps, 'accessibilityState' | 'accessibilityLabel'>,
         TouchableWithoutFeedbackPropsAndroid,
         TVProps {
     /**


### PR DESCRIPTION
Adds missing component props for `Button` and the props they pass into for `TouchableOpacity` and `TouchableNativeFeedback` 

Discussion here: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/56288#discussioncomment-1441532

I'd note that there are quite a bit of discrepancies on React-Native's docs here on `Button` as well as the other two components versus their original source code. I'll probably be over there next fixing docs...
* Reformatted `button` and added missing props, soon to use accessibilityProps more in v0.66+ of react-native
* Some docs which mistakenly state a prop that don't actually do anything. I've left this in for now but a note will have to be made to change this one the confusion on docs is cleared up `TouchableOpacity` has [tvParallaxProperties](https://reactnative.dev/docs/touchableopacity#tvparallaxproperties-android), which doesn't do anything in [src](https://github.com/facebook/react-native/blob/main/Libraries/Components/Touchable/TouchableOpacity.js)
* Shifted wrong types outside of `TouchableWithoutFeedbackProps`, and into their places where they are actually required as a type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test react-native`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://reactnative.dev/docs/0.65/button>>
<<https://github.com/facebook/react-native/blob/v0.65.0/Libraries/Components/Button.js>>
<<https://reactnative.dev/docs/0.65/touchableopacity#props>>
<<https://github.com/facebook/react-native/blob/v0.65.0/Libraries/Components/Touchable/TouchableOpacity.js>>
<<https://reactnative.dev/docs/0.65/touchablenativefeedback#props>>
<<https://github.com/facebook/react-native/blob/v0.65.0/Libraries/Components/Touchable/TouchableNativeFeedback.js>>
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


