### PR TITLE
[@types/svg-path-parser] Update `makeAbsolute`'s type

### DIFF
--- a/types/svg-path-parser/index.d.ts
+++ b/types/svg-path-parser/index.d.ts
@@ -1,10 +1,30 @@
 // Type definitions for svg-path-parser 1.1
 // Project: https://github.com/hughsk/svg-path-parser#readme
 // Definitions by: tyru <https://github.com/tyru>
+//                 sozysozbot <https://github.com/sozysozbot>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export function parseSVG(input: string): Command[];
-export function makeAbsolute(commands: Command[]): Command[];
+
+// This function modifies the `commands` in place and returns it.
+// In TypeScript, the only way to modify the argument's type is to write
+// `function f(cs: Command[]): asserts cs is CommandMadeAbsolute[];`, but then this makes the function return void.
+// Hence, the only solution possible is to exploit the fact that this function returns the modified argument
+// and make the return value be of type `CommandMadeAbsolute[]` and the argument to remain in `Command[]`.
+export function makeAbsolute(commands: Command[]): CommandMadeAbsolute[];
+
+export type CommandMadeAbsolute = (
+    MoveToCommandMadeAbsolute |
+    LineToCommandMadeAbsolute |
+    HorizontalLineToCommandMadeAbsolute |
+    VerticalLineToCommandMadeAbsolute |
+    ClosePathCommandMadeAbsolute |
+    CurveToCommandMadeAbsolute |
+    SmoothCurveToCommandMadeAbsolute |
+    QuadraticCurveToCommandMadeAbsolute |
+    SmoothQuadraticCurveToCommandMadeAbsolute |
+    EllipticalArcCommandMadeAbsolute
+);
 
 export type Command = (
     MoveToCommand |
@@ -112,4 +132,117 @@ export interface EllipticalArcCommand extends BaseCommand {
     sweep: boolean;
     x: number;
     y: number;
+}
+
+export interface MoveToCommandMadeAbsolute extends BaseCommand {
+    code: 'M';
+    command: 'moveto';
+    relative: false;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
+}
+
+export interface LineToCommandMadeAbsolute extends BaseCommand {
+    code: 'L';
+    command: 'lineto';
+    relative: false;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
+}
+
+export interface HorizontalLineToCommandMadeAbsolute extends BaseCommand {
+    code: 'H';
+    command: 'horizontal lineto';
+    relative: false;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
+}
+
+export interface VerticalLineToCommandMadeAbsolute extends BaseCommand {
+    code: 'V';
+    command: 'vertical lineto';
+    relative: false;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
+}
+
+export interface ClosePathCommandMadeAbsolute extends BaseCommand {
+    code: 'Z';
+    command: 'closepath';
+    relative: false;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
+}
+
+export interface CurveToCommandMadeAbsolute extends BaseCommand {
+    code: 'C';
+    command: 'curveto';
+    relative: false;
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
+}
+
+export interface SmoothCurveToCommandMadeAbsolute extends BaseCommand {
+    code: 'S';
+    command: 'smooth curveto';
+    relative: false;
+    x2: number;
+    y2: number;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
+}
+
+export interface QuadraticCurveToCommandMadeAbsolute extends BaseCommand {
+    code: 'Q';
+    command: 'quadratic curveto';
+    relative: false;
+    x1: number;
+    y1: number;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
+}
+
+export interface SmoothQuadraticCurveToCommandMadeAbsolute extends BaseCommand {
+    code: 'T';
+    command: 'smooth quadratic curveto';
+    relative: false;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
+}
+
+export interface EllipticalArcCommandMadeAbsolute extends BaseCommand {
+    code: 'A';
+    command: 'elliptical arc';
+    relative: false;
+    rx: number;
+    ry: number;
+    xAxisRotation: number;
+    largeArc: boolean;
+    sweep: boolean;
+    x: number;
+    y: number;
+    x0: number;
+    y0: number;
 }

--- a/types/svg-path-parser/svg-path-parser-tests.ts
+++ b/types/svg-path-parser/svg-path-parser-tests.ts
@@ -92,9 +92,18 @@ function testUnion(cmd: svgParser.Command): number {
   }
 }
 
-const cmds = svgParser.parseSVG('M 10 80 C 40 10, 65 10, 95 80 S 150 150, 180 80');
-svgParser.makeAbsolute(cmds); // makeAbsolute() changes cmds in-place
+const cmds: svgParser.Command[] = svgParser.parseSVG('M 10 80 C 40 10, 65 10, 95 80 S 150 150, 180 80');
+const cmds_made_absolute: svgParser.CommandMadeAbsolute[] = svgParser.makeAbsolute(cmds);
+// `makeAbsolute()` modifies the argument in place and returns it.
+// In TypeScript, the only way to modify the argument's type is to write
+// `function f(cs: Command[]): asserts cs is CommandMadeAbsolute[];`, but then this makes the function return void.
+// Hence, the only solution possible is to exploit the fact that this function returns the modified argument
+// and make the return value be of type `CommandMadeAbsolute[]` and the argument to remain in `Command[]`.
 
 assert(cmds.every(cmd => !cmd.relative)); // relative commands must not exist
 cmds.forEach(testUnion);  // doesn't really do much, but the function itself must type-check
 cmds.map(stringify).forEach(console.log); // could throw
+
+// If we access the return value, `.x0` and `.y0` are guaranteed to exist
+cmds_made_absolute.forEach(a => a.x0);
+cmds_made_absolute.forEach(a => a.y0);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sozysozbot/DefinitelyTyped/blob/sozysozbot-patch-2/types/svg-path-parser/index.d.ts#L9-L14 and https://github.com/hughsk/svg-path-parser/blob/master/index.js#L11-L24
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

