### PR TITLE
[Bootbox] Added missing default properties

### DIFF
--- a/types/bootbox/bootbox-tests.ts
+++ b/types/bootbox/bootbox-tests.ts
@@ -145,7 +145,15 @@ bootbox.setDefaults({
     backdrop: false,
     className: 'newClassName',
     closeButton: true,
-    show: true
+    show: true,
+    container: 'body',
+    value: '',
+    inputType: "textarea",
+    swapButtonOrder: true,
+    centerVertical: true,
+    multiple: true,
+    scrollable: true,
+    reusable: true
 })
 
 bootbox.hideAll();

--- a/types/bootbox/index.d.ts
+++ b/types/bootbox/index.d.ts
@@ -42,11 +42,13 @@ interface BootboxConfirmOptions extends BootboxDialogOptions<boolean> {
     buttons?: BootboxConfirmPromptButtonMap | undefined;
 }
 
+type BootboxInputType = "text" | "textarea" | "email" | "select" | "checkbox" | "date" | "time" | "number" | "password" | "radio" | "range";
+
 /** Bootbox options available for prompt modals */
 interface BootboxPromptOptions extends BootboxBaseOptions<string> {
     title: string;
     value?: string | undefined;
-    inputType?: "text" | "textarea" | "email" | "select" | "checkbox" | "date" | "time" | "number" | "password" | "radio" | "range" | undefined;
+    inputType?: BootboxInputType | undefined;
     callback: (result: string) => any;
     buttons?: BootboxConfirmPromptButtonMap | undefined;
     inputOptions?: { text: string, value: string, group?: string | undefined }[] | undefined;
@@ -60,6 +62,14 @@ interface BootboxDefaultOptions {
     closeButton?: boolean | undefined;
     animate?: boolean | undefined;
     className?: string | undefined;
+	container?: string | Element | JQuery | undefined;
+	value?: string | number | Array<string> | undefined;
+	inputType?: BootboxInputType | undefined;
+	swapButtonOrder?: boolean | undefined;
+	centerVertical?: boolean | undefined;
+	multiple?: boolean | undefined;
+	scrollable?: boolean | undefined;
+	reusable?: boolean | undefined;
 }
 
 interface BootboxButton {


### PR DESCRIPTION
added missing properties:
// dialog container | defaults to 'body'
        container?: string | Element | JQuery;
// default value (used by the prompt helper) | defaults to ''
	value?: string | number | Array<string>;
// default input type (used by the prompt helper) | defaults to 'text'
	inputType?: BootboxInputType;
// switch button order from cancel/confirm (default) to confirm/cancel | defaults to false
	swapButtonOrder?: boolean;
// center modal vertically in page | defaults to false
	centerVertical?: boolean;
// Append "multiple" property to the select when using the "prompt" helper | defaults to false
	multiple?: boolean;
// Automatically scroll modal content when height exceeds viewport height | defaults to false
	scrollable?: boolean;
// whether or not to destroy the modal on hide | defaults to false
	reusable?: boolean;

gave Input Types their own type for reusability: BootboxInputType

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/makeusabrew/bootbox/blob/af166c2965727c39dbae4b2abb7676239ced48e3/bootbox.js#L131-L160
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
