### PR TITLE
fix(jsoneditor): update types according to newest api doc

### DIFF
--- a/types/jsoneditor/index.d.ts
+++ b/types/jsoneditor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jsoneditor 8.6
+// Type definitions for jsoneditor 9.5
 // Project: https://github.com/josdejong/jsoneditor
 // Definitions by: Alejandro Sánchez <https://github.com/alejo90>
 //                 Errietta Kostala <https://github.com/errietta>
@@ -594,6 +594,11 @@ export default class JSONEditor {
      * Also see `setText()`. This method throws an exception when the provided jsonString does not contain valid JSON and the editor is in mode 'tree', 'view', or 'form'.
      */
     updateText(jsonString: string): void;
+    /**
+     * Validate the JSON document against the configured JSON schema or custom validator. See also the `onValidationError` callback.
+     * Returns a promise which resolves with the current validation errors, or an empty list when there are no errors.
+     */
+    validate(): Promise<ValidationError[]>;
 
     /**
      * An array with the names of all known options.

--- a/types/jsoneditor/jsoneditor-tests.ts
+++ b/types/jsoneditor/jsoneditor-tests.ts
@@ -70,3 +70,4 @@ jsonEditor.getTextSelection();
 jsonEditor.refresh();
 jsonEditor.update(null);
 jsonEditor.updateText('');
+jsonEditor.validate();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/josdejong/jsoneditor/blob/master/docs/api.md>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
