### PR TITLE
`carbon-components-react` Change titleText in Dropdown to be optional

### DIFF
--- a/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
+++ b/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
@@ -33,7 +33,7 @@ export interface DropdownProps<ItemType = string> extends
     onChange?(data: OnChangeData<ItemType>): void,
     selectedItem?: ItemType | null | undefined,
     size?: ListBoxProps["size"] | undefined,
-    titleText?: NonNullable<React.ReactNode>,
+    titleText?: React.ReactNode | undefined,
     type?: ListBoxProps["type"] | undefined,
     warn?: boolean | undefined,
     warnText?: React.ReactNode | undefined,

--- a/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
+++ b/types/carbon-components-react/lib/components/Dropdown/Dropdown.d.ts
@@ -33,7 +33,7 @@ export interface DropdownProps<ItemType = string> extends
     onChange?(data: OnChangeData<ItemType>): void,
     selectedItem?: ItemType | null | undefined,
     size?: ListBoxProps["size"] | undefined,
-    titleText: NonNullable<React.ReactNode>,
+    titleText?: NonNullable<React.ReactNode>,
     type?: ListBoxProps["type"] | undefined,
     warn?: boolean | undefined,
     warnText?: React.ReactNode | undefined,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/Dropdown/Dropdown.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Add or edit tests isn't checked because from what I can see from the Carbon test the optional props are still provided, and so I don't think any change to the tests is needed