### PR TITLE
Update React Native v0.65 KeyboardStatic to no longer extend NativeEventEmitter

### DIFF
--- a/types/react-native/v0.65/index.d.ts
+++ b/types/react-native/v0.65/index.d.ts
@@ -9489,7 +9489,7 @@ export interface KeyboardEvent extends Partial<KeyboardEventIOS> {
 
 type KeyboardEventListener = (event: KeyboardEvent) => void;
 
-export interface KeyboardStatic extends NativeEventEmitter {
+export interface KeyboardStatic {
     /**
      * Dismisses the active keyboard and removes focus.
      */

--- a/types/react-native/v0.65/test/index.tsx
+++ b/types/react-native/v0.65/test/index.tsx
@@ -1423,6 +1423,7 @@ const KeyboardTest = () => {
         startCoordinates: { screenX: 0, screenY: 0, width: 0, height: 0 },
         isEventFromThisApp: true,
     });
+    Keyboard.emit('keyboardDidHide', {}) // $ExpectError
 };
 
 const PermissionsAndroidTest = () => {


### PR DESCRIPTION
The actual class no long extends NativeEventEmitter so the type is updated to reflect that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/commit/1049835b504cece42ee43ac5b554687891da1349#diff-d9dde9eb15ec5d28d380df3eeb779241b4859794d73f8fb20af73d331d8f00bcR104
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
