### PR TITLE
Revert "prosemirror-markdown@1.5: Fix `getAttrs` function in `TokenConfig`"

### DIFF
--- a/types/prosemirror-markdown/index.d.ts
+++ b/types/prosemirror-markdown/index.d.ts
@@ -46,11 +46,10 @@ export interface TokenConfig {
     /**
      * A function used to compute the attributes for the node or mark
      * that takes a [markdown-it
-     * token](https://markdown-it.github.io/markdown-it/#Token), list of [markdown-it
-     * token](https://markdown-it.github.io/markdown-it/#Token)s, the token's index and
+     * token](https://markdown-it.github.io/markdown-it/#Token) and
      * returns an attribute object.
      */
-    getAttrs?(token: Token, tokens: Token[], i: number): Record<string, any>;
+    getAttrs?(token: Token): Record<string, any>;
 
     /**
      * When true, ignore content for the matched token.


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#56651

Reason: The arguments are not part of public API (see https://github.com/ProseMirror/prosemirror-markdown/blob/master/README.md, which is generated from special documentation comments). Three other PRs (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52752, https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53662, https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55631) "fixing" the same issue were already rejected for this reason in the past.