### PR TITLE
fix(jsdom): reference `dom` lib in source

### DIFF
--- a/types/jsdom/base.d.ts
+++ b/types/jsdom/base.d.ts
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 /// <reference types="node" />
 
 import { EventEmitter } from "events";

--- a/types/jsdom/tsconfig.json
+++ b/types/jsdom/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["ESNext", "DOM"],
+        "lib": ["ESNext"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

See https://github.com/facebook/jest/issues/12098

Having some DOM types that does not pollute the global namespace would be better, but 🤷 