### PR TITLE
`@types/auth0` Add support for `include_totals` to `getInvitations` method

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -1401,6 +1401,27 @@ management.organizations
     });
 
 /**
+ * Get Organization Invitations with pagination and totals using a callback
+ */
+management.organizations.getInvitations(
+    { id: 'organization_id', per_page: 2, page: 1, include_totals: true },
+    (err, pagedInvitations: auth0.OrganizationInvitationsPaged) => {
+        // $ExpectType OrganizationInvitationsPaged
+        pagedInvitations;
+    },
+);
+
+/**
+ * Get Organization Invitations with pagination and totals returning a Promise
+ */
+management.organizations
+    .getInvitations({ id: 'organization_id', per_page: 2, page: 1, include_totals: true })
+    .then((pagedInvitations: auth0.OrganizationInvitationsPaged) => {
+        // $ExpectType OrganizationInvitationsPaged
+        pagedInvitations;
+    });
+
+/**
  * Get Organization Invitations with properties using a callback
  */
 management.organizations.getInvitations(

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1258,6 +1258,10 @@ export interface OrganizationInvitation {
     roles?: string[] | undefined;
 }
 
+export interface OrganizationInvitationsPaged extends Omit<Page, 'length'> {
+    invitations: OrganizationInvitation[];
+}
+
 export interface CreateOrganizationInvitation {
     inviter: {
         name: string;
@@ -1366,11 +1370,22 @@ export class OrganizationsManager {
     removeMembers(params: ObjectWithId, data: RemoveOrganizationMembers, cb: (err: Error) => void): void;
 
     getInvitations(
-        params: ObjectWithId & PagingOptions & { fields?: string; include_fields?: boolean; sort?: string },
+        params: ObjectWithId &
+            PagingOptions & { fields?: string; include_fields?: boolean; sort?: string; include_totals?: false },
     ): Promise<OrganizationInvitation[]>;
     getInvitations(
-        params: ObjectWithId & PagingOptions & { fields?: string; include_fields?: boolean; sort?: string },
+        params: ObjectWithId &
+            PagingOptions & { fields?: string; include_fields?: boolean; sort?: string; include_totals: true },
+    ): Promise<OrganizationInvitationsPaged>;
+    getInvitations(
+        params: ObjectWithId &
+            PagingOptions & { fields?: string; include_fields?: boolean; sort?: string; include_totals?: false },
         cb: (err: Error, invitations: OrganizationInvitation[]) => void,
+    ): void;
+    getInvitations(
+        params: ObjectWithId &
+            PagingOptions & { fields?: string; include_fields?: boolean; sort?: string; include_totals: true },
+        cb: (err: Error, pagedInvitations: OrganizationInvitationsPaged) => void,
     ): void;
 
     getInvitation(


### PR DESCRIPTION
This PR adds the `include_totals` parameter for the `getInvitations` method on the OrganizationsManager class.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [`getInvitations` documentation](https://auth0.com/docs/api/management/v2#!/Organizations/get_invitations)*
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

_*Like in #56432 and #56868, this endpoint does not return a length property, so we cannot fully reuse the `Page` type, hence the omitting of the length property in `OrganizationInvitationsPaged`._
