### PR TITLE
[react-lines-ellipsis] Change react-lines-ellipsis onReflow return type from string to void

### DIFF
--- a/types/react-lines-ellipsis/index.d.ts
+++ b/types/react-lines-ellipsis/index.d.ts
@@ -15,7 +15,7 @@ declare namespace LinesEllipsis {
         trimRight?: boolean;
         basedOn?: 'letters' | 'words';
         winWidth?: number;
-        onReflow?: ({ clamped, text }: { clamped: boolean; text: string }) => string;
+        onReflow?: ({ clamped, text }: { clamped: boolean; text: string }) => void;
         component?: string;
     };
 

--- a/types/react-lines-ellipsis/react-lines-ellipsis-tests.ts
+++ b/types/react-lines-ellipsis/react-lines-ellipsis-tests.ts
@@ -14,7 +14,7 @@ type commonPropsType2 = CommonReactLinesEllipsisProps['trimRight'];
 type commonPropsType3 = CommonReactLinesEllipsisProps['basedOn'];
 // $ExpectType number | undefined
 type commonPropsType4 = CommonReactLinesEllipsisProps['winWidth'];
-// $ExpectType (({ clamped, text }: { clamped: boolean; text: string; }) => string) | undefined
+// $ExpectType (({ clamped, text }: { clamped: boolean; text: string; }) => void) | undefined
 type commonPropsType5 = CommonReactLinesEllipsisProps['onReflow'];
 // $ExpectType string | undefined
 type commonPropsType6 = CommonReactLinesEllipsisProps['component'];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: `onReflow` used as a callback in `setState`, it doesn't have to return anything, because result is not being used: https://github.com/xiaody/react-lines-ellipsis/blob/8159c69c2e84e32baf41436eef91bf8cb3db6e3e/src/html.jsx#L156 https://github.com/xiaody/react-lines-ellipsis/blob/8159c69c2e84e32baf41436eef91bf8cb3db6e3e/src/index.jsx#L111
