### PR TITLE
[ioredis] fix xreadgroup command typing

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1286,7 +1286,7 @@ declare namespace IORedis {
 
         xread: OverloadedListCommand<ValueType, Array<[string, Array<[string, string[]]>]>>;
 
-        xreadgroup: OverloadedListCommand<ValueType, Array<[string, Array<[string, string[]]>]>>;
+        xreadgroup: OverloadedKeyCommand<ValueType, Array<[string, Array<[string, string[]]>]>>;
 
         xrevrange: OverloadedKeyCommand<ValueType, Array<[string, string[]]>>;
 

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1286,7 +1286,7 @@ declare namespace IORedis {
 
         xread: OverloadedListCommand<ValueType, Array<[string, Array<[string, string[]]>]>>;
 
-        xreadgroup: OverloadedKeyCommand<ValueType, Array<[string, string[]]>>;
+        xreadgroup: OverloadedListCommand<ValueType, Array<[string, Array<[string, string[]]>]>>;
 
         xrevrange: OverloadedKeyCommand<ValueType, Array<[string, string[]]>>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://redis.io/commands/xread> <https://redis.io/topics/streams-intro#:~:text=xreadgroup%20group%20mygroup%20alice%20count%201%20streams%20mystream%20%3E>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

