### PR TITLE
webextension-polyfill fix manifest commands field type

### DIFF
--- a/types/webextension-polyfill/namespaces/manifest.d.ts
+++ b/types/webextension-polyfill/namespaces/manifest.d.ts
@@ -153,7 +153,7 @@ export namespace Manifest {
         /**
          * Optional.
          */
-        commands?: WebExtensionManifestCommandsType;
+        commands?: Record<string, WebExtensionManifestCommandsType>;
 
         /**
          * Optional.


### PR DESCRIPTION
webextension-polyfill fix manifest commands field type
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands

