### PR TITLE
[types/yargs] expose types for ESM import

### DIFF
--- a/types/yargs/index.d.mts
+++ b/types/yargs/index.d.mts
@@ -10,3 +10,30 @@ interface MainType {
 }
 declare const _instanceFactory: (processArgs: string[], cwd?: string, parentRequire?: RequireType) => yargs.Argv;
 export default _instanceFactory;
+
+export type {
+    BuilderCallback,
+    ParserConfigurationOptions,
+    Argv,
+    Arguments,
+    RequireDirectoryOptions,
+    Options,
+    PositionalOptions,
+    Defined,
+    ToArray,
+    ToString,
+    ToNumber,
+    InferredOptionType,
+    InferredOptionTypeInner,
+    RequiredOptionType,
+    InferredOptionTypes,
+    CommandModule,
+    ParseCallback,
+    CommandBuilder,
+    SyncCompletionFunction,
+    AsyncCompletionFunction,
+    PromiseCompletionFunction,
+    MiddlewareFunction,
+    Choices,
+    PositionalOptionsType,
+} from './index.js';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [commit adding explicit ESM typing+support](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/05d77ca74603d6eeb04e9ecb3162c6d53a503f67)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

Given that Yargs exports a slightly different package for ESM, it doesn't expose all the internal types by default. This PR hopefully changes that, exposing all the types+interfaces except `Omit` (I can add if reasonable, but typescript has a default version of that type...).

Now something like 
```ts
import type { CommandModule } from 'yargs'
```
should work regardless of the module type of that file.

Note did not update tests because:
1) No existing tests for mts version
2) Only appending already-tested types, actual functionality remains unchanged