### PR TITLE
[readable-stream] fix compatibility with NodeJS Streams

### DIFF
--- a/types/duplex-to/duplex-to-tests.ts
+++ b/types/duplex-to/duplex-to-tests.ts
@@ -12,6 +12,6 @@ function testBuiltIn() {
 function testReadableStream() {
     const duplex: readableStream.Duplex = <any> {};
 
-    const readable: readableStream.Readable = duplexTo.readable(duplex);
-    const writable: readableStream.Writable = duplexTo.writable(duplex);
+    const readable: Readable = duplexTo.readable(duplex);
+    const writable: Writable = duplexTo.writable(duplex);
 }

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -15,7 +15,43 @@ declare class StringDecoder {
     end(buffer?: Buffer): string;
 }
 
-declare class _Readable {
+interface _IEventEmitter {
+    addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    emit(event: string | symbol, ...args: any[]): boolean;
+    on(event: string | symbol, listener: (...args: any[]) => void): this;
+    once(event: string | symbol, listener: (...args: any[]) => void): this;
+    prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+    removeAllListeners(event?: string | symbol): this;
+    off(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    setMaxListeners(n: number): this;
+    getMaxListeners(): number;
+    // tslint:disable-next-line:ban-types
+    listeners(eventName: string | symbol): Function[];
+    // tslint:disable-next-line:ban-types
+    rawListeners(eventName: string | symbol): Function[];
+    listenerCount(eventName: string | symbol): number;
+    eventNames(): Array<string | symbol>;
+}
+
+interface _IReadable extends _IEventEmitter {
+    _read(size: number): void;
+    read(size?: number): any;
+    setEncoding(encoding: string): this;
+    pause(): this;
+    resume(): this;
+    isPaused(): boolean;
+    unpipe(destination?: _Readable.Writable): this;
+    unshift(chunk: any): void;
+    wrap(oldStream: _Readable.Readable): this;
+    push(chunk: any, encoding?: string): boolean;
+    _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
+    destroy(error?: Error): void;
+}
+
+declare class _Readable implements _IReadable {
     readable: boolean;
     readonly readableFlowing: boolean | null;
     readonly readableHighWaterMark: number;
@@ -30,7 +66,7 @@ declare class _Readable {
     unshift(chunk: any): void;
     wrap(oldStream: _Readable.Readable): this;
     push(chunk: any, encoding?: string): boolean;
-    _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+    _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
     destroy(error?: Error): void;
 
     /**
@@ -91,6 +127,17 @@ declare class _Readable {
     removeListener(event: "error", listener: (err: Error) => void): this;
     removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
+    removeAllListeners(event?: string | symbol): this;
+    off(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    setMaxListeners(n: number): this;
+    getMaxListeners(): number;
+    // tslint:disable-next-line:ban-types
+    listeners(eventName: string | symbol): Function[];
+    // tslint:disable-next-line:ban-types
+    rawListeners(eventName: string | symbol): Function[];
+    listenerCount(eventName: string | symbol): number;
+    eventNames(): Array<string | symbol>;
+
     [Symbol.asyncIterator](): AsyncIterableIterator<any>;
 
     // static ReadableState: _Readable.ReadableState;
@@ -140,7 +187,9 @@ declare namespace _Readable {
         destroy?(this: Duplex, error: Error | null, callback: (error: Error | null) => void): void;
     };
 
-    class Duplex extends Writable implements /*extends*/_Readable, Duplex {
+    type _IDuplex = _IReadable & _IWritable;
+
+    class Duplex extends _Writable implements _IDuplex, /*extends*/_Readable, Duplex {
         /**
          * This is a dummy function required to retain type compatibility to node.
          * @deprecated DO NOT USE
@@ -157,6 +206,13 @@ declare namespace _Readable {
         readonly readableLength: number;
         readonly readableObjectMode: boolean;
         readonly writableObjectMode: boolean;
+
+        readonly readableAborted: never;
+        readonly readableDidRead: never;
+        readonly writableEnded: never;
+        readonly writableFinished: never;
+        readonly writableCorked: never;
+
         _readableState: ReadableState;
 
         _read(size?: number): void;
@@ -171,7 +227,7 @@ declare namespace _Readable {
         push(chunk: any, encoding?: BufferEncoding): boolean;
         _destroy(err: Error | null, callback: (error: Error | null) => void): void;
         destroy(err?: Error, callback?: (error: Error | null) => void): this;
-        pipe<S extends Writable>(dest: S, pipeOpts?: { end?: boolean | undefined }): S;
+        pipe<S extends _IWritable>(dest: S, pipeOpts?: { end?: boolean | undefined }): S;
         addListener(ev: string | symbol, fn: (...args: any[]) => void): this;
         on(ev: string | symbol, fn: (...args: any[]) => void): this;
 
@@ -226,24 +282,36 @@ declare namespace _Readable {
     }
 
     type ReadableOptions = ReadableStateOptions & {
-        read?(this: _Readable, size: number): void;
-        destroy?(this: _Readable, error: Error | null, callback: (error: Error | null) => void): void;
+        read?(this: _IReadable, size: number): void;
+        destroy?(this: _IReadable, error: Error | null, callback: (error: Error | null) => void): void;
     };
 
     class Readable extends _Readable {
+        readonly readableAborted: never;
+        readonly readableDidRead: never;
+        readonly readableEncoding: never;
+        readonly readableEnded: never;
+        readonly readableObjectMode: never;
+
         constructor(options?: ReadableOptions);
+        pipe<T extends _IWritable>(destination: T, options?: { end?: boolean | undefined; }): T;
     }
 
     // ==== _stream_transform ====
-    type TransformOptions = DuplexOptions & {
-        read?(this: Transform, size: number): void;
-        write?(this: Transform, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
-        writev?(this: Transform, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
-        final?(this: Transform, callback: (error?: Error | null) => void): void;
-        destroy?(this: Transform, error: Error | null, callback: (error: Error | null) => void): void;
-        transform?(this: Transform, chunk: any, encoding: BufferEncoding, callback: (error?: Error, data?: any) => void): void;
-        flush?(this: Transform, callback: (er: any, data: any) => void): void;
+    type TransformOptions = ReadableOptions & WritableOptions & {
+        read?(this: _ITransform, size: number): void;
+        write?(this: _ITransform, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
+        writev?(this: _ITransform, chunks: Array<{ chunk: any, encoding: BufferEncoding }>, callback: (error?: Error | null) => void): void;
+        final?(this: _ITransform, callback: (error?: Error | null) => void): void;
+        destroy?(this: _ITransform, error: Error | null, callback: (error: Error | null) => void): void;
+        transform?(this: _ITransform, chunk: any, encoding: BufferEncoding, callback: (error?: Error | null, data?: any) => void): void;
+        flush?(callback: (error?: Error | null, data?: any) => void): void;
     };
+
+    interface _ITransform extends _IDuplex {
+        _transform(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null, data?: any) => void): void;
+        _flush(callback: (error?: Error | null, data?: any) => void): void;
+    }
 
     class Transform extends Duplex {
         _transformState: {
@@ -257,8 +325,8 @@ declare namespace _Readable {
 
         constructor(options?: TransformOptions);
 
-        _transform(chunk: any, encoding: BufferEncoding, callback: (error?: Error, data?: any) => void): void;
-        _flush(callback: (error?: Error, data?: any) => void): void;
+        _transform(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null, data?: any) => void): void;
+        _flush(callback: (error?: Error | null, data?: any) => void): void;
     }
 
     // ==== _stream_writable ====
@@ -319,13 +387,22 @@ declare namespace _Readable {
     }
 
     type WritableOptions = WritableStateOptions & {
-        write?(this: Writable, chunk: any, encoding: BufferEncoding | string, callback: (error?: Error | null) => void): void;
-        writev?(this: Writable, chunk: ArrayLike<{ chunk: any; encoding: BufferEncoding | string }>, callback: (error?: Error | null) => void): void;
-        destroy?(this: Writable, error: Error | null, callback: (error: Error | null) => void): void;
-        final?(this: Writable, callback: (error?: Error | null) => void): void;
+        write?(this: _IWritable, chunk: any, encoding: BufferEncoding | string, callback: (error?: Error | null) => void): void;
+        writev?(this: _IWritable, chunk: ArrayLike<{ chunk: any; encoding: BufferEncoding | string }>, callback: (error?: Error | null) => void): void;
+        destroy?(this: _IWritable, error: Error | null, callback: (error: Error | null) => void): void;
+        final?(this: _IWritable, callback: (error?: Error | null) => void): void;
     };
 
-    class Writable extends Stream {
+    interface _IWritable extends _IEventEmitter {
+        writable: boolean;
+        write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
+        write(chunk: any, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
+        end(cb?: () => void): void;
+        end(data: string | Uint8Array, cb?: () => void): void;
+        end(str: string, encoding?: BufferEncoding, cb?: () => void): void;
+    }
+
+    class _Writable extends Stream implements _IWritable {
         writable: boolean;
         readonly writableHighWaterMark: number;
         readonly writableLength: number;
@@ -418,9 +495,18 @@ declare namespace _Readable {
         _undestroy(): void;
     }
 
+    class Writable extends _Writable {
+        readonly writableEnded: never;
+        readonly writableFinished: never;
+        readonly writableObjectMode: never;
+        readonly writableCorked: never;
+
+        constructor(opts?: WritableOptions);
+    }
+
     class Stream extends _Readable {
         constructor(options?: ReadableOptions);
-        pipe<T extends Writable>(destination: T, options?: { end?: boolean | undefined; }): T;
+        pipe<T extends _IWritable>(destination: T, options?: { end?: boolean | undefined; }): T;
     }
 }
 

--- a/types/readable-stream/readable-stream-tests.ts
+++ b/types/readable-stream/readable-stream-tests.ts
@@ -1,7 +1,23 @@
+import stream = require("stream");
 import RStream = require("readable-stream");
 
+function testTypes() {
+    const ANY: any = undefined;
+    const _readableOpts: stream.ReadableOptions = ANY as RStream.ReadableOptions;
+    const _writableOpts: stream.WritableOptions = ANY as RStream.WritableOptions;
+    const _transformOpts: stream.TransformOptions = ANY as RStream.TransformOptions;
+    const _duplexOpts: stream.DuplexOptions = ANY as RStream.DuplexOptions;
+
+    const _readable: stream.Readable = new RStream.Readable(_readableOpts);
+    const _writable: stream.Writable = new RStream.Writable(_writableOpts);
+    const _transform: stream.Transform = new RStream.Transform(_transformOpts);
+    const _duplex: stream.Duplex = new RStream.Duplex(_duplexOpts);
+
+    _readable.pipe(_duplex).pipe(_transform).pipe(_writable);
+}
+
 function test() {
-    const rs: RStream.Stream = (null as any) as RStream.Stream;
+    const rs: stream.Stream = (null as any) as RStream.Stream;
     const RS_Readable = RStream;
     const RS_Writable = RStream.Writable;
     const RS_Transform = RStream.Transform;


### PR DESCRIPTION
## TODO
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test readable-stream`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/57038
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header: It updates the library's type declaration to match the new version of NodeJS

## What

readable-stream:
- Add EventEmitter properties from node >= 10: These properties are inherited without updating the library
- Use `never` type for Stream properties introduced in node > 10: Make `readable-stream` types compatible with new Node Stream while showing they are not implemented yet.
- Fix `pipe()` definition: Use a Writable interface to hide `readable-stream` implementation details
- Add `pipe()` property to the `Readable` class

duplex-to:
- use NodeJS Streams as destination type in `duplex-to` tests
