### PR TITLE
Fixed the electron-positioner type when a type of position is `Position | TrayPosition`

### DIFF
--- a/types/electron-positioner/electron-positioner-tests.ts
+++ b/types/electron-positioner/electron-positioner-tests.ts
@@ -1,4 +1,4 @@
-import Positioner = require("electron-positioner");
+import Positioner = require('electron-positioner');
 import { BrowserWindow } from 'electron';
 
 const positioner = new Positioner(new BrowserWindow());
@@ -27,6 +27,20 @@ positioner.calculate('topLeft');
 
 // $ExpectType { x: number; y: number; }
 positioner.calculate('topLeft', rectangle);
+
+const positionOrTrayPosition = 'trayLeft' as Positioner.Position | Positioner.TrayPosition;
+
+// $ExpectError
+positioner.move(positionOrTrayPosition);
+
+// $ExpectType void
+positioner.move(positionOrTrayPosition, rectangle);
+
+// $ExpectError
+positioner.calculate(positionOrTrayPosition);
+
+// $ExpectType { x: number; y: number; }
+positioner.calculate(positionOrTrayPosition, rectangle);
 
 positioner.move('trayLeft', rectangle);
 positioner.move('trayBottomLeft', rectangle);

--- a/types/electron-positioner/index.d.ts
+++ b/types/electron-positioner/index.d.ts
@@ -30,10 +30,13 @@ declare class ElectronPositioner {
     constructor(browserWindow: BrowserWindow);
 
     move(position: ElectronPositioner.Position, trayBounds?: Rectangle): void;
-    move(position: ElectronPositioner.TrayPosition, trayBounds: Rectangle): void;
+    move(position: ElectronPositioner.Position | ElectronPositioner.TrayPosition, trayBounds: Rectangle): void;
 
     calculate(position: ElectronPositioner.Position, trayBounds?: Rectangle): { x: number; y: number };
-    calculate(position: ElectronPositioner.TrayPosition, trayBounds: Rectangle): { x: number; y: number };
+    calculate(
+        position: ElectronPositioner.Position | ElectronPositioner.TrayPosition,
+        trayBounds: Rectangle,
+    ): { x: number; y: number };
 }
 
 export = ElectronPositioner;


### PR DESCRIPTION
I'm sorry but [the PR I requested](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57354) was a bit incorrect.

If the`trayBounds` argument is passed, no type error should occur regardless of whether the type of `position` is `Position ` nor `TrayPosition`. But the previous PR is wasn't.

a type error has occurred.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jenslind/electron-positioner#traybounds
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
