### PR TITLE
winston-loggly-bulk - Fixes LogglyOptions mispelling

### DIFF
--- a/types/winston-loggly-bulk/index.d.ts
+++ b/types/winston-loggly-bulk/index.d.ts
@@ -21,7 +21,7 @@ export interface LogglyOptions extends TransportStream.TransportStreamOptions {
     bufferOptions?: BufferOptions | undefined;
     isBulk?: boolean | undefined;
     json?: boolean | undefined;
-    networkErrorOnConsole?: boolean | undefined;
+    networkErrorsOnConsole?: boolean | undefined;
     proxy?: null | string | Url | undefined;
     stripColors?: boolean | undefined;
     subdomain: string;

--- a/types/winston-loggly-bulk/winston-loggly-bulk-tests.ts
+++ b/types/winston-loggly-bulk/winston-loggly-bulk-tests.ts
@@ -11,7 +11,7 @@ const loggly = new Loggly({
     },
     isBulk: false,
     json: true,
-    networkErrorOnConsole: false,
+    networkErrorsOnConsole: false,
     proxy: 'www.example.com',
     stripColors: true,
     subdomain: 'my_subdomain',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/loggly/winston-loggly-bulk/blob/master/lib/winston-loggly.js#L63

The current definition has networkErrorOnConsole but the source code of the winston-loggly-bulk project indicates it should be networkErrorsOnConsole . It looks to have had that pluralization for years, so this isn't due to a version change.