### PR TITLE
[@types/async] Added return types to iterator

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -29,6 +29,7 @@ export interface AsyncFunctionEx<T, E = Error> { (callback: (err?: E | null, ...
 export interface AsyncIterator<T, E = Error> { (item: T, callback: ErrorCallback<E>): void; }
 export interface AsyncForEachOfIterator<T, E = Error> { (item: T, key: number|string, callback: ErrorCallback<E>): void; }
 export interface AsyncResultIterator<T, R, E = Error> { (item: T, callback: AsyncResultCallback<R, E>): void; }
+export interface AsyncResultIteratorPromise<T, R> { (item: T): Promise<R>; }
 export interface AsyncMemoIterator<T, R, E = Error> { (memo: R | undefined, item: T, callback: AsyncResultCallback<R, E>): void; }
 export interface AsyncBooleanIterator<T, E = Error> { (item: T, callback: AsyncBooleanResultCallback<E>): void; }
 
@@ -246,10 +247,10 @@ export const eachOf: typeof forEachOf;
 export const eachOfSeries: typeof forEachOf;
 export const eachOfLimit: typeof forEachOfLimit;
 export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIterator<T, R, E>, callback: AsyncResultArrayCallback<R, E>): void;
-export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIterator<T, R, E>): Promise<R[]>;
+export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIteratorPromise<T, R>): Promise<R[]>;
 export const mapSeries: typeof map;
 export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIterator<T, R, E>, callback: AsyncResultArrayCallback<R, E>): void;
-export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIterator<T, R, E>): Promise<R[]>;
+export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIteratorPromise<T, R>): Promise<R[]>;
 
 export function mapValuesLimit<T, R, E = Error>(
     obj: Dictionary<T>,
@@ -415,10 +416,10 @@ export function timeout<T, E = Error>(fn: AsyncFunction<T, E>, milliseconds: num
 export function timeout<T, R, E = Error>(fn: AsyncResultIterator<T, R, E>, milliseconds: number, info?: any): AsyncResultIterator<T, R, E>;
 
 export function times<T, E = Error>(n: number, iterator: AsyncResultIterator<number, T, E>, callback: AsyncResultArrayCallback<T, E>): void;
-export function times<T, E = Error>(n: number, iterator: AsyncResultIterator<number, T, E>): Promise<T>;
+export function times<T, E = Error>(n: number, iterator: AsyncResultIteratorPromise<number, T>): Promise<T>;
 export const timesSeries: typeof times;
 export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIterator<number, T, E>, callback: AsyncResultArrayCallback<T, E>): void;
-export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIterator<number, T, E>): Promise<T>;
+export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIteratorPromise<number, T>): Promise<T>;
 
 export function transform<T, R, E = Error>(arr: T[], iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void, callback?: AsyncResultArrayCallback<T, E>): void;
 export function transform<T, R, E = Error>(arr: T[], acc: R[], iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void, callback?: AsyncResultArrayCallback<T, E>): void;

--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -246,11 +246,26 @@ export function forEachOfLimit<T, E = Error>(obj: IterableCollection<T>, limit: 
 export const eachOf: typeof forEachOf;
 export const eachOfSeries: typeof forEachOf;
 export const eachOfLimit: typeof forEachOfLimit;
-export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>), callback: AsyncResultArrayCallback<R, E>): void;
-export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>)): Promise<R[]>;
+export function map<T, R, E = Error>(
+    arr: T[] | IterableIterator<T> | Dictionary<T>,
+    iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>),
+    callback: AsyncResultArrayCallback<R, E>
+    ): void;
+export function map<T, R, E = Error>(
+    arr: T[] | IterableIterator<T> | Dictionary<T>,
+    iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>)
+    ): Promise<R[]>;
+
 export const mapSeries: typeof map;
