### PR TITLE
Add a missing property and fix a type for `prosemirror-*` module

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -11,6 +11,7 @@
 // TypeScript Version: 2.3
 
 import OrderedMap = require('orderedmap');
+import { EditorView } from 'prosemirror-view';
 
 /**
  * Instances of this class represent a match state of a node
@@ -1242,6 +1243,11 @@ export interface NodeSpec {
      */
     toDebugString?: ((node: ProsemirrorNode) => string) | null | undefined;
     /**
+     * @note Require `prosemirror-dropcursor` module.
+     * This property controls the showing of a drop cursor inside the node.
+     */
+    disableDropCursor?: boolean | ((view: EditorView, pos: number) => boolean);
+    /**
      * Allow specifying arbitrary fields on a NodeSpec.
      */
     [key: string]: any;
@@ -1393,7 +1399,7 @@ export interface DOMOutputSpecArray {
     8?: DOMOutputSpec | 0 | undefined;
     9?: DOMOutputSpec | 0 | undefined;
 }
-export type DOMOutputSpec = string | Node | DOMOutputSpecArray | {dom: Node, contentDOM?: Node | undefined};
+export type DOMOutputSpec = string | Node | DOMOutputSpecArray | { dom: Node; contentDOM?: Node | undefined };
 /**
  * A DOM serializer knows how to convert ProseMirror nodes and
  * marks of various types to DOM nodes.

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -587,7 +587,7 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
               [name: string]: (
                   node: ProsemirrorNode<S>,
                   view: EditorView<S>,
-                  getPos: (() => number) | boolean,
+                  getPos: () => number,
                   decorations: Decoration[],
               ) => NodeView<S>;
           }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- Add `disableDropCursor ` to NodeSpec. 
  - https://github.com/ProseMirror/prosemirror-dropcursor/blob/master/src/dropcursor.js#L9
- Remove boolean type of getPos
  - https://prosemirror.net/docs/ref/#view.EditorProps.nodeViews

