### PR TITLE
[react-addons-test-utils] Update definitions for 15.6

### DIFF
--- a/types/react-addons-test-utils/index.d.ts
+++ b/types/react-addons-test-utils/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React (react-addons-test-utils) 0.14
+// Type definitions for React (react-addons-test-utils) 15.6
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-addons-test-utils/react-addons-test-utils-tests.ts
+++ b/types/react-addons-test-utils/react-addons-test-utils-tests.ts
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import * as TestUtils from 'react-addons-test-utils';
+import * as DOM from 'react-dom-factories';
+
+declare const container: Element;
+
+interface Props {
+    hello: string;
+    world?: string | null | undefined;
+    foo: number;
+}
+declare class ModernComponent extends React.Component<Props> {}
+
+interface SCProps {
+    foo?: number | undefined;
+}
+function FunctionComponent(props: SCProps) {
+    return props.foo ? DOM.div(null, props.foo) : null;
+}
+
+const props: Props & React.ClassAttributes<any> = {
+    key: 42,
+    ref: 'myComponent42',
+    hello: 'world',
+    foo: 42,
+};
+const element: React.CElement<Props, ModernComponent> = React.createElement(ModernComponent, props);
+const inst: ModernComponent = TestUtils.renderIntoDocument<ModernComponent>(element);
+const node: Element = TestUtils.renderIntoDocument(DOM.div());
+
+TestUtils.Simulate.click(node);
+TestUtils.Simulate.change(node);
+TestUtils.Simulate.keyDown(node, { key: 'Enter', cancelable: false });
+
+const renderer: TestUtils.ShallowRenderer = TestUtils.createRenderer();
+renderer.render(React.createElement(ModernComponent));
+const output: React.ReactElement<Props> = renderer.getRenderOutput();
+
+const foundComponent: ModernComponent = TestUtils.findRenderedComponentWithType(inst, ModernComponent);
+const foundComponents: ModernComponent[] = TestUtils.scryRenderedComponentsWithType(inst, ModernComponent);
+
+// ReactTestUtils custom type guards
+
+const emptyElement1: React.ReactElement<Props> = React.createElement(ModernComponent);
+if (TestUtils.isElementOfType(emptyElement1, FunctionComponent)) {
+    emptyElement1.props.foo;
+}
+const emptyElement2: React.ReactElement<SCProps> = React.createElement(FunctionComponent);
+if (TestUtils.isElementOfType(emptyElement2, FunctionComponent)) {
+    emptyElement2.props.foo;
+}
+
+if (TestUtils.isDOMComponent(container)) {
+    const reassignedContainer: Element = container;
+} else if (TestUtils.isCompositeComponent(new ModernComponent({ hello: 'hi', foo: 3 }))) {
+    new ModernComponent({ hello: 'hi', foo: 3 }).props;
+}

--- a/types/react-addons-test-utils/tsconfig.json
+++ b/types/react-addons-test-utils/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "react-addons-test-utils-tests.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",
@@ -17,6 +18,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "react": [
+                "react/v15"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     }

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -8,7 +8,6 @@ import * as LinkedStateMixin from "react-addons-linked-state-mixin";
 import * as Perf from "react-addons-perf";
 import * as PureRenderMixin from "react-addons-pure-render-mixin";
 import shallowCompare = require("react-addons-shallow-compare");
-import * as TestUtils from "react-addons-test-utils";
 import TransitionGroup = require("react-addons-transition-group");
 import update = require("react-addons-update");
 import createReactClass = require("create-react-class");
@@ -730,44 +729,6 @@ createReactClass({
     mixins: [PureRenderMixin],
     render() { return DOM.div(null); }
 });
