### PR TITLE
Fix wrong k6 SharedArray type

### DIFF
--- a/types/k6/data.d.ts
+++ b/types/k6/data.d.ts
@@ -7,5 +7,5 @@ export const SharedArray: {
      * Given a name and a function that returns an array, the SharedArray constructor returns the same array but sharing the array memory between VUs.
      * https://k6.io/docs/javascript-api/k6-data/sharedarray/
      */
-    new(name: string, callback: () => []): [];
+    new<T>(name: string, callback: () => T[]): T[];
 };

--- a/types/k6/test/data.ts
+++ b/types/k6/test/data.ts
@@ -1,3 +1,9 @@
 import { SharedArray } from 'k6/data';
 
-new SharedArray('hola', () => []); // $ExpectType []
+interface Foo {
+  bar: string
+}
+
+const foos: Foo[] = [{bar: "a"}, {bar: "a"}]
+
+new SharedArray('hola', () => foos); // $ExpectType Foo[]

--- a/types/k6/test/data.ts
+++ b/types/k6/test/data.ts
@@ -1,9 +1,9 @@
 import { SharedArray } from 'k6/data';
 
 interface Foo {
-  bar: string
+  readonly bar: string;
 }
 
-const foos: Foo[] = [{bar: "a"}, {bar: "a"}]
+const foos: Foo[] = [{bar: "a"}, {bar: "a"}];
 
 new SharedArray('hola', () => foos); // $ExpectType Foo[]


### PR DESCRIPTION
In Typescript type `[]` means empty array, so there is no other option than casting a non-empty array into an empty one to be able to use this. Look at the example below. 

```
interface Foo {
  bar: string
}

const foos: Foo[] = [{bar: "a"}, {bar: "a"}]

const fooData = new SharedArray("Foo Data", () => {
  return foos; 
});
```

This end up with the following error:

```
TS2345: Argument of type '() => Foo[]' is not assignable to parameter of type '() => []'.   
Type 'Foo[]' is not assignable to type '[]'.     
Target allows only 0 element(s) but source may have more.
```

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
