### PR TITLE
[emscripten] fix: better type hints for cwrap and ccall

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -34,10 +34,10 @@ function ModuleTest(): void {
 
     Module.print = text => alert('stdout: ' + text);
 
-    let int_sqrt = Module.cwrap('int_sqrt', 'number', ['number']);
-    int_sqrt = Module.cwrap('int_sqrt', null, ['number']);
-    int_sqrt(12);
-    int_sqrt(28);
+    const int_sqrt_number = Module.cwrap('int_sqrt', 'number', ['number']);
+    const int_sqrt_null = Module.cwrap('int_sqrt', null, ['number']);
+    const num: number = int_sqrt_number(12);
+    const empty: null = int_sqrt_null(28);
 
     const myTypedArray = new Uint8Array(10);
     const buf = Module._malloc(myTypedArray.length * myTypedArray.BYTES_PER_ELEMENT);

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -253,6 +253,28 @@ declare var MEMFS: Emscripten.FileSystemType;
 declare var NODEFS: Emscripten.FileSystemType;
 declare var IDBFS: Emscripten.FileSystemType;
 
+// https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html
+type StringToType<R extends any> = R extends Emscripten.JSType
+  ? {
+      number: number;
+      string: string;
+      array: number[] | string[] | boolean[] | Uint8Array | Int8Array;
+      boolean: boolean;
+      null: null;
+    }[R]
+  : never;
+
+type ArgsToType<T extends Array<Emscripten.JSType | null>> = Extract<
+  {
+    [P in keyof T]: StringToType<T[P]>;
+  },
+  any[]
+>;
+
+type ReturnToType<R extends Emscripten.JSType | null> = R extends null
+  ? null
+  : StringToType<Exclude<R, null>>;
+
 // Below runtime function/variable declarations are exportable by
 // -s EXTRA_EXPORTED_RUNTIME_METHODS. You can extend or merge
 // EmscriptenModule interface to add runtime functions.
@@ -267,19 +289,26 @@ declare var IDBFS: Emscripten.FileSystemType;
 //
 // See: https://emscripten.org/docs/getting_started/FAQ.html#why-do-i-get-typeerror-module-something-is-not-a-function
 
-declare function ccall(
-    ident: string,
-    returnType: Emscripten.JSType | null,
-    argTypes: Emscripten.JSType[],
-    args: Emscripten.TypeCompatibleWithC[],
-    opts?: Emscripten.CCallOpts,
-): any;
-declare function cwrap(
-    ident: string,
-    returnType: Emscripten.JSType | null,
-    argTypes: Emscripten.JSType[],
-    opts?: Emscripten.CCallOpts,
-): (...args: any[]) => any;
+declare function cwrap<
+  I extends Array<Emscripten.JSType | null> | [],
+  R extends Emscripten.JSType | null
+>(
+  ident: string,
+  returnType: R,
+  argTypes: I,
+  opts?: Emscripten.CCallOpts
+): (...arg: ArgsToType<I>) => ReturnToType<R>;
+
+declare function ccall<
+  I extends Array<Emscripten.JSType | null> | [],
+  R extends Emscripten.JSType | null
+>(
+  ident: string,
+  returnType: R,
+  argTypes: I,
+  args: ArgsToType<I>,
+  opts?: Emscripten.CCallOpts
+): ReturnToType<R>;
 
 declare function setValue(ptr: number, value: any, type: Emscripten.CType, noSafe?: boolean): void;
 declare function getValue(ptr: number, type: Emscripten.CType, noSafe?: boolean): number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
 
Just optimization type hint, no change api
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Now we have better type hints~
![image](https://user-images.githubusercontent.com/19884146/141787383-81d75ce1-ee59-4e1f-ae20-5a946a9a01d6.png)

You can also also use [e-emscripten](https://www.npmjs.com/package/e-emscripten) to experience now.