### PR TITLE
Make leaflet-offline a non-npm package

### DIFF
--- a/types/leaflet-offline/index.d.ts
+++ b/types/leaflet-offline/index.d.ts
@@ -1,8 +1,7 @@
-// Type definitions for leaflet-offline 1.1
+// Type definitions for non-npm package leaflet-offline 1.1
 // Project: https://github.com/robertomlsoares/leaflet-offline#readme
 // Definitions by: BETOXL <https://github.com/BETOXL>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 import * as L from 'leaflet';
 declare module 'leaflet' {
     class TileLayerOffline {


### PR DESCRIPTION
Its source npm package has been unpublished. Both leaflet-offline and @types/leaflet-offline are little used, so it might be better to delete the directory and mark it as not needed instead. However, that would leave `@types/leaflet-offline` still accessible, unlike `leaflet-offline` itself.