### PR TITLE
`webpack-node-externals`: upgrade webpack types to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,5 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
-    },
-    "dependencies": {
-        "webpack": "^5.58.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
             "_comment": "This will remove husky from when we started migrating to use prettier",
             "pre-commit": "npm uninstall husky"
         }
+    },
+    "dependencies": {
+        "webpack": "^5.58.1"
     }
 }

--- a/types/webpack-node-externals/index.d.ts
+++ b/types/webpack-node-externals/index.d.ts
@@ -6,11 +6,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
-import { ExternalsFunctionElement } from 'webpack';
+/// <reference types="node" />
+import { ExternalsPlugin } from 'webpack';
 
 export = webpackNodeExternals;
 
-declare function webpackNodeExternals(options?: webpackNodeExternals.Options): ExternalsFunctionElement;
+type GetArrayInnerType<T> = T extends Array<infer U> ? U : never;
+/** The webpack types don't export this so we have to derive it. */
+type ExternalItem = GetArrayInnerType<ExternalsPlugin['externals']>;
+
+declare function webpackNodeExternals(options?: webpackNodeExternals.Options): ExternalItem;
 
 declare namespace webpackNodeExternals {
     type AllowlistOption = string | RegExp | AllowlistFunctionType;

--- a/types/webpack-node-externals/package.json
+++ b/types/webpack-node-externals/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "webpack": "^5"
+    }
+}

--- a/types/webpack-node-externals/tsconfig.json
+++ b/types/webpack-node-externals/tsconfig.json
@@ -14,10 +14,10 @@
         ],
         "paths": {
             "webpack": [
-                "webpack/v4"
+                "./node_modules/webpack"
             ],
             "tapable": [
-                "tapable/v1"
+                "./node_modules/tapable"
             ]
         },
         "types": [],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
