### PR TITLE
react-vis: Add missing strokeWidth property to LineMarkSeriesProps

### DIFF
--- a/types/react-vis/index.d.ts
+++ b/types/react-vis/index.d.ts
@@ -421,6 +421,7 @@ export interface LineMarkSeriesProps extends AbstractSeriesProps<LineMarkSeriesP
     lineStyle?: CSSProperties | undefined; // default: {}
     markStyle?: CSSProperties | undefined; // default: {}
     strokeStyle?: 'dashed' | 'solid' | undefined; // default: 'solid'
+    strokeWidth?: number;
 }
 export class LineMarkSeries extends AbstractSeries<LineMarkSeriesProps> {}
 

--- a/types/react-vis/react-vis-tests.tsx
+++ b/types/react-vis/react-vis-tests.tsx
@@ -61,6 +61,7 @@ export function Example() {
                     { x: 2, y: 5 },
                     { x: 3, y: 15 },
                 ]}
+                strokeWidth={3}
             />
             <LineMarkSeries
                 className="linemark-series-example-2"


### PR DESCRIPTION
Add missing `strokeWidth` property to `LineMarkSeriesProps` (https://uber.github.io/react-vis/documentation/series-reference/line-mark-series#strokewidth-optional-)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://uber.github.io/react-vis/documentation/series-reference/line-mark-series#strokewidth-optional-
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