-export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>), callback: AsyncResultArrayCallback<R, E>): void;
-export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>)): Promise<R[]>;
+export function mapLimit<T, R, E = Error>(
+    arr: IterableCollection<T>,
+    limit: number, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>),
+    callback: AsyncResultArrayCallback<R, E>
+    ): void;
+export function mapLimit<T, R, E = Error>(
+    arr: IterableCollection<T>,
+    limit: number, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>)
+    ): Promise<R[]>;
 
 export function mapValuesLimit<T, R, E = Error>(
     obj: Dictionary<T>,
@@ -419,8 +434,17 @@ export function times<T, E = Error>(n: number, iterator: (AsyncResultIterator<nu
 export function times<T, E = Error>(n: number, iterator: (AsyncResultIterator<number, T, E> | AsyncResultIteratorPromise<number, T>)): Promise<T>;
 
 export const timesSeries: typeof times;
-export function timesLimit<T, E = Error>(n: number, limit: number, iterator: (AsyncResultIterator<number, T, E> | AsyncResultIteratorPromise<number, T>), callback: AsyncResultArrayCallback<T, E>): void;
-export function timesLimit<T, E = Error>(n: number, limit: number, iterator: (AsyncResultIterator<number, T, E> | AsyncResultIteratorPromise<number, T>)): Promise<T>;
+export function timesLimit<T, E = Error>(
+    n: number,
+    limit: number,
+    iterator: (AsyncResultIterator<number, T, E> | AsyncResultIteratorPromise<number, T>),
+    callback: AsyncResultArrayCallback<T, E>
+    ): void;
+export function timesLimit<T, E = Error>(
+    n: number,
+    limit: number,
+    iterator: (AsyncResultIterator<number, T, E> | AsyncResultIteratorPromise<number, T>)
+    ): Promise<T>;
 
 export function transform<T, R, E = Error>(arr: T[], iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void, callback?: AsyncResultArrayCallback<T, E>): void;
 export function transform<T, R, E = Error>(arr: T[], acc: R[], iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void, callback?: AsyncResultArrayCallback<T, E>): void;

--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -246,15 +246,11 @@ export function forEachOfLimit<T, E = Error>(obj: IterableCollection<T>, limit: 
 export const eachOf: typeof forEachOf;
 export const eachOfSeries: typeof forEachOf;
 export const eachOfLimit: typeof forEachOfLimit;
-export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIterator<T, R, E>, callback: AsyncResultArrayCallback<R, E>): void
-export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIterator<T, R, E>): Promise<R[]>
-export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIteratorPromise<T, R>, callback: AsyncResultArrayCallback<R, E>): void
-export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIteratorPromise<T, R>): Promise<R[]>
+export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>), callback: AsyncResultArrayCallback<R, E>): void;
+export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>)): Promise<R[]>;
 export const mapSeries: typeof map;
-export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIterator<T, R, E>, callback: AsyncResultArrayCallback<R, E>): void
-export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIterator<T, R, E>): Promise<R[]>
-export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIteratorPromise<T, R>, callback: AsyncResultArrayCallback<R, E>): void
-export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIteratorPromise<T, R>): Promise<R[]>
+export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>), callback: AsyncResultArrayCallback<R, E>): void;
+export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>)): Promise<R[]>;
 
 export function mapValuesLimit<T, R, E = Error>(
     obj: Dictionary<T>,
@@ -419,16 +415,12 @@ export function reflectAll<T, E = Error>(tasks: Array<AsyncFunction<T, E>>): Arr
 export function timeout<T, E = Error>(fn: AsyncFunction<T, E>, milliseconds: number, info?: any): AsyncFunction<T, E>;
 export function timeout<T, R, E = Error>(fn: AsyncResultIterator<T, R, E>, milliseconds: number, info?: any): AsyncResultIterator<T, R, E>;
 
-export function times<T, E = Error>(n: number, iterator: AsyncResultIterator<number, T, E>, callback: AsyncResultArrayCallback<T, E>): void;
-export function times<T, E = Error>(n: number, iterator: AsyncResultIterator<number, T, E>): Promise<T>;
-export function times<T, E = Error>(n: number, iterator: AsyncResultIteratorPromise<number, T>, callback: AsyncResultArrayCallback<T, E>): void;
-export function times<T, E = Error>(n: number, iterator: AsyncResultIteratorPromise<number, T>): Promise<T>;
+export function times<T, E = Error>(n: number, iterator: (AsyncResultIterator<number, T, E> | AsyncResultIteratorPromise<number, T>), callback: AsyncResultArrayCallback<T, E>): void;
+export function times<T, E = Error>(n: number, iterator: (AsyncResultIterator<number, T, E> | AsyncResultIteratorPromise<number, T>)): Promise<T>;
 
 export const timesSeries: typeof times;
-export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIterator<number, T, E>, callback: AsyncResultArrayCallback<T, E>): void;
-export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIterator<number, T, E>): Promise<T>;
-export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIteratorPromise<number, T>, callback: AsyncResultArrayCallback<T, E>): void;
-export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIteratorPromise<number, T>): Promise<T>;
+export function timesLimit<T, E = Error>(n: number, limit: number, iterator: (AsyncResultIterator<number, T, E> | AsyncResultIteratorPromise<number, T>), callback: AsyncResultArrayCallback<T, E>): void;
+export function timesLimit<T, E = Error>(n: number, limit: number, iterator: (AsyncResultIterator<number, T, E> | AsyncResultIteratorPromise<number, T>)): Promise<T>;
 
 export function transform<T, R, E = Error>(arr: T[], iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void, callback?: AsyncResultArrayCallback<T, E>): void;
 export function transform<T, R, E = Error>(arr: T[], acc: R[], iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void, callback?: AsyncResultArrayCallback<T, E>): void;

