### PR TITLE
[jsrsasign] add missing param gracePeriod

### DIFF
--- a/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
+++ b/types/jsrsasign/modules/KJUR/jws/JWS.d.ts
@@ -363,6 +363,7 @@ declare namespace jsrsasign.KJUR.jws {
                 jti?: string;
                 sub?: string[];
                 verifyAt?: string | number;
+                gracePeriod?: number
             },
         ): boolean;
 


### PR DESCRIPTION
In "jsrsasign" the function verifyJWT has a missing property (gracePeriod).
This property is described in the jsdoc for that function but missing in the type.