### PR TITLE
[spotify-web-playback-sdk] Add type for autoplay_failed listener

### DIFF
--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -95,9 +95,11 @@ declare namespace Spotify {
     type ErrorListener = (err: Error) => void;
     type PlaybackInstanceListener = (inst: WebPlaybackInstance) => void;
     type PlaybackStateListener = (s: PlaybackState) => void;
+    type EmptyListener = () => void;
 
     type AddListenerFn =
         & ((event: 'ready' | 'not_ready', cb: PlaybackInstanceListener) => void)
+        & ((event: 'autoplay_failed', cb: EmptyListener) => void)
         & ((event: 'player_state_changed', cb: PlaybackStateListener) => void)
         & ((event: ErrorTypes, cb: ErrorListener) => void);
 

--- a/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
+++ b/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
@@ -30,6 +30,10 @@ player.addListener("not_ready", ({ device_id }) => {
     console.log("The Web Playback SDK is not ready to play music!");
 });
 
+player.addListener("autoplay_failed", () => {
+    console.log("Autoplay is turned off for your browser");
+});
+
 player.getCurrentState().then((playbackState: Spotify.PlaybackState | null) => {
     if (playbackState) {
         const { current_track, next_tracks } = playbackState.track_window;
@@ -91,6 +95,10 @@ player.on("ready", (data: Spotify.WebPlaybackInstance) => {
 player.on("not_ready", (data: Spotify.WebPlaybackInstance) => {
     const { device_id } = data;
     console.log("Connected with Device ID", device_id);
+});
+
+player.on("autoplay_failed", () => {
+    console.log("Autoplay failed");
 });
 
 player.on("player_state_changed", (playbackState: Spotify.PlaybackState) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.spotify.com/documentation/web-playback-sdk/reference/#event-autoplay-failed
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - This is not an NPM package.