### PR TITLE
feat(asana): task/workspace/custom field/stream-related additions

### DIFF
--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -164,3 +164,53 @@ client.tasks.findAll({section: 'foobar'}).then();
 // Projects.FindAllParams should accept a workspace gid
 // https://developers.asana.com/docs/get-multiple-projects
 client.projects.findAll({workspace: 'foobar'}).then();
+
+// minimal task update
+client.tasks.updateTask('my_gid', {});
+
+// christmas tree update
+// https://developers.asana.com/docs/update-a-task
+client.tasks.updateTask('task_gid', {
+    approval_status: 'approved',
+    assignee: 'their_gid',
+    assignee_section: 'section_or_my_tasks_column_gid',
+    completed: true,
+    custom_fields: { custom_field_gid_1: 123, custom_field_gid_2: 456 },
+    due_at: 'some_date_and_time',
+    due_on: 'some_date',
+    html_notes: '<b>some html</b>',
+    liked: true,
+    name: 'some task name',
+    notes: 'some description',
+    parent: 'some parent task gid',
+    start_on: 'some_date',
+    workspace: 'some_workspace_gid',
+});
+
+client.tasks.getTask('task_gid');
+
+client.workspaces.getWorkspaces();
+
+client.customFields
+    .getCustomFieldsForWorkspace('workspace_gid')
+    .then((customFields: asana.resources.ResourceList<asana.resources.CustomFields.Type>) => {
+        const stream = customFields.stream();
+        stream.on('data', data => {
+            console.log(data);
+        });
+        stream.on('end', () => {});
+        stream.on('finish', () => {});
+        stream.on('error', () => {});
+    });
+
+// no type in params
+// $ExpectError
+client.typeahead.typeaheadForWorkspace('workspace_gid', {});
+
+const typeaheadForWorkspaceQuery: asana.resources.Typeahead.TypeaheadParams = {
+    resource_type: 'task',
+    query: 'my query',
+    opt_pretty: true,
+    opt_fields: ['name', 'completed', 'parent', 'custom_fields.gid', 'custom_fields.number_value'],
+};
+client.typeahead.typeaheadForWorkspace('workspace_gid', typeaheadForWorkspaceQuery);

--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -112,6 +112,26 @@ client.projects.createInWorkspace('foobar', { name: 'test' }).then();
 client.projects.findById('foobar', {opt_fields: 'id,name'}).then();
 client.projects.findByWorkspace('foobar', {opt_fields: 'id,name'}).then();
 client.projects.update('foobar', { name: 'test' }).then();
+// minimal task update
+client.tasks.update('my_gid', {}).then((task) => console.log(task.name));
+// christmas tree update
+// https://developers.asana.com/docs/update-a-task
+client.tasks.update('task_gid', {
+    approval_status: 'approved',
+    assignee: 'their_gid',
+    assignee_section: 'section_or_my_tasks_column_gid',
+    completed: true,
+    custom_fields: { custom_field_gid_1: 123, custom_field_gid_2: 456 },
+    due_at: 'some_date_and_time',
+    due_on: 'some_date',
+    html_notes: '<b>some html</b>',
+    liked: true,
+    name: 'some task name',
+    notes: 'some description',
+    parent: 'some parent task gid',
+    start_on: 'some_date',
+    workspace: 'some_workspace_gid',
+}).then((task) => console.log(task.name));
 client.projects.delete('foobar').then();
 // https://github.com/Asana/node-asana/blob/master/test/resources/stories_spec.js
 client.stories.findById('foobar', {opt_fields: 'id,name'}).then();
@@ -166,42 +186,42 @@ client.tasks.findAll({section: 'foobar'}).then();
 client.projects.findAll({workspace: 'foobar'}).then();
 
 // minimal task update
