### PR TITLE
[assets-webpack-plugin] Update to webpack 5

### DIFF
--- a/types/assets-webpack-plugin/assets-webpack-plugin-tests.ts
+++ b/types/assets-webpack-plugin/assets-webpack-plugin-tests.ts
@@ -1,7 +1,7 @@
-import * as webpack from 'webpack';
+import { Configuration } from 'webpack';
 import AssetsPlugin = require('assets-webpack-plugin');
 
-const config: webpack.Configuration = {
+const config: Configuration = {
     plugins: [
         new AssetsPlugin(),
         new AssetsPlugin({
@@ -34,5 +34,3 @@ const config: webpack.Configuration = {
         })
     ]
 };
-
-new AssetsPlugin().apply(new webpack.Compiler());

--- a/types/assets-webpack-plugin/index.d.ts
+++ b/types/assets-webpack-plugin/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for assets-webpack-plugin 6.1
+// Type definitions for assets-webpack-plugin 7.1
 // Project: https://github.com/ztoben/assets-webpack-plugin
 // Definitions by: Michael Strobel <https://github.com/kryops>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
+/// <reference types="node" />
 import { Compiler } from 'webpack';
 
 declare namespace AssetsWebpackPlugin {

--- a/types/assets-webpack-plugin/package.json
+++ b/types/assets-webpack-plugin/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "tapable": "^2.2.0",
+        "webpack": "^5"
+    }
+}

--- a/types/assets-webpack-plugin/tsconfig.json
+++ b/types/assets-webpack-plugin/tsconfig.json
@@ -14,10 +14,10 @@
         ],
         "paths": {
             "webpack": [
-                "webpack/v4"
+                "./node_modules/webpack"
             ],
             "tapable": [
-                "tapable/v1"
+                "./node_modules/tapable"
             ]
         },
         "types": [],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ztoben/assets-webpack-plugin/blob/master/changelog.md#700---2020-12-11
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Via the discussion https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/56527

The types of `assets-webpack-plugin` were already compatible to webpack 5 via https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49366. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51712 pinned them to webpack 4 again.

As the plugin requires webpack 5 for the current major version, I updated the definition to require webpack 5 now as well.