### PR TITLE
Add `tab` to @ember/test-helpers

### DIFF
--- a/types/ember__test-helpers/ember__test-helpers-tests.ts
+++ b/types/ember__test-helpers/ember__test-helpers-tests.ts
@@ -9,6 +9,7 @@ import {
     tap,
     focus,
     blur,
+    tab,
     triggerEvent,
     triggerKeyEvent,
     typeIn,
@@ -58,6 +59,7 @@ test('DOM interactions', async () => {
     await blur(messageElement);
     await triggerEvent(messageElement, 'custom-event');
     await triggerKeyEvent(messageElement, 'keydown', 'Enter', { ctrlKey: true });
+    await tab();
     await fillIn(messageElement, 'content');
     await typeIn(messageElement, 'content');
     await select(messageElement, 'content');

--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @ember/test-helpers 2.0
+// Type definitions for @ember/test-helpers 2.6
 // Project: https://github.com/emberjs/ember-test-helpers
 // Definitions by: Dan Freeman <https://github.com/dfreeman>
 //                 James C. Davis <https://github.com/jamescdavis>
@@ -22,6 +22,7 @@ declare module '@ember/test-helpers' {
     export { default as blur } from '@ember/test-helpers/dom/blur';
     export { default as triggerEvent } from '@ember/test-helpers/dom/trigger-event';
     export { default as triggerKeyEvent } from '@ember/test-helpers/dom/trigger-key-event';
+    export { default as tab } from '@ember/test-helpers/dom/triggerTab';
     export { default as fillIn } from '@ember/test-helpers/dom/fill-in';
     export { default as typeIn } from '@ember/test-helpers/dom/type-in';
     export { default as select } from '@ember/test-helpers/dom/select';
@@ -114,6 +115,10 @@ declare module '@ember/test-helpers/dom/trigger-key-event' {
     }
 
     export default function(target: Target, eventType: KeyEvent, key: number | string, modifiers?: KeyModifiers): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/triggerTab' {
+    export default function triggerTab(options?: { backwards?: boolean; unRestrainTabIndex?: boolean }): Promise<void>;
 }
 
 declare module '@ember/test-helpers/dom/fill-in' {


### PR DESCRIPTION
The `tab` helper was introduced in 2.6 with this PR:
https://github.com/emberjs/ember-test-helpers/pull/1113/files

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/setup-onerror.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Include tests for your changes
- [x] If you are making substantial changes, consider adding a tslint.json containing { "extends": "dtslint/dt.json" }. If for reason the any rule need to be disabled, disable it for that line using // tslint:disable-next-line [ruleName] and not for whole package so that the need for disabling can be reviewed.
