### PR TITLE
fabric: Add currentTarget and currentSubTargets to fabric event

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -179,6 +179,8 @@ interface IEvent<E extends Event = Event> {
     pointer?: Point | undefined;
     absolutePointer?: Point | undefined;
     transform?: { corner: string; original: Object; originX: string; originY: string; width: number } | undefined;
+    currentTarget?: Object | undefined;
+    currentSubTargets?: Object[] | undefined;
 }
 
 interface IFillOptions {

--- a/types/fabric/test/index.ts
+++ b/types/fabric/test/index.ts
@@ -7,6 +7,10 @@ function sample1() {
 
   canvas.on('object:moving', (e: fabric.IEvent) => {
     e.target.opacity = 0.5;
+    e.currentTarget.sendBackwards();
+    e.currentSubTargets.forEach((subTarget) => {
+      subTarget.bringToFront();
+    });
   });
   canvas.on('object:modified', (e: fabric.IEvent) => {
     e.target.opacity = 1;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [These properties are set on the event here](https://github.com/fabricjs/fabric.js/blob/e8f9eea80d8a5f90bccd8acfa638e011eed0a1e5/src/mixins/canvas_events.mixin.js#L535)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (Note: This PR could apply for Fabric 4.2 up to latest, and the type definitions here are already at 4.5)
