### PR TITLE
[node] Be more specific on return type of path#extname

### DIFF
--- a/types/node/path.d.ts
+++ b/types/node/path.d.ts
@@ -123,7 +123,7 @@ declare module 'path' {
              *
              * @param p the path to evaluate.
              */
-            extname(p: string): string;
+            extname(p: string): '' | `.${string}`;
             /**
              * The platform-specific file separator. '\\' or '/'.
              */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/path.html#pathextnamepath
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---
This PR changes the return value of `path.extname` to reflect the fact that the returned string aleys starts with a `.`, or the entire string is empty.
This way, the user knows whether the returned file extension has a leading dot without reading the documentation.

Don't hesitate to reject this PR if this feels like an unnatural or incompatible change.
