### PR TITLE
[react-native-settings-list] Add explicit types for children

### DIFF
--- a/types/react-native-settings-list/index.d.ts
+++ b/types/react-native-settings-list/index.d.ts
@@ -16,6 +16,7 @@ interface SettingsListProps {
      * default: black
      */
     borderColor?: string | undefined;
+    children?: React.ReactNode;
     /**
      * default: 50
      */


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/evetstech/react-native-settings-list/blob/8592e47cc31ac0c1eb33be54a24032a631786116/index.js#L45

