### PR TITLE
[luxon] add singular units for duration object

### DIFF
--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -8,6 +8,15 @@ export interface DurationOptions {
 }
 
 export interface DurationObjectUnits {
+    year?: number | undefined;
+    quarter?: number | undefined;
+    month?: number | undefined;
+    week?: number | undefined;
+    day?: number | undefined;
+    hour?: number | undefined;
+    minute?: number | undefined;
+    second?: number | undefined;
+    millisecond?: number | undefined;
     years?: number | undefined;
     quarters?: number | undefined;
     months?: number | undefined;
@@ -149,7 +158,7 @@ export class Duration {
      * @example
      * Duration.fromISOTime('T1100').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
      */
-    static fromISOTime(text: string, opts: DurationOptions): Duration;
+    static fromISOTime(text: string, opts?: DurationOptions): Duration;
 
     /**
      * Create an invalid Duration.

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -8,15 +8,6 @@ export interface DurationOptions {
 }
 
 export interface DurationObjectUnits {
-    year?: number | undefined;
-    quarter?: number | undefined;
-    month?: number | undefined;
-    week?: number | undefined;
-    day?: number | undefined;
-    hour?: number | undefined;
-    minute?: number | undefined;
-    second?: number | undefined;
-    millisecond?: number | undefined;
     years?: number | undefined;
     quarters?: number | undefined;
     months?: number | undefined;
@@ -28,7 +19,19 @@ export interface DurationObjectUnits {
     milliseconds?: number | undefined;
 }
 
-export type DurationUnit = keyof DurationObjectUnits;
+export interface DurationLikeObject extends DurationObjectUnits {
+    year?: number | undefined;
+    quarter?: number | undefined;
+    month?: number | undefined;
+    week?: number | undefined;
+    day?: number | undefined;
+    hour?: number | undefined;
+    minute?: number | undefined;
+    second?: number | undefined;
+    millisecond?: number | undefined;
+}
+
+export type DurationUnit = keyof DurationLikeObject;
 export type DurationUnits = DurationUnit | DurationUnit[];
 
 export type ToISOFormat = 'basic' | 'extended';
@@ -61,12 +64,12 @@ export interface ToISOTimeDurationOptions {
  *
  * @deprecated Use DurationLike instead.
  */
-export type DurationInput = Duration | number | DurationObjectUnits;
+export type DurationInput = Duration | number | DurationLikeObject;
 
 /**
  * Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
  */
-export type DurationLike = Duration | DurationObjectUnits | number;
+export type DurationLike = Duration | DurationLikeObject | number;
 
 /**
  * A Duration object represents a period of time, like "2 months" or "1 day, 1 hour".
@@ -116,7 +119,7 @@ export class Duration {
      * @param opts.numberingSystem - the numbering system to use
      * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
      */
-    static fromObject(obj: DurationObjectUnits, opts?: DurationOptions): Duration;
+    static fromObject(obj: DurationLikeObject, opts?: DurationOptions): Duration;
 
     /**
      * Create a Duration from an ISO 8601 duration string.
@@ -327,7 +330,7 @@ export class Duration {
      * @example
      * dur.set({ hours: 8, minutes: 30 })
      */
-    set(values: DurationObjectUnits): Duration;
+    set(values: DurationLikeObject): Duration;
 
     /**
      * "Set" the locale and/or numberingSystem.  Returns a newly-constructed Duration.

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -203,6 +203,7 @@ dt.plus({ quarters: 2, months: 1 }); // $ExpectType DateTime
 dur.hours; // $ExpectType number
 dur.minutes; // $ExpectType number
 dur.seconds; // $ExpectType number
+dur.set({ hour: 2, minutes: 15 }); // $ExpectType Duration
 
 dur.as('seconds'); // $ExpectType number
 dur.toObject();
@@ -371,6 +372,7 @@ d1.hasSame(d2, 'minute'); // $ExpectType boolean
 d1.hasSame(d2, 'year'); // $ExpectType boolean
 
 dur.toObject().days; // $ExpectType number | undefined
+dur.toObject().day; // $ExpectError
 dur.as('minutes'); // $ExpectType number
 dur.shiftTo('minutes').toObject().minutes; // $ExpectType number | undefined
 // prettier-ignore

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -194,6 +194,7 @@ const { input, result, zone } = DateTime.fromFormatExplain('Aug 6 1982', 'MMMM d
 
 /* Duration */
 const dur = Duration.fromObject({ hours: 2, minutes: 7 }); // $ExpectType Duration
+Duration.fromObject({ hour: 2, minute: 7 }); // $ExpectType Duration
 Duration.fromObject({ locale: 'ru' }); // $ExpectError
 Duration.fromObject({ conversionAccuracy: 'casual' }); // $ExpectError
 Duration.fromObject({}, { conversionAccuracy: 'casual' }); // $ExpectType Duration
@@ -392,6 +393,7 @@ dur.shiftTo('weeks', 'hours').toObject().weeks; // $ExpectType number | undefine
 DateTime.local().plus(dur.shiftTo('milliseconds')).year; // $ExpectType number
 
 Duration.fromISO('PY23', { conversionAccuracy: 'longterm' }); // $ExpectType Duration
+Duration.fromISOTime('21:37.000'); // $ExpectType Duration
 Duration.fromISOTime('21:37.000', { conversionAccuracy: 'longterm' }); // $ExpectType Duration
 
 end.diff(start, 'hours', { conversionAccuracy: 'longterm' }); // $ExpectType Duration


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://runkit.com/kurtgokhan/luxon-singular-unit-tests

If the API to pass singular units to Duration objects isn't deprecated, I ask them to be added back. I ran into compilation errors when migrating from v1 to v2 in a fairly big codebase.