### PR TITLE
Add types for native-duplexpair

### DIFF
--- a/types/native-duplexpair/index.d.ts
+++ b/types/native-duplexpair/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for native-duplexpair 1.0
+// Project: https://github.com/tediousjs/native-duplexpair#readme
+// Definitions by: Tim Perry <https://github.com/pimterry>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+
+import { Duplex, DuplexOptions } from 'stream';
+
+declare class DuplexPair {
+    readonly socket1: Duplex;
+    readonly socket2: Duplex;
+
+    constructor(options?: DuplexOptions);
+}
+
+export = DuplexPair;

--- a/types/native-duplexpair/native-duplexpair-tests.ts
+++ b/types/native-duplexpair/native-duplexpair-tests.ts
@@ -1,0 +1,12 @@
+// Taken straight from the package README:
+import DuplexPair = require('native-duplexpair');
+
+const { socket1, socket2 } = new DuplexPair();
+
+socket1.write('Hi');
+console.log(socket2.read());  // => <Buffer 48 69>
+
+const { socket1: encodedSocket1, socket2: encodedSocket2 } = new DuplexPair({ encoding: 'utf8' });
+
+socket1.write('Hi');
+console.log(socket2.read());  // => 'Hi'

--- a/types/native-duplexpair/tsconfig.json
+++ b/types/native-duplexpair/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "native-duplexpair-tests.ts"
+    ]
+}

--- a/types/native-duplexpair/tslint.json
+++ b/types/native-duplexpair/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/native-duplexpair/tslint.json
+++ b/types/native-duplexpair/tslint.json
@@ -1,1 +1,1 @@
-{ "extends": "dtslint/dt.json" }
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
This PR adds types for [native-duplexpair](https://www.npmjs.com/package/native-duplexpair), a tiny but very widely used package for Node.js stream management.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
