### PR TITLE
bunyan: add writerfn interface to writer stream

### DIFF
--- a/types/bunyan/bunyan-tests.ts
+++ b/types/bunyan/bunyan-tests.ts
@@ -62,7 +62,14 @@ const options: Logger.LoggerOptions = {
         stream: rotatingFileStream,
         level: Logger.ERROR,
         reemitErrorEvents: true
-    }]
+    },
+        {
+        type: 'raw',
+        stream: { write: (obj: Object) => console.log(JSON.stringify(obj)) },
+        level: Logger.ERROR,
+        reemitErrorEvents: true
+    }
+    ]
 };
 
 const log = Logger.createLogger(options);

--- a/types/bunyan/index.d.ts
+++ b/types/bunyan/index.d.ts
@@ -221,11 +221,15 @@ declare namespace Logger {
 
     function resolveLevel(value: LogLevel): number;
 
+    interface WriteFn {
+        write: (object: Object) => void;
+    }
+
     interface Stream {
         type?: string | undefined;
         level?: LogLevel | undefined;
         path?: string | undefined;
-        stream?: NodeJS.WritableStream | Stream | undefined;
+        stream?: NodeJS.WritableStream | WriteFn | undefined;
         closeOnExit?: boolean | undefined;
         period?: string | undefined;
         count?: number | undefined;


### PR DESCRIPTION
It doesn't have to actually implement the nodejs writer interface but can just provide an object with a writer function as shown in https://github.com/trentm/node-bunyan/blob/0ff1ae29cc9e028c6c11cd6b60e3b90217b66a10/examples/raw-stream.js#L12-L20 and https://github.com/trentm/node-bunyan/blob/0ff1ae29cc9e028c6c11cd6b60e3b90217b66a10/lib/bunyan.js#L310
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/trentm/node-bunyan/blob/0ff1ae29cc9e028c6c11cd6b60e3b90217b66a10/examples/raw-stream.js#L12-L20 https://github.com/trentm/node-bunyan/blob/0ff1ae29cc9e028c6c11cd6b60e3b90217b66a10/lib/bunyan.js#L310
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

