### PR TITLE
@types/validator: added missing options param to isAlpha

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -100,12 +100,20 @@ declare namespace validator {
 
     const isAlphaLocales: AlphaLocale[];
 
+    interface IsAlphaOptions {
+        /**
+         * @default undefined
+         */
+        ignore?: string | RegExp | undefined;
+    }
+
     /**
      * Check if the string contains only letters (a-zA-Z).
      *
      * @param [locale] - AlphaLocale
+     * @param [options] - IsAlphaOptions
      */
-    function isAlpha(str: string, locale?: AlphaLocale): boolean;
+    function isAlpha(str: string, locale?: AlphaLocale,  options?: IsAlphaOptions): boolean;
 
     type AlphanumericLocale =
         | 'en-US'

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -503,6 +503,9 @@ const any: any = null;
     result = validator.isAlpha('sample', 'sv-SE');
     result = validator.isAlpha('sample', 'tr-TR');
     result = validator.isAlpha('sample', 'uk-UA');
+    result = validator.isAlpha('sample', undefined, {ignore: /[\s!?]/g});
+    result = validator.isAlpha('sample', 'fr-FR', {ignore: /[\s!?]/g});
+    result = validator.isAlpha('sample', 'fr-FR', {ignore: ' !?'});
 
     result = validator.isAlphanumeric('sample');
     result = validator.isAlphanumeric('sample', 'ar');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/validatorjs/validator.js/blob/master/src/lib/isAlpha.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

For some reason, `isAlpha` validator's type definition is missing the third optional parameter called `options`. Added this missing parameter.