### PR TITLE
chore(umzug): move from @types/mongodb deprecated to mongodb package

### DIFF
--- a/types/umzug/index.d.ts
+++ b/types/umzug/index.d.ts
@@ -212,7 +212,7 @@ declare namespace umzug {
 
     interface Migration {
         file: string;
-        
+
         migration(): Promise<any>;
         up(): Promise<any>;
         down(): Promise<any>;
@@ -222,7 +222,7 @@ declare namespace umzug {
     interface MigrationDefinitionWithName extends Migration {
         name: string;
     }
-    
+
     interface Umzug extends EventEmitter {
         /**
          * The execute method is a general purpose function that runs for

--- a/types/umzug/package.json
+++ b/types/umzug/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^3.6.20"
+        "mongodb": "^4.1.4"
     }
 }

--- a/types/umzug/umzug-tests.ts
+++ b/types/umzug/umzug-tests.ts
@@ -123,7 +123,7 @@ new Umzug({
 
 });
 
-const mongodb = new MongoDB.Db('database', new MongoDB.Server('host', 21017));
+const mongodb = new MongoDB.Db(new MongoDB.MongoClient('host', { localPort: 21017 }), 'database');
 
 new Umzug({
     // The storage.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://www.npmjs.com/package/mongodb)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Following discussion : https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/57134
