### PR TITLE
fix(react-native): add getParts function type to FormData class

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -51,8 +51,15 @@ declare var Blob: {
     new (blobParts?: Array<Blob | string>, options?: BlobOptions): Blob;
 };
 
+interface FormDataPart {
+    string: string;
+    headers: { [name: string]: string };
+    fieldName: string;
+}
+
 declare class FormData {
     append(name: string, value: any): void;
+    getParts(): Array<FormDataPart>;
 }
 
 declare interface Body {

--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -51,10 +51,14 @@ declare var Blob: {
     new (blobParts?: Array<Blob | string>, options?: BlobOptions): Blob;
 };
 
-interface FormDataPart {
+type FormDataPart = {
     string: string;
     headers: { [name: string]: string };
-    fieldName: string;
+} | {
+    uri: string
+    headers: { [name: string]: string }
+    name?: string
+    type?: string
 }
 
 declare class FormData {
@@ -352,9 +356,9 @@ type WebsocketOpenEventListener = (event: 'open', handler: () => void) => void;
 type WebsocketCloseEventListener = (event: 'close', handler: (e: WebSocketCloseEvent) => void) => void;
 
 type WebsocketEventListener = WebsocketMessageEventListener &
-  WebsocketErrorEventListener &
-  WebsocketOpenEventListener &
-  WebsocketCloseEventListener;
+    WebsocketErrorEventListener &
+    WebsocketOpenEventListener &
+    WebsocketCloseEventListener;
 
 interface WebSocket extends EventTarget {
     readonly readyState: number;
@@ -404,15 +408,27 @@ declare class AbortSignal implements EventTarget {
 
     onabort: (event: AbortEvent) => void;
 
-    addEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
-        capture?: boolean,
-        once?: boolean,
-        passive?: boolean
-    }) => void;
+    addEventListener: (
+        type: 'abort',
+        listener: (this: AbortSignal, event: any) => any,
+        options?:
+            | boolean
+            | {
+                  capture?: boolean;
+                  once?: boolean;
+                  passive?: boolean;
+              },
+    ) => void;
 
-    removeEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
-        capture?: boolean
-    }) => void;
+    removeEventListener: (
+        type: 'abort',
+        listener: (this: AbortSignal, event: any) => any,
+        options?:
+            | boolean
+            | {
+                  capture?: boolean;
+              },
+    ) => void;
 }
 
 declare class AbortController {

--- a/types/react-native/test/globals.tsx
+++ b/types/react-native/test/globals.tsx
@@ -72,3 +72,7 @@ socket.addEventListener('message', e => console.log(e.data));
 socket.onmessage = e => console.log(e.data);
 socket.addEventListener('error', e => console.log(e.message));
 socket.onerror = e => console.log(e.message);
+
+const formData = new FormData();
+formData.append('file', { fileName: 'example' });
+console.log(formData.getParts());


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/main/Libraries/Network/FormData.js#L67
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
This has been there for a long time. 