### PR TITLE
[module-deps] Allow persistentCache fallback to take null file data

### DIFF
--- a/types/module-deps/index.d.ts
+++ b/types/module-deps/index.d.ts
@@ -83,7 +83,7 @@ declare namespace moduleDeps {
         /**
          * A complex cache handler that allows async and persistent caching of data.
          */
-        persistentCache?: ((file: string, id: string, pkg: PackageObject, fallback: (dataAsString: string, cb: CacheCallback) => void, cb: CacheCallback) => void) | undefined;
+        persistentCache?: ((file: string, id: string, pkg: PackageObject, fallback: (dataAsString: string | null | undefined, cb: CacheCallback) => void, cb: CacheCallback) => void) | undefined;
 
         /**
          * Array of global paths to search. Defaults to splitting on ':' in process.env.NODE_PATH
@@ -147,7 +147,7 @@ declare namespace moduleDeps {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 
-    type CacheCallback = (err: Error | null, res?: { source: string; package: any; deps: { [dep: string]: boolean } }) => void;
+    type CacheCallback = (err: Error | null, res?: PersistentCacheItem) => void;
 
     type Transform = string | ((file: string, opts: { basedir?: string | undefined }) => NodeJS.ReadWriteStream);
 
@@ -187,7 +187,15 @@ declare namespace moduleDeps {
         deps: { [requireName: string]: any };
     }
 
+    interface PersistentCacheItem {
+        source: string;
+        package: PackageObject;
+        deps: { [dep: string]: boolean };
+    }
+
     /**
+     * Parsed package.json file data, as obtained from running JSON.parse on the file.
+     *
      * Placeholder, feel free to redefine or put in a pull request to improve
      */
     interface PackageObject {

--- a/types/module-deps/module-deps-tests.ts
+++ b/types/module-deps/module-deps-tests.ts
@@ -47,11 +47,27 @@ function rifiTest() {
     });
 }
 
+const fileContentCache = new Map<string, string>();
+const depsDataCache = new Map<string, moduleDeps.PersistentCacheItem>();
+
 function browserifyTest(opts: moduleDeps.Options) {
     const packOpts: moduleDeps.Options = {
         basedir: opts.basedir || "./",
         externalRequireName: opts["externalRequireName"] || "require",
         hasExports: opts["hasExports"] || false,
+        persistentCache: (file, id, pkg, fallback, cb) => {
+            const cachedDeps = depsDataCache.get(file);
+            if (cachedDeps) {
+                cb(null, cachedDeps);
+                return;
+            }
+            const fileData = fileContentCache.get(file);
+            if (fileData) {
+                fallback(fileData, cb);
+            } else {
+                fallback(null, cb);
+            }
+        },
         prelude: opts["prelude"] || undefined,
         preludePath: opts["preludePath"] || undefined,
         raw: opts["raw"] || false,


### PR DESCRIPTION
In the module-deps README for `persistentCache`, it states that the `fallback` function can be passed `null`:

https://github.com/browserify/module-deps/blob/ac7e85e330d636b87674fbf33ac537395e2f296e/readme.markdown?plain=1#L129-L142

Accordingly, this PR adds type support for passing `null` or `undefined` to the first `fallback` parameter, `dataAsString`.

This is the implementation of the fallback, showing that it handles a null/undefined `dataAsString` by reading from disk:

https://github.com/browserify/module-deps/blob/ac7e85e330d636b87674fbf33ac537395e2f296e/index.js#L420-L421

## PR template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)
