### PR TITLE
node-telegram-bot-api: Added missing MessageEntityTypes for Telegram API

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -76,7 +76,8 @@ declare namespace TelegramBot {
         'chat_invite_link' |
         'chat_member_updated';
 
-    type MessageEntityType = 'mention' | 'hashtag' | 'bot_command' | 'url' | 'email' | 'bold' | 'italic' | 'code' | 'pre' | 'text_link' | 'text_mention';
+    //From https://core.telegram.org/bots/api#messageentity
+    type MessageEntityType = 'mention' | 'hashtag' | 'cashtag' | 'bot_command' | 'url' | 'email' | 'phone_number' | 'bold' | 'italic' | 'underline' | 'strikethrough' | 'code' | 'pre' | 'text_link' | 'text_mention';
 
     type ParseMode = 'Markdown' | 'MarkdownV2' | 'HTML';
 

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -76,8 +76,9 @@ declare namespace TelegramBot {
         'chat_invite_link' |
         'chat_member_updated';
 
-    //From https://core.telegram.org/bots/api#messageentity
-    type MessageEntityType = 'mention' | 'hashtag' | 'cashtag' | 'bot_command' | 'url' | 'email' | 'phone_number' | 'bold' | 'italic' | 'underline' | 'strikethrough' | 'code' | 'pre' | 'text_link' | 'text_mention';
+    // From https://core.telegram.org/bots/api#messageentity
+    type MessageEntityType = 'mention' | 'hashtag' | 'cashtag' | 'bot_command' | 'url' | 'email' | 'phone_number' |
+        'bold' | 'italic' | 'underline' | 'strikethrough' | 'code' | 'pre' | 'text_link' | 'text_mention';
 
     type ParseMode = 'Markdown' | 'MarkdownV2' | 'HTML';
 

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -76,7 +76,6 @@ declare namespace TelegramBot {
         'chat_invite_link' |
         'chat_member_updated';
 
-    // From https://core.telegram.org/bots/api#messageentity
     type MessageEntityType = 'mention' | 'hashtag' | 'cashtag' | 'bot_command' | 'url' | 'email' | 'phone_number' |
         'bold' | 'italic' | 'underline' | 'strikethrough' | 'code' | 'pre' | 'text_link' | 'text_mention';
 


### PR DESCRIPTION
Added missing MessageEntityTypes from Telegram API docs: https://core.telegram.org/bots/api#messageentity

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://core.telegram.org/bots/api#messageentity
