### PR TITLE
fix(semver): toComparators returns string[][]

### DIFF
--- a/types/semver/ranges/to-comparators.d.ts
+++ b/types/semver/ranges/to-comparators.d.ts
@@ -4,6 +4,6 @@ import semver = require('../index');
 /**
  * Mostly just for testing and legacy API reasons
  */
-declare function toComparators(range: string | Range, optionsOrLoose?: boolean | semver.Options): string[];
+declare function toComparators(range: string | Range, optionsOrLoose?: boolean | semver.Options): string[][];
 
 export = toComparators;

--- a/types/semver/ranges/to-comparators.d.ts
+++ b/types/semver/ranges/to-comparators.d.ts
@@ -4,6 +4,6 @@ import semver = require('../index');
 /**
  * Mostly just for testing and legacy API reasons
  */
-declare function toComparators(range: string | Range, optionsOrLoose?: boolean | semver.Options): string;
+declare function toComparators(range: string | Range, optionsOrLoose?: boolean | semver.Options): string[];
 
 export = toComparators;

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -97,7 +97,6 @@ const op: semver.Operator = '';
 // declare const arr: any[];
 // declare const exp: RegExp;
 let strArr: ReadonlyArray<string> | null;
-let strArrArr: string[][];
 let prereleaseIdAttr: ReadonlyArray<string | number> | null;
 let strNumArr: ReadonlyArray<string | number>;
 declare const numArr: string[];
@@ -159,8 +158,6 @@ strn = semver.validRange(str, loose);
 bool = semver.satisfies(version, str, loose);
 strn = semver.maxSatisfying(versions, str, loose);
 strn = semver.minSatisfying(versions, str, loose);
-strArrArr = semver.toComparators('1.x'); // $ExpectType string[][]
-strArrArr = semver.toComparators(new Range('1.2.3')); // $ExpectType string[][]
 bool = semver.gtr(version, str, loose);
 bool = semver.ltr(version, str, loose);
 bool = semver.outside(version, str, '<', loose);
@@ -177,6 +174,8 @@ semver.subset('1.x', '1.x'); // $ExpectType boolean
 semver.subset(new Range('1.2.3'), new Range('1.2.3')); // $ExpectType boolean
 semver.subset('^1.2.3-pre.0', '1.x', { includePrerelease: true }); // $ExpectType boolean
 semver.subset('', ''); // $ExpectType boolean
+semver.toComparators('1.x'); // $ExpectType string[][]
+semver.toComparators(new Range('1.2.3')); // $ExpectType string[][]
 
 // Coercion
 sem = semver.coerce(str);

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -97,6 +97,7 @@ const op: semver.Operator = '';
 // declare const arr: any[];
 // declare const exp: RegExp;
 let strArr: ReadonlyArray<string> | null;
+let strArrArr: string[][];
 let prereleaseIdAttr: ReadonlyArray<string | number> | null;
 let strNumArr: ReadonlyArray<string | number>;
 declare const numArr: string[];
@@ -158,6 +159,8 @@ strn = semver.validRange(str, loose);
 bool = semver.satisfies(version, str, loose);
 strn = semver.maxSatisfying(versions, str, loose);
 strn = semver.minSatisfying(versions, str, loose);
+strArrArr = semver.toComparators('1.x'); // $ExpectType string[][]
+strArrArr = semver.toComparators(new Range('1.2.3')); // $ExpectType string[][]
 bool = semver.gtr(version, str, loose);
 bool = semver.ltr(version, str, loose);
 bool = semver.outside(version, str, '<', loose);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. **Tests pass without change**
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). **I saw the bit about ReadOnlyArray but that seems to apply to function arguments rather than the return value. Making the return value ReadOnlyArray would prevent doing something like `.pop()`.**
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/node-semver/blob/main/ranges/to-comparators.js#L6
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.