### PR TITLE
tailwindcss: added type-hinting for default theme screen sizes.

### DIFF
--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -16,6 +16,17 @@ export type Variant =
     | 'disabled'
     | 'dark';
 
+export type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>);
+
+export type TailwindScreens =
+    | 'sm'
+    | 'md'
+    | 'lg'
+    | 'xl'
+    | '2xl';
+
+export type TailwindScreensUnion = LiteralUnion<TailwindScreens>;
+
 export interface TailwindColorGroup {
     readonly '50': string;
     readonly '100': string;
@@ -132,14 +143,7 @@ export interface TailwindPurgeConfig {
 export interface TailwindConfig {
     theme: Partial<{
         readonly extend: Omit<TailwindConfig['theme'], 'extend'>;
-        readonly screens: {
-            readonly sm: string;
-            readonly md: string;
-            readonly lg: string;
-            readonly xl: string;
-            readonly '2xl': string;
-            readonly [key: string]: string;
-        };
+        readonly screens: Record<TailwindScreensUnion, string>;
         readonly colors: TailwindColorConfig;
         readonly spacing: TailwindStandardSpacing & {
             readonly [key: string]: string;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

When writing JavaScript/TypeScript for utilizing screen sizes defined in Tailwindcss config, it was nearly impossible to get type hinting for default screen sizes without overriding the type definition itself. Utilizing a `LiteralUnion` type and exposing the screen sizes as a separate string union, consumers of tailwindcss type definitions now get the best of both worlds: strong(-enough) type hinting and access to custom properties defined inside `tailwind.config.js`.
