### PR TITLE
fix: [ramda] make assoc test more precise

### DIFF
--- a/types/ramda/test/assoc-tests.ts
+++ b/types/ramda/test/assoc-tests.ts
@@ -11,14 +11,17 @@ import * as R from 'ramda';
   const c: ABC = R.assoc('c', 3)({ a: 1, b: 2 }); // => {a: 1, b: 2, c: 3}
   const d: ABC = R.assoc(R.__, 3, { a: 1, b: 2 })('c'); // => {a: 1, b: 2, c: 3}
   const e: ABC = R.assoc('c', R.__, { a: 1, b: 2 })(3); // => {a: 1, b: 2, c: 3}
-  // $ExpectError
-  const f: ABC = R.assoc('c', "test", {a: 1, b: 2, c: 3}); // => {a: 1, b: 2, c: "test"}
-  // $ExpectError
-  const g: ABC = R.assoc('c', "test")({a: 1, b: 2, c: 3});  // => {a: 1, b: 2, c: "test"}
-  // $ExpectError
-  const h: ABC = R.assoc('c')("test")({a: 1, b: 2, c: 3});  // => {a: 1, b: 2, c: "test"}
-  // $ExpectError
-  const i: ABC = R.assoc('c')("test", {a: 1, b: 2, c: 3});  // => {a: 1, b: 2, c: "test"}
+
+  // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
+  R.assoc('c', "test", {a: 1, b: 2, c: 3}); // => {a: 1, b: 2, c: "test"}
+  // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
+  R.assoc('c', "test")({a: 1, b: 2, c: 3});  // => {a: 1, b: 2, c: "test"}
+  // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
+  R.assoc('c')("test")({a: 1, b: 2, c: 3});  // => {a: 1, b: 2, c: "test"}
+  // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
+  R.assoc('c')("test", {a: 1, b: 2, c: 3});  // => {a: 1, b: 2, c: "test"}
+  // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
+  R.assoc('c')("test", {a: 1, b: 2, c: 3});
 };
 
 () => {

--- a/types/ramda/test/keys-tests.ts
+++ b/types/ramda/test/keys-tests.ts
@@ -1,7 +1,9 @@
 import * as R from 'ramda';
 
 () => {
-  const objKeys = R.keys({a: 1, b: 2, c: 3}); // $ExpectType ("a" | "b" | "c")[]
+  // Order of string keys matters. c, a, b ¯\_(ツ)_/¯
+  // $ExpectType ("c" | "a" | "b")[]
+  const objKeys = R.keys({a: 1, b: 2, c: 3});
   const numberKeys = R.keys(1); // $ExpectType string[]
   const arrayKeys = R.keys([]); // List of array members
   const stringKeys = R.keys('foo'); // $ExpectType string[]

--- a/types/ramda/test/map-tests.ts
+++ b/types/ramda/test/map-tests.ts
@@ -49,7 +49,8 @@ import * as R from 'ramda';
 
   type KeyOfUnion<T> = T extends infer U ? keyof U : never;
 
-  // $ExpectType Record<"a" | "b" | "c", void>
+  // Order of string keys matters. c, a, b ¯\_(ツ)_/¯
+  // $ExpectType Record<"c" | "a" | "b", void>
   R.map<A | C, Record<KeyOfUnion<A | C>, void>>(
     // $ExpectType (value: string | number) => void
     value => {

--- a/types/ramda/test/zipObj-tests.ts
+++ b/types/ramda/test/zipObj-tests.ts
@@ -1,10 +1,12 @@
 import * as R from 'ramda';
 
 () => {
-  // $ExpectType { a: number; b: number; c: number; }
+  // Order of string keys matters. c, a, b ¯\_(ツ)_/¯
+  // $ExpectType { c: number; a: number; b: number; }
   R.zipObj(['a', 'b', 'c'], [1, 2, 3]); // => {a: 1, b: 2, c: 3}
 
-  // $ExpectType { a: number; b: number; c: number; }
+  // Order of string keys matters. c, a, b ¯\_(ツ)_/¯
+  // $ExpectType { c: number; a: number; b: number; }
   R.zipObj(['a', 'b', 'c'])([1, 2, 3]); // => {a: 1, b: 2, c: 3}
 
   // Order of numeric keys matters. 2, 3, 1 ¯\_(ツ)_/¯


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
