### PR TITLE
[@wordpress/data-controls]: Update to version 2.2.6

### DIFF
--- a/types/wordpress__data-controls/index.d.ts
+++ b/types/wordpress__data-controls/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/data-controls 1.0
+// Type definitions for @wordpress/data-controls 2.2.6
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/data-controls/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -59,6 +59,8 @@ export const controls: {
 };
 
 /**
+ * Deprecated in favor of @wordpress/data dispatc method.
+ *
  * Dispatches a control action for triggering a registry dispatch.
  *
  * @param storeKey - The key for the store the action belongs to
@@ -79,6 +81,8 @@ export const controls: {
 export function dispatch(storeKey: string, actionName: string, ...args: any[]): void;
 
 /**
+ * Deprecated in favor of @wordpress/data select method.
+ *
  * Dispatches a control action for triggering a registry select.
  *
  * Note: when this control action is handled, it automatically considers selectors that may have a

--- a/types/wordpress__data-controls/index.d.ts
+++ b/types/wordpress__data-controls/index.d.ts
@@ -24,7 +24,7 @@ import { Action } from '@wordpress/data';
  * }
  * ```
  */
-export function apiFetch(options: APIFetchOptions): void;
+export function apiFetch(options: APIFetchOptions): unknown;
 
 /**
  * What you use to register the controls with your custom store.

--- a/types/wordpress__data-controls/index.d.ts
+++ b/types/wordpress__data-controls/index.d.ts
@@ -59,7 +59,7 @@ export const controls: {
 };
 
 /**
- * Deprecated in favor of @wordpress/data dispatc method.
+ * Deprecated in favor of the @wordpress/data dispatch method.
  *
  * Dispatches a control action for triggering a registry dispatch.
  *
@@ -81,7 +81,7 @@ export const controls: {
 export function dispatch(storeKey: string, actionName: string, ...args: any[]): void;
 
 /**
- * Deprecated in favor of @wordpress/data select method.
+ * Deprecated in favor of the @wordpress/data select method.
  *
  * Dispatches a control action for triggering a registry select.
  *

--- a/types/wordpress__data-controls/index.d.ts
+++ b/types/wordpress__data-controls/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/data-controls 2.2.6
+// Type definitions for @wordpress/data-controls 2.2
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/data-controls/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__data-controls/package.json
+++ b/types/wordpress__data-controls/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/api-fetch": "^3.23.1"
+        "@wordpress/api-fetch": "^5.2.5"
     }
 }

--- a/types/wordpress__data-controls/wordpress__data-controls-tests.ts
+++ b/types/wordpress__data-controls/wordpress__data-controls-tests.ts
@@ -1,7 +1,7 @@
 import { apiFetch, controls, dispatch, select } from '@wordpress/data-controls';
 import { registerStore } from '@wordpress/data';
 
-// $ExpectType void
+// $ExpectType unknown
 apiFetch({ path: '/wp/v2/posts' });
 
 // $ExpectType void
@@ -18,6 +18,11 @@ select('core/edit-post', 'isEditorPanelEnabled', 'foo');
 // $ExpectType void
 select('core/edit-post', 'isEditorPanelEnabled', 'foo', 123, true, 'bar');
 
+function* testAction(): Generator {
+    const items = yield apiFetch({ path: '/v2/my-api/items' }) as string[];
+    // do something with items.
+}
+
 const myExistingControls = {
     FOO: () => Promise.resolve('foo'),
     BAR: () => 'bar',
@@ -29,4 +34,7 @@ registerStore('my-store', {
         ...controls,
         ...myExistingControls,
     },
+    actions: {
+        testAction,
+    }
 });


### PR DESCRIPTION
There have been very few changes to wordpress/data-controls. I don't think any of the existing types need to be updated. My main purpose for this PR is to get the transitive dependency on api-fetch up to date so that it no longer has a rogue peer dependency on react-native.

Honestly, this package could probably be updated to Typescript very easily in gutenberg.

cc @sarayourfriend 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/trunk/packages/data-controls/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
