### PR TITLE
[three] Add `createShaderMaterial` function to GPUComputationRenderer

### DIFF
--- a/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
+++ b/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
@@ -8,6 +8,7 @@ import {
     Wrapping,
     TextureFilter,
     TextureDataType,
+    IUniform,
 } from '../../../src/Three';
 
 export interface Variable {
@@ -36,6 +37,7 @@ export class GPUComputationRenderer {
     getCurrentRenderTarget(variable: Variable): RenderTarget;
     getAlternateRenderTarget(variable: Variable): RenderTarget;
     addResolutionDefine(materialShader: ShaderMaterial): void;
+    createShaderMaterial(computeFragmentShader: string, uniforms?: { [uniform: string]: IUniform }): ShaderMaterial;
     createRenderTarget(
         sizeXTexture: number,
         sizeYTexture: number,
@@ -47,4 +49,6 @@ export class GPUComputationRenderer {
     createTexture(): DataTexture;
     renderTexture(input: Texture, output: Texture): void;
     doRenderTarget(material: Material, output: RenderTarget): void;
+    getPassThroughVertexShader(): string;
+    getPassThroughFragmentShader(): string;
 }

--- a/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
+++ b/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
@@ -49,6 +49,4 @@ export class GPUComputationRenderer {
     createTexture(): DataTexture;
     renderTexture(input: Texture, output: Texture): void;
     doRenderTarget(material: Material, output: RenderTarget): void;
-    getPassThroughVertexShader(): string;
-    getPassThroughFragmentShader(): string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. _(Looks like these are kept sparse for `three`_
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/blob/r133/examples/jsm/misc/GPUComputationRenderer.js#L302-L318
