### PR TITLE
Node: Extend http.AgentOptions from TcpSocketConnectOpts

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -42,7 +42,7 @@
 declare module 'http' {
     import * as stream from 'node:stream';
     import { URL } from 'node:url';
-    import { Socket, Server as NetServer, LookupFunction } from 'node:net';
+    import { TcpSocketConnectOpts, Socket, Server as NetServer, LookupFunction } from 'node:net';
     // incoming headers will never contain number
     interface IncomingHttpHeaders extends NodeJS.Dict<string | string[]> {
         accept?: string | undefined;
@@ -951,7 +951,7 @@ declare module 'http' {
          */
         destroy(error?: Error): void;
     }
-    interface AgentOptions {
+    interface AgentOptions extends Partial<TcpSocketConnectOpts> {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -59,7 +59,8 @@ import * as trace_events from 'node:trace_events';
         maxSockets: Infinity,
         maxFreeSockets: 256,
         maxCachedSessions: 100,
-        timeout: 15000
+        timeout: 15000,
+        family: 4,
     });
 
     agent = https.globalAgent;


### PR DESCRIPTION
The [http.Agent constructor options extends the `socket.connect` options
according to the documentation](https://nodejs.org/api/http.html#new-agentoptions):

> options in `socket.connect()` are also supported.

I've assumed that the http agent accepts [TCP `socket.connect()` options](https://nodejs.org/api/net.html#socketconnectoptions-connectlistener).

According to the documentation, [the following should be supported](https://www.typescriptlang.org/play?noLib=true&target=99&jsx=0&ssl=5&ssc=47&pln=5&pc=48#code/JYWwDg9gTgLgBAbwIIHMCmA7eBDAznACRhjFUxgF84AzKCEOAcgwgBM0AuAC2LEYG4AUKEixEZLHDyFeuCZRp0GzNpx4lcAwYIDGEDLnjrS6SQF44GNAHcZJeQAoE1bCGAAbAJ4c4AFgoAlEJ6Bkay8nAWVrZEGo7Orh7efoH8QA):

```ts
import {Agent as HttpAgent} from 'node:http';
import {Agent as HttpsAgent} from 'node:https';

const httpAgent = new HttpAgent({family: 4});
const httpsAgent = new HttpsAgent({family: 4});
```

Both of the agent constructors above are currently a type error:

>  Argument of type '{ family: number; }' is not assignable to parameter of type 'AgentOptions'

With the proposed changes, they are no longer an error.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/http.html#new-agentoptions
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
