### PR TITLE
[lucene] Add missing properties and fix property types in AST interface

### DIFF
--- a/types/lucene/index.d.ts
+++ b/types/lucene/index.d.ts
@@ -44,12 +44,17 @@ export type Node =
 
 export type Operator = '<implicit>' | 'NOT' | 'OR' | 'AND' | 'AND NOT' | 'OR NOT';
 
-export interface LeftOnlyAST {
+export interface ASTField {
+    field?: string;
+    parenthesized?: boolean;
+}
+
+export interface LeftOnlyAST extends ASTField {
     left: Node;
     start?: Operator;
 }
 
-export interface BinaryAST {
+export interface BinaryAST extends ASTField {
     left: AST | Node;
     operator: Operator;
     right: AST | Node;

--- a/types/lucene/index.d.ts
+++ b/types/lucene/index.d.ts
@@ -46,6 +46,10 @@ export type Operator = '<implicit>' | 'NOT' | 'OR' | 'AND' | 'AND NOT' | 'OR NOT
 
 export interface ASTField {
     field?: string;
+    fieldLocation?: null | {
+        end: TermLocation;
+        start: TermLocation;
+    };
     parenthesized?: boolean;
 }
 

--- a/types/lucene/index.d.ts
+++ b/types/lucene/index.d.ts
@@ -54,7 +54,7 @@ export interface ASTField {
 }
 
 export interface LeftOnlyAST extends ASTField {
-    left: Node;
+    left: AST | Node;
     start?: Operator | undefined;
 }
 

--- a/types/lucene/lucene-tests.ts
+++ b/types/lucene/lucene-tests.ts
@@ -5,6 +5,18 @@ lucene.parse(1); // $ExpectError
 
 lucene.toString(ast); // $ExpectType string
 
+if ('right' in ast) {
+    ast; // $ExpectType BinaryAST
+    ast.left; // $ExpectType AST | Node || LeftOnlyAST | BinaryAST | NodeTerm | NodeRangedTerm
+    ast.operator; // $ExpectType Operator
+    ast.right; // $ExpectType AST | Node || LeftOnlyAST | BinaryAST | NodeTerm | NodeRangedTerm
+} else {
+    ast; // $ExpectType LeftOnlyAST
+    ast.left; // $ExpectType AST | Node || LeftOnlyAST | BinaryAST | NodeTerm | NodeRangedTerm
+    ast.operator; // $ExpectError
+    ast.right; // $ExpectError
+}
+
 lucene.phrase.escape(''); // $ExpectType string
 lucene.phrase.escape(1); // $ExpectError
 


### PR DESCRIPTION
This PR includes and extends https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49174

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Parenthesized ASTs also have a [fieldLocation](https://github.com/bripkens/lucene/blob/f34a55b3387d760effda7f20d8833aad1b2af3e0/lib/lucene.grammar#L181)
  - [Left expression can be an AST](https://github.com/bripkens/lucene/blob/f34a55b3387d760effda7f20d8833aad1b2af3e0/lib/lucene.grammar#L26)
  - [Example on ASTExplorer](https://astexplorer.net/#/gist/1d01f60535fb7fe8fd10cf73b67e9685/latest) which covers both changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.