### PR TITLE
(jest) Add export map entry

### DIFF
--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -3,5 +3,10 @@
     "dependencies": {
         "jest-diff": "^27.0.0",
         "pretty-format": "^27.0.0"
+    },
+    "exports": {
+        ".": {
+            "types": "./index.d.ts"
+        }
     }
 }


### PR DESCRIPTION
This mirrors jest's own [export map](https://github.com/facebook/jest/blob/main/packages/jest/package.json#L7) and will forbid things like `import "jest/index"`.