### PR TITLE
Fabric: update `freeDrawingBrush`, add `StaticCanvas#toCanvasElement`

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -1194,18 +1194,6 @@ interface IStaticCanvasOptions {
     svgViewportTransformation?: boolean | undefined;
 }
 
-export interface FreeDrawingBrush {
-    /**
-     * Can be any regular color value.
-     */
-    color: string;
-
-    /**
-     * Brush width measured in pixels.
-     */
-    width: number;
-}
-
 export interface StaticCanvas
     extends IObservable<StaticCanvas>,
         IStaticCanvasOptions,
@@ -1222,7 +1210,7 @@ export class StaticCanvas {
 
     _activeObject?: Object | Group | undefined;
 
-    freeDrawingBrush: FreeDrawingBrush;
+    freeDrawingBrush: BaseBrush;
 
     /**
      * Calculates canvas element offset relative to the document
@@ -1638,6 +1626,26 @@ export class StaticCanvas {
      * @param [callback] Receives cloned instance as a first argument
      */
     cloneWithoutData(callback?: any): void;
+
+    /**
+     * Create a new HTMLCanvas element painted with the current canvas content.
+     * No need to resize the actual one or repaint it.
+     * Will transfer object ownership to a new canvas, paint it, and set everything back.
+     * This is an intermediary step used to get to a dataUrl but also it is useful to
+     * create quick image copies of a canvas without passing for the dataUrl string
+     * @param {Number} [multiplier] a zoom factor.
+     * @param {Object} [cropping] Cropping informations
+     * @param {Number} [cropping.left] Cropping left offset.
+     * @param {Number} [cropping.top] Cropping top offset.
+     * @param {Number} [cropping.width] Cropping width.
+     * @param {Number} [cropping.height] Cropping height.
+     */
+    toCanvasElement(multiplier?: number, cropping?: Readonly<{
+      left?: number;
+      top?: number;
+      width?: number;
+      height?: number;
+    }>): HTMLCanvasElement;
 
     /**
      * Populates canvas with data from the specified JSON.

--- a/types/fabric/test/index.ts
+++ b/types/fabric/test/index.ts
@@ -1065,3 +1065,16 @@ function sample16() {
   canvas.freeDrawingBrush.width = 2;
   canvas.isDrawingMode = true;
 }
+
+function sample17() {
+  const canvas = new fabric.Canvas('c');
+  canvas.toCanvasElement();
+  canvas.toCanvasElement(2);
+  canvas.toCanvasElement(2, { left: 10 });
+  canvas.toCanvasElement(2, {
+    left: 1,
+    top: 2,
+    width: 3,
+    height: 4,
+  });
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test fabric`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - There is no `FreeDrawingBrush` type. It's [instantiated as a `PencilBrush`](https://github.com/fabricjs/fabric.js/blob/d33b9af62090072fc41ee7196b638c5638d7e431/dist/fabric.js#L11615) but [can be any other kind of brush](http://fabricjs.com/freedrawing)
  - `StaticCanvas#toCanvasElement` is [documented here](http://fabricjs.com/docs/fabric.StaticCanvas.html#toCanvasElement) and [defined in code here](https://github.com/fabricjs/fabric.js/blob/d33b9af62090072fc41ee7196b638c5638d7e431/dist/fabric.js#L13796-L13809)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.