### PR TITLE
Added the test case for maxAge as number

### DIFF
--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -182,6 +182,15 @@ if (typeof verified2 !== 'string') {
     verified2;
 }
 
+// This tests creates a token with iat as now, verifies with maxAge=now()+3600sec
+const tokenExpiresIn10h = jwt.sign({test: 1}, key, {expiresIn: '10h'});
+const payloadForTokenExpiresIn10h = jwt.verify(tokenExpiresIn10h, key, {maxAge: 3600});
+
+if (typeof payloadForTokenExpiresIn10h !== 'string') {
+    // $ExpectType JwtPayload
+    payloadForTokenExpiresIn10h;
+}
+
 /**
  * jwt.decode
  * https://github.com/auth0/node-jsonwebtoken#jwtdecodetoken


### PR DESCRIPTION
Based on @LinusU 's comment here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57146#pullrequestreview-805494301
Added a test case that sets maxAge as a number (3600).
I am not familiar with eslint-plugin-expect-type, please feel free to correct me.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [PR link](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57146#pullrequestreview-805494301)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.