### PR TITLE
slug@v5.1.0 - Adds trim property for the slug package

### DIFF
--- a/types/slug/index.d.ts
+++ b/types/slug/index.d.ts
@@ -32,6 +32,7 @@ declare namespace slug {
         remove?: RegExp | null | undefined;
         replacement?: string | null | undefined;
         symbols?: boolean | null | undefined;
+        trim?: boolean | null | undefined;
     }
 
     type Options = {

--- a/types/slug/slug-tests.ts
+++ b/types/slug/slug-tests.ts
@@ -19,6 +19,8 @@ slug("string", {}); // $ExpectType string
 
 slug("string", "replacement"); // $ExpectType string
 
+slug("string something something ", { trim: false }); // $ExpectType string 
+
 slug.defaults.mode = "pretty";
 slug.defaults.modes["rfc3986"] = {
     replacement: "-", // replace spaces with replacement

--- a/types/slug/slug-tests.ts
+++ b/types/slug/slug-tests.ts
@@ -19,9 +19,6 @@ slug("string", {}); // $ExpectType string
 
 slug("string", "replacement"); // $ExpectType string
 
-// eslint-disable-next-line no-trailing-spaces
-slug("string something something ", { trim: false }); // $ExpectType string 
-
 slug.defaults.mode = "pretty";
 slug.defaults.modes["rfc3986"] = {
     replacement: "-", // replace spaces with replacement

--- a/types/slug/slug-tests.ts
+++ b/types/slug/slug-tests.ts
@@ -19,6 +19,7 @@ slug("string", {}); // $ExpectType string
 
 slug("string", "replacement"); // $ExpectType string
 
+// eslint-disable-next-line no-trailing-spaces
 slug("string something something ", { trim: false }); // $ExpectType string 
 
 slug.defaults.mode = "pretty";


### PR DESCRIPTION
The slug package support an option to allow having whitespace at the end of a string.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/Trott/slug#options](https://github.com/Trott/slug#options)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
