### PR TITLE
Add update_seq option to PouchDB query

### DIFF
--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -69,6 +69,11 @@ declare namespace PouchDB {
              * 'update_after': Returns results immediately, but kicks off a build afterwards.
              */
             stale?: 'ok' | 'update_after' | undefined;
+            /**
+             * Include an update_seq value indicating which sequence id
+             * of the underlying database the view reflects.
+             */
+            update_seq?: boolean | undefined;
         }
 
         interface Response<Content extends {}> {


### PR DESCRIPTION
I've added the missing update_seq option, this is specified in the [CouchDB Docs](https://docs.couchdb.org/en/3.2.0/api/ddoc/views.html#get--db-_design-ddoc-_view-view) and the [PouchDB Docs](https://pouchdb.com/api.html#query_database)
