### PR TITLE
[@types/fluent-ffmpeg] Fix return for PresetFunction. Fix typos. Closes #52550

### DIFF
--- a/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
+++ b/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
@@ -110,3 +110,6 @@ ffmpeg.ffprobe('/path/to/file.mp4', (err, data) => {
 ffmpeg('/path/to.mp4')
     .loop()
     .videoBitrate(300, true);
+
+ffmpeg('/path/to/file.avi')
+    .preset((command) => { command.format('avi').size('720x?'); });

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -39,7 +39,7 @@ declare namespace Ffmpeg {
         options?: any | string | any[] | undefined;
     }
 
-    type GetPreset = (command: FfmpegCommand) => string;
+    type PresetFunction = (command: FfmpegCommand) => void;
 
     interface Filter {
         description: string;
@@ -359,8 +359,8 @@ declare namespace Ffmpeg {
         complexFilter(spec: string | FilterSpecification | Array<string | FilterSpecification>, map?: string[] | string): FfmpegCommand;
 
         // options/misc
-        usingPreset(proset: string | GetPreset): FfmpegCommand;
-        pnreset(proset: string | GetPreset): FfmpegCommand;
+        usingPreset(preset: string | PresetFunction): FfmpegCommand;
+        preset(preset: string | PresetFunction): FfmpegCommand;
 
         // processor
         renice(niceness: number): FfmpegCommand;

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -320,7 +320,6 @@ declare namespace Ffmpeg {
         map(spec: string): FfmpegCommand;
         updateFlvMetadata(): FfmpegCommand;
         flvmeta(): FfmpegCommand;
-        preset(format: string): FfmpegCommand;
 
         // options/custom
         addInputOption(options: string[]): FfmpegCommand;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg#presetpreset-use-fluent-ffmpeg-preset and https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/blob/master/lib/options/misc.js#L20
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Closes #52550