### PR TITLE
[tar] Add noChmod option to extract

### DIFF
--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for tar 4.0
+// Type definitions for tar 6.1
 // Project: https://github.com/npm/node-tar
 // Definitions by: Maxime LUCE <https://github.com/SomaticIT>, Connor Peet <https://github.com/connor4312>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -102,8 +102,8 @@ export const fieldEnds: number[];
  */
 export const types: {
     0: string;
-    "\0": string;
-    "": string;
+    '\0': string;
+    '': string;
     1: string;
     2: string;
     3: string;
@@ -490,6 +490,14 @@ export interface ExtractOptions {
      */
     onentry?(entry: ReadEntry): void;
 
+    /**
+     * Set to true to omit calling `fs.chmod()` to ensure that the extracted file
+     * matches the entry mode. This also suppresses the call to `process.umask()`
+     * to determine the default umask value, since tar will extract with whatever
+     * mode is provided, and let the process `umask` apply normally.
+     */
+    noChmod?: boolean | undefined;
+
     // The following options are mostly internal, but can be modified in some
     // advanced use cases, such as re-using caches between runs.
 
@@ -658,7 +666,11 @@ export interface FileOptions {
  *
  * Archive data may be read from the returned stream.
  */
-export function create(options: CreateOptions, fileList: ReadonlyArray<string>, callback?: (err?: Error) => void): stream.Readable;
+export function create(
+    options: CreateOptions,
+    fileList: ReadonlyArray<string>,
+    callback?: (err?: Error) => void,
+): stream.Readable;
 
 /**
  * Create a tarball archive. The fileList is an array of paths to add to the
@@ -668,7 +680,11 @@ export function create(options: CreateOptions, fileList: ReadonlyArray<string>, 
  */
 export function create(options: CreateOptions & FileOptions, fileList: ReadonlyArray<string>): Promise<void>;
 export function create(options: CreateOptions & FileOptions & { sync: true }, fileList: ReadonlyArray<string>): void;
-export function create(options: CreateOptions & FileOptions, fileList: ReadonlyArray<string>, callback: (err?: Error) => void): void;
+export function create(
+    options: CreateOptions & FileOptions,
+    fileList: ReadonlyArray<string>,
+    callback: (err?: Error) => void,
+): void;
 
 /**
  * Alias for create
@@ -687,7 +703,11 @@ export const c: typeof create;
  *
  * Archive data should be written to the returned stream.
  */
-export function extract(options: ExtractOptions, fileList?: ReadonlyArray<string>, callback?: (err?: Error) => void): stream.Writable;
+export function extract(
+    options: ExtractOptions,
+    fileList?: ReadonlyArray<string>,
+    callback?: (err?: Error) => void,
+): stream.Writable;
 
 /**
  * Extract a tarball archive. The fileList is an array of paths to extract
@@ -701,7 +721,11 @@ export function extract(options: ExtractOptions, fileList?: ReadonlyArray<string
  */
 export function extract(options: ExtractOptions & FileOptions, fileList?: ReadonlyArray<string>): Promise<void>;
 export function extract(options: ExtractOptions & FileOptions & { sync: true }, fileList?: ReadonlyArray<string>): void;
-export function extract(options: ExtractOptions & FileOptions, fileList: ReadonlyArray<string> | undefined, callback: (err?: Error) => void): void;
+export function extract(
+    options: ExtractOptions & FileOptions,
+    fileList: ReadonlyArray<string> | undefined,
+    callback: (err?: Error) => void,
+): void;
 
 /**
  * Alias for extract
@@ -716,7 +740,11 @@ export const x: typeof extract;
  *
  * Archive data should be written to the returned stream.
  */
-export function list(options?: ListOptions  & FileOptions, fileList?: ReadonlyArray<string>, callback?: (err?: Error) => void): stream.Writable;
+export function list(
+    options?: ListOptions & FileOptions,
+    fileList?: ReadonlyArray<string>,
+    callback?: (err?: Error) => void,
+): stream.Writable;
 
 /**
  * List the contents of a tarball archive. The fileList is an array of paths
@@ -741,7 +769,11 @@ export const t: typeof list;
  * starts with @, prepend it with ./.
  */
 export function replace(options: ReplaceOptions, fileList?: ReadonlyArray<string>): Promise<void>;
-export function replace(options: ReplaceOptions, fileList: ReadonlyArray<string> | undefined, callback: (err?: Error) => void): Promise<void>;
+export function replace(
+    options: ReplaceOptions,
+    fileList: ReadonlyArray<string> | undefined,
+    callback: (err?: Error) => void,
+): Promise<void>;
 
 /**
  * Alias for replace
@@ -756,7 +788,11 @@ export const r: typeof replace;
  * To add a file that starts with @, prepend it with ./.
  */
 export function update(options: ReplaceOptions, fileList?: ReadonlyArray<string>): Promise<void>;
-export function update(options: ReplaceOptions, fileList: ReadonlyArray<string> | undefined, callback: (err?: Error) => void): Promise<void>;
+export function update(
+    options: ReplaceOptions,
+    fileList: ReadonlyArray<string> | undefined,
+    callback: (err?: Error) => void,
+): Promise<void>;
 
 /**
  * Alias for update

--- a/types/tar/tar-tests.ts
+++ b/types/tar/tar-tests.ts
@@ -54,6 +54,7 @@ tar.c(
 tar.x(
     {
         file: 'my-tarball.tgz',
+        noChmod: true,
     }
 ).then(() => undefined);
 


### PR DESCRIPTION
Requested in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/54156

- Add option `noChmod` to `ExtractOptions` as documented: https://github.com/npm/node-tar#tarxoptions-filelist-callback-alias-tarextract
- Bump package version to 6.1
- (Formatting changes enforced by Prettier)

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/node-tar/pull/270
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

