### PR TITLE
[prosemirror-state] Mark undocumented Transaction constructor as private

### DIFF
--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -495,6 +495,8 @@ export class EditorState<S extends Schema = any> {
  * a `"paste"` property of true to transactions caused by a paste..
  */
 export class Transaction<S extends Schema = any> extends Transform<S> {
+    private constructor(state: EditorState);
+
     /**
      * The timestamp associated with this transaction, in the same
      * format as `Date.now()`.

--- a/types/prosemirror-state/prosemirror-state-tests.ts
+++ b/types/prosemirror-state/prosemirror-state-tests.ts
@@ -69,3 +69,6 @@ const res3_2: state.Selection = state.Selection.findFrom({} as model.ResolvedPos
 
 const res4_1 = new state.PluginKey<string>();
 const res4_2: string = res4_1.getState({} as state.EditorState)!;
+
+// $ExpectError
+new state.Transaction({} as ConstructorParameters<typeof state.Transaction>[0]);


### PR DESCRIPTION
The constructor for `Transaction` is not documented (i.e. not public), so it was not included in the type definitions. The problem here though is that the type now inherits the (public) constructor from `Transform`, which has a different type signature (it takes a `Node` while `Transaction` takes an `EditorState`).

Since this is undocumented, I added a constructor declaration but marked it as private. This is a breaking change, though code that compiled before it would be broken. Of course, if this is something that _should_ be public I'm happy to update my changes.

I added a test that is meant to only check that using the constructor fails, but if the arity of the constructor changes it will cause another error which could result in a false pass. I wanted to do `new Transaction(...([] as ConstructorParameters<typeof Transaction>))` but it seems that the ES target is too old to allow that. Any preference on keeping things as-is vs bumping the target to allow that? Or is there a better way to do this?

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [no constructor documentation][doc], [source where the parameter is an EditorState][param]
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

[doc]: https://prosemirror.net/docs/ref/#state.Transaction
[param]: https://github.com/ProseMirror/prosemirror-state/blob/master/src/transaction.js#L25

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
