### PR TITLE
[mjml-react] Add explicit types for children

### DIFF
--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -206,6 +206,7 @@ export interface MjmlCarouselProps {
 export class MjmlCarousel extends React.Component<MjmlCarouselProps & ClassNameProps> {}
 
 export interface MjmlCarouselImageProps {
+    children?: React.ReactNode;
     src?: string | undefined;
     thumbnailsSrc?: string | undefined;
     alt?: string | undefined;
@@ -229,6 +230,7 @@ export interface MjmlDividerProps {
     borderColor?: React.CSSProperties['borderColor'] | undefined;
     borderStyle?: React.CSSProperties['borderStyle'] | undefined;
     borderWidth?: string | number | undefined;
+    children?: React.ReactNode;
     width?: string | number | undefined;
     containerBackgroundColor?: React.CSSProperties['backgroundColor'] | undefined;
 }
@@ -263,6 +265,7 @@ export class MjmlHero extends React.Component<MjmlHeroProps & ClassNameProps & P
 
 // mj-image
 export interface MjmlImageProps {
+    children?: React.ReactNode;
     containerBackgroundColor?: React.CSSProperties['backgroundColor'] | undefined;
     border?: React.CSSProperties['border'] | undefined;
     borderRadius?: string | number | undefined;
@@ -377,6 +380,7 @@ export class MjmlSocialElement extends React.Component<MjmlSocialElementProps & 
 
 // mj-spacer
 export interface MjmlSpacerProps {
+    children?: React.ReactNode;
     height?: string | number | undefined;
     width?: string | number | undefined;
     containerBackgroundColor?: React.CSSProperties['backgroundColor'] | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/wix-incubator/mjml-react/blob/c1eb06ab366697a609dc6f552f86855b03ae4d80/src/mjml-carousel-image.js#L9
https://github.com/wix-incubator/mjml-react/blob/c1eb06ab366697a609dc6f552f86855b03ae4d80/src/mjml-divider.js#L7
https://github.com/wix-incubator/mjml-react/blob/c1eb06ab366697a609dc6f552f86855b03ae4d80/src/mjml-image.js#L7
https://github.com/wix-incubator/mjml-react/blob/c1eb06ab366697a609dc6f552f86855b03ae4d80/src/mjml-spacer.js#L7