### PR TITLE
Update types for postcss-import 14

### DIFF
--- a/types/postcss-import/index.d.ts
+++ b/types/postcss-import/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postcss-import 12.0
+// Type definitions for postcss-import 14.0
 // Project: https://github.com/postcss/postcss-import#readme
 // Definitions by: Remco Haszing <https://github.com/remcohaszing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -29,6 +29,14 @@ declare function atImport(options?: atImport.AtImportOptions): Transformer;
 declare namespace atImport {
     interface AtImportOptions {
         /**
+         * Only transform imports for which the test function returns `true`. Imports for which the test function returns `false` will be left as is. The function gets the path to import as an
+         * argument and should return a boolean.
+         *
+         * @default () => true
+         */
+        filter?: (path: string) => boolean;
+
+        /**
          * Define the root where to resolve path (eg: place where `node_modules` are). Should not be used that much.
          *
          * _Note: nested @import will additionally benefit of the relative dirname of imported files._
@@ -52,11 +60,13 @@ declare namespace atImport {
          * the path(s). If you do not return an absolute path, your path will be resolved to an absolute path using the default resolver. You can use
          * [resolve](https://github.com/substack/node-resolve) for this.
          */
-        resolve?: ((
-            id: string,
-            basedir: string,
-            importOptions: AtImportOptions,
-        ) => string | string[] | PromiseLike<string | string[]>) | undefined;
+        resolve?:
+            | ((
+                  id: string,
+                  basedir: string,
+                  importOptions: AtImportOptions,
+              ) => string | string[] | PromiseLike<string | string[]>)
+            | undefined;
 
         /**
          * You can overwrite the default loading way by setting this option. This function gets `(filename, importOptions)` arguments and returns content or promised content.

--- a/types/postcss-import/package.json
+++ b/types/postcss-import/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "^7.0.27"
+        "postcss": "^8.0.0"
     }
 }

--- a/types/postcss-import/postcss-import-tests.ts
+++ b/types/postcss-import/postcss-import-tests.ts
@@ -1,7 +1,8 @@
-import postcss = require('postcss');
+import postcss from 'postcss';
 import atImport = require('postcss-import');
 
 postcss().use(atImport());
+postcss().use(atImport({ filter: path => path !== 'ignore.css' }));
 postcss().use(atImport({ root: '' }));
 postcss().use(atImport({ path: '' }));
 postcss().use(atImport({ path: [''] }));

--- a/types/postcss-import/tsconfig.json
+++ b/types/postcss-import/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es2018"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
This adds a new option and updates to Postcss 8. Postcss 8 requires a more modern lib and uses a default export.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.