### PR TITLE
[react-simple-maps] update `ZoomableGroupProps` interface

### DIFF
--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -7,6 +7,7 @@
 // TypeScript Version: 2.8
 
 import { GeoPath, GeoProjection } from 'd3-geo';
+import { D3ZoomEvent } from 'd3-zoom';
 import { Feature } from 'geojson';
 import * as React from 'react';
 
@@ -77,12 +78,10 @@ export interface ZoomableGroupProps extends React.SVGAttributes<SVGGElement> {
      * @default false
      */
     disableZooming?: boolean | undefined;
-    onMoveStart?: ((position: { coordinates: [number, number], zoom: number }, event: any) => void) | undefined;
-    onMove?: ((position: {x: number, y: number, k: number, dragging: WheelEvent }, event: any) => void) | undefined;
-    onMoveEnd?: ((position: { coordinates: [number, number], zoom: number }, event: any) => void) | undefined;
-    onZoomStart?: ((event: any, position: Position) => void) | undefined;
-    onZoomEnd?: ((event: any, position: Position) => void) | undefined;
-    filterZoomEvent?: ((event: any) => boolean) | undefined;
+    onMoveStart?: ((position: { coordinates: [number, number], zoom: number }, event: D3ZoomEvent<SVGElement, any>) => void) | undefined;
+    onMove?: ((position: {x: number, y: number, k: number, dragging: WheelEvent }, event: D3ZoomEvent<SVGElement, any>) => void) | undefined;
+    onMoveEnd?: ((position: { coordinates: [number, number], zoom: number }, event: D3ZoomEvent<SVGElement, any>) => void) | undefined;
+    filterZoomEvent?: ((element: SVGElement) => boolean) | undefined;
     translateExtent?: [[number, number], [number, number]] | undefined;
 }
 

--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -4,7 +4,6 @@
 //                 Andrej Mihajlov <https://github.com/pronebird>
 //                 Kouame Komenan  <https://github.com/komenank>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
 
 import { GeoPath, GeoProjection } from 'd3-geo';
 import { D3ZoomEvent } from 'd3-zoom';

--- a/types/react-simple-maps/react-simple-maps-tests.tsx
+++ b/types/react-simple-maps/react-simple-maps-tests.tsx
@@ -8,7 +8,28 @@ const Map = () => (
         style={{ height: 'auto', width: '100%' }}
         width={980}
     >
-        <ZoomableGroup center={[0, 20]} disablePanning={true} filterZoomEvent={(event: any) => event.type === 'wheel'}>
+        <ZoomableGroup
+            center={[0, 20]}
+            disablePanning={true}
+            filterZoomEvent={(event: any) => event.type === 'wheel'}
+            onMoveStart={({ coordinates, zoom }, event) => {
+                coordinates; // $ExpectType [number, number]
+                zoom; // $ExpectType number
+                event; // $ExpectType D3ZoomEvent<SVGElement, any>
+            }}
+            onMove={({ x, y, k, dragging }, event) => {
+                x; // $ExpectType number
+                y; // $ExpectType number
+                k; // $ExpectType number
+                dragging; // $ExpectType WheelEvent
+                event; // $ExpectType D3ZoomEvent<SVGElement, any>
+            }}
+            onMoveEnd={({ coordinates, zoom }, event) => {
+                coordinates; // $ExpectType [number, number]
+                zoom; // $ExpectType number
+                event; // $ExpectType D3ZoomEvent<SVGElement, any>
+            }}
+        >
             <Geographies geography="/worldmap.json">
                 {({ geographies }) =>
                     geographies.map((geography, index) => (

--- a/types/react-simple-maps/tsconfig.json
+++ b/types/react-simple-maps/tsconfig.json
@@ -1,7 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6"],
+        "lib": [
+            "es6",
+            "DOM"
+        ],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
@@ -11,6 +14,9 @@
         "paths": {
             "d3-geo": [
                 "d3-geo/v1"
+            ],
+            "d3-zoom": [
+                "d3-zoom/v1"
             ]
         },
         "jsx": "react",


### PR DESCRIPTION
- `onZoomStart` and `onZoomEnd` methods are not available anymore (here are docs with all available methods/props https://www.react-simple-maps.io/docs/zoomable-group/, here is code: https://github.com/zcreativelabs/react-simple-maps/blob/master/src/components/useZoomPan.js, here is some mentioning of that: https://github.com/zcreativelabs/react-simple-maps/issues/201)
- `onMoveStart`, `onMove`, `onMoveEnd` and `filterZoomEvent` methods definitions are updated.
  - code is here: https://github.com/zcreativelabs/react-simple-maps/blob/master/src/components/useZoomPan.js#L43,  https://github.com/zcreativelabs/react-simple-maps/blob/master/src/components/useZoomPan.js#L51, https://github.com/zcreativelabs/react-simple-maps/blob/master/src/components/useZoomPan.js#L62, https://github.com/zcreativelabs/react-simple-maps/blob/master/src/components/useZoomPan.js#L67)