### PR TITLE
Update react-native-auth0 authorize types in 2.10.0

### DIFF
--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native-auth0 2.5
+// Type definitions for react-native-auth0 2.10
 // Project: https://github.com/auth0/react-native-auth0
 // Definitions by: Andrea Ascari <https://github.com/ascariandrea>
 //                 Mark Nelissen <https://github.com/marknelissen>
@@ -6,6 +6,7 @@
 //                 Will Dady <https://github.com/willdady>
 //                 Bogdan Vitoc <https://github.com/bogidon>
 //                 Yam Mesicka <https://github.com/yammesicka>
+//                 Mathias Djärv <https://github.com/mdjarv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -199,19 +200,23 @@ export const users: Users;
  * Web Auth
  */
 export interface AuthorizeParams {
-    state?: string | undefined;
-    nonce?: string | undefined;
-    audience?: string | undefined;
-    scope?: string | undefined;
-    connection?: string | undefined;
-    language?: string | undefined;
-    prompt?: string | undefined;
-    max_age?: number | undefined;
+    state?: string; // Random string to prevent CSRF attacks and used to discard unexepcted results. By default its a cryptographically secure random.
+    nonce?: string; // Random string to prevent replay attacks of id_tokens.
+    audience?: string; // Identifier of Resource Server (RS) to be included as audience (aud claim) of the issued access token
+    scope?: string; // Scopes requested for the issued tokens. e.g. `openid profile`
+    connection?: string; // The name of the identity provider to use, e.g. "google-oauth2" or "facebook". When not set, it will display Auth0's Universal Login Page.
+    language?: string;
+    prompt?: string;
+    max_age?: number; // The allowable elapsed time in seconds since the last time the user was authenticated (optional).
+    organization?: string; // The ID of the organization to join
+    invitationUrl?: string; // The invitation URL to join an organization. Takes precedence over the "organization" parameter.
 }
 
 export interface AuthorizeOptions {
-    ephemeralSession?: boolean | undefined;
-    customScheme?: string;
+    ephemeralSession?: boolean; //  Disable Single-Sign-On (SSO). It only affects iOS with versions 13 and above. Defaults to `false`.
+    customScheme?: string; //  Custom scheme to build the callback URL with.
+    leeway?: number; // The amount of leeway, in seconds, to accommodate potential clock skew when validating an ID token's claims. Defaults to 60 seconds if not specified.
+    skipLegacyListener?: string; // Whether to register the event listener necessary for the SDK to work on iOS <11 or not. Defaults to `false`.
 }
 
 export interface ClearSessionParams {

--- a/types/react-native-auth0/react-native-auth0-tests.ts
+++ b/types/react-native-auth0/react-native-auth0-tests.ts
@@ -72,6 +72,7 @@ auth0.webAuth.authorize({
     scope: 'openid',
     language: 'en',
     prompt: 'login',
+    organization: 'orgId',
 });
 
 auth0.webAuth.authorize({


### PR DESCRIPTION
* Added `organization` and `invitationUrl` to AuthorizeParams
* Added `leeway` and `skipLegacyListener` to AuthorizeOptions
* Added parameter comments from `react-native-auth0`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/react-native-auth0/blame/master/src/webauth/index.js#L51
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
