### PR TITLE
[jsts] Add precision.GeometryPrecisionReducer to typings

### DIFF
--- a/types/jsts/index.d.ts
+++ b/types/jsts/index.d.ts
@@ -29,35 +29,30 @@ declare namespace jsts {
     }
 
     namespace geom {
-
-
-
         /**
          * Specifies the precision model of the Coordinates in a Geometry. In other words, specifies the grid of allowable points for all Geometrys.
          * The makePrecise method allows rounding a coordinate to a "precise" value; that is, one whose precision is known exactly.
          *
          * Coordinates are assumed to be precise in geometries. That is, the coordinates are assumed to be rounded to the precision model given for the geometry. JTS input routines automatically round coordinates to the precision model before creating Geometries. All internal operations assume that coordinates are rounded to the precision model. Constructive methods (such as boolean operations) always round computed coordinates to the appropriate precision model.
-         * 
+         *
          * Currently one type of precision model are supported:
          *
          * FLOATING - represents full double precision floating point.
          * Coordinates are represented internally as Java double-precision values. Since Java uses the IEEE-754 floating point standard, this provides 53 bits of precision.
-         * 
+         *
          * JSTS methods currently do not handle inputs with different precision models.
          *
          */
         export class PrecisionModel {
-
-
             static FIXED: string;
             static FLOATING: string;
             static FLOATING_SINGLE: string;
 
             /**
-             * 
+             *
              * @param modelType
              */
-            constructor(modelType?: number|string);
+            constructor(modelType?: number | string);
         }
 
         /**
@@ -71,12 +66,10 @@ declare namespace jsts {
          * It is assumed that input Coordinates meet the given precision.
          */
         export class GeometryFactory {
-
             /**
              * Constructs a GeometryFactory that generates Geometries having a floating PrecisionModel and a spatial-reference ID of 0.
              */
             constructor(precisionModel?: PrecisionModel);
-
 
             /**
              * Creates a LineString using the given Coordinates; a null or empty array will
@@ -98,27 +91,25 @@ declare namespace jsts {
              */
             createPoint(coordinates: Coordinate): Point;
             /**
-            * Creates a LinearRing using the given Coordinates; a null or empty array
-            * will create an empty LinearRing. Consecutive points must not be equal.
-            *
-            * @param {Coordinate[]}
-            *          coordinates an array without null elements, or an empty array,
-            * or null.
-            * @return {LineString} A new LinearRing.
-            */
+             * Creates a LinearRing using the given Coordinates; a null or empty array
+             * will create an empty LinearRing. Consecutive points must not be equal.
+             *
+             * @param {Coordinate[]}
+             *          coordinates an array without null elements, or an empty array,
+             * or null.
+             * @return {LineString} A new LinearRing.
+             */
             createLinearRing(coordinates: Array<Coordinate>): LinearRing;
             /**
-            * Creates a Polygon using the given LinearRing.
-            *
-            * @param {LinearRing} A LinearRing constructed by coordinates.
-            * @return {Polygon} A new Polygon.
-            */
-            createPolygon(shell: LinearRing, holes: Array<LinearRing>): Polygon;            
-
+             * Creates a Polygon using the given LinearRing.
+             *
+             * @param {LinearRing} A LinearRing constructed by coordinates.
+             * @return {Polygon} A new Polygon.
+             */
+            createPolygon(shell: LinearRing, holes: Array<LinearRing>): Polygon;
         }
 
         export class GeometryCollection extends jsts.geom.Geometry {
-
             constructor(geometries?: Array<Geometry>, factory?: GeometryFactory);
         }
 
@@ -639,8 +630,8 @@ declare namespace jsts {
             constructor(factory?: any);
 
             /**
-            * The bounding box of this <code>Geometry</code>.
-            */
+             * The bounding box of this <code>Geometry</code>.
+             */
             envelope: Envelope;
 
             /**
@@ -1601,15 +1592,9 @@ declare namespace jsts {
         }
 
         export class IntersectionMatrix {
-            static matches(
-                actualDimensionValue: number,
-                requiredDimensionSymbol: string
-            ): boolean;
+            static matches(actualDimensionValue: number, requiredDimensionSymbol: string): boolean;
 
-            static matches(
-                actualDimensionSymbols: string,
-                requiredDimensionSymbols: string
-            ): boolean;
+            static matches(actualDimensionSymbols: string, requiredDimensionSymbols: string): boolean;
 
             static isTrue(actualDimensionValue: number): boolean;
 
@@ -1629,28 +1614,15 @@ declare namespace jsts {
 
             setAtLeast(row: number, col: number, dimensionValue: number): void;
 
-            setAtLeastIfValid(
-                row: number,
-                col: number,
-                minimumDimensionValue: number
-            ): void;
+            setAtLeastIfValid(row: number, col: number, minimumDimensionValue: number): void;
 
             isWithin(): boolean;
 
-            isTouches(
-                dimensionOfGeometryA: number,
-                dimensionOfGeometryB: number
-            ): boolean;
+            isTouches(dimensionOfGeometryA: number, dimensionOfGeometryB: number): boolean;
 
-            isOverlaps(
-                dimensionOfGeometryA: number,
-                dimensionOfGeometryB: number
-            ): boolean;
+            isOverlaps(dimensionOfGeometryA: number, dimensionOfGeometryB: number): boolean;
 
-            isEquals(
-                dimensionOfGeometryA: number,
-                dimensionOfGeometryB: number
-            ): boolean;
+            isEquals(dimensionOfGeometryA: number, dimensionOfGeometryB: number): boolean;
 
             toString(): string;
 
@@ -1661,27 +1633,14 @@ declare namespace jsts {
             transpose(): IntersectionMatrix;
 
             matches(
-                requiredDimensionSymbols: [
-                    string,
-                    string,
-                    string,
-                    string,
-                    string,
-                    string,
-                    string,
-                    string,
-                    string
-                ]
+                requiredDimensionSymbols: [string, string, string, string, string, string, string, string, string],
             ): boolean;
 
             add(im: IntersectionMatrix): void;
 
             isDisjoint(): boolean;
 
-            isCrosses(
-                dimensionOfGeometryA: number,
-                dimensionOfGeometryB: number
-            ): boolean;
+            isCrosses(dimensionOfGeometryA: number, dimensionOfGeometryB: number): boolean;
 
             constructor(elements?: string[]);
 
@@ -1698,8 +1657,7 @@ declare namespace jsts {
          * must be equal (in 2D). If these conditions are not met, the constructors
          * throw an {@link IllegalArgumentException}
          */
-        export class LinearRing extends LineString {
-        }
+        export class LinearRing extends LineString {}
 
         export class LineString extends Geometry {
             /**
@@ -1813,51 +1771,21 @@ declare namespace jsts {
             export class AffineTransformation {
                 static translationInstance(x: number, y: number): AffineTransformation;
 
-                static shearInstance(
-                    xShear: number,
-                    yShear: number
-                ): AffineTransformation;
+                static shearInstance(xShear: number, yShear: number): AffineTransformation;
 
-                static reflectionInstance(
-                    x0: number,
-                    y0: number,
-                    x1?: number,
-                    y1?: number
-                ): AffineTransformation;
+                static reflectionInstance(x0: number, y0: number, x1?: number, y1?: number): AffineTransformation;
 
                 static rotationInstance(theta: number): AffineTransformation;
 
-                static rotationInstance(
-                    sinTheta: number,
-                    cosTheta: number
-                ): AffineTransformation;
+                static rotationInstance(sinTheta: number, cosTheta: number): AffineTransformation;
 
-                static rotationInstance(
-                    theta: number,
-                    x: number,
-                    y: number
-                ): AffineTransformation;
+                static rotationInstance(theta: number, x: number, y: number): AffineTransformation;
 
-                static rotationInstance(
-                    sinTheta: number,
-                    cosTheta: number,
-                    x: number,
-                    y: number
-                ): AffineTransformation;
+                static rotationInstance(sinTheta: number, cosTheta: number, x: number, y: number): AffineTransformation;
 
-                static scaleInstance(
-                    xScale: number,
-                    yScale: number,
-                    x?: number,
-                    y?: number
-                ): AffineTransformation;
+                static scaleInstance(xScale: number, yScale: number, x?: number, y?: number): AffineTransformation;
 
-                setToReflectionBasic(
-                    x0: number,
-                    y0: number,
-                    x1: number,
-                    y1: number
-                ): AffineTransformation;
+                setToReflectionBasic(x0: number, y0: number, x1: number, y1: number): AffineTransformation;
 
                 getInverse(): AffineTransformation;
 
@@ -1883,25 +1811,16 @@ declare namespace jsts {
                     m02: number,
                     m10: number,
                     m11: number,
-                    m12: number
+                    m12: number,
                 ): AffineTransformation;
 
                 setToRotation(theta: number): AffineTransformation;
 
                 setToRotation(sinTheta: number, cosTheta: number): AffineTransformation;
 
-                setToRotation(
-                    theta: number,
-                    x: number,
-                    y: number
-                ): AffineTransformation;
+                setToRotation(theta: number, x: number, y: number): AffineTransformation;
 
-                setToRotation(
-                    sinTheta: number,
-                    cosTheta: number,
-                    x: number,
-                    y: number
-                ): AffineTransformation;
+                setToRotation(sinTheta: number, cosTheta: number, x: number, y: number): AffineTransformation;
 
                 getMatrixEntries(): [number, number, number, number, number, number];
 
@@ -1913,12 +1832,7 @@ declare namespace jsts {
 
                 rotate(theta: number, x: number, y: number): AffineTransformation;
 
-                rotate(
-                    sinTheta: number,
-                    cosTheta: number,
-                    x: number,
-                    y: number
-                ): AffineTransformation;
+                rotate(sinTheta: number, cosTheta: number, x: number, y: number): AffineTransformation;
 
                 getDeterminant(): number;
 
@@ -1934,12 +1848,7 @@ declare namespace jsts {
 
                 setToReflection(x: number, y: number): AffineTransformation;
 
-                setToReflection(
-                    x0: number,
-                    y0: number,
-                    x1: number,
-                    y1: number
-                ): AffineTransformation;
+                setToReflection(x0: number, y0: number, x1: number, y1: number): AffineTransformation;
 
                 toString(): string;
 
@@ -1953,23 +1862,11 @@ declare namespace jsts {
 
                 transform(seq: CoordinateSequence, i: number): void;
 
-                reflect(
-                    x0: number,
-                    y0: number,
-                    x1?: number,
-                    y1?: number
-                ): AffineTransformation;
+                reflect(x0: number, y0: number, x1?: number, y1?: number): AffineTransformation;
 
                 constructor(trans?: AffineTransformation);
 
-                constructor(
-                    m00: number,
-                    m01: number,
-                    m02: number,
-                    m10: number,
-                    m11: number,
-                    m12: number
-                );
+                constructor(m00: number, m01: number, m02: number, m10: number, m11: number, m12: number);
 
                 constructor(
                     src0: Coordinate,
@@ -1977,7 +1874,7 @@ declare namespace jsts {
                     src2: Coordinate,
                     dest0: Coordinate,
                     dest1: Coordinate,
-                    dest2: Coordinate
+                    dest2: Coordinate,
                 );
             }
         }
@@ -2139,10 +2036,7 @@ declare namespace jsts {
              *    (positive is to the left, negative is to the right)
              * @return {jsts.geom.Coordinate} the point at that distance and offset
              */
-            pointAlongOffset(
-                segmentLengthFraction: number,
-                offsetDistance: number
-            ): Coordinate;
+            pointAlongOffset(segmentLengthFraction: number, offsetDistance: number): Coordinate;
 
             /**
              * Computes the Projection Factor for the projection of the point p onto this
@@ -2313,8 +2207,6 @@ declare namespace jsts {
     }
 
     namespace io {
-
-
         /**
          * OpenLayers 3 Geometry parser and writer
          */
@@ -2410,7 +2302,7 @@ declare namespace jsts {
              * @return {string} a <Geometry Tagged Text> string (see the OpenGIS Simple
              *         Features Specification).
              */
-             write(geometry: geom.Geometry): string;
+            write(geometry: geom.Geometry): string;
         }
     }
 
@@ -2426,11 +2318,7 @@ declare namespace jsts {
 
             constructor(g0: Geometry, g1?: Geometry);
 
-            constructor(
-                g0: Geometry,
-                g1: Geometry,
-                boundaryNodeRule: BoundaryNodeRule
-            );
+            constructor(g0: Geometry, g1: Geometry, boundaryNodeRule: BoundaryNodeRule);
         }
 
         namespace relate {
@@ -2446,11 +2334,7 @@ declare namespace jsts {
 
                 static equalsTopo(g1: Geometry, g2: Geometry): boolean;
 
-                static relate(
-                    g1: Geometry,
-                    g2: Geometry,
-                    boundaryNodeRule?: BoundaryNodeRule
-                ): IntersectionMatrix;
+                static relate(g1: Geometry, g2: Geometry, boundaryNodeRule?: BoundaryNodeRule): IntersectionMatrix;
 
                 static overlaps(g1: Geometry, g2: Geometry): boolean;
 
@@ -2460,14 +2344,10 @@ declare namespace jsts {
 
                 getIntersectionMatrix(): IntersectionMatrix;
 
-                constructor(
-                    g1: Geometry,
-                    g2: Geometry,
-                    boundaryNodeRule?: BoundaryNodeRule
-                );
+                constructor(g1: Geometry, g2: Geometry, boundaryNodeRule?: BoundaryNodeRule);
             }
         }
-          
+
         namespace buffer {
             import Geometry = jsts.geom.Geometry;
             import PrecisionModel = jsts.geom.PrecisionModel;
@@ -2528,12 +2408,7 @@ declare namespace jsts {
                  *
                  * @constructor
                  */
-                constructor(
-                    quadrantSegments?: number,
-                    endCapStyle?: number,
-                    joinStyle?: number,
-                    mitreLimit?: number
-                );
+                constructor(quadrantSegments?: number, endCapStyle?: number, joinStyle?: number, mitreLimit?: number);
 
                 /**
                  * Gets the number of quadrant segments which will be used
@@ -2743,11 +2618,7 @@ declare namespace jsts {
                  *
                  * @return {double} a scale factor for the buffer computation.
                  */
-                static precisionScaleFactor(
-                    g: Geometry,
-                    distance: number,
-                    maxPrecisionDigits: number
-                ): number;
+                static precisionScaleFactor(g: Geometry, distance: number, maxPrecisionDigits: number): number;
 
                 /**
                  * Computes the buffer of a geometry for a given buffer distance.
@@ -2773,11 +2644,7 @@ declare namespace jsts {
                  * @return {Geometry} the buffer of the input geometry.
                  *
                  */
-                static bufferOp2(
-                    g: Geometry,
-                    distance: number,
-                    params: BufferParameters
-                ): Geometry;
+                static bufferOp2(g: Geometry, distance: number, params: BufferParameters): Geometry;
 
                 /**
                  * Computes the buffer for a geometry for a given buffer distance and accuracy
@@ -2793,11 +2660,7 @@ declare namespace jsts {
                  * @return {Geometry} the buffer of the input geometry.
                  *
                  */
-                static bufferOp3(
-                    g: Geometry,
-                    distance: number,
-                    quadrantSegments: number
-                ): Geometry;
+                static bufferOp3(g: Geometry, distance: number, quadrantSegments: number): Geometry;
 
                 /**
                  * Computes the buffer for a geometry for a given buffer distance and accuracy
@@ -2819,7 +2682,7 @@ declare namespace jsts {
                     g: Geometry,
                     distance: number,
                     quadrantSegments: number,
-                    endCapStyle: number
+                    endCapStyle: number,
                 ): Geometry;
 
                 /**
@@ -2873,7 +2736,6 @@ declare namespace jsts {
          * ensuring that the result is topologically valid.
          */
         export class GeometryPrecisionReducer {
-          
             constructor(precisionModel: PrecisionModel);
 
             reduce(geom: Geometry): Geometry;
@@ -2882,10 +2744,10 @@ declare namespace jsts {
              * Convenience method for doing precision reduction on a single geometry,
              * with collapses removed and keeping the geometry precision model the same,
              * and preserving polygonal topology.
-             * 
+             *
              * @param g the geometry to reduce
              * @param precModel the precision model to use
-             * 
+             *
              * @returns the reduced geometry
              */
             static reduce(g: Geometry, precModel: PrecisionModel): Geometry;
@@ -2894,10 +2756,10 @@ declare namespace jsts {
              * Convenience method for doing pointwise precision reduction on a single geometry,
              * with collapses removed and keeping the geometry precision model the same,
              * but NOT preserving valid polygonal topology.
-             * 
+             *
              * @param g the geometry to reduce
              * @param precModel the precision model to use
-             * 
+             *
              * @returns the reduced geometry
              */
             static reducePointwise(g: Geometry, precModel: PrecisionModel): Geometry;
@@ -2906,7 +2768,7 @@ declare namespace jsts {
              * Sets whether the PrecisionModel of the new reduced Geometry will be changed
              * to be the PrecisionModel supplied to specify the precision reduction.
              * The default is to NOT change the precision model
-             * 
+             *
              * @param changePrecisionModel if true the precision model of the created Geometry
              * will be the the precisionModel supplied in the constructor.
              */
@@ -2917,7 +2779,7 @@ declare namespace jsts {
              * Pointwise precision reduction reduces the precision of the individual coordinates only,
              * but does not attempt to recreate valid topology.
              * This is only relevant for geometries containing polygonal components.
-             * 
+             *
              * @param isPointwise if reduction should be done pointwise only
              */
             setPointwise(isPointwise: boolean): void;
@@ -2926,7 +2788,7 @@ declare namespace jsts {
              * Sets whether the reduction will result in collapsed components being removed completely,
              * or simply being collapsed to an (invalid) Geometry of the same type.
              * The default is to remove collapsed components.
-             * 
+             *
              * @param removeCollapsed if true collapsed components will be removed
              */
             setRemoveCollapsedComponents(removeCollapsed: boolean): void;
@@ -2934,6 +2796,6 @@ declare namespace jsts {
     }
 }
 
-declare module "jsts" {
+declare module 'jsts' {
     export = jsts;
 }

--- a/types/jsts/index.d.ts
+++ b/types/jsts/index.d.ts
@@ -2863,6 +2863,75 @@ declare namespace jsts {
             }
         }
     }
+
+    namespace precision {
+        import Geometry = jsts.geom.Geometry;
+        import PrecisionModel = jsts.geom.PrecisionModel;
+
+        /**
+         * Reduces the precision of a Geometry according to the supplied PrecisionModel,
+         * ensuring that the result is topologically valid.
+         */
+        export class GeometryPrecisionReducer {
+          
+            constructor(precisionModel: PrecisionModel);
+
+            reduce(geom: Geometry): Geometry;
+
+            /**
+             * Convenience method for doing precision reduction on a single geometry,
+             * with collapses removed and keeping the geometry precision model the same,
+             * and preserving polygonal topology.
+             * 
+             * @param g the geometry to reduce
+             * @param precModel the precision model to use
+             * 
+             * @returns the reduced geometry
+             */
+            static reduce(g: Geometry, precModel: PrecisionModel): Geometry;
+
+            /**
+             * Convenience method for doing pointwise precision reduction on a single geometry,
+             * with collapses removed and keeping the geometry precision model the same,
+             * but NOT preserving valid polygonal topology.
+             * 
+             * @param g the geometry to reduce
+             * @param precModel the precision model to use
+             * 
+             * @returns the reduced geometry
+             */
+            static reducePointwise(g: Geometry, precModel: PrecisionModel): Geometry;
+
+            /**
+             * Sets whether the PrecisionModel of the new reduced Geometry will be changed
+             * to be the PrecisionModel supplied to specify the precision reduction.
+             * The default is to NOT change the precision model
+             * 
+             * @param changePrecisionModel if true the precision model of the created Geometry
+             * will be the the precisionModel supplied in the constructor.
+             */
+            setChangePrecisionModel(changePrecisionModel: boolean): void;
+
+            /**
+             * Sets whether the precision reduction will be done in pointwise fashion only.
+             * Pointwise precision reduction reduces the precision of the individual coordinates only,
+             * but does not attempt to recreate valid topology.
+             * This is only relevant for geometries containing polygonal components.
+             * 
+             * @param isPointwise if reduction should be done pointwise only
+             */
+            setPointwise(isPointwise: boolean): void;
+
+            /**
+             * Sets whether the reduction will result in collapsed components being removed completely,
+             * or simply being collapsed to an (invalid) Geometry of the same type.
+             * The default is to remove collapsed components.
+             * 
+             * @param removeCollapsed if true collapsed components will be removed
+             */
+            setRemoveCollapsedComponents(removeCollapsed: boolean): void;
+        }
+    }
 }
 
 declare module "jsts" {

--- a/types/jsts/jsts-tests.ts
+++ b/types/jsts/jsts-tests.ts
@@ -256,3 +256,11 @@ bool = jsts.operation.relate.RelateOp.overlaps(g, g);
 bool = jsts.operation.relate.RelateOp.crosses(g, g);
 bool = jsts.operation.relate.RelateOp.contains(g, g);
 im0 = ro0.getIntersectionMatrix();
+
+var pr = new jsts.precision.GeometryPrecisionReducer(precisionModel);
+g = pr.reduce(g);
+g = jsts.precision.GeometryPrecisionReducer.reduce(g, precisionModel);
+g = jsts.precision.GeometryPrecisionReducer.reducePointwise(g, precisionModel);
+pr.setChangePrecisionModel(bool);
+pr.setPointwise(bool);
+pr.setRemoveCollapsedComponents(bool);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [GeometryPrecisionReducer doc](https://locationtech.github.io/jts/javadoc-1.17.0/org/locationtech/jts/precision/GeometryPrecisionReducer.html)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I ran prettier on the index.d.ts file and it resulted in quite a few changes, it's in a separate commit to avoid obscuring the actual changes.