### PR TITLE
[react-mdl] Add explicit types for children

### DIFF
--- a/types/react-mdl/index.d.ts
+++ b/types/react-mdl/index.d.ts
@@ -270,6 +270,7 @@ declare namespace __ReactMDL {
 
 
     interface BadgeProps extends __MDLClassProps {
+        children?: string | React.ReactElement;
         text: string | number;
         className?: string | undefined;
         noBackground?: boolean | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/tleunen/react-mdl/blob/v1.7.2/src/Badge/index.js#L5-L8
