### PR TITLE
[node] [JSDoc-only] Retain `fs` methods deprecated in IDE suggestions

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -768,6 +768,7 @@ declare module 'fs' {
      * @deprecated Since v0.4.7
      */
     export function lchmod(path: PathLike, mode: Mode, callback: NoParamCallback): void;
+    /** @deprecated */
     export namespace lchmod {
         /**
          * Asynchronous lchmod(2) - Change permissions of a file. Does not dereference symbolic links.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -3000,6 +3000,7 @@ declare module 'fs' {
      * @deprecated Since v1.0.0 - Use {@link stat} or {@link access} instead.
      */
     export function exists(path: PathLike, callback: (exists: boolean) => void): void;
+    /** @deprecated */
     export namespace exists {
         /**
          * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] ~~[Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).~~

Select one of these and delete the others:

If changing an existing definition:
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

That PR brings back deprecated suggestion for `fs.exists`. Here is comparison in VSCode:

Current (`v16.10.3`) look:
![image](https://user-images.githubusercontent.com/46503702/136946059-70492873-cb23-471a-be7b-c6fec185697a.png)

With this PR:
![image](https://user-images.githubusercontent.com/46503702/136946100-fb4dc34b-8489-41bc-a1bc-7deaa0548e14.png)


This might be important for some folks since it changes the order of suggestions (see above).