### PR TITLE
[react] Fix `ComponentPropsWithRef` inferring `any` when used with `JSXElementConstructor`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -836,7 +836,7 @@ declare namespace React {
                 ? JSX.IntrinsicElements[T]
                 : {};
     type ComponentPropsWithRef<T extends ElementType> =
-        T extends ComponentClass<infer P>
+        T extends (new (props: infer P) => Component<any, any>)
             ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
             : PropsWithRef<ComponentProps<T>>;
     type ComponentPropsWithoutRef<T extends ElementType> =

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -872,3 +872,20 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     // $ExpectError
     React.createElement(Wrapper, { value: 'C' });
 }
+
+// ComponentPropsWithRef and JSXElementConstructor
+{
+    interface Props {
+        value: string;
+    }
+    type InferredProps = React.ComponentPropsWithRef<React.JSXElementConstructor<Props>>;
+    const props: Props = {
+        value: 'inferred',
+        // $ExpectError
+        notImplemented: 5
+    };
+    const inferredProps: InferredProps = {
+        value: 'inferred',
+        notImplemented: 5
+    };
+}

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -886,6 +886,7 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     };
     const inferredProps: InferredProps = {
         value: 'inferred',
+        // $ExpectError
         notImplemented: 5
     };
 }

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -831,7 +831,7 @@ declare namespace React {
                 ? JSX.IntrinsicElements[T]
                 : {};
     type ComponentPropsWithRef<T extends ElementType> =
-        T extends ComponentClass<infer P>
+        T extends (new (props: infer P) => Component<any, any>)
             ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
             : PropsWithRef<ComponentProps<T>>;
     type ComponentPropsWithoutRef<T extends ElementType> =

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -857,3 +857,21 @@ const propsWithChildren: React.PropsWithChildren<Props> = {
     // $ExpectError
     React.createElement(Wrapper, { value: 'C' });
 }
+
+// ComponentPropsWithRef and JSXElementConstructor
+{
+    interface Props {
+        value: string;
+    }
+    type InferredProps = React.ComponentPropsWithRef<React.JSXElementConstructor<Props>>;
+    const props: Props = {
+        value: 'inferred',
+        // $ExpectError
+        notImplemented: 5
+    };
+    const inferredProps: InferredProps = {
+        value: 'inferred',
+        // $ExpectError
+        notImplemented: 5
+    };
+}


### PR DESCRIPTION
Review by commit advised.
Fixes a regression introduced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56413.

Since we used `ComponentClass<infer P>` in `ComponentPropsWithRef`, TypeScript decided to infer `any` when it could decide whether it wants to infer `P` from the `props` parameter of the constructor or from the returntype of the constructor. In `ComponentClass` both are the same. But in `JSXElementConstructor` we `any` the returntype props to workaround variance restrictions.


Originally reported in https://github.com/mui-org/material-ui/issues/29293