### PR TITLE
[react] Fix return value of convenience overload

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1041,13 +1041,10 @@ declare namespace React {
      * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
      * value around similar to how you’d use instance fields in classes.
      *
-     * Usage note: if you need the result of useRef to be directly mutable, include `| null` in the type
-     * of the generic argument.
-     *
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    function useRef<T>(initialValue: T|null): RefObject<T>;
+    function useRef<T = null>(initialValue: null): MutableRefObject<T | null>;
     // convenience overload for potentially undefined initialValue / call with 0 arguments
     // has a default to stop it from defaulting to {} instead
     /**
@@ -1060,7 +1057,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+    function useRef<T = undefined>(initialValue?: undefined): MutableRefObject<T | undefined>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -122,8 +122,19 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     typedCallback({});
 
     // test useRef and its convenience overloads
+    // $ExpectType MutableRefObject<boolean>
+    React.useRef(true);
     // $ExpectType MutableRefObject<number>
     React.useRef(0);
+    // $ExpectType MutableRefObject<string>
+    React.useRef('');
+
+    // $ExpectType MutableRefObject<boolean>
+    React.useRef<boolean>(true);
+    // $ExpectType MutableRefObject<number>
+    React.useRef<number>(0);
+    // $ExpectType MutableRefObject<string>
+    React.useRef<string>('');
 
     // these are not very useful (can't assign anything else to .current)
     // but it's the only safe way to resolve them
@@ -133,12 +144,12 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useRef(undefined);
 
     // |null convenience overload
-    // it should _not_ be mutable if the generic argument doesn't include null
-    // $ExpectType RefObject<number>
+    // $ExpectType MutableRefObject<number | null>
     React.useRef<number>(null);
-    // but it should be mutable if it does (i.e. is not the convenience overload)
     // $ExpectType MutableRefObject<number | null>
     React.useRef<number | null>(null);
+    // $ExpectType MutableRefObject<number | null | undefined>
+    React.useRef<number | null | undefined>(null);
 
     // |undefined convenience overload
     // with no contextual type or generic argument it should default to undefined only (not {} or unknown!)
@@ -146,9 +157,10 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useRef();
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>();
-    // don't just accept a potential undefined if there is a generic argument
-    // $ExpectError
+    // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>(undefined);
+    // $ExpectType MutableRefObject<number | undefined>
+    React.useRef<number | undefined>(undefined);
     // make sure once again there's no |undefined if the initial value doesn't either
     // $ExpectType MutableRefObject<number>
     React.useRef<number>(1);

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -168,6 +168,14 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number | undefined>(1);
 
+    // useRef error cases
+    // $ExpectError
+    React.useRef<number>('not a number');
+    // $ExpectError
+    React.useRef<string>(true);
+    // $ExpectError
+    React.useRef<boolean>(10);
+
     // should be contextually typed
     const a: React.MutableRefObject<number | undefined> = React.useRef(undefined);
     const b: React.MutableRefObject<number | undefined> = React.useRef();

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1036,13 +1036,10 @@ declare namespace React {
      * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
      * value around similar to how you’d use instance fields in classes.
      *
-     * Usage note: if you need the result of useRef to be directly mutable, include `| null` in the type
-     * of the generic argument.
-     *
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    function useRef<T>(initialValue: T|null): RefObject<T>;
+    function useRef<T = null>(initialValue: null): MutableRefObject<T | null>;
     // convenience overload for potentially undefined initialValue / call with 0 arguments
     // has a default to stop it from defaulting to {} instead
     /**
@@ -1055,7 +1052,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+    function useRef<T = undefined>(initialValue?: undefined): MutableRefObject<T | undefined>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside

--- a/types/react/v16/test/hooks.tsx
+++ b/types/react/v16/test/hooks.tsx
@@ -122,8 +122,19 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     typedCallback({});
 
     // test useRef and its convenience overloads
+    // $ExpectType MutableRefObject<boolean>
+    React.useRef(true);
     // $ExpectType MutableRefObject<number>
     React.useRef(0);
+    // $ExpectType MutableRefObject<string>
+    React.useRef('');
+
+    // $ExpectType MutableRefObject<boolean>
+    React.useRef<boolean>(true);
+    // $ExpectType MutableRefObject<number>
+    React.useRef<number>(0);
+    // $ExpectType MutableRefObject<string>
+    React.useRef<string>('');
 
     // these are not very useful (can't assign anything else to .current)
     // but it's the only safe way to resolve them
@@ -133,12 +144,12 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useRef(undefined);
 
     // |null convenience overload
-    // it should _not_ be mutable if the generic argument doesn't include null
-    // $ExpectType RefObject<number>
+    // $ExpectType MutableRefObject<number | null>
     React.useRef<number>(null);
-    // but it should be mutable if it does (i.e. is not the convenience overload)
     // $ExpectType MutableRefObject<number | null>
     React.useRef<number | null>(null);
+    // $ExpectType MutableRefObject<number | null | undefined>
+    React.useRef<number | null | undefined>(null);
 
     // |undefined convenience overload
     // with no contextual type or generic argument it should default to undefined only (not {} or unknown!)
@@ -146,9 +157,10 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useRef();
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>();
-    // don't just accept a potential undefined if there is a generic argument
-    // $ExpectError
+    // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>(undefined);
+    // $ExpectType MutableRefObject<number | undefined>
+    React.useRef<number | undefined>(undefined);
     // make sure once again there's no |undefined if the initial value doesn't either
     // $ExpectType MutableRefObject<number>
     React.useRef<number>(1);

--- a/types/react/v16/test/hooks.tsx
+++ b/types/react/v16/test/hooks.tsx
@@ -168,6 +168,14 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number | undefined>(1);
 
+    // useRef error cases
+    // $ExpectError
+    React.useRef<number>('not a number');
+    // $ExpectError
+    React.useRef<string>(true);
+    // $ExpectError
+    React.useRef<boolean>(10);
+
     // should be contextually typed
     const a: React.MutableRefObject<number | undefined> = React.useRef(undefined);
     const b: React.MutableRefObject<number | undefined> = React.useRef();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/hooks-reference.html#useref
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

I'm open to discussing this change, but the previous behaviour didn't really make any sense to me. This is the note that was removed:

```text
* Usage note: if you need the result of useRef to be directly mutable, include `| null` in the type
* of the generic argument.
```

This overload happens when doing e.g. this:

```ts
const ref = useRef<number>(null)
```

The returned `ref` is now immutable, but I don't see a use case for that at all. If it actually was immutable when starting with the `null` value, then it would never be mutated to hold anything other than `null` and thus it would be useless as each usage of it could just be replaced with `null`.

-----

Another change was to make it so that `useRef()` and `useRef(undefined)` works exactly the same. React doesn't do any arity-checks, so the two calls are exactly identical. They both create a ref-object with the initial value of `undefined`.


