### PR TITLE
[@types/plotly.js] Update Plotly toImage and downloadImage API

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -301,7 +301,15 @@ export interface PolarLayout {
     uirevision: string | number;
 }
 
+export interface PlotlyDataLayoutConfig {
+    data: Data[];
+    layout?: Partial<Layout>;
+    config?: Partial<Config>;
+}
+
 export type Root = string | HTMLElement;
+
+export type RootOrData = string | HTMLElement | PlotlyDataLayoutConfig;
 
 export function newPlot(
     root: Root,
@@ -348,8 +356,8 @@ export function prependTraces(
     update: Data | Data[],
     indices: number | number[],
 ): Promise<PlotlyHTMLElement>;
-export function toImage(root: Root, opts: ToImgopts): Promise<string>;
-export function downloadImage(root: Root, opts: DownloadImgopts): Promise<string>;
+export function toImage(root: RootOrData, opts: ToImgopts): Promise<string>;
+export function downloadImage(root: RootOrData, opts: DownloadImgopts): Promise<string>;
 export function react(
     root: Root,
     data: Data[],

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -309,7 +309,7 @@ export interface PlotlyDataLayoutConfig {
 
 export type Root = string | HTMLElement;
 
-export type RootOrData = string | HTMLElement | PlotlyDataLayoutConfig;
+export type RootOrData = Root | PlotlyDataLayoutConfig;
 
 export function newPlot(
     root: Root,

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -356,7 +356,7 @@ export function prependTraces(
     update: Data | Data[],
     indices: number | number[],
 ): Promise<PlotlyHTMLElement>;
-export function toImage(root: RootOrData, opts: ToImgopts): Promise<string>;
+export function toImage(root: RootOrData, opts?: ToImgopts): Promise<string>;
 export function downloadImage(root: RootOrData, opts: DownloadImgopts): Promise<string>;
 export function react(
     root: Root,

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -681,6 +681,17 @@ function rand() {
 //////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////
+// Plotly.toImage raw data input
+(() => {
+    // Plotly.toImage will turn the plot data into a data URL string
+    // toImage takes the data as the first argument and an object specifying image properties as the other
+    Plotly.toImage({data, layout}, { format: 'png', width: 800, height: 600, scale: 2 }).then(dataUrl => {
+        // use the dataUrl
+    });
+})();
+//////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////
 // Plotly.downloadImage
 (() => {
     // downloadImage will accept the div as the first argument and an object specifying image properties as the other

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -2,45 +2,45 @@ import * as Plotly from 'plotly.js/lib/core';
 import { Datum, ScatterData, Layout, newPlot, PlotData, ViolinData, CandlestickData, PieData } from 'plotly.js/lib/core';
 
 const graphDiv = '#test';
+const trace1 = {
+    x: [1999, 2000, 2001, 2002],
+    y: [10, 15, 13, 17],
+    customdata: [1, 2, 3],
+    type: 'scatter',
+} as ScatterData;
+const trace2 = {
+    x: [1999, 2000, 2001, 2002],
+    y: [16, 5, 11, 9],
+    customdata: [
+        [1, 'a'],
+        [2, 'b'],
+        [3, 'c'],
+    ],
+    type: 'scatter',
+} as ScatterData;
+const data = [trace1, trace2];
+const tickangle: "auto" = "auto";
+const layout = {
+    title: 'Sales Growth',
+    xaxis: {
+        title: 'Year',
+        showgrid: false,
+        zeroline: false,
+        tickangle
+    },
+    yaxis: {
+        title: 'Percent',
+        showline: false,
+    },
+    uirevision: 'true',
+    datarevision: 0,
+    editrevision: 0,
+    selectionrevision: 0
+};
 
 //////////////////////////////////////////////////////////////////////
 // Plotly.newPlot
 (() => {
-    const trace1 = {
-        x: [1999, 2000, 2001, 2002],
-        y: [10, 15, 13, 17],
-        customdata: [1, 2, 3],
-        type: 'scatter',
-    } as ScatterData;
-    const trace2 = {
-        x: [1999, 2000, 2001, 2002],
-        y: [16, 5, 11, 9],
-        customdata: [
-            [1, 'a'],
-            [2, 'b'],
-            [3, 'c'],
-        ],
-        type: 'scatter',
-    } as ScatterData;
-    const data = [trace1, trace2];
-    const tickangle: "auto" = "auto";
-    const layout = {
-        title: 'Sales Growth',
-        xaxis: {
-            title: 'Year',
-            showgrid: false,
-            zeroline: false,
-            tickangle
-        },
-        yaxis: {
-            title: 'Percent',
-            showline: false,
-        },
-        uirevision: 'true',
-        datarevision: 0,
-        editrevision: 0,
-        selectionrevision: 0
-    };
     Plotly.newPlot(graphDiv, data, layout);
 
     const violinTrace = {


### PR DESCRIPTION
Right now the definitions are outdated. See:

https://github.com/plotly/plotly.js/blob/v2.6.4/src/plot_api/to_image.js#L73-L76

The current Type definition does not account for the data/layout/config object, so passing this type of object fails even though it should work.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.