### PR TITLE
Update Zendesk Chat Web SDK types

### DIFF
--- a/types/zchat-browser/index.d.ts
+++ b/types/zchat-browser/index.d.ts
@@ -1,19 +1,23 @@
-// Type definitions for non-npm package zchat-browser 1.81
+// Type definitions for non-npm package zchat-browser 1.112
 // Project: https://api.zopim.com/web-sdk/#introduction
 // Definitions by: David Copley <https://github.com/davidcopley>
+//                 Matthew Go <https://github.com/lezgomatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
 export as namespace zChat;
 
-export interface InitProps {
+export interface InitOptions {
     account_key: string;
-    authentication?: {
-        jwt_fn?: ((callback: (jwt: string) => void) => void) | undefined;
-    } | undefined;
+    suppress_console_error?: boolean | undefined;
+    authentication?:
+        | {
+              jwt_fn?: ((callback: (jwt: string) => void) => void) | undefined;
+          }
+        | undefined;
 }
 
-export function init(initProps: InitProps): void;
+export function init(options: InitOptions): void;
 
 export function getAccountStatus(): 'online' | 'offline' | 'away';
 
@@ -31,7 +35,8 @@ export function getAllDepartments(): Department[];
 
 export function getDepartment(id: number): Department;
 
-export function getVisitorDefaultDepartment(id?: number): Department;
+// TODO
+export function getVisitorDefaultDepartment(): Department;
 
 export function setVisitorDefaultDepartment(id: number, callback?: (err: Error) => void): void;
 
@@ -45,140 +50,7 @@ export function clearVisitorDefaultDepartment(callback?: (err: Error) => void): 
  */
 export function sendChatMsg(msg: string, callback?: (err: Error) => void): void;
 
-/**
- * The size of each file attachment sent cannot exceed 20MB as of v1.1.4.
- * The previous limit was 5MB.
- * @param file
- * @param callback
- */
-export function sendFile(file: File, callback?: (err: SendFileErrorMessage, data: {
-    mime_type: string,
-    name: string,
-    size: number,
-    url: string,
-}) => void): void;
-
-export function sendOfflineMsg(
-    options: {
-        name: string;
-        email: string;
-        phone?: string | undefined;
-        message: string;
-        department?: number | undefined;
-    },
-    callback: (err: Error) => void
-): void;
-
-export function addTags(tags: string[], callback?: (err: Error) => void): void;
-
-export function removeTags(tags: ReadonlyArray<string>, callback?: (err: Error) => void): void;
-
-export function sendTyping(is_typing: boolean): void;
-
-export function getChatInfo(): { rating?: string | undefined; comment?: string | undefined };
-
-export function sendChatRating(rating: 'good' | 'bad' | undefined, callback?: (err: Error) => void): void;
-
-export function sendChatComment(comment: string, callback?: (err: Error) => void): void;
-
-export function isChatting(): boolean;
-
-export function getChatLog(): ChatEvent.ChatEventData[];
-
-export function on(event_name: EventName, handler: (event_data?: EventData) => void): void;
-
-export function un(event_name: EventName, handler: (event_data?: EventData) => void): void;
-
-export namespace ChatEvent {
-    interface BaseChatEventData {
-        nick: string;
-        display_name: string;
-        time_stamp: number;
-    }
-
-    type ChatEventData =
-        | BaseChatEventData & {
-        type: 'chat.msg';
-        msg: string;
-        options: string[];
-        structured_msg: StructuredMessage;
-    }
-        | BaseChatEventData & {
-        type: 'chat.file';
-        attachment: Attachment;
-        deleted: boolean;
-    }
-        | BaseChatEventData & {
-        type: 'chat.memberjoin';
-    }
-        | BaseChatEventData & {
-        type: 'chat.memberleave';
-    }
-        | BaseChatEventData & {
-        type: 'chat.request.rating';
-    }
-        | BaseChatEventData & {
-        type: 'chat.rating';
-        rating?: string | undefined;
-        new_rating?: string | undefined;
-    }
-        | BaseChatEventData & {
-        type: 'chat.comment';
-        comment?: string | undefined;
-        new_comment?: string | undefined;
-    };
-
-    interface Action {
-        type: 'QUICK_REPLY_ACTION' | 'LINK_ACTION';
-        value: string;
-    }
-
-    interface Button {
-        text: string;
-        action: Action;
-    }
-
-    interface Panel {
-        heading: string;
-        paragraph?: string | undefined;
-        image_url: string;
-        action: Action;
-    }
-
-    interface PanelTemplate {
-        type: 'PANEL_TEMPLATE';
-        panel: Panel;
-        buttons: Button[];
-    }
-
-    interface ListItem {
-        heading: string;
-        paragraph: string;
-        image_url?: string | undefined;
-        action: Action;
-    }
-
-    type StructuredMessage =
-        | {
-        type: 'QUICK_REPLIES';
-        msg: string;
-        quick_replies: Button[];
-    }
-        | {
-        type: 'PANEL_TEMPLATE';
-        panel: Panel;
-        buttons: Button[];
-    }
-        | {
-        type: 'PANEL_TEMPLATE_CAROUSEL';
-        items: PanelTemplate[];
-    }
-        | {
-        type: 'LIST_TEMPLATE';
-        items: ListItem[];
-        buttons: Button[];
-    };
-}
+export type SendFileError = Error & { message: SendFileErrorMessage };
 
 export type SendFileErrorMessage =
     | 'NOT_SUPPORTED'
@@ -189,16 +61,203 @@ export type SendFileErrorMessage =
     | 'INTERNAL_ERROR'
     | 'UNKNOWN_ERROR';
 
+export interface SendFileCallbackData {
+    mime_type: string;
+    name: string;
+    size: number;
+    url: string;
+}
+
+/**
+ * The size of each file attachment sent cannot exceed 20MB as of v1.1.4.
+ * The previous limit was 5MB.
+ * @param file
+ * @param callback
+ */
+export function sendFile(file: File, callback?: (err: SendFileError, data: SendFileCallbackData) => void): void;
+
+export interface SendOfflineMsgOptions {
+    name: string;
+    email: string;
+    phone?: string | undefined;
+    message: string;
+    department?: number | undefined;
+}
+
+export function sendOfflineMsg(options: SendOfflineMsgOptions, callback?: (err: Error) => void): void;
+
+export function addTags(tags: ReadonlyArray<string>, callback?: (err: Error) => void): void;
+
+export function removeTags(tags: ReadonlyArray<string>, callback?: (err: Error) => void): void;
+
+export function sendTyping(is_typing: boolean): void;
+
+export function getChatInfo(): { rating: string | null; comment: string | null };
+
+export function sendChatRating(rating: 'good' | 'bad' | null, callback?: (err: Error) => void): void;
+
+export function sendChatComment(comment: string, callback?: (err: Error) => void): void;
+
+export function isChatting(): boolean;
+
+export function getChatLog(): ChatEventData[];
+
+export function getServingAgentsInfo(): AgentInfo[];
+
+export function getOperatingHours(): OperatingHours | undefined;
+
+export function sendEmailTranscript(email: string, callback?: (err: Error) => void): void;
+
+export function fetchChatHistory(callback: (err: Error, data: { count: number; has_more: boolean }) => void): void;
+
+export function markAsRead(): void;
+
+export function reconnect(): void;
+
+export function endChat(
+    options?: { clear_dept_id_on_chat_ended?: boolean | undefined },
+    callback?: (err: Error) => void,
+): void;
+
+export function logout(): void;
+
+export const EMAIL_REGEX: RegExp;
+
+export function on(event_name: 'account_status', handler: (event_data: AccountsStatusEventData) => void): void;
+export function on(event_name: 'connection_update', handler: (event_data: ConnectionUpdateEventData) => void): void;
+export function on(event_name: 'department_update', handler: (event_data: Department) => void): void;
+export function on(event_name: 'visitor_update', handler: (event_data: VisitorInfo) => void): void;
+export function on(event_name: 'agent_update', handler: (event_data: AgentInfo) => void): void;
+export function on(event_name: 'chat', handler: (event_data: ChatEventData) => void): void;
+export function on(event_name: 'history', handler: (event_data: HistoryEventData) => void): void;
+export function on(event_name: 'error', handler: (event_data: ErrorEventData) => void): void;
+
+export function un(event_name: 'account_status', handler: (event_data: AccountsStatusEventData) => void): void;
+export function un(event_name: 'connection_update', handler: (event_data: ConnectionUpdateEventData) => void): void;
+export function un(event_name: 'department_update', handler: (event_data: Department) => void): void;
+export function un(event_name: 'visitor_update', handler: (event_data: VisitorInfo) => void): void;
+export function un(event_name: 'agent_update', handler: (event_data: AgentInfo) => void): void;
+export function un(event_name: 'chat', handler: (event_data: ChatEventData) => void): void;
+export function un(event_name: 'history', handler: (event_data: HistoryEventData) => void): void;
+export function un(event_name: 'error', handler: (event_data: ErrorEventData) => void): void;
+
 export interface VisitorInfo {
     display_name: string;
     email: string;
     phone: string;
 }
 
+export interface AgentInfo {
+    nick: string;
+    display_name: string;
+    avatar_path: string;
+    title: string;
+}
+
 export interface Department {
     id: number;
     name: string;
-    status: 'online' | 'offline';
+    status: 'online' | 'away' | 'offline';
+}
+
+export type OperatingHours = { enabled: boolean; timezone: string } & (
+    | { type: 'account'; acount_schedule: Schedule }
+    | { type: 'department'; department_schedule: { [id: number]: Schedule } }
+);
+
+export interface Schedule {
+    0: Period[];
+    1: Period[];
+    2: Period[];
+    3: Period[];
+    4: Period[];
+    5: Period[];
+    6: Period[];
+}
+
+export interface Period {
+    start: number;
+    end: number;
+}
+
+export type AccountsStatusEventData = 'online' | 'away' | 'offline';
+
+export type ConnectionUpdateEventData = 'connecting' | 'connected' | 'closed';
+
+export interface ChatMsgChatEventData {
+    type: 'chat.msg';
+    nick: string;
+    display_name: string;
+    timestamp: number;
+    msg: string;
+    options: string[];
+    structured_msg: StructuredMessage.Message;
+}
+
+export namespace StructuredMessage {
+    type Message = QuickReplies | ButtonTemplate | PanelTemplate | PanelTemplateCarousel | ListTemplate;
+
+    interface QuickReplies {
+        type: 'QUICK_REPLIES';
+        msg: string;
+        quick_replies: Array<Button<'QUICK_REPLY_ACTION'>>;
+    }
+
+    interface ButtonTemplate {
+        type: 'BUTTON_TEMPLATE';
+        msg: string;
+        buttons: Array<Button<'QUICK_REPLY_ACTION' | 'LINK_ACTION'>>;
+    }
+
+    interface PanelTemplate {
+        type: 'PANEL_TEMPLATE';
+        panel: Panel;
+        buttons?: Array<Button<'LINK_ACTION'>> | undefined;
+    }
+
+    interface Panel {
+        heading: string;
+        paragraph?: string | undefined;
+        image_url?: string | undefined;
+        action?: Action<'LINK_ACTION'> | undefined;
+    }
+
+    interface PanelTemplateCarousel {
+        type: 'PANEL_TEMPLATE_CAROUSEL';
+        items: PanelTemplate[];
+    }
+
+    interface ListItem {
+        heading: string;
+        paragraph: string;
+        image_url?: string | undefined;
+        action: Action<'LINK_ACTION'>;
+    }
+
+    interface ListTemplate {
+        type: 'LIST_TEMPLATE';
+        items: ListItem[];
+        buttons?: Array<Button<'QUICK_REPLY_ACTION' | 'LINK_ACTION'>> | undefined;
+    }
+
+    interface Button<T extends 'QUICK_REPLY_ACTION' | 'LINK_ACTION'> {
+        text: string;
+        action: Action<T>;
+    }
+
+    interface Action<T extends 'QUICK_REPLY_ACTION' | 'LINK_ACTION'> {
+        type: T;
+        value: string;
+    }
+}
+
+export interface ChatFileChatEventData {
+    type: 'chat.file';
+    nick: string;
+    display_name: string;
+    timestamp: number;
+    attachment: Attachment;
+    deleted: boolean;
 }
 
 export interface Attachment {
@@ -214,37 +273,80 @@ export interface AttachmentMetadata {
     height: number;
 }
 
-export type EventName =
-    | 'account_status'
-    | 'connection_update'
-    | 'department_update'
-    | 'visitor_update'
-    | 'agent_update'
-    | 'chat'
-    | 'history'
-    | 'typing'
-    | 'error';
-
-export type EventData =
-    | ChatEvent.ChatEventData
-    | {
+export interface ChatQueuePositionChatEventData {
     type: 'chat.queue_position';
     nick: string;
     queue_position: number;
 }
-    | {
+
+export interface ChatMemberJoinChatEventData {
+    type: 'chat.memberjoin';
+    nick: string;
+    display_name: string;
+    timestamp: number;
+}
+
+export interface ChatMemberLeaveChatEventData {
+    type: 'chat.memberleave';
+    nick: string;
+    display_name: string;
+    timestamp: number;
+}
+
+export interface ChatRequestRatingChatEventData {
+    type: 'chat.request.rating';
+    nick: string;
+    display_name: string;
+    timestamp: number;
+}
+
+export interface ChatRatingChatEventData {
+    type: 'chat.rating';
+    nick: string;
+    display_name: string;
+    timestamp: number;
+    rating?: string | undefined;
+    new_rating?: string | undefined;
+}
+
+export interface ChatCommentChatEventData {
+    type: 'chat.comment';
+    nick: string;
+    display_name: string;
+    timestamp: number;
+    comment?: string | undefined;
+    new_comment?: string | undefined;
+}
+
+export interface TypingChatEventData {
     type: 'typing';
     nick: string;
     typing: boolean;
 }
-    | {
+
+export interface LastReadChatEventData {
     type: 'last_read';
     nick: string;
     timestamp: number;
 }
-    | 'online'
-    | 'away'
-    | 'offline'
-    | 'connecting'
-    | 'connected'
-    | 'closed';
+
+export type ChatEventData =
+    | ChatMsgChatEventData
+    | ChatFileChatEventData
+    | ChatQueuePositionChatEventData
+    | ChatMemberJoinChatEventData
+    | ChatMemberLeaveChatEventData
+    | ChatRequestRatingChatEventData
+    | ChatCommentChatEventData
+    | TypingChatEventData
+    | LastReadChatEventData;
+
+export type HistoryEventData =
+    | ChatMsgChatEventData
+    | ChatFileChatEventData
+    | ChatMemberJoinChatEventData
+    | ChatMemberLeaveChatEventData
+    | ChatRequestRatingChatEventData
+    | ChatCommentChatEventData;
+
+export type ErrorEventData = Error & { context: string; extra?: any };

--- a/types/zchat-browser/index.d.ts
+++ b/types/zchat-browser/index.d.ts
@@ -35,8 +35,7 @@ export function getAllDepartments(): Department[];
 
 export function getDepartment(id: number): Department;
 
-// TODO
-export function getVisitorDefaultDepartment(): Department;
+export function getVisitorDefaultDepartment(): number | undefined;
 
 export function setVisitorDefaultDepartment(id: number, callback?: (err: Error) => void): void;
 

--- a/types/zchat-browser/zchat-browser-tests.ts
+++ b/types/zchat-browser/zchat-browser-tests.ts
@@ -5,36 +5,80 @@ const fakeFile = new File(['foo'], 'foo.txt', {
     type: 'text/plain',
 });
 
-zChat.addTags(['tag1', 'tag2']);
-zChat.clearVisitorDefaultDepartment(fakeCallback);
-zChat.getAccountStatus();
-zChat.getAllDepartments();
-zChat.getChatInfo();
-zChat.getChatLog();
-zChat.getConnectionStatus();
-zChat.getDepartment(1);
-zChat.getQueuePosition();
-zChat.getVisitorDefaultDepartment();
-zChat.getVisitorInfo();
 zChat.init({ account_key: 'fake_account_key' });
-zChat.isChatting();
-zChat.removeTags(['tag1', 'tag2']);
-zChat.sendChatComment('fake_comment', fakeCallback);
+zChat.getAccountStatus();
+zChat.getConnectionStatus();
+zChat.getVisitorInfo();
+zChat.setVisitorInfo({ display_name: 'fake_name' }, fakeCallback);
+zChat.setVisitorInfo(
+    {
+        display_name: 'fake_name',
+        email: 'fake_email',
+        phone: 'fake_phone',
+    },
+    fakeCallback,
+);
+zChat.sendVisitorPath({ title: 'fake_title', url: 'fake_url' }, fakeCallback);
+zChat.getQueuePosition();
+zChat.getAllDepartments();
+zChat.getDepartment(1);
+zChat.getVisitorDefaultDepartment();
+zChat.setVisitorDefaultDepartment(1, fakeCallback);
+zChat.clearVisitorDefaultDepartment(fakeCallback);
 zChat.sendChatMsg('fake_message', fakeCallback);
-zChat.sendChatRating('good', fakeCallback);
 zChat.sendFile(
     fakeFile,
-    (err: zChat.SendFileErrorMessage, data: { mime_type: string; name: string; size: number; url: string }) => 0
+    (err: zChat.SendFileError, data: { mime_type: string; name: string; size: number; url: string }) => 0,
 );
 zChat.sendOfflineMsg({ name: 'fake_name', email: 'fake_email', message: 'fake_message' }, fakeCallback);
+zChat.addTags(['tag1', 'tag2']);
+zChat.removeTags(['tag1', 'tag2']);
 zChat.sendTyping(true);
-zChat.sendVisitorPath({ title: 'fake_title', url: 'fake_url' }, fakeCallback);
-zChat.setVisitorDefaultDepartment(1, fakeCallback);
-zChat.setVisitorInfo({
-    display_name: 'fake_name',
-    email: 'fake_email',
-    phone: 'fake_phone',
-});
-const fakeHandler = (event_data?: zChat.EventData) => 0;
-zChat.on('account_status', fakeHandler);
-zChat.un('account_status', fakeHandler);
+zChat.getChatInfo();
+zChat.sendChatRating('good', fakeCallback);
+zChat.sendChatComment('fake_comment', fakeCallback);
+zChat.isChatting();
+zChat.getChatLog();
+zChat.getServingAgentsInfo();
+zChat.getOperatingHours();
+zChat.sendEmailTranscript('fake_email', fakeCallback);
+zChat.fetchChatHistory((err: Error, data: { count: number; has_more: boolean }) => 0);
+zChat.markAsRead();
+zChat.reconnect();
+zChat.endChat();
+zChat.endChat({ clear_dept_id_on_chat_ended: true });
+zChat.logout();
+
+'fake_email'.match(zChat.EMAIL_REGEX);
+
+const accountStatusHandler = (event_data: zChat.AccountsStatusEventData) => 0;
+zChat.on('account_status', accountStatusHandler);
+zChat.un('account_status', accountStatusHandler);
+
+const connectionUpdateHandler = (event_data: zChat.ConnectionUpdateEventData) => 0;
+zChat.on('connection_update', connectionUpdateHandler);
+zChat.un('connection_update', connectionUpdateHandler);
+
+const departmentUpdateHandler = (event_data: zChat.Department) => 0;
+zChat.on('department_update', departmentUpdateHandler);
+zChat.un('department_update', departmentUpdateHandler);
+
+const visitorUpdateHandler = (event_data: zChat.VisitorInfo) => 0;
+zChat.on('visitor_update', visitorUpdateHandler);
+zChat.un('visitor_update', visitorUpdateHandler);
+
+const agentUpdateHandler = (event_data: zChat.AgentInfo) => 0;
+zChat.on('agent_update', agentUpdateHandler);
+zChat.un('agent_update', agentUpdateHandler);
+
+const chatHandler = (event_data: zChat.ChatEventData) => 0;
+zChat.on('chat', chatHandler);
+zChat.un('chat', chatHandler);
+
+const historyHandler = (event_data: zChat.HistoryEventData) => 0;
+zChat.on('history', historyHandler);
+zChat.un('history', historyHandler);
+
+const errorHandler = (event_data: zChat.ErrorEventData) => 0;
+zChat.on('error', errorHandler);
+zChat.un('error', errorHandler);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.zopim.com/web-sdk/#api-reference
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

# Summary of changes

* Fixes incorrect types (`sendFile` callback error, `sendOfflineMsg` optional callback, `getVisitorDefaultDepartment` signature, `addTags` readonly array, `getChatInfo` and `sendChatRating` null)
* Adds missing types (`getServingAgentsInfo`, `getOperatingHours`, `sendEmailTranscript`, `fetchChatHistory`, `markAsRead`, `reconnect`, `endChat`, `logout`, `ButtonTemplate`)
* Introduces more precise types (event handlers, structured message buttons and actions)
