### PR TITLE
[react-native-simple-radio-button] Add explicit types for children

### DIFF
--- a/types/react-native-simple-radio-button/index.d.ts
+++ b/types/react-native-simple-radio-button/index.d.ts
@@ -15,6 +15,7 @@ export interface DefaultRadioFormProps {
 }
 
 export interface ReactNativeRadioFormProps extends DefaultRadioFormProps {
+    children?: React.ReactNode;
     radio_props?: Array<{label: string, value: string | number}> | undefined;
     initial?: number | undefined;
     buttonColor?: string | undefined;
@@ -25,6 +26,7 @@ export interface ReactNativeRadioFormProps extends DefaultRadioFormProps {
 }
 
 export interface RadioButtonProps {
+    children?: React.ReactNode;
     isSelected?: boolean | undefined;
     labelHorizontal?: boolean | undefined;
     buttonColor?: string | undefined;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/moschan/react-native-simple-radio-button/blob/v2.7.3/lib/SimpleRadioButton.js#L81
