### PR TITLE
[react-native-video] Add missing property for video buffering on iOS

### DIFF
--- a/types/react-native-video/index.d.ts
+++ b/types/react-native-video/index.d.ts
@@ -179,6 +179,7 @@ export interface VideoProperties extends ViewProps {
     audioOnly?: boolean | undefined;
     preventsDisplaySleepDuringVideoPlayback?: boolean | undefined;
     drm?: DRMSettings | undefined;
+    preferredForwardBufferDuration?: number | undefined;
 
     onLoadStart?(): void;
     onLoad?(data: OnLoadData): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-native-video/react-native-video#preferredforwardbufferduration
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
