### PR TITLE
[@types/sinon] extend SinonStubbedInstance with original type

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1464,7 +1464,7 @@ declare namespace Sinon {
      *
      * @template TType Object type being stubbed.
      */
-    type SinonStubbedInstance<TType> = {
+    type SinonStubbedInstance<TType> = TType & {
         [P in keyof TType]: SinonStubbedMember<TType[P]>;
     };
 

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -104,6 +104,33 @@ function testSandbox() {
     sb.createStubInstance(cls, {
         foo: 1, // used as return value
     });
+
+    class ClassWithPrivateMembers {
+        private readonly priVar: number;
+        readonly pubVar: number;
+        constructor() {
+            this.priVar = 42;
+            this.pubVar = 21;
+        }
+
+        getPriVar() {
+            return this.priVar;
+        }
+    }
+
+    function callGetPriVar(instance: ClassWithPrivateMembers) {
+        return instance.getPriVar();
+    }
+
+    const objWithPrivateMembers = sinon.createStubInstance(ClassWithPrivateMembers);
+    objWithPrivateMembers.getPriVar.returns(84);
+    callGetPriVar(objWithPrivateMembers);
+
+    // $ExpectError
+    objWithPrivateMembers.priVar;
+
+    // $ExpectType number
+    objWithPrivateMembers.pubVar;
 }
 
 function testFakeServer() {


### PR DESCRIPTION
This enables typescript to assume a stubbed instance is a compatible
object even if the original class have private members as only public
ones are seen using keyof;

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/56694

