### PR TITLE
[react-native] type global timer arguments

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -9,12 +9,13 @@
 //
 declare function clearInterval(handle: number): void;
 declare function clearTimeout(handle: number): void;
-declare function setInterval(handler: (...args: any[]) => void, timeout: number): number;
-declare function setInterval(handler: any, timeout?: any, ...args: any[]): number;
-declare function setTimeout(handler: (...args: any[]) => void, timeout: number): number;
-declare function setTimeout(handler: any, timeout?: any, ...args: any[]): number;
+declare function setInterval(handler: () => void, timeout: number): number;
+declare function setInterval<Args extends any[]>(handler: (...args: Args) => void, timeout?: number, ...args: Args): number;
+declare function setTimeout(handler: () => void, timeout: number): number;
+declare function setTimeout<Args extends any[]>(handler: (...args: Args) => void, timeout?: number, ...args: Args): number;
 declare function clearImmediate(handle: number): void;
-declare function setImmediate(handler: (...args: any[]) => void): number;
+declare function setImmediate(handler: () => void): number;
+declare function setImmediate<Args extends any[]>(handler: (...args: Args) => void, ...args: Args): number;
 
 declare function cancelAnimationFrame(handle: number): void;
 declare function requestAnimationFrame(callback: (time: number) => void): number;

--- a/types/react-native/test/globals.tsx
+++ b/types/react-native/test/globals.tsx
@@ -1,3 +1,86 @@
+const noop = () => { };
+
+function testInterval() {
+    let handle = setInterval(noop, 0);
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 100, '200');
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 'wrong-type', '200'); // $ExpectError
+    clearInterval(handle);
+
+    handle = setInterval((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    }, 0);
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 0, 100, 'missing-arg'); // $ExpectError
+    clearInterval(handle);
+}
+
+function testTimeout() {
+    let handle = setTimeout(noop, 0);
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 100, '200');
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 'wrong-type', '200'); // $ExpectError
+    clearTimeout(handle);
+
+    handle = setTimeout((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    }, 0);
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 0, 100, 'missing-arg'); // $ExpectError
+    clearTimeout(handle);
+}
+
+function testImmediate() {
+    let handle = setImmediate(noop);
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 100, '200');
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 'wrong-type', '200'); // $ExpectError
+    clearImmediate(handle);
+
+    handle = setImmediate((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    });
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 100, 'missing-arg'); // $ExpectError
+    clearImmediate(handle);
+}
+
 const fetchCopy: WindowOrWorkerGlobalScope['fetch'] = fetch;
 
 const myHeaders = new Headers();

--- a/types/react-native/v0.63/globals.d.ts
+++ b/types/react-native/v0.63/globals.d.ts
@@ -9,12 +9,13 @@
 //
 declare function clearInterval(handle: number): void;
 declare function clearTimeout(handle: number): void;
-declare function setInterval(handler: (...args: any[]) => void, timeout: number): number;
-declare function setInterval(handler: any, timeout?: any, ...args: any[]): number;
-declare function setTimeout(handler: (...args: any[]) => void, timeout: number): number;
-declare function setTimeout(handler: any, timeout?: any, ...args: any[]): number;
+declare function setInterval(handler: () => void, timeout: number): number;
+declare function setInterval<Args extends any[]>(handler: (...args: Args) => void, timeout?: number, ...args: Args): number;
+declare function setTimeout(handler: () => void, timeout: number): number;
+declare function setTimeout<Args extends any[]>(handler: (...args: Args) => void, timeout?: number, ...args: Args): number;
 declare function clearImmediate(handle: number): void;
-declare function setImmediate(handler: (...args: any[]) => void): number;
+declare function setImmediate(handler: () => void): number;
+declare function setImmediate<Args extends any[]>(handler: (...args: Args) => void, ...args: Args): number;
 
 declare function cancelAnimationFrame(handle: number): void;
 declare function requestAnimationFrame(callback: (time: number) => void): number;

--- a/types/react-native/v0.63/test/globals.tsx
+++ b/types/react-native/v0.63/test/globals.tsx
@@ -1,3 +1,86 @@
+const noop = () => { };
+
+function testInterval() {
+    let handle = setInterval(noop, 0);
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 100, '200');
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 'wrong-type', '200'); // $ExpectError
+    clearInterval(handle);
+
+    handle = setInterval((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    }, 0);
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 0, 100, 'missing-arg'); // $ExpectError
+    clearInterval(handle);
+}
+
+function testTimeout() {
+    let handle = setTimeout(noop, 0);
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 100, '200');
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 'wrong-type', '200'); // $ExpectError
+    clearTimeout(handle);
+
+    handle = setTimeout((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    }, 0);
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 0, 100, 'missing-arg'); // $ExpectError
+    clearTimeout(handle);
+}
+
+function testImmediate() {
+    let handle = setImmediate(noop);
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 100, '200');
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 'wrong-type', '200'); // $ExpectError
+    clearImmediate(handle);
+
+    handle = setImmediate((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    });
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 100, 'missing-arg'); // $ExpectError
+    clearImmediate(handle);
+}
+
 const fetchCopy: WindowOrWorkerGlobalScope['fetch'] = fetch;
 
 const myHeaders = new Headers();

--- a/types/react-native/v0.64/globals.d.ts
+++ b/types/react-native/v0.64/globals.d.ts
@@ -9,12 +9,13 @@
 //
 declare function clearInterval(handle: number): void;
 declare function clearTimeout(handle: number): void;
