### PR TITLE
Revert "🤖 Merge PR #57190 fix(auth0): missing `getInvitations` option

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -1372,14 +1372,6 @@ management.organizations.getInvitations(
     },
 );
 
-management.organizations.getInvitations(
-    //  checkpoint pagination tests
-    { id: 'organization_id', take: 2, from: '' },
-    (err, invitations: auth0.OrganizationInvitation[]) => {
-        console.log(invitations);
-    },
-);
-
 /**
  * Get Organization Invitations returning a Promise
  */

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1084,9 +1084,6 @@ export interface PagingOptions {
 }
 
 export interface CheckpointPagingOptions {
-    /**
-     * @default 50
-     */
     take?: number | undefined;
     from?: string | undefined;
 }
@@ -1374,44 +1371,20 @@ export class OrganizationsManager {
 
     getInvitations(
         params: ObjectWithId &
-            PagingOptions &
-            CheckpointPagingOptions & {
-                fields?: string;
-                include_fields?: boolean;
-                sort?: string;
-                include_totals?: false;
-            },
+            PagingOptions & { fields?: string; include_fields?: boolean; sort?: string; include_totals?: false },
     ): Promise<OrganizationInvitation[]>;
     getInvitations(
         params: ObjectWithId &
-            PagingOptions &
-            CheckpointPagingOptions & {
-                fields?: string;
-                include_fields?: boolean;
-                sort?: string;
-                include_totals: true;
-            },
+            PagingOptions & { fields?: string; include_fields?: boolean; sort?: string; include_totals: true },
     ): Promise<OrganizationInvitationsPaged>;
     getInvitations(
         params: ObjectWithId &
-            PagingOptions &
-            CheckpointPagingOptions & {
-                fields?: string;
-                include_fields?: boolean;
-                sort?: string;
-                include_totals?: false;
-            },
+            PagingOptions & { fields?: string; include_fields?: boolean; sort?: string; include_totals?: false },
         cb: (err: Error, invitations: OrganizationInvitation[]) => void,
     ): void;
     getInvitations(
         params: ObjectWithId &
-            PagingOptions &
-            CheckpointPagingOptions & {
-                fields?: string;
-                include_fields?: boolean;
-                sort?: string;
-                include_totals: true;
-            },
+            PagingOptions & { fields?: string; include_fields?: boolean; sort?: string; include_totals: true },
         cb: (err: Error, pagedInvitations: OrganizationInvitationsPaged) => void,
     ): void;
 


### PR DESCRIPTION
This reverts commit 762266aa068854135c37a3631be0b5fa2e7909ae.

It appears there is now know problem with Auth0 documentation, that
resulted in api change covered in #57190. This should be reverted as not
supported:
auth0/node-auth0#678

Thanks!

/cc @pscz

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).