### PR TITLE
fix(ci): correct DT types resolution in Node ecosystem

### DIFF
--- a/types/ari-client/package.json
+++ b/types/ari-client/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/pino": "6.3"
-    }
-}

--- a/types/pino-pretty/index.d.ts
+++ b/types/pino-pretty/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Adam Vigneaux <https://github.com/AdamVig>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 2.7
+/// <reference types="node"/>
 
 import { LogDescriptor } from "pino";
 


### PR DESCRIPTION
- 'ari-client': remove dependency on `pino` from tests as this is not
  resolved as direct `ari-client` dependency during CI tests
- correct `pino-pretty` to depend directly on `node`, otherwise
  dependencies for package like `hapi-pino` are not fully resolved for
  CI tests

Required as aftermath of #57023

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)