### PR TITLE
[auth0] Fix idToken.validate() return type

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -981,14 +981,14 @@ decoded.header; // $ExpectType any
 decoded.payload; // $ExpectType any
 decoded.signature; // $ExpectType string
 
-async () => {
+() => {
     const defaultOptions = {
         issuer: 'issuer',
         audience: ['clientId', 'clientIdAlt'],
         nonce: 'a1b2c3d4e5',
     };
-    await idToken.validate('{YOUR_API_V2_TOKEN}'); // $ExpectType DecodedToken
-    await idToken.validate('{YOUR_API_V2_TOKEN}', defaultOptions); // $ExpectType DecodedToken
+    idToken.validate('{YOUR_API_V2_TOKEN}'); // $ExpectType DecodedToken
+    idToken.validate('{YOUR_API_V2_TOKEN}', defaultOptions); // $ExpectType DecodedToken
 };
 
 // Token manager

--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -975,7 +975,7 @@ async function signupTest(): Promise<void> {
     signupResult.email_verified; // $ExpectType boolean
 }
 
-const decoded = idToken.decode('{YOUR_API_V2_TOKEN}');
+const decoded = idToken.decode('{YOUR_API_V2_TOKEN}'); // $ExpectType DecodedToken
 decoded._raw; // $ExpectType string
 decoded.header; // $ExpectType any
 decoded.payload; // $ExpectType any
@@ -987,8 +987,8 @@ async () => {
         audience: ['clientId', 'clientIdAlt'],
         nonce: 'a1b2c3d4e5',
     };
-    await idToken.validate('{YOUR_API_V2_TOKEN}'); // $ExpectType string
-    await idToken.validate('{YOUR_API_V2_TOKEN}', defaultOptions); // $ExpectType string
+    await idToken.validate('{YOUR_API_V2_TOKEN}'); // $ExpectType DecodedToken
+    await idToken.validate('{YOUR_API_V2_TOKEN}', defaultOptions); // $ExpectType DecodedToken
 };
 
 // Token manager

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -13,6 +13,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Dan Ursin <https://github.com/danursin>
 //                 Nathan Hardy <https://github.com/nhardy>
+//                 Nicholas Molen <https://github.com/robotastronaut>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface ManagementClientOptions {

--- a/types/auth0/src/auth/idToken.d.ts
+++ b/types/auth0/src/auth/idToken.d.ts
@@ -26,4 +26,4 @@ export interface ValidateOptions {
  * @param options the options required to run this verification
  * @returns A promise containing the decoded token payload, or throws an exception if validation failed
  */
-export function validate(token: string, options?: ValidateOptions): Promise<DecodedToken>;
+export function validate(token: string, options?: ValidateOptions): DecodedToken;

--- a/types/auth0/src/auth/idToken.d.ts
+++ b/types/auth0/src/auth/idToken.d.ts
@@ -24,6 +24,6 @@ export interface ValidateOptions {
  * Validator for ID Tokens following OIDC spec.
  * @param token the string token to verify
  * @param options the options required to run this verification
- * @returns A promise containing the decoded token payload, or throws an exception if validation failed
+ * @returns The decoded token payload, or throws an exception if validation failed
  */
 export function validate(token: string, options?: ValidateOptions): DecodedToken;

--- a/types/auth0/src/auth/idToken.d.ts
+++ b/types/auth0/src/auth/idToken.d.ts
@@ -2,14 +2,16 @@
  * Decodes a string token into the 3 parts, throws if the format is invalid
  * @param token
  */
-export function decode(
-    token: string,
-): {
+export interface DecodedToken {
     _raw: string;
     header: any;
     payload: any;
     signature: string;
-};
+}
+
+export function decode(
+    token: string,
+): DecodedToken;
 
 export interface ValidateOptions {
     audience: string | ReadonlyArray<string>;
@@ -24,4 +26,4 @@ export interface ValidateOptions {
  * @param options the options required to run this verification
  * @returns A promise containing the decoded token payload, or throws an exception if validation failed
  */
-export function validate(token: string, options?: ValidateOptions): Promise<string>;
+export function validate(token: string, options?: ValidateOptions): Promise<DecodedToken>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The return type for `validate()` in  `src/auth/idToken` was declared as `Promise<string>`, which is incorrect as seen [here](https://github.com/auth0/node-auth0/blob/master/src/auth/idToken.js#L158) (and in the function's docstring). It returns the value returned from `decode()` without modification, so a single interface was declared and set as the return type for both of these functions. The interface matches the shape previously declared as the unnamed return type of `decode()`. Importantly, this return type is no longer a `Promise<>` -- the `validate()` function and the `decode()` function it calls are both synchronous and don't return promises.
