### PR TITLE
braintree-web: Update ThreeDSecureVerifyPayload

### DIFF
--- a/types/braintree-web/modules/three-d-secure.d.ts
+++ b/types/braintree-web/modules/three-d-secure.d.ts
@@ -6,12 +6,40 @@ export interface ThreeDSecureAccountDetails {
     lastTwo: string;
 }
 
-export interface ThreeDSecureVerifyPayload {
-    nonce: string;
-    details: ThreeDSecureAccountDetails;
-    description: string;
+export interface ThreeDSecureBinData {
+    commercial: string;
+    countryOfIssuance: string;
+    debit: string;
+    durbinRegulated: string;
+    healthcare: string;
+    issuingBank: string;
+    payroll: string;
+    prepaid: string;
+    productId: string;
+}
+
+export interface ThreeDSecureInfo {
     liabilityShiftPossible: boolean;
     liabilityShifted: boolean;
+    cavv: string;
+    xid: string;
+    dsTransactionId: string;
+    threeDSecureVersion: string;
+    eciFlag: string;
+    threeDSecureAuthenticationId: string;
+}
+
+export interface ThreeDSecureVerifyPayload {
+    nonce: string;
+    type: string;
+    details: ThreeDSecureAccountDetails;
+    description: string;
+    binData: ThreeDSecureBinData;
+    /** @deprecated Use threeDSecureInfo.liabilityShiftPossible */
+    liabilityShiftPossible: boolean;
+    /** @deprecated Use threeDSecureInfo.liabilityShifted */
+    liabilityShifted: boolean;
+    threeDSecureInfo: ThreeDSecureInfo;
 }
 
 export interface ThreeDSecureBillingAddress {

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -840,8 +840,10 @@ braintree.threeDSecure.cancelVerifyCard(
         }
 
         verifyPayload.nonce; // The nonce returned from the 3ds lookup call
-        verifyPayload.liabilityShifted; // boolean
-        verifyPayload.liabilityShiftPossible; // boolean
+        verifyPayload.type; // The payment method type.
+        verifyPayload.liabilityShifted || verifyPayload.threeDSecureInfo.liabilityShifted; // boolean
+        verifyPayload.liabilityShiftPossible || verifyPayload.threeDSecureInfo.liabilityShiftPossible; // boolean
+        verifyPayload.binData.issuingBank; // The issuing bank.
     },
 );
 


### PR DESCRIPTION
Updates `ThreeDSecureVerifyPayload` on the `braintree-web` package. This is suggested action from `braintree-web` package contributor @crookedneighbor [discussed](https://github.com/braintree/braintree-web/issues/602) within an issue on github.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ThreeDSecure verifyPayload](https://braintree.github.io/braintree-web/current/ThreeDSecure.html#~verifyPayload)
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ `ThreeDSecureVerifyPayload` was updated in earlier version than the current typings indicate, hence not updating the version listed by the typings.
