### PR TITLE
update(node): `fs.promises.open` accepts optional flags

### DIFF
--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -487,7 +487,7 @@ declare module 'fs/promises' {
      * @param [mode=0o666] Sets the file mode (permission and sticky bits) if the file is created.
      * @return Fulfills with a {FileHandle} object.
      */
-    function open(path: PathLike, flags: string | number, mode?: Mode): Promise<FileHandle>;
+    function open(path: PathLike, flags?: string | number, mode?: Mode): Promise<FileHandle>;
     /**
      * Renames `oldPath` to `newPath`.
      * @since v10.0.0

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -407,6 +407,9 @@ async function testPromisify() {
 }
 
 async () => {
+    // openAsync
+    // $ExpectType FileHandle
+    await openAsync('./index.d.ts');
     const handle: FileHandle = await openAsync('test', 'r');
     const writeStream = fs.createWriteStream('./index.d.ts', {
         fd: handle,
@@ -603,6 +606,7 @@ async function testStat(
     util.promisify(fs.fstat)(fd, opts); // $ExpectType Promise<Stats | BigIntStats>
 
     // fs.promises mode
+    fs.promises.open(path); // $ExpectType Promise<FileHandle>
     const fh = await fs.promises.open(path, 'r');
     fs.promises.stat(path); // $ExpectType Promise<Stats>
     fs.promises.lstat(path); // $ExpectType Promise<Stats>

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -1089,12 +1089,14 @@ declare module 'fs' {
     /**
      * Asynchronous open(2) - open and possibly create a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param flags See `support of file system `flags``.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
      */
     function open(path: PathLike, flags: string | number, mode: string | number | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
 
     /**
      * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
+     * @param flags See `support of file system `flags``.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
     function open(path: PathLike, flags: string | number, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
@@ -2179,10 +2181,11 @@ declare module 'fs' {
         /**
          * Asynchronous open(2) - open and possibly create a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not
+         * @param [flags='r'] See `support of file system `flags``.
+         * @param [mode] A file mode. If a string is passed, it is parsed as an octal integer. If not
          * supplied, defaults to `0o666`.
          */
-        function open(path: PathLike, flags: string | number, mode?: string | number): Promise<FileHandle>;
+        function open(path: PathLike, flags?: string | number, mode?: string | number): Promise<FileHandle>;
 
         /**
          * Asynchronously reads data from the file referenced by the supplied `FileHandle`.

--- a/types/node/v12/test/fs.ts
+++ b/types/node/v12/test/fs.ts
@@ -305,6 +305,8 @@ async function testPromisify() {
 
 (async () => {
     try {
+        await fs.promises.open('./index.d.ts');
+        await fs.promises.open('./index.d.ts', 'r');
         await fs.promises.rmdir('some/test/path');
         await fs.promises.rmdir('some/test/path', { recursive: true });
     } catch (e) {}

--- a/types/node/v14/fs/promises.d.ts
+++ b/types/node/v14/fs/promises.d.ts
@@ -184,10 +184,11 @@ declare module 'fs/promises' {
     /**
      * Asynchronous open(2) - open and possibly create a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not
+     * @param [flags='r'] See `support of file system `flags``.
+     * @param [mode] A file mode. If a string is passed, it is parsed as an octal integer. If not
      * supplied, defaults to `0o666`.
      */
-    function open(path: PathLike, flags: string | number, mode?: Mode): Promise<FileHandle>;
+    function open(path: PathLike, flags?: string | number, mode?: Mode): Promise<FileHandle>;
 
     /**
      * Asynchronously reads data from the file referenced by the supplied `FileHandle`.

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -562,6 +562,8 @@ async function testStat(
     util.promisify(fs.fstat)(fd, opts); // $ExpectType Promise<Stats | BigIntStats>
 
     // fs.promises mode
+    // $ExpectType FileHandle
+    await fs.promises.open(path);
     const fh = await fs.promises.open(path, 'r');
     fs.promises.stat(path); // $ExpectType Promise<Stats>
     fs.promises.lstat(path); // $ExpectType Promise<Stats>


### PR DESCRIPTION
- make param optional
- update JSDocs
- update tests

/cc @jzabinski-dolios

Fixes #56994

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
https://nodejs.org/docs/latest-v16.x/api/fs.html#fspromisesopenpath-flags-mode