### PR TITLE
`@types/auth0` add support for `include_totals` to `getMembers` and `getMemberRoles` organization functions.

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -1466,14 +1466,21 @@ management.organizations.getMemberRoles({ id: 'organization_id', user_id: 'user_
 });
 
 /**
- * Get Organization Member Roles returning a Promise
+ * Get a paged result of an Organization Member Roles using a callback
  */
-management.organizations.getMemberRoles({ id: 'organization_id', user_id: 'user_id' }).then((roles: auth0.Role[]) => {
-    console.log(roles);
+management.organizations.getMemberRoles({ id: 'organization_id', user_id: 'user_id', include_totals: true }, (err, pagedRoles: Omit<auth0.RolePage, 'length'>) => {
+    console.log(pagedRoles);
 });
 
 /**
- * Get Organization Member Roles with pagination using a callback
+ * Get a paged result of an Organization Member Roles returning a Promise
+ */
+management.organizations.getMemberRoles({ id: 'organization_id', user_id: 'user_id', include_totals: true }).then((pagedRoles: Omit<auth0.RolePage, 'length'>) => {
+    console.log(pagedRoles);
+});
+
+/**
+ * Get a paged result of an Organization Member Roles with pagination using a callback
  */
 management.organizations.getMemberRoles(
     { id: 'organization_id', user_id: 'user_id', page: 0, per_page: 2 },

--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -1268,8 +1268,9 @@ management.organizations.getMembers({ id: 'organization_id' }, (err, members: au
 /**
  * Get a paged result of an Organization's Members using a callback
  */
-management.organizations.getMembers({ id: 'organization_id', include_totals: true }, (err, pagedMembers: auth0.OrganizationMembersPaged) => {
-    console.log(pagedMembers);
+management.organizations.getMembers({ id: 'organization_id', include_totals: true }, (err, pagedMembers) => {
+    // $ExpectType OrganizationMembersPaged
+    pagedMembers;
 });
 
 /**
@@ -1282,8 +1283,9 @@ management.organizations.getMembers({ id: 'organization_id' }).then((members: au
 /**
  * Get a paged result of an Organization's members returning a promise.
  */
-management.organizations.getMembers({id: 'organization_id', include_totals: true }).then((pagedMembers: auth0.OrganizationMembersPaged) => {
-    console.log(pagedMembers);
+management.organizations.getMembers({id: 'organization_id', include_totals: true }).then((pagedMembers) => {
+    // $ExpectType OrganizationMembersPaged
+    pagedMembers;
 });
 
 /**

--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -1266,10 +1266,24 @@ management.organizations.getMembers({ id: 'organization_id' }, (err, members: au
 });
 
 /**
+ * Get a paged result of an Organization's Members using a callback
+ */
+management.organizations.getMembers({ id: 'organization_id', include_totals: true }, (err, pagedMembers: auth0.OrganizationMembersPaged) => {
+    console.log(pagedMembers);
+});
+
+/**
  * Get an Organization's Members returning a Promise
  */
 management.organizations.getMembers({ id: 'organization_id' }).then((members: auth0.OrganizationMember[]) => {
     console.log({ members });
+});
+
+/**
+ * Get a paged result of an Organization's members returning a promise.
+ */
+management.organizations.getMembers({id: 'organization_id', include_totals: true }).then((pagedMembers: auth0.OrganizationMembersPaged) => {
+    console.log(pagedMembers);
 });
 
 /**

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1229,6 +1229,10 @@ export interface OrganizationMember {
     email?: string | undefined;
 }
 
+export interface OrganizationMembersPaged extends Omit<Page, 'length'> {
+    members: OrganizationMember[];
+}
+
 export interface OrganizationInvitation {
     id: string;
     organization_id: string;
@@ -1338,8 +1342,10 @@ export class OrganizationsManager {
         cb: (err: Error, connection: OrganizationConnection) => void,
     ): void;
 
-    getMembers(params: ObjectWithId & PagingOptions): Promise<OrganizationMember[]>;
-    getMembers(params: ObjectWithId & PagingOptions, cb: (err: Error, members: OrganizationMember[]) => void): void;
+    getMembers(params: ObjectWithId & PagingOptions & { include_totals?: false; }): Promise<OrganizationMember[]>;
+    getMembers(params: ObjectWithId & PagingOptions & { include_totals: true; }): Promise<OrganizationMembersPaged>;
+    getMembers(params: ObjectWithId & PagingOptions & { include_totals?: false; }, cb: (err: Error, members: OrganizationMember[]) => void): void;
+    getMembers(params: ObjectWithId & PagingOptions & { include_totals: true; }, cb: (err: Error, pagedMembers: OrganizationMembersPaged) => void): void;
     getMembers(params: ObjectWithId & CheckpointPagingOptions): Promise<OrganizationMember[]>;
     getMembers(
         params: ObjectWithId & CheckpointPagingOptions,

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1384,10 +1384,15 @@ export class OrganizationsManager {
     deleteInvitation(params: ObjectWithId & { invitation_id: string }): Promise<void>;
     deleteInvitation(params: ObjectWithId & { invitation_id: string }, cb: (err: Error) => void): void;
 
-    getMemberRoles(params: ObjectWithId & PagingOptions & { user_id: string }): Promise<Role[]>;
+    getMemberRoles(params: ObjectWithId & PagingOptions & { user_id: string; include_totals?: false }): Promise<Role[]>;
+    getMemberRoles(params: ObjectWithId & PagingOptions & { user_id: string; include_totals: true }): Promise<Omit<RolePage, 'length'>>;
     getMemberRoles(
-        params: ObjectWithId & PagingOptions & { user_id: string },
+        params: ObjectWithId & PagingOptions & { user_id: string; include_totals?: false },
         cb: (err: Error, roles: Role[]) => void,
+    ): void;
+    getMemberRoles(
+        params: ObjectWithId & PagingOptions & { user_id: string; include_totals: true },
+        cb: (err: Error, roles: Omit<RolePage, 'length'>) => void,
     ): void;
 
     addMemberRoles(params: ObjectWithId & { user_id: string }, data: AddOrganizationMemberRoles): Promise<void>;


### PR DESCRIPTION
This PR adds `include_totals` types for two of the new `organization` endpoints, `getMembers` and `getMemberRoles`.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [`getMembers` documentation*](https://auth0.com/docs/api/management/v2#!/Organizations/get_members)
  - [`getMemberRoles` documentation*](https://auth0.com/docs/api/management/v2#!/Organizations/get_organization_member_roles)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

_*neither of these endpoints actually return a `length`, so we cannot fully reuse the `Page` type, so I have omitted the `length` property_

---

### Additional Context
When you supply a `include_totals: true` to a request, it returns the data with additional details, this PR adds missing types that have already been released in the sdk.

I have tested both of these changes locally both with a promise and a callback and they work as expected.

