### PR TITLE
[react-instantsearch]: accept correct props in findResultsState

### DIFF
--- a/types/react-instantsearch-dom/react-instantsearch-dom-tests.tsx
+++ b/types/react-instantsearch-dom/react-instantsearch-dom-tests.tsx
@@ -13,9 +13,9 @@ import {
   Index,
   SortBy,
   HitsPerPage,
-  MenuSelect
+  MenuSelect,
 } from 'react-instantsearch/dom';
-import { Hit, connectRefinementList, connectMenu } from 'react-instantsearch-core';
+import { Hit, connectRefinementList, connectMenu, InstantSearchProps } from 'react-instantsearch-core';
 
 // DOM
 () => {
@@ -233,15 +233,11 @@ declare function createServer(handler: (req: any, res: any) => any): any;
 import { renderToString } from 'react-dom/server';
 
 const test = () => {
-  class App extends React.Component<any> {
+  class App extends React.Component<InstantSearchProps & { something: boolean }> {
     render() {
       return (
-        <InstantSearch
-          indexName="indexName"
-          searchClient={{}}
-          searchState={this.props.searchState}
-          resultsState={this.props.resultsState}
-        >
+        <InstantSearch {...this.props}>
+          {this.props.something}
           <SearchBox />
           <Hits />
         </InstantSearch>
@@ -251,13 +247,18 @@ const test = () => {
 
   const server = createServer(async (req, res) => {
     const searchState = { query: 'chair' };
-    const resultsState = await findResultsState(App, {
+    const props = {
       searchClient: {},
       indexName: '',
       searchState,
-    });
-    const appInitialState = { searchState, resultsState };
-    const appAsString = renderToString(<App {...appInitialState} />);
+      something: false,
+    };
+    const resultsState = await findResultsState(App, props);
+    const appInitialState = {
+      searchState,
+      resultsState,
+    };
+    const appAsString = renderToString(<App {...props} {...appInitialState} />);
     res.send(
       `
   <!doctype html>

--- a/types/react-instantsearch-dom/server.d.ts
+++ b/types/react-instantsearch-dom/server.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { InstantSearchProps } from 'react-instantsearch-core';
 
-export function findResultsState(
-    App: React.ComponentType<Pick<InstantSearchProps, 'widgetsCollector'> & Record<string, any>>,
-    props: Pick<InstantSearchProps, 'searchClient' | 'indexName'> & Record<string, any>,
-): Promise<InstantSearchProps['resultsState']>;
+export function findResultsState<
+  TProps extends Pick<InstantSearchProps, 'widgetsCollector' | 'searchClient' | 'indexName'>
+>(App: React.ComponentType<TProps>, props: TProps): Promise<InstantSearchProps['resultsState']>;


### PR DESCRIPTION
findResultsState allows a root component to have other props than just the InstantSearch ones, as can be seen here: 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.algolia.com/doc/guides/building-search-ui/going-further/server-side-rendering/react/#serverjs>

> If you need to pass other props to the component, you can add them to the object.


- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

closes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56859 cc @backendtea