### PR TITLE
(js-yaml) Add export map and esm entrypoint

### DIFF
--- a/types/js-yaml/OTHER_FILES.txt
+++ b/types/js-yaml/OTHER_FILES.txt
@@ -1,0 +1,1 @@
+index.d.mts

--- a/types/js-yaml/index.d.mts
+++ b/types/js-yaml/index.d.mts
@@ -1,0 +1,2 @@
+export * from "./index.js";
+export { default } from "./index.js";

--- a/types/js-yaml/package.json
+++ b/types/js-yaml/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "exports": {
+        ".": {
+            "types": {
+                "import": "./index.d.mts",
+                "default": "./index.d.ts"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This mirrors the export map [provided by js-yaml itself](https://github.com/nodeca/js-yaml/blob/master/package.json#L29) to expose an esm-format entrypoint.