### PR TITLE
[express] Fix response status code

### DIFF
--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -19,7 +19,7 @@ namespace express_tests {
         '/static',
         express.static(__dirname + '/public', {
             setHeaders: res => {
-                // $ExpectType Response<any, Record<string, any>>
+                // $ExpectType Response<any, Record<string, any>, number>
                 res;
                 res.set('foo', 'bar');
             },
@@ -120,7 +120,7 @@ namespace express_tests {
         const header3: string | undefined = req.header('header');
 
         req.headers.existingHeader as string;
-        (req.headers.nonExistingHeader as any) as undefined;
+        req.headers.nonExistingHeader as any as undefined;
 
         // Since 4.14.0 req.range() has options
         req.range(2, { combine: true });
@@ -212,6 +212,12 @@ namespace express_tests {
         res.json();
         res.json(1); // $ExpectError
         res.send(1); // $ExpectError
+    });
+
+    // Response status will be of Type provided
+    router.get('/', (req: Request, res: express.Response<string, {}, 200>) => {
+        res.status(200);
+        res.status(500); // $ExpectError
     });
 
     app.use((req, res, next) => {

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -99,7 +99,7 @@ declare namespace e {
         ResBody = any,
         ReqBody = any,
         ReqQuery = core.Query,
-        Locals extends Record<string, any> = Record<string, any>
+        Locals extends Record<string, any> = Record<string, any>,
     > extends core.ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> {}
     interface Express extends core.Express {}
     interface Handler extends core.Handler {}
@@ -114,18 +114,21 @@ declare namespace e {
         ResBody = any,
         ReqBody = any,
         ReqQuery = core.Query,
-        Locals extends Record<string, any> = Record<string, any>
+        Locals extends Record<string, any> = Record<string, any>,
     > extends core.Request<P, ResBody, ReqBody, ReqQuery, Locals> {}
     interface RequestHandler<
         P = core.ParamsDictionary,
         ResBody = any,
         ReqBody = any,
         ReqQuery = core.Query,
-        Locals extends Record<string, any> = Record<string, any>
+        Locals extends Record<string, any> = Record<string, any>,
     > extends core.RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> {}
     interface RequestParamHandler extends core.RequestParamHandler {}
-    export interface Response<ResBody = any, Locals extends Record<string, any> = Record<string, any>>
-        extends core.Response<ResBody, Locals> {}
+    export interface Response<
+        ResBody = any,
+        Locals extends Record<string, any> = Record<string, any>,
+        StatusCode extends number = number,
+    > extends core.Response<ResBody, Locals, StatusCode> {}
     interface Router extends core.Router {}
     interface Send extends core.Send {}
 }

--- a/types/express/ts4.0/express-tests.ts
+++ b/types/express/ts4.0/express-tests.ts
@@ -19,7 +19,7 @@ namespace express_tests {
         '/static',
         express.static(__dirname + '/public', {
             setHeaders: res => {
-                // $ExpectType Response<any, Record<string, any>>
+                // $ExpectType Response<any, Record<string, any>, number>
                 res;
                 res.set('foo', 'bar');
             },
@@ -120,7 +120,7 @@ namespace express_tests {
         const header3: string | undefined = req.header('header');
 
         req.headers.existingHeader as string;
-        (req.headers.nonExistingHeader as any) as undefined;
+        req.headers.nonExistingHeader as any as undefined;
 
         // Since 4.14.0 req.range() has options
         req.range(2, { combine: true });
@@ -212,6 +212,12 @@ namespace express_tests {
         res.json();
         res.json(1); // $ExpectError
         res.send(1); // $ExpectError
+    });
+
+    // Response status will be of Type provided
+    router.get('/', (req: Request, res: express.Response<string, {}, 200>) => {
+        res.status(200);
+        res.status(500); // $ExpectError
     });
 
     app.use((req, res, next) => {

--- a/types/express/ts4.0/index.d.ts
+++ b/types/express/ts4.0/index.d.ts
@@ -84,7 +84,7 @@ declare namespace e {
         ResBody = any,
         ReqBody = any,
         ReqQuery = core.Query,
-        Locals extends Record<string, any> = Record<string, any>
+        Locals extends Record<string, any> = Record<string, any>,
     > extends core.ErrorRequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> {}
     interface Express extends core.Express {}
     interface Handler extends core.Handler {}
@@ -99,18 +99,21 @@ declare namespace e {
         ResBody = any,
         ReqBody = any,
         ReqQuery = core.Query,
-        Locals extends Record<string, any> = Record<string, any>
+        Locals extends Record<string, any> = Record<string, any>,
     > extends core.Request<P, ResBody, ReqBody, ReqQuery, Locals> {}
     interface RequestHandler<
         P = core.ParamsDictionary,
         ResBody = any,
         ReqBody = any,
         ReqQuery = core.Query,
-        Locals extends Record<string, any> = Record<string, any>
+        Locals extends Record<string, any> = Record<string, any>,
     > extends core.RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> {}
     interface RequestParamHandler extends core.RequestParamHandler {}
-    export interface Response<ResBody = any, Locals extends Record<string, any> = Record<string, any>>
-        extends core.Response<ResBody, Locals> {}
+    export interface Response<
+        ResBody = any,
+        Locals extends Record<string, any> = Record<string, any>,
+        StatusCode extends number = number,
+    > extends core.Response<ResBody, Locals, StatusCode> {}
     interface Router extends core.Router {}
     interface Send extends core.Send {}
 }

--- a/types/ghost-storage-base/ghost-storage-base-tests.ts
+++ b/types/ghost-storage-base/ghost-storage-base-tests.ts
@@ -41,5 +41,5 @@ storage.getSanitizedFileName('IMAGE.jpg'); // $ExpectType string
 
 storage.exists('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>
 storage.save(image, '/'); // $ExpectType Promise<string>
-storage.serve(); // $ExpectType (req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, Record<string, any>>, next: NextFunction) => void
+storage.serve(); // $ExpectType (req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, Record<string, any>, number>, next: NextFunction) => void
 storage.delete('tmp/123456.jpg', '/'); // $ExpectType Promise<boolean>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## What's changed ?

I find it interesting to add the possibilty to type the `status code` of the `res` object.

For example, if you are building an API with OpenAPI definitions and using OpenAPI generated types to type the api's routes, you may want to type  the `status code` of the `res` object based on the response definitions.

example : 
```ts
res : Response<responseBody,{},200 >
```

But you can still type the res object without passing a status code : 
example : 
```ts
res : Response<responseBody>
```

