### PR TITLE
Use ubuntu-latest instead of 16.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 jobs:
 - job: npmRunTest
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: ubuntu-latest
     demands: npm
 
   timeoutInMinutes: 360


### PR DESCRIPTION
16.04 will be removed from Pipelines in the next few days.