### PR TITLE
Fix spelling of GeneratorType "octogons" in GeoPattern types

### DIFF
--- a/types/geopattern/index.d.ts
+++ b/types/geopattern/index.d.ts
@@ -39,7 +39,7 @@ export interface PatternOptions {
     generator?: GeneratorType | undefined;
 }
 
-export type GeneratorType = 'chevrons' | 'octagons' | 'overlappingCircles' |
+export type GeneratorType = 'chevrons' | 'octogons' | 'overlappingCircles' |
     'plusSigns' | 'xes' | 'sineWaves' | 'hexagons' | 'overlappingRings' |
     'plaid' |'triangles' | 'squares' | 'nestedSquares' | 'mosaicSquares' |
     'concentricCircles' | 'diamonds' | 'tessellation';


### PR DESCRIPTION
The GeoPattern library misspells octagon as "octogon" (on-brand for Github). "Octagons" is not a pattern option.

See https://github.com/btmills/geopattern/blob/master/lib/pattern.js#L14 for the definition of the available patterns.

