### PR TITLE
[throng] Fix type signature for throng worker callback function

### DIFF
--- a/types/throng/index.d.ts
+++ b/types/throng/index.d.ts
@@ -9,6 +9,7 @@ declare function throng(workers: throng.WorkerCount, start: throng.ProcessCallba
 declare namespace throng {
     type WorkerCount = number | string;
     type ProcessCallback = (id: number) => any;
+    type WorkerCallback = (id: number, disconnect: () => void) => void;
 
     type Options = {
         signals?: string[] | undefined;
@@ -17,7 +18,7 @@ declare namespace throng {
         master?: ProcessCallback | undefined;
         count?: number | undefined;
         workers?: WorkerCount | undefined;
-    } & ({start: ProcessCallback} | {worker: ProcessCallback});
+    } & ({start: WorkerCallback} | {worker: WorkerCallback});
 }
 
 export = throng;

--- a/types/throng/index.d.ts
+++ b/types/throng/index.d.ts
@@ -4,18 +4,18 @@
 //                 Tate Thurston <https://github.com/tatethurston>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function throng(startOrOptions: throng.ProcessCallback | throng.Options): Promise<void>;
-declare function throng(workers: throng.WorkerCount, start: throng.ProcessCallback): Promise<void>;
+declare function throng(startOrOptions: throng.WorkerCallback | throng.Options): Promise<void>;
+declare function throng(workers: throng.WorkerCount, start: throng.WorkerCallback): Promise<void>;
 declare namespace throng {
     type WorkerCount = number | string;
-    type ProcessCallback = (id: number) => any;
     type WorkerCallback = (id: number, disconnect: () => void) => void;
+    type MasterCallback = () => void;
 
     type Options = {
         signals?: string[] | undefined;
         grace?: number | undefined;
         lifetime?: number | undefined;
-        master?: ProcessCallback | undefined;
+        master?: MasterCallback | undefined;
         count?: number | undefined;
         workers?: WorkerCount | undefined;
     } & ({start: WorkerCallback} | {worker: WorkerCallback});

--- a/types/throng/throng-tests.ts
+++ b/types/throng/throng-tests.ts
@@ -1,7 +1,7 @@
 import throng = require("throng");
 
 function masterFunction() { }
-function startFunction(id: number) { }
+function startFunction(id: number, disconnect: () => void) { }
 
 throng((id: number) => {});
 


### PR DESCRIPTION
There is a slight mistake in the existing types for `throng`. As can be seen in the throng code https://github.com/hunterloftis/throng/blob/a030d7825299bd9f512f01f5c589bfbb4ffb4158/lib/throng.js#L24, the worker process now has a `disconnect` callback passed to it. This adds a separate callback function that applies to workers only.

Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

