### PR TITLE
[color-string] Define behaviour on get.[rbg|hsl|hwb](null) 

### DIFF
--- a/types/color-string/color-string-tests.ts
+++ b/types/color-string/color-string-tests.ts
@@ -21,6 +21,11 @@ color = colorString.get.hwb('hwb(60, 3%, 60%, 0.6)');
 
 color = colorString.get.rgb('invalid color string');
 
+let nothing: null;
+nothing = colorString.get.rgb(null);
+nothing = colorString.get.hsl(null);
+nothing = colorString.get.hwb(null);
+
 let stringifiedColor: string;
 stringifiedColor = colorString.to.hex([255, 255, 255]);
 stringifiedColor = colorString.to.hex([0, 0, 255, 0.4]);

--- a/types/color-string/index.d.ts
+++ b/types/color-string/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/qix-/color-string#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
 //                 Dan Marshall <https://github.com/danmarshall>
+//                 Eric NICOLAS (ccjmne) <https://github.com/ccjmne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export type Color = [number, number, number, number];
@@ -15,8 +16,11 @@ export function get(colorString: string): ColorDescriptor | null;
 
 export namespace get {
     function hsl(colorString: string): Color | null;
+    function hsl(empty: null | undefined): null;
     function hwb(colorString: string): Color | null;
+    function hwb(empty: null | undefined): null;
     function rgb(colorString: string): Color | null;
+    function rgb(empty: null | undefined): null;
 }
 
 export namespace to {


### PR DESCRIPTION
- [x] I used a meaningful title for the pull request. I included the name of the package modified.
- [x] I tested the change in your own code. (I compiled and ran.)
- [x] I [added tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] I followed the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] I avoided [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] I [ran `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

For changing an existing definition:
- [x] I hereby provide a URL to documentation or source code that provides context for the suggested changes: 
https://github.com/Qix-/color-string/blob/b541d55cc678fd9ac9574f8faec791ee7bf2cf05/index.js#L47-L49
