### PR TITLE
express-rate-limit: fix options.message type

### DIFF
--- a/types/express-rate-limit/index.d.ts
+++ b/types/express-rate-limit/index.d.ts
@@ -43,12 +43,6 @@ declare namespace rateLimit {
         resetAll(): void;
     }
 
-    interface Message {
-        status: number;
-        message: string;
-        [key: string]: any;
-    }
-
     type MaxValueFn = (req: express.Request, res: express.Response) => number | Promise<number>;
 
     interface Options {
@@ -93,7 +87,7 @@ declare namespace rateLimit {
          * Error message sent to user when `max` is exceeded. May be a `string`, JSON object, or any other value
          * that Express's `req.send()` supports. Defaults to `'Too many requests, please try again later.'`.
          */
-        message?: string | Buffer | Message | undefined;
+        message?: any;
 
         /**
          * Function that is called the first time `max` is exceeded. The `req.rateLimit` object has `limit`, `current`,


### PR DESCRIPTION
express-rate-limit doesn't care at all about the format of `options.message`, it's just passed verbatim to express's `res.send()` method, which is defined as accepting `any` if I'm reading things correctly. See 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0a9c9d85e8a9ae8aa4a96abbb2d9feac53dda9f6/types/express-serve-static-core/index.d.ts#L662 and https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0a9c9d85e8a9ae8aa4a96abbb2d9feac53dda9f6/types/express-serve-static-core/index.d.ts#L707

Fixes https://github.com/nfriedly/express-rate-limit/issues/262

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
  - No, I don't actually use typescript that much. Perhaps @angelovdev can confirm this works for them?
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
  - Sorry, I'm just editing in the github web interface, I don't actually have anything set up to test this locally.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nfriedly/express-rate-limit/blob/b9e0e59d1b65621d92827ec50208420936114106/lib/express-rate-limit.js#L32
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Sorry kind of a half-assed PR. I'd like to do more, but I don't really have the time today, and I think this will fix the problem.