### PR TITLE
[jscodeshift] Added better typing

### DIFF
--- a/types/jscodeshift/index.d.ts
+++ b/types/jscodeshift/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Brie Bunge <https://github.com/brieb>
 //                 Brian Jacobel <https://github.com/bjacobel>
 //                 Will Nguyen <https://github.com/willtn>
+//                 Bartosz Szewczyk <https://github.com/sztobar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 

--- a/types/jscodeshift/src/collections/Node.d.ts
+++ b/types/jscodeshift/src/collections/Node.d.ts
@@ -1,15 +1,25 @@
-import astTypes = require("ast-types");
-import nodePath = require("ast-types/lib/node-path");
-import types = require("ast-types/lib/types");
-import Collection = require("../Collection");
+import astTypes = require('ast-types');
+import nodePath = require('ast-types/lib/node-path');
+import types = require('ast-types/lib/types');
+import Collection = require('../Collection');
 
 type ASTPath<N> = nodePath.NodePath<N, N>;
+
+type RecursiveMatchNode<T> =
+    | (T extends {}
+          ? {
+                [K in keyof T]?: RecursiveMatchNode<T[K]>;
+            }
+          : T)
+    | ((value: T) => boolean);
+
+type ASTNode = types.ASTNode;
 
 export interface TraversalMethods {
     /**
      * Find nodes of a specific type within the nodes of this collection.
      */
-    find<T>(type: types.Type<T>, filter?: ((value: any) => boolean) | object): Collection.Collection<T>;
+    find<T extends ASTNode>(type: types.Type<T>, filter?: RecursiveMatchNode<T>): Collection.Collection<T>;
 
     /**
      * Returns a collection containing the paths that create the scope of the
@@ -20,7 +30,7 @@ export interface TraversalMethods {
     /**
      * Traverse the AST up and finds the closest node of the provided type.
      */
-    closest<T>(type: types.Type<T>, filter?: any): Collection.Collection<T>;
+    closest<T>(type: types.Type<T>, filter?: RecursiveMatchNode<T>): Collection.Collection<T>;
 
     /**
      * Finds the declaration for each selected path. Useful for member expressions
@@ -29,7 +39,9 @@ export interface TraversalMethods {
      *
      * If the callback returns a falsy value, the element is skipped.
      */
-    getVariableDeclarators(nameGetter: (...args: any[]) => any): Collection.Collection<astTypes.namedTypes.VariableDeclarator>;
+    getVariableDeclarators(
+        nameGetter: (...args: any[]) => any,
+    ): Collection.Collection<astTypes.namedTypes.VariableDeclarator>;
 }
 
 export interface MutationMethods<N> {

--- a/types/jscodeshift/src/testUtils.d.ts
+++ b/types/jscodeshift/src/testUtils.d.ts
@@ -1,32 +1,61 @@
 import { Transform, Options, Parser } from './core';
 
 export interface TestOptions {
-  parser?: Parser | string | undefined;
+    parser?: Parser | string | undefined;
 }
 
+export function applyTransform(
+    module: { default: Transform; parser: TestOptions['parser'] } | Transform,
+    options: Options | null | undefined,
+    input: {
+        path?: string;
+        source: string;
+    },
+    testOptions?: TestOptions,
+): string;
+
 export function defineTest(
-  dirName: string,
-  transformName: string,
-  options: Options,
-  testFilePrefix?: string,
-  testOptions?: TestOptions
-): () => any;
+    dirName: string,
+    transformName: string,
+    options?: Options | null,
+    testFilePrefix?: string,
+    testOptions?: TestOptions,
+): void;
+
+export function runTest(
+    dirName: string,
+    transformName: string,
+    options: Options,
+    testFilePrefix?: string,
+    testOptions?: TestOptions,
+): string;
 
 export function defineInlineTest(
-  module: Transform,
-  options: Options,
-  inputSource: string,
-  expectedOutputSource: string,
-  testName?: string
-): () => any;
+    module: Transform,
+    options: Options,
+    inputSource: string,
+    expectedOutputSource: string,
+    testName?: string,
+): void;
 
 export function runInlineTest(
-  module: Transform,
-  options: Options,
-  input: {
-    path?: string,
-    source: string,
-  },
-  expectedOutput: string,
-  testOptions?: TestOptions
+    module: Transform,
+    options: Options,
+    input: {
+        path?: string;
+        source: string;
+    },
+    expectedOutput: string,
+    testOptions?: TestOptions,
+): string;
+
+export function defineSnapshotTest(module: Transform, options: Options, input: string, testName?: string): void;
+
+export function runSnapshotTest(
+    module: Transform,
+    options: Options,
+    input: {
+        path?: string;
+        source: string;
+    },
 ): string;

