### PR TITLE
[jwplayer]: update addButton signature

### DIFF
--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -343,7 +343,7 @@ declare namespace jwplayer {
         | 'remove';
 
     interface JWPlayer {
-        addButton(icon: string, label: string, handler: () => void, id: string): JWPlayer;
+        addButton(icon: string, label: string, handler: () => void, id: string, className?: string): JWPlayer;
         getAudioTracks(): any[];
         getBuffer(): number;
         getCaptionsList(): any[];


### PR DESCRIPTION
The classname parameter was missing in addButton method definition. 
[Link to the jwplayer doc](https://developer.jwplayer.com/jwplayer/docs/jw8-javascript-api-reference#jwplayeraddbuttonimg-tooltip-callback-id-btnclass)
