### PR TITLE
[lodash] iteratee: allow passing number and symbol

### DIFF
--- a/types/lodash/common/util.d.ts
+++ b/types/lodash/common/util.d.ts
@@ -424,7 +424,7 @@ declare module "../index" {
         /**
          * @see _.iteratee
          */
-        iteratee(func: string | object): (...args: any[]) => any;
+        iteratee(func: symbol | number | string | object): (...args: any[]) => any;
     }
     interface Function<T extends (...args: any) => any> {
         /**


### PR DESCRIPTION
Added `number` and `symbol` as possible parameters for _.iteratee function

This works in lodash:

```tsx
const s = Symbol('test');
const a = { [s]: 'foo' };

_.iteratee(s)(a); // 'foo'
```

However typescript throws an error complaining about using symbol for the iteratee argument

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.15#iteratee (I see nothing explicitly states if it is accepted or not)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
