### PR TITLE
[carbon-components-react] `Checkbox` accepts a `ref`

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -1201,7 +1201,6 @@ const dataTableSkeletonBasic = (
     <Checkbox
         id=""
         labelText=""
-        // $ExpectError
         ref={inputRef}
     />;
 }

--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -3,6 +3,7 @@ import {
     AccordionItem,
     AspectRatio,
     Button,
+    Checkbox,
     CodeSnippet,
     CodeSnippetType,
     Column,
@@ -1190,4 +1191,17 @@ const dataTableSkeletonBasic = (
             Test
         </Dialog>
     );
+}
+
+//
+// Checkbox
+//
+{
+    const inputRef = React.createRef<HTMLInputElement>();
+    <Checkbox
+        id=""
+        labelText=""
+        // $ExpectError
+        ref={inputRef}
+    />;
 }

--- a/types/carbon-components-react/lib/components/Checkbox/Checkbox.d.ts
+++ b/types/carbon-components-react/lib/components/Checkbox/Checkbox.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ReactInputAttr } from "../../../typings/shared";
+import { ForwardRefReturn, ReactInputAttr } from "../../../typings/shared";
 
 type ExcludedAttributes = "id" | "onChange" | "type";
 
@@ -20,6 +20,6 @@ export interface CheckboxProps extends Omit<ReactInputAttr, ExcludedAttributes> 
     wrapperClassName?: string | undefined,
 }
 
-declare const Checkbox: React.RefForwardingComponent<HTMLInputElement, CheckboxProps>;
+declare const Checkbox: ForwardRefReturn<HTMLInputElement, CheckboxProps>;
 
 export default Checkbox;


### PR DESCRIPTION
Noticed during work for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46691

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://github.com/carbon-design-system/carbon/blob/v10.44.0/packages/react/src/components/Checkbox/Checkbox.js#L48-L68
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
