### PR TITLE
prosemirror-markdown@1.5: Fix `getAttrs` function in `TokenConfig`

### DIFF
--- a/types/prosemirror-markdown/index.d.ts
+++ b/types/prosemirror-markdown/index.d.ts
@@ -46,10 +46,11 @@ export interface TokenConfig {
     /**
      * A function used to compute the attributes for the node or mark
      * that takes a [markdown-it
-     * token](https://markdown-it.github.io/markdown-it/#Token) and
+     * token](https://markdown-it.github.io/markdown-it/#Token), list of [markdown-it
+     * token](https://markdown-it.github.io/markdown-it/#Token)s, the token's index and
      * returns an attribute object.
      */
-    getAttrs?(token: Token): Record<string, any>;
+    getAttrs?(token: Token, tokens: Token[], i: number): Record<string, any>;
 
     /**
      * When true, ignore content for the matched token.


### PR DESCRIPTION
prosemirror-markdown@1.5

`getAttrs` function is missing the second and third parameters. The official package `prosemirror-markdown` is using these parameters here - https://github.com/ProseMirror/prosemirror-markdown/blob/master/src/from_markdown.js#L240.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
