### PR TITLE
[webpack]: Deprecate webpack.optimize.UglifyJsPlugin

### DIFF
--- a/types/webpack/v4/index.d.ts
+++ b/types/webpack/v4/index.d.ts
@@ -2191,6 +2191,7 @@ declare namespace webpack {
             constructor(options?: UglifyJsPlugin.Options);
         }
 
+        /** @deprecated use config.optimization.minimize instead */
         namespace UglifyJsPlugin {
             type CommentFilter = (astNode: any, comment: any) => boolean;
 

--- a/types/webpack/v4/test/index.ts
+++ b/types/webpack/v4/test/index.ts
@@ -466,41 +466,6 @@ plugin = new webpack.optimize.LimitChunkCountPlugin(options);
 plugin = new webpack.optimize.MinChunkSizePlugin(options);
 plugin = new webpack.optimize.OccurrenceOrderPlugin(preferEntry);
 plugin = new webpack.optimize.OccurrenceOrderPlugin(preferEntry);
-plugin = new webpack.optimize.UglifyJsPlugin(options);
-plugin = new webpack.optimize.UglifyJsPlugin();
-plugin = new webpack.optimize.UglifyJsPlugin({
-    parallel: true
-});
-plugin = new webpack.optimize.UglifyJsPlugin({
-    parallel: {
-        cache: true,
-        workers: 2
-    }
-});
-plugin = new webpack.optimize.UglifyJsPlugin({
-    compress: {
-        dead_code: true,
-        collapse_vars: true,
-        drop_debugger: true,
-    },
-    warnings: false,
-});
-plugin = new webpack.optimize.UglifyJsPlugin({
-    sourceMap: false,
-    comments: true,
-    beautify: true,
-    test: 'foo',
-    exclude: /node_modules/,
-    include: 'test'
-});
-plugin = new webpack.optimize.UglifyJsPlugin({
-    mangle: {
-        reserved: ['$super', '$', 'exports', 'require']
-    }
-});
-plugin = new webpack.optimize.UglifyJsPlugin({
-    comments: (astNode: any, comment: any) => false
-});
 plugin = new webpack.DefinePlugin(definitions);
 plugin = new webpack.DefinePlugin({
     VERSION: JSON.stringify("5fa3b9"),


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Webpack v4 source](https://github.com/webpack/webpack/blob/3956274f1eada621e105208dcab4608883cdfdb2/lib/webpack.js#L195-L199)

Any use of `webpack.optimize.UglifyJsPlugin` will be met with the following error in Webpack 4:

```
Error: webpack.optimize.UglifyJsPlugin has been removed, please use config.optimization.minimize instead.
    at Object.get [as UglifyJsPlugin] (/<project_path>/node_modules/webpack/lib/webpack.js:189:10)
```

As such, I've put a deprecation message on the type, which seems to be the style, and removed the tests for `webpack.optimize.UglifyJsPlugin` as they are no longer relevant. There is no way to customize the minification without adding an external dependency (like `UglifyJsPlugin`) to the config, so those tests no longer serve any purpose.