### PR TITLE
@type/qr-image: Move comments ahead

### DIFF
--- a/types/qr-image/index.d.ts
+++ b/types/qr-image/index.d.ts
@@ -39,11 +39,16 @@ export interface Bitmap {
 }
 
 export interface Options {
-    ec_level?: ec_level | undefined;    // error correction level. One of L, M, Q, H. Default M.
-    type?: image_type | undefined;        // image type. Possible values png(default), svg, pdf and eps.
-    size?: number | undefined;        // (png and svg only) for png and undefined for svg.-(png and svg only) — size of one module in pixels.
-    margin?: number | undefined;        // (only png)for png and 1 for others.-white space around QR image in modules.
-    parse_url?: boolean | undefined;    // (experimental, default false) try to optimize QR-code for URLs.
+    // error correction level. One of L, M, Q, H. Default M.
+    ec_level?: ec_level | undefined;
+    // image type. Possible values png(default), svg, pdf and eps.
+    type?: image_type | undefined;
+    // (png and svg only) for png and undefined for svg.-(png and svg only) — size of one module in pixels.
+    size?: number | undefined;
+    // (only png)for png and 1 for others.-white space around QR image in modules.
+    margin?: number | undefined;
+    // (experimental, default false) try to optimize QR-code for URLs.
+    parse_url?: boolean | undefined;
     /**
      * (only png) — function to customize qr bitmap before encoding to PNG
      */

--- a/types/qr-image/qr-image-tests.ts
+++ b/types/qr-image/qr-image-tests.ts
@@ -7,7 +7,6 @@ qr_svg.pipe(fs.createWriteStream('i_love_qr.svg'));
 const svg_string = qr.imageSync('I love QR!', { type: 'svg' });
 
 // customize
-
 function coord2offset(x: number, y: number, size: number) {
     return (size + 1) * y + x + 1;
 }


### PR DESCRIPTION
Most IDE treat comments ahead of properties as document, which causing document for 'type' is actually document for 'ec_level'.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. 
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/alexeyten/qr-image
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
