### PR TITLE
[react-outside-click-handler] Replace React.SyntheticEvent with MouseEvent

### DIFF
--- a/types/react-outside-click-handler/index.d.ts
+++ b/types/react-outside-click-handler/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for react-outside-click-handler 1.3
 // Project: https://github.com/airbnb/react-outside-click-handler
 // Definitions by: Ivan Zub <https://github.com/zubivan>
+//                 JadowityHerbatnik <https://github.com/JadowityHerbatnik>
+//                 Adam Jones <https://github.com/domdomegg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -15,7 +17,7 @@ export interface DefaultProps {
 // TODO: Remove partial once DT support TS 3.0, so skipping mandatory listed in default props won't result in compile error
 export interface Props extends Partial<DefaultProps> {
     children: React.ReactNode;
-    onOutsideClick: (e: React.MouseEvent<HTMLElement>) => void;
+    onOutsideClick: (e: MouseEvent) => void;
 }
 
 export default class OutsideClickHandler extends React.Component<Props> {

--- a/types/react-outside-click-handler/test/react-outside-click-handler-tests.tsx
+++ b/types/react-outside-click-handler/test/react-outside-click-handler-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import OutsideClickHandler from "react-outside-click-handler";
 
-const onClickOutside: (event: React.MouseEvent<any>) => void = () => {};
+const onClickOutside: (event: MouseEvent) => void = () => {};
 
 <OutsideClickHandler onOutsideClick={onClickOutside}>
     <span>Child</span>

--- a/types/react-outside-click-handler/tsconfig.json
+++ b/types/react-outside-click-handler/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Self explanatory, the package never uses React's SynetheticEvent

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/react-outside-click-handler/blob/master/src/OutsideClickHandler.jsx#L77
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
