### PR TITLE
(marked) Add export map and esm entrypoint

### DIFF
--- a/types/marked/OTHER_FILES.txt
+++ b/types/marked/OTHER_FILES.txt
@@ -1,0 +1,1 @@
+index.d.mts

--- a/types/marked/index.d.mts
+++ b/types/marked/index.d.mts
@@ -1,0 +1,1 @@
+export * from "./index.js";

--- a/types/marked/package.json
+++ b/types/marked/package.json
@@ -1,0 +1,11 @@
+{
+    "private": true,
+    "exports": {
+        ".": {
+            "types": {
+                "import": "./index.d.mts",
+                "default": "./index.d.ts"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds an [export map that mirror's marked's own](https://github.com/markedjs/marked/blob/master/package.json) and a [compatible esm entrypoint](https://github.com/markedjs/marked/blob/master/lib/marked.esm.js) which ensures typescript can correctly allow both esm and cjs imports of the package under `module: nodenext`.