### PR TITLE
[klaw] Make Walker extend AsyncIterable to add for-await...of type annotations

### DIFF
--- a/types/klaw/index.d.ts
+++ b/types/klaw/index.d.ts
@@ -32,7 +32,7 @@ declare module "klaw" {
 
         type Event = "close" | "data" | "end" | "error" | "pause" | "readable" | "resume"
 
-        interface Walker extends Readable {
+        interface Walker extends Readable, AsyncIterable<Item> {
             on(event: Event, listener: Function): this
             on(event: "close", listener: () => void): this
             on(event: "data", listener: (item: Item) => void): this
@@ -40,6 +40,7 @@ declare module "klaw" {
             on(event: "readable", listener: () => void): this
             on(event: "error", listener: (err: Error) => void): this
             read(): Item
+            [Symbol.asyncIterator](): AsyncIterableIterator<Item>
         }
     }
 

--- a/types/klaw/klaw-tests.ts
+++ b/types/klaw/klaw-tests.ts
@@ -41,3 +41,12 @@ klaw('/some/dir', { filter: filterFunc })
     .on('data', function(item: klaw.Item) {
         // only items of none hidden folders will reach here
     })
+
+async () => {
+    for await (const file of klaw('/some/dir')) {
+        // $ExpectType string
+        file.path;
+        // $ExpectType Stats
+        file.stats;
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/klaw#:~:text=array%20of%20files%5D-,for-await-of,-example%3A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
