### PR TITLE
[pdfobject] Add string type to fallbackLink option

### DIFF
--- a/types/pdfobject/index.d.ts
+++ b/types/pdfobject/index.d.ts
@@ -12,7 +12,7 @@ export interface Options {
     id?: string | undefined;
     page?: boolean | undefined;
     pdfOpenParams?: Record<string, string | number | boolean> | undefined;
-    fallbackLink?: boolean | undefined;
+    fallbackLink?: boolean | string | undefined;
     width?: string | undefined;
     height?: string | undefined;
     assumptionMode?: boolean | undefined;

--- a/types/pdfobject/pdfobject-tests.ts
+++ b/types/pdfobject/pdfobject-tests.ts
@@ -6,5 +6,9 @@ PDFObject.embed("url", ".css-selector"); // $ExpectType HTMLElement
 PDFObject.embed("url", ".css-selector", {
     height: "200px",
 });
+// $ExpectType HTMLElement
+PDFObject.embed("url", ".css-selector", {
+    fallbackLink: "Unsupported browser",
+});
 PDFObject.pdfobjectversion; // $ExpectType "2.2.3"
 PDFObject.supportsPDFs; // $ExpectType boolean


### PR DESCRIPTION
Type `string` is missing from union type of `fallbackLink` option

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pdfobject.com/#fallbackLink
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
