### PR TITLE
[node]: fix the first argument of opendir from string to PathLike

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -3649,7 +3649,7 @@ declare module 'fs' {
      * directory and subsequent read operations.
      * @since v12.12.0
      */
-    export function opendirSync(path: string, options?: OpenDirOptions): Dir;
+    export function opendirSync(path: PathLike, options?: OpenDirOptions): Dir;
     /**
      * Asynchronously open a directory. See the POSIX [`opendir(3)`](http://man7.org/linux/man-pages/man3/opendir.3.html) documentation for
      * more details.
@@ -3661,10 +3661,10 @@ declare module 'fs' {
      * directory and subsequent read operations.
      * @since v12.12.0
      */
-    export function opendir(path: string, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
-    export function opendir(path: string, options: OpenDirOptions, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
+    export function opendir(path: PathLike, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
+    export function opendir(path: PathLike, options: OpenDirOptions, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
     export namespace opendir {
-        function __promisify__(path: string, options?: OpenDirOptions): Promise<Dir>;
+        function __promisify__(path: PathLike, options?: OpenDirOptions): Promise<Dir>;
     }
     export interface BigIntStats extends StatsBase<bigint> {
         atimeNs: bigint;

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -928,7 +928,7 @@ declare module 'fs/promises' {
      * @since v12.12.0
      * @return Fulfills with an {fs.Dir}.
      */
-    function opendir(path: string, options?: OpenDirOptions): Promise<Dir>;
+    function opendir(path: PathLike, options?: OpenDirOptions): Promise<Dir>;
     /**
      * Returns an async iterator that watches for changes on `filename`, where `filename`is either a file or a directory.
      *

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -1,6 +1,7 @@
 import { FileHandle, open as openAsync, writeFile as writeFileAsync, watch as watchAsync, cp as cpAsync } from 'node:fs/promises';
 import * as fs from 'node:fs';
 import * as util from 'node:util';
+import { URL } from 'node:url';
 import assert = require('node:assert');
 import { CopyOptions, cpSync, cp } from 'fs';
 
@@ -357,7 +358,23 @@ async function testPromisify() {
         const dirEnt: fs.Dirent | null = await dir.read();
     });
 
+    fs.opendir(Buffer.from('test'), async (err, dir) => {
+        const dirEnt: fs.Dirent | null = await dir.read();
+    });
+
+    fs.opendir(new URL(`file://${__dirname}`), async (err, dir) => {
+        const dirEnt: fs.Dirent | null = await dir.read();
+    });
+
     const dir: fs.Dir = fs.opendirSync('test', {
+        encoding: 'utf8',
+    });
+
+    const dirBuffer: fs.Dir = fs.opendirSync(Buffer.from('test'), {
+        encoding: 'utf8',
+    });
+
+    const dirUrl: fs.Dir = fs.opendirSync(new URL(`file://${__dirname}`), {
         encoding: 'utf8',
     });
 
@@ -365,9 +382,25 @@ async function testPromisify() {
         // tslint:disable-next-line: await-promise
         for await (const thing of dir) {
         }
+        // tslint:disable-next-line: await-promise
+        for await (const thing of dirBuffer) {
+        }
+        // tslint:disable-next-line: await-promise
+        for await (const thing of dirUrl) {
+        }
     });
 
     const dirEntProm: Promise<fs.Dir> = fs.promises.opendir('test', {
+        encoding: 'utf8',
+        bufferSize: 42,
+    });
+
+    const dirEntBufferProm: Promise<fs.Dir> = fs.promises.opendir(Buffer.from('test'), {
+        encoding: 'utf8',
+        bufferSize: 42,
+    });
+
+    const dirEntUrlProm: Promise<fs.Dir> = fs.promises.opendir(new URL(`file://${__dirname}`), {
         encoding: 'utf8',
         bufferSize: 42,
     });

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -2008,13 +2008,13 @@ declare module 'fs' {
         encoding?: BufferEncoding | undefined;
     }
 
-    function opendirSync(path: string, options?: OpenDirOptions): Dir;
+    function opendirSync(path: PathLike, options?: OpenDirOptions): Dir;
 
-    function opendir(path: string, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
-    function opendir(path: string, options: OpenDirOptions, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
+    function opendir(path: PathLike, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
+    function opendir(path: PathLike, options: OpenDirOptions, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
 
     namespace opendir {
-        function __promisify__(path: string, options?: OpenDirOptions): Promise<Dir>;
+        function __promisify__(path: PathLike, options?: OpenDirOptions): Promise<Dir>;
     }
 
     namespace promises {
@@ -2535,7 +2535,7 @@ declare module 'fs' {
          */
         function readFile(path: PathLike | FileHandle, options?: { encoding?: string | null | undefined, flag?: string | number | undefined } | string | null): Promise<string | Buffer>;
 
-        function opendir(path: string, options?: OpenDirOptions): Promise<Dir>;
+        function opendir(path: PathLike, options?: OpenDirOptions): Promise<Dir>;
     }
 
     interface BigIntStats extends StatsBase<bigint> {

--- a/types/node/v12/test/fs.ts
+++ b/types/node/v12/test/fs.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import assert = require('assert');
 import * as util from 'util';
+import * as url from 'url';
 
 {
     fs.writeFile("thebible.txt",
@@ -314,7 +315,23 @@ async function testPromisify() {
         const dirEnt: fs.Dirent | null = await dir.read();
     });
 
+    fs.opendir(Buffer.from('test'), async (err, dir) => {
+        const dirEnt: fs.Dirent | null = await dir.read();
+    });
+
+    fs.opendir(new url.URL(`file://${__dirname}`), async (err, dir) => {
+        const dirEnt: fs.Dirent | null = await dir.read();
+    });
+
     const dir: fs.Dir = fs.opendirSync('test', {
+        encoding: 'utf8',
+    });
+
+    const dirBuffer: fs.Dir = fs.opendirSync(Buffer.from('test'), {
+        encoding: 'utf8',
+    });
+
+    const dirUrl: fs.Dir = fs.opendirSync(new url.URL(`file://${__dirname}`), {
         encoding: 'utf8',
     });
 
@@ -325,6 +342,14 @@ async function testPromisify() {
     // });
 
     const dirEntProm: Promise<fs.Dir> = fs.promises.opendir('test', {
+        encoding: 'utf8',
+    });
+
+    const dirEntBufferProm: Promise<fs.Dir> = fs.promises.opendir(Buffer.from('test'), {
+        encoding: 'utf8',
+    });
+
+    const dirEntURLProm: Promise<fs.Dir> = fs.promises.opendir(new url.URL(`file://${__dirname}`), {
         encoding: 'utf8',
     });
 }

--- a/types/node/v14/fs.d.ts
+++ b/types/node/v14/fs.d.ts
@@ -2241,13 +2241,13 @@ declare module 'fs' {
         bufferSize?: number | undefined;
     }
 
-    export function opendirSync(path: string, options?: OpenDirOptions): Dir;
+    export function opendirSync(path: PathLike, options?: OpenDirOptions): Dir;
 
-    export function opendir(path: string, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
-    export function opendir(path: string, options: OpenDirOptions, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
+    export function opendir(path: PathLike, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
+    export function opendir(path: PathLike, options: OpenDirOptions, cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void): void;
 
     export namespace opendir {
-        function __promisify__(path: string, options?: OpenDirOptions): Promise<Dir>;
+        function __promisify__(path: PathLike, options?: OpenDirOptions): Promise<Dir>;
     }
 
     export interface BigIntStats extends StatsBase<bigint> {

--- a/types/node/v14/fs/promises.d.ts
+++ b/types/node/v14/fs/promises.d.ts
@@ -561,5 +561,5 @@ declare module 'fs/promises' {
      */
     function readFile(path: PathLike | FileHandle, options?: BaseEncodingOptions & { flag?: OpenMode | undefined } | BufferEncoding | null): Promise<string | Buffer>;
 
-    function opendir(path: string, options?: OpenDirOptions): Promise<Dir>;
+    function opendir(path: PathLike, options?: OpenDirOptions): Promise<Dir>;
 }

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import assert = require('assert');
 import * as util from 'util';
+import * as url from 'url';
 
 {
     fs.writeFile("thebible.txt",
@@ -352,7 +353,23 @@ async function testPromisify() {
         const dirEnt: fs.Dirent | null = await dir.read();
     });
 
+    fs.opendir(Buffer.from('test'), async (err, dir) => {
+        const dirEnt: fs.Dirent | null = await dir.read();
+    });
+
+    fs.opendir(new url.URL(`file://${__dirname}`), async (err, dir) => {
+        const dirEnt: fs.Dirent | null = await dir.read();
+    });
+
     const dir: fs.Dir = fs.opendirSync('test', {
+        encoding: 'utf8',
+    });
+
+    const dirBuffer: fs.Dir = fs.opendirSync(Buffer.from('test'), {
+        encoding: 'utf8',
+    });
+
+    const dirUrl: fs.Dir = fs.opendirSync(new url.URL(`file://${__dirname}`), {
         encoding: 'utf8',
     });
 
@@ -363,6 +380,16 @@ async function testPromisify() {
     // });
 
     const dirEntProm: Promise<fs.Dir> = fs.promises.opendir('test', {
+        encoding: 'utf8',
+        bufferSize: 42,
+    });
+
+    const dirEntBufferProm: Promise<fs.Dir> = fs.promises.opendir(Buffer.from('test'), {
+        encoding: 'utf8',
+        bufferSize: 42,
+    });
+
+    const dirEntURLProm: Promise<fs.Dir> = fs.promises.opendir(new url.URL(`file://${__dirname}`), {
         encoding: 'utf8',
         bufferSize: 42,
     });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/fs.html#fs_fs_opendir_path_options_callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
