### PR TITLE
pouchdb-core: add reference to dom lib

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -9,6 +9,7 @@
 
 /// <reference types="debug" />
 /// <reference types="pouchdb-find" />
+/// <reference lib="dom" />
 
 interface Blob {
     readonly size: number;


### PR DESCRIPTION
pouchdb-core's index.d.ts file references ambient "DOM" types like Request and RequestInit. These types are included in the "dom" library. TypeScript projects that don't include the library in their tsconfig.json will produce an error.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7b923cdfd33922ed4435565e5144da70f7edce98/types/pouchdb-core/index.d.ts#L92-L94
