### PR TITLE
fix(twig): define `extend` method and related internal types

### DIFF
--- a/types/twig/index.d.ts
+++ b/types/twig/index.d.ts
@@ -47,17 +47,201 @@ export interface CompileOptions {
 
 export interface RenderOptions {
     allowAsync?: boolean | undefined;
-    settings?: {
-        views: any;
-        'twig options': any;
-    } | undefined;
+    settings?:
+        | {
+              views: any;
+              'twig options': any;
+          }
+        | undefined;
+}
+
+export interface TagToken {
+    type: string;
+    match: RegExpExecArray;
+    stack?: CompiledToken[];
+}
+
+export interface RawOutput {
+    type: 'raw';
+    value: string;
+}
+
+export interface TagTokenWithOutput extends TagToken {
+    output: RawOutput[];
+}
+
+export interface ExtendableParseContext {} // tslint:disable-line:no-empty-interface
+
+export interface ParseLoopContext {
+    index: number;
+    index0: number;
+    revindex: number;
+    revindex0: number;
+    first: boolean;
+    last: boolean;
+    length: number;
+    parent: ParseContext;
+}
+
+export interface ParseContext extends ExtendableParseContext {
+    filename: string;
+    partials: Record<string, unknown>;
+    loop?: ParseLoopContext;
+    path: string;
+}
+
+export interface Twig {
+    exports: {
+        twig: typeof twig;
+        extendFilter: typeof extendFilter;
+        extendFunction: typeof extendFunction;
+        extendTest: typeof extendTest;
+        extendTag: typeof extendTag;
+        extend: typeof extend;
+        compile: typeof compile;
+        renderFile: typeof renderFile;
+        __express: typeof __express;
+        cache: typeof cache;
+    };
+
+    expression: {
+        /**
+         * Compile an expression token.
+         *
+         * @param rawToken the uncompiled token
+         *
+         * @return The compiled token
+         */
+        compile<T>(rawToken: { value: unknown } & T): { stack: CompiledToken[] } & Omit<T, 'value'>;
+        /**
+         * Parse an RPN expression stack within a context.
+         *
+         * @param tokens An array of compiled expression tokens.
+         * @param context The render context to parse the tokens with.
+         *
+         * @return The result of parsing all the tokens. The result
+         *             can be anything, String, Array, Object, etc... based on
+         *             the given expression.
+         */
+        parse(tokens: CompiledToken[], context: ParseContext): unknown;
+        type: {
+            comma: 'Twig.expression.type.comma';
+            operator: {
+                unary: 'Twig.expression.type.operator.unary';
+                binary: 'Twig.expression.type.operator.binary';
+            };
+            string: 'Twig.expression.type.string';
+            bool: 'Twig.expression.type.bool';
+            slice: 'Twig.expression.type.slice';
+            array: {
+                start: 'Twig.expression.type.array.start';
+                end: 'Twig.expression.type.array.end';
+            };
+            object: {
+                start: 'Twig.expression.type.object.start';
+                end: 'Twig.expression.type.object.end';
+            };
+            parameter: {
+                start: 'Twig.expression.type.parameter.start';
+                end: 'Twig.expression.type.parameter.end';
+            };
+            subexpression: {
+                start: 'Twig.expression.type.subexpression.start';
+                end: 'Twig.expression.type.subexpression.end';
+            };
+            key: {
+                period: 'Twig.expression.type.key.period';
+                brackets: 'Twig.expression.type.key.brackets';
+            };
+            filter: 'Twig.expression.type.filter';
+            _function: 'Twig.expression.type._function';
+            variable: 'Twig.expression.type.variable';
+            number: 'Twig.expression.type.number';
+            _null: 'Twig.expression.type.null';
+            context: 'Twig.expression.type.context';
+            test: 'Twig.expression.type.test';
+        };
+    };
+}
+
+export interface CompiledGenericToken<TType, TValue> {
+    type: TType;
+    value: TValue;
+}
+
+export interface CompiledGenericTokenWithMatch<TType, TValue> extends CompiledGenericToken<TType, TValue> {
+    match: Array<string | undefined | unknown>;
+}
+
+export interface CompiledSubexpressionToken
+    extends CompiledGenericTokenWithMatch<'Twig.expression.type.subexpression.end', ')'> {
+    expression: boolean;
+    params: CompiledToken[];
+}
+
+export type BinaryOperator = '*' | '**' | '%' | '+' | '-' | '/' | '<' | '>' | '==' | '!=' | '>=' | '<=';
+
+export interface CompiledBinaryOperatorToken<TOperator extends BinaryOperator = BinaryOperator>
+    extends CompiledGenericTokenWithMatch<'Twig.expression.type.operator.binary', TOperator> {
+    precidence: number;
+    associativity: 'leftToRight' | string;
+    operator: TOperator;
+}
+
+export interface CompiledTokenTypesWithoutMatchMap {
+    'Twig.expression.type.bool': boolean;
+    'Twig.expression.type.string': string;
+    'Twig.expression.type.null': null;
+}
+
+export interface CompiledTokenTypesWithMatchMap {
+    'Twig.expression.type.number': number;
+    'Twig.expression.type.variable': string;
+    'Twig.expression.type.array.start': '[';
+    'Twig.expression.type.array.end': ']';
+    'Twig.expression.type.object.start': '{';
+    'Twig.expression.type.object.end': '}';
+}
+
+export type CompiledTokenWithoutMatch<
+    TType extends keyof CompiledTokenTypesWithoutMatchMap = keyof CompiledTokenTypesWithoutMatchMap,
+> = CompiledGenericToken<TType, CompiledTokenTypesWithoutMatchMap[TType]>;
+
+export type CompiledTokenWithMatch<
+    TType extends keyof CompiledTokenTypesWithMatchMap = keyof CompiledTokenTypesWithMatchMap,
+> = CompiledGenericTokenWithMatch<TType, CompiledTokenTypesWithMatchMap[TType]>;
+
+export type CompiledToken =
+    | CompiledTokenWithoutMatch
+    | CompiledTokenWithMatch
+    | CompiledSubexpressionToken
+    | CompiledBinaryOperatorToken;
+
+export interface TagParseOutput {
+    chain: boolean;
+    output: string;
+}
+
+export interface ExtendTagOptions {
+    /** A unique name for the tag (e.g. "tag") */
+    type: string;
+    /** Expression used to match the tag */
+    regex: RegExp;
+    /** Represents any expected following tags (e.g. "endtag") */
+    next: string[];
+    open: boolean;
+    /** Called on matched tokens when the template is loaded, once per template */
+    compile?: (token: TagToken) => TagToken;
+    /** Runs when the template is rendered */
+    parse?: (token: TagToken, context: ParseContext, chain: boolean) => TagParseOutput;
 }
 
 export function twig(params: Parameters): Template;
 export function extendFilter(name: string, definition: (left: any, ...params: any[]) => string): void;
 export function extendFunction(name: string, definition: (...params: any[]) => string): void;
 export function extendTest(name: string, definition: (value: any) => boolean): void;
-export function extendTag(definition: any): void;
+export function extendTag(definition: ExtendTagOptions): void;
+export function extend(extension: (twig: Twig) => void): void;
 export function compile(markup: string, options: CompileOptions): (context: any) => any;
 export function renderFile(path: string, options: RenderOptions, fn: (err: Error, result: any) => void): void;
 export function renderFile(path: string, fn: (err: Error, result: any) => void): void;

--- a/types/twig/twig-tests.ts
+++ b/types/twig/twig-tests.ts
@@ -1,7 +1,7 @@
 import twig = require('twig');
 
-const value: any = "";
-const str = "";
+const value: any = '';
+const str = '';
 const bool = false;
 
 const params: twig.Parameters = {
@@ -14,7 +14,7 @@ const params: twig.Parameters = {
     name: value,
     options: value,
     href: value,
-    async: value
+    async: value,
 };
 
 const temp: twig.Template = twig.twig(params);
@@ -34,8 +34,8 @@ const compOpts: twig.CompileOptions = {
     filename: str,
     settings: {
         views: value,
-        'twig options': value
-    }
+        'twig options': value,
+    },
 };
 
 twig.extendFilter(str, (left: any, ...params: any[]) => {
@@ -53,14 +53,55 @@ const compiled = twig.compile(str, compOpts);
 
 const renderOpts: twig.RenderOptions = {
     allowAsync: true,
-    settings: value
+    settings: value,
 };
 
-twig.renderFile(str, renderOpts, (err, result) => {
-});
-twig.renderFile(str, (err, result) => {
-});
+twig.renderFile(str, renderOpts, (err, result) => {});
+twig.renderFile(str, (err, result) => {});
 
-twig.__express(str, compOpts, (err, result) => {
-});
+twig.__express(str, compOpts, (err, result) => {});
 twig.cache(bool);
+
+// expose the internal Twig object for extension
+twig.extend(Twig => {
+    Twig.exports.extendTag({
+        // unique name for tag type
+        type: 'flag',
+        // regex match for tag (flag white-space anything)
+        regex: /^flag\s+(.+)$/u,
+        // this is a standalone tag and doesn't require a following tag
+        next: [],
+        open: true,
+
+        // runs on matched tokens when the template is loaded. (once per template)
+        compile(token) {
+            const [, expression] = token.match;
+
+            // compile returns the raw token, mutating it before returning
+            // by adding "stack" and deleting the "value" property
+            const compiled = Twig.expression.compile({ value: expression, type: 'my-type' });
+
+            compiled.type; // $ExpectType string
+
+            // while technically tokens don't start with this property,
+            // this is a pattern used heavily in the library itself
+            token.stack = Twig.expression.compile({
+                value: expression,
+            }).stack;
+
+            return token;
+        },
+
+        // Runs when the template is rendered
+        parse(token, context, chain) {
+            // parse the tokens into a value with the render context
+            const name = Twig.expression.parse.apply(this, [token.stack, context]);
+            const output = '';
+
+            return {
+                chain,
+                output,
+            };
+        },
+    });
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/twigjs/twig.js/wiki/Extending-twig.js-With-Custom-Tags & some manual logging + rooting around the source code
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

This is needed to support adding our own tags - I think I've covered the core of the types, but know there are still more that could be typed, both in terms of properties on `Twig` & the possible tokens; these changes will let me start diving into actually using custom tags, which'll in turn reveal those missing types so I can add them.