### PR TITLE
maxAge seems to be actively used and is mistyped

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -84,11 +84,7 @@ export interface VerifyOptions {
      */
     nonce?: string | undefined;
     subject?: string | undefined;
-    /**
-     * @deprecated
-     * Max age of token
-     */
-    maxAge?: string | undefined;
+    maxAge?: string | number | undefined;
 }
 
 export interface DecodeOptions {

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -182,6 +182,15 @@ if (typeof verified2 !== 'string') {
     verified2;
 }
 
+// This tests creates a token with iat as now, verifies with maxAge=now()+3600sec
+cert = fs.readFileSync("public.pem"); // get public key
+const verified3 = jwt.verify(token, cert, {maxAge: 3600});
+
+if (typeof verified3 !== 'string') {
+    // $ExpectType JwtPayload
+    verified3;
+}
+
 /**
  * jwt.decode
  * https://github.com/auth0/node-jsonwebtoken#jwtdecodetoken


### PR DESCRIPTION
https://github.com/auth0/node-jsonwebtoken/blob/master/verify.js#L199-L211

1. **Removed deprecation label:** maxAge is actively used in the project and there is no indication of deprecation in the documentation.
2. **`maxAge` type fixed:** `maxAge` can be `number`, `string` or `undefined`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Link to the jsonwebtoken repo code](https://github.com/auth0/node-jsonwebtoken/blob/master/verify.js#L199-L211)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

