### PR TITLE
fix(papaparse): Add a common overload to accept file or string

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -22,11 +22,8 @@ export as namespace Papa;
  * @param config a config object which contains a callback.
  * @returns Doesn't return anything. Results are provided asynchronously to a callback function.
  */
-export function parse<T, TFile extends Blob | NodeJS.ReadableStream>(
-    file: TFile,
-    // tslint:disable-next-line: no-unnecessary-generics
-    config: ParseLocalConfig<T, TFile>,
-): void;
+// tslint:disable-next-line: no-unnecessary-generics
+export function parse<T, TFile extends LocalFile = LocalFile>(file: TFile, config: ParseLocalConfig<T, TFile>): void;
 /**
  * Parse remote files
  * @param url the path or URL to the file to download.
@@ -54,6 +51,21 @@ export function parse<T>(
     config?: ParseConfig<T> & { download?: false | undefined; worker?: false | undefined },
 ): ParseResult<T>;
 /**
+ * Parse string, remote files or  local files
+ * @param source data to be parsed.
+ * @param config a config object.
+ * @returns Doesn't return anything. Results are provided asynchronously to a callback function.
+ */
+export function parse<T>(
+    source: LocalFile | string,
+    config: ParseLocalConfig<T, LocalFile> &
+        (
+            | (ParseConfig<T> & { download?: false | undefined; worker?: false | undefined })
+            | (ParseWorkerConfig<T> & { download?: false | undefined })
+            | ParseRemoteConfig<T>
+        ),
+): void;
+/**
  * Parse in a node streaming style
  * @param stream `NODE_STREAM_INPUT`
  * @param config a config object.
@@ -78,10 +90,10 @@ export function unparse<T>(data: T[] | UnparseObject<T>, config?: UnparseConfig)
 export const BAD_DELIMITERS: ReadonlyArray<string>;
 
 /** The true delimiter. Invisible. ASCII code 30. Should be doing the job we strangely rely upon commas and tabs for. */
-export const RECORD_SEP = '\x1E';
+export const RECORD_SEP: '\x1E';
 
 /** Also sometimes used as a delimiting character. ASCII code 31. */
-export const UNIT_SEP = '\x1F';
+export const UNIT_SEP: '\x1F';
 /**
  * Whether or not the browser supports HTML5 Web Workers.
  * If false, `worker: true` will have no effect.
@@ -114,6 +126,9 @@ export let RemoteChunkSize: number;
  * @default ','
  */
 export let DefaultDelimiter: string;
+
+/** File object */
+export type LocalFile = Blob | NodeJS.ReadableStream;
 
 /**
  * On Papa there are actually more classes exposed

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -85,6 +85,37 @@ Papa.parse(file, {
 });
 
 // $ExpectType void
+Papa.parse<[string], File>(file, {
+    transform(value, field) {},
+    transformHeader(header, index) {
+        return header;
+    },
+    complete(a, b) {
+        // $ExpectType ParseResult<[string]>
+        a;
+        // $ExpectType string[] | undefined
+        a.meta.fields;
+        // $ExpectType File
+        b;
+    },
+});
+// $ExpectType void
+Papa.parse<[string]>(file, {
+    transform(value, field) {},
+    transformHeader(header, index) {
+        return header;
+    },
+    complete(a, b) {
+        // $ExpectType ParseResult<[string]>
+        a;
+        // $ExpectType string[] | undefined
+        a.meta.fields;
+        // $ExpectType LocalFile
+        b;
+    },
+});
+
+// $ExpectType void
 Papa.parse('/resources/files/normal.csv', {
     download: true,
 
@@ -154,6 +185,25 @@ Papa.parse<[string, string]>('/resources/files/normal.csv', {
         r;
         // $ExpectType string
         file;
+    },
+});
+
+declare const dataOrFile: string | File;
+// $ExpectType void
+Papa.parse<string[]>(dataOrFile, {
+    complete(r: Papa.ParseResult<string[]>) {
+        // $ExpectType ParseResult<string[]>
+        r;
+    },
+});
+
+declare const urlOrFile: string | File;
+// $ExpectType void
+Papa.parse<string[]>(urlOrFile, {
+    download: true,
+    complete(r: Papa.ParseResult<string[]>) {
+        // $ExpectType ParseResult<string[]>
+        r;
     },
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.papaparse.com/docs#config>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
