### PR TITLE
react-imgix: add type definition for `ImgixProvider` class

### DIFF
--- a/types/react-imgix/index.d.ts
+++ b/types/react-imgix/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-imgix 9.0
+// Type definitions for react-imgix 9.2.0
 // Project: https://github.com/imgix/react-imgix
 // Definitions by: Sherwin Heydarbeygi <https://github.com/sherwinski>
 //                 Luis Ball <https://github.com/luqven>

--- a/types/react-imgix/index.d.ts
+++ b/types/react-imgix/index.d.ts
@@ -211,6 +211,7 @@ interface CommonProps {
   className?: string | undefined;
   onMounted?: ((ref?: React.RefObject<HTMLPictureElement | HTMLImageElement | HTMLSourceElement>) => void) | undefined;
   htmlAttributes?: ImgixHTMLAttributes | undefined;
+  domain?: string | undefined;
 }
 
 export interface SharedImigixAndSourceProps extends CommonProps {
@@ -225,8 +226,21 @@ export interface SharedImigixAndSourceProps extends CommonProps {
   attributeConfig?: AttributeConfig | undefined;
 }
 
+export interface ImgixProviderProps extends CommonProps {
+  src?: string | undefined;
+  disableQualityByDPR?: boolean | undefined;
+  disableSrcSet?: boolean | undefined;
+  disableLibraryParam?: boolean | undefined;
+  imgixParams?: ImigixParams | undefined;
+  sizes?: string | undefined;
+  width?: number | undefined;
+  height?: number | undefined;
+  attributeConfig?: AttributeConfig | undefined;
+}
+
 export class Picture extends React.Component<React.PropsWithChildren<CommonProps>> {}
 export class Source extends React.Component<SharedImigixAndSourceProps> {}
+export class ImgixProvider extends React.Component<React.PropsWithChildren<ImgixProviderProps>> {}
 export function buildURL(src: string, imgixParams?: ImigixParams, options?: SharedImigixAndSourceProps): string;
 
 type Warnings = 'fallbackImage' | 'sizesAttribute' | 'invalidARFormat';

--- a/types/react-imgix/index.d.ts
+++ b/types/react-imgix/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-imgix 9.2.0
+// Type definitions for react-imgix 9.2
 // Project: https://github.com/imgix/react-imgix
 // Definitions by: Sherwin Heydarbeygi <https://github.com/sherwinski>
 //                 Luis Ball <https://github.com/luqven>

--- a/types/react-imgix/react-imgix-tests.tsx
+++ b/types/react-imgix/react-imgix-tests.tsx
@@ -36,7 +36,7 @@ const BackgroundTest = () => (
     </Background>
 );
 
-const ProviderTest = () => {
+const ProviderTest = () => (
     <ImgixProvider domain="sdk-test.imgix.net">
         <Imgix
             src="https://.../image.png"
@@ -57,7 +57,7 @@ const ProviderTest = () => {
             }}
         />
     </ImgixProvider>
-};
+);
 
 buildURL('http://yourdomain.imgix.net/image.png', { w: 450, h: 100 });
 

--- a/types/react-imgix/react-imgix-tests.tsx
+++ b/types/react-imgix/react-imgix-tests.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import Imgix, { Picture, Source, Background, buildURL, PublicConfigAPI } from 'react-imgix';
+import Imgix, { Picture, Source, Background, buildURL, PublicConfigAPI, ImgixProvider } from 'react-imgix';
 
 const ImgixTest = () => (
     <Imgix
         src="https://.../image.png"
         sizes="100vw"
+        domain="assets.imgix.net"
         width={100}
         height={200}
         imgixParams={{ ar: '16:9' }}
@@ -34,6 +35,29 @@ const BackgroundTest = () => (
         <h2>Blog Title</h2>
     </Background>
 );
+
+const ProviderTest = () => {
+    <ImgixProvider domain="sdk-test.imgix.net">
+        <Imgix
+            src="https://.../image.png"
+            sizes="100vw"
+            domain="assets.imgix.net"
+            width={100}
+            height={200}
+            imgixParams={{ ar: '16:9' }}
+            attributeConfig={{
+                src: 'data-src',
+                srcSet: 'data-srcset',
+                sizes: 'data-sizes',
+            }}
+            className="lazyload"
+            htmlAttributes={{
+                src: '...',
+                'data-testid': 'testid',
+            }}
+        />
+    </ImgixProvider>
+};
 
 buildURL('http://yourdomain.imgix.net/image.png', { w: 450, h: 100 });
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

----

This PR adds a definition for the `ImgixProvider` component class, added in this [react-imgix pull request](https://github.com/imgix/react-imgix/pull/791) and subsequently released in [v9.2.0](https://github.com/imgix/react-imgix/releases/tag/v9.2.0). More context can be found in the project [documentation](https://github.com/imgix/react-imgix#imgixprovider-component).
