### PR TITLE
fix(koa__router): unify function overloads

### DIFF
--- a/types/koa__router/index.d.ts
+++ b/types/koa__router/index.d.ts
@@ -364,8 +364,7 @@ declare class Router<StateT = Koa.DefaultState, ContextT = Koa.DefaultContext> {
     /**
      * Lookup route with given `name`.
      */
-    route(name: string): Router.Layer;
-    route(name: string): boolean;
+    route(name: string): Router.Layer | boolean;
 
     /**
      * Generate URL for route. Takes either map of named `params` or series of
@@ -386,8 +385,7 @@ declare class Router<StateT = Koa.DefaultState, ContextT = Koa.DefaultContext> {
      * // => "/users/3?limit=1"
      *
      */
-    url(name: string, params?: any, options?: Router.UrlOptionsQuery): string;
-    url(name: string, params?: any, options?: Router.UrlOptionsQuery): Error;
+    url(name: string, params?: any, options?: Router.UrlOptionsQuery): Error | string;
 
     /**
      * Match given `path` and return corresponding routes.

--- a/types/koa__router/koa__router-tests.ts
+++ b/types/koa__router/koa__router-tests.ts
@@ -218,3 +218,9 @@ router6.put<string>('/blerg', async (ctx) => {
 
 const optsName = router6.stack[0].opts.name; // $ExpectType string | null
 const layerName = router6.stack[0].name; // $ExpectType string | null
+
+class MyRouter2 extends Router {
+  route(name: string): Router.Layer | boolean {
+    return super.route(name);
+  }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

----

These signatures can be unified, which means we don't have to duplicate their overload definitions if we want to extend the method:

 ```
class MyRouter extends Router {
  // TS2416: Property 'route' in type 'MyRouter' is not assignable to the same property in base type
  public route(name: string): Router.Layer | boolean {
    return super.route(name);
  }
}
```

This also means the types work properly, as e.g. right now this _isn't_ an error:

```
export const pathTo = (route: string, params: unknown): string => {
  return router.url(route, params);
};
```

and this _is_:

```
export const pathTo = (route: string, params: unknown): string => {
  const result = router.url(route, params);

  if (result instanceof Error) {
    throw result;
  }

  return result;
};
```

Because TypeScript always uses the first overload that matches, so doesn't report the return of `#url` as `Error | string`.