### PR TITLE
[node] `util` module fixes

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 16.10
+// Type definitions for non-npm package Node.js 16.11
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -1,6 +1,6 @@
 import * as util from 'node:util';
 import assert = require('node:assert');
-import { readFile } from 'node:fs';
+import { access, readFile } from 'node:fs';
 
 // Old and new util.inspect APIs
 util.inspect(["This is nice"], false, 5);
@@ -182,8 +182,18 @@ const errorMap: Map<number, [string, string]> = util.getSystemErrorMap();
     const logger: util.DebugLogger = util.debuglog('section');
     logger.enabled; // $ExpectType boolean
     util.debuglog('section', (fn: util.DebugLoggerFunction) => { });
+    util.debug('section', (fn: util.DebugLoggerFunction) => { });
 }
 
 {
     const foo: string = util.toUSVString('foo');
+}
+
+access('file/that/does/not/exist', (err) => {
+    const name = util.getSystemErrorName(err!.errno!);
+    console.error(name);
+});
+
+{
+    const foo: string = util.stripVTControlCharacters('\u001B[4mvalue\u001B[0m');
 }

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -114,6 +114,13 @@ declare module 'util' {
      */
     export function formatWithOptions(inspectOptions: InspectOptions, format?: any, ...param: any[]): string;
     /**
+     * Returns the string name for a numeric error code that comes from a Node.js API.
+     * The mapping between error codes and error names is platform-dependent.
+     * @param err A numeric error code.
+     * @since v9.7.0
+     */
+    export function getSystemErrorName(err: number): string;
+    /**
      * Returns a Map of all system error codes available from the Node.js API.
      * The mapping between error codes and error names is platform-dependent.
      * See `Common System Errors` for the names of common errors.
@@ -314,6 +321,9 @@ declare module 'util' {
          * Allows changing inspect settings from the repl.
          */
         let replDefaults: InspectOptions;
+        /**
+         * That can be used to declare custom inspect functions.
+         */
         const custom: unique symbol;
     }
     /**
@@ -520,6 +530,7 @@ declare module 'util' {
      * @return The logging function
      */
     export function debuglog(section: string, callback?: (fn: DebugLoggerFunction) => void): DebugLogger;
+    export const debug: typeof debuglog;
     /**
      * Returns `true` if the given `object` is a `Boolean`. Otherwise, returns `false`.
      *
@@ -961,8 +972,16 @@ declare module 'util' {
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
     export function promisify(fn: Function): Function;
     export namespace promisify {
+        /**
+         * That can be used to declare custom promisified variants of functions.
+         */
         const custom: unique symbol;
     }
+    /**
+     * Returns `str` with any ANSI escape codes removed.
+     * @since v16.11.0
+     */
+    export function stripVTControlCharacters(str: string): string;
     /**
      * An implementation of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) `TextDecoder` API.
      *

--- a/types/node/v14/test/util.ts
+++ b/types/node/v14/test/util.ts
@@ -1,6 +1,6 @@
 import * as util from 'util';
 import assert = require('assert');
-import { readFile } from 'fs';
+import { access, readFile } from 'fs';
 
 {
     // Old and new util.inspect APIs
@@ -322,4 +322,18 @@ function testUtilTypes(
     if (util.types.isWeakSet(object)) {
         object; // $ExpectType WeakSet<any>
     }
+}
+
+{
+    const logger: util.DebugLogger = util.debuglog('section');
+    logger.enabled; // $ExpectType boolean
+    util.debuglog('section', (fn: util.DebugLoggerFunction) => { });
+    util.debug('section', (fn: util.DebugLoggerFunction) => { });
+}
+
+{
+    access('file/that/does/not/exist', (err) => {
+        const name = util.getSystemErrorName(err!.errno!);
+        console.error(name);
+    });
 }

--- a/types/node/v14/util.d.ts
+++ b/types/node/v14/util.d.ts
@@ -7,6 +7,7 @@ declare module 'util' {
     }
     function format(format?: any, ...param: any[]): string;
     function formatWithOptions(inspectOptions: InspectOptions, format?: any, ...param: any[]): string;
+    function getSystemErrorName(err: number): string;
     /** @deprecated since v0.11.3 - use a third party module instead. */
     function log(string: string): void;
     function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
@@ -32,7 +33,12 @@ declare module 'util' {
     /** @deprecated since v4.0.0 - use `util.types.isNativeError()` instead. */
     function isError(object: any): object is Error;
     function inherits(constructor: any, superConstructor: any): void;
-    function debuglog(key: string): (msg: string, ...param: any[]) => void;
+    type DebugLoggerFunction = (msg: string, ...param: any[]) => void;
+    interface DebugLogger extends DebugLoggerFunction {
+        enabled: boolean;
+    }
+    function debuglog(key: string, callback?: (fn: DebugLoggerFunction) => void): DebugLogger;
+    const debug: typeof debuglog;
     /** @deprecated since v4.0.0 - use `typeof value === 'boolean'` instead. */
     function isBoolean(object: any): object is boolean;
     /** @deprecated since v4.0.0 - use `Buffer.isBuffer()` instead. */


### PR DESCRIPTION
node 16.x
- Add `debug` alias.
- Add `getSystemErrorName`.
- Add `stripVTControlCharacters`.

node 14.x
- Add `debug` alias. Fix `debuglog` types.
- Add `getSystemErrorName`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v16.x/docs/api/util.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.