### PR TITLE
[braintree-web]: Add PayPalCheckout to the loadPayPalSDK Promise return type

### DIFF
--- a/types/braintree-web/modules/paypal-checkout.d.ts
+++ b/types/braintree-web/modules/paypal-checkout.d.ts
@@ -168,7 +168,7 @@ export interface PayPalCheckout {
      *
      * @link https://braintree.github.io/braintree-web/current/PayPalCheckout.html#loadPayPalSDK
      */
-    loadPayPalSDK(options?: PayPalCheckoutLoadPayPalSDKOptions): Promise<void>;
+    loadPayPalSDK(options?: PayPalCheckoutLoadPayPalSDKOptions): Promise<PayPalCheckout>;
     loadPayPalSDK(options?: PayPalCheckoutLoadPayPalSDKOptions, callback?: callback): void;
 
     /**

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -576,7 +576,7 @@ braintree.client.create(
                 intent: 'capture',
                 vault: true,
             })
-            .then(() => {
+            .then((paypalCheckout: braintree.PayPalCheckout) => {
                 // window.paypal.Buttons is now available to use
             });
 


### PR DESCRIPTION
The `loadPayPalSDK` method return type was `Promise<void>`, but according to the [documentation](https://braintree.github.io/braintree-web/current/PayPalCheckout.html#loadPayPalSDK):

> If no callback is provided, the promise resolves with the PayPal Checkout instance when the PayPal SDK has been loaded onto the page

It should be `Promise<PayPalCheckout>` instead of `Promise<void>`.