### PR TITLE
k6: fix SharedArray to return a non-typed array

### DIFF
--- a/types/k6/data.d.ts
+++ b/types/k6/data.d.ts
@@ -7,5 +7,10 @@ export const SharedArray: {
      * Given a name and a function that returns an array, the SharedArray constructor returns the same array but sharing the array memory between VUs.
      * https://k6.io/docs/javascript-api/k6-data/sharedarray/
      */
+    new(name: string, callback: () => []): [];
+    /**
+     * Given a name and a function that returns an array, the SharedArray constructor returns the same array but sharing the array memory between VUs.
+     * https://k6.io/docs/javascript-api/k6-data/sharedarray/
+     */
     new<T>(name: string, callback: () => T[]): T[];
 };

--- a/types/k6/test/data.ts
+++ b/types/k6/test/data.ts
@@ -7,3 +7,4 @@ interface Foo {
 const foos: Foo[] = [{bar: "a"}, {bar: "a"}];
 
 new SharedArray('hola', () => foos); // $ExpectType Foo[]
+new SharedArray('adios', () => []); // $ExpectType []


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

This PR brings back a constructor method removed by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56385/

