### PR TITLE
feat(koa__router): add `opts` property to `Router`

### DIFF
--- a/types/koa__router/index.d.ts
+++ b/types/koa__router/index.d.ts
@@ -157,6 +157,7 @@
 
 declare class Router<StateT = Koa.DefaultState, ContextT = Koa.DefaultContext> {
     opts: Router.RouterOptions;
+    methods: string[];
     params: object;
     stack: Router.Layer[];
 

--- a/types/koa__router/index.d.ts
+++ b/types/koa__router/index.d.ts
@@ -156,6 +156,7 @@
 }
 
 declare class Router<StateT = Koa.DefaultState, ContextT = Koa.DefaultContext> {
+    opts: Router.RouterOptions;
     params: object;
     stack: Router.Layer[];
 

--- a/types/koa__router/koa__router-tests.ts
+++ b/types/koa__router/koa__router-tests.ts
@@ -9,6 +9,12 @@ interface MyContext { bar: string; }
 
 const app = new Koa<{}, {}>();
 
+class MyRouter extends Router {
+  myMethod() {
+    const prefix = this.opts.prefix; // $ExpectType string | undefined
+  }
+}
+
 const router = new Router<MyState, MyContext>({
     prefix: "/users"
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: ---
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

While not expressly documented, it mirrors the same property on `Layer` (which is completely undocumented) and is very useful when you're extending `Router` e.g. in my case I'm looking to generate default names, which for nested routes should be prefixed based on whatever the `prefix` is - this allows me to access that :)

Result of logging `Object.keys(this)` & `this.opts` within my extended router's method:
![image](https://user-images.githubusercontent.com/3151613/140403879-3cc23401-5122-486f-abc3-291c9bbab82c.png)
