### PR TITLE
Add onComment method to ParseOptions in css-tree

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -703,3 +703,10 @@ csstree.definitionSyntax.walk(syntax, (node) => {
 csstree.definitionSyntax.walk(syntax, (node) => {
     node; // $ExpectType DSNode
 }, undefined);
+
+csstree.parse('.selector { /* comment */ }', {
+  onComment(value, loc) {
+    value; // $ExpectType string
+    loc; // $ExpectType CssLocation
+  }
+});

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -489,7 +489,7 @@ export interface ParseOptions {
     context?: string | undefined;
     atrule?: string | undefined;
     positions?: boolean | undefined;
-    onComment?: (value: string, CssLocation: loc) => void;
+    onComment?: (value: string, loc: CssLocation) => void;
     onParseError?: ((error: SyntaxParseError, fallbackNode: CssNode) => void) | undefined;
     filename?: string | undefined;
     offset?: number | undefined;

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -489,6 +489,7 @@ export interface ParseOptions {
     context?: string | undefined;
     atrule?: string | undefined;
     positions?: boolean | undefined;
+    onComment?: (value: string, CssLocation: loc) => void;
     onParseError?: ((error: SyntaxParseError, fallbackNode: CssNode) => void) | undefined;
     filename?: string | undefined;
     offset?: number | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/csstree/csstree/blob/master/lib/parser/create.js#L313-L330
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
