### PR TITLE
[bull]: `getState()` can return 'stuck'

### DIFF
--- a/types/bull/bull-tests.tsx
+++ b/types/bull/bull-tests.tsx
@@ -283,6 +283,13 @@ myQueue.obliterate({ force: true }).then(() => {
     console.log('queue obliterated');
 });
 
+myQueue.add({ foo: 'bar' }).then(job => {
+    job.getState().then(state => {
+        // state could equal 'stuck'
+        state === 'stuck';
+    });
+});
+
 // Close queues
 
 myQueue.close();

--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -235,7 +235,7 @@ declare namespace Bull {
      * it atomic. If your queue does have a very large quantity of jobs, you may want to
      * avoid using this method.
      */
-    getState(): Promise<JobStatus>;
+    getState(): Promise<JobStatus | 'stuck'>;
 
     /**
      * Update a specific job's data. Promise resolves when the job has been updated.


### PR DESCRIPTION
The `getState()` function can return `'stuck'`.

Documentation: https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#jobgetstate
Code: https://github.com/OptimalBits/bull/blob/30d59590c34cb664e3b9a62695c4092c9b1ae3f3/lib/job.js#L435-L459

I didn't change any tests because there are no existing tests for the `getState()` function.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