-
-//
-// TestUtils addon
-// --------------------------------------------------------------------------
-
-const inst: ModernComponent = TestUtils.renderIntoDocument<ModernComponent>(element);
-const node: Element = TestUtils.renderIntoDocument(DOM.div());
-
-TestUtils.Simulate.click(node);
-TestUtils.Simulate.change(node);
-TestUtils.Simulate.keyDown(node, { key: "Enter", cancelable: false });
-
-const renderer: TestUtils.ShallowRenderer = TestUtils.createRenderer();
-renderer.render(React.createElement(Timer));
-const output: React.ReactElement<React.Props<Timer>> =
-    renderer.getRenderOutput();
-
-const foundComponent: ModernComponent = TestUtils.findRenderedComponentWithType(
-    inst, ModernComponent);
-const foundComponents: ModernComponent[] = TestUtils.scryRenderedComponentsWithType(
-    inst, ModernComponent);
-
-// ReactTestUtils custom type guards
-
-const emptyElement1: React.ReactElement<Props> = React.createElement(ModernComponent);
-if (TestUtils.isElementOfType(emptyElement1, FunctionComponent)) {
-    emptyElement1.props.foo;
-}
-const emptyElement2: React.ReactElement<SCProps> = React.createElement(FunctionComponent);
-if (TestUtils.isElementOfType(emptyElement2, FunctionComponent)) {
-    emptyElement2.props.foo;
-}
-
-if (TestUtils.isDOMComponent(container)) {
-    const reassignedContainer: Element = container;
-} else if (TestUtils.isCompositeComponent(new ModernComponent({ hello: 'hi', foo: 3 }))) {
-    new ModernComponent({ hello: 'hi', foo: 3 }).props;
-}
 
 //
 // TransitionGroup addon

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -8,7 +8,6 @@ import * as LinkedStateMixin from "react-addons-linked-state-mixin";
 import * as Perf from "react-addons-perf";
 import * as PureRenderMixin from "react-addons-pure-render-mixin";
 import shallowCompare = require("react-addons-shallow-compare");
-import * as TestUtils from "react-addons-test-utils";
 import TransitionGroup = require("react-addons-transition-group");
 import update = require("react-addons-update");
 import createReactClass = require("create-react-class");
@@ -725,44 +724,6 @@ createReactClass({
     mixins: [PureRenderMixin],
     render() { return DOM.div(null); }
 });
-
-//
-// TestUtils addon
-// --------------------------------------------------------------------------
-
-const inst: ModernComponent = TestUtils.renderIntoDocument<ModernComponent>(element);
-const node: Element = TestUtils.renderIntoDocument(DOM.div());
-
-TestUtils.Simulate.click(node);
-TestUtils.Simulate.change(node);
-TestUtils.Simulate.keyDown(node, { key: "Enter", cancelable: false });
-
-const renderer: TestUtils.ShallowRenderer = TestUtils.createRenderer();
-renderer.render(React.createElement(Timer));
-const output: React.ReactElement<React.Props<Timer>> =
-    renderer.getRenderOutput();
-
-const foundComponent: ModernComponent = TestUtils.findRenderedComponentWithType(
-    inst, ModernComponent);
-const foundComponents: ModernComponent[] = TestUtils.scryRenderedComponentsWithType(
-    inst, ModernComponent);
-
-// ReactTestUtils custom type guards
-
-const emptyElement1: React.ReactElement<Props> = React.createElement(ModernComponent);
-if (TestUtils.isElementOfType(emptyElement1, FunctionComponent)) {
-    emptyElement1.props.foo;
-}
-const emptyElement2: React.ReactElement<SCProps> = React.createElement(FunctionComponent);
-if (TestUtils.isElementOfType(emptyElement2, FunctionComponent)) {
-    emptyElement2.props.foo;
-}
-
-if (TestUtils.isDOMComponent(container)) {
-    const reassignedContainer: Element = container;
-} else if (TestUtils.isCompositeComponent(new ModernComponent({ hello: 'hi', foo: 3 }))) {
-    new ModernComponent({ hello: 'hi', foo: 3 }).props;
-}
 
 //
 // TransitionGroup addon


### PR DESCRIPTION
Basically just moved the tests from `react/` to `react-addons-test-utils/`

`react-addons-test-utils` only works with React 15 so the types should also use the lowest available typings not the latest (currently v17).

Prepares for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46691 by using deprecated `SFCElement` from pinned major release. Otherwise this package would failing once we remove `SFCElement` from the latest published major.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://unpkg.com/react-addons-test-utils@15.6.2/package.json
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