--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -246,11 +246,15 @@ export function forEachOfLimit<T, E = Error>(obj: IterableCollection<T>, limit: 
 export const eachOf: typeof forEachOf;
 export const eachOfSeries: typeof forEachOf;
 export const eachOfLimit: typeof forEachOfLimit;
-export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIterator<T, R, E>, callback: AsyncResultArrayCallback<R, E>): void;
-export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIteratorPromise<T, R>): Promise<R[]>;
+export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIterator<T, R, E>, callback: AsyncResultArrayCallback<R, E>): void
+export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIterator<T, R, E>): Promise<R[]>
+export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIteratorPromise<T, R>, callback: AsyncResultArrayCallback<R, E>): void
+export function map<T, R, E = Error>(arr: T[] | IterableIterator<T> | Dictionary<T>, iterator: AsyncResultIteratorPromise<T, R>): Promise<R[]>
 export const mapSeries: typeof map;
-export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIterator<T, R, E>, callback: AsyncResultArrayCallback<R, E>): void;
-export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIteratorPromise<T, R>): Promise<R[]>;
+export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIterator<T, R, E>, callback: AsyncResultArrayCallback<R, E>): void
+export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIterator<T, R, E>): Promise<R[]>
+export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIteratorPromise<T, R>, callback: AsyncResultArrayCallback<R, E>): void
+export function mapLimit<T, R, E = Error>(arr: IterableCollection<T>, limit: number, iterator: AsyncResultIteratorPromise<T, R>): Promise<R[]>
 
 export function mapValuesLimit<T, R, E = Error>(
     obj: Dictionary<T>,
@@ -416,9 +420,14 @@ export function timeout<T, E = Error>(fn: AsyncFunction<T, E>, milliseconds: num
 export function timeout<T, R, E = Error>(fn: AsyncResultIterator<T, R, E>, milliseconds: number, info?: any): AsyncResultIterator<T, R, E>;
 
 export function times<T, E = Error>(n: number, iterator: AsyncResultIterator<number, T, E>, callback: AsyncResultArrayCallback<T, E>): void;
+export function times<T, E = Error>(n: number, iterator: AsyncResultIterator<number, T, E>): Promise<T>;
+export function times<T, E = Error>(n: number, iterator: AsyncResultIteratorPromise<number, T>, callback: AsyncResultArrayCallback<T, E>): void;
 export function times<T, E = Error>(n: number, iterator: AsyncResultIteratorPromise<number, T>): Promise<T>;
+
 export const timesSeries: typeof times;
 export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIterator<number, T, E>, callback: AsyncResultArrayCallback<T, E>): void;
+export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIterator<number, T, E>): Promise<T>;
+export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIteratorPromise<number, T>, callback: AsyncResultArrayCallback<T, E>): void;
 export function timesLimit<T, E = Error>(n: number, limit: number, iterator: AsyncResultIteratorPromise<number, T>): Promise<T>;
 
 export function transform<T, R, E = Error>(arr: T[], iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void, callback?: AsyncResultArrayCallback<T, E>): void;

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -552,15 +552,15 @@ async function promiseTest() {
                 setTimeout(
                     () => {
                         console.log(`async.map: ${val}`);
-                        resolve(val.toString())
+                        resolve(val.toString());
                     },
                     500);
-            })
+            });
         }
     );
     console.log("async.map promise: done with results", promiseMap);
 }
-promiseTest()
+promiseTest();
 
 async.mapSeries<number, string>(
     { a: 1, b: 2, c: 3 },

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -544,6 +544,24 @@ async.map<number, string>(
     (err: Error, results: string[]) => { console.log("async.map: done with results", results); }
 );
 
+async function promiseTest() {
+    const promiseMap = await async.map<number, string>(
+        { a: 1, b: 2, c: 3 },
+        async (val: number) => {
+            return new Promise<string>((resolve, reject) => {
+                setTimeout(
+                    () => {
+                        console.log(`async.map: ${val}`);
+                        resolve(val.toString())
+                    },
+                    500);
+            })
+        }
+    );
+    console.log("async.map promise: done with results", promiseMap);
+}
+promiseTest()
+
 async.mapSeries<number, string>(
     { a: 1, b: 2, c: 3 },
     (val: number, next: AsyncResultCallback<string>) => {


### PR DESCRIPTION
Returns types of results generated from functions `map`, `mapSeries` like native `map` function, instead of type `unknown`, which requires explicitly declaring types for results for later use.

### Example:
#### Before:
![image](https://user-images.githubusercontent.com/5325408/142052212-67ee20b6-dad3-4b6d-854a-c56b93a48fce.png)

#### After:
![image](https://user-images.githubusercontent.com/5325408/142052054-60f989a4-dca5-4442-a02a-b684d04ae4a8.png)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

Original package doesn't have type declarations but this pr is based on the `Array.map` function:

![image](https://user-images.githubusercontent.com/5325408/142052664-b088db01-b8a5-49b9-b02e-e0faa485f994.png)