### PR TITLE
Expose draft-js namespaces to enable complex application typings and prevent limiting developers

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -1171,6 +1171,9 @@ import DraftHandleValue = Draft.Model.Constants.DraftHandleValue;
 import DraftInsertionType = Draft.Model.Constants.DraftInsertionType;
 import DraftStyleMap = Draft.Component.Base.DraftStyleMap;
 
+import DraftModel = Draft.Model;
+import DraftComponent = Draft.Component;
+
 export {
     Editor,
     EditorProps,
@@ -1219,4 +1222,6 @@ export {
     DraftHandleValue,
     DraftInsertionType,
     DraftStyleMap,
+    DraftModel,
+    DraftComponent
 };


### PR DESCRIPTION
One problem I noticed is that the type `DraftBlockType` collapses the constant union `CoreDraftBlockType` to a `string` type. This is unfortunate cause it is effectively information lost. Exposing the native Flow namespaces would be helpful to create custom types.