### PR TITLE
yargs: Add Argv.showVersion type to yargs v17

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -560,6 +560,12 @@ declare namespace yargs {
          */
         showHelpOnFail(enable: boolean, message?: string): Argv<T>;
 
+        /**
+         * Print the version data using the console function consoleLevel or the specified function.
+         * @param [level='error']
+         */
+        showVersion(level?: 'error' | 'log' | ((message: string) => void)): Argv<T>;
+
         /** Specifies either a single option key (string), or an array of options. If any of the options is present, yargs validation is skipped. */
         skipValidation(key: string | ReadonlyArray<string>): Argv<T>;
 

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -559,6 +559,20 @@ function Argv$version() {
         .version(false);
 }
 
+function Argv$showVersion() {
+    const argv1 = yargs
+        .showVersion();
+
+    const argv2 = yargs
+        .showVersion('error');
+
+    const argv3 = yargs
+        .showVersion('log');
+
+    const argv4 = yargs
+        .showVersion(s => console.log(`Thar be a version! ${s}`));
+}
+
 function Argv$wrap() {
     const argv1 = yargs
         .wrap(null);


### PR DESCRIPTION
Fixes #57145.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). -> Running prettier on `index.d.ts` and `yargs-tests.ts` generated a large changeset, so I skipped it.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://yargs.js.org/docs/#api-reference-showversionconsolelevel-printcallback
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -> N/A
