### PR TITLE
Fix the import path in violin.d.ts

### DIFF
--- a/types/plotly.js/lib/traces/violin.d.ts
+++ b/types/plotly.js/lib/traces/violin.d.ts
@@ -1,5 +1,5 @@
 import { BoxPlotData } from './box';
-import { Color } from '../..';
+import { Color } from '../../index';
 
 // See https://github.com/plotly/plotly.js/blob/master/src/traces/violin/attributes.js
 export interface ViolinData {


### PR DESCRIPTION
tsc can't find the module without filename

File Tree is :
@types
├── plotly.js
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├── index.d.ts
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├── lib
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├── traces
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└── violin.d.ts
