### PR TITLE
[multer-s3] import S3 client only

### DIFF
--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -6,11 +6,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import * as AWS from "aws-sdk";
+import * as S3 from "aws-sdk/clients/s3";
 import { StorageEngine } from "multer";
 
 interface Options {
-    s3: AWS.S3;
+    s3: S3;
     bucket: ((req: Express.Request, file: Express.Multer.File, callback: (error: any, bucket?: string) => void) => void) | string;
     key?(req: Express.Request, file: Express.Multer.File, callback: (error: any, key?: string) => void): void;
     acl?: ((req: Express.Request, file: Express.Multer.File, callback: (error: any, acl?: string) => void) => void) | string | undefined;

--- a/types/multer-s3/multer-s3-tests.ts
+++ b/types/multer-s3/multer-s3-tests.ts
@@ -1,4 +1,4 @@
-import AWS = require("aws-sdk");
+import S3 = require("aws-sdk/clients/s3");
 import multer = require("multer");
 import s3Storage = require("multer-s3");
 
@@ -7,7 +7,7 @@ declare const secretAccessKey: string;
 declare const region: string;
 declare const bucket: string;
 
-const s3 = new AWS.S3({ accessKeyId, secretAccessKey, region });
+const s3 = new S3({ accessKeyId, secretAccessKey, region });
 
 const s3Upload = multer({
     storage: s3Storage({


### PR DESCRIPTION
### What

This PR imports only the S3 client definition from the aws-sdk type definitions. This reduces the overall compilation scope and should improve the compile times for projects that use multer-s3. In our case we ran out of memory before making this change.
