### PR TITLE
sinon-chai: add SinonSpyCall type to `calledBefore` and `calledAfter`

### DIFF
--- a/types/sinon-chai/index.d.ts
+++ b/types/sinon-chai/index.d.ts
@@ -43,11 +43,11 @@ declare global {
             /**
              * Returns true if the spy was called before anotherSpy.
              */
-            calledBefore(anotherSpy: Sinon.SinonSpy): Assertion;
+            calledBefore(anotherSpy: Sinon.SinonSpy|Sinon.SinonSpyCall): Assertion;
             /**
              * Returns true if the spy was called after anotherSpy.
              */
-            calledAfter(anotherSpy: Sinon.SinonSpy): Assertion;
+            calledAfter(anotherSpy: Sinon.SinonSpy|Sinon.SinonSpyCall): Assertion;
             /**
              * Returns true if spy was called before anotherSpy, and no spy calls occurred
              * between spy and anotherSpy.

--- a/types/sinon-chai/sinon-chai-tests.ts
+++ b/types/sinon-chai/sinon-chai-tests.ts
@@ -7,6 +7,8 @@ chai.use(sinonChai);
 var expect = chai.expect;
 declare var spy: Sinon.SinonSpy;
 declare var anotherSpy: Sinon.SinonSpy;
+declare var spyCall: Sinon.SinonSpyCall;
+declare var anotherSpyCall: Sinon.SinonSpyCall;
 declare var context: {};
 declare var match: RegExp;
 
@@ -40,4 +42,6 @@ function test() {
     expect(spy).to.have.always.thrown(new Error());
     expect(spy).to.have.always.thrown(Error);
     expect(spy).to.have.always.thrown('an error');
+    expect(spyCall).to.have.been.calledBefore(anotherSpyCall);
+    expect(spyCall).to.have.been.calledAfter(anotherSpyCall);
 }


### PR DESCRIPTION
`calledBefore` and `calledAfter` can be called with `SinonSpyCall`. This PR adds this types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/sinon/index.d.ts#L161
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
