### PR TITLE
Allow return type of SVG.create to be inferred for leaflet

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1101,6 +1101,7 @@ export class Renderer extends Layer {
 export class SVG extends Renderer {}
 
 export namespace SVG {
+    function create<K extends keyof SVGElementTagNameMap>(name: K): SVGElementTagNameMap[K];
     function create(name: string): SVGElement;
 
     function pointsToPath(rings: PointExpression[], close: boolean): string;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference-1.7.1.html#svg-create
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This adds an overload to SVG.create which allows the value of name to be restricted to elements in SVGElementTagNameMap and infer the return type of the SVG element.