### PR TITLE
[`callback-to-async-iterator`] Accurater return type

### DIFF
--- a/types/callback-to-async-iterator/callback-to-async-iterator-tests.ts
+++ b/types/callback-to-async-iterator/callback-to-async-iterator-tests.ts
@@ -1,9 +1,9 @@
 import callbackToAsyncIterator from "callback-to-async-iterator";
 
-callbackToAsyncIterator(async () => {}); // $ExpectType AsyncIterator<unknown, any, undefined>
+callbackToAsyncIterator(async () => {}); // $ExpectType AsyncIterableIterator<unknown>
 
-callbackToAsyncIterator<string>(async () => {}); // $ExpectType AsyncIterator<string, any, undefined>
+callbackToAsyncIterator<string>(async () => {}); // $ExpectType AsyncIterableIterator<string>
 
-callbackToAsyncIterator<string>(async () => {}, { onClose() {} }); // $ExpectType AsyncIterator<string, any, undefined>
+callbackToAsyncIterator<string>(async () => {}, { onClose() {} }); // $ExpectType AsyncIterableIterator<string>
 
-callbackToAsyncIterator<string, number>(async () => 1, { onClose(arg: number) {} });  // $ExpectType AsyncIterator<string, any, undefined>
+callbackToAsyncIterator<string, number>(async () => 1, { onClose(arg: number) {} });  // $ExpectType AsyncIterableIterator<string>

--- a/types/callback-to-async-iterator/index.d.ts
+++ b/types/callback-to-async-iterator/index.d.ts
@@ -14,4 +14,4 @@ export interface AsyncifyOptions<T, R> {
 export default function callbackToAsyncIterator<T, R = void>(
     listener: (callback: (message: T) => void) => Promise<R>,
     options?: AsyncifyOptions<T, R>,
-): AsyncIterator<T>;
+): AsyncIterableIterator<T>;


### PR DESCRIPTION
`AsyncIterator` is correct, but the returned object also implements `Symbol.asyncIterator` [here](https://github.com/withspectrum/callback-to-async-iterator/blob/c4f5c27a066aa1e5c1a0316e73c239cf52387302/src/index.js#L74). By changing the returned type to `AsyncIterableIterator`, the returned value can be used in a `for ... await` loop.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/withspectrum/callback-to-async-iterator/blob/c4f5c27a066aa1e5c1a0316e73c239cf52387302/src/index.js#L74

