### PR TITLE
[prosemirror-view] Improve the type definition of `nodeViews` property.

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -587,9 +587,18 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
               [name: string]: (
                   node: ProsemirrorNode<S>,
                   view: EditorView<S>,
-                  getPos: (() => number) | boolean,
+                  /** get the node's current position */
+                  getPos: () => number,
                   decorations: Decoration[],
               ) => NodeView<S>;
+          }
+        | {
+              [name: string]: (
+                  mark: Mark<S>,
+                  view: EditorView<S>,
+                  /** indicates whether the mark's content is inline */
+                  inline: boolean,
+              ) => Pick<NodeView<S>, 'dom' | 'contentDOM'>; /** Mark views only support dom and contentDOM */
           }
         | null
         | undefined;

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -584,21 +584,18 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
      */
     nodeViews?:
         | {
-              [name: string]: (
+              [name: string]: ((
                   node: ProsemirrorNode<S>,
                   view: EditorView<S>,
                   /** get the node's current position */
                   getPos: () => number,
                   decorations: Decoration[],
-              ) => NodeView<S>;
-          }
-        | {
-              [name: string]: (
+              ) => NodeView<S>) | ((
                   mark: Mark<S>,
                   view: EditorView<S>,
                   /** indicates whether the mark's content is inline */
                   inline: boolean,
-              ) => Pick<NodeView<S>, 'dom' | 'contentDOM'>; /** Mark views only support dom and contentDOM */
+              ) => Pick<NodeView<S>, 'dom' | 'contentDOM'>);
           }
         | null
         | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

@Narretz  Hi.  I split the nodeViews type for node and mark. I think this will be more clearly.🦦

> https://prosemirror.net/docs/ref/#view.NodeView
>
> Mark views only support dom and contentDOM, and don't support any of the node view methods.

> https://prosemirror.net/docs/ref/#view.EditorProps.nodeViews
>
> For nodes, the third argument getPos is a function that can be called to get the node's current position, which can be useful when creating transactions to update it. For marks, the third argument is a boolean that indicates whether the mark's content is inline.

> According to the [source code](https://github.com/ProseMirror/prosemirror-view/blob/master/src/viewdesc.js#L574), mark views only has three arguments.