### PR TITLE
[@types/async] Fix types of whilst and company

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -9,6 +9,7 @@
 //                 Etienne Rossignon <https://github.com/erossignon>
 //                 Lifeng Zhu <https://github.com/Juliiii>
 //                 Tümay Çeber <https://github.com/brendtumi>
+//                 Andrew Pensinger <https://github.com/apnsngr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -316,14 +317,44 @@ export function parallel<T, R, E = Error>(tasks: Array<AsyncFunction<T, E>> | Di
 export function parallelLimit<T, E = Error>(tasks: Array<AsyncFunction<T, E>>, limit: number, callback?: AsyncResultArrayCallback<T, E>): void;
 export function parallelLimit<T, E = Error>(tasks: Dictionary<AsyncFunction<T, E>>, limit: number, callback?: AsyncResultObjectCallback<T, E>): void;
 export function parallelLimit<T, R, E = Error>(tasks: Array<AsyncFunction<T, E>> | Dictionary<AsyncFunction<T, E>>, limit: number): Promise<R>;
-export function whilst<E = Error>(test: (cb: (err: any, truth: boolean) => boolean) => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
-export function whilst<R, E = Error>(test: (cb: (err: any, truth: boolean) => boolean) => boolean, fn: AsyncVoidFunction<E>): Promise<R>;
-export function doWhilst<T, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean, callback: ErrorCallback<E>): void;
-export function doWhilst<T, R, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean): Promise<R>;
-export function until<E = Error>(test: () => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
-export function until<R, E = Error>(test: () => boolean, fn: AsyncVoidFunction<E>): Promise<R>;
-export function doUntil<T, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean, callback: ErrorCallback<E>): void;
-export function doUntil<T, R, E = Error>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean): Promise<R>;
+
+export function whilst<T, E = Error>(
+    test: (cb: AsyncBooleanResultCallback) => void,
+    fn: AsyncFunctionEx<T, E>,
+    callback: AsyncFunctionEx<T, E>
+): void;
+export function whilst<T, R, E = Error>(
+    test: (cb: AsyncBooleanResultCallback) => void,
+    fn: AsyncFunctionEx<T, E>
+): Promise<R>;
+export function doWhilst<T, E = Error>(
+    fn: AsyncFunctionEx<T, E>,
+    test: (/* ...results: T[], */ cb: AsyncBooleanResultCallback) => void,
+    callback: AsyncFunctionEx<T, E>
+): void;
+export function doWhilst<T, R, E = Error>(
+    fn: AsyncFunctionEx<T, E>,
+    test: (/* ...results: T[], */ cb: AsyncBooleanResultCallback) => void
+): Promise<R>;
+export function until<T, E = Error>(
+    test: (cb: AsyncBooleanResultCallback) => void,
+    fn: AsyncFunctionEx<T, E>,
+    callback: AsyncFunctionEx<T, E>
+): void;
+export function until<T, R, E = Error>(
+    test: (cb: AsyncBooleanResultCallback) => void,
+    fn: AsyncFunctionEx<T, E>
+): Promise<R>;
+export function doUntil<T, E = Error>(
+    fn: AsyncFunctionEx<T, E>,
+    test: (/* ...results: T[], */ cb: AsyncBooleanResultCallback) => void,
+    callback: AsyncFunctionEx<T, E>
+): void;
+export function doUntil<T, R, E = Error>(
+    fn: AsyncFunctionEx<T, E>,
+    test: (/* ...results: T[], */ cb: AsyncBooleanResultCallback) => void
+): Promise<R>;
+
 export function during<E = Error>(test: (testCallback: AsyncBooleanResultCallback<E>) => void, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
 export function doDuring<E = Error>(fn: AsyncVoidFunction<E>, test: (testCallback: AsyncBooleanResultCallback<E>) => void, callback: ErrorCallback<E>): void;
 export function forever<E = Error>(next: (next: ErrorCallback<E>) => void, errBack: ErrorCallback<E>): void;

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -152,19 +152,16 @@ async.parallelLimit({
     (err, results) => { }
 );
 
-function whileFn(callback: any) {
+function whileFn(callback: (err: any, ...rest: any[]) => void) {
     setTimeout(() => callback(null, ++count), 1000);
 }
-
-function whileTest() { return count < 5; }
-function whilstTest(callback: (error: any, truth: boolean) => boolean) { return callback(null, count < 5); }
-function doWhileTest(count: number) { return count < 5; }
+function whileTest(callback: (err: any, truth: boolean) => void) { callback(null, count < 5); }
 
 let count = 0;
-async.whilst(whilstTest, whileFn, err => { });
+async.whilst(whileTest, whileFn, err => { });
 async.until(whileTest, whileFn, err => { });
-async.doWhilst(whileFn, doWhileTest, err => { });
-async.doUntil(whileFn, doWhileTest, err => { });
+async.doWhilst(whileFn, whileTest, err => { });
+async.doUntil(whileFn, whileTest, err => { });
 
 async.during(testCallback => { testCallback(new Error(), false); }, callback => { callback(); }, error => { console.log(error); });
 async.doDuring(callback => { callback(); }, testCallback => { testCallback(new Error(), false); }, error => { console.log(error); });


### PR DESCRIPTION
Fixes types of the whilst function and its related functions until,
doWhilst, and doUntil. The main issue was that the test argument should
be an async boolean function instead of a plain boolean function.

`whilst` and `until`:

- Changes test argument to be an async boolean function
- Includes rest parameters in callback for iteratee argument
- Includes rest parameters for callback argument

`doWhilst` and `doUntil`:

- Changes test function to be an async boolean function
- Includes rest parameters in callback argument
- Technically the callback for the test argument of these functions
  includes rest parameters, but this happens *before* the callback
  parameter, which is invalid TypeScript.

Relevant source code from async module:
- [whilst](https://github.com/caolan/async/blob/v3.2.1/lib/whilst.js)
- [until](https://github.com/caolan/async/blob/v3.2.1/lib/until.js)
- [doWhilst](https://github.com/caolan/async/blob/v3.2.1/lib/doWhilst.js)
- [doUntil](https://github.com/caolan/async/blob/v3.2.1/lib/doUntil.js)
