### PR TITLE
`@types/auth0` Add support for `include_totals` to `getAll` organizations method

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -1059,6 +1059,22 @@ management.organizations.getAll({ page: 0, per_page: 5 }).then((organizations: a
 });
 
 /**
+ * Get All Organizations with pagination and totals using a callback
+ */
+management.organizations.getAll({ page: 0, per_page: 5, include_totals: true }, (err, pagedOrganizations) => {
+    // $ExpectType OrganizationsPaged
+    pagedOrganizations;
+});
+
+/**
+ * Get All Organizations with pagination and totals returning a Promise
+ */
+management.organizations.getAll({ page: 0, per_page: 5, include_totals: true }).then((pagedOrganizations) => {
+    // $ExpectType OrganizationsPaged
+    pagedOrganizations;
+});
+
+/**
  * Get All Organizations with checkpoint pagination using a callback
  */
 management.organizations.getAll({ take: 5, from: '' }, (err, organizations: auth0.Organization[]) => {

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1170,6 +1170,10 @@ export interface Organization {
     metadata?: any;
 }
 
+export interface OrganizationsPaged extends Omit<Page, 'length'> {
+    organizations: Organization[];
+}
+
 export interface CreateOrganization {
     name: string;
     display_name?: string | undefined;
@@ -1295,6 +1299,10 @@ export class OrganizationsManager {
     getAll(cb: (err: Error, organizations: Organization[]) => void): void;
     getAll(params: PagingOptions): Promise<Organization[]>;
     getAll(params: PagingOptions, cb: (err: Error, organizations: Organization[]) => void): void;
+    getAll(params: PagingOptions & { include_totals?: false; }): Promise<Organization[]>;
+    getAll(params: PagingOptions & { include_totals: true; }): Promise<OrganizationsPaged>;
+    getAll(params: PagingOptions & { include_totals?: false; }, cb: (err: Error, organizations: Organization[]) => void): void;
+    getAll(params: PagingOptions & { include_totals: true; }, cb: (err: Error, pagedOrganizations: OrganizationsPaged) => void): void;
     getAll(params: CheckpointPagingOptions): Promise<Organization[]>;
     getAll(params: CheckpointPagingOptions, cb: (err: Error, organizations: Organization[]) => void): void;
 

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1297,8 +1297,6 @@ export class OrganizationsManager {
 
     getAll(): Promise<Organization[]>;
     getAll(cb: (err: Error, organizations: Organization[]) => void): void;
-    getAll(params: PagingOptions): Promise<Organization[]>;
-    getAll(params: PagingOptions, cb: (err: Error, organizations: Organization[]) => void): void;
     getAll(params: PagingOptions & { include_totals?: false; }): Promise<Organization[]>;
     getAll(params: PagingOptions & { include_totals: true; }): Promise<OrganizationsPaged>;
     getAll(params: PagingOptions & { include_totals?: false; }, cb: (err: Error, organizations: Organization[]) => void): void;


### PR DESCRIPTION
This PR adds the `include_totals` parameter for the `getAll` organizations method.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [`getAll` organizations documentation](https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations)*
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

_*Like in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56432, this endpoint does not return a `length` property, so we cannot fully reuse the Page type, hence the omitting of the `length` property in `OrganizationsPaged`._
