### PR TITLE
[@types/fluent-ffmpeg] Update tags field to better reflect the format used by fluent-ffmpeg

### DIFF
--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -178,7 +178,7 @@ declare namespace Ffmpeg {
         size?: number | undefined;
         bit_rate?: number | undefined;
         probe_score?: number | undefined;
-        tags?: any[] | undefined;
+        tags?: any[] | undefined | Record<string, string>;
     }
 
     interface ScreenshotsConfig {

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -178,7 +178,7 @@ declare namespace Ffmpeg {
         size?: number | undefined;
         bit_rate?: number | undefined;
         probe_score?: number | undefined;
-        tags?: any[] | undefined | Record<string, string>;
+        tags?: Record<string, string> | undefined;
     }
 
     interface ScreenshotsConfig {

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -178,7 +178,7 @@ declare namespace Ffmpeg {
         size?: number | undefined;
         bit_rate?: number | undefined;
         probe_score?: number | undefined;
-        tags?: Record<string, string> | undefined;
+        tags?: Record<string, string | number> | undefined;
     }
 
     interface ScreenshotsConfig {


### PR DESCRIPTION
The current implementation of `FfprobeFormat` types `FfprobeFormat.tags` as `any[] | undefined`. This is problematic, and actually not accurate to the format in which fluent-ffmpeg returns this data.

In addition to the fact that this field seems to be where `fluent-ffmpeg` puts id3 information like artist, genre etc. the information itself is also provided as a key => value type object, rather than an array.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/blob/master/lib/ffprobe.js#L197-L221