### PR TITLE
Node-RSA: Support for sourceEncoding in NodeRSA.verify and NodeRSA.sign

### DIFF
--- a/types/node-rsa/index.d.ts
+++ b/types/node-rsa/index.d.ts
@@ -84,7 +84,7 @@ declare class NodeRSA {
     decryptPublic<T extends object>(data: Buffer | string, encoding: 'json'): T;
 
     sign(data: NodeRSA.Data, encoding?: 'buffer'): Buffer;
-    sign(data: NodeRSA.Data, encoding: NodeRSA.Encoding, source_encoding: NodeRSA.Encoding): string;
+    sign(data: NodeRSA.Data, encoding: NodeRSA.Encoding, source_encoding?: NodeRSA.Encoding): string;
     sign(data: Buffer, encoding: 'buffer', sourceEncoding?: NodeRSA.Encoding): Buffer;
     sign(data: Buffer, encoding: NodeRSA.Encoding, sourceEncoding?: NodeRSA.Encoding): string;
 

--- a/types/node-rsa/index.d.ts
+++ b/types/node-rsa/index.d.ts
@@ -84,7 +84,7 @@ declare class NodeRSA {
     decryptPublic<T extends object>(data: Buffer | string, encoding: 'json'): T;
 
     sign(data: NodeRSA.Data, encoding?: 'buffer'): Buffer;
-    sign(data: NodeRSA.Data, encoding: NodeRSA.Encoding): string;
+    sign(data: NodeRSA.Data, encoding: NodeRSA.Encoding, source_encoding: NodeRSA.Encoding): string;
     sign(data: Buffer, encoding: 'buffer', sourceEncoding?: NodeRSA.Encoding): Buffer;
     sign(data: Buffer, encoding: NodeRSA.Encoding, sourceEncoding?: NodeRSA.Encoding): string;
 
@@ -99,7 +99,7 @@ declare class NodeRSA {
     verify(
         data: NodeRSA.Data,
         signature: string,
-        sourceEncoding: undefined,
+        sourceEncoding: undefined|NodeRSA.Encoding,
         signatureEncoding: NodeRSA.Encoding,
     ): boolean;
 }

--- a/types/node-rsa/index.d.ts
+++ b/types/node-rsa/index.d.ts
@@ -84,7 +84,7 @@ declare class NodeRSA {
     decryptPublic<T extends object>(data: Buffer | string, encoding: 'json'): T;
 
     sign(data: NodeRSA.Data, encoding?: 'buffer'): Buffer;
-    sign(data: NodeRSA.Data, encoding: NodeRSA.Encoding, source_encoding?: NodeRSA.Encoding): string;
+    sign(data: NodeRSA.Data, encoding: NodeRSA.Encoding, sourceEncoding?: NodeRSA.Encoding): string;
     sign(data: Buffer, encoding: 'buffer', sourceEncoding?: NodeRSA.Encoding): Buffer;
     sign(data: Buffer, encoding: NodeRSA.Encoding, sourceEncoding?: NodeRSA.Encoding): string;
 


### PR DESCRIPTION
I've added support for _sourceEncoding_ in `NodeRSA.verify` and `NodeRSA.sign`, if using `NodeRSA.Data` rather than `Buffer`. 

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Documentation](https://www.npmjs.com/package/node-rsa#signingverifying)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

**This PR doesn't bring the type definitions up to date with a new version.**