### PR TITLE
fix(twig): improve type of `extendFilter` params

### DIFF
--- a/types/twig/index.d.ts
+++ b/types/twig/index.d.ts
@@ -54,7 +54,7 @@ export interface RenderOptions {
 }
 
 export function twig(params: Parameters): Template;
-export function extendFilter(name: string, definition: (left: any, ...params: any[]) => string): void;
+export function extendFilter(name: string, definition: (left: any, params: any[] | false) => string): void;
 export function extendFunction(name: string, definition: (...params: any[]) => string): void;
 export function extendTest(name: string, definition: (value: any) => boolean): void;
 export function extendTag(definition: any): void;

--- a/types/twig/twig-tests.ts
+++ b/types/twig/twig-tests.ts
@@ -38,7 +38,7 @@ const compOpts: twig.CompileOptions = {
     }
 };
 
-twig.extendFilter(str, (left: any, ...params: any[]) => {
+twig.extendFilter(str, (left: any, params: any[] | false) => {
     return str;
 });
 

--- a/types/twig/twig-tests.ts
+++ b/types/twig/twig-tests.ts
@@ -38,6 +38,10 @@ const compOpts: twig.CompileOptions = {
     }
 };
 
+twig.extendFilter('backwords', value => {
+    return value.split(' ').reverse().join(' ');
+});
+
 twig.extendFilter(str, (left: any, params: any[] | false) => {
     return str;
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/twigjs/twig.js/wiki/Extending-twig.js#filters
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Have tested this locally - Twig will pass an array if there are brackets, otherwise it'll pass `false`.