### PR TITLE
[node] Support null data argument for readline.write

### DIFF
--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -236,6 +236,7 @@ declare module 'readline' {
          * @since v0.1.98
          */
         write(data: string | Buffer, key?: Key): void;
+        write(data: undefined | null | string | Buffer, key: Key): void;
         /**
          * Returns the real position of the cursor in relation to the input
          * prompt + string. Long input (wrapping) strings, as well as multiple

--- a/types/node/test/readline.ts
+++ b/types/node/test/readline.ts
@@ -92,6 +92,19 @@ const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
 }
 
 {
+    const data: undefined | null | string | Buffer = null;
+    const key: readline.Key = { ctrl: true, name: 'u' };
+
+    rl.line; // $ExpectType string
+    rl.cursor; // $ExpectType number
+
+    rl.write(data, key);
+
+    rl.line; // $ExpectType string
+    rl.cursor; // $ExpectType number
+}
+
+{
     const strm: NodeJS.WritableStream = new stream.Writable();
     const x = 1;
     const y = 1;

--- a/types/node/v12/readline.d.ts
+++ b/types/node/v12/readline.d.ts
@@ -45,6 +45,7 @@ declare module 'readline' {
         resume(): this;
         close(): void;
         write(data: string | Buffer, key?: Key): void;
+        write(data: undefined | null | string | Buffer, key: Key): void;
 
         /**
          * events.EventEmitter

--- a/types/node/v12/test/readline.ts
+++ b/types/node/v12/test/readline.ts
@@ -83,6 +83,19 @@ const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
 }
 
 {
+    const data: undefined | null | string | Buffer = null;
+    const key: readline.Key = { ctrl: true, name: 'u' };
+
+    rl.line; // $ExpectType string
+    rl.cursor; // $ExpectType number
+
+    rl.write(data, key);
+
+    rl.line; // $ExpectType string
+    rl.cursor; // $ExpectType number
+}
+
+{
     const strm: NodeJS.WritableStream = new stream.Writable();
     const x = 1;
     const y = 1;

--- a/types/node/v14/readline.d.ts
+++ b/types/node/v14/readline.d.ts
@@ -45,6 +45,7 @@ declare module 'readline' {
         resume(): this;
         close(): void;
         write(data: string | Buffer, key?: Key): void;
+        write(data: undefined | null | string | Buffer, key: Key): void;
 
         /**
          * Returns the real position of the cursor in relation to the input

--- a/types/node/v14/test/readline.ts
+++ b/types/node/v14/test/readline.ts
@@ -87,6 +87,19 @@ const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
 }
 
 {
+    const data: undefined | null | string | Buffer = null;
+    const key: readline.Key = { ctrl: true, name: 'u' };
+
+    rl.line; // $ExpectType string
+    rl.cursor; // $ExpectType number
+
+    rl.write(data, key);
+
+    rl.line; // $ExpectType string
+    rl.cursor; // $ExpectType number
+}
+
+{
     const strm: NodeJS.WritableStream = new stream.Writable();
     const x = 1;
     const y = 1;


### PR DESCRIPTION
Node's `readline.write(data, key?)` method supports a `null` data argument, and to my knowledge has support in all LTS versions going back as far as v4, perhaps even further. The documentation (see [v10](https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_rl_write_data_key), [v12](https://nodejs.org/dist/latest-v12.x/docs/api/readline.html#readline_rl_write_data_key), [v14](https://nodejs.org/dist/latest-v14.x/docs/api/readline.html#readline_rl_write_data_key), and [v16](https://nodejs.org/dist/latest-v16.x/docs/api/readline.html#readline_rl_write_data_key)) include an example of this when triggering key combinations and escape characters to the prompt:

```js
rl.write('Delete this!');
// Simulate Ctrl+U to delete the line written previously
rl.write(null, { ctrl: true, name: 'u' });
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://nodejs.org/dist/latest-v16.x/docs/api/readline.html#readline_rl_write_data_key](https://nodejs.org/dist/latest-v16.x/docs/api/readline.html#readline_rl_write_data_key)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
