### PR TITLE
[forge-viewer] Add getter and setter of WorldUpVector to Navigation

### DIFF
--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -37,6 +37,7 @@ Autodesk.Viewing.Initializer(options, async () => {
     modelStructurePanelTests(viewer);
     preferencesTests(viewer);
     showHideTests(viewer);
+    worldUpTests(viewer);
     await bulkPropertiesTests(model);
     await compGeomTests(viewer);
     await dataVizTests(viewer);
@@ -495,6 +496,13 @@ async function visualClustersTests(viewer: Autodesk.Viewing.GuiViewer3D): Promis
 
     await ext.setLayoutActive(true);
     ext.reset();
+}
+
+function worldUpTests(viewer: Autodesk.Viewing.GuiViewer3D): void {
+    const expectedUp = new THREE.Vector3(0, 0, 1);
+
+    viewer.navigation.setWorldUpVector(expectedUp, true, true);
+    const actualUp = viewer.navigation.getWorldUpVector();
 }
 
 function loadDocument(urn: string): Promise<Autodesk.Viewing.Document> {

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -895,6 +895,20 @@ declare namespace Autodesk {
             setUseLeftHandedInput(value: boolean): any;
             setZoomTowardsPivot(value: boolean): any;
             getWorldPoint(x: number, y: number): THREE.Vector3;
+            /**
+             * Get the current world up direction.
+             *
+             * @returns the current world up direction (normalized)
+             */
+            getWorldUpVector(): THREE.Vector3;
+            /**
+             * Change the current world up direction.
+             *
+             * @param up - the new world up direction
+             * @param reorient - if true, make sure the camera up is oriented towards the world up direction.
+             * @param force - if true, will set the new direction regardless of navigation lock
+             */
+            setWorldUpVector(up: THREE.Vector3, reorient: boolean, force: boolean): void;
             screenToViewport(x: number, y: number): THREE.Vector3;
             toOrthographic(): void;
             toPerspective(): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/viewer3D.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.