### PR TITLE
Add support for @types/prompt to take a schema directly

### DIFF
--- a/types/prompt/index.d.ts
+++ b/types/prompt/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for prompt 1.1
 // Project: https://github.com/flatiron/prompt#readme
-// Definitions by: Florian Imdahl <https://github.com/ffflorian>
+// Definitions by: Florian Imdahl <https://github.com/ffflorian>, Matthew Berryman <https://github.com/matthewberryman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -63,10 +63,10 @@ declare class prompt extends EventEmitter {
         callback: prompt.GetCallback<prompt.Properties>,
     ): void;
     static get<T extends prompt.Properties>(
-        values: Array<keyof T | prompt.Schema | prompt.RevalidatorSchema>,
+        values: Array<keyof T | prompt.Schema | prompt.RevalidatorSchema> | prompt.Schema | prompt.RevalidatorSchema,
     ): Promise<T>;
     static get<T extends prompt.Properties>(
-        values: Array<keyof T | prompt.Schema | prompt.RevalidatorSchema>,
+        values: Array<keyof T | prompt.Schema | prompt.RevalidatorSchema> | prompt.Schema | prompt.RevalidatorSchema,
         callback: prompt.GetCallback<T>,
     ): void;
     static history(name?: string | number): prompt.History | null;

--- a/types/prompt/prompt-tests.ts
+++ b/types/prompt/prompt-tests.ts
@@ -60,4 +60,8 @@ prompt.get(
     },
 );
 
+// prompt 1.1 (at least) and higher also take a schema directly
+// per https://github.com/flatiron/prompt#prompting-with-validation-default-values-and-more-complex-properties , so add a test for that:
+prompt.get(schema);
+
 prompt.colors = false;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Prompting with Validation, Default Values, and More (Complex Properties)](https://github.com/flatiron/prompt#prompting-with-validation-default-values-and-more-complex-properties)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The last checklist item for updating is not relevant: I checked back in the docs for v1.1 of prompt and it also supports this way of calling `prompt.get(schema, callback)`.

