### PR TITLE
Fix `@types/sharp` chromaSubsampling comment for AVIF

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -938,7 +938,7 @@ declare namespace sharp {
         lossless?: boolean | undefined;
         /** CPU effort vs file size, 0 (slowest/smallest) to 9 (fastest/largest) (optional, default 5) */
         speed?: number | undefined;
-        /** set to '4:4:4' to prevent chroma subsampling otherwise defaults to '4:2:0' chroma subsampling, requires libvips v8.11.0 (optional, default '4:2:0') */
+        /** set to '4:2:0' to use chroma subsampling, requires libvips v8.11.0 (optional, default '4:4:4') */
         chromaSubsampling?: string;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

Relevant links

- Docs https://sharp.pixelplumbing.com/api-output#avif
- Related to https://github.com/lovell/sharp/issues/2850#issuecomment-901943531