### PR TITLE
fix(node): fs.{Read,Write}Stream::close with callback

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -297,7 +297,7 @@ declare module 'fs' {
      * @since v0.1.93
      */
     export class ReadStream extends stream.Readable {
-        close(): void;
+        close(callback?: (err?: NodeJS.ErrnoException | null) => void): void;
         /**
          * The number of bytes that have been read so far.
          * @since v6.4.0
@@ -385,7 +385,7 @@ declare module 'fs' {
          * callback that will be executed once the `writeStream`is closed.
          * @since v0.9.4
          */
-        close(): void;
+        close(callback?: (err?: NodeJS.ErrnoException | null) => void): void;
         /**
          * The number of bytes written so far. Does not include data that is still queued
          * for writing.

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -457,6 +457,14 @@ async () => {
 };
 
 {
+    fs.createReadStream('path').close();
+    fs.createReadStream('path').close((err?: NodeJS.ErrnoException | null) => {});
+
+    fs.createWriteStream('path').close();
+    fs.createWriteStream('path').close((err?: NodeJS.ErrnoException | null) => {});
+}
+
+{
     fs.readvSync(123, [Buffer.from('wut')] as ReadonlyArray<NodeJS.ArrayBufferView>);
     fs.readv(123, [Buffer.from('wut')] as ReadonlyArray<NodeJS.ArrayBufferView>, 123, (err: NodeJS.ErrnoException | null, bytesRead: number, buffers: NodeJS.ArrayBufferView[]) => {
     });

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -131,7 +131,7 @@ declare module 'fs' {
     }
 
     class ReadStream extends stream.Readable {
-        close(): void;
+        close(callback?: (err?: NodeJS.ErrnoException | null) => void): void;
         bytesRead: number;
         path: string | Buffer;
 
@@ -162,7 +162,7 @@ declare module 'fs' {
     }
 
     class WriteStream extends stream.Writable {
-        close(): void;
+        close(callback?: (err?: NodeJS.ErrnoException | null) => void): void;
         bytesWritten: number;
         path: string | Buffer;
 

--- a/types/node/v12/test/fs.ts
+++ b/types/node/v12/test/fs.ts
@@ -311,6 +311,14 @@ async function testPromisify() {
 })();
 
 {
+    fs.createReadStream('path').close();
+    fs.createReadStream('path').close((err?: NodeJS.ErrnoException | null) => {});
+
+    fs.createWriteStream('path').close();
+    fs.createWriteStream('path').close((err?: NodeJS.ErrnoException | null) => {});
+}
+
+{
     fs.opendir('test', async (err, dir) => {
         const dirEnt: fs.Dirent | null = await dir.read();
     });

--- a/types/node/v14/fs.d.ts
+++ b/types/node/v14/fs.d.ts
@@ -143,7 +143,7 @@ declare module 'fs' {
     }
 
     export class ReadStream extends stream.Readable {
-        close(): void;
+        close(callback?: (err?: NodeJS.ErrnoException | null) => void): void;
         bytesRead: number;
         path: string | Buffer;
         pending: boolean;
@@ -211,7 +211,7 @@ declare module 'fs' {
     }
 
     export class WriteStream extends stream.Writable {
-        close(): void;
+        close(callback?: (err?: NodeJS.ErrnoException | null) => void): void;
         bytesWritten: number;
         path: string | Buffer;
         pending: boolean;

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -422,6 +422,14 @@ async function testPromisify() {
 }
 
 {
+    fs.createReadStream('path').close();
+    fs.createReadStream('path').close((err?: NodeJS.ErrnoException | null) => {});
+
+    fs.createWriteStream('path').close();
+    fs.createWriteStream('path').close((err?: NodeJS.ErrnoException | null) => {});
+}
+
+{
     fs.readvSync(123, [Buffer.from('wut')] as ReadonlyArray<NodeJS.ArrayBufferView>);
     fs.readv(123, [Buffer.from('wut')] as ReadonlyArray<NodeJS.ArrayBufferView>, 123, (err: NodeJS.ErrnoException | null, bytesRead: number, buffers: NodeJS.ArrayBufferView[]) => {
     });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://nodejs.org/api/fs.html#writestreamclosecallback
  - [ReadStream.prototype.close](https://github.com/nodejs/node/blob/3ff8c355c892dca5cf044543f6bbfd6b1a129693/lib/internal/fs/streams.js#L296-L299)
  - [WriteStream.prototype.close](https://github.com/nodejs/node/blob/3ff8c355c892dca5cf044543f6bbfd6b1a129693/lib/internal/fs/streams.js#L464-L482)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.



___


resolve #56805