### PR TITLE
[PDFKit] Add missing properties to "TextOptions" interface

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -7,6 +7,7 @@
 //                 Evgeny Baram <https://github.com/r4tz52/>
 //                 Benjamin Just <https://github.com/BamButz/>
 //                 Joanna Gabis <https://github.com/jg-mms/>
+//                 Robin Guinant <https://github.com/Foohx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -191,6 +192,8 @@ declare namespace PDFKit.Mixins {
         bulletIndent?: number | undefined;
         /** The indent of text in a list */
         textIndent?: number | undefined;
+        destination?: string | undefined;
+        goTo?: string | undefined;
     }
 
     interface PDFText {

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -195,6 +195,10 @@ doc.text('Text with features', { features: [ "kern" ] });
 
 doc.goTo(0, 0, 0, 0, 'lorem');
 
+doc.text('Text with destination', {destination: "test-anchor"})
+
+doc.text('Text with goTo', {goTo: 'test-anchor'})
+
 doc.image('path/to/image.png', {
     fit: [250, 300],
     align: 'center',
@@ -280,3 +284,6 @@ structureElement.add(structureContent);
 structureElement.setAttached();
 structureElement.setParent(doc.ref({}));
 structureElement.end();
+
+// Text
+doc.text("")

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -195,9 +195,9 @@ doc.text('Text with features', { features: [ "kern" ] });
 
 doc.goTo(0, 0, 0, 0, 'lorem');
 
-doc.text('Text with destination', {destination: "test-anchor"})
+doc.text('Text with destination', {destination: "test-anchor"});
 
-doc.text('Text with goTo', {goTo: 'test-anchor'})
+doc.text('Text with goTo', {goTo: 'test-anchor'});
 
 doc.image('path/to/image.png', {
     fit: [250, 300],

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -284,6 +284,3 @@ structureElement.add(structureContent);
 structureElement.setAttached();
 structureElement.setParent(doc.ref({}));
 structureElement.end();
-
-// Text
-doc.text("")


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/foliojs/pdfkit/blob/352524718ad972d99aaab265dcc4835581741a25/lib/mixins/text.js#L367
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.