### PR TITLE
@types/react - Update KeyboardEvent to extend UIEvent

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1209,7 +1209,7 @@ declare namespace React {
         target: EventTarget & T;
     }
 
-    interface KeyboardEvent<T = Element> extends SyntheticEvent<T, NativeKeyboardEvent> {
+    interface KeyboardEvent<T = Element> extends UIEvent<T, NativeKeyboardEvent> {
         altKey: boolean;
         /** @deprecated */
         charCode: number;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -741,7 +741,7 @@ function handler(e: React.MouseEvent) {
     eventHandler(e);
 }
 
-const keyboardExtendsUI: React.UIEventHandler = (e: React.KeyboardEvent) => {}
+const keyboardExtendsUI: React.UIEventHandler = (e: React.KeyboardEvent) => {};
 
 //
 // The SyntheticEvent.target.value should be accessible for onChange

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -741,6 +741,8 @@ function handler(e: React.MouseEvent) {
     eventHandler(e);
 }
 
+const keyboardExtendsUI: React.UIEventHandler = (e: React.KeyboardEvent) => {}
+
 //
 // The SyntheticEvent.target.value should be accessible for onChange
 // --------------------------------------------------------------------------

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1208,7 +1208,7 @@ declare namespace React {
         target: EventTarget & T;
     }
 
-    interface KeyboardEvent<T = Element> extends SyntheticEvent<T, NativeKeyboardEvent> {
+    interface KeyboardEvent<T = Element> extends UIEvent<T, NativeKeyboardEvent> {
         altKey: boolean;
         /** @deprecated */
         charCode: number;

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -736,7 +736,7 @@ function handler(e: React.MouseEvent) {
     eventHandler(e);
 }
 
-const keyboardExtendsUI: React.UIEventHandler = (e: React.KeyboardEvent) => {}
+const keyboardExtendsUI: React.UIEventHandler = (e: React.KeyboardEvent) => {};
 
 //
 // The SyntheticEvent.target.value should be accessible for onChange

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -736,6 +736,8 @@ function handler(e: React.MouseEvent) {
     eventHandler(e);
 }
 
+const keyboardExtendsUI: React.UIEventHandler = (e: React.KeyboardEvent) => {}
+
 //
 // The SyntheticEvent.target.value should be accessible for onChange
 // --------------------------------------------------------------------------


### PR DESCRIPTION
`KeyboardEvent` extends `UIEvent`, not the base Event. It has both a `view` and `detail` field from the `UIEvent`. It looks like `MouseEvent` was updated to extend `UIEvent` in the v16 types, so adding this update to v16 and current.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#properties
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)
