### PR TITLE
Fix chrome.window events

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10742,8 +10742,13 @@ declare namespace chrome.windows {
         extends chrome.events.Event<(windowId: number, filters?: WindowEventFilter) => void> { }
 
     export interface WindowReferenceEvent
-        extends chrome.events.Event<callback: (window: Window) => void, filters?: WindowEventFilter> { }
-
+        extends chrome.events.Event<(window: Window) => void> {
+            addListener(
+                callback: (window: Window) => void,
+                filters?: WindowEventFilter,
+            ): void;
+    }
+    
     /**
      * Specifies what type of browser window to create.
      * 'panel' is deprecated and is available only to existing whitelisted extensions on Chrome OS.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10753,7 +10753,7 @@ declare namespace chrome.windows {
                 filters?: WindowEventFilter,
             ): void;
     }
- 
+
     /**
      * Specifies what type of browser window to create.
      * 'panel' is deprecated and is available only to existing whitelisted extensions on Chrome OS.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10742,7 +10742,7 @@ declare namespace chrome.windows {
         extends chrome.events.Event<(windowId: number, filters?: WindowEventFilter) => void> { }
 
     export interface WindowReferenceEvent
-        extends chrome.events.Event<(window: Window, filters?: WindowEventFilter) => void> { }
+        extends chrome.events.Event<callback: (window: Window) => void, filters?: WindowEventFilter> { }
 
     /**
      * Specifies what type of browser window to create.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10739,7 +10739,12 @@ declare namespace chrome.windows {
     }
 
     export interface WindowIdEvent
-        extends chrome.events.Event<(windowId: number, filters?: WindowEventFilter) => void> { }
+        extends chrome.events.Event<(windowId: number) => void> {
+            addListener(
+                callback: (windowId: number) => void,
+                filters?: WindowEventFilter,
+            ): void;
+    }
 
     export interface WindowReferenceEvent
         extends chrome.events.Event<(window: Window) => void> {
@@ -10748,7 +10753,7 @@ declare namespace chrome.windows {
                 filters?: WindowEventFilter,
             ): void;
     }
-    
+ 
     /**
      * Specifies what type of browser window to create.
      * 'panel' is deprecated and is available only to existing whitelisted extensions on Chrome OS.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -638,7 +638,7 @@ function testWindows() {
         var windowIdResult: number = windowId;
     }, { windowTypes: ['normal'] });
     chrome.windows.onBoundsChanged.addListener(function (window) {
-        var windowResult : chrome.windows.Window = window;
+        var windowResult: chrome.windows.Window = window;
     }, { windowTypes: ['normal'] });
     chrome.windows.onFocusChanged.addListener(function (windowId) {
         var windowIdResult: number = windowId;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -629,6 +629,22 @@ function testDeclarativeContent() {
     };
 }
 
+// https://developer.chrome.com/docs/extensions/reference/windows
+function testWindows() {
+    chrome.windows.onCreated.addListener(function (window) {
+        var windowResult: chrome.windows.Window = window;
+    }, { windowTypes: ['normal'] });
+    chrome.windows.onRemoved.addListener(function (windowId) {
+        var windowIdResult: number = windowId;
+    }, { windowTypes: ['normal'] });
+    chrome.windows.onBoundsChanged.addListener(function (window) {
+        var windowResult : chrome.windows.Window = window;
+    }, { windowTypes: ['normal'] });
+    chrome.windows.onFocusChanged.addListener(function (windowId) {
+        var windowIdResult: number = windowId;
+    }, { windowTypes: ['normal'] });
+}
+
 // https://developer.chrome.com/extensions/storage#type-StorageArea
 function testStorage() {
     function getCallback(loadedData: { [key: string]: any }) {


### PR DESCRIPTION
Hey,
it looks like the `chrome.window` listener signatures (e.g., `chrome.window.OnChanged.addListener`) don't fit Chrome's [documentation](https://developer.chrome.com/docs/extensions/reference/windows/#event-onCreated). Instead of accepting `filter` as an additional argument to `addListener`, it's specified as an argument to the callback.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
