### PR TITLE
[@koa/multer] fix type of "files" that can be an object

### DIFF
--- a/types/koa__multer/index.d.ts
+++ b/types/koa__multer/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for @koa/multer 2.0
-// Project: https://github.com/koa-modules/multer
+// Project: https://github.com/koajs/multer
 // Definitions by: benstevens48 <https://github.com/benstevens48>
 //                 Nikita Umnov <https://github.com/nomnes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -40,12 +40,12 @@ import { IncomingMessage } from 'http';
 declare module 'koa' {
     interface DefaultContext {
         file: multer.File;
-        files: multer.File[];
+        files: { [fieldname: string]: multer.File[] } | multer.File[] | undefined;
     }
 
     interface Request {
         file: multer.File;
-        files: multer.File[];
+        files: { [fieldname: string]: multer.File[] } | multer.File[] | undefined;
     }
 }
 

--- a/types/koa__multer/koa__multer-tests.ts
+++ b/types/koa__multer/koa__multer-tests.ts
@@ -5,7 +5,7 @@ const upload = multer({
     dest: 'uploads/',
     fileFilter: (req, file, cb) => {
         cb(null, true);
-    }
+    },
 });
 
 const app = new Koa();
@@ -14,14 +14,19 @@ app.use(upload.single('avatar'));
 
 app.use(upload.array('photos', 12));
 app.use(async (ctx, next) => {
-    for (const file of ctx.request.files) {
-        console.info(`Received file: ${file.filename}`);
-    }
+    ctx.request.files; // $ExpectType { [fieldname: string]: File[]; } | File[] | undefined
     await next();
 });
 
-const cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }]);
+const cpUpload = upload.fields([
+    { name: 'avatar', maxCount: 1 },
+    { name: 'gallery', maxCount: 8 },
+]);
 app.use(cpUpload);
+app.use(async (ctx, next) => {
+    ctx.request.files; // $ExpectType { [fieldname: string]: File[]; } | File[] | undefined
+    await next();
+});
 
 const diskStorage = multer.diskStorage({
     destination(req, file, cb) {
@@ -29,7 +34,7 @@ const diskStorage = multer.diskStorage({
     },
     filename(req, file, cb) {
         cb(null, `${file.fieldname}-${Date.now()}`);
-    }
+    },
 });
 
 const diskUpload = multer({ storage: diskStorage });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/expressjs/multer#usage>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

ref of `files` type from multer package
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/596d3684ea66215c8530c80b6fa3ea9b2d4a1903/types/multer/index.d.ts#L57-L59


fixes #52929