### PR TITLE
fix(zeromq): add ```Socket``` class ```constructor``` definition

### DIFF
--- a/types/zeromq/index.d.ts
+++ b/types/zeromq/index.d.ts
@@ -133,6 +133,11 @@ export class Context {
 
 export class Socket extends EventEmitter {
     /**
+     * @param type keyof SocketTypes | SocketTypes[keyof SocketTypes]
+     */
+    constructor(type: keyof SocketTypes | SocketTypes[keyof SocketTypes]);
+    
+    /**
      * Set `opt` to `val`.
      *
      * @param opt Option

--- a/types/zeromq/index.d.ts
+++ b/types/zeromq/index.d.ts
@@ -136,7 +136,7 @@ export class Socket extends EventEmitter {
      * @param type keyof SocketTypes | SocketTypes[keyof SocketTypes]
      */
     constructor(type: keyof SocketTypes | SocketTypes[keyof SocketTypes]);
-    
+
     /**
      * Set `opt` to `val`.
      *

--- a/types/zeromq/zeromq-tests.ts
+++ b/types/zeromq/zeromq-tests.ts
@@ -204,3 +204,9 @@ function test8() {
     // Socket.closed getter
     sock.closed;
 }
+
+function test9() {
+    const socket = new zeromq.Socket('pub');
+    socket.bindSync('tcp://127.0.0.1:3000');
+    socket.send(new Buffer(1000));
+}

--- a/types/zeromq/zeromq-tests.ts
+++ b/types/zeromq/zeromq-tests.ts
@@ -206,7 +206,17 @@ function test8() {
 }
 
 function test9() {
-    const socket = new zeromq.Socket('pub');
-    socket.bindSync('tcp://127.0.0.1:3000');
-    socket.send(new Buffer(1000));
+  new zeromq.Socket('xpub');
+  new zeromq.Socket('sub');
+  new zeromq.Socket('xsub');
+  new zeromq.Socket('req');
+  new zeromq.Socket('xreq');
+  new zeromq.Socket('rep');
+  new zeromq.Socket('xrep');
+  new zeromq.Socket('push');
+  new zeromq.Socket('pull');
+  new zeromq.Socket('dealer');
+  new zeromq.Socket('router');
+  new zeromq.Socket('pair');
+  new zeromq.Socket('stream');
 }


### PR DESCRIPTION
The declaration of the ```Socket``` class constructor does not match the class implementation in the [```zeromq```](https://github.com/zeromq/zeromq.js) package

More specifically:
On this line [here](https://github.com/zeromq/zeromq.js/blob/64a92ab68c3918490ff45626365bf7b47c580e90/lib/index.js#L294), the constructor requires a ```type``` argument, which is not present in the ```Socket``` constructor type declaration.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
* [JS constructor function definition](https://github.com/zeromq/zeromq.js/blob/64a92ab68c3918490ff45626365bf7b47c580e90/lib/index.js#L295)

