### PR TITLE
[styled-components] Add explicit types for children

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -412,6 +412,7 @@ export type StylisPlugin = (
 ) => string | void;
 
 export interface StyleSheetManagerProps {
+    children?: React.ReactNode;
     disableCSSOMInjection?: boolean | undefined;
     disableVendorPrefixes?: boolean | undefined;
     stylisPlugins?: StylisPlugin[] | undefined;

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1151,8 +1151,7 @@ const wrapperClassNoChildren = <StyledWrapperClassFuncChild>Text</StyledWrapperC
 
 const WrapperFunction: React.FunctionComponent<WrapperProps> = () => <div />;
 const StyledWrapperFunction = styled(WrapperFunction)``;
-// React.FunctionComponent typings always add `children` to props, so this should accept children
-const wrapperFunction = <StyledWrapperFunction>Text</StyledWrapperFunction>;
+const wrapperFunction = <StyledWrapperFunction />;
 
 const WrapperFunc = (props: WrapperProps) => <div />;
 const StyledWrapperFunc = styled(WrapperFunc)``;

--- a/types/styled-components/v3/index.d.ts
+++ b/types/styled-components/v3/index.d.ts
@@ -90,7 +90,7 @@ export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
 export interface DefaultTheme {}
 
 export interface ThemeProviderProps<T> {
-    children: React.ReactElement;
+    children?: React.ReactElement | undefined | null;
     theme?: T | ((theme: T) => T) | undefined;
 }
 export type BaseThemeProviderComponent<T> = React.ComponentClass<ThemeProviderProps<T>>;

--- a/types/styled-components/v3/index.d.ts
+++ b/types/styled-components/v3/index.d.ts
@@ -90,6 +90,7 @@ export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
 export interface DefaultTheme {}
 
 export interface ThemeProviderProps<T> {
+    children: React.ReactElement;
     theme?: T | ((theme: T) => T) | undefined;
 }
 export type BaseThemeProviderComponent<T> = React.ComponentClass<ThemeProviderProps<T>>;
@@ -147,6 +148,7 @@ interface StylesheetComponentProps {
 }
 
 interface StyleSheetManagerProps {
+    children?: React.ReactNode;
     sheet?: StyleSheet | undefined;
     target?: Node | undefined;
 }

--- a/types/styled-components/v3/styled-components-tests.tsx
+++ b/types/styled-components/v3/styled-components-tests.tsx
@@ -121,7 +121,6 @@ class Example extends React.Component {
                     <Input placeholder="@mxstbr" type="text" />
                     <TomatoButton name="demo" />
                 </Wrapper>
-                ;
             </ThemeProvider>
         );
     }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/styled-components/styled-components/blob/v5.1.1/packages/styled-components/src/models/StyleSheetManager.js#L8
https://github.com/styled-components/styled-components/blob/v3.0.2/src/models/StyleSheetManager.js#L17
