### PR TITLE
Correct GM_config type licensing to avert a DMCA inclusion

### DIFF
--- a/types/gm_config/index.d.ts
+++ b/types/gm_config/index.d.ts
@@ -4,6 +4,31 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 2.8
 
+/**
+ Copyright 2009+, GM_config Contributors (https://github.com/sizzlemctwizzle/GM_config)
+
+ GM_config Collaborators:
+     Mike Medley <medleymind@gmail.com>
+     Joe Simmons
+     Izzy Soft
+     Marti Martz
+
+ GM_config is distributed under the terms of the GNU Lesser General Public License.
+
+     GM_config is free software: you can redistribute it and/or modify
+     it under the terms of the GNU Lesser General Public License as published by
+     the Free Software Foundation, either version 3 of the License, or
+     (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU Lesser General Public License for more details.
+
+     You should have received a copy of the GNU Lesser General Public License
+     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 type FieldValue = string | number | boolean;
 /** Valid types for Field `type` property */
 type FieldTypes =

--- a/types/gm_config/index.d.ts
+++ b/types/gm_config/index.d.ts
@@ -5,28 +5,28 @@
 // Minimum TypeScript Version: 2.8
 
 /**
- Copyright 2009+, GM_config Contributors (https://github.com/sizzlemctwizzle/GM_config)
-
- GM_config Collaborators:
-     Mike Medley <medleymind@gmail.com>
-     Joe Simmons
-     Izzy Soft
-     Marti Martz
-
- GM_config is distributed under the terms of the GNU Lesser General Public License.
-
-     GM_config is free software: you can redistribute it and/or modify
-     it under the terms of the GNU Lesser General Public License as published by
-     the Free Software Foundation, either version 3 of the License, or
-     (at your option) any later version.
-
-     This program is distributed in the hope that it will be useful,
-     but WITHOUT ANY WARRANTY; without even the implied warranty of
-     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     GNU Lesser General Public License for more details.
-
-     You should have received a copy of the GNU Lesser General Public License
-     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * Copyright 2009+, GM_config Contributors (https://github.com/sizzlemctwizzle/GM_config)
+ *
+ * GM_config Collaborators:
+ *    Mike Medley <medleymind@gmail.com>
+ *    Joe Simmons
+ *    Izzy Soft
+ *    Marti Martz
+ *
+ * GM_config is distributed under the terms of the GNU Lesser General Public License.
+ *
+ *    GM_config is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Lesser General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public License
+ *    along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 type FieldValue = string | number | boolean;


### PR DESCRIPTION
* While we, the Copyright holders, can see the value of this project it was inadvertently merged by your maintainers without confirmation or knowledge of the actual "Code owners". The project and any derivatives are not owned by Microsoft as mentioned at https://www.npmjs.com/package/@types/gm_config
* Licensing of any derivative is dictated solely by the terms of LGPL 3 or later which was omitted by the third party in #57016 . GNU requires, at least, this header block to be added. A "publicação" is still a "publication" in a different language including, but not limited to, subsets of JavaScript or definitions of alternate scripting languages.
* This PR is submitted in hopes that this project will abide by the terms of licensing in a good faith effort to reconcile the Copyright violation.
* This is by no means an official verified TypeScript of the GM_config project but may be at a later date providing the licensing is corrected.

Thank you for your cooperation.

Signed-off-by: Martii <martii@users.noreply.github.com>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
