### PR TITLE
Update react-native-webrtc's mediaDevices.getUserMedia

### DIFF
--- a/types/react-native-webrtc/index.d.ts
+++ b/types/react-native-webrtc/index.d.ts
@@ -235,7 +235,7 @@ export class mediaDevices {
 
     static enumerateDevices(): Promise<any>;
 
-    static getUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream | boolean>;
+    static getUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream>;
 }
 
 export function registerGlobals(): void;


### PR DESCRIPTION
We checked the code and it doesn't seem like it would return a boolean, it either returns a MediaStream or it rejects so the type here is wrong.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [HERE](https://github.com/react-native-webrtc/react-native-webrtc/blob/d93dd7d451b01b9015b65e4f79db0991edac0919/src/getDisplayMedia.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - Not sure?
