### PR TITLE
Drop Jongsu Liam Kim (myself) from the Cytoscape owners list

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -8,7 +8,6 @@
 //                  Andrej Kirejeŭ <https://github.com/gsbelarus>
 //                  Peter Ferrarotto <https://github.com/peterjferrarotto>
 //                  Xavier Ho <https://github.com/spaxe>
-//                  Jongsu Liam Kim <https://github.com/appleparan>
 //                  Fredrik Sandström <https://github.com/Veckodag>
 //                  Jan Zak <https://github.com/zakjan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
I also haven't used Cytoscape for a while, and like @Cerber-Ursi, I'm not keeping up with current developments. Therefore, I also resign from the Cytoscape type definitions ownership.