### PR TITLE
In trtc-js-sdk, removed Client.setDefaultMuteRemoteStreams(), added ClientConfig.autoSubscribe flag

### DIFF
--- a/types/trtc-js-sdk/index.d.ts
+++ b/types/trtc-js-sdk/index.d.ts
@@ -231,12 +231,6 @@ export interface Client {
     /** 获取当前房间内远端用户音视频 mute 状态列表。 */
     getRemoteMutedState(): RemoteMutedState[];
 
-    /**
-     * 设置是否默认接收远端流。该方法可在 join() 调用前使用，若在进房后调用，会接收不到后续进房的远端用户音视频流。
-     * @param muted 是否默认不接收远端流: true true 默认不接收任何远端流。false 默认接收所有远端流。（默认）
-     */
-    setDefaultMuteRemoteStreams(muted: boolean): void;
-
     /** 获取当前网络传输状况统计数据, 该方法需要在 `publish()` 后调用 */
     getTransportStats(): Promise<TransportStats>;
 
@@ -285,6 +279,11 @@ export interface ClientConfig {
      * - 2 表示本次是纯音频推流，录制文件为 MP3
      */
     pureAudioPushMode?: 1 | 2 | undefined;
+    /**
+     * autoSubscribe flag instead of deprecated Client.setDefaultMuteRemoteStreams
+     * default: true
+     */
+    autoSubscribe?: boolean;
 }
 
 /** 客户端事件 */

--- a/types/trtc-js-sdk/trtc-js-sdk-tests.ts
+++ b/types/trtc-js-sdk/trtc-js-sdk-tests.ts
@@ -45,6 +45,14 @@ const client = TRTC.createClient({
     mode: 'live',
 });
 
+const clientNotAutoSubscribed = TRTC.createClient({
+    sdkAppId: 123,
+    userId: '123',
+    userSig: 'userSig',
+    mode: 'live',
+    autoSubscribe: false,
+});
+
 const stream = TRTC.createStream({
     userId: '123',
     audio: true,


### PR DESCRIPTION
The definitions list setDefaultMuteRemoteStreams which has been deprecated and removed in TRTC SDK Web in v.4.8.2. In the changelog, TRTC SDK authors recommend using the autoSubscribe flag in ClientConfig. This flag was not listed in these definitions.

**Version number note:** this breaking change was released by Tencent in version 4.8.2. The dt-header linting rules do not allow bumping versions to Maintenance release numbers. If someone knows what should be done in this case, please let me know.

Release notes URL (with the deprecation notice) provided below.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://intl.cloud.tencent.com/document/product/647/39779#version-4.8.2-released-on-december-31.2C-2020>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
