### PR TITLE
fix(parse5): attributes can be undefined on start tags

### DIFF
--- a/types/parse5/index.d.ts
+++ b/types/parse5/index.d.ts
@@ -45,7 +45,7 @@ export interface StartTagLocation extends Location {
     /**
      * Start tag attributes' location info
      */
-    attrs: AttributesLocation;
+    attrs?: AttributesLocation;
 }
 
 export interface ElementLocation extends StartTagLocation {

--- a/types/parse5/parse5-tests.ts
+++ b/types/parse5/parse5-tests.ts
@@ -87,12 +87,14 @@ loc.startTag.endCol; // $ExpectType number
 loc.startTag.startOffset; // $ExpectType number
 loc.startTag.endOffset; // $ExpectType number
 
-loc.startTag.attrs["someAttr"].startLine; // $ExpectType number
-loc.startTag.attrs["someAttr"].startCol; // $ExpectType number
-loc.startTag.attrs["someAttr"].endLine; // $ExpectType number
-loc.startTag.attrs["someAttr"].endCol; // $ExpectType number
-loc.startTag.attrs["someAttr"].startOffset; // $ExpectType number
-loc.startTag.attrs["someAttr"].endOffset; // $ExpectType number
+const attrs = loc.startTag.attrs!;
+
+attrs["someAttr"].startLine; // $ExpectType number
+attrs["someAttr"].startCol; // $ExpectType number
+attrs["someAttr"].endLine; // $ExpectType number
+attrs["someAttr"].endCol; // $ExpectType number
+attrs["someAttr"].startOffset; // $ExpectType number
+attrs["someAttr"].endOffset; // $ExpectType number
 
 loc.endTag.startLine; // $ExpectType number
 loc.endTag.startCol; // $ExpectType number


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

**This is a breaking change, so some advice/opinions would be helpful here.**

The tokenizer inside parse5 will actually populate `attrs` only once the _first attribute has been seen_. This means elements with no attributes will actually have `undefined` here.

Examples:

```ts
// <div></div>
div.sourceCodeLocation.startTag.attrs; // undefined

// <div hidden></div>
div.sourceCodeLocation.startTag.attrs; // { hidden: Location }
```

One could argue this is actually a bug inside the tokenizer of parse5 (i would say it is). but we're far less likely to get a fix into that repo anytime soon i would say (last commit 2020).

Of course, this change can break many, many builds for all those people (including myself) who have been relying on this assumption.

Should we just bump the major version? this comes back to the same old problem: do we try keep DT versions aligned with their source packages, or do we do semver properly?