### PR TITLE
[css-font-loading-module] augment global FontFaceSet type rather than exporting

### DIFF
--- a/types/css-font-loading-module/css-font-loading-module-tests.ts
+++ b/types/css-font-loading-module/css-font-loading-module-tests.ts
@@ -27,3 +27,6 @@ contexts.forEach(context => {
     };
     context.fonts.dispatchEvent(e);
 });
+
+const ffs: FontFaceSet = document.fonts;
+ffs.addEventListener('loading', (e) => e.fontfaces);

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -44,16 +44,16 @@ declare global {
         readonly loaded: Promise<FontFace>;
     }
 
-    export interface FontFaceSet extends Set<FontFace>, EventTarget {
+    interface FontFaceSet extends Set<FontFace>, EventTarget {
         // events for when loading state changes
         onloading: ((this: FontFaceSet, event: Event) => any) | null;
         onloadingdone: ((this: FontFaceSet, event: Event) => any) | null;
         onloadingerror: ((this: FontFaceSet, event: Event) => any) | null;
 
         // EventTarget
-        addEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: FontFaceSetCallbackMap[K], options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof FontFaceSetCallbackMap>(type: K, listener: FontFaceSetCallbackMap[K], options?: boolean | AddEventListenerOptions): void;
         addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: FontFaceSetCallbackMap[K], options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof FontFaceSetCallbackMap>(type: K, listener: FontFaceSetCallbackMap[K], options?: boolean | EventListenerOptions): void;
         removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 
         // check and start loads if appropriate

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -11,38 +11,10 @@ export interface FontFaceSetLoadEventInit extends EventInit {
     fontfaces?: FontFace[] | undefined;
 }
 
-export interface FontFaceSetEventMap {
+export interface FontFaceSetCallbackMap {
     "loading": (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
     "loadingdone": (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
     "loadingerror": (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
-}
-
-export interface FontFaceSet extends Set<FontFace>, EventTarget {
-    // events for when loading state changes
-    onloading: ((this: FontFaceSet, event: Event) => any) | null;
-    onloadingdone: ((this: FontFaceSet, event: Event) => any) | null;
-    onloadingerror: ((this: FontFaceSet, event: Event) => any) | null;
-
-    // EventTarget
-    addEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: FontFaceSetEventMap[K], options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: FontFaceSetEventMap[K], options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-
-    // check and start loads if appropriate
-    // and fulfill promise when all loads complete
-    load(font: string, text?: string): Promise<FontFace[]>;
-    // return whether all fonts in the fontlist are loaded
-    // (does not initiate load if not available)
-    check(font: string, text?: string): boolean;
-
-    forEach(callbackfn: (value: FontFace, key: FontFace, parent: FontFaceSet) => void, thisArg?: any): void;
-
-    // async notification that font loading and layout operations are done
-    readonly ready: Promise<FontFaceSet>;
-
-    // loading state, "loading" while one or more fonts loading, "loaded" otherwise
-    readonly status: FontFaceSetLoadStatus;
 }
 
 declare global {
@@ -72,6 +44,34 @@ declare global {
         readonly loaded: Promise<FontFace>;
     }
 
+    export interface FontFaceSet extends Set<FontFace>, EventTarget {
+        // events for when loading state changes
+        onloading: ((this: FontFaceSet, event: Event) => any) | null;
+        onloadingdone: ((this: FontFaceSet, event: Event) => any) | null;
+        onloadingerror: ((this: FontFaceSet, event: Event) => any) | null;
+
+        // EventTarget
+        addEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: FontFaceSetCallbackMap[K], options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof FontFaceSetEventMap>(type: K, listener: FontFaceSetCallbackMap[K], options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+
+        // check and start loads if appropriate
+        // and fulfill promise when all loads complete
+        load(font: string, text?: string): Promise<FontFace[]>;
+        // return whether all fonts in the fontlist are loaded
+        // (does not initiate load if not available)
+        check(font: string, text?: string): boolean;
+
+        forEach(callbackfn: (value: FontFace, key: FontFace, parent: FontFaceSet) => void, thisArg?: any): void;
+
+        // async notification that font loading and layout operations are done
+        readonly ready: Promise<FontFaceSet>;
+
+        // loading state, "loading" while one or more fonts loading, "loaded" otherwise
+        readonly status: FontFaceSetLoadStatus;
+    }
+
     var FontFace: {
         prototype: FontFace;
         new(family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace;
@@ -94,3 +94,6 @@ declare global {
         fonts: FontFaceSet;
     }
 }
+
+type FontFaceSetCopy = FontFaceSet;
+export { FontFaceSetCopy as FontFaceSet };

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -12,9 +12,9 @@ export interface FontFaceSetLoadEventInit extends EventInit {
 }
 
 export interface FontFaceSetCallbackMap {
-    "loading": (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
-    "loadingdone": (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
-    "loadingerror": (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
+    loading: (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
+    loadingdone: (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
+    loadingerror: (this: FontFaceSet, event: FontFaceSetLoadEvent) => any;
 }
 
 declare global {
@@ -51,10 +51,26 @@ declare global {
         onloadingerror: ((this: FontFaceSet, event: Event) => any) | null;
 
         // EventTarget
-        addEventListener<K extends keyof FontFaceSetCallbackMap>(type: K, listener: FontFaceSetCallbackMap[K], options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof FontFaceSetCallbackMap>(type: K, listener: FontFaceSetCallbackMap[K], options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+        addEventListener<K extends keyof FontFaceSetCallbackMap>(
+            type: K,
+            listener: FontFaceSetCallbackMap[K],
+            options?: boolean | AddEventListenerOptions,
+        ): void;
+        addEventListener(
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | AddEventListenerOptions,
+        ): void;
+        removeEventListener<K extends keyof FontFaceSetCallbackMap>(
+            type: K,
+            listener: FontFaceSetCallbackMap[K],
+            options?: boolean | EventListenerOptions,
+        ): void;
+        removeEventListener(
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | EventListenerOptions,
+        ): void;
 
         // check and start loads if appropriate
         // and fulfill promise when all loads complete
@@ -74,7 +90,7 @@ declare global {
 
     var FontFace: {
         prototype: FontFace;
-        new(family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace;
+        new (family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace;
     };
 
     interface FontFaceSetLoadEvent extends Event {
@@ -83,7 +99,7 @@ declare global {
 
     var FontFaceSetLoadEvent: {
         prototype: FontFaceSetLoadEvent;
-        new(type: string, eventInitDict?: FontFaceSetLoadEventInit): FontFaceSetLoadEvent;
+        new (type: string, eventInitDict?: FontFaceSetLoadEventInit): FontFaceSetLoadEvent;
     };
 
     interface Document {


### PR DESCRIPTION
Previous version forces users to import `FontFaceSet`. This means that we have an import of a module that cannot be imported at runtime, which breaks assumptions that some tools make.

Moving the `interface` into the `declare global {}` block augments the type instead. I've also aliased + re-exported the type at the bottom of this module so it stays backwards compatible.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: described here
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header (N/A)