### PR TITLE
Fix double-edit of native-duplexpair's tslint.json

### DIFF
--- a/types/native-duplexpair/tslint.json
+++ b/types/native-duplexpair/tslint.json
@@ -1,1 +1,1 @@
-{ "extends": "@definitelytyped/@definitelytyped/dtslint/dt.json" }
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
sed ran amok and added an extra `@definitelytyped/`