### PR TITLE
fix(body-parser): rework @deprecate implementation

### DIFF
--- a/types/body-parser-xml/index.d.ts
+++ b/types/body-parser-xml/index.d.ts
@@ -6,12 +6,11 @@
 
 /// <reference types="node" />
 
-import bodyParser = require('body-parser');
+// import bodyParser = require('body-parser');
+import { BodyParser } from 'body-parser';
 import { NextHandleFunction } from 'connect';
 import { Request, Response } from 'express-serve-static-core';
 import { ParserOptions } from 'xml2js';
-
-type BodyParser = typeof bodyParser;
 
 /**
  * This library adds an xml method to the body-parser object.
@@ -56,5 +55,7 @@ declare namespace bodyParserXml {
 export = bodyParserXml;
 
 declare module 'body-parser' {
-    function xml(options?: bodyParserXml.Options): NextHandleFunction;
+    interface BodyParser {
+        xml(options?: bodyParserXml.Options): NextHandleFunction;
+    }
 }

--- a/types/body-parser/body-parser-tests.ts
+++ b/types/body-parser/body-parser-tests.ts
@@ -2,6 +2,16 @@ import * as http from 'http';
 import express = require('express');
 import { json, raw, text, urlencoded } from 'body-parser';
 
+import bodyParser = require('body-parser');
+
+// expected: deprecated
+bodyParser(); // $ExpectType NextHandleFunction
+// expected: no deprecation
+bodyParser.json();
+bodyParser.raw();
+bodyParser.text();
+bodyParser.urlencoded();
+
 const app = express();
 
 app.use(json());

--- a/types/body-parser/index.d.ts
+++ b/types/body-parser/index.d.ts
@@ -16,12 +16,35 @@ import * as http from 'http';
 
 // for docs go to https://github.com/expressjs/body-parser/tree/1.19.0#body-parser
 
-/** @deprecated */
-declare function bodyParser(
-    options?: bodyParser.OptionsJson & bodyParser.OptionsText & bodyParser.OptionsUrlencoded,
-): NextHandleFunction;
-
 declare namespace bodyParser {
+    interface BodyParser {
+        /**
+         * @deprecated  use individual json/urlencoded middlewares
+         */
+        (options?: OptionsJson & OptionsText & OptionsUrlencoded): NextHandleFunction;
+        /**
+         * Returns middleware that only parses json and only looks at requests
+         * where the Content-Type header matches the type option.
+         */
+        json(options?: OptionsJson): NextHandleFunction;
+        /**
+         * Returns middleware that parses all bodies as a Buffer and only looks at requests
+         * where the Content-Type header matches the type option.
+         */
+        raw(options?: Options): NextHandleFunction;
+
+        /**
+         * Returns middleware that parses all bodies as a string and only looks at requests
+         * where the Content-Type header matches the type option.
+         */
+        text(options?: OptionsText): NextHandleFunction;
+        /**
+         * Returns middleware that only parses urlencoded bodies and only looks at requests
+         * where the Content-Type header matches the type option
+         */
+        urlencoded(options?: OptionsUrlencoded): NextHandleFunction;
+    }
+
     interface Options {
         /** When set to true, then deflated (compressed) bodies will be inflated; when false, deflated bodies are rejected. Defaults to true. */
         inflate?: boolean | undefined;
@@ -77,28 +100,8 @@ declare namespace bodyParser {
          */
         parameterLimit?: number | undefined;
     }
-
-    /**
-     * Returns middleware that only parses json and only looks at requests
-     * where the Content-Type header matches the type option.
-     */
-    function json(options?: OptionsJson): NextHandleFunction;
-    /**
-     * Returns middleware that parses all bodies as a Buffer and only looks at requests
-     * where the Content-Type header matches the type option.
-     */
-    function raw(options?: Options): NextHandleFunction;
-
-    /**
-     * Returns middleware that parses all bodies as a string and only looks at requests
-     * where the Content-Type header matches the type option.
-     */
-    function text(options?: OptionsText): NextHandleFunction;
-    /**
-     * Returns middleware that only parses urlencoded bodies and only looks at requests
-     * where the Content-Type header matches the type option
-     */
-    function urlencoded(options?: OptionsUrlencoded): NextHandleFunction;
 }
+
+declare const bodyParser: bodyParser.BodyParser;
 
 export = bodyParser;


### PR DESCRIPTION
This change should solve recurring problem with users trying to remove
deprecation warning. The change should properly show deprecation only
when module is used directly as func, instead of when used as namespaced
import, etc.

see #52314, #57167

/cc @patelnets

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).