### PR TITLE
feat(uuid-browser): add types

### DIFF
--- a/types/uuid-browser/index.d.ts
+++ b/types/uuid-browser/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for uuid-browser 3.1
+// Project: https://github.com/heikomat/uuid-browser
+// Definitions by: Emily Klassen <https://github.com/forivall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
+
+import { v1, v4 } from './interfaces';
+
+interface UuidStatic {
+    v1: v1;
+    v4: v4;
+}
+
+declare const uuid_browser: UuidStatic & v4;
+export = uuid_browser;

--- a/types/uuid-browser/interfaces.d.ts
+++ b/types/uuid-browser/interfaces.d.ts
@@ -1,0 +1,29 @@
+// Uses ArrayLike to admit Unit8 and co.
+export type OutputBuffer = ArrayLike<number>;
+export type InputBuffer = ArrayLike<number>;
+
+export interface V1Options {
+    node?: InputBuffer;
+    clockseq?: number;
+    msecs?: number | Date;
+    nsecs?: number;
+}
+
+export type V4Options = { random: InputBuffer } | { rng(): InputBuffer };
+
+export type v1String = (options?: V1Options) => string;
+export type v1Buffer = <T extends OutputBuffer>(options: V1Options | null | undefined, buffer: T, offset?: number) => T;
+export type v1 = v1Buffer & v1String;
+
+export type v4String = (options?: V4Options) => string;
+export type v4Buffer = <T extends OutputBuffer>(options: V4Options | null | undefined, buffer: T, offset?: number) => T;
+export type v4 = v4Buffer & v4String;
+
+export type v5String = (name: string | InputBuffer, namespace: string | InputBuffer) => string;
+export type v5Buffer = <T extends OutputBuffer>(
+    name: string | InputBuffer,
+    namespace: string | InputBuffer,
+    buffer: T,
+    offset?: number,
+) => T;
+export type v5 = v5Buffer & v5String;

--- a/types/uuid-browser/tsconfig.json
+++ b/types/uuid-browser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "uuid-browser-tests.ts"
+    ]
+}

--- a/types/uuid-browser/tslint.json
+++ b/types/uuid-browser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/uuid-browser/uuid-browser-tests.ts
+++ b/types/uuid-browser/uuid-browser-tests.ts
@@ -1,0 +1,61 @@
+/// <reference types="node" />
+
+import v1 = require('uuid-browser/v1');
+import v4 = require('uuid-browser/v4');
+import v5 = require('uuid-browser/v5');
+
+let uuidv1: string = v1();
+
+uuidv1 = v1({
+    node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
+    clockseq: 0x1234,
+    msecs: new Date('2011-11-01').getTime(),
+    nsecs: 5678,
+});
+
+uuidv1 = v1();
+uuidv1 = v1({
+    node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
+    clockseq: 0x1234,
+    msecs: new Date('2011-11-01').getTime(),
+    nsecs: 5678,
+});
+
+let bufferv1 = new Uint8Array(32);
+bufferv1 = v1(null, bufferv1);
+bufferv1 = v1(undefined, bufferv1, 16);
+bufferv1 = v1(undefined, bufferv1);
+bufferv1 = v1(null, bufferv1, 16);
+
+let uuidv4: string = v4();
+
+// prettier-ignore
+const randoms = [
+    0x10, 0x91, 0x56, 0xbe, 0xc4, 0xfb, 0xc1, 0xea,
+    0x71, 0xb4, 0xef, 0xe1, 0x67, 0x1c, 0x58, 0x36
+];
+uuidv4 = v4({ random: randoms });
+uuidv4 = v4({ rng: () => randoms });
+
+let bufferv4: number[] = new Array(32);
+bufferv4 = v4(undefined, bufferv4);
+bufferv4 = v4(null, bufferv4, 16);
+bufferv4 = v4(null, bufferv4);
+bufferv4 = v4(undefined, bufferv4, 16);
+
+const MY_NAMESPACE = v4();
+const a: string = v5('hello', MY_NAMESPACE);
+const b: string = v5('world', MY_NAMESPACE);
+const c: Buffer = v5('world', MY_NAMESPACE, new Buffer(16));
+const d: number[] = v5('world', MY_NAMESPACE, [], 0);
+
+// https://github.com/kelektiv/node-uuid#quickstart---commonjs-recommended
+const e: string = v5('hello.example.com', v5.DNS);
+const f: string = v5('http://example.com/hello', v5.URL);
+
+const g = Buffer.alloc(16);
+v4(null, g); // $ExpectType Buffer
+
+class CustomBuffer extends Uint8Array {}
+const h = new CustomBuffer(10);
+v4(null, h); // $ExpectType CustomBuffer

--- a/types/uuid-browser/v1.d.ts
+++ b/types/uuid-browser/v1.d.ts
@@ -1,0 +1,5 @@
+import { v1 } from './interfaces';
+
+declare const v1: v1;
+
+export = v1;

--- a/types/uuid-browser/v4.d.ts
+++ b/types/uuid-browser/v4.d.ts
@@ -1,0 +1,5 @@
+import { v4 } from './interfaces';
+
+declare const v4: v4;
+
+export = v4;

--- a/types/uuid-browser/v5.d.ts
+++ b/types/uuid-browser/v5.d.ts
@@ -1,0 +1,12 @@
+import { v5 } from './interfaces';
+
+interface v5Static {
+    // https://github.com/kelektiv/node-uuid/blob/master/v5.js#L47
+    DNS: string;
+    // https://github.com/kelektiv/node-uuid/blob/master/v5.js#L48
+    URL: string;
+}
+
+declare const v5: v5Static & v5;
+
+export = v5;


### PR DESCRIPTION
I noticed that this package is used in parts of storybook and was missing types. It's generally just a clone of the uuid package at v3.1, but with some browser targeted modules instead of node ones.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
