### PR TITLE
Fix bad merge in ckeditor__ckeditor5-alignment

### DIFF
--- a/types/ckeditor__ckeditor5-alignment/src/alignmentcommand.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentcommand.d.ts
@@ -2,7 +2,7 @@ import { Command } from '@ckeditor/ckeditor5-core';
 import { AlignmentFormat } from './alignmentediting';
 
 export default class AlignmentCommand extends Command {
-    value?: AlignmentFormat['name'];
+    value: AlignmentFormat['name'];
     /**
      * Executes the command. Applies the alignment `value` to the selected blocks.
      * If no `value` is passed, the `value` is the default one or it is equal to the currently selected block"s alignment attribute,


### PR DESCRIPTION
The PR #56595 interacts with the changes in #56295 to ckeditor5-core, but the two PRs overlapped in time such that the second was never compiled against the first.

This change makes AlignmentCommand.value non-optional, to match Command.value.