### PR TITLE
[@giusto/ink-router] Add explicit types for children

### DIFF
--- a/types/giusto__ink-router/index.d.ts
+++ b/types/giusto__ink-router/index.d.ts
@@ -4,9 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { History, Location } from "history";
-import { Component, ComponentType } from "react";
+import { Component, ComponentType, ReactNode } from "react";
 
 export interface RouterProps {
+    children: NonNullable<ReactNode>;
     initialEntries?: Array<(string | {
         pathname: string;
         search?: string | undefined;
@@ -21,6 +22,7 @@ export interface RouterProps {
 export class Router extends Component<RouterProps> { }
 
 export interface CommandLineRouterProps {
+    children: NonNullable<ReactNode>;
     args?: string[] | undefined;
     options?: Record<string, any> | undefined;
     initialEntries?: string[] | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/lujiajing1126/ink-router/blob/97e3edce2ae41308b91ca429747f5aa4d0841ab2/src/router.js#L25
https://github.com/lujiajing1126/ink-router/blob/a08272a1c78b2de84d3539353bb0fb742a6ef1f9/src/cliRouter.js#L29-L32
