### PR TITLE
[parse5] Add `ReadonlyTreeAdapter`

### DIFF
--- a/types/parse5/index.d.ts
+++ b/types/parse5/index.d.ts
@@ -89,7 +89,7 @@ export interface ParserOptions<T extends TreeAdapter = TreeAdapter> {
     treeAdapter?: T | undefined;
 }
 
-export interface SerializerOptions<T extends TreeAdapter = TreeAdapter> {
+export interface SerializerOptions<T extends ReadonlyTreeAdapter = ReadonlyTreeAdapter> {
     /***
      * Specifies input tree format.
      *
@@ -308,59 +308,140 @@ export interface TreeAdapterTypeMap {
     textNode: unknown;
 }
 
-export interface TreeAdapter {
-    adoptAttributes(recipient: unknown, attrs: unknown[]): void;
-    appendChild(parentNode: unknown, newNode: unknown): void;
-    createCommentNode(data: string): unknown;
-    createDocument(): unknown;
-    createDocumentFragment(): unknown;
-    createElement(
-        tagName: string,
-        namespaceURI: string,
-        attrs: unknown[]
-    ): unknown;
-    detachNode(node: unknown): void;
+/**
+ * Tree adapter is a set of utility functions that provides minimal required abstraction layer beetween parser and a specific AST format.
+ * Note that `TreeAdapter` is not designed to be a general purpose AST manipulation library. You can build such library
+ * on top of existing `TreeAdapter` or use one of the existing libraries from npm.
+ *
+ * @see [default implementation](https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/tree-adapters/default.js)
+ */
+export interface ReadonlyTreeAdapter {
+    /**
+     * Returns the given element's attributes in an array, in the form of name-value pairs.
+     * Foreign attributes may contain `namespace` and `prefix` fields as well.
+     *
+     * @param element - Element.
+     */
     getAttrList(element: unknown): unknown[];
+
+    /**
+     * Returns the given node's children in an array.
+     *
+     * @param node - Node.
+     */
     getChildNodes(node: unknown): unknown[];
+
+    /**
+     * Returns the given comment node's content.
+     *
+     * @param commentNode - Comment node.
+     */
     getCommentNodeContent(commentNode: unknown): string;
+
+    /**
+     * Returns [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     *
+     * @param document - Document node.
+     */
     getDocumentMode(document: unknown): unknown;
+
+    /**
+     * Returns the given document type node's name.
+     *
+     * @param doctypeNode - Document type node.
+     */
     getDocumentTypeNodeName(doctypeNode: unknown): string;
+
+    /**
+     * Returns the given document type node's public identifier.
+     *
+     * @param doctypeNode - Document type node.
+     */
     getDocumentTypeNodePublicId(doctypeNode: unknown): string;
+
+    /**
+     * Returns the given document type node's system identifier.
+     *
+     * @param doctypeNode - Document type node.
+     */
     getDocumentTypeNodeSystemId(doctypeNode: unknown): string;
+
+    /**
+     * Returns the first child of the given node.
+     *
+     * @param node - Node.
+     */
     getFirstChild(node: unknown): unknown;
+
+    /**
+     * Returns the given element's namespace.
+     *
+     * @param element - Element.
+     */
     getNamespaceURI(element: unknown): string;
-    getNodeSourceCodeLocation(node: unknown): Location | StartTagLocation | ElementLocation;
+
+    /**
+     * Returns the given node's source code location information.
+     *
+     * @param node - Node.
+     */
+    getNodeSourceCodeLocation(node: unknown): Location | StartTagLocation | ElementLocation | null;
+
+    /**
+     * Returns the given node's parent.
+     *
+     * @param node - Node.
+     */
     getParentNode(node: unknown): unknown;
+
+    /**
+     * Returns the given element's tag name.
+     *
+     * @param element - Element.
+     */
     getTagName(element: unknown): string;
+
+    /**
+     * Returns the given text node's content.
+     *
+     * @param textNode - Text node.
+     */
     getTextNodeContent(textNode: unknown): string;
+
+    /**
+     * Returns the `<template>` element content element.
+     *
+     * @param templateElement - `<template>` element.
+     */
     getTemplateContent(templateElement: unknown): unknown;
-    insertBefore(
-        parentNode: unknown,
-        newNode: unknown,
-        referenceNode: unknown
-    ): void;
-    insertText(parentNode: unknown, text: string): void;
-    insertTextBefore(
-        parentNode: unknown,
-        text: string,
-        referenceNode: unknown
-    ): void;
+
+    /**
+     * Determines if the given node is a comment node.
+     *
+     * @param node - Node.
+     */
     isCommentNode(node: unknown): boolean;
+
+    /**
+     * Determines if the given node is a document type node.
+     *
+     * @param node - Node.
+     */
     isDocumentTypeNode(node: unknown): boolean;
+
+    /**
+     * Determines if the given node is an element.
+     *
+     * @param node - Node.
+     */
     isElementNode(node: unknown): boolean;
+
+    /**
+     * Determines if the given node is a text node.
+     *
+     * @param node - Node.
+     */
     isTextNode(node: unknown): boolean;
-    setDocumentMode(document: unknown, mode: DocumentMode): void;
-    setDocumentType(
-        document: unknown,
-        name: string,
-        publicId: string,
-        systemId: string
-    ): void;
-    setNodeSourceCodeLocation(node: unknown, location: Location | StartTagLocation | ElementLocation): void;
-    setTemplateContent(
-        templateElement: unknown,
-        contentElement: unknown
-    ): void;
 }
 
 /**
@@ -370,14 +451,14 @@ export interface TreeAdapter {
  *
  * @see [default implementation](https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/tree-adapters/default.js)
  */
-export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdapter {
+export interface TreeAdapter extends ReadonlyTreeAdapter {
     /**
      * Copies attributes to the given element. Only attributes that are not yet present in the element are copied.
      *
      * @param recipient - Element to copy attributes into.
      * @param attrs - Attributes to copy.
      */
-    adoptAttributes(recipient: T['element'], attrs: Array<T['attribute']>): void;
+    adoptAttributes(recipient: unknown, attrs: unknown[]): void;
 
     /**
      * Appends a child node to the given parent node.
@@ -385,24 +466,24 @@ export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdap
      * @param parentNode - Parent node.
      * @param newNode -  Child node.
      */
-    appendChild(parentNode: T['parentNode'], newNode: T['node']): void;
+    appendChild(parentNode: unknown, newNode: unknown): void;
 
     /**
      * Creates a comment node.
      *
      * @param data - Comment text.
      */
-    createCommentNode(data: string): T['commentNode'];
+    createCommentNode(data: string): unknown;
 
     /**
      * Creates a document node.
      */
-    createDocument(): T['document'];
+    createDocument(): unknown;
 
     /**
      * Creates a document fragment node.
      */
-    createDocumentFragment(): T['documentFragment'];
+    createDocumentFragment(): unknown;
 
     /**
      * Creates an element node.
@@ -414,114 +495,15 @@ export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdap
     createElement(
         tagName: string,
         namespaceURI: string,
-        attrs: Array<T['attribute']>
-    ): T['element'];
+        attrs: unknown[]
+    ): unknown;
 
     /**
      * Removes a node from its parent.
      *
      * @param node - Node to remove.
      */
-    detachNode(node: T['node']): void;
-
-    /**
-     * Returns the given element's attributes in an array, in the form of name-value pairs.
-     * Foreign attributes may contain `namespace` and `prefix` fields as well.
-     *
-     * @param element - Element.
-     */
-    getAttrList(element: T['element']): Array<T['attribute']>;
-
-    /**
-     * Returns the given node's children in an array.
-     *
-     * @param node - Node.
-     */
-    getChildNodes(node: T['parentNode']): Array<T['childNode']>;
-
-    /**
-     * Returns the given comment node's content.
-     *
-     * @param commentNode - Comment node.
-     */
-    getCommentNodeContent(commentNode: T['commentNode']): string;
-
-    /**
-     * Returns [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
-     *
-     * @param document - Document node.
-     */
-    getDocumentMode(document: T['document']): DocumentMode;
-
-    /**
-     * Returns the given document type node's name.
-     *
-     * @param doctypeNode - Document type node.
-     */
-    getDocumentTypeNodeName(doctypeNode: T['documentType']): string;
-
-    /**
-     * Returns the given document type node's public identifier.
-     *
-     * @param doctypeNode - Document type node.
-     */
-    getDocumentTypeNodePublicId(doctypeNode: T['documentType']): string;
-
-    /**
-     * Returns the given document type node's system identifier.
-     *
-     * @param doctypeNode - Document type node.
-     */
-    getDocumentTypeNodeSystemId(doctypeNode: T['documentType']): string;
-
-    /**
-     * Returns the first child of the given node.
-     *
-     * @param node - Node.
-     */
-    getFirstChild(node: T['parentNode']): T['childNode']|undefined;
-
-    /**
-     * Returns the given element's namespace.
-     *
-     * @param element - Element.
-     */
-    getNamespaceURI(element: T['element']): string;
-
-    /**
-     * Returns the given node's source code location information.
-     *
-     * @param node - Node.
-     */
-    getNodeSourceCodeLocation(node: T['node']): Location | StartTagLocation | ElementLocation;
-
-    /**
-     * Returns the given node's parent.
-     *
-     * @param node - Node.
-     */
-    getParentNode(node: T['childNode']): T['parentNode'];
-
-    /**
-     * Returns the given element's tag name.
-     *
-     * @param element - Element.
-     */
-    getTagName(element: T['element']): string;
-
-    /**
-     * Returns the given text node's content.
-     *
-     * @param textNode - Text node.
-     */
-    getTextNodeContent(textNode: T['textNode']): string;
-
-    /**
-     * Returns the `<template>` element content element.
-     *
-     * @param templateElement - `<template>` element.
-     */
-    getTemplateContent(templateElement: T['element']): T['documentFragment'];
+    detachNode(node: unknown): void;
 
     /**
      * Inserts a child node to the given parent node before the given reference node.
@@ -531,9 +513,9 @@ export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdap
      * @param referenceNode -  Reference node.
      */
     insertBefore(
-        parentNode: T['parentNode'],
-        newNode: T['node'],
-        referenceNode: T['node']
+        parentNode: unknown,
+        newNode: unknown,
+        referenceNode: unknown
     ): void;
 
     /**
@@ -543,7 +525,7 @@ export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdap
      * @param parentNode - Node to insert text into.
      * @param text - Text to insert.
      */
-    insertText(parentNode: T['parentNode'], text: string): void;
+    insertText(parentNode: unknown, text: string): void;
 
     /**
      * Inserts text into a sibling node that goes before the reference node. If this sibling node is the text node,
@@ -555,38 +537,10 @@ export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdap
      * @param referenceNode - Node to insert text before.
      */
     insertTextBefore(
-        parentNode: T['parentNode'],
+        parentNode: unknown,
         text: string,
-        referenceNode: T['node']
+        referenceNode: unknown
     ): void;
-
-    /**
-     * Determines if the given node is a comment node.
-     *
-     * @param node - Node.
-     */
-    isCommentNode(node: T['node']): node is T['commentNode'];
-
-    /**
-     * Determines if the given node is a document type node.
-     *
-     * @param node - Node.
-     */
-    isDocumentTypeNode(node: T['node']): node is T['documentType'];
-
-    /**
-     * Determines if the given node is an element.
-     *
-     * @param node - Node.
-     */
-    isElementNode(node: T['node']): node is T['element'];
-
-    /**
-     * Determines if the given node is a text node.
-     *
-     * @param node - Node.
-     */
-    isTextNode(node: T['node']): node is T['textNode'];
 
     /**
      * Sets the [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
@@ -594,7 +548,7 @@ export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdap
      * @param document - Document node.
      * @param mode - Document mode.
      */
-    setDocumentMode(document: T['document'], mode: DocumentMode): void;
+    setDocumentMode(document: unknown, mode: DocumentMode): void;
 
     /**
      * Sets the document type. If the `document` already contains a document type node, the `name`, `publicId` and `systemId`
@@ -607,7 +561,7 @@ export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdap
      * @param systemId - Document type system identifier.
      */
     setDocumentType(
-        document: T['document'],
+        document: unknown,
         name: string,
         publicId: string,
         systemId: string
@@ -618,7 +572,10 @@ export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdap
      *
      * @param node - Node.
      */
-    setNodeSourceCodeLocation(node: T['node'], location: Location | StartTagLocation | ElementLocation): void;
+    setNodeSourceCodeLocation(
+        node: unknown,
+        location: Location | StartTagLocation | ElementLocation | null,
+    ): void;
 
     /**
      * Sets the `<template>` element content element.
@@ -627,8 +584,100 @@ export interface TypedTreeAdapter<T extends TreeAdapterTypeMap> extends TreeAdap
      * @param contentElement -  Content element.
      */
     setTemplateContent(
+        templateElement: unknown,
+        contentElement: unknown
+    ): void;
+
+    /**
+     * Updates source code location information of the node.
+     *
+     * @param node - Node.
+     */
+    updateNodeSourceCodeLocation(
+        node: unknown,
+        location: Partial<Location> | Partial<StartTagLocation> | Partial<ElementLocation>,
+    ): void;
+}
+
+/**
+ * Tree adapter is a set of utility functions that provides minimal required abstraction layer beetween parser and a specific AST format.
+ * Note that `TreeAdapter` is not designed to be a general purpose AST manipulation library. You can build such library
+ * on top of existing `TreeAdapter` or use one of the existing libraries from npm.
+ *
+ * @see [default implementation](https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/tree-adapters/default.js)
+ */
+export interface ReadonlyTypedTreeAdapter<T extends TreeAdapterTypeMap> extends ReadonlyTreeAdapter {
+    getAttrList(element: T['element']): Array<T['attribute']>;
+    getChildNodes(node: T['parentNode']): Array<T['childNode']>;
+    getCommentNodeContent(commentNode: T['commentNode']): string;
+    getDocumentMode(document: T['document']): DocumentMode;
+    getDocumentTypeNodeName(doctypeNode: T['documentType']): string;
+    getDocumentTypeNodePublicId(doctypeNode: T['documentType']): string;
+    getDocumentTypeNodeSystemId(doctypeNode: T['documentType']): string;
+    getFirstChild(node: T['parentNode']): T['childNode'] | undefined;
+    getNamespaceURI(element: T['element']): string;
+    getNodeSourceCodeLocation(node: T['node']): Location | StartTagLocation | ElementLocation | null;
+    getParentNode(node: T['childNode']): T['parentNode'];
+    getTagName(element: T['element']): string;
+    getTextNodeContent(textNode: T['textNode']): string;
+    getTemplateContent(templateElement: T['element']): T['documentFragment'];
+    isCommentNode(node: T['node']): node is T['commentNode'];
+    isDocumentTypeNode(node: T['node']): node is T['documentType'];
+    isElementNode(node: T['node']): node is T['element'];
+    isTextNode(node: T['node']): node is T['textNode'];
+}
+
+/**
+ * Tree adapter is a set of utility functions that provides minimal required abstraction layer beetween parser and a specific AST format.
+ * Note that `TreeAdapter` is not designed to be a general purpose AST manipulation library. You can build such library
+ * on top of existing `TreeAdapter` or use one of the existing libraries from npm.
+ *
+ * @see [default implementation](https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/tree-adapters/default.js)
+ */
+export interface TypedTreeAdapter<T extends TreeAdapterTypeMap>
+    extends ReadonlyTypedTreeAdapter<T>,
+        // Omit<...> is necessary in order to not need to duplicate definitions from `ReadonlyTypedTreeAdapter`
+        Omit<TreeAdapter, keyof ReadonlyTreeAdapter> {
+    adoptAttributes(recipient: T['element'], attrs: Array<T['attribute']>): void;
+    appendChild(parentNode: T['parentNode'], newNode: T['node']): void;
+    createCommentNode(data: string): T['commentNode'];
+    createDocument(): T['document'];
+    createDocumentFragment(): T['documentFragment'];
+    createElement(
+        tagName: string,
+        namespaceURI: string,
+        attrs: Array<T['attribute']>
+    ): T['element'];
+    detachNode(node: T['node']): void;
+    insertBefore(
+        parentNode: T['parentNode'],
+        newNode: T['node'],
+        referenceNode: T['node']
+    ): void;
+    insertText(parentNode: T['parentNode'], text: string): void;
+    insertTextBefore(
+        parentNode: T['parentNode'],
+        text: string,
+        referenceNode: T['node']
+    ): void;
+    setDocumentMode(document: T['document'], mode: DocumentMode): void;
+    setDocumentType(
+        document: T['document'],
+        name: string,
+        publicId: string,
+        systemId: string
+    ): void;
+    setNodeSourceCodeLocation(
+        node: T['node'],
+        location: Location | StartTagLocation | ElementLocation | null,
+    ): void;
+    setTemplateContent(
         templateElement: T['element'],
         contentElement: T['documentFragment']
+    ): void;
+    updateNodeSourceCodeLocation(
+        node: T['node'],
+        location: Partial<Location> | Partial<StartTagLocation> | Partial<ElementLocation>,
     ): void;
 }
 
@@ -705,6 +754,6 @@ export function parseFragment<T extends TreeAdapter = typeof import('./lib/tree-
  * console.log(str); //> '<head></head><body>Hi there!</body>'
  * ```
  */
-export function serialize<T extends TreeAdapter = typeof import('./lib/tree-adapters/default')>(
-    node: T extends TypedTreeAdapter<infer TMap> ? TMap['node'] : Node,
+export function serialize<T extends ReadonlyTreeAdapter = import('./lib/tree-adapters/default').Readonly>(
+    node: T extends ReadonlyTypedTreeAdapter<infer TMap> ? TMap['node'] : Node,
     options?: SerializerOptions<T>): string;

--- a/types/parse5/lib/tree-adapters/default.d.ts
+++ b/types/parse5/lib/tree-adapters/default.d.ts
@@ -13,6 +13,10 @@ interface TreeAdapterTypeMap extends parse5.TreeAdapterTypeMap {
     textNode: parse5.TextNode;
 }
 
+declare namespace treeAdapter {
+    type Readonly = parse5.ReadonlyTypedTreeAdapter<TreeAdapterTypeMap>;
+}
+
 declare const treeAdapter: parse5.TypedTreeAdapter<TreeAdapterTypeMap>;
 
 export = treeAdapter;

--- a/types/parse5/parse5-tests.ts
+++ b/types/parse5/parse5-tests.ts
@@ -1,4 +1,4 @@
-import * as parse5 from "parse5";
+import parse5 = require("parse5");
 import defaultAdapter = require("parse5/lib/tree-adapters/default");
 
 // Shorthands
@@ -67,8 +67,10 @@ const html = parse5.serialize(element);
 
 html; // $ExpectType string
 
+const readonlyAdapter: defaultAdapter.Readonly = defaultAdapter;
+
 parse5.serialize(element, { treeAdapter: defaultAdapter });
-parse5.serialize(element, { treeAdapter: defaultAdapter });
+parse5.serialize(element, { treeAdapter: readonlyAdapter });
 
 // Location info
 const loc = element.sourceCodeLocation!;
@@ -102,6 +104,8 @@ loc.endTag.startOffset; // $ExpectType number
 loc.endTag.endOffset; // $ExpectType number
 
 // Default AST
+declare const defaultNode: parse5.Node;
+
 declare const defaultDocument: parse5.Document;
 
 defaultDocument.childNodes; // $ExpectType ChildNode[]
@@ -165,11 +169,13 @@ adapter.insertBefore(document, element, element);
 adapter.setTemplateContent(element, fragment);
 
 adapter.getTemplateContent(element); // $ExpectType DocumentFragment
+readonlyAdapter.getTemplateContent(element); // $ExpectType DocumentFragment
 
 adapter.setDocumentType(document, "name", "publicId", "systemId");
 adapter.setDocumentMode(document, "quirks");
 
 adapter.getDocumentMode(document); // $ExpectType DocumentMode
+readonlyAdapter.getDocumentMode(document); // $ExpectType DocumentMode
 
 adapter.detachNode(element);
 adapter.insertText(element, "text");
@@ -187,12 +193,63 @@ adapter.getCommentNodeContent(defaultCommentNode); // $ExpectType string
 adapter.getDocumentTypeNodeName(defaultDoctype); // $ExpectType string
 adapter.getDocumentTypeNodePublicId(defaultDoctype); // $ExpectType string
 adapter.getDocumentTypeNodeSystemId(defaultDoctype); // $ExpectType string
+
+readonlyAdapter.getFirstChild(element); // $ExpectType Element | CommentNode | TextNode | undefined || ChildNode | undefined
+readonlyAdapter.getChildNodes(element)[0]; // $ExpectType ChildNode
+readonlyAdapter.getParentNode(element); // $ExpectType ParentNode
+readonlyAdapter.getAttrList(element)[0]; // $ExpectType Attribute
+readonlyAdapter.getTagName(element); // $ExpectType string
+readonlyAdapter.getNamespaceURI(element); // $ExpectType string
+readonlyAdapter.getTextNodeContent(defaultTextNode); // $ExpectType string
+readonlyAdapter.getCommentNodeContent(defaultCommentNode); // $ExpectType string
+readonlyAdapter.getDocumentTypeNodeName(defaultDoctype); // $ExpectType string
+readonlyAdapter.getDocumentTypeNodePublicId(defaultDoctype); // $ExpectType string
+readonlyAdapter.getDocumentTypeNodeSystemId(defaultDoctype); // $ExpectType string
+
 adapter.isTextNode(element); // $ExpectType boolean
 adapter.isCommentNode(element); // $ExpectType boolean
 adapter.isDocumentTypeNode(element); // $ExpectType boolean
 adapter.isElementNode(element); // $ExpectType boolean
+if (adapter.isTextNode(defaultNode)) {
+    defaultNode; // $ExpectType TextNode
+}
+if (adapter.isCommentNode(defaultNode)) {
+    defaultNode; // $ExpectType CommentNode
+}
+if (adapter.isDocumentTypeNode(defaultNode)) {
+    defaultNode; // $ExpectType DocumentType
+}
+if (adapter.isElementNode(defaultNode)) {
+    defaultNode; // $ExpectType Element
+}
+
+readonlyAdapter.isTextNode(element); // $ExpectType boolean
+readonlyAdapter.isCommentNode(element); // $ExpectType boolean
+readonlyAdapter.isDocumentTypeNode(element); // $ExpectType boolean
+readonlyAdapter.isElementNode(element); // $ExpectType boolean
+if (readonlyAdapter.isTextNode(defaultNode)) {
+    defaultNode; // $ExpectType TextNode
+}
+if (readonlyAdapter.isCommentNode(defaultNode)) {
+    defaultNode; // $ExpectType CommentNode
+}
+if (readonlyAdapter.isDocumentTypeNode(defaultNode)) {
+    defaultNode; // $ExpectType DocumentType
+}
+if (readonlyAdapter.isElementNode(defaultNode)) {
+    defaultNode; // $ExpectType Element
+}
 
 declare const location: parse5.ElementLocation | parse5.StartTagLocation | parse5.Location;
+declare const nullableLocation: typeof location | null;
+declare const partialLocation: Partial<typeof location>;
 
 adapter.setNodeSourceCodeLocation(defaultTextNode, location); // $ExpectType void
-adapter.getNodeSourceCodeLocation(defaultTextNode); // $ExpectType Location | StartTagLocation | ElementLocation
+adapter.setNodeSourceCodeLocation(defaultTextNode, nullableLocation); // $ExpectType void
+adapter.updateNodeSourceCodeLocation(defaultTextNode, partialLocation); // $ExpectType void
+
+// $ExpectType Location | StartTagLocation | ElementLocation | null || ElementLocation | StartTagLocation | Location | null
+adapter.getNodeSourceCodeLocation(defaultTextNode);
+
+// $ExpectType Location | StartTagLocation | ElementLocation | null || ElementLocation | StartTagLocation | Location | null
+readonlyAdapter.getNodeSourceCodeLocation(defaultTextNode);


### PR DESCRIPTION
This is because `parse5.serialize(…)` only reads the tree, and therefore doesn’t need the `create*`, `set*`, and `update*` methods.

I also moved the **TSDoc** comments from `TypedTreeAdapter` to `TreeAdapter` so that they’re inherited correctly even when only `extends TreeAdapter` is used, which is why the diff is ugly.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/inikulin/parse5/blob/master/packages/parse5/lib/serializer/index.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
