### PR TITLE
[k6] fix Response.message and Params.timeout type

### DIFF
--- a/types/k6/net/grpc.d.ts
+++ b/types/k6/net/grpc.d.ts
@@ -21,7 +21,7 @@ export interface ConnectParams {
 
     reflect?: boolean;
 
-    timeout?: number;
+    timeout?: string | number;
 }
 
 export interface Params {

--- a/types/k6/net/grpc.d.ts
+++ b/types/k6/net/grpc.d.ts
@@ -29,7 +29,7 @@ export interface Params {
 
     tags?: object;
 
-    timeout?: number;
+    timeout?: string | number;
 }
 
 /**

--- a/types/k6/net/grpc.d.ts
+++ b/types/k6/net/grpc.d.ts
@@ -7,7 +7,7 @@
 export interface Response {
     status: number;
 
-    message: string;
+    message: object;
 
     headers: object;
 
@@ -29,7 +29,7 @@ export interface Params {
 
     tags?: object;
 
-    timeout?: string;
+    timeout?: number;
 }
 
 /**

--- a/types/k6/test/grpc.ts
+++ b/types/k6/test/grpc.ts
@@ -17,6 +17,7 @@ const req = {
 const params = {
     headers: { 'x-my-header': 'k6test' },
     tags: { k6test: 'yes' },
+    timeout: 30,
 };
 const response = client.invoke('main.RouteGuide/GetFeature', req, params);
 response.error;

--- a/types/k6/test/grpc.ts
+++ b/types/k6/test/grpc.ts
@@ -22,7 +22,7 @@ const params = {
 const response = client.invoke('main.RouteGuide/GetFeature', req, params);
 response.error;
 response.headers;
-response.message;
+response.message; // $ExpectType object
 response.status;
 response.trailers;
 

--- a/types/k6/test/grpc.ts
+++ b/types/k6/test/grpc.ts
@@ -5,6 +5,8 @@ const client = new grpc.Client();
 client.connect('hola');
 client.connect('localhost:8080', { plaintext: true });
 client.connect('localhost:8080', { plaintext: true, reflect: true });
+client.connect('localhost:8080', { timeout: 30 });
+client.connect('localhost:8080', { timeout: '30' });
 
 client.close();
 

--- a/types/k6/test/grpc.ts
+++ b/types/k6/test/grpc.ts
@@ -26,6 +26,13 @@ response.message;
 response.status;
 response.trailers;
 
+const params_with_string_timeout = {
+    headers: { 'x-my-header': 'k6test' },
+    tags: { k6test: 'yes' },
+    timeout: '30',
+};
+client.invoke('main.RouteGuide/UpdateFeature', req, params_with_string_timeout);
+
 grpc.StatusOK;
 grpc.StatusCanceled;
 grpc.StatusUnknown;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `Params` ... https://k6.io/docs/javascript-api/k6-net-grpc/params/
  - `Response` ... https://k6.io/docs/javascript-api/k6-net-grpc/response
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.