### PR TITLE
leaflet: Fix Class.extend() type

### DIFF
--- a/types/leaflet-draw/leaflet-draw-tests.ts
+++ b/types/leaflet-draw/leaflet-draw-tests.ts
@@ -112,7 +112,7 @@ function testExampleControlOptions() {
                 }
             },
             marker: {
-                icon: new MyCustomMarker()
+                icon: new MyCustomMarker({})
             }
         },
         edit: {

--- a/types/leaflet.markercluster/leaflet.markercluster-tests.ts
+++ b/types/leaflet.markercluster/leaflet.markercluster-tests.ts
@@ -105,7 +105,7 @@ class Subclass4 extends L.MarkerCluster {
 
 const s1 = new Subclass1(); // any
 const s2 = new Subclass2();
-const s3 = new Subclass3(); // any
+const s3 = new Subclass3([0, 0]); // any
 const s4 = new Subclass4([1, 2]);
 
 // call subclass function

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -18,8 +18,13 @@ import * as geojson from 'geojson';
 /** A constant that represents the Leaflet version in use. */
 export const version: string;
 
+/** Type for extensions of class instance type C - all functions have this bound   */
+export interface ClassExtensions<C> {
+    [prop: string]: ((this: C, ...args: any[]) => any) | boolean | number | string  | null | undefined | Record<string | number | symbol, unknown> | any[];
+}
+
 export class Class {
-    static extend(props: any): {new(...args: any[]): any} & typeof Class;
+    static extend<P extends { new (...args: any[]): InstanceType<P> }, T extends ClassExtensions<InstanceType<P>>>(this: P, props: T): { new (...args: any[]): T & InstanceType<P> } & P;
     static include(props: any): any & typeof Class;
     static mergeOptions(props: any): any & typeof Class;
 
@@ -1425,7 +1430,6 @@ export interface ControlOptions {
 }
 
 export class Control extends Class {
-    static extend<T extends object>(props: T): {new(...args: any[]): T} & typeof Control;
     constructor(options?: ControlOptions);
     getPosition(): ControlPosition;
     setPosition(position: ControlPosition): this;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -837,3 +837,11 @@ export class ExtendedTileLayer extends L.TileLayer {
         }
     }
 }
+
+// Built-in extends function with polymorphic types
+const SubIconClass = L.Icon.extend({ extra: true });
+const subIcon: { extra: boolean } & L.Icon<L.BaseIconOptions> = new SubIconClass({});
+
+// Confirm that static methods are passed through
+const SubSubIconClass = SubIconClass.extend({ second: true });
+const subSubIcon: { extra: boolean, second: boolean } & L.Icon<L.BaseIconOptions> = new SubSubIconClass({});


### PR DESCRIPTION
The type now returns a class object that whose instances are of the right type.

The details of its behaviour are covered in https://leafletjs.com/examples/extending/extending-1-classes.html