### PR TITLE
Support full logger options in sass warn logger

### DIFF
--- a/types/sass/index.d.ts
+++ b/types/sass/index.d.ts
@@ -153,18 +153,12 @@ export interface Options {
     logger?: Logger;
 }
 
-export interface LoggerOptions {
-    deprecation: boolean;
-    span?: SourceSpan;
-    stack?: string;
-}
-
 export interface Logger {
     /** This method is called when Sass emits a debug message due to a @debug rule. */
-    debug?(message: string, options: LoggerOptions): void;
+    debug?(message: string, options: { span?: SourceSpan }): void;
 
     /** This method is called when Sass emits a debug message due to a @warn rule. */
-    warn?(message: string, options: LoggerOptions): void;
+    warn?(message: string, options: { deprecation: boolean; span?: SourceSpan; stack?: string }): void;
 }
 
 /**

--- a/types/sass/index.d.ts
+++ b/types/sass/index.d.ts
@@ -153,12 +153,18 @@ export interface Options {
     logger?: Logger;
 }
 
+export interface LoggerOptions {
+    deprecation: boolean;
+    span?: SourceSpan;
+    stack?: string
+}
+
 export interface Logger {
     /** This method is called when Sass emits a debug message due to a @debug rule. */
-    debug?(message: string, options: { deprecation: boolean; span?: SourceSpan; stack?: string }): void;
+    debug?(message: string, options: LoggerOptions): void;
 
     /** This method is called when Sass emits a debug message due to a @warn rule. */
-    warn?(message: string, options: { span: SourceSpan }): void;
+    warn?(message: string, options: LoggerOptions): void;
 }
 
 /**

--- a/types/sass/index.d.ts
+++ b/types/sass/index.d.ts
@@ -156,7 +156,7 @@ export interface Options {
 export interface LoggerOptions {
     deprecation: boolean;
     span?: SourceSpan;
-    stack?: string
+    stack?: string;
 }
 
 export interface Logger {

--- a/types/sass/sass-tests.ts
+++ b/types/sass/sass-tests.ts
@@ -8,7 +8,7 @@ sass.renderSync({
     logger: {
         warn: (message, options) => {
             // $ExpectType boolean
-            options.deprecation
+            options.deprecation;
             if (options.span) {
                 const log = `${options.span.url}:${options.span.start.line}:${options.span.start.column}`;
             } else {
@@ -17,7 +17,7 @@ sass.renderSync({
         },
         debug: (message, options) => {
             // $ExpectType boolean
-            options.deprecation
+            options.deprecation;
             if (options.span) {
                 const log = `${options.span.url}:${options.span.start.line}:${options.span.start.column}`;
             } else {

--- a/types/sass/sass-tests.ts
+++ b/types/sass/sass-tests.ts
@@ -16,8 +16,6 @@ sass.renderSync({
             }
         },
         debug: (message, options) => {
-            // $ExpectType boolean
-            options.deprecation;
             if (options.span) {
                 const log = `${options.span.url}:${options.span.start.line}:${options.span.start.column}`;
             } else {

--- a/types/sass/sass-tests.ts
+++ b/types/sass/sass-tests.ts
@@ -7,6 +7,8 @@ sass.renderSync({
     quietDeps: true,
     logger: {
         warn: (message, options) => {
+            // $ExpectType boolean
+            options.deprecation
             if (options.span) {
                 const log = `${options.span.url}:${options.span.start.line}:${options.span.start.column}`;
             } else {
@@ -14,6 +16,8 @@ sass.renderSync({
             }
         },
         debug: (message, options) => {
+            // $ExpectType boolean
+            options.deprecation
             if (options.span) {
                 const log = `${options.span.url}:${options.span.start.line}:${options.span.start.column}`;
             } else {


### PR DESCRIPTION
I just tried this locally and these properties exist in the `warn` logger method.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
