### PR TITLE
dom-navigation-preload: Add types for service worker navigation preload

### DIFF
--- a/types/dom-navigation-preload/dom-navigation-preload-tests.ts
+++ b/types/dom-navigation-preload/dom-navigation-preload-tests.ts
@@ -1,0 +1,13 @@
+// This throws a TypeError at runtime, but TypeScript should probably allow it.
+new NavigationPreloadManager();
+
+navigator.serviceWorker.ready.then(async registration => {
+    await registration.navigationPreload.enable();
+    await registration.navigationPreload.disable();
+
+    await registration.navigationPreload.setHeaderValue('test');
+
+    const state = await registration.navigationPreload.getState();
+    console.log(state.enabled);
+    console.log(state.headerValue);
+});

--- a/types/dom-navigation-preload/index.d.ts
+++ b/types/dom-navigation-preload/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for non-npm package dom-navigation-preload-browser 0.0
 // Project: https://w3c.github.io/ServiceWorker/#service-worker-registration-navigationpreload
 // Definitions by: Jan Kuehle <https://github.com/frigus02>
+//                 Martin Probst <https://github.com/mprobst>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.4
 

--- a/types/dom-navigation-preload/index.d.ts
+++ b/types/dom-navigation-preload/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for non-npm package dom-navigation-preload-browser 0.0
+// Project: https://w3c.github.io/ServiceWorker/#service-worker-registration-navigationpreload
+// Definitions by: Jan Kuehle <https://github.com/frigus02>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.4
+
+interface ServiceWorkerRegistration {
+    /*~ https://w3c.github.io/ServiceWorker/#ref-for-dom-serviceworkerregistration-navigationpreload */
+    readonly navigationPreload: NavigationPreloadManager;
+}
+
+/*~ https://w3c.github.io/ServiceWorker/#navigationpreloadmanager */
+interface NavigationPreloadManager {
+    disable(): Promise<void>;
+    enable(): Promise<void>;
+    getState(): Promise<NavigationPreloadState>;
+    setHeaderValue(value: string): Promise<void>;
+}
+
+declare var NavigationPreloadManager: {
+    prototype: NavigationPreloadManager;
+    new (): NavigationPreloadManager;
+};
+
+/*~ https://w3c.github.io/ServiceWorker/#dictdef-navigationpreloadstate */
+interface NavigationPreloadState {
+    enabled: boolean;
+    headerValue: string;
+}

--- a/types/dom-navigation-preload/tsconfig.json
+++ b/types/dom-navigation-preload/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dom-navigation-preload-tests.ts"
+    ]
+}

--- a/types/dom-navigation-preload/tslint.json
+++ b/types/dom-navigation-preload/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
TypeScript 4.4 removed types for [navigation preload](https://w3c.github.io/ServiceWorker/#service-worker-registration-navigationpreload). This makes sense because it's currently only supported by Chromium based browsers. It seems to make sense to add those types to DefinitelyTyped until more browser engines support it.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test dom-navigation-preload`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.