### PR TITLE
Add exports entries for yargs to support extensionless esm specifiers

### DIFF
--- a/types/yargs/OTHER_FILES.txt
+++ b/types/yargs/OTHER_FILES.txt
@@ -1,0 +1,2 @@
+helpers.d.mts
+index.d.mts

--- a/types/yargs/helpers.d.mts
+++ b/types/yargs/helpers.d.mts
@@ -1,0 +1,1 @@
+export * from "./helpers.js";

--- a/types/yargs/index.d.mts
+++ b/types/yargs/index.d.mts
@@ -1,0 +1,2 @@
+import yargs = require("./index.js");
+export default yargs;

--- a/types/yargs/index.d.mts
+++ b/types/yargs/index.d.mts
@@ -1,2 +1,12 @@
 import yargs = require("./index.js");
-export default yargs;
+interface RequireType {
+  (path: string): Function;
+  main: MainType;
+}
+
+interface MainType {
+  filename: string;
+  children: MainType[];
+}
+declare const _instanceFactory: (processArgs: string[], cwd?: string, parentRequire?: RequireType) => yargs.Argv;
+export default _instanceFactory;

--- a/types/yargs/package.json
+++ b/types/yargs/package.json
@@ -1,0 +1,22 @@
+{
+    "private": true,
+    "exports": {
+        ".": {
+            "types": {
+                "import": "./index.d.mts",
+                "default": "./index.d.ts"
+            }
+        },
+        "./helpers": {
+            "types": {
+                "import": "./helpers.d.mts",
+                "default": "./helpers.d.ts"
+            }
+        },
+        "./yargs": {
+            "types": {
+                "default": "./yargs.d.ts"
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the new TS `node12` and `nodenext` module modes. These entries align with those used by [yargs itself](https://github.com/yargs/yargs/blob/main/package.json#L6) to export the main entrypoint, `yargs/helpers`, and `yargs/yargs`. The `.d.mts` files are needed to remap the formats/shapes of the esm entrypoints - notably, the esm `yargs` main entrypoint uses `export default`, vs the cjs entrypoint's `module.exports =`. (The esm and cjs versions of `yargs/helpers` have the same shape, but the esm version shouldn't have an implicit `default` import, so we still need to remap its' format. The `yargs/yargs` entrypoint is only exported as cjs.)

This is probably going to be a big test of our automation to see if it correctly handles `.d.mts` files and `exports` maps.