-client.tasks.updateTask('my_gid', {});
+client.tasks.updateTask('my_gid', {}).then((task) => console.log(task.name));
 
 // christmas tree update
 // https://developers.asana.com/docs/update-a-task
 client.tasks.updateTask('task_gid', {
-    approval_status: 'approved',
-    assignee: 'their_gid',
-    assignee_section: 'section_or_my_tasks_column_gid',
-    completed: true,
-    custom_fields: { custom_field_gid_1: 123, custom_field_gid_2: 456 },
-    due_at: 'some_date_and_time',
-    due_on: 'some_date',
-    html_notes: '<b>some html</b>',
-    liked: true,
-    name: 'some task name',
-    notes: 'some description',
-    parent: 'some parent task gid',
-    start_on: 'some_date',
-    workspace: 'some_workspace_gid',
-});
+  approval_status: 'approved',
+  assignee: 'their_gid',
+  assignee_section: 'section_or_my_tasks_column_gid',
+  completed: true,
+  custom_fields: { custom_field_gid_1: 123, custom_field_gid_2: 456 },
+  due_at: 'some_date_and_time',
+  due_on: 'some_date',
+  html_notes: '<b>some html</b>',
+  liked: true,
+  name: 'some task name',
+  notes: 'some description',
+  parent: 'some parent task gid',
+  start_on: 'some_date',
+  workspace: 'some_workspace_gid',
+}).then((task) => console.log(task.name));
 
 client.tasks.getTask('task_gid');
 
 client.workspaces.getWorkspaces();
 
 client.customFields
