### PR TITLE
[react] Allow assigning a "wider" React.Component to React.JSXElementConstructor

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -83,7 +83,7 @@ declare namespace React {
 
     type JSXElementConstructor<P> =
         | ((props: P) => ReactElement<any, any> | null)
-        | (new (props: P) => Component<P, any>);
+        | (new (props: P) => Component<any, any>);
 
     interface RefObject<T> {
         readonly current: T | null;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -906,3 +906,35 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     type: 'single',
     value: [2],
 };
+
+// JSXElemenConstructor vs Component assignability
+{
+    interface ExactProps {
+        value: 'A' | 'B';
+    }
+    interface NarrowerProps {
+        value: 'A';
+    }
+    interface WiderProps {
+        value: 'A' | 'B' | 'C';
+    }
+
+    // We don't actually care about the concrete type of `Wrapper` i.e.
+    // we don't care about the value created by `new Wrapper()`.
+    // We only care about the props we can pass to the component.
+    let Wrapper: React.JSXElementConstructor<ExactProps>;
+    // $ExpectError
+    Wrapper = class Narrower extends React.Component<NarrowerProps> {};
+    // $ExpectError
+    Wrapper = (props: NarrowerProps) => null;
+    Wrapper = class Exact extends React.Component<ExactProps> {};
+    Wrapper = (props: ExactProps) => null;
+    // $ExpectError
+    Wrapper = class Wider extends React.Component<WiderProps> {};
+    Wrapper = (props: WiderProps) => null;
+
+    React.createElement(Wrapper, { value: 'A' });
+    React.createElement(Wrapper, { value: 'B' });
+    // $ExpectError
+    React.createElement(Wrapper, { value: 'C' });
+}

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -929,7 +929,6 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     Wrapper = (props: NarrowerProps) => null;
     Wrapper = class Exact extends React.Component<ExactProps> {};
     Wrapper = (props: ExactProps) => null;
-    // $ExpectError
     Wrapper = class Wider extends React.Component<WiderProps> {};
     Wrapper = (props: WiderProps) => null;
 

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -79,7 +79,7 @@ declare namespace React {
 
     type JSXElementConstructor<P> =
         | ((props: P) => ReactElement<any, any> | null)
-        | (new (props: P) => Component<P, any>);
+        | (new (props: P) => Component<any, any>);
 
     interface RefObject<T> {
         readonly current: T | null;

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -891,3 +891,35 @@ const propsWithChildren: React.PropsWithChildren<Props> = {
     foo: 42,
     children: functionComponent,
 };
+
+// JSXElemenConstructor vs Component assignability
+{
+    interface ExactProps {
+        value: 'A' | 'B';
+    }
+    interface NarrowerProps {
+        value: 'A';
+    }
+    interface WiderProps {
+        value: 'A' | 'B' | 'C';
+    }
+
+    // We don't actually care about the concrete type of `Wrapper` i.e.
+    // we don't care about the value created by `new Wrapper()`.
+    // We only care about the props we can pass to the component.
+    let Wrapper: React.JSXElementConstructor<ExactProps>;
+    // $ExpectError
+    Wrapper = class Narrower extends React.Component<NarrowerProps> {};
+    // $ExpectError
+    Wrapper = (props: NarrowerProps) => null;
+    Wrapper = class Exact extends React.Component<ExactProps> {};
+    Wrapper = (props: ExactProps) => null;
+    // $ExpectError
+    Wrapper = class Wider extends React.Component<WiderProps> {};
+    Wrapper = (props: WiderProps) => null;
+
+    React.createElement(Wrapper, { value: 'A' });
+    React.createElement(Wrapper, { value: 'B' });
+    // $ExpectError
+    React.createElement(Wrapper, { value: 'C' });
+}

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -914,7 +914,6 @@ const propsWithChildren: React.PropsWithChildren<Props> = {
     Wrapper = (props: NarrowerProps) => null;
     Wrapper = class Exact extends React.Component<ExactProps> {};
     Wrapper = (props: ExactProps) => null;
-    // $ExpectError
     Wrapper = class Wider extends React.Component<WiderProps> {};
     Wrapper = (props: WiderProps) => null;
 


### PR DESCRIPTION
Review by commit advised.

When we expect a `JSXElementConstructor` we almost never care about the concrete type i.e. we wouldn't directly call it (`Component()`) or instantiate it (and use its value) (`new Component()`). Ideally it would just be an opaque type.

However, TypeScript does have to structurally check the type which fails for newables if the accepted props are wider. These would crash if I actually instantiate the component (`new Component({ value: 'A' })`) and then access the props `component.props.value` because TypeScript thinks `props.value` is `'A' | 'B' | 'C'`. Though this can never happen in React since `this.props` always reflects the input props.

To get the same assignability behavior from `React.Component` and `React.FC` we just `any` the instance props in JSXElementConstructor.

Originally reported in https://github.com/testing-library/react-testing-library/issues/972