### PR TITLE
fix(Node): Array.at's index parameter is optional

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -83,7 +83,7 @@ interface RelativeIndexable<T> {
      * allowing for positive and negative integers.
      * Negative integers count back from the last item in the array.
      */
-    at(index: number): T | undefined;
+    at(index?: number): T | undefined;
 }
 interface String extends RelativeIndexable<string> {}
 interface Array<T> extends RelativeIndexable<T> {}

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -26,3 +26,18 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
         gc();
     }
 }
+
+// ArrayLike.at() tests
+const arr = [1, 2, 3];
+
+arr.at(); // $ExpectType number | undefined
+arr.at(0); // $ExpectType number | undefined
+arr.at(-1); // $ExpectType number | undefined
+arr.at(3); // $ExpectType number | undefined
+
+const str = 'hello world';
+
+str.at(); // $ExpectType string | undefined
+str.at(0); // $ExpectType string | undefined
+str.at(-1); // $ExpectType string | undefined
+str.at(11); // $ExpectType string | undefined


### PR DESCRIPTION
This PR makes the index parameter in Array.at() optional as this defaults to 0 as per the [spec](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at). This is not documented in MDN so I can't link that

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

