### PR TITLE
[@sinonjs/fake-timers]: add performance to node clock interface

### DIFF
--- a/types/sinonjs__fake-timers/index.d.ts
+++ b/types/sinonjs__fake-timers/index.d.ts
@@ -267,7 +267,7 @@ export interface FakeClock<TTimerId extends TimerId> extends GlobalTimers<TTimer
 /**
  * Fake clock for a browser environment.
  */
-export type BrowserClock = FakeClock<number> & {};
+export type BrowserClock = FakeClock<number>;
 
 /**
  * Fake clock for a Node environment.

--- a/types/sinonjs__fake-timers/index.d.ts
+++ b/types/sinonjs__fake-timers/index.d.ts
@@ -123,6 +123,13 @@ export interface FakeClock<TTimerId extends TimerId> extends GlobalTimers<TTimer
     now: number;
 
     /**
+     * Mimics performance.now().
+     */
+    performance: {
+        now: () => number;
+    };
+
+    /**
      * Don't know what this prop is for, but it was included in the clocks that `createClock` or
      * `install` return (it is never used in the code, for now).
      */
@@ -260,14 +267,7 @@ export interface FakeClock<TTimerId extends TimerId> extends GlobalTimers<TTimer
 /**
  * Fake clock for a browser environment.
  */
-export type BrowserClock = FakeClock<number> & {
-    /**
-     * Mimics performance.now().
-     */
-    performance: {
-        now: () => number;
-    };
-};
+export type BrowserClock = FakeClock<number> & {};
 
 /**
  * Fake clock for a Node environment.

--- a/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
+++ b/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
@@ -141,6 +141,7 @@ secs.toFixed();
 nanos.toExponential();
 
 browserInstalledClock.performance.now();
+nodeInstalledClock.performance.now();
 nodeInstalledClock.nextTick(() => {});
 
 browserInstalledClock.uninstall();


### PR DESCRIPTION
Sinon Fake Timers makes the `.performance` object available on the clock object conditionally based on the current environment. The global `performance` object has been made available as of v16, so Fake Timers will provide `clock.performance` when running on modern Node.js.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [sinonjs source](https://github.com/sinonjs/fake-timers/blob/1b1ac4a781c57498b8aa9015c6448bd02e54830c/src/fake-timers-src.js#L155-L159) [node.js merge](https://github.com/nodejs/node/pull/37970)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
