### PR TITLE
[pdfkit] add types for new accessibility features

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -532,7 +532,16 @@ declare module 'pdfkit/js/structure_content' {
 declare namespace PDFKit {
     /** PDFStructureElement */
     class PDFStructureElement {
-        constructor(type: string, options: {});
+        constructor(
+            document: PDFDocument,
+            type: string,
+            options?: { title: string; lang: string; alt: string; expanded: string; actual: string },
+            children?:
+                | (() => any)
+                | PDFStructureElement
+                | PDFStructureContent
+                | ((() => any) | PDFStructureContent | PDFStructureElement)[],
+        );
         add(el: PDFStructureContent | PDFStructureElement | (() => any)): PDFStructureElement;
         setParent(parentRef: PDFKitReference): void;
         setAttached(): void;

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -535,7 +535,16 @@ declare namespace PDFKit {
         constructor(
             document: PDFDocument,
             type: string,
-            options?: { title: string; lang: string; alt: string; expanded: string; actual: string },
+            options?: { title?: string; lang?: string; alt?: string; expanded?: string; actual?: string },
+            children?:
+                | (() => any)
+                | PDFStructureElement
+                | PDFStructureContent
+                | ((() => any) | PDFStructureContent | PDFStructureElement)[],
+        );
+        constructor(
+            document: PDFDocument,
+            type: string,
             children?:
                 | (() => any)
                 | PDFStructureElement

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -533,7 +533,7 @@ declare namespace PDFKit {
     /** PDFStructureElement */
     class PDFStructureElement {
         constructor(type: string, options: {});
-        add(el: PDFStructureContent | PDFStructureElement): PDFStructureElement;
+        add(el: PDFStructureContent | PDFStructureElement | (() => any)): PDFStructureElement;
         setParent(parentRef: PDFKitReference): void;
         setAttached(): void;
         end(): void;

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Pdfkit v0.11.0
+// Type definitions for Pdfkit v0.12.3
 // Project: http://pdfkit.org
 // Definitions by: Eric Hillah <https://github.com/erichillah>
 //                 Erik Berreßem <https://github.com/she11sh0cked>
@@ -6,6 +6,7 @@
 //                 Thales Agapito <https://github.com/thalesagapito/>
 //                 Evgeny Baram <https://github.com/r4tz52/>
 //                 BamButz <https://github.com/BamButz/>
+//                 Joanna Gabis <https://github.com/jg-mms/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -273,6 +274,35 @@ declare namespace PDFKit.Mixins {
         formRadioButton(name: string, x: number, y: number, w: number, h: number, options?: object): this;
         formCheckbox(name: string, x: number, y: number, w: number, h: number, options?: object): this;
     }
+
+    interface PDFMarking {
+        markContent(tag: string, options?: MarkingOptions): this;
+        endMarkedContent(): this;
+        struct(tag: string, options?: MarkingOptions, children?: (() => any) | (PDFStructureElement | PDFStructureContent)[]): PDFStructureElement;
+        addStructure(structElem: PDFStructureElement): this;
+        initMarkings(options?: { tagged?: boolean }): void;
+        initPageMarkings(pageMarkings: PageMarking[]): void;
+        endPageMarkings(page: PDFPage): PageMarking[];
+        markStructureContent(tag: string, options?: MarkingOptions): PDFStructureContent;
+        getMarkingsDictionary(): PDFKitReference;
+        getStructTreeRoot(): PDFKitReference;
+        createStructParentTreeNextKey(): number;
+        endMarkings(): void;
+    }
+    interface MarkingOptions {
+        type?: 'Pagination' | 'Layout' | 'Page';
+        bbox?: [number, number, number, number];
+        attached?: string[];
+        lang?: string;
+        alt?: string;
+        expanded?: string;
+        actual?: string;
+    }
+    interface PageMarking {
+        tag: string;
+        structContent?: PDFStructureContent;
+        options?: MarkingOptions;
+    }
 }
 
 declare namespace PDFKit {
@@ -349,6 +379,9 @@ declare namespace PDFKit {
         layout?: 'portrait' | 'landscape' | undefined;
 
         bufferPages?: boolean | undefined;
+        tagged?: boolean;
+        lang?: string;
+        displayTitle?: boolean;
     }
 
     interface PDFDocument
@@ -359,7 +392,8 @@ declare namespace PDFKit {
             Mixins.PDFText,
             Mixins.PDFVector,
             Mixins.PDFFont,
-            Mixins.PDFAcroForm {
+            Mixins.PDFAcroForm,
+            Mixins.PDFMarking {
         /**
          * PDF Version
          */
@@ -482,6 +516,34 @@ declare module 'pdfkit/js/reference' {
 
     export = PDFKitReference;
 }
+declare namespace PDFKit {
+    /** PDFStructureContent */
+    class PDFStructureContent {
+        constructor(pageRef: PDFKitReference, mcid: number);
+        push(structContent: PDFStructureContent): void;
+    }
+}
+
+declare module 'pdfkit/js/structure_content' {
+    var PDFStructureContent: PDFKit.PDFStructureContent;
+    export = PDFStructureContent;
+}
+
+declare namespace PDFKit {
+    /** PDFStructureElement */
+    class PDFStructureElement {
+        constructor(type: string, options: {});
+        add(el: PDFStructureContent | PDFStructureElement): PDFStructureElement;
+        setParent(parentRef: PDFKitReference): void;
+        setAttached(): void;
+        end(): void;
+    }
+}
+
+declare module 'pdfkit/js/structure_element' {
+    var PDFStructureElement: PDFKit.PDFStructureElement;
+    export = PDFStructureElement;
+}
 
 declare module 'pdfkit/js/mixins/annotations' {
     var PDFKitAnnotation: PDFKit.Mixins.PDFAnnotation;
@@ -511,4 +573,9 @@ declare module 'pdfkit/js/mixins/text' {
 declare module 'pdfkit/js/mixins/vector' {
     var PDFKitVector: PDFKit.Mixins.PDFVector;
     export = PDFKitVector;
+}
+
+declare module 'pdfkit/js/mixins/markings' {
+    var PDFKitMarking: PDFKit.Mixins.PDFMarking;
+    export = PDFKitMarking;
 }

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -255,3 +255,27 @@ var subDoc = new SubPDFDocument({});
 
 subDoc.moveTo(subDoc.page.width / 2, subDoc.page.height / 2).text(10);
 subDoc.lineWidth(3).segment(10, subDoc.page.width - 10, subDoc.page.height - 10, 10).stroke("#00FFFF");
+
+// Markings
+doc.markContent('Figure', { alt: 'some alternative value'});
+doc.endMarkedContent();
+const structureContent = doc.markStructureContent('P');
+doc.text('Test');
+doc.endMarkedContent();
+const structureElement = doc.struct('Div', {}, [structureContent]);
+doc.addStructure(structureElement);
+doc.initMarkings();
+doc.initPageMarkings([{ tag: 'P' }]);
+doc.endPageMarkings(doc.page);
+doc.getMarkingsDictionary();
+doc.getStructTreeRoot();
+doc.createStructParentTreeNextKey();
+doc.endMarkings();
+// structure content methods
+const structureContent2 = doc.markStructureContent('H1');
+structureContent.push(structureContent2);
+// structure element methods
+structureElement.add(structureContent);
+structureElement.setAttached();
+structureElement.setParent(doc.ref({}));
+structureElement.end();


### PR DESCRIPTION
In version 12.x of pdfkit the features to enhance pdfs accessibility have been added - new markings mixin along with structure content and structure elements.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [a11y PR for pdfkit](https://github.com/foliojs/pdfkit/pull/1177/files)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
