### PR TITLE
chromecast-caf-sender: Add reason param to __onGCastApiAvailable

### DIFF
--- a/types/chromecast-caf-sender/chromecast-caf-sender-tests.ts
+++ b/types/chromecast-caf-sender/chromecast-caf-sender-tests.ts
@@ -3,7 +3,7 @@
 cast.framework.VERSION === "1.0.06";
 cast.framework.setLoggerLevel(cast.framework.LoggerLevel.DEBUG);
 
-window.__onGCastApiAvailable = (available: boolean) => {};
+window.__onGCastApiAvailable = (available: boolean, reason: string | undefined) => {};
 
 const context = cast.framework.CastContext.getInstance();
 context.getCastState() === cast.framework.CastState.CONNECTED;

--- a/types/chromecast-caf-sender/index.d.ts
+++ b/types/chromecast-caf-sender/index.d.ts
@@ -11,7 +11,7 @@
 ////////////////////
 interface Window {
   cast: typeof cast;
-  __onGCastApiAvailable(available: boolean): void;
+  __onGCastApiAvailable(available: boolean, reason?: string): void;
 }
 
 ////////////////////


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1 Unfortunately this is not well documented but only in the minified source. Function is being called like this from the framework loader: 
	- not available: `a(!1,"No cast extension found")`
	- available: `b(!0)`.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
