### PR TITLE
[mailparser] Add support for MailParser options

### DIFF
--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mailparser 3.0
+// Type definitions for mailparser 3.4
 // Project: https://github.com/nodemailer/mailparser
 // Definitions by: Peter Snider <https://github.com/psnider>
 //                 Andrey Volynkin <https://github.com/Avol-V>
@@ -7,6 +7,7 @@
 /// <reference types="node" />
 
 import StreamModule = require('stream');
+import { DecoderStream } from 'iconv-lite';
 import Stream = StreamModule.Stream;
 
 /**
@@ -292,7 +293,7 @@ export interface MessageText {
  * and emits data objects for attachments and text contents.
  */
 export class MailParser extends StreamModule.Transform {
-    constructor(options?: StreamModule.TransformOptions);
+    constructor(options?: MailParserOptions);
     on(event: string, callback: (any: any) => void): this;
     on(event: 'headers', callback: (headers: Headers) => void): this;
     on(event: 'data' | 'readable', callback: (data: AttachmentStream | MessageText) => void): this;
@@ -304,11 +305,23 @@ export class MailParser extends StreamModule.Transform {
 export type Source = Buffer | Stream | string;
 
 /**
- * Options object for simpleParser.
+ * Options object for MailParser.
  */
-export interface SimpleParserOptions extends StreamModule.TransformOptions {
+export interface MailParserOptions extends StreamModule.TransformOptions {
+    skipHtmlToText?: boolean | undefined;
+    maxHtmlLengthToParse?: number | undefined;
+    formatDateString?: ((d: Date) => string) | undefined;
+    skipImageLinks?: boolean | undefined;
+    skipTextToHtml?: boolean | undefined;
+    skipTextLinks?: boolean | undefined;
+    Iconv?: DecoderStream | undefined;
     keepCidLinks?: boolean | undefined;
 }
+
+/**
+ * Options for SimpleParser.
+ */
+export type SimpleParserOptions = MailParserOptions;
 
 /**
  * Parse email message to structure object.

--- a/types/mailparser/mailparser-tests.ts
+++ b/types/mailparser/mailparser-tests.ts
@@ -1,4 +1,5 @@
 import { MailParser, simpleParser } from 'mailparser';
+import { getDecoder } from 'iconv-lite';
 
 const mailparser = new MailParser();
 
@@ -20,6 +21,20 @@ mailparser.on('data', data => {
         console.log(data.html);
     }
 });
+
+// Validate options
+const mailparser2 = new MailParser(
+    {
+       skipHtmlToText: true,
+       maxHtmlLengthToParse: 88,
+       formatDateString: (d: Date) => d.toDateString(),
+       skipImageLinks: true,
+       skipTextToHtml: true,
+       skipTextLinks: true,
+       Iconv: getDecoder("ascii"),
+       keepCidLinks: true
+    }
+);
 
 // Pipe file to MailParser
 // This example pipes a readableStream file to MailParser

--- a/types/mailparser/package.json
+++ b/types/mailparser/package.json
@@ -1,0 +1,6 @@
+{
+	"private": true,
+	"dependencies": {
+		"iconv-lite": "^0.6.3"
+	}
+}


### PR DESCRIPTION
Extend both simpleParser and MailParser to support the documented options.  simpleParserOptions was kept for compatibility.

To support `iconv-lite`, a `package.json` has been added.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
NOTE this gets errors:
Error: Errors in typescript@3.6 for external dependencies:
../node/assert.d.ts(12,64): error TS2304: Cannot find name 'asserts'.
UPDATE: Need fresh `npm install` to update old install.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodemailer.com/extras/mailparser/#options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
