### PR TITLE
[ramda] Update slice type

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1777,12 +1777,12 @@ export function set<S, A>(lens: Lens<S, A>): (a: A, obj: S) => S;
 export function slice(a: number, b: number, list: string): string;
 export function slice<T>(a: number, b: number, list: readonly T[]): T[];
 export function slice(a: number, b: number): {
-    (list: string): string;
     <T>(list: readonly T[]): T[];
+    (list: string): string;
 };
 export function slice(a: number): {
-    (b: number, list: string): string;
     <T>(b: number, list: readonly T[]): T[];
+    (b: number, list: string): string;
 };
 
 /**

--- a/types/ramda/test/slice-tests.ts
+++ b/types/ramda/test/slice-tests.ts
@@ -10,4 +10,30 @@ import * as R from 'ramda';
   R.slice(2, 5, str); // => 'llo'
   R.slice(2, 5)(str); // => 'llo'
   R.slice(2)(5, str); // => 'llo'
+  console.log('str : ', str);
+};
+
+() => {
+  // make type inference work well
+  const str = 'Hello World';
+
+  // $ExpectType string
+  R.pipe(
+    R.slice(2, 5)
+  )(str);
+
+  // $ExpectType string[]
+  R.pipe(
+    (str: string[]) => R.slice(2, 5)(str)
+  )([str, str]);
+
+  // $ExpectType string
+  R.pipe(
+    R.slice(2)
+  )(5, str);
+
+  // $ExpectType string[]
+  R.pipe(
+    (b: number, str: string[]) => R.slice(2)(b, str)
+  )(5, [str, str]);
 };

--- a/types/ramda/test/slice-tests.ts
+++ b/types/ramda/test/slice-tests.ts
@@ -13,26 +13,55 @@ import * as R from 'ramda';
 };
 
 () => {
+  // check generic type works
+  interface A {
+    text: string;
+  }
+
+  const arr: A[] = [
+    { text : 'one' },
+    { text : 'two' },
+    { text : 'three' },
+    { text : 'four' },
+  ];
+
+  const sliceFromSecondToThird = R.slice(1, 3);
+
+  sliceFromSecondToThird<A>(arr); // => [ { text: 'two' }, { text: 'three' } ]
+
+  // $ExpectError
+  sliceFromSecondToThird<string>(arr);
+
+  const sliceFromSecondTo = R.slice(1);
+
+  sliceFromSecondTo<A>(3, arr);  // => [ { text: 'two' }, { text: 'three' } ]
+
+  // $ExpectError
+  sliceFromSecondTo<string>(3, arr);
+};
+
+() => {
   // make type inference work well
   const str = 'Hello World';
+  const arr = ['one', 'two', 'three', 'four', 'five'];
 
   // $ExpectType string
   R.pipe(
     R.slice(2, 5)
-  )(str);
+  )(str); // => 'llo'
 
   // $ExpectType string[]
   R.pipe(
     (str: string[]) => R.slice(2, 5)(str)
-  )([str, str]);
+  )(arr); // => ['three', 'four', 'five']
 
   // $ExpectType string
   R.pipe(
     R.slice(2)
-  )(5, str);
+  )(5, str); // => 'llo'
 
   // $ExpectType string[]
   R.pipe(
     (b: number, str: string[]) => R.slice(2)(b, str)
-  )(5, [str, str]);
+  )(5, arr);  // => ['three', 'four', 'five']
 };

--- a/types/ramda/test/slice-tests.ts
+++ b/types/ramda/test/slice-tests.ts
@@ -10,7 +10,6 @@ import * as R from 'ramda';
   R.slice(2, 5, str); // => 'llo'
   R.slice(2, 5)(str); // => 'llo'
   R.slice(2)(5, str); // => 'llo'
-  console.log('str : ', str);
 };
 
 () => {


### PR DESCRIPTION
I'm trying to use slice like this code.
```ts
import { pipe, slice } from 'ramda';

// slice => (list: string): string;
function testMethod1(text: string) {
  return pipe(
    slice(0, 7)
  )(text);
  // Error : Argument of type 'string' is not assignable to parameter of type 'readonly unknown[]'.ts(2345)
}

// slice => <T>(list: readonly T[]): T[];
function testMethod2(texts: string[]) {
  const sliceMethod = slice(0, 7)

  return pipe(
    (texts: string[]) => sliceMethod<string>(texts),
  )(texts);
}
```
I get ts(2345) error because type of slice inside `testMethod1` trying to use `<T>(list: readonly T[]): T[];` instead of `(list: string): string;`.
Above error is gone when I change `<T>(list: readonly T[]): T[];` type to precde `(list: string): string;` type.
(It seems that the order of types affects type inferring)


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
