### PR TITLE
dynamodb-lock-client: add retryCount to GenericConfig interface

### DIFF
--- a/types/dynamodb-lock-client/dynamodb-lock-client-tests.ts
+++ b/types/dynamodb-lock-client/dynamodb-lock-client-tests.ts
@@ -1,4 +1,4 @@
-import  { DynamoDB } from 'aws-sdk'
+import { DynamoDB } from 'aws-sdk';
 import * as DynamoDBLockClient from 'dynamodb-lock-client';
 
 const dynamodb = new DynamoDB.DocumentClient({
@@ -10,7 +10,7 @@ const failClosedClient = new DynamoDBLockClient.FailClosed({
     lockTable: "my-lock-table-name",
     partitionKey: "mylocks",
     acquirePeriodMs: 1e4,
-    retryCount:1
+    retryCount: 1
 });
 
 failClosedClient.acquireLock("my-fail-closed-lock", (error, lock) => {
@@ -35,7 +35,7 @@ const failOpenClient = new DynamoDBLockClient.FailOpen({
     partitionKey: "mylocks",
     heartbeatPeriodMs: 3e3,
     leaseDurationMs: 1e4,
-    retryCount:1
+    retryCount: 1
 });
 
 failOpenClient.acquireLock("my-fail-open-lock", (error, lock) => {

--- a/types/dynamodb-lock-client/dynamodb-lock-client-tests.ts
+++ b/types/dynamodb-lock-client/dynamodb-lock-client-tests.ts
@@ -1,7 +1,7 @@
-import * as AWS from "aws-sdk";
-import * as DynamoDBLockClient from "dynamodb-lock-client";
+import  { DynamoDB } from 'aws-sdk'
+import * as DynamoDBLockClient from 'dynamodb-lock-client';
 
-const dynamodb = new AWS.DynamoDB.DocumentClient({
+const dynamodb = new DynamoDB.DocumentClient({
     region: "us-east-1",
 });
 
@@ -10,6 +10,7 @@ const failClosedClient = new DynamoDBLockClient.FailClosed({
     lockTable: "my-lock-table-name",
     partitionKey: "mylocks",
     acquirePeriodMs: 1e4,
+    retryCount:1
 });
 
 failClosedClient.acquireLock("my-fail-closed-lock", (error, lock) => {
@@ -34,6 +35,7 @@ const failOpenClient = new DynamoDBLockClient.FailOpen({
     partitionKey: "mylocks",
     heartbeatPeriodMs: 3e3,
     leaseDurationMs: 1e4,
+    retryCount:1
 });
 
 failOpenClient.acquireLock("my-fail-open-lock", (error, lock) => {

--- a/types/dynamodb-lock-client/index.d.ts
+++ b/types/dynamodb-lock-client/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for dynamodb-lock-client 0.7
+// Type definitions for dynamodb-lock-client 0.7.3
 // Project: https://github.com/tristanls/dynamodb-lock-client#readme
 // Definitions by: RyoshiKayo <https://github.com/RyoshiKayo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/dynamodb-lock-client/index.d.ts
+++ b/types/dynamodb-lock-client/index.d.ts
@@ -19,6 +19,7 @@ interface GenericConfig {
     partitionKey: string;
     sortKey?: string | undefined;
     owner?: string | undefined;
+    retryCount?: number | undefined
 }
 
 export interface FailClosedConfig extends GenericConfig {

--- a/types/dynamodb-lock-client/index.d.ts
+++ b/types/dynamodb-lock-client/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for dynamodb-lock-client 0.7.3
+// Type definitions for dynamodb-lock-client 0.7
 // Project: https://github.com/tristanls/dynamodb-lock-client#readme
 // Definitions by: RyoshiKayo <https://github.com/RyoshiKayo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -19,7 +19,7 @@ interface GenericConfig {
     partitionKey: string;
     sortKey?: string | undefined;
     owner?: string | undefined;
-    retryCount?: number | undefined
+    retryCount?: number | undefined;
 }
 
 export interface FailClosedConfig extends GenericConfig {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). This fails with an Out of Memory exception although the tests were not touched and seem to have been submitted originally in this state.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [FailClosedConfig](https://github.com/tristanls/dynamodb-lock-client/commit/8c52936f2feecc33d09a64f4d94a8482f825ad42#diff-5db02ad11a9304a29393e6e12c22a0cddef236728974e52a21c66eabd1581022) and [FailOpenConfig](https://github.com/tristanls/dynamodb-lock-client/commit/8c52936f2feecc33d09a64f4d94a8482f825ad42#diff-f617b7bd938306a8215c9dd6fc47c15547791314010438a7d4a50e34ab418353) include retryCount
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
