### PR TITLE
`react`: remove `undefined` from `className` prop

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2486,7 +2486,7 @@ declare namespace React {
     interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
         // Attributes which also defined in HTMLAttributes
         // See comment in SVGDOMPropertyConfig.js
-        className?: string | undefined;
+        className?: string;
         color?: string | undefined;
         height?: number | string | undefined;
         id?: string | undefined;


### PR DESCRIPTION
Under `exactOptionalPropertyTypes`, `className={undefined}` should not be allowed as this will produce HTML such as `className="undefined"`.

If `exactOptionalPropertyTypes` is not enabled then `className={undefined}` would still be allowed.

I wanted to add a test for this however `dtslint` doesn't have support for `exactOptionalPropertyTypes` yet: https://github.com/microsoft/dtslint/issues/348 /cc @sandersn 

`| undefined` was added in [this commit](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/d4f392fc96b00ee40ba76acfdc859890bb6b4272#diff-32cfd8cb197872bcba371f5018185d2e75fa540b52cda2dd7d8ac12dcc021299R1823) to provide [backwards compatibility](https://github.com/microsoft/TypeScript/issues/44419#issuecomment-874662681).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.