### PR TITLE
Fix typings for chrome MV3 extensions api

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10127,6 +10127,13 @@ declare namespace chrome.webNavigation {
      */
     export function getFrame(details: GetFrameDetails, callback: (details: GetFrameResultDetails | null) => void): void;
     /**
+     * Retrieves information about the given frame. A frame refers to an <iframe> or a <frame> of a web page and is identified by a tab ID and a frame ID.
+     * @param details Information about the frame to retrieve information about.
+     * @return The getFrame method provides its result via callback or returned as a Promise (MV3 only).
+     */
+    export function getFrame(details: GetFrameDetails): Promise<GetFrameResultDetails | null>;
+
+    /**
      * Retrieves information about all frames of a given tab.
      * @param details Information about the tab to retrieve all frames from.
      * @param callback
@@ -10136,7 +10143,14 @@ declare namespace chrome.webNavigation {
         details: GetAllFrameDetails,
         callback: (details: GetAllFrameResultDetails[] | null) => void,
     ): void;
-
+    /**
+     * Retrieves information about all frames of a given tab.
+     * @param details Information about the tab to retrieve all frames from.
+     * @return The getAllFrames method provides its result via callback or returned as a Promise (MV3 only).
+     */
+    export function getAllFrames(
+        details: GetAllFrameDetails,
+    ): Promise<GetAllFrameResultDetails[] | null>;
     /** Fired when the reference fragment of a frame was updated. All future events for that frame will use the updated URL. */
     export var onReferenceFragmentUpdated: WebNavigationTransitionalEvent;
     /** Fired when a document, including the resources it refers to, is completely loaded and initialized. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -208,6 +208,45 @@ function beforeRedditNavigation() {
     );
 }
 
+// https://developer.chrome.com/docs/extensions/reference/webNavigation/#method-getFrame
+async function getFrame() {
+    const testTabId = 0;
+    const testFrameId = 0;
+
+    chrome.webNavigation.getFrame({
+        tabId: testTabId,
+        frameId: testFrameId,
+    }, (frame: chrome.webNavigation.GetFrameResultDetails | null) => {
+        console.log('Frame (in-callback): ', frame);
+    });
+
+
+    const frame: chrome.webNavigation.GetFrameResultDetails | null = await chrome.webNavigation.getFrame({
+        tabId: testTabId,
+        frameId: testFrameId,
+    });
+
+    console.log('Frame (promise resolved):', frame);
+}
+
+// https://developer.chrome.com/docs/extensions/reference/webNavigation/#method-getAllFrames
+async function getAllFrames() {
+    const testTabId = 0;
+
+    chrome.webNavigation.getAllFrames({
+        tabId: testTabId,
+    }, (frames: chrome.webNavigation.GetAllFrameResultDetails[] | null) => {
+        console.log('All frames (in-callback): ', frames);
+    });
+
+
+    const frames: chrome.webNavigation.GetAllFrameResultDetails[] = await chrome.webNavigation.getAllFrames({
+        tabId: testTabId,
+    }) || [];
+
+    console.log('All frames (promise resolved):', frames);
+}
+
 // for chrome.tabs.InjectDetails.frameId
 function executeScriptFramed() {
     const tabId = 123;


### PR DESCRIPTION
## Fix typings for chrome MV3 extensions api

Since MV3 extension api in addition to callback supports promise-based approach.

##  Documentation reference:

-  [webNavigation.getAllFrames](https://developer.chrome.com/docs/extensions/reference/webNavigation/#method-getAllFrames)
-  [webNavigation.getFrame](https://developer.chrome.com/docs/extensions/reference/webNavigation/#method-getFrame)

-----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see above)

