### PR TITLE
[react] Document type limitations of Suspense#fallback in React 18

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -395,9 +395,12 @@ declare namespace React {
     interface SuspenseProps {
         children?: ReactNode | undefined;
 
+        // TODO(react18): `fallback?: ReactNode;`
         /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
         fallback: NonNullable<ReactNode>|null;
     }
+
+    // TODO(react18): Updated JSDoc to reflect that Suspense works on the server.
     /**
      * This feature is not yet available for server-side rendering.
      * Suspense support will be added in a later release.

--- a/types/react/test/next.tsx
+++ b/types/react/test/next.tsx
@@ -116,3 +116,17 @@ function InvalidOpaqueIdentifierUsage() {
 
     return null;
 }
+
+function SuspenseTest() {
+    // TODO(react18): Should not error.
+    // `fallback` is optional in React 18
+    // $ExpectError
+    <React.Suspense></React.Suspense>;
+    // TODO(react18): Should not error.
+    // `fallback` is optional in React 18.
+    // $ExpectError
+    <React.Suspense fallback={undefined}></React.Suspense>;
+    // Workaround.
+    // TODO(react18): Remove.
+    <React.Suspense fallback={undefined!}></React.Suspense>;
+}


### PR DESCRIPTION
Doesn't change any public types but explains and prepares for type changes for https://github.com/reactwg/react-18/discussions/72.

We can't use module augmentation like

```ts
interface SuspenseProps {
  fallback?: React.ReactNode;
}
```
since that triggers "Subsequent property declarations must have the same type".

We also can't redeclare `Suspense` itself since it's a constant.