### PR TITLE
Added `workflow` to docusign-esign types

### DIFF
--- a/types/docusign-esign/index.d.ts
+++ b/types/docusign-esign/index.d.ts
@@ -12986,6 +12986,58 @@ export interface CompositeTemplate {
      */
     serverTemplates?: ServerTemplate[] | undefined;
 }
+
+export interface ConditionalRecipientRule {
+    /**
+     * An array of conditions that satisfy the rule.
+     */
+    conditions?: ConditionalRecipientRuleCondition[] | undefined;
+    /**
+     * An integer that specifies the order in which rules are processed. Lower values are processed before higher values.
+     */
+    order?: string | undefined;
+    recipientGroup?: RecipientGroup | undefined;
+    /**
+     * Unique for the recipient. It is used by the tab element to indicate which recipient is to sign the Document.
+     */
+    recipientId?: string | undefined;
+}
+
+export interface ConditionalRecipientRuleCondition {
+    filters?: ConditionalRecipientRuleFilter[] | undefined;
+    /**
+     * An integer that specifies the order in which rules are processed. Lower values are processed before higher values.
+     */
+    order?: string | undefined;
+    recipientLabel?: string | undefined;
+}
+
+export interface ConditionalRecipientRuleFilter {
+    operator?: string | undefined;
+    /**
+     * Unique for the recipient. It is used by the tab element to indicate which recipient is to sign the Document.
+     */
+    recipientId?: string | undefined;
+    /**
+     * Must be set to "api".
+     */
+    scope?: string | undefined;
+    /**
+     * The unique identifier for the tab.
+     */
+    tabId?: string | undefined;
+    /**
+     * The label associated with the tab. This value may be an empty string. If no value is provided, the tab type is used as the value.
+     *
+     * Maximum Length: 500 characters.
+     */
+    tabLabel?: string | undefined;
+    /**
+     * Specifies the value of the tab.
+     */
+    value?: string | undefined;
+}
+
 /**
  * This object contains the results of a ConnectConfigurations::GET method.
  */
@@ -19440,6 +19492,8 @@ export interface Envelope {
      * The reason the envelope or template was voided.
      */
     voidedReason?: string | undefined;
+
+    workflow?: /* A complex element that specifies the workflow settings for the envelope. */ Workflow | undefined;
 }
 
 export interface EnvelopeAttachment {
@@ -20204,6 +20258,8 @@ export interface EnvelopeDefinition {
      * The reason the envelope or template was voided.
      */
     voidedReason?: string | undefined;
+
+    workflow?: /* A complex element that specifies the workflow settings for the envelope. */ Workflow | undefined;
 }
 
 /**
@@ -33561,6 +33617,21 @@ export interface RecipientFormData {
     SignedTime?: string | undefined;
 }
 
+export interface RecipientGroup {
+    /**
+     * The group message, typically a description of the group.
+     */
+    groupMessage?: string | undefined;
+    /**
+     * The name of the group
+     */
+    groupName?: string | undefined;
+    /**
+     * An array of recipient objects that provides details about the recipients of the envelope.
+     */
+    recipients?: RecipientOption[] | undefined;
+}
+
 export interface RecipientIdentityInputOption {
     name?: string | undefined;
 
@@ -33611,6 +33682,24 @@ export interface RecipientNamesResponse {
      * When set to **true**, new names cannot be added to the email address.
      */
     reservedRecipientEmail?: string | undefined;
+}
+
+export interface RecipientOption {
+    email?: string | undefined;
+    name?: string | undefined;
+    recipientLabel?: string | undefined;
+    /**
+     * Optional element. Specifies the role name associated with the recipient.
+     *
+     * This property is required when you are working with template recipients.
+     */
+    roleName?: string | undefined;
+    /**
+     * When set to **true** and the feature is enabled in the sender's account, the signing recipient is required to draw
+     * signatures and initials at each signature/initial tab ( instead of adopting a signature/initial style or only drawing
+     * a signature/initial once).
+     */
+    signingGroupId?: string | undefined;
 }
 
 /**
@@ -33736,6 +33825,17 @@ export interface RecipientPreviewRequest {
 
 export interface RecipientProofFile {
     isInProofFile?: string | undefined;
+}
+
+export interface RecipientRules {
+    conditionalRecipients?: ConditionalRecipientRule[] | undefined;
+}
+
+export interface RecipientRouting {
+    /**
+     * The recipient routing rules.
+     */
+    rules?: RecipientRules | undefined;
 }
 
 /**
@@ -45244,6 +45344,65 @@ export interface Witness {
      * The GUID of the person or party for whom the recipient is a witness.
      */
     witnessForGuid?: string | undefined;
+}
+
+export interface Workflow {
+    /**
+     * The workflowStepId of the current step.This is not an index into the workflowSteps array in this object.See the workflowStep object.
+     */
+    currentWorkflowStepId?: string | undefined;
+    /**
+     * The status of the workflow:
+     * - `paused` if the workflow is paused
+     * - `in_progress` if the workflow is in progress
+     */
+    workflowStatus?: string | undefined;
+    /**
+     * An array of workflow steps.
+     */
+    workflowSteps?: WorkflowStep[] | undefined;
+}
+
+export interface WorkflowStep {
+    /**
+     * Indicates the action to perform.
+     * - `pause_before`: The workflow should pause before the trigger described by `triggerOnItem` is reached.
+     */
+    action?: string | undefined;
+    /**
+     * The timestamp of when the workflow step transitioned to `completed` status.
+     */
+    completedDate?: string | undefined;
+    /**
+     * The unique ID of the item being triggered.
+     */
+    itemId?: string | undefined;
+    /**
+     * The rules for recipient routing.
+     */
+    recipientRouting?: RecipientRouting | undefined;
+    /**
+     * The status of the step. One of:
+     * - inactive
+     * - in_progress
+     * - paused
+     * - pending
+     * - completed
+     * This is a read-only property.
+     */
+    status?: string | undefined;
+    /**
+     * The timestamp of when the workflow step transitioned to `in_progress` status.
+     */
+    triggeredDate?: string | undefined;
+    /**
+     * The type of item that triggers this workflow step. Currently, only `routing_order`, is the only supported value.
+     */
+    triggerOnItem?: string | undefined;
+    /**
+     * A unique identifier for this workflow step. This value is available from the `currentWorkflowStepId` property of the workflow object,
+     */
+    workflowStepId?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://docusign.github.io/docusign-esign-node-client/module-model_Envelope.html and https://docusign.github.io/docusign-esign-node-client/model_Envelope.js.html#line656
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