-    .getCustomFieldsForWorkspace('workspace_gid')
-    .then((customFields: asana.resources.ResourceList<asana.resources.CustomFields.Type>) => {
-        const stream = customFields.stream();
-        stream.on('data', data => {
-            console.log(data);
-        });
-        stream.on('end', () => {});
-        stream.on('finish', () => {});
-        stream.on('error', () => {});
+  .getCustomFieldsForWorkspace('workspace_gid')
+  .then((customFields: asana.resources.ResourceList<asana.resources.CustomFields.Type>) => {
+    const stream = customFields.stream();
+    stream.on('data', data => {
+      console.log(data);
     });
+    stream.on('end', () => { });
+    stream.on('finish', () => { });
+    stream.on('error', () => { });
+  });
 
 // no type in params
 // $ExpectError

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -1764,7 +1764,7 @@ declare namespace asana {
              * @param dispatchOptions?
              * @return
              */
-            update(task: string | number, data: Tasks.CreateParams, dispatchOptions?: any): Promise<Tasks.Type>;
+            update(task: string | number, data: Tasks.UpdateParams, dispatchOptions?: any): Promise<Tasks.Type>;
 
             /**
              * * A specific, existing task can be deleted by making a DELETE request on the
@@ -2068,7 +2068,7 @@ declare namespace asana {
              * @param {Object} [dispatchOptions]: Options, if any, to pass the dispatcher for the request
              * @return {Promise} The requested resource
              */
-            updateTask(taskGid: string, data?: Tasks.UpdateParams, dispatchOptions?: any): Promise<void>;
+            updateTask(taskGid: string, data?: Tasks.UpdateParams, dispatchOptions?: any): Promise<Tasks.Type>;
         }
 
         interface SectionsStatic {
@@ -2980,7 +2980,6 @@ declare namespace asana {
         var CustomFields: CustomFieldsStatic;
 
         namespace Typeahead {
-            //
             interface TypeaheadParams {
                 resource_type: string;
                 query?: string | undefined;

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -105,6 +105,11 @@ declare namespace asana {
          */
         attachments: resources.Attachments;
         /**
+         * An instance of the CustomFields resource.
+         * @type {CustomFields}
+         */
+         customFields: resources.CustomFields;
+        /**
          * An instance of the Events resource.
          * @type {Events}
          */
@@ -149,6 +154,11 @@ declare namespace asana {
          * @type {Users}
          */
         users: resources.Users;
+        /**
+         * An instance of the Typeahead resource.
+         * @type {Typeahead}
+         */
+        typeahead: resources.Typeahead;
         /**
          * An instance of the Workspaces resource.
          * @type {Workspaces}
@@ -1599,6 +1609,24 @@ declare namespace asana {
                 custom_fields?: Object | undefined;
             }
 
+            // https://developers.asana.com/docs/update-a-task
+            interface UpdateParams {
+                approval_status?: string | undefined;
+                assignee?: string | undefined;
+                assignee_section?: string | undefined;
+                completed?: boolean | undefined;
+                custom_fields?: { [index: string]: number | string } | undefined;
+                due_at?: string | undefined;
+                due_on?: string | null | undefined;
+                html_notes?: string | undefined;
+                liked?: boolean | undefined;
+                name?: string | undefined;
+                notes?: string | undefined;
+                parent?: string | undefined;
+                start_on?: string | null | undefined;
+                workspace?: string | undefined;
+            }
+
             interface FollowersParams {
                 followers: (number | string)[];
             }
@@ -2015,6 +2043,32 @@ declare namespace asana {
              * @return
              */
             addComment(task: string | number, data: Tasks.CommentParams, dispatchOptions?: any): Promise<Stories.Type>;
+
+            // https://github.com/Asana/node-asana/blob/6bf00fb3257847744bf0ebe2dc0e95c445477282/lib/resources/gen/tasks.js#L245-L262
+            /**
+             * Get a task
+             * @param {String} taskGid: (required) The task to operate on.
+             * @param {Object} params: Parameters for the request
+             *  - optFields {[String]}:  Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more
+             *    efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for
+             *    the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options.
+             *  - optPretty {Boolean}:  Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to
+             *    make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging.
+             * @param {Object} [dispatchOptions]: Options, if any, to pass the dispatcher for the request
+             * @return {Promise} The requested resource
+             */
+            getTask(taskGid: string, params?: any, dispatchOptions?: any): Promise<Tasks.Type>;
+
+            // https://developers.asana.com/docs/update-a-task
+            // https://github.com/Asana/node-asana/blob/6bf00fb3257847744bf0ebe2dc0e95c445477282/lib/resources/gen/tasks.js#L563-L578
+            /**
+             * Update a task
+             * @param {String} taskGid: (required) The task to operate on.
+             * @param {Object} data: Data for the request
+             * @param {Object} [dispatchOptions]: Options, if any, to pass the dispatcher for the request
+             * @return {Promise} The requested resource
+             */
+            updateTask(taskGid: string, data?: Tasks.UpdateParams, dispatchOptions?: any): Promise<void>;
         }
 
         interface SectionsStatic {
@@ -2572,6 +2626,24 @@ declare namespace asana {
              * @return
              */
             removeUser(workspace: string | number, data: UserParams, dispatchOptions?: any): Promise<any>;
+
+            // https://github.com/Asana/node-asana/blob/6bf00fb3257847744bf0ebe2dc0e95c445477282/lib/resources/gen/workspaces.js#L57-L74
+            /**
+             * Get multiple workspaces
+             * @param {Object} params: Parameters for the request
+             *  - offset {String}:  Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next
+             *    request. If an offset is not passed in, the API will return the first page of results. 'Note: You can only pass in an offset that was returned to you via a previously
+             *    paginated request.'
+             *  - limit {Number}:  Results per page. The number of objects to return per page. The value must be between 1 and 100.
+             *  - optFields {[String]}:  Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more
+             *    efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the
+             *    objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options.
+             * - optPretty {Boolean}:  Provides "pretty" output. Provides the response in a "pretty" format. In the case of JSON this means doing proper line breaking and indentation to make it
+             *    readable. This will take extra time and increase the response size so it is advisable only to use this during debugging.
+             * @param {Object} [dispatchOptions]: Options, if any, to pass the dispatcher for the request
+             * @return {Promise} The requested resource
+             */
+            getWorkspaces(params?: any, dispatchOptions?: any): Promise<ResourceList<Workspaces.Type>>;
         }
 
         interface UserTaskListsStatic {
@@ -2776,6 +2848,11 @@ declare namespace asana {
             dispatchDelete(path: string, dispatchOptions?: any): Promise<any>;
         }
 
+        interface ResourceStream<T extends Resource> {
+            on(command: 'data', callback: (resource: T) => any): void;
+            on(command: 'end' | 'finish' | 'error', callback: () => void): void;
+        }
+
         interface ResourceList<T extends Resource> {
             /**
              * Get the next page of results in a collection.
@@ -2784,6 +2861,7 @@ declare namespace asana {
              *     the next page of results, or null if no more pages.
              */
             nextPage(): Promise<ResourceList<T> | null>;
+            stream(): ResourceStream<T>;
             data: T[];
             _response: {
                 data: T[];
@@ -2854,10 +2932,89 @@ declare namespace asana {
             enabled: boolean;
         }
 
+        namespace CustomFields {
+            interface Type extends Resource {
+                readonly gid: string;
+            }
+        }
+
+        interface CustomFields extends Resource {
+            // https://github.com/Asana/node-asana/blob/6bf00fb3257847744bf0ebe2dc0e95c445477282/lib/resources/gen/custom_fields.js#L91-L110
+            /**
+             * Get a workspace's custom fields
+             * @param {String} workspaceGid: (required) Globally unique identifier for the workspace or organization.
+             * @param {Object} params: Parameters for the request
+             *  - offset {String}:    Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input
+             *    parameter to the next request. If an offset is not passed in, the API will return the first page of results. 'Note: You can only pass in an offset that was returned to
+             *    you via a previously paginated request.'
+             *  - limit {Number}:    Results per page. The number of objects to return per page. The value must be between 1 and 100.
+             *  - optFields {[String]}:    Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request
+             *    more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to
+             *    return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options.
+             *  - optPretty {Boolean}:    Provides "pretty" output. Provides the response in a "pretty" format. In the case of JSON this means doing proper line breaking and indentation
+             *    to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging.
+             * @param {Object} [dispatchOptions]: Options, if any, to pass the dispatcher for the request
+             * @return {Promise} The requested resource
+             */
+            getCustomFieldsForWorkspace(
+                workspaceGid: string,
+                params?: any,
+                dispatchOptions?: any,
+            ): Promise<ResourceList<CustomFields.Type>>;
+        }
+
         interface CustomField extends Resource {
             enabled: boolean;
             enum_options: EnumValue[] | null;
             enum_value: EnumValue | null;
+            number_value: number | null;
+        }
+
+        interface CustomFieldsStatic {
+            /**
+             * @param dispatcher
+             */
+            new (dispatcher: Dispatcher): CustomFields;
+        }
+
+        var CustomFields: CustomFieldsStatic;
+
+        namespace Typeahead {
+            //
+            interface TypeaheadParams {
+                resource_type: string;
+                query?: string | undefined;
+                count?: number | undefined;
+                opt_pretty?: boolean | undefined;
+                opt_fields?: string[] | undefined;
+            }
+        }
+
+        interface Typeahead extends Resource {
+            // https://github.com/Asana/node-asana/blob/6bf00fb3257847744bf0ebe2dc0e95c445477282/lib/resources/gen/typeahead.js#L19-L40
+            /**
+             * Get objects via typeahead
+             * @param {String} workspaceGid: (required) Globally unique identifier for the workspace or organization.
+             * @param {Object} params: Parameters for the request
+             *  - resourceType {String}:  (required) The type of values the typeahead should return. You can choose from one of the following: `custom_field`, `project`, `portfolio`, `tag`,
+             *    `task`, and `user`. Note that unlike in the names of endpoints, the types listed here are in singular form (e.g. `task`). Using multiple types is not yet supported.
+             *  - type {String}:  *Deprecated: new integrations should prefer the resource_type field.*
+             *  - query {String}:  The string that will be used to search for relevant objects. If an empty string is passed in, the API will currently return an empty result set.
+             *  - count {Number}:  The number of results to return. The default is 20 if this parameter is omitted, with a minimum of 1 and a maximum of 100. If there are fewer results
+             *    found than requested, all will be returned.
+             *  - optFields {[String]}:  Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request
+             *    more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to
+             *    return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options.
+             *  - optPretty {Boolean}:  Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to
+             *    make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging.
+             * @param {Object} [dispatchOptions]: Options, if any, to pass the dispatcher for the request
+             * @return {Promise} The requested resource
+             */
+            typeaheadForWorkspace(
+                workspaceGid: string,
+                params?: Typeahead.TypeaheadParams,
+                dispatchOptions?: any,
+            ): Promise<ResourceList<Tasks.Type>>;
         }
     }
 


### PR DESCRIPTION
Enough additions to get https://github.com/apiology/upvoter_for_asana to type check against the Asana API Javascript client library.

Add:
* client.tasks.updateTask()
* client.tasks.getTask()
* client.workspaces.getWorkspaces()
* client.customFields.getCustomFieldsForWorkspace()

Modify:
* ResourceList to include stream() method.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Asana API docs](https://developers.asana.com/docs/asana) [JS client library](https://github.com/Asana/node-asana)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - this is not tied to a particular new release; the current bindings were not complete against the node-asana version advertised regardless (0.18.4).  Let me know if that's an issue, if it'd be best to just bump the version to the latest published or if leaving it is fine.