-declare function setInterval(handler: (...args: any[]) => void, timeout: number): number;
-declare function setInterval(handler: any, timeout?: any, ...args: any[]): number;
-declare function setTimeout(handler: (...args: any[]) => void, timeout: number): number;
-declare function setTimeout(handler: any, timeout?: any, ...args: any[]): number;
+declare function setInterval(handler: () => void, timeout: number): number;
+declare function setInterval<Args extends any[]>(handler: (...args: Args) => void, timeout?: number, ...args: Args): number;
+declare function setTimeout(handler: () => void, timeout: number): number;
+declare function setTimeout<Args extends any[]>(handler: (...args: Args) => void, timeout?: number, ...args: Args): number;
 declare function clearImmediate(handle: number): void;
-declare function setImmediate(handler: (...args: any[]) => void): number;
+declare function setImmediate(handler: () => void): number;
+declare function setImmediate<Args extends any[]>(handler: (...args: Args) => void, ...args: Args): number;
 
 declare function cancelAnimationFrame(handle: number): void;
 declare function requestAnimationFrame(callback: (time: number) => void): number;

--- a/types/react-native/v0.64/test/globals.tsx
+++ b/types/react-native/v0.64/test/globals.tsx
@@ -1,3 +1,86 @@
+const noop = () => { };
+
+function testInterval() {
+    let handle = setInterval(noop, 0);
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 100, '200');
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 'wrong-type', '200'); // $ExpectError
+    clearInterval(handle);
+
+    handle = setInterval((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    }, 0);
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 0, 100, 'missing-arg'); // $ExpectError
+    clearInterval(handle);
+}
+
+function testTimeout() {
+    let handle = setTimeout(noop, 0);
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 100, '200');
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 'wrong-type', '200'); // $ExpectError
+    clearTimeout(handle);
+
+    handle = setTimeout((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    }, 0);
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 0, 100, 'missing-arg'); // $ExpectError
+    clearTimeout(handle);
+}
+
+function testImmediate() {
+    let handle = setImmediate(noop);
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 100, '200');
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 'wrong-type', '200'); // $ExpectError
+    clearImmediate(handle);
+
+    handle = setImmediate((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    });
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 100, 'missing-arg'); // $ExpectError
+    clearImmediate(handle);
+}
+
 const fetchCopy: WindowOrWorkerGlobalScope['fetch'] = fetch;
 
 const myHeaders = new Headers();

--- a/types/react-native/v0.65/globals.d.ts
+++ b/types/react-native/v0.65/globals.d.ts
@@ -9,12 +9,13 @@
 //
 declare function clearInterval(handle: number): void;
 declare function clearTimeout(handle: number): void;
-declare function setInterval(handler: (...args: any[]) => void, timeout: number): number;
-declare function setInterval(handler: any, timeout?: any, ...args: any[]): number;
-declare function setTimeout(handler: (...args: any[]) => void, timeout: number): number;
-declare function setTimeout(handler: any, timeout?: any, ...args: any[]): number;
+declare function setInterval(handler: () => void, timeout: number): number;
+declare function setInterval<Args extends any[]>(handler: (...args: Args) => void, timeout?: number, ...args: Args): number;
+declare function setTimeout(handler: () => void, timeout: number): number;
+declare function setTimeout<Args extends any[]>(handler: (...args: Args) => void, timeout?: number, ...args: Args): number;
 declare function clearImmediate(handle: number): void;
-declare function setImmediate(handler: (...args: any[]) => void): number;
+declare function setImmediate(handler: () => void): number;
+declare function setImmediate<Args extends any[]>(handler: (...args: Args) => void, ...args: Args): number;
 
 declare function cancelAnimationFrame(handle: number): void;
 declare function requestAnimationFrame(callback: (time: number) => void): number;

--- a/types/react-native/v0.65/test/globals.tsx
+++ b/types/react-native/v0.65/test/globals.tsx
@@ -1,3 +1,86 @@
+const noop = () => { };
+
+function testInterval() {
+    let handle = setInterval(noop, 0);
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 100, '200');
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 'wrong-type', '200'); // $ExpectError
+    clearInterval(handle);
+
+    handle = setInterval((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    }, 0);
+    clearInterval(handle);
+
+    handle = setInterval((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 0, 100, 'missing-arg'); // $ExpectError
+    clearInterval(handle);
+}
+
+function testTimeout() {
+    let handle = setTimeout(noop, 0);
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 100, '200');
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 0, 'wrong-type', '200'); // $ExpectError
+    clearTimeout(handle);
+
+    handle = setTimeout((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    }, 0);
+    clearTimeout(handle);
+
+    handle = setTimeout((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 0, 100, 'missing-arg'); // $ExpectError
+    clearTimeout(handle);
+}
+
+function testImmediate() {
+    let handle = setImmediate(noop);
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 100, '200');
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number, arg2: string) => {
+        console.log('arg1', arg1);
+        console.log('arg2', arg2);
+    }, 'wrong-type', '200'); // $ExpectError
+    clearImmediate(handle);
+
+    handle = setImmediate((missingArg: any) => { // $ExpectError
+        console.log('missingArg', missingArg);
+    });
+    clearImmediate(handle);
+
+    handle = setImmediate((arg1: number) => {
+        console.log('arg1', arg1);
+    }, 100, 'missing-arg'); // $ExpectError
+    clearImmediate(handle);
+}
+
 const fetchCopy: WindowOrWorkerGlobalScope['fetch'] = fetch;
 
 const myHeaders = new Headers();


### PR DESCRIPTION
Adding argument typings to the global timers, which lines up more closely with how they are typed by `@types/node` [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/timers.d.ts).

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  Example NodeJS timer definitions: [https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/timers.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/timers.d.ts)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.