### PR TITLE
[chec/commerce.js] Fix bug where assets was incorrectly defined as an Asset, should be string[]

### DIFF
--- a/types/chec__commerce.js/test/products.ts
+++ b/types/chec__commerce.js/test/products.ts
@@ -124,10 +124,12 @@ const products: Products.ProductCollection = {
                                 formatted_with_symbol: '$0.00',
                                 formatted_with_code: '0.00 USD',
                             },
-                            assets: [],
+                            assets: [
+                                'ast_bO6J5ag49wEjpK',
+                            ],
                             meta: null,
-                            created: null,
-                            updated: null,
+                            created: 1594413988,
+                            updated: 1605921891,
                         },
                     ],
                 },
@@ -229,8 +231,8 @@ const variants: Products.VariantCollection = {
     ],
     meta: {
         pagination: {
-            total: 2,
-            count: 2,
+            total: 1,
+            count: 1,
             per_page: 100,
             current_page: 1,
             total_pages: 1,

--- a/types/chec__commerce.js/types/product-variant-group.d.ts
+++ b/types/chec__commerce.js/types/product-variant-group.d.ts
@@ -1,4 +1,3 @@
-import { Asset } from './asset';
 import { Price } from './price';
 
 export interface ProductVariantGroup {
@@ -14,7 +13,7 @@ export interface ProductVariantOption {
     id: string;
     name: string;
     price: Price;
-    assets: Asset[];
+    assets: string[] | null;
     meta: any;
     created: number | null;
     updated: number | null;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chec/commerce.js/issues/212
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
