### PR TITLE
[@types/stylelint] Add missing context parameter to Plugin

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -73,6 +73,11 @@ export interface LintResult {
     invalidOptionWarnings: any[];
 }
 
+expoort interface RuleContext {
+    fix: boolean;
+    newline: string;
+};
+
 export namespace formatters {
     function json(results: LintResult[]): string;
     function string(results: LintResult[]): string;
@@ -124,7 +129,8 @@ export namespace utils {
 
 export type Plugin = (
     primaryOption: any,
-    secondaryOptions?: object,
+    secondaryOptions: object | undefined,
+    context: RuleContext,
 ) => (root: postcss.Root, result: postcss.Result) => void | PromiseLike<void>;
 
 export function createPlugin(ruleName: string, plugin: Plugin): any;


### PR DESCRIPTION
### What's changed?

* Added missing `context: { fix: boolean; newline: string; }` argument to rule function. This allows rules created with `createPlugin(...)` to autofix linting mistakes.

See [stylelint docs](https://stylelint.io/developer-guide/rules#add-autofix):
> If your plugin rule supports autofixing, then ruleFunction should also accept a third argument: context.

### Template

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
