### PR TITLE
Backbone: add support for view without model

### DIFF
--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -578,6 +578,15 @@ class SVGView extends Backbone.View<Backbone.Model, SVGGraphicsElement> {
     }
 }
 
+function testViewWithoutModel() {
+    const view = new Backbone.View<undefined>();
+    view.model.id; // $ExpectError
+    const view2 = new Backbone.View<Backbone.Model>({
+        model: new Backbone.Model()
+    });
+    view2.model.id; // $ExpectType string | number
+}
+
 interface TypedModelAttributes {
     stringAttr: string;
     numberAttr: number;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -532,7 +532,7 @@ declare namespace Backbone {
     }
 
     interface ViewOptions<TModel extends (Model | undefined) = Model, TElement extends Element = HTMLElement> {
-        model?: TModel extends Model ? TModel : undefined;
+        model?: TModel | undefined;
         // TODO: quickfix, this can't be fixed easy. The collection does not need to have the same model as the parent view.
         collection?: Collection<any> | undefined; // was: Collection<TModel>;
         el?: TElement | JQuery | string | undefined;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -531,8 +531,8 @@ declare namespace Backbone {
         private _updateHash(location: Location, fragment: string, replace: boolean): void;
     }
 
-    interface ViewOptions<TModel extends Model = Model, TElement extends Element = HTMLElement> {
-        model?: TModel | undefined;
+    interface ViewOptions<TModel extends (Model | undefined) = Model, TElement extends Element = HTMLElement> {
+        model?: TModel extends Model ? TModel : undefined;
         // TODO: quickfix, this can't be fixed easy. The collection does not need to have the same model as the parent view.
         collection?: Collection<any> | undefined; // was: Collection<TModel>;
         el?: TElement | JQuery | string | undefined;
@@ -545,7 +545,7 @@ declare namespace Backbone {
 
     type ViewEventListener = (event: JQuery.Event) => void;
 
-    class View<TModel extends Model = Model, TElement extends Element = HTMLElement> extends EventsMixin implements Events {
+    class View<TModel extends (Model | undefined) = Model, TElement extends Element = HTMLElement> extends EventsMixin implements Events {
         /**
          * Do not use, prefer TypeScript's extend functionality.
          */
@@ -569,8 +569,8 @@ declare namespace Backbone {
          */
         events(): EventsHash;
 
-        model: TModel;
-        collection: Collection<TModel>;
+        model: TModel extends Model ? TModel : undefined;
+        collection: TModel extends Model ? Collection<TModel> : undefined;
         setElement(element: TElement | JQuery): this;
         id?: string | undefined;
         cid: string;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -570,7 +570,7 @@ declare namespace Backbone {
         events(): EventsHash;
 
         model: TModel extends Model ? TModel : undefined;
-        collection?: Collection<any>;
+        collection: Collection<any>;
         setElement(element: TElement | JQuery): this;
         id?: string | undefined;
         cid: string;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -569,6 +569,7 @@ declare namespace Backbone {
          */
         events(): EventsHash;
 
+        // A conditional type used here to prevent `TS2532: Object is possibly 'undefined'`
         model: TModel extends Model ? TModel : undefined;
         collection: Collection<any>;
         setElement(element: TElement | JQuery): this;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -570,7 +570,7 @@ declare namespace Backbone {
         events(): EventsHash;
 
         model: TModel extends Model ? TModel : undefined;
-        collection: TModel extends Model ? Collection<TModel> : undefined;
+        collection?: Collection<any>;
         setElement(element: TElement | JQuery): this;
         id?: string | undefined;
         cid: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test backbone`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/8997375/backbonejs-view-without-a-model
- [ ] Increase the version number in the header if appropriate.

---

Also, there is no Backbone.View `collection` property in Backbone. Why is it that part of this definition?

I had to change  the `collection` property to  `Collection<any>` (same hack as [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/backbone/index.d.ts#L536-L537)) so the `giraffe` library types to tests pass. Can not we just remove the `collection` property? 

Thank you!



