### PR TITLE
rsync: Add typings for "build" static method

### DIFF
--- a/types/rsync/index.d.ts
+++ b/types/rsync/index.d.ts
@@ -22,8 +22,7 @@ interface Flag {
 
 interface Rsync {
     // instance methods
-    set(option: string, value: string): Rsync;
-    set(option: string): Rsync;
+    set(option: string, value?: string): Rsync;
 
     unset(option: string): Rsync;
 

--- a/types/rsync/index.d.ts
+++ b/types/rsync/index.d.ts
@@ -27,10 +27,8 @@ interface Rsync {
 
     unset(option: string): Rsync;
 
-    flags(flags: string, set?: boolean): Rsync;
-    flags(flags: Flag): Rsync;
-    flags(flags: string[], set?: boolean): Rsync;
-    flags(...flags: any[]): Rsync;
+    flags(flags: string | string[] | Flag, set?: boolean): Rsync;
+    flags(...args: any[]): Rsync;
 
     isSet(option: string): boolean;
 
@@ -42,11 +40,10 @@ interface Rsync {
 
     output(stdout: StreamDataHandler, stderr: StreamDataHandler): Rsync;
 
-    execute(callback: (err: Error, code: number, cmd: string) => void): child_process.ChildProcess;
     execute(
-        callback: (err: Error, code: number, cmd: string) => void,
-        stdout: StreamDataHandler,
-        stderr: StreamDataHandler
+        callback?: (err: Error | null, code: number, cmd: string) => void,
+        stdout?: StreamDataHandler,
+        stderr?: StreamDataHandler
     ): child_process.ChildProcess;
 
     // cwd
@@ -67,31 +64,26 @@ interface Rsync {
     dry(): Rsync;
 
     // accessor methods
-    executable(): string;
-    executable(e: string): Rsync;
+    executable(e?: string): Rsync;
 
-    executableShell(): string;
-    executableShell(e: string): Rsync;
+    executableShell(e?: string): Rsync;
 
-    destination(): string;
-    destination(d: string): Rsync;
+    destination(d?: string): Rsync;
 
-    source(): string[];
-    source(s: string): Rsync;
-    source(s: string[]): Rsync;
+    source(s?: string | string[]): Rsync;
 
     // pattern accessors
     patterns(patterns: (string | Pattern)[]): Rsync;
 
-    exclude(p: string): Rsync;
-    exclude(p: string[]): Rsync;
+    exclude(p: string | string[]): Rsync;
 
-    include(p: string): Rsync;
-    include(p: string[]): Rsync;
+    include(p: string | string[]): Rsync;
 }
 
 interface RsyncStatic {
     new (): Rsync;
+
+    build: (options: Partial<{ [ Property in keyof Rsync ]: Parameters<Rsync[Property]>[0] }>) => Rsync;
 }
 
 declare const e: RsyncStatic;

--- a/types/rsync/rsync-tests.ts
+++ b/types/rsync/rsync-tests.ts
@@ -154,3 +154,17 @@ rsync.include('/a/file')
 
 // as Array
 rsync.include(['/a/file', '/b/file']);
+
+// Static build
+Rsync.build({
+  source: '/path/to/source',
+  destination: 'server:/path/to/destination',
+  exclude: ['.git'],
+  flags: 'avz',
+  shell: 'ssh'
+});
+
+// Static build with different argument formats
+Rsync.build({
+  flags: [ 'avz', '123' ],
+})

--- a/types/rsync/tslint.json
+++ b/types/rsync/tslint.json
@@ -9,7 +9,6 @@
         "object-literal-key-quotes": false,
         "only-arrow-functions": false,
         "prefer-const": false,
-        "semicolon": false,
-        "unified-signatures": false
+        "semicolon": false
     }
 }


### PR DESCRIPTION
This change adds typings for the [build static method](https://www.npmjs.com/package/rsync#static-methods).
The build method takes an options object, where the keys are Rsync methods and the values are arguments to the methods.
I was able to accurately type this using `keyof` and `Parameters`, but to make this work efffectively I had to refactor
the overloads in the Rsync interface to use union types instead. This is because overloading and `Paramaters` do not
play well together, see https://github.com/microsoft/TypeScript/issues/32164

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

