### PR TITLE
[conventional-changelog-core] Add missing optional argument 

### DIFF
--- a/types/conventional-changelog-core/conventional-changelog-core-tests.ts
+++ b/types/conventional-changelog-core/conventional-changelog-core-tests.ts
@@ -11,7 +11,6 @@ namespace Module {
     declare const parserOpts: conventionalChangelogCore.ParserOptions;
     declare const writerOpts: conventionalChangelogCore.WriterOptions;
     declare const execOpts: gitRawCommits.ExecOptions;
-    
     // $ExpectType Readable
     conventionalChangelogCore();
     // $ExpectType Readable

--- a/types/conventional-changelog-core/conventional-changelog-core-tests.ts
+++ b/types/conventional-changelog-core/conventional-changelog-core-tests.ts
@@ -2,6 +2,7 @@
 "use strict";
 
 import conventionalChangelogCore from "conventional-changelog-core";
+import gitRawCommits from "git-raw-commits";
 
 namespace Module {
     declare const context: conventionalChangelogCore.Context;
@@ -9,7 +10,8 @@ namespace Module {
     declare const options: conventionalChangelogCore.Options;
     declare const parserOpts: conventionalChangelogCore.ParserOptions;
     declare const writerOpts: conventionalChangelogCore.WriterOptions;
-
+    declare const execOpts: gitRawCommits.ExecOptions;
+    
     // $ExpectType Readable
     conventionalChangelogCore();
     // $ExpectType Readable
@@ -22,4 +24,6 @@ namespace Module {
     conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts);
     // $ExpectType Readable
     conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts, writerOpts);
+    // $ExpectType Readable
+    conventionalChangelogCore(options, context, gitRawCommitsOpts, parserOpts, writerOpts, execOpts);
 }

--- a/types/conventional-changelog-core/index.d.ts
+++ b/types/conventional-changelog-core/index.d.ts
@@ -31,7 +31,7 @@ import { Package } from "normalize-package-data";
  * @param writerOpts
  */
 // tslint:disable-next-line max-line-length
-declare function conventionalChangelogCore<TCommit extends Commit = Commit, TContext extends BaseContext = Context>(options?: Options<TCommit, TContext>, context?: Partial<TContext>, gitRawCommitsOpts?: GitRawCommitsOptions, parserOpts?: ParserOptions, writerOpts?: WriterOptions<TCommit, TContext>, execOpts:GitRawExecOptions): Stream.Readable;
+declare function conventionalChangelogCore<TCommit extends Commit = Commit, TContext extends BaseContext = Context>(options?: Options<TCommit, TContext>, context?: Partial<TContext>, gitRawCommitsOpts?: GitRawCommitsOptions, parserOpts?: ParserOptions, writerOpts?: WriterOptions<TCommit, TContext>, execOpts?: GitRawExecOptions): Stream.Readable;
 
 declare namespace conventionalChangelogCore {
     interface Context extends BaseContext {

--- a/types/conventional-changelog-core/index.d.ts
+++ b/types/conventional-changelog-core/index.d.ts
@@ -17,7 +17,7 @@ import {
     Options as BaseParserOptions,
 } from "conventional-commits-parser";
 import { Options as RecommendedBumpOptions } from "conventional-recommended-bump";
-import { GitOptions as BaseGitRawCommitsOptions } from "git-raw-commits";
+import { ExecOptions as GitRawExecOptions, GitOptions as BaseGitRawCommitsOptions } from "git-raw-commits";
 
 import { Package } from "normalize-package-data";
 
@@ -31,7 +31,7 @@ import { Package } from "normalize-package-data";
  * @param writerOpts
  */
 // tslint:disable-next-line max-line-length
-declare function conventionalChangelogCore<TCommit extends Commit = Commit, TContext extends BaseContext = Context>(options?: Options<TCommit, TContext>, context?: Partial<TContext>, gitRawCommitsOpts?: GitRawCommitsOptions, parserOpts?: ParserOptions, writerOpts?: WriterOptions<TCommit, TContext>): Stream.Readable;
+declare function conventionalChangelogCore<TCommit extends Commit = Commit, TContext extends BaseContext = Context>(options?: Options<TCommit, TContext>, context?: Partial<TContext>, gitRawCommitsOpts?: GitRawCommitsOptions, parserOpts?: ParserOptions, writerOpts?: WriterOptions<TCommit, TContext>, execOpts:GitRawExecOptions): Stream.Readable;
 
 declare namespace conventionalChangelogCore {
     interface Context extends BaseContext {


### PR DESCRIPTION
Currently the last parameter `gitExecOpts` isn't documented in the typings 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source Reference](https://github.com/conventional-changelog/conventional-changelog/blob/840d139c40a2c4e773794d794c34bc4dbfde27c2/packages/conventional-changelog-core/index.js#L13)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
