### PR TITLE
Add URL support to vimeo__player.loadVideo

### DIFF
--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @vimeo/player 2.10
+// Type definitions for @vimeo/player 2.16
 // Project: https://github.com/vimeo/player.js
 // Definitions by: Denis Yılmaz <https://github.com/denisyilmaz>
 //                 Felix Albert <f.albert.work@icloud.com>
@@ -34,7 +34,7 @@ export class Player {
 
     on(event: EventName, callback: EventCallback): void;
     off(event: EventName, callback?: EventCallback): void;
-    loadVideo(id: number): VimeoPromise<number, TypeError | PasswordError | PrivacyError | Error>;
+    loadVideo(id: number | string): VimeoPromise<number, TypeError | PasswordError | PrivacyError | Error>;
     ready(): VimeoPromise<void, Error>;
     enableTextTrack(language: string, kind?: string): VimeoPromise<VimeoTextTrack, InvalidTrackLanguageError | InvalidTrackError | Error>;
     disableTextTrack(): VimeoPromise<void, Error>;

--- a/types/vimeo__player/vimeo__player-tests.ts
+++ b/types/vimeo__player/vimeo__player-tests.ts
@@ -59,6 +59,29 @@ player.loadVideo(76979871).then((id) => {
     }
 });
 
+player.loadVideo('http://vimeo.com/video/76979871').then((id) => {
+    // the video successfully loaded
+}).catch((error) => {
+    switch (error.name) {
+        case 'TypeError':
+            // the id was not a number
+            break;
+
+        case 'PasswordError':
+            // the video is password-protected and the viewer needs to enter the
+            // password first
+            break;
+
+        case 'PrivacyError':
+            // the video is password-protected or private
+            break;
+
+        default:
+            // some other error occurred
+            break;
+    }
+});
+
 player.ready().then(() => {
     // the player is ready
 });


### PR DESCRIPTION
This PR adds support for a missing option to vimeo__player's `loadVideo`
method which can accept either a numeric video ID or a full
video URL.

See documentation here: https://developer.vimeo.com/player/sdk/reference#load-a-new-video-into-a-player

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: developer.vimeo.com/player/sdk/reference#load-a-new-video-into-a-player
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (n/a).32