### PR TITLE
[tailwindcss] add function color type, and plugin type

### DIFF
--- a/types/tailwindcss/index.d.ts
+++ b/types/tailwindcss/index.d.ts
@@ -1,14 +1,13 @@
 // Type definitions for tailwindcss 2.2
 // Project: https://github.com/tailwindlabs/tailwindcss
-// Definitions by: Dolan Miu <https://github.com/dolanmiu>
+// Definitions by: Dolan Miu <https://github.com/dolanmiu>,
+//                 Dylan Vann <https://github.com/DylanVann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.1
 
 import type { TailwindConfig } from './tailwind-config';
 
-declare function tailwindcss(
-    config: TailwindConfig,
-): {
+declare function tailwindcss(config: TailwindConfig): {
     postcssPlugin: 'tailwindcss';
     plugins: string[];
 };

--- a/types/tailwindcss/plugin.d.ts
+++ b/types/tailwindcss/plugin.d.ts
@@ -1,0 +1,24 @@
+// Opaque type for the return of the
+// plugin function.
+export interface TailwindPlugin {
+    _: 'OPAQUE_TAILWIND_PLUGIN';
+}
+
+// https://tailwindcss.com/docs/plugins
+declare function plugin(
+    plugin: (helpers: {
+        addUtilities: any;
+        addComponents: any;
+        addBase: any;
+        addVariant: any;
+        e: any;
+        prefix: any;
+        theme: any;
+        variants: any;
+        config: any;
+        postcss: any;
+    }) => void,
+    config?: any,
+): TailwindPlugin;
+
+export default plugin;

--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -1,3 +1,5 @@
+import { TailwindPlugin } from './plugin';
+
 export type TailwindVariant =
     | 'empty'
     | 'read-only'
@@ -181,6 +183,8 @@ export type TailwindCorePlugin =
     | 'mixBlendMode'
     | 'filter';
 
+export type TailwindColorFunction = (props: { opacityVariable: string; opacityValue: string }) => string;
+
 export interface TailwindColorGroup {
     readonly [key: string]: string;
 }
@@ -231,8 +235,10 @@ export interface TailwindValues {
     readonly [key: string]: string;
 }
 
+export type TailwindColorValue = string | TailwindColorGroup | TailwindColorFunction;
+
 export interface TailwindValuesColor {
-    readonly [key: string]: string | TailwindColorGroup;
+    readonly [key: string]: TailwindColorValue;
 }
 
 export interface TailwindValuesAnimation {
@@ -499,7 +505,7 @@ export interface TailwindConfig {
     theme: TailwindTheme;
     variants?: TailwindVariants;
     corePlugins?: TailwindCorePlugin[];
-    plugins?: any[];
+    plugins?: TailwindPlugin[];
     purge?: string[] | TailwindPurgeConfig;
     // Not documented yet.
     content?: string[] | { files: string[]; extract: any; transform: any };

--- a/types/tailwindcss/test/tailwindcss-plugin-tests.ts
+++ b/types/tailwindcss/test/tailwindcss-plugin-tests.ts
@@ -1,0 +1,17 @@
+import type { TailwindConfig } from 'tailwindcss/tailwind-config';
+import plugin from 'tailwindcss/plugin';
+
+const tailwindConfig: TailwindConfig = {
+    content: ['testing'],
+    darkMode: 'class',
+    theme: {},
+    plugins: [
+        plugin(({ addUtilities }) => {
+            addUtilities({
+                '.skew-10deg': {
+                    transform: 'skewY(-10deg)',
+                },
+            });
+        }),
+    ],
+};

--- a/types/tailwindcss/test/tailwindcss-tests.ts
+++ b/types/tailwindcss/test/tailwindcss-tests.ts
@@ -2558,7 +2558,7 @@ defaultTheme.darkMode;
 // @ts-expect-error `colors` is possibly undefined
 defaultTheme.colors.blue[800];
 
-// $ExpectType any[] | undefined
+// $ExpectType TailwindPlugin[] | undefined
 tailwindConfig.plugins;
 
 // $ExpectType any[] | undefined

--- a/types/tailwindcss/tsconfig.json
+++ b/types/tailwindcss/tsconfig.json
@@ -16,6 +16,7 @@
     "files": [
         "index.d.ts",
         "test/tailwindcss-tests.ts",
+        "test/tailwindcss-plugin-tests.ts",
         "test/tailwindcss-default-config-code-tests.ts",
         "test/tailwindcss-default-config-value-tests.ts"
     ]


### PR DESCRIPTION
This adds types for `tailwindcss/plugin`, https://tailwindcss.com/docs/plugins#official-plugins

This also adds types for color functions in the config. This is useful for using custom properties with opacity modifiers. On this page https://tailwindcss.com/docs/customizing-colors there is a note:

> Note that colors defined using custom properties will not work with color opacity utilities like bg-opacity-50 without additional configuration. See this example repository for more information on how to make this work.

Which links to a repo showing this API: https://github.com/adamwathan/tailwind-css-variable-text-opacity-demo/blob/master/tailwind.config.js#L9

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.