### PR TITLE
[accept-language-parser] allow undefined to be passed on parse

### DIFF
--- a/types/accept-language-parser/accept-language-parser-tests.ts
+++ b/types/accept-language-parser/accept-language-parser-tests.ts
@@ -25,6 +25,7 @@ const enUs: Lang = "en-US";
 const koKr: Lang = "ko-KR";
 
 const parsed1: AcceptLanguageParser.Language[] = AcceptLanguageParser.parse('');
+const parsed: AcceptLanguageParser.Language[] = AcceptLanguageParser.parse();
 const pick1: string | null = AcceptLanguageParser.pick([''], '');
 const pick2: string | null = AcceptLanguageParser.pick([''], [l1, l2, l3]);
 const pick3: string | null = AcceptLanguageParser.pick([''], '', {});

--- a/types/accept-language-parser/index.d.ts
+++ b/types/accept-language-parser/index.d.ts
@@ -7,7 +7,7 @@
 
 // https://github.com/opentable/accept-language-parser/blob/v1.5.0/index.js
 
-export function parse(acceptLanguage: string): Language[];
+export function parse(acceptLanguage?: string): Language[];
 export function pick<T extends string>(
     supportedLanguages: T[],
     acceptLanguage: string | Language[],


### PR DESCRIPTION
`parser.parse` actually accepts that you pass undefined as a value (see link below), so the type should reflect that if you have a variable that is `string | undefined` you should be able to call parse too

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/opentable/accept-language-parser/blob/master/index.js#L8
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

