### PR TITLE
react-router-hash-link: Fix `ref` type

### DIFF
--- a/types/react-router-hash-link/index.d.ts
+++ b/types/react-router-hash-link/index.d.ts
@@ -21,8 +21,8 @@ export interface NavHashLinkProps extends Omit<NavLinkProps, 'className' | 'styl
   style?: React.CSSProperties;
 }
 
-export class HashLink extends React.Component<HashLinkProps, any> { }
+export const HashLink: React.ForwardRefExoticComponent<HashLinkProps & React.RefAttributes<HTMLAnchorElement>>;
 
-export class NavHashLink extends React.Component<NavHashLinkProps, any> { }
+export const NavHashLink: React.ForwardRefExoticComponent<NavHashLinkProps & React.RefAttributes<HTMLAnchorElement>>;
 
 export function genericHashLink<P>(Component: React.FunctionComponent<P>): React.FunctionComponent<P>;

--- a/types/react-router-hash-link/react-router-hash-link-tests.tsx
+++ b/types/react-router-hash-link/react-router-hash-link-tests.tsx
@@ -61,3 +61,11 @@ const providedTimeout = {
 };
 
 <NavHashLink {...providedTimeout}/>;
+
+React.forwardRef<HTMLAnchorElement>((_, ref) =>
+  <HashLink ref={ref} to="/" />
+);
+
+React.forwardRef<HTMLAnchorElement>((_, ref) =>
+  <NavHashLink ref={ref} to="/" />
+);


### PR DESCRIPTION
These components are implemented using `React.forwardRef`. The existing class-based definitions mess with the type of the `ref` prop.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/rafgraph/react-router-hash-link/blob/v2.4.3/src/HashLink.jsx#L92
  - https://github.com/remix-run/react-router/blob/v6.0.0/packages/react-router-dom/index.tsx#L211
  - https://github.com/remix-run/react-router/blob/v6.0.0/packages/react-router-dom/index.tsx#L256
  - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7b62f878cc218c8e94e6efafa55cea6796b501f7/types/react/index.d.ts#L810
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.