### PR TITLE
[koa-route] Republish package to contain `types` field

### DIFF
--- a/types/koa-route/index.d.ts
+++ b/types/koa-route/index.d.ts
@@ -11,6 +11,9 @@ import * as pathToRegexp from 'path-to-regexp';
 declare namespace KoaRoute {
     type Path = string | RegExp | Array<string | RegExp>;
 
+    /**
+     * The Koa handler will receive parameters extracted from the route as extra arguments.
+     */
     type Handler = (this: Koa.Context, ctx: Koa.Context, ...params: any[]) => any;
 
     type CreateRoute = (routeFunc: Handler) => Koa.Middleware;

--- a/types/koa-route/koa-route-tests.ts
+++ b/types/koa-route/koa-route-tests.ts
@@ -1,7 +1,7 @@
 import Koa = require('koa');
 import * as route from 'koa-route';
 
-const app = new Koa();
+const app: Koa = new Koa();
 
 const getData = async (param: string) => Promise.resolve({ foo: param });
 


### PR DESCRIPTION
The types for `koa-route` were published 3 years ago and don't contain the `types` field like new type declarations. This in turn makes it incompatible with the upcoming `node12` module resolution. The goal of this commit is simply to trigger a rebuild of the package to publish a new version with the `types` field.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#esm-nodejs>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.