### PR TITLE
[restify-cookies] parse takes three args

### DIFF
--- a/types/restify-cookies/index.d.ts
+++ b/types/restify-cookies/index.d.ts
@@ -7,24 +7,24 @@
 import * as restify from 'restify';
 
 declare module 'restify' {
-  interface CookieOptions {
-    encode?: ((input: string) => string) | undefined;
-    maxAge?: number | undefined;
-    domain?: string | undefined;
-    path?: string | undefined;
-    expires?: Date | undefined;
-    httpOnly?: boolean | undefined;
-    secure?: boolean | undefined;
-    sameSite?: boolean|'lax'|'strict'|'none' | undefined;
-  }
+    interface CookieOptions {
+        encode?: ((input: string) => string) | undefined;
+        maxAge?: number | undefined;
+        domain?: string | undefined;
+        path?: string | undefined;
+        expires?: Date | undefined;
+        httpOnly?: boolean | undefined;
+        secure?: boolean | undefined;
+        sameSite?: boolean | 'lax' | 'strict' | 'none' | undefined;
+    }
 
-  interface Request {
-    cookies: any;
-  }
+    interface Request {
+        cookies: any;
+    }
 
-  interface Response {
-    setCookie(key: string, val: string, options?: CookieOptions): void;
-  }
+    interface Response {
+        setCookie(key: string, val: string, options?: CookieOptions): void;
+    }
 }
 
-export function parse(): any;
+export function parse(req: restify.Request, res: restify.Response, next: restify.Next): any;

--- a/types/restify-cookies/restify-cookies-tests.ts
+++ b/types/restify-cookies/restify-cookies-tests.ts
@@ -1,7 +1,8 @@
 import { Request, Response, Server } from 'restify';
-import 'restify-cookies';
+import { parse } from 'restify-cookies';
 
 function test(server: Server) {
+  server.use(parse);
   server.get('/api/test', (req: Request, res: Response) => {
     res.setCookie('myCookie', 'test' + req.cookies.foo, { path: '/' });
   });


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See https://github.com/nathschmidt/restify-cookies/blame/master/README.md#L36, which implicitly passes `req`, `res`, and `next` to the function.