### PR TITLE
Add definition types for 'formatcoords' npm package

### DIFF
--- a/types/formatcoords/formatcoords-tests.ts
+++ b/types/formatcoords/formatcoords-tests.ts
@@ -1,0 +1,38 @@
+import formatcoords = require('formatcoords');
+
+const coords = {
+    floats: formatcoords(-35.282, 149.128684),
+    floatslonlat: formatcoords(149.128684, -35.282, true),
+    array: formatcoords([-35.282, 149.128684]),
+    arraylonlat: formatcoords([149.128684, -35.282], true),
+    string: formatcoords('-35.282000, 149.128684'),
+    latlon: formatcoords({ lat: -35.282, lng: 149.128684 }),
+};
+
+for (const key in coords) {
+    const coord = coords[key as keyof typeof coords];
+    coord.east;
+    coord.north;
+
+    const { latValues, lonValues } = coord;
+    const latAndLonValues = { latValues, lonValues };
+    for (const latOrLonKey in latAndLonValues) {
+        const latOrLonValues = latAndLonValues[latOrLonKey as keyof typeof latAndLonValues];
+        latOrLonValues.initValue;
+        latOrLonValues.degrees;
+        latOrLonValues.degreesInt;
+        latOrLonValues.degreesFrac;
+        latOrLonValues.secondsTotal;
+        latOrLonValues.minutes;
+        latOrLonValues.minutesInt;
+        latOrLonValues.seconds;
+    }
+
+    coord.format();
+    coord.format('Ff');
+    coord.format('f');
+    coord.format('-D M s', ', ');
+    coord.format('-D M s', { latLonSeparator: ', ' });
+    coord.format('DD MM ss X', { latLonSeparator: ' - ', decimalPlaces: 0 });
+    coord.format({ decimalPlaces: 0 });
+}

--- a/types/formatcoords/index.d.ts
+++ b/types/formatcoords/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for formatcoords 1.1
+// Project: https://github.com/nerik/formatcoords
+// Definitions by: Vít Stanislav <https://github.com/slaweet>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface CoordsFormatOptions {
+    latLonSeparator?: string;
+    decimalPlaces?: number;
+}
+
+declare function format(options?: CoordsFormatOptions): string;
+
+declare function format(formatString?: string, options?: CoordsFormatOptions): string;
+
+declare function format(formatString: string, latLonSeparator: string): string;
+
+interface LonLatValues {
+    initValue: number;
+    degrees: number;
+    degreesInt: number;
+    degreesFrac: number;
+    secondsTotal: number;
+    minutes: number;
+    minutesInt: number;
+    seconds: number;
+}
+
+interface CoordsObject {
+    format: typeof format;
+    north: boolean;
+    east: boolean;
+    latValues: LonLatValues;
+    lonValues: LonLatValues;
+}
+
+declare function formatcoords(lat: number, lon?: number, latlonSwapped?: boolean): CoordsObject;
+
+declare function formatcoords([lat, lon]: [number, number], latlonSwapped?: boolean): CoordsObject;
+
+declare function formatcoords(coords: string | { lat: number; lng: number }): CoordsObject;
+
+export = formatcoords;

--- a/types/formatcoords/tsconfig.json
+++ b/types/formatcoords/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "formatcoords-tests.ts"
+    ]
+}

--- a/types/formatcoords/tslint.json
+++ b/types/formatcoords/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
