### PR TITLE
Add an export map and esm entrypoint for uuid

### DIFF
--- a/types/uuid/OTHER_FILES.txt
+++ b/types/uuid/OTHER_FILES.txt
@@ -1,0 +1,1 @@
+index.d.mts

--- a/types/uuid/index.d.mts
+++ b/types/uuid/index.d.mts
@@ -1,0 +1,1 @@
+export * from "./index.js"

--- a/types/uuid/index.d.mts
+++ b/types/uuid/index.d.mts
@@ -1,1 +1,10 @@
-export * from "./index.js"
+import uuid from './index.js';
+export import v1 = uuid.v1;
+export import v3 = uuid.v3;
+export import v4 = uuid.v4;
+export import v5 = uuid.v5;
+export import NIL = uuid.NIL;
+export import version = uuid.version;
+export import validate = uuid.validate;
+export import stringify = uuid.stringify;
+export import parse = uuid.parse;

--- a/types/uuid/package.json
+++ b/types/uuid/package.json
@@ -1,0 +1,10 @@
+{
+    "exports": {
+        ".": {
+            "types": {
+                "module": "./index.d.mts",
+                "default": "./index.d.ts"
+            }
+        }
+    }
+}

--- a/types/uuid/package.json
+++ b/types/uuid/package.json
@@ -1,4 +1,5 @@
 {
+    "private": true,
     "exports": {
         ".": {
             "types": {


### PR DESCRIPTION
Per [uuid](https://github.com/uuidjs/uuid/blob/main/package.json#L21)'s export map, which exposed an esm wrapper for the cjs entrypoint. 
