### PR TITLE
Allow string component aliasing in MDX types

### DIFF
--- a/types/mdx/mdx-tests.tsx
+++ b/types/mdx/mdx-tests.tsx
@@ -137,13 +137,16 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
                             // $ExpectType any
                             props;
                             return <div />;
-                        }
+                        },
+                        span: 'div',
                     }
                 }
             },
         },
         // $ExpectError
         invalid: 'Not just any type is allowed though',
+        // Aliasing is valid though
+        span: 'div',
     }}
 />;
 
@@ -193,13 +196,16 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
                             // $ExpectType any
                             props;
                             return <div />;
-                        }
+                        },
+                        span: 'div',
                     }
                 }
             },
         },
         // $ExpectError
         invalid: 'Not just any type is allowed though',
+        // Aliasing is valid though
+        span: 'div',
     }}
 />;
 
@@ -249,13 +255,16 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
                             // $ExpectType any
                             props;
                             return <div />;
-                        }
+                        },
+                        span: 'div',
                     }
                 }
             },
         },
         // $ExpectError
         invalid: 'Not just any type is allowed though',
+        // Aliasing is valid though
+        span: 'div',
     }}
 />;
 
@@ -305,13 +314,16 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
                             // $ExpectType any
                             props;
                             return <div />;
-                        }
+                        },
+                        span: 'div',
                     }
                 }
             },
         },
         // $ExpectError
         invalid: 'Not just any type is allowed though',
+        // Aliasing is valid though
+        span: 'div',
     }}
 />;
 
@@ -361,13 +373,16 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
                             // $ExpectType any
                             props;
                             return <div />;
-                        }
+                        },
+                        span: 'div',
                     }
                 }
             },
         },
         // $ExpectError
         invalid: 'Not just any type is allowed though',
+        // Aliasing is valid though
+        span: 'div',
     }}
 />;
 
@@ -417,13 +432,16 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
                             // $ExpectType any
                             props;
                             return <div />;
-                        }
+                        },
+                        span: 'div',
                     }
                 }
             },
         },
         // $ExpectError
         invalid: 'Not just any type is allowed though',
+        // Aliasing is valid though
+        span: 'div',
     }}
 />;
 
@@ -473,13 +491,16 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
                             // $ExpectType any
                             props;
                             return <div />;
-                        }
+                        },
+                        span: 'div',
                     }
                 }
             },
         },
         // $ExpectError
         invalid: 'Not just any type is allowed though',
+        // Aliasing is valid though
+        span: 'div',
     }}
 />;
 
@@ -529,12 +550,15 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
                             // $ExpectType any
                             props;
                             return <div />;
-                        }
+                        },
+                        span: 'div',
                     }
                 }
             },
         },
         // $ExpectError
         invalid: 'Not just any type is allowed though',
+        // Aliasing is valid though
+        span: 'div',
     }}
 />;

--- a/types/mdx/types.d.ts
+++ b/types/mdx/types.d.ts
@@ -8,7 +8,7 @@ type ClassComponent<Props> = new (props: Props) => JSX.ElementClass;
 type Component<Props> = FunctionComponent<Props> | ClassComponent<Props>;
 // tslint:disable-next-line: strict-export-declare-modifiers
 interface NestedMDXComponents {
-    [key: string]: NestedMDXComponents | Component<any>;
+    [key: string]: NestedMDXComponents | Component<any> | keyof JSX.IntrinsicElements;
 }
 
 // Public MDX helper types
@@ -20,7 +20,7 @@ interface NestedMDXComponents {
  */
 export type MDXComponents = NestedMDXComponents &
     {
-        [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]>;
+        [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]> | keyof JSX.IntrinsicElements;
     } & {
         /**
          * If a wrapper component is defined, the MDX content will be wrapped inside of it.


### PR DESCRIPTION
This adds support for MDX string component aliasing, for example:

```ts
import MDXPage from 'page.mdx';

<MDXPage components={{ p: 'section' }} />
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://v2.mdxjs.com/using-mdx/#components
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
