### PR TITLE
[react-native-modal-filter-picker] Remove remnants of ListView & variable rename

### DIFF
--- a/types/react-native-modal-filter-picker/index.d.ts
+++ b/types/react-native-modal-filter-picker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native-modal-filter-picker 1.3
+// Type definitions for react-native-modal-filter-picker 2.1.0
 // Project: https://github.com/hiddentao/react-native-modal-filter-picker#readme
 // Definitions by: Chang Yanwei <https://github.com/ywchang>
 //                 Cheng Gibson <https://github.com/nossbigg>

--- a/types/react-native-modal-filter-picker/index.d.ts
+++ b/types/react-native-modal-filter-picker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native-modal-filter-picker 2.1.0
+// Type definitions for react-native-modal-filter-picker 2.1
 // Project: https://github.com/hiddentao/react-native-modal-filter-picker#readme
 // Definitions by: Chang Yanwei <https://github.com/ywchang>
 //                 Cheng Gibson <https://github.com/nossbigg>

--- a/types/react-native-modal-filter-picker/index.d.ts
+++ b/types/react-native-modal-filter-picker/index.d.ts
@@ -13,7 +13,6 @@ import {
   TextStyle,
   KeyboardAvoidingView,
   ModalProps,
-  ListViewProps,
   FlatListProps,
 } from 'react-native';
 
@@ -36,7 +35,7 @@ export interface ModalFilterPickerProps<T extends ModalFilterPickerOption> {
     showFilter?: boolean | undefined;
     modal?: ModalProps | undefined;
     selectedOption?: string | undefined;
-    listViewProps?: Partial<ListViewProps | FlatListProps<T>> | undefined;
+    flatListProps?: Partial<FlatListProps<T>> | undefined;
     renderOption?: ((option: T, isSelected: boolean) => JSX.Element) | undefined;
     renderList?: (() => JSX.Element) | undefined;
     renderCancelButton?: (() => JSX.Element) | undefined;

--- a/types/react-native-modal-filter-picker/react-native-modal-filter-picker-tests.tsx
+++ b/types/react-native-modal-filter-picker/react-native-modal-filter-picker-tests.tsx
@@ -38,7 +38,7 @@ const renderPicker = () => (
         showFilter
         modal={{ animated: true }}
         selectedOption="some-option-key"
-        listViewProps={{ accessible: true }}
+        flatListProps={{ accessible: true }}
         renderOption={(option, isSelected) => (
             <View key={option.key}>
                 <Text>


### PR DESCRIPTION
A couple of days ago my [change](https://github.com/hiddentao/react-native-modal-filter-picker/pull/49) was merged into **react-native-modal-filter-picker**, and now I'm updating its types.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [PR#49](https://github.com/hiddentao/react-native-modal-filter-picker/pull/49)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

