### PR TITLE
elliptic: Improve typings for ec.Signature

### DIFF
--- a/types/elliptic/elliptic-tests.ts
+++ b/types/elliptic/elliptic-tests.ts
@@ -11,9 +11,8 @@ const msgHash = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 const signature = key.sign(msgHash);
 
 // Export DER encoded signature in Array
-const derSign = signature.toDER();
-
-const decodedSignature = new elliptic.ec.Signature(derSign);
+const derSign = signature.toDER(); // $ExpectType number[]
+const derSignHex = signature.toDER('hex'); // $ExpectType string
 
 // Verify signature
 console.log(key.verify(msgHash, derSign));

--- a/types/elliptic/index.d.ts
+++ b/types/elliptic/index.d.ts
@@ -272,14 +272,13 @@ export namespace ec {
         inspect(): string;
     }
 
-    class Signature {
+    interface Signature {
         r: BN;
         s: BN;
         recoveryParam: number | null;
 
-        constructor(options: SignatureInput, enc?: string);
-
-        toDER(enc?: string | null): any; // ?
+        toDER(): number[];
+        toDER(enc: "hex"): string;
     }
 
     interface SignatureOptions {


### PR DESCRIPTION
- `toDER()` overloads for `number[]` and hex `string` return values instead of `any`.
- elliptic module does not export the ec Signature class/constructor so defining as an interface. Using the previously declared constructor results in *TypeError: elliptic.ec.Signature is not a constructor*.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - Signature imported but not exported (only [EC is exported](https://github.com/indutny/elliptic/blob/43ac7f230069bd1575e1e4a58394a512303ba803/lib/elliptic/ec/index.js#L41)): https://github.com/indutny/elliptic/blob/43ac7f230069bd1575e1e4a58394a512303ba803/lib/elliptic/ec/index.js
    - toDer() parameter is passed to [utils.encode()](https://github.com/indutny/elliptic/blob/43ac7f230069bd1575e1e4a58394a512303ba803/lib/elliptic/ec/signature.js#L165), which passes it to [minimalistic-crypto-utils.encode()](https://github.com/indutny/elliptic/blob/43ac7f230069bd1575e1e4a58394a512303ba803/lib/elliptic/utils.js#L12)
    - [minimalistic-crypto-utils.encode()](https://github.com/indutny/minimalistic-crypto-utils/blob/f4f2b13a3ac78d8ee6991994bae89ec93304d225/lib/utils.js#L45-L58) returns a hex string if `"hex"` is passed as its `enc` parameter; otherwise it returns the array passed to it, which in this case is a [number[]](https://github.com/indutny/elliptic/blob/43ac7f230069bd1575e1e4a58394a512303ba803/lib/elliptic/ec/signature.js#L156-L165)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
