### PR TITLE
[react] Replace deprecated SFCElement in favor of FunctionComponentElement

### DIFF
--- a/types/mirrorx/index.d.ts
+++ b/types/mirrorx/index.d.ts
@@ -123,7 +123,7 @@ export interface Renderer {
   ): Element;
 
   (
-    element: React.SFCElement<any> | Array<React.SFCElement<any>>,
+    element: React.FunctionComponentElement<any> | Array<React.FunctionComponentElement<any>>,
     container: Element | null,
     callback?: () => void
   ): void;
@@ -154,7 +154,7 @@ export interface Renderer {
 
   (
     parentComponent: React.Component<any> | Array<React.Component<any>>,
-    element: React.SFCElement<any>,
+    element: React.FunctionComponentElement<any>,
     container: Element,
     callback?: () => void
   ): void;

--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -22,7 +22,7 @@ export as namespace ReactDOM;
 
 import {
     ReactInstance, Component, ComponentState,
-    ReactElement, SFCElement, CElement,
+    ReactElement, FunctionComponentElement, CElement,
     DOMAttributes, DOMElement, ReactNode, ReactPortal
 } from 'react';
 
@@ -77,7 +77,7 @@ export interface Renderer {
     ): Element;
 
     (
-        element: SFCElement<any> | Array<SFCElement<any>>,
+        element: FunctionComponentElement<any> | Array<FunctionComponentElement<any>>,
         container: Container| null,
         callback?: () => void
     ): void;

--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -1,7 +1,7 @@
 import {
     AbstractView, Component, ComponentClass,
     ReactElement, ReactInstance, ClassType,
-    DOMElement, SFCElement, CElement,
+    DOMElement, FunctionComponentElement, CElement,
     ReactHTMLElement, DOMAttributes, SFC
 } from 'react';
 
@@ -157,7 +157,7 @@ export namespace Simulate {
 export function renderIntoDocument<T extends Element>(
     element: DOMElement<any, T>): T;
 export function renderIntoDocument(
-    element: SFCElement<any>): void;
+    element: FunctionComponentElement<any>): void;
 // If we replace `P` with `any` in this overload, then some tests fail because
 // calls to `renderIntoDocument` choose the last overload on the
 // subtype-relation pass and get an undesirably broad return type.  Using `P`
@@ -194,7 +194,7 @@ export function isElementOfType<P extends DOMAttributes<{}>, T extends Element>(
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<P>(
-    element: ReactElement, type: SFC<P>): element is SFCElement<P>;
+    element: ReactElement, type: SFC<P>): element is FunctionComponentElement<P>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */


### PR DESCRIPTION
Prepares for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46691