### PR TITLE
fix(find-duplicated-property-keys): Remove isArray

### DIFF
--- a/types/find-duplicated-property-keys/find-duplicated-property-keys-tests.ts
+++ b/types/find-duplicated-property-keys/find-duplicated-property-keys-tests.ts
@@ -5,7 +5,6 @@ const jsonString = '{"name": "Carl", "name": "Carla", "data": 1, "data": [{ "dat
 const result = findDuplicatedPropertyKeys(jsonString); // $ExpectType PropertyInfo[]
 
 result.forEach(item => {
-    item.isArray; // $ExpectgType boolean
     item.key; // $ExpecgtType string
     item.occurrence; // $ExpectType number
     item.parent; // $ExpectType PropertyInfo

--- a/types/find-duplicated-property-keys/index.d.ts
+++ b/types/find-duplicated-property-keys/index.d.ts
@@ -25,10 +25,6 @@ declare namespace findDuplicatedPropertyKeys {
          * The number of property keys having the same key and parent object
          */
         occurrence: number;
-        /**
-         * Is this property an array
-         */
-        isArray: boolean;
 
         /**
          * Returns a list of property keys, which represents the path to the property key of the current object.


### PR DESCRIPTION
Because it is not part of the public API

See discussion in https://github.com/SebastianG77/find-duplicated-property-keys/issues/3 by the author.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). (I hope the CI does this.)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/SebastianG77/find-duplicated-property-keys/issues/3)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. N/A

I guess this obsoletes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57475