### PR TITLE
[knex-db-manager]: fix type definition of knexInstance

### DIFF
--- a/types/knex-db-manager/index.d.ts
+++ b/types/knex-db-manager/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for knex-db-manager 0.6
 // Project: https://github.com/Vincit/knex-db-manager#readme
 // Definitions by: Dmitrii Solovev <https://github.com/dimonnwc3>
+//                 Nicusor Chiciuc <https://github.com/nicu-chiciuc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import { QueryBuilder, Config as KnexConfig } from 'knex';
+import { Knex } from 'knex';
 
 export interface KnexDbManager {
     createDbOwnerIfNotExist(): Promise<void>;
@@ -16,7 +17,7 @@ export interface KnexDbManager {
     populateDb(glob?: string): Promise<void>;
     copyDb(fromDbName?: string, toDbName?: string): Promise<void>;
     truncateDb(ignoreTables?: string[]): Promise<void>;
-    knexInstance(): QueryBuilder;
+    knexInstance(): Knex;
 }
 
 export interface DbManagerConfig {
@@ -26,9 +27,9 @@ export interface DbManagerConfig {
     populatePathPattern?: string | undefined;
 }
 
-export interface DbanagerFactoryConfig {
-    knex: KnexConfig | string;
+export interface DbManagerFactoryConfig {
+    knex: Knex.Config | string;
     dbManager: DbManagerConfig;
 }
 
-export function databaseManagerFactory(config: DbanagerFactoryConfig): KnexDbManager;
+export function databaseManagerFactory(config: DbManagerFactoryConfig): KnexDbManager;

--- a/types/knex-db-manager/index.d.ts
+++ b/types/knex-db-manager/index.d.ts
@@ -3,7 +3,8 @@
 // Definitions by: Dmitrii Solovev <https://github.com/dimonnwc3>
 //                 Nicusor Chiciuc <https://github.com/nicu-chiciuc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import { Knex } from 'knex';
+
+import { Seeder, Config } from 'knex';
 
 export interface KnexDbManager {
     createDbOwnerIfNotExist(): Promise<void>;
@@ -17,7 +18,11 @@ export interface KnexDbManager {
     populateDb(glob?: string): Promise<void>;
     copyDb(fromDbName?: string, toDbName?: string): Promise<void>;
     truncateDb(ignoreTables?: string[]): Promise<void>;
-    knexInstance(): Knex;
+
+    // Warning: We actually just want the Knex interface, but it's not exported in the current version of `knex`
+    // Updating to a newer version of `knex` is also problematic since older version of Typescript throw errors
+    // The current solution extracts the Knex interface from the Seeder constructor
+    knexInstance(): ConstructorParameters<typeof Seeder>[0];
 }
 
 export interface DbManagerConfig {
@@ -28,7 +33,7 @@ export interface DbManagerConfig {
 }
 
 export interface DbManagerFactoryConfig {
-    knex: Knex.Config | string;
+    knex: Config | string;
     dbManager: DbManagerConfig;
 }
 

--- a/types/knex-db-manager/knex-db-manager-tests.ts
+++ b/types/knex-db-manager/knex-db-manager-tests.ts
@@ -1,3 +1,8 @@
 import { databaseManagerFactory } from 'knex-db-manager';
 
-databaseManagerFactory({ knex: 'abc', dbManager: {} }); // $ExpectType KnexDbManager
+const factory = databaseManagerFactory({ knex: 'abc', dbManager: {} }); // $ExpectType KnexDbManager
+
+const knexInstance = factory.knexInstance();
+
+// Should be able to destroy an knex instance
+knexInstance.destroy();

--- a/types/knex-db-manager/package.json
+++ b/types/knex-db-manager/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "knex": "^0.95.14"
+        "knex": "0.17.6"
     }
 }

--- a/types/knex-db-manager/package.json
+++ b/types/knex-db-manager/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "knex": "^0.16.3"
+        "knex": "^0.95.14"
     }
 }


### PR DESCRIPTION
The initial types defined the return value of `knexInstance` to be `QueryBuilder` that's incorrect since the actual code returns a Knex object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Vincit/knex-db-manager/blob/f1e565c5888e031bdea9bf1521de91a820a1cd7c/lib/DatabaseManager.js?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L171
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
