### PR TITLE
use `this` type in array methods

### DIFF
--- a/types/chocolatechipjs/chocolatechipjs-tests.ts
+++ b/types/chocolatechipjs/chocolatechipjs-tests.ts
@@ -54,6 +54,12 @@ $.fn.extend({
     }
 });
 
+// ChocolateChipElementArray this type
+$('li').find((_value, _index, arr) => {
+    arr.each(() => {});
+    return true;
+});
+
 // ChocolateChipElementArray extensions:
 $('li').each((ctx, idx) => {
     console.log(ctx.nodeName);

--- a/types/chocolatechipjs/index.d.ts
+++ b/types/chocolatechipjs/index.d.ts
@@ -617,7 +617,7 @@ interface ChocolateChipElementArray extends Array<HTMLElement> {
   /**
    * Same overload as is present in the base type
    */
-  find(predicate: (value: HTMLElement, index: number, obj: HTMLElement[]) => boolean, thisArg?: any): HTMLElement;
+  find(predicate: (value: HTMLElement, index: number, obj: this) => boolean, thisArg?: any): HTMLElement;
 
   /**
    * Get the descendants of each element in the current set of matched elements, filtered by a selector or element.

--- a/types/ember/v2/index.d.ts
+++ b/types/ember/v2/index.d.ts
@@ -1630,12 +1630,7 @@ declare module 'ember' {
          * false, this will be applied automatically. Otherwise you can apply the mixin
          * at anytime by calling `Ember.NativeArray.apply(Array.prototype)`.
          */
-        interface NativeArray<T> extends GlobalArray<T>, MutableArray<T>, Observable, Copyable {
-            /**
-             * __Required.__ You must implement this method to apply this mixin.
-             */
-            length: number;
-        }
+        type NativeArray<T> = GlobalArray<T> &  MutableArray<T> & Observable & Copyable;
         const NativeArray: Mixin<NativeArray<any>>;
         /**
          * Ember.NoneLocation does not interact with the browser. It is useful for

--- a/types/ember__array/-private/native-array.d.ts
+++ b/types/ember__array/-private/native-array.d.ts
@@ -12,12 +12,12 @@ type GlobalArray<T> = T[];
  * false, this will be applied automatically. Otherwise you can apply the mixin
  * at anytime by calling `Ember.NativeArray.apply(Array.prototype)`.
  */
-interface NativeArray<T> extends GlobalArray<T>, MutableArray<T>, Observable {
+type NativeArray<T> = GlobalArray<T> & MutableArray<T> & Observable & {
     /**
      * __Required.__ You must implement this method to apply this mixin.
      */
     length: number;
-}
+};
 
 declare const NativeArray: Mixin<NativeArray<unknown>>;
 export default NativeArray;

--- a/types/winjs/index.d.ts
+++ b/types/winjs/index.d.ts
@@ -9805,7 +9805,7 @@ declare namespace WinJS.Utilities {
          * @param thisArg The argument to bind to callbackFn.
          * @returns The QueryCollection.
         **/
-        forEach(callbackFn: (value: T, index: number, array: T[]) => void, thisArg?: any): QueryCollection<T>;
+        forEach(callbackFn: (value: T, index: number, array: this) => void, thisArg?: any): QueryCollection<T>;
 
         /**
          * Gets an item from the QueryCollection.
@@ -10008,59 +10008,59 @@ declare namespace WinJS.Utilities {
          * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         **/
-        every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+        every(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
 
         /**
          * Determines whether the specified callback function returns true for any element of an array.
          * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         **/
-        some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+        some(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
 
         /**
          * Calls a defined callback function on each element of an array, and returns an array that contains the results.
         * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
         * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         */
-        map<U>(this: [T, T, T, T, T], callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): [U, U, U, U, U];
+        map<U>(this: [T, T, T, T, T], callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): [U, U, U, U, U];
         /**
          * Calls a defined callback function on each element of an array, and returns an array that contains the results.
         * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
         * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         */
-        map<U>(this: [T, T, T, T], callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): [U, U, U, U];
+        map<U>(this: [T, T, T, T], callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): [U, U, U, U];
         /**
          * Calls a defined callback function on each element of an array, and returns an array that contains the results.
         * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
         * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         */
-        map<U>(this: [T, T, T], callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): [U, U, U];
+        map<U>(this: [T, T, T], callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): [U, U, U];
         /**
          * Calls a defined callback function on each element of an array, and returns an array that contains the results.
         * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
         * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         */
-        map<U>(this: [T, T], callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): [U, U];
+        map<U>(this: [T, T], callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): [U, U];
         /**
          * Calls a defined callback function on each element of an array, and returns an array that contains the results.
         * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
         * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         */
-        map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+        map<U>(callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): U[];
 
         /**
          * Returns the elements of an array that meet the condition specified in a callback function.
          * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
         **/
-        filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
+        filter(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): T[];
 
         /**
          * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
          * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
         **/
-        reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+        reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
         /**
          * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
          * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
@@ -10073,13 +10073,13 @@ declare namespace WinJS.Utilities {
          * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
         **/
-        reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+        reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
         /**
          * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
          * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
          * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
         **/
-        reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+        reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
 
         /**
          * Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.

--- a/types/winjs/tsconfig.json
+++ b/types/winjs/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "winjs-tests.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",

--- a/types/winjs/v1/index.d.ts
+++ b/types/winjs/v1/index.d.ts
@@ -6383,7 +6383,7 @@ declare namespace WinJS.Utilities {
          * @param thisArg The argument to bind to callbackFn.
          * @returns The QueryCollection.
         **/
-        forEach(callbackFn: (value: T, index: number, array: T[]) => void, thisArg?: any): QueryCollection<T>;
+        forEach(callbackFn: (value: T, index: number, array: this) => void, thisArg?: any): QueryCollection<T>;
 
         /**
          * Gets an item from the QueryCollection.

--- a/types/winjs/v2/index.d.ts
+++ b/types/winjs/v2/index.d.ts
@@ -6559,7 +6559,7 @@ declare namespace WinJS.Utilities {
          * @param thisArg The argument to bind to callbackFn.
          * @returns The QueryCollection.
         **/
-        forEach(callbackFn: (value: T, index: number, array: T[]) => void, thisArg?: any): QueryCollection<T>;
+        forEach(callbackFn: (value: T, index: number, array: this) => void, thisArg?: any): QueryCollection<T>;
 
         /**
          * Gets an item from the QueryCollection.

--- a/types/winjs/winjs-tests.ts
+++ b/types/winjs/winjs-tests.ts
@@ -1,0 +1,5 @@
+declare const foo: WinJS.Utilities.QueryCollection<number>;
+
+foo.forEach((_value, _index, array) => {
+    array.addClass("");
+});


### PR DESCRIPTION
this PR fixes some issues with some packages that extend Array/ReadonlyArray, making it compatible with https://github.com/microsoft/TypeScript/pull/46781, as they now use the polymorphic this type for the third argument in the callback methods (map, 'forEach`, etc)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
  - [X] chocolatechipjs
  - [X] ember (and @ember/array) - see https://github.com/microsoft/TypeScript/issues/16936#issuecomment-972880088
  - [X] winjs

- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run npm test <package to test>](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/pull/46781