### PR TITLE
braintree-web: Add 'binAvailable' event

### DIFF
--- a/types/braintree-web/index.d.ts
+++ b/types/braintree-web/index.d.ts
@@ -17,6 +17,7 @@ import {
     HostedFieldsTokenizePayload,
     HostedFieldsEvent,
     HostedFieldsStateObject,
+    HostedFieldsBinPayload,
 } from './modules/hosted-fields';
 import { PayPal, PayPalTokenizePayload } from './modules/paypal';
 import { PayPalCheckout, PayPalCheckoutCreatePaymentOptions } from './modules/paypal-checkout';
@@ -61,6 +62,7 @@ export {
     GooglePaymentTokenizePayload,
     HostedFields,
     HostedFieldFieldOptions,
+    HostedFieldsBinPayload,
     HostedFieldsTokenizePayload,
     HostedFieldsEvent,
     HostedFieldsStateObject,

--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -48,6 +48,13 @@ export interface HostedFieldFieldOptions {
 }
 
 /**
+ * @description The event payload sent from {@link HostedFields#on|on} when the `binAvailable` event is emitted.
+ */
+export interface HostedFieldsBinPayload {
+    bin: string;
+}
+
+/**
  * @description Information about the card type, sent in {@link HostedFields~stateObject|stateObjects}.
  * - `american-express`
  * - `diners-club`
@@ -138,14 +145,18 @@ export interface HostedFieldsEvent extends HostedFieldsState {
  */
 export type HostedFieldsStateObject = HostedFieldsEvent;
 
-export type HostedFieldEventType =
-    | 'blur'
-    | 'focus'
-    | 'empty'
-    | 'notEmpty'
-    | 'cardTypeChange'
-    | 'validityChange'
-    | 'inputSubmitRequest';
+export interface HostedFieldsEventTypeMap {
+    blur: HostedFieldsEvent;
+    focus: HostedFieldsEvent;
+    empty: HostedFieldsEvent;
+    notEmpty: HostedFieldsEvent;
+    cardTypeChange: HostedFieldsEvent;
+    validityChange: HostedFieldsEvent;
+    inputSubmitRequest: HostedFieldsEvent;
+    binAvailable: HostedFieldsBinPayload;
+}
+
+export type HostedFieldEventType = keyof HostedFieldsEventTypeMap;
 
 export interface HostedFieldsAccountDetails {
     bin: string;
@@ -252,8 +263,8 @@ export interface HostedFields {
      */
     VERSION: string;
 
-    on(event: HostedFieldEventType, handler: (event: HostedFieldsEvent) => void): void;
-    off(event: HostedFieldEventType, handler: (event: HostedFieldsEvent) => void): void;
+    on<EventType extends HostedFieldEventType>(event: EventType, handler: (event: HostedFieldsEventTypeMap[EventType]) => void): void;
+    off<EventType extends HostedFieldEventType>(event: EventType, handler: (event: HostedFieldsEventTypeMap[EventType]) => void): void;
 
     teardown(callback?: callback): void;
     teardown(): Promise<void>;

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -1,4 +1,5 @@
 import * as braintree from 'braintree-web';
+import { HostedFieldsBinPayload } from 'braintree-web/modules/hosted-fields';
 
 const version: string = braintree.VERSION;
 
@@ -311,6 +312,13 @@ braintree.client.create(
 
                 hostedFieldsInstance.on('validityChange', onValidityChange);
                 hostedFieldsInstance.off('validityChange', onValidityChange);
+
+                function onBinAvailable(event: HostedFieldsBinPayload) {
+                    console.log(event.bin);
+                }
+
+                hostedFieldsInstance.on('binAvailable', onBinAvailable);
+                hostedFieldsInstance.off('binAvailable', onBinAvailable);
             },
         );
 


### PR DESCRIPTION
Adds the `binAvailable` event for `HostedFields` to the `braintree-web` package. Adds a type parameter to the `on` and `off` methods to infer the correct type for the event payload depending on the event name.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [HostedFields#on](https://braintree.github.io/braintree-web/current/HostedFields.html#on) [HostedFields event:binAvailable](https://braintree.github.io/braintree-web/current/HostedFields.html#event:binAvailable)
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header~. This event was added in a version earlier than the current typings indicate, hence not updating the version listed by the typings.
