### PR TITLE
Restore koa-better-body types

### DIFF
--- a/types/koa-better-body/index.d.ts
+++ b/types/koa-better-body/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for koa-better-body 3.3
-// Project: https://github.com/tunnckoCore/koa-better-body
+// Project: https://github.com/tunnckoCore/opensource/tree/master/%40packages/koa-better-body
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/koa-better-body/index.d.ts
+++ b/types/koa-better-body/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for koa-better-body 3.3
 // Project: https://github.com/tunnckoCore/opensource/tree/master/%40packages/koa-better-body
-// Definitions by: Daniel Byrne <https://github.com/danwbyrne>
+// Definitions by: David Tanner <https://github.com/DavidTanner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Context } from 'koa';
@@ -11,25 +11,83 @@ declare function KoaBetterBody(
 
 declare namespace KoaBetterBody {
   interface Options {
-    fields?: boolean | string;  // default: false
-    files?: boolean | string;  // default: false
-    multipart?: boolean;  // default: true
-    textLimit?: string;  // default: false
-    formLimit?: string;  // default: false
-    jsonLimit?: string;  // default: false
-    jsonStrict?: boolean;  // default: true
+    /**
+     * @default false
+     */
+    fields?: boolean | string;
+    /**
+     * @default false
+     */
+    files?: boolean | string;
+    /**
+     * @default true
+     */
+    multipart?: boolean;
+    /**
+     * @default false
+     */
+    textLimit?: string;
+    /**
+     * @default false
+     */
+    formLimit?: string;
+    /**
+     * @default false
+     */
+    jsonLimit?: string;
+    /**
+     * @default true
+     */
+    jsonStrict?: boolean;
+    /**
+     * @default () => false
+     */
     detectJSON?: (ctx: Context) => boolean;
-    bufferLimit?: string;  // default: false
-    buffer?: boolean;  // default: false
-    strict?: boolean;  // default: true
+    /**
+     * @default false
+     */
+    bufferLimit?: string;
+    /**
+     * @default false
+     */
+    buffer?: boolean;
+    /**
+     * @default true
+     */
+    strict?: boolean;
 
-    delimiter?: symbol; // default: '&'
+    /**
+     * @default '&'
+     */
+    delimiter?: string; // default: '&'
+    /**
+     * @default require('querystring').unescape
+     */
     decodeURIComponent?: (query: string) => string; // default: require('querystring').unescape
+    /**
+     * @default 1000
+     */
     maxKeys?: number; // default: 1000
 
+    /**
+     * @deprecated use formLimit instead
+     * @default config.formLimit
+     */
     urlencodedLimit?: string;
 
+    /**
+     * @deprecated use delimiter instead
+     * @default config.delimiter
+     */
+    sep?: string;
+
+    /**
+     * @default undefined
+     */
     onError?: (err: any, ctx: Context) => void;
+    /**
+     * @default undefined
+     */
     handler?: (ctx: Context, options: Options, next: () => any) => void;
   }
 

--- a/types/koa-better-body/index.d.ts
+++ b/types/koa-better-body/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for koa-better-body 3.3.9
+// Project: https://github.com/tunnckoCore/koa-better-body
+// Definitions by: Daniel Byrne <https://github.com/danwbyrne>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Context } from 'koa';
+
+declare function KoaBetterBody<Context>(
+  options?: KoaBetterBody.Options<Context>
+): KoaBetterBody.Body;
+
+declare namespace KoaBetterBody {
+  interface Options<Context> {
+    fields?: boolean | string;  // default: false
+    files?: boolean | string;  // default: false
+    multipart?: boolean;  // default: true
+    textLimit?: string;  // default: false
+    formLimit?: string;  // default: false
+    jsonLimit?: string;  // default: false
+    jsonStrict?: boolean;  // default: true
+    detectJSON?: boolean | ((ctx: Context) => boolean);
+    bufferLimit?: string;  // default: false
+    buffer?: boolean;  // default: false
+    strict?: boolean;  // default: true
+
+    delimiter?: symbol; // default: '&'
+    decodeURIComponent?: typeof decodeURIComponent; // default: require('querystring').unescape
+    maxKeys?: number; // default: 1000
+
+    urlencodedLimit?: string;
+
+    onError?: Function;
+    handler?: Function;
+  }
+
+  type Body = (context: Context, next: () => void) => Generator;
+}
+
+export = KoaBetterBody;

--- a/types/koa-better-body/index.d.ts
+++ b/types/koa-better-body/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-better-body 3.3.9
+// Type definitions for koa-better-body 3.3
 // Project: https://github.com/tunnckoCore/koa-better-body
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,12 +6,12 @@
 
 import { Context } from 'koa';
 
-declare function KoaBetterBody<Context>(
-  options?: KoaBetterBody.Options<Context>
+declare function KoaBetterBody(
+  options?: KoaBetterBody.Options,
 ): KoaBetterBody.Body;
 
 declare namespace KoaBetterBody {
-  interface Options<Context> {
+  interface Options {
     fields?: boolean | string;  // default: false
     files?: boolean | string;  // default: false
     multipart?: boolean;  // default: true
@@ -19,22 +19,22 @@ declare namespace KoaBetterBody {
     formLimit?: string;  // default: false
     jsonLimit?: string;  // default: false
     jsonStrict?: boolean;  // default: true
-    detectJSON?: boolean | ((ctx: Context) => boolean);
+    detectJSON?: (ctx: Context) => boolean;
     bufferLimit?: string;  // default: false
     buffer?: boolean;  // default: false
     strict?: boolean;  // default: true
 
     delimiter?: symbol; // default: '&'
-    decodeURIComponent?: typeof decodeURIComponent; // default: require('querystring').unescape
+    decodeURIComponent?: (query: string) => string; // default: require('querystring').unescape
     maxKeys?: number; // default: 1000
 
     urlencodedLimit?: string;
 
-    onError?: Function;
-    handler?: Function;
+    onError?: (err: any, ctx: Context) => void;
+    handler?: (ctx: Context, options: Options, next: () => any) => void;
   }
 
-  type Body = (context: Context, next: () => void) => Generator;
+  type Body = (next: any) => Generator;
 }
 
 export = KoaBetterBody;

--- a/types/koa-better-body/index.d.ts
+++ b/types/koa-better-body/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/tunnckoCore/koa-better-body
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import { Context } from 'koa';
 

--- a/types/koa-better-body/koa-better-body-tests.ts
+++ b/types/koa-better-body/koa-better-body-tests.ts
@@ -1,0 +1,11 @@
+import body = require('koa-better-body');
+
+// $ExpectType Body
+body();
+
+const testOptions: body.Options = {
+  jsonLimit: '100mb',
+};
+
+// $ExpectType Body
+body(testOptions);

--- a/types/koa-better-body/koa-better-body-tests.ts
+++ b/types/koa-better-body/koa-better-body-tests.ts
@@ -2,7 +2,7 @@ import body = require('koa-better-body');
 
 // $ExpectType Body
 const parser1: body.Body = body();
-typeof parser1 === 'function'
+typeof parser1 === 'function';
 
 const testOptions: body.Options = {
   jsonLimit: '100mb',

--- a/types/koa-better-body/koa-better-body-tests.ts
+++ b/types/koa-better-body/koa-better-body-tests.ts
@@ -1,11 +1,13 @@
 import body = require('koa-better-body');
 
 // $ExpectType Body
-body();
+const parser1: body.Body = body();
+typeof parser1 === 'function'
 
 const testOptions: body.Options = {
   jsonLimit: '100mb',
+  delimiter: '&',
 };
 
 // $ExpectType Body
-body(testOptions);
+const parser: body.Body = body(testOptions);

--- a/types/koa-better-body/tsconfig.json
+++ b/types/koa-better-body/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": ["../"],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+		"index.d.ts",
+		"koa-better-body-tests.ts"
+	]
+}

--- a/types/koa-better-body/tsconfig.json
+++ b/types/koa-better-body/tsconfig.json
@@ -13,7 +13,7 @@
     "forceConsistentCasingInFileNames": true
   },
   "files": [
-		"index.d.ts",
-		"koa-better-body-tests.ts"
-	]
+    "index.d.ts",
+    "koa-better-body-tests.ts"
+  ]
 }

--- a/types/koa-better-body/tslint.json
+++ b/types/koa-better-body/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [N/A] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
