### PR TITLE
Dropped myself from the Cytoscape owners list

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -4,7 +4,6 @@
 //                  Shenghan Gao <https://github.com/wy193777>
 //                  Yuri Pereira Constante <https://github.com/ypconstante>
 //                  Jan-Niclas Struewer <https://github.com/janniclas>
-//                  Cerberuser <https://github.com/cerberuser>
 //                  Andrej Kirejeŭ <https://github.com/gsbelarus>
 //                  Peter Ferrarotto <https://github.com/peterjferrarotto>
 //                  Xavier Ho <https://github.com/spaxe>


### PR DESCRIPTION
I wasn't able to follow Cytoscape development for quite some time. There's an extensive list of developers who made more substantial and more recent contributions to these typings, and, to be honest, I simply don't fully understand the state they are currently in. Therefore, I resign from the Cytoscape type definitions ownership.