### PR TITLE
[k6] fix `Client.load` args with rest parameters

### DIFF
--- a/types/k6/net/grpc.d.ts
+++ b/types/k6/net/grpc.d.ts
@@ -50,7 +50,7 @@ declare namespace grpc {
         connect(address: string, params?: ConnectParams): void;
 
         /** Loads and parses the protocol buffer descriptors. */
-        load(importPaths: string[], protoFiles: string): void;
+        load(importPaths: string[], ...protoFiles: string[]): void;
 
         /** Invokes an unary RPC request. */
         invoke(url: string, request: object, params?: Params): Response;

--- a/types/k6/test/grpc.ts
+++ b/types/k6/test/grpc.ts
@@ -2,23 +2,23 @@ import grpc from 'k6/net/grpc';
 
 const client = new grpc.Client();
 
-client.connect("hola");
-client.connect("localhost:8080", { plaintext: true });
-client.connect("localhost:8080", { plaintext: true, reflect: true });
+client.connect('hola');
+client.connect('localhost:8080', { plaintext: true });
+client.connect('localhost:8080', { plaintext: true, reflect: true });
 
 client.close();
 
-client.load(["../googleapis/google"], "language_service.proto");
+client.load(['../googleapis/google'], 'language_service.proto', 'extra_service.proto');
 
 const req = {
     latitude: 410248224,
     longitude: -747127767,
 };
 const params = {
-    headers: { "x-my-header": "k6test" },
-    tags: { k6test: "yes" },
+    headers: { 'x-my-header': 'k6test' },
+    tags: { k6test: 'yes' },
 };
-const response = client.invoke("main.RouteGuide/GetFeature", req, params);
+const response = client.invoke('main.RouteGuide/GetFeature', req, params);
 response.error;
 response.headers;
 response.message;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://k6.io/docs/javascript-api/k6-net-grpc/client/client-load-importpaths----protofiles
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
