### PR TITLE
(ws) Add export map and esm entrypoint

### DIFF
--- a/types/ws/OTHER_FILES.txt
+++ b/types/ws/OTHER_FILES.txt
@@ -1,0 +1,1 @@
+index.d.mts

--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -1,0 +1,3 @@
+export { createWebSocketStream, WebSocket, WebSocketServer, RawData, Data, CertMeta, VerifyClientCallbackSync, VerifyClientCallbackAsync, ClientOptions, PerMessageDeflateOptions, Event, ErrorEvent, CloseEvent, MessageEvent, EventListenerOptions, ServerOptions, AddressInfo } from "./index.js";
+import WebSocket = require("./index.js");
+export default WebSocket;

--- a/types/ws/package.json
+++ b/types/ws/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "exports": {
+        ".": {
+            "types": {
+                "import": "./index.d.mts",
+                "default": "./index.d.ts"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This mirrors the [export map](https://github.com/websockets/ws/blob/master/package.json#L19) and [esm entrypoint](https://github.com/websockets/ws/blob/master/wrapper.mjs) provided by `ws` at runtime.