### PR TITLE
[ramda] extend return type of type function by Error string

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1976,7 +1976,7 @@ export function tryCatch<F extends (...args: readonly any[]) => any>(tryer: F): 
  * 'Number', 'Array', or 'Null'. Does not attempt to distinguish user Object types any further, reporting them
  * all as 'Object'.
  */
-export function type(val: any): 'Object' | 'Number' | 'Boolean' | 'String' | 'Null' | 'Array' | 'RegExp' | 'Function' | 'Undefined' | 'Symbol';
+export function type(val: any): 'Object' | 'Number' | 'Boolean' | 'String' | 'Null' | 'Array' | 'RegExp' | 'Function' | 'Undefined' | 'Symbol' | 'Error';
 
 /**
  * Takes a function fn, which takes a single array argument, and returns a function which:

--- a/types/ramda/test/type-tests.ts
+++ b/types/ramda/test/type-tests.ts
@@ -1,5 +1,7 @@
 import * as R from 'ramda';
 
+class ExtendedError extends Error {}
+
 () => {
   R.type({}); // => "Object"
   R.type(1); // => "Number"
@@ -9,4 +11,6 @@ import * as R from 'ramda';
   R.type([]); // => "Array"
   R.type(/[A-z]/); // => "RegExp"
   R.type(Symbol()); // => "Symbol"
+  R.type(Error()); // => "Error"
+  R.type(new ExtendedError()); // => "Error"
 };


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Ramda REPL (Showcases, that `'Error'` is a possible return type)](https://ramdajs.com/repl/#?R.type%28Error%28%29%29)
