### PR TITLE
[express-jwt] Widen ErrorCode to string, supporting autocomplete

### DIFF
--- a/types/express-jwt/express-jwt-tests.ts
+++ b/types/express-jwt/express-jwt-tests.ts
@@ -37,9 +37,10 @@ const tenants: Record<string, { secret: string }> = {
 const multiTenancySecretCallback: jwt.SecretCallback = (req, payload, done) => {
     const issuer: string = payload.iss;
     if (tenants[issuer]) {
-        return done(null, tenants[issuer].secret);
+        done(null, tenants[issuer].secret);
+    } else {
+        done(new jwt.UnauthorizedError('missing_secret', { message: 'Could not find secret for issuer.' }));
     }
-    return done(new jwt.UnauthorizedError('missing_secret', { message: 'Could not find secret for issuer.' }));
 };
 app.use(
     jwt({

--- a/types/express-jwt/express-jwt-tests.ts
+++ b/types/express-jwt/express-jwt-tests.ts
@@ -29,6 +29,25 @@ app.use(
     }),
 );
 
+const tenants: Record<string, { secret: string }> = {
+    a: {
+        secret: 'secret-a',
+    },
+};
+const multiTenancySecretCallback: jwt.SecretCallback = (req, payload, done) => {
+    const issuer: string = payload.iss;
+    if (tenants[issuer]) {
+        return done(null, tenants[issuer].secret);
+    }
+    return done(new jwt.UnauthorizedError('missing_secret', { message: 'Could not find secret for issuer.' }));
+};
+app.use(
+    jwt({
+        algorithms: ['HS256'],
+        secret: multiTenancySecretCallback,
+    }),
+);
+
 app.use(
     jwt({
         algorithms: ['HS256'],

--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -20,7 +20,8 @@ declare namespace jwt {
         | 'invalid_token'
         | 'credentials_bad_scheme'
         | 'credentials_bad_format'
-        | 'credentials_required';
+        | 'credentials_required'
+        | 'missing_secret';
 
     interface SecretCallbackLong {
         (req: express.Request, header: any, payload: any, done: (err: any, secret?: secretType) => void): void;

--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -15,15 +15,11 @@ export = jwt;
 declare function jwt(options: jwt.Options): jwt.RequestHandler;
 declare namespace jwt {
     type secretType = string | Buffer;
-    /**
-     * The express-jwt library specifies the following ErrorCode values by default:
-     * - `"revoked_token"`
-     * - `"invalid_token"`
-     * - `"credentials_bad_scheme"`
-     * - `"credentials_bad_format"`
-     * - `"credentials_required"`
-     */
-    type ErrorCode = string;
+    type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>);
+
+    type ErrorCode = LiteralUnion<
+        'revoked_token' | 'invalid_token' | 'credentials_bad_scheme' | 'credentials_bad_format' | 'credentials_required'
+    >;
 
     interface SecretCallbackLong {
         (req: express.Request, header: any, payload: any, done: (err: any, secret?: secretType) => void): void;

--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -15,13 +15,7 @@ export = jwt;
 declare function jwt(options: jwt.Options): jwt.RequestHandler;
 declare namespace jwt {
     type secretType = string | Buffer;
-    type ErrorCode =
-        | 'revoked_token'
-        | 'invalid_token'
-        | 'credentials_bad_scheme'
-        | 'credentials_bad_format'
-        | 'credentials_required'
-        | 'missing_secret';
+    type ErrorCode = string;
 
     interface SecretCallbackLong {
         (req: express.Request, header: any, payload: any, done: (err: any, secret?: secretType) => void): void;

--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -15,6 +15,14 @@ export = jwt;
 declare function jwt(options: jwt.Options): jwt.RequestHandler;
 declare namespace jwt {
     type secretType = string | Buffer;
+    /**
+     * The express-jwt library specifies the following ErrorCode values by default:
+     * - `"revoked_token"`
+     * - `"invalid_token"`
+     * - `"credentials_bad_scheme"`
+     * - `"credentials_bad_format"`
+     * - `"credentials_required"`
+     */
     type ErrorCode = string;
 
     interface SecretCallbackLong {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [The multi-tenancy example shows `"missing_secret"` as the code for the `UnauthorizedError`](https://github.com/auth0/express-jwt/blob/master/test/multitenancy.test.js)

