### PR TITLE
(winston-syslog) Add customProducer to SyslogTransportOptions

### DIFF
--- a/types/winston-syslog/index.d.ts
+++ b/types/winston-syslog/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for winston-syslog 2.0
+// Type definitions for winston-syslog 2.4
 // Project: https://github.com/winstonjs/winston-syslog, https://github.com/indexzero/winston-syslog
 // Definitions by: Chris Barth <https://github.com/cjbarth>, Felix Hochgruber <https://github.com/felix-hoc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -7,6 +7,7 @@
 /// <reference types="node" />
 import * as Transport from 'winston-transport';
 import * as dgram from 'dgram';
+import * as glossy from 'glossy';
 import * as net from 'net';
 
 export interface SyslogTransportOptions extends Transport.TransportStreamOptions {
@@ -20,6 +21,7 @@ export interface SyslogTransportOptions extends Transport.TransportStreamOptions
     type?: string | undefined;
     app_name?: string | undefined;
     eol?: string | undefined;
+    customProducer?: typeof glossy.Produce;
 }
 
 export interface SyslogTransportInstance extends Transport {

--- a/types/winston-syslog/tsconfig.json
+++ b/types/winston-syslog/tsconfig.json
@@ -14,7 +14,6 @@
         ],
         "types": [],
         "noEmit": true,
-        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/winston-syslog/winston-syslog-tests.ts
+++ b/types/winston-syslog/winston-syslog-tests.ts
@@ -1,3 +1,4 @@
+import glossy = require('glossy');
 import winston = require('winston');
 import { Syslog, SyslogTransportOptions } from 'winston-syslog';
 
@@ -16,7 +17,8 @@ const syslogOptions: SyslogTransportOptions = {
     localhost: str,
     type: str,
     app_name: str,
-    eol: str
+    eol: str,
+    customProducer: glossy.Produce
 };
 
 const syslogTransport = new Syslog(syslogOptions);


### PR DESCRIPTION
Add `customProducer` to `SyslogTransportOptions` as documented here:

> By default, syslog messages are produced by glossy, but you can override that behavior by providing a custom Producer instance via the customProducer setting.

(https://github.com/winstonjs/winston-syslog#usage)

I've also updated the winston-syslog version to the latest version (2.4) and removed `"esModuleInterop": true,` as per the DefinitelyTyped readme:

> TL;DR: `esModuleInterop` and `allowSyntheticDefaultImports` are not allowed in your `tsconfig.json`.

(https://github.com/DefinitelyTyped/DefinitelyTyped#esmoduleinteropallowsyntheticdefaultimports)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/winstonjs/winston-syslog#usage
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
