### PR TITLE
[react-loadable]: declare dependency on Webpack 5

### DIFF
--- a/types/react-loadable/package.json
+++ b/types/react-loadable/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "webpack": "^5.40.0"
+    "webpack": "4.x || 5.x"
   }
 }

--- a/types/react-loadable/package.json
+++ b/types/react-loadable/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "webpack": "^5.40.0"
+  }
+}


### PR DESCRIPTION
`react-loadable` works on both Webpack 4 and 5, but `@types/react-loadable` when installed still declares `@types/webpack@^4` as dependency, leading to [type mismatch errors](https://github.com/facebook/docusaurus/issues/5772).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.