### PR TITLE
Update index.d.ts

### DIFF
--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -182,6 +182,10 @@ export interface DateRangeProps extends Range, CommonCalendarProps {
     onPreviewChange?: ((preview: Preview) => void) | undefined;
     /** default: none */
     onChange?: ((range: OnDateRangeChangeProps) => void) | undefined;
+    /** default: forwards */
+    calendarFocus?: 'forwards' | 'backwards'
+    /** default: false */
+    preventSnapRefocus?: boolean
 }
 
 export interface DateRangePickerProps extends DateRangeProps {


### PR DESCRIPTION
Changes for version 1.4.0

**1.4.0**
Added
`calendarFocus` prop: Whether calendar focus month should be forward-driven or backwards-driven. can be forwards or backwards (Default: `forwards`)
`preventSnapRefocus` prop: prevents unneceessary refocus of shown range on selection. (Default: `false`)