--- a/types/jscodeshift/src/testUtils.d.ts
+++ b/types/jscodeshift/src/testUtils.d.ts
@@ -1,7 +1,7 @@
 import { Transform, Options, Parser } from './core';
 
 export interface TestOptions {
-    parser?: Parser | string | undefined;
+    parser?: Parser | 'babylon' | 'flow' | 'ts' | 'tsx' | 'babel' | undefined;
 }
 
 export function applyTransform(

--- a/types/jscodeshift/test/js-transforms/bind-this-to-bind-expression.ts
+++ b/types/jscodeshift/test/js-transforms/bind-this-to-bind-expression.ts
@@ -14,7 +14,7 @@ const transform: j.Transform = (file, api) => {
   const j = api.jscodeshift;
   return j(file.source)
     // Find stuff that looks like this.xyz.bind(this)
-    .find(j.CallExpression, {callee: {object: {object: j.ThisExpression}, property: {name: 'bind'}}})
+    .find(j.CallExpression, {callee: {object: {type: 'ThisExpression'}, property: {name: 'bind'}}})
     // Ensure that .bind() is being called with only one argument, and that argument is "this".
     .filter(p => p.value.arguments.length === 1 && p.value.arguments[0].type === "ThisExpression")
     // We can now replace it with ::this.xyz

--- a/types/jscodeshift/test/jscodeshift-tests.ts
+++ b/types/jscodeshift/test/jscodeshift-tests.ts
@@ -1,18 +1,24 @@
-import { ASTNode, FileInfo, API, Transform, Parser, JSCodeshift, Collection, ImportDeclaration } from "jscodeshift";
-import * as testUtils from "jscodeshift/src/testUtils";
+import {
+    ASTNode,
+    FileInfo,
+    API,
+    Transform,
+    Parser,
+    JSCodeshift,
+    Collection,
+    ImportDeclaration,
+} from 'jscodeshift';
+import * as testUtils from 'jscodeshift/src/testUtils';
 
 // Can define transform with `function`.
 function replaceWithFooTransform(fileInfo: FileInfo, api: API) {
-    return api
-        .jscodeshift(fileInfo.source)
-        .findVariableDeclarators("foo")
-        .renameTo("bar")
-        .toSource();
+    return api.jscodeshift(fileInfo.source).findVariableDeclarators('foo').renameTo('bar').toSource();
 }
 
 // Type-force parameter for .map is optional
 function mapSignature(fileInfo: FileInfo, api: API) {
-    return api.jscodeshift(fileInfo.source)
+    return api
+        .jscodeshift(fileInfo.source)
         .map(p => p)
         .toSource();
 }
@@ -24,14 +30,7 @@ const reverseIdentifiersTransform: Transform = (file, api) => {
     return j(file.source)
         .find(j.Identifier)
         .forEach(path => {
-            j(path).replaceWith(
-                j.identifier(
-                    path.node.name
-                        .split("")
-                        .reverse()
-                        .join("")
-                )
-            );
+            j(path).replaceWith(j.identifier(path.node.name.split('').reverse().join('')));
         })
         .toSource();
 };
@@ -40,13 +39,13 @@ const reverseIdentifiersTransform: Transform = (file, api) => {
 const parser: Parser = {
     parse(source, options) {
         // return estree compatible AST
-        return { type: "root" };
-    }
+        return { type: 'root' };
+    },
 };
 
 // Can pass options to recast
 const transformWithRecastFormattingOptions: Transform = (file, { j }) => {
-    return j(file.source).toSource({ quote: "single" });
+    return j(file.source).toSource({ quote: 'single' });
 };
 
 const transformWithRecastParseOptions: Transform = (file, { j }) => {
@@ -55,20 +54,42 @@ const transformWithRecastParseOptions: Transform = (file, { j }) => {
     }).toSource();
 };
 
+const transformImportSpecifier: Transform = (file, { j }) => {
+    return j(file.source).find(j.ImportDeclaration, {
+        source: { value: 'specific-library' },
+        specifiers: specifiers =>
+            specifiers?.some(
+                specifier => specifier.type === 'ImportSpecifier' && specifier.imported.name === 'import-to-remove',
+            ) || false,
+    })
+    .replaceWith((path) => {
+      const specifiersExceptImportToRemove =
+        path.node.specifiers?.filter(
+          (specifier) => !(specifier.type === 'ImportSpecifier' && specifier.imported.name === 'import-to-remove')
+        ) ?? [];
+
+      return specifiersExceptImportToRemove.length > 0
+        ? j.importDeclaration(
+            specifiersExceptImportToRemove,
+            path.node.source,
+            path.node.importKind
+          )
+        : null;
+    }).toSource();
+};
+
 const transformExportDefaultArrow: Transform = (file, { j }) => {
     return j(file.source)
         .find(j.ExportDefaultDeclaration, {
-            type: "ExportDefaultDeclaration",
+            type: 'ExportDefaultDeclaration',
             declaration: {
-                type: "ArrowFunctionExpression",
+                type: 'ArrowFunctionExpression',
             },
         })
-        .forEach((path) => {
-            const arrow = path.node.declaration as import("ast-types/gen/kinds").ArrowFunctionExpressionKind;
-            const body = arrow.body.type === "BlockStatement" ? arrow.body :
-                j.blockStatement([
-                    j.returnStatement(arrow.body)
-                ]);
+        .forEach(path => {
+            const arrow = path.node.declaration as import('ast-types/gen/kinds').ArrowFunctionExpressionKind;
+            const body =
+                arrow.body.type === 'BlockStatement' ? arrow.body : j.blockStatement([j.returnStatement(arrow.body)]);
             j(path).replaceWith(
                 j.exportDefaultDeclaration(
                     j.functionDeclaration.from({
@@ -84,8 +105,8 @@ const transformExportDefaultArrow: Transform = (file, { j }) => {
                         rest: arrow.rest,
                         returnType: arrow.returnType,
                         typeParameters: arrow.typeParameters,
-                    })
-                )
+                    }),
+                ),
             );
         })
         .toSource();
@@ -93,23 +114,20 @@ const transformExportDefaultArrow: Transform = (file, { j }) => {
 
 // `ASTNode` supports type narrowing.
 {
-    const node = ({} as any) as ASTNode;
-    if (node.type === "CatchClause") {
+    const node = {} as any as ASTNode;
+    if (node.type === 'CatchClause') {
         // $ExpectType CatchClause
         node;
 
-        if (node.param && node.param.type === "Identifier") {
+        if (node.param && node.param.type === 'Identifier') {
             // $ExpectType Identifier
             node.param;
 
-            if (
-                node.param.typeAnnotation &&
-                node.param.typeAnnotation.type === "TSTypeAnnotation"
-            ) {
+            if (node.param.typeAnnotation && node.param.typeAnnotation.type === 'TSTypeAnnotation') {
                 // $ExpectType TSTypeAnnotation
                 node.param.typeAnnotation;
 
-                if (node.param.typeAnnotation.typeAnnotation.type === "TSArrayType") {
+                if (node.param.typeAnnotation.typeAnnotation.type === 'TSArrayType') {
                     // $ExpectType TSArrayType
                     node.param.typeAnnotation.typeAnnotation;
                 }
@@ -123,23 +141,40 @@ function getFileDefaultImport(file: FileInfo, j: JSCodeshift): Collection<Import
     return j(file.source).find(j.ImportDeclaration);
 }
 
-// Can define a test
-testUtils.defineTest(
-    "directory",
-    "transformName",
-    { opt: true },
-    undefined,
-    { parser: 'tsx' }
-);
+// Can apply a transform passed as module
+testUtils.applyTransform({ default: transformImportSpecifier, parser: 'ts' }, null, { source: "import test from 'test';"});
+
+// Can apply a transform passed as function
+testUtils.applyTransform(transformImportSpecifier, {}, { source: "import test from 'test';", path: '/file/path' }, { parser: 'esprima' });
 
 // Can define a test
+testUtils.defineTest('directory', 'transformName', { opt: true }, undefined, { parser: 'tsx' });
+
+// Can run a test
+testUtils.runTest('dirname', 'transformName', {});
+
+// Can define an inline test
 testUtils.defineInlineTest(() => {}, { opt: true }, "import test from 'test';", "import test from './test';");
 
-// Can run inline test
+// Can run an inline test
 testUtils.runInlineTest(
     () => {},
     { opt: true },
     { source: "import test from 'test';" },
     "import test from './test';",
-    {}
+    {},
 );
+
+// Can define a snapshot test
+testUtils.defineSnapshotTest(
+    reverseIdentifiersTransform,
+    {},
+    `
+var firstWord = 'Hello ';
+var secondWord = 'world';
+var message = firstWord + secondWord;
+    `,
+);
+
+// Can run a snapshot test
+testUtils.runSnapshotTest(reverseIdentifiersTransform, {}, { source: "var firstWord = 'Hello ';" });

--- a/types/jscodeshift/test/jscodeshift-tests.ts
+++ b/types/jscodeshift/test/jscodeshift-tests.ts
@@ -145,7 +145,7 @@ function getFileDefaultImport(file: FileInfo, j: JSCodeshift): Collection<Import
 testUtils.applyTransform({ default: transformImportSpecifier, parser: 'ts' }, null, { source: "import test from 'test';"});
 
 // Can apply a transform passed as function
-testUtils.applyTransform(transformImportSpecifier, {}, { source: "import test from 'test';", path: '/file/path' }, { parser: 'esprima' });
+testUtils.applyTransform(transformImportSpecifier, {}, { source: "import test from 'test';", path: '/file/path' }, { parser: 'babylon' });
 
 // Can define a test
 testUtils.defineTest('directory', 'transformName', { opt: true }, undefined, { parser: 'tsx' });


### PR DESCRIPTION
* added missing `testUtils` functions
* added better type autosuggestion for `find` and `closest` methods
* added additional calls to `jscodeshift-tests` to cover better types for
`find` and `testUtils`
* fixed invalid example file (`bind-this-to-bind-expression.ts`)
* applied consistent formatting
* added better type constraint for parser names

Template part:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test jscodeshift`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [testUtils.js](https://github.com/facebook/jscodeshift/blob/main/src/testUtils.js) [matchNode.js](https://github.com/facebook/jscodeshift/blob/main/src/matchNode.js#L21) [getParser.js](https://github.com/facebook/jscodeshift/blob/aea20523d9d616e7debc7bc00b66835284278555/src/getParser.js)