### PR TITLE
types/mixpanel-browser: Add send_immediately option

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for mixpanel-browser 2.35
+// Type definitions for mixpanel-browser 2.36
 // Project: https://github.com/mixpanel/mixpanel-js
 // Definitions by: Carlos López <https://github.com/karlos1337>
 //                 Ricardo Rodrigues <https://github.com/RicardoRodrigues>
 //                 Kristian Randall <https://github.com/randak>
 //                 Dan Wilt <https://github.com/dwilt>
 //                 Lee Dogeon <https://github.com/moreal>
+//                 Justin Helmer <https://github.com/justinhelmer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -20,6 +21,7 @@ export interface Dict {
 
 export interface RequestOptions {
     transport?: 'xhr' | 'sendBeacon' | undefined;
+    send_immediately?: boolean | undefined;
 }
 
 export interface XhrHeadersDef {

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -15,6 +15,7 @@ mixpanel.track_forms('#register', 'Created Account');
 mixpanel.time_event('Registered');
 mixpanel.track('Registered', { Gender: 'Male', Age: 21 });
 mixpanel.track('Left page', { duration_seconds: 35 }, { transport: 'sendBeacon' });
+mixpanel.track('Left page', { duration_seconds: 35 }, { send_immediately: true });
 mixpanel.track('Left page', { duration_seconds: 35 }, () => {
     /* callback function */
 });


### PR DESCRIPTION
**Checklist**
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[url here](https://github.com/mixpanel/mixpanel-js/compare/v2.35.0...v2.36.0#diff-7ee347fb24b1a0fafa61ea847381bcbaf393aa64f90e2c28aa99c56ae08b2ce8R6928)>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

**Other notes**
- This change is particularly timely because a new release came out [4 days ago](https://github.com/mixpanel/mixpanel-js/releases/tag/v2.42.0) that changes the batching behavior to enabled by default.
- When the batch behavior is enabled, track() behaves differently (i.e. the callback is fired synchronously instead of asynchronously, and before the actual tracking event completes).
- Any code that relies on track() only executing after the event request is completed will now break.
- By using send_immedately=true (which was added in [v2.36.0](https://github.com/mixpanel/mixpanel-js/compare/v2.35.0...v2.36.0#diff-7ee347fb24b1a0fafa61ea847381bcbaf393aa64f90e2c28aa99c56ae08b2ce8R6928)), the behavior reverts to track() only completing after the event request completes.
- I bumped the version to 2.36, because the send_immediately option did not appear in 2.35. However this does not necessarily mean that all the other types are updated to 2.36. The intention of this PR is just to add support for send_immediately.