### PR TITLE
[@brainhubeu/react-carousel] Add explicit types for children

### DIFF
--- a/types/brainhubeu__react-carousel/index.d.ts
+++ b/types/brainhubeu__react-carousel/index.d.ts
@@ -52,6 +52,7 @@ export interface CarouselBreakpoints {
 }
 
 export interface CarouselProps {
+    children?: React.ReactNode;
     itemWidth?: number | undefined;
     value?: number | undefined;
     onChange?(value: number): void;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/brainhubeu/react-carousel/blob/be0aeda9804f16fd7482e42a1b1010a7ec9bb302/react-carousel/src/components/Carousel.js#L278