### PR TITLE
[@types/express-serve-static-core] Fix express-serve-static-core locals type so it can be overwritten

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -1,6 +1,13 @@
 import * as express from 'express-serve-static-core';
 
-const app: express.Application = {} as any;
+const app: express.Application<{
+    aKey: 'aValue'
+}> = {} as any;
+
+// App.locals can be extended
+app.locals.aKey; // $ExpectType "aValue"
+app.locals.bKey; // $ExpectError
+
 app.listen(3000);
 app.listen(3000, () => {
     // no-op error callback

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -1044,7 +1044,9 @@ export type ApplicationRequestHandler<T> = IRouterHandler<T> &
     IRouterMatcher<T> &
     ((...handlers: RequestHandlerParams[]) => T);
 
-export interface Application extends EventEmitter, IRouter, Express.Application {
+export interface Application<
+    Locals extends Record<string, any> = Record<string, any>,
+> extends EventEmitter, IRouter, Express.Application {
     /**
      * Express instance itself is a request handler, which could be invoked without
      * third argument.
@@ -1210,7 +1212,7 @@ export interface Application extends EventEmitter, IRouter, Express.Application 
 
     map: any;
 
-    locals: Record<string, any>;
+    locals: Locals;
 
     /**
      * The app.routes object houses all of the routes defined mapped by the

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -1045,7 +1045,7 @@ export type ApplicationRequestHandler<T> = IRouterHandler<T> &
     ((...handlers: RequestHandlerParams[]) => T);
 
 export interface Application<
-    Locals extends Record<string, any> = Record<string, any>,
+    Locals extends Record<string, any> = Record<string, any>
 > extends EventEmitter, IRouter, Express.Application {
     /**
      * Express instance itself is a request handler, which could be invoked without

--- a/types/express-serve-static-core/ts4.0/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/ts4.0/express-serve-static-core-tests.ts
@@ -1,6 +1,13 @@
 import * as express from 'express-serve-static-core';
 
-const app: express.Application = {} as any;
+const app: express.Application<{
+    aKey: 'aValue'
+}> = {} as any;
+
+// App.locals can be extended
+app.locals.aKey; // $ExpectType "aValue"
+app.locals.bKey; // $ExpectError
+
 app.listen(3000);
 app.listen(3000, () => {
     // no-op error callback

--- a/types/express-serve-static-core/ts4.0/index.d.ts
+++ b/types/express-serve-static-core/ts4.0/index.d.ts
@@ -954,7 +954,9 @@ export type ApplicationRequestHandler<T> = IRouterHandler<T> &
     IRouterMatcher<T> &
     ((...handlers: RequestHandlerParams[]) => T);
 
-export interface Application extends EventEmitter, IRouter, Express.Application {
+export interface Application<
+    Locals extends Record<string, any> = Record<string, any>,
+> extends EventEmitter, IRouter, Express.Application {
     /**
      * Express instance itself is a request handler, which could be invoked without
      * third argument.
@@ -1120,7 +1122,7 @@ export interface Application extends EventEmitter, IRouter, Express.Application 
 
     map: any;
 
-    locals: Record<string, any>;
+    locals: Locals;
 
     /**
      * The app.routes object houses all of the routes defined mapped by the

--- a/types/express-serve-static-core/ts4.0/index.d.ts
+++ b/types/express-serve-static-core/ts4.0/index.d.ts
@@ -955,7 +955,7 @@ export type ApplicationRequestHandler<T> = IRouterHandler<T> &
     ((...handlers: RequestHandlerParams[]) => T);
 
 export interface Application<
-    Locals extends Record<string, any> = Record<string, any>,
+    Locals extends Record<string, any> = Record<string, any>
 > extends EventEmitter, IRouter, Express.Application {
     /**
      * Express instance itself is a request handler, which could be invoked without


### PR DESCRIPTION
As mentioned in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46639#issuecomment-695227732, the `locals` type on the `Application` interface is of type `Record<string, any>` which currently prevents it from being extended. This adds a generic parameter to `Application` which allows you to extend `locals`

Closes #46639

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/issues/46639>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.