### PR TITLE
node: Add support for node: prefix on v14

### DIFF
--- a/types/node/v14/assert.d.ts
+++ b/types/node/v14/assert.d.ts
@@ -122,3 +122,7 @@ declare module 'assert' {
 
     export = assert;
 }
+declare module 'node:assert' {
+    import assert = require('assert');
+    export = assert;
+}

--- a/types/node/v14/async_hooks.d.ts
+++ b/types/node/v14/async_hooks.d.ts
@@ -224,3 +224,6 @@ declare module 'async_hooks' {
         enterWith(store: T): void;
     }
 }
+declare module 'node:async_hooks' {
+    export * from 'async_hooks';
+}

--- a/types/node/v14/buffer.d.ts
+++ b/types/node/v14/buffer.d.ts
@@ -20,3 +20,6 @@ declare module 'buffer' {
 
     export { BuffType as Buffer };
 }
+declare module 'node:buffer' {
+    export * from 'buffer';
+}

--- a/types/node/v14/child_process.d.ts
+++ b/types/node/v14/child_process.d.ts
@@ -509,3 +509,6 @@ declare module 'child_process' {
     function execFileSync(command: string, args: ReadonlyArray<string>, options: ExecFileSyncOptionsWithBufferEncoding): Buffer;
     function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptions): string | Buffer;
 }
+declare module 'node:child_process' {
+    export * from 'child_process';
+}

--- a/types/node/v14/cluster.d.ts
+++ b/types/node/v14/cluster.d.ts
@@ -260,3 +260,6 @@ declare module 'cluster' {
 
     function eventNames(): string[];
 }
+declare module 'node:cluster' {
+    export * from 'cluster';
+}

--- a/types/node/v14/console.d.ts
+++ b/types/node/v14/console.d.ts
@@ -1,4 +1,8 @@
 declare module 'console' {
+    import console = require('node:console');
+    export = console;
+}
+declare module 'node:console' {
     import { InspectOptions } from 'util';
 
     global {

--- a/types/node/v14/constants.d.ts
+++ b/types/node/v14/constants.d.ts
@@ -11,3 +11,8 @@ declare module 'constants' {
         typeof fsConstants;
     export = exp;
 }
+
+declare module 'node:constants' {
+    import constants = require('constants');
+    export = constants;
+}

--- a/types/node/v14/crypto.d.ts
+++ b/types/node/v14/crypto.d.ts
@@ -1184,3 +1184,6 @@ declare module 'crypto' {
      */
     function diffieHellman(options: { privateKey: KeyObject; publicKey: KeyObject }): Buffer;
 }
+declare module 'node:crypto' {
+    export * from 'crypto';
+}

--- a/types/node/v14/dgram.d.ts
+++ b/types/node/v14/dgram.d.ts
@@ -139,3 +139,6 @@ declare module 'dgram' {
         prependOnceListener(event: "message", listener: (msg: Buffer, rinfo: RemoteInfo) => void): this;
     }
 }
+declare module 'node:dgram' {
+    export * from 'dgram';
+}

--- a/types/node/v14/dns.d.ts
+++ b/types/node/v14/dns.d.ts
@@ -382,3 +382,6 @@ declare module 'dns' {
         }
     }
 }
+declare module 'node:dns' {
+    export * from 'dns';
+}

--- a/types/node/v14/domain.d.ts
+++ b/types/node/v14/domain.d.ts
@@ -22,3 +22,6 @@ declare module 'domain' {
 
     function create(): Domain;
 }
+declare module 'node:domain' {
+    export * from 'domain';
+}

--- a/types/node/v14/events.d.ts
+++ b/types/node/v14/events.d.ts
@@ -76,3 +76,7 @@ declare module 'events' {
 
     export = EventEmitter;
 }
+declare module 'node:events' {
+    import events = require('events');
+    export = events;
+}

--- a/types/node/v14/fs.d.ts
+++ b/types/node/v14/fs.d.ts
@@ -2268,3 +2268,6 @@ declare module 'fs' {
         bigint?: boolean | undefined;
     }
 }
+declare module 'node:fs' {
+    export * from 'fs';
+}

--- a/types/node/v14/fs/promises.d.ts
+++ b/types/node/v14/fs/promises.d.ts
@@ -563,3 +563,6 @@ declare module 'fs/promises' {
 
     function opendir(path: PathLike, options?: OpenDirOptions): Promise<Dir>;
 }
+declare module 'node:fs/promises' {
+    export * from 'fs/promises';
+}

--- a/types/node/v14/http.d.ts
+++ b/types/node/v14/http.d.ts
@@ -485,3 +485,6 @@ declare module 'http' {
      */
     const maxHeaderSize: number;
 }
+declare module 'node:http' {
+    export * from 'http';
+}

--- a/types/node/v14/http2.d.ts
+++ b/types/node/v14/http2.d.ts
@@ -956,3 +956,6 @@ declare module 'http2' {
         listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void
     ): ClientHttp2Session;
 }
+declare module 'node:http2' {
+    export * from 'http2';
+}

--- a/types/node/v14/https.d.ts
+++ b/types/node/v14/https.d.ts
@@ -137,3 +137,6 @@ declare module 'https' {
     function get(url: string | URL, options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
     let globalAgent: Agent;
 }
+declare module 'node:https' {
+    export * from 'https';
+}

--- a/types/node/v14/index.d.ts
+++ b/types/node/v14/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 14.17
+// Type definitions for non-npm package Node.js 14.18
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>
@@ -41,6 +41,7 @@
 //                 Victor Perin <https://github.com/victorperin>
 //                 Yongsheng Zhang <https://github.com/ZYSzys>
 //                 Bond <https://github.com/bondz>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // NOTE: These definitions support NodeJS and TypeScript 3.7+

--- a/types/node/v14/inspector.d.ts
+++ b/types/node/v14/inspector.d.ts
@@ -3045,3 +3045,7 @@ declare module 'inspector' {
      */
     function waitForDebugger(): void;
 }
+declare module 'node:inspector' {
+    import EventEmitter = require('inspector');
+    export = EventEmitter;
+}

--- a/types/node/v14/module.d.ts
+++ b/types/node/v14/module.d.ts
@@ -50,3 +50,7 @@ declare module 'module' {
     }
     export = Module;
 }
+declare module 'node:module' {
+    import module = require('module');
+    export = module;
+}

--- a/types/node/v14/net.d.ts
+++ b/types/node/v14/net.d.ts
@@ -291,3 +291,6 @@ declare module 'net' {
     function isIPv4(input: string): boolean;
     function isIPv6(input: string): boolean;
 }
+declare module 'node:net' {
+    export * from 'net';
+}

--- a/types/node/v14/os.d.ts
+++ b/types/node/v14/os.d.ts
@@ -237,3 +237,6 @@ declare module 'os' {
      */
     function setPriority(pid: number, priority: number): void;
 }
+declare module 'node:os' {
+    export * from 'os';
+}

--- a/types/node/v14/path.d.ts
+++ b/types/node/v14/path.d.ts
@@ -151,3 +151,7 @@ declare module 'path' {
     const path: path.PlatformPath;
     export = path;
 }
+declare module 'node:path' {
+    import path = require('path');
+    export = path;
+}

--- a/types/node/v14/perf_hooks.d.ts
+++ b/types/node/v14/perf_hooks.d.ts
@@ -269,3 +269,6 @@ declare module 'perf_hooks' {
 
     function monitorEventLoopDelay(options?: EventLoopMonitorOptions): EventLoopDelayMonitor;
 }
+declare module 'node:perf_hooks' {
+    export * from 'perf_hooks';
+}

--- a/types/node/v14/process.d.ts
+++ b/types/node/v14/process.d.ts
@@ -407,3 +407,7 @@ declare module 'process' {
 
     export = process;
 }
+declare module 'node:process' {
+    import process = require('process');
+    export = process;
+}

--- a/types/node/v14/punycode.d.ts
+++ b/types/node/v14/punycode.d.ts
@@ -73,3 +73,6 @@ declare module 'punycode' {
      */
     const version: string;
 }
+declare module 'node:punycode' {
+    export * from 'punycode';
+}

--- a/types/node/v14/querystring.d.ts
+++ b/types/node/v14/querystring.d.ts
@@ -26,3 +26,6 @@ declare module 'querystring' {
     function escape(str: string): string;
     function unescape(str: string): string;
 }
+declare module 'node:querystring' {
+    export * from 'querystring';
+}

--- a/types/node/v14/readline.d.ts
+++ b/types/node/v14/readline.d.ts
@@ -169,3 +169,6 @@ declare module 'readline' {
      */
     function moveCursor(stream: NodeJS.WritableStream, dx: number, dy: number, callback?: () => void): boolean;
 }
+declare module 'node:readline' {
+    export * from 'readline';
+}

--- a/types/node/v14/repl.d.ts
+++ b/types/node/v14/repl.d.ts
@@ -393,3 +393,6 @@ declare module 'repl' {
         constructor(err: Error);
     }
 }
+declare module 'node:repl' {
+    export * from 'repl';
+}

--- a/types/node/v14/stream.d.ts
+++ b/types/node/v14/stream.d.ts
@@ -353,3 +353,7 @@ declare module 'stream' {
 
     export = internal;
 }
+declare module 'node:stream' {
+    import stream = require('stream');
+    export = stream;
+}

--- a/types/node/v14/string_decoder.d.ts
+++ b/types/node/v14/string_decoder.d.ts
@@ -5,3 +5,6 @@ declare module 'string_decoder' {
         end(buffer?: Buffer): string;
     }
 }
+declare module 'node:string_decoder' {
+    export * from 'string_decoder';
+}

--- a/types/node/v14/test/assert.ts
+++ b/types/node/v14/test/assert.ts
@@ -1,4 +1,4 @@
-import assert = require('assert');
+import assert = require('node:assert');
 
 {
     const { stack } = new assert.AssertionError({});

--- a/types/node/v14/test/async_hooks.ts
+++ b/types/node/v14/test/async_hooks.ts
@@ -6,7 +6,7 @@ import {
     executionAsyncResource,
     HookCallbacks,
     AsyncLocalStorage,
-} from 'async_hooks';
+} from 'node:async_hooks';
 
 {
     const hooks: HookCallbacks = {

--- a/types/node/v14/test/buffer.ts
+++ b/types/node/v14/test/buffer.ts
@@ -7,7 +7,7 @@ import {
     constants,
     kMaxLength,
     kStringMaxLength,
-} from 'buffer';
+} from 'node:buffer';
 
 const utf8Buffer = new Buffer('test');
 const base64Buffer = new Buffer('', 'base64');

--- a/types/node/v14/test/child_process.ts
+++ b/types/node/v14/test/child_process.ts
@@ -1,9 +1,9 @@
-import * as childProcess from 'child_process';
-import * as net from 'net';
-import * as fs from 'fs';
-import assert = require('assert');
-import { promisify } from 'util';
-import { Writable, Readable, Pipe } from 'stream';
+import * as childProcess from 'node:child_process';
+import * as net from 'node:net';
+import * as fs from 'node:fs';
+import assert = require('node:assert');
+import { promisify } from 'node:util';
+import { Writable, Readable, Pipe } from 'node:stream';
 
 {
     childProcess.exec("echo test");

--- a/types/node/v14/test/cluster.ts
+++ b/types/node/v14/test/cluster.ts
@@ -1,4 +1,4 @@
-import * as cluster from 'cluster';
+import * as cluster from 'node:cluster';
 
 cluster.fork();
 Object.keys(cluster.workers).forEach(key => {

--- a/types/node/v14/test/constants.ts
+++ b/types/node/v14/test/constants.ts
@@ -1,4 +1,4 @@
-import * as constants from 'constants';
+import * as constants from 'node:constants';
 {
     let str: string;
     let num: number;

--- a/types/node/v14/test/crypto.ts
+++ b/types/node/v14/test/crypto.ts
@@ -1,6 +1,6 @@
-import * as crypto from 'crypto';
-import assert = require('assert');
-import { promisify } from 'util';
+import * as crypto from 'node:crypto';
+import assert = require('node:assert');
+import { promisify } from 'node:util';
 
 {
     const copied: crypto.Hash = crypto.createHash('md5').copy();

--- a/types/node/v14/test/dgram.ts
+++ b/types/node/v14/test/dgram.ts
@@ -1,6 +1,6 @@
-import * as dgram from 'dgram';
-import * as net from 'net';
-import * as dns from 'dns';
+import * as dgram from 'node:dgram';
+import * as net from 'node:net';
+import * as dns from 'node:dns';
 
 {
     let ds: dgram.Socket = dgram.createSocket("udp4", (msg: Buffer, rinfo: dgram.RemoteInfo): void => {

--- a/types/node/v14/test/dns.ts
+++ b/types/node/v14/test/dns.ts
@@ -14,7 +14,7 @@ import {
     ALL,
     promises,
     setDefaultResultOrder,
-} from 'dns';
+} from 'node:dns';
 
 lookup("nodejs.org", (err, address, family) => {
     const _err: NodeJS.ErrnoException | null = err;

--- a/types/node/v14/test/events.ts
+++ b/types/node/v14/test/events.ts
@@ -1,4 +1,4 @@
-import events = require('events');
+import events = require('node:events');
 
 const emitter: events = new events.EventEmitter();
 declare const listener: (...args: any[]) => void;

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -1,7 +1,7 @@
-import * as fs from 'fs';
-import assert = require('assert');
-import * as util from 'util';
-import * as url from 'url';
+import * as fs from 'node:fs';
+import assert = require('node:assert');
+import * as util from 'node:util';
+import * as url from 'node:url';
 
 {
     fs.writeFile("thebible.txt",

--- a/types/node/v14/test/global.ts
+++ b/types/node/v14/test/global.ts
@@ -1,4 +1,4 @@
-import { Readable, Writable } from 'stream';
+import { Readable, Writable } from 'node:stream';
 
 {
     const x: NodeModule = {} as any;

--- a/types/node/v14/test/http.ts
+++ b/types/node/v14/test/http.ts
@@ -1,8 +1,8 @@
-import * as http from 'http';
-import * as stream from 'stream';
-import * as url from 'url';
-import * as net from 'net';
-import * as dns from 'dns';
+import * as http from 'node:http';
+import * as stream from 'node:stream';
+import * as url from 'node:url';
+import * as net from 'node:net';
+import * as dns from 'node:dns';
 
 // http Server
 {

--- a/types/node/v14/test/http2.ts
+++ b/types/node/v14/test/http2.ts
@@ -31,13 +31,13 @@ import {
     createServer,
     constants,
     ServerOptions,
-} from 'http2';
-import EventEmitter = require('events');
-import { Stats } from 'fs';
-import { Socket, Server } from 'net';
-import { TLSSocket } from 'tls';
-import { Duplex, Readable } from 'stream';
-import { URL } from 'url';
+} from 'node:http2';
+import EventEmitter = require('node:events');
+import { Stats } from 'node:fs';
+import { Socket, Server } from 'node:net';
+import { TLSSocket } from 'node:tls';
+import { Duplex, Readable } from 'node:stream';
+import { URL } from 'node:url';
 
 // Headers & Settings
 {

--- a/types/node/v14/test/https.ts
+++ b/types/node/v14/test/https.ts
@@ -1,10 +1,10 @@
-import * as http from "http";
-import * as https from 'https';
-import * as net from 'net';
-import * as stream from 'stream';
-import * as tls from 'tls';
-import * as url from 'url';
-import * as dns from 'dns';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import * as net from 'node:net';
+import * as stream from 'node:stream';
+import * as tls from 'node:tls';
+import * as url from 'node:url';
+import * as dns from 'node:dns';
 
 // https tests
 {

--- a/types/node/v14/test/module.ts
+++ b/types/node/v14/test/module.ts
@@ -1,5 +1,5 @@
-import Module = require('module');
-import { URL } from 'url';
+import Module = require('node:module');
+import { URL } from 'node:url';
 require.extensions[".ts"] = () => "";
 
 Module.runMain();

--- a/types/node/v14/test/net.ts
+++ b/types/node/v14/test/net.ts
@@ -1,5 +1,5 @@
-import * as net from 'net';
-import { LookupOneOptions } from 'dns';
+import * as net from 'node:net';
+import { LookupOneOptions } from 'node:dns';
 
 {
     const connectOpts: net.NetConnectOpts = {

--- a/types/node/v14/test/os.ts
+++ b/types/node/v14/test/os.ts
@@ -1,4 +1,4 @@
-import * as os from 'os';
+import * as os from 'node:os';
 {
     let result: string;
 

--- a/types/node/v14/test/path.ts
+++ b/types/node/v14/test/path.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 path.normalize('/foo/bar//baz/asdf/quux/..');
 

--- a/types/node/v14/test/perf_hooks.ts
+++ b/types/node/v14/test/perf_hooks.ts
@@ -7,7 +7,7 @@ import {
     EntryType,
     constants,
     EventLoopUtilization,
-} from 'perf_hooks';
+} from 'node:perf_hooks';
 
 performance.mark('start');
 (

--- a/types/node/v14/test/process.ts
+++ b/types/node/v14/test/process.ts
@@ -1,6 +1,6 @@
-import * as p from 'process';
-import assert = require('assert');
-import EventEmitter = require('events');
+import * as p from 'node:process';
+import assert = require('node:assert');
+import EventEmitter = require('node:events');
 
 {
     let eventEmitter: EventEmitter;

--- a/types/node/v14/test/querystring.ts
+++ b/types/node/v14/test/querystring.ts
@@ -1,4 +1,4 @@
-import * as querystring from 'querystring';
+import * as querystring from 'node:querystring';
 
 interface SampleObject { [key: string]: string; }
 

--- a/types/node/v14/test/readline.ts
+++ b/types/node/v14/test/readline.ts
@@ -1,6 +1,6 @@
-import * as readline from 'readline';
-import * as stream from 'stream';
-import * as fs from 'fs';
+import * as readline from 'node:readline';
+import * as stream from 'node:stream';
+import * as fs from 'node:fs';
 
 const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
 

--- a/types/node/v14/test/repl.ts
+++ b/types/node/v14/test/repl.ts
@@ -1,5 +1,5 @@
-import { start, Recoverable } from 'repl';
-import { Context } from 'vm';
+import { start, Recoverable } from 'node:repl';
+import { Context } from 'node:vm';
 
 {
     let server = start({

--- a/types/node/v14/test/stream.ts
+++ b/types/node/v14/test/stream.ts
@@ -1,9 +1,9 @@
-import { Readable, Writable, Transform, finished, pipeline, Duplex } from 'stream';
-import { promisify } from 'util';
-import { createReadStream, createWriteStream } from 'fs';
-import { createGzip, constants } from 'zlib';
-import assert = require('assert');
-import { Http2ServerResponse } from 'http2';
+import { Readable, Writable, Transform, finished, pipeline, Duplex } from 'node:stream';
+import { promisify } from 'node:util';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { createGzip, constants } from 'node:zlib';
+import assert = require('node:assert');
+import { Http2ServerResponse } from 'node:http2';
 
 // Simplified constructors
 function simplified_stream_ctor_test() {

--- a/types/node/v14/test/string_decoder.ts
+++ b/types/node/v14/test/string_decoder.ts
@@ -1,4 +1,4 @@
-import { StringDecoder } from 'string_decoder';
+import { StringDecoder } from 'node:string_decoder';
 
 const buffer = new Buffer('test');
 const decoder1 = new StringDecoder();

--- a/types/node/v14/test/tls.ts
+++ b/types/node/v14/test/tls.ts
@@ -14,8 +14,8 @@ import {
     rootCertificates,
     Server,
     TlsOptions,
-} from 'tls';
-import * as fs from 'fs';
+} from 'node:tls';
+import * as fs from 'node:fs';
 
 {
     const ctx: SecureContext = createSecureContext({

--- a/types/node/v14/test/tty.ts
+++ b/types/node/v14/test/tty.ts
@@ -1,5 +1,5 @@
-import * as tty from 'tty';
-import { Readable } from 'stream';
+import * as tty from 'node:tty';
+import { Readable } from 'node:stream';
 
 const rs: tty.ReadStream = new tty.ReadStream(0);
 const ws: tty.WriteStream = new tty.WriteStream(1);

--- a/types/node/v14/test/url.ts
+++ b/types/node/v14/test/url.ts
@@ -1,5 +1,5 @@
-import assert = require('assert');
-import * as url from 'url';
+import assert = require('node:assert');
+import * as url from 'node:url';
 
 {
     url.format(url.parse('http://www.example.com/xyz'));

--- a/types/node/v14/test/util.ts
+++ b/types/node/v14/test/util.ts
@@ -1,6 +1,6 @@
-import * as util from 'util';
-import assert = require('assert');
-import { access, readFile } from 'fs';
+import * as util from 'node:util';
+import assert = require('node:assert');
+import { access, readFile } from 'node:fs';
 
 {
     // Old and new util.inspect APIs

--- a/types/node/v14/test/v8.ts
+++ b/types/node/v14/test/v8.ts
@@ -1,5 +1,5 @@
-import * as v8 from 'v8';
-import { Readable } from 'stream';
+import * as v8 from 'node:v8';
+import { Readable } from 'node:stream';
 
 const heapStats = v8.getHeapStatistics();
 const numOfDetached = heapStats.number_of_detached_contexts;

--- a/types/node/v14/test/vm.ts
+++ b/types/node/v14/test/vm.ts
@@ -7,8 +7,8 @@ import {
     compileFunction,
     measureMemory,
     MemoryMeasurement,
-} from 'vm';
-import { inspect } from 'util';
+} from 'node:vm';
+import { inspect } from 'node:util';
 
 {
     const sandbox = {

--- a/types/node/v14/test/wasi.ts
+++ b/types/node/v14/test/wasi.ts
@@ -1,5 +1,5 @@
-import { WASI } from 'wasi';
-import * as fs from 'fs';
+import { WASI } from 'node:wasi';
+import * as fs from 'node:fs';
 
 {
     const wasi = new WASI({

--- a/types/node/v14/test/worker_threads.ts
+++ b/types/node/v14/test/worker_threads.ts
@@ -1,8 +1,8 @@
-import * as workerThreads from 'worker_threads';
-import assert = require('assert');
-import { createContext } from 'vm';
-import { Readable } from 'stream';
-import * as fs from 'fs';
+import * as workerThreads from 'node:worker_threads';
+import assert = require('node:assert');
+import { createContext } from 'node:vm';
+import { Readable } from 'node:stream';
+import * as fs from 'node:fs';
 
 {
     if (workerThreads.isMainThread) {

--- a/types/node/v14/test/zlib.ts
+++ b/types/node/v14/test/zlib.ts
@@ -22,8 +22,8 @@ import {
     brotliCompress,
     brotliDecompressSync,
     brotliDecompress,
-} from 'zlib';
-import { promisify } from 'util';
+} from 'node:zlib';
+import { promisify } from 'node:util';
 
 const compressMe = new Buffer("some data");
 const compressMeString = "compress me!";

--- a/types/node/v14/timers.d.ts
+++ b/types/node/v14/timers.d.ts
@@ -14,3 +14,6 @@ declare module 'timers' {
     }
     function clearImmediate(immediateId: NodeJS.Immediate): void;
 }
+declare module 'node:timers' {
+    export * from 'timers';
+}

--- a/types/node/v14/tls.d.ts
+++ b/types/node/v14/tls.d.ts
@@ -778,3 +778,6 @@ declare module 'tls' {
      */
     const rootCertificates: ReadonlyArray<string>;
 }
+declare module 'node:tls' {
+    export * from 'tls';
+}

--- a/types/node/v14/trace_events.d.ts
+++ b/types/node/v14/trace_events.d.ts
@@ -59,3 +59,6 @@ declare module 'trace_events' {
      */
     function getEnabledCategories(): string | undefined;
 }
+declare module 'node:trace_events' {
+    export * from 'trace_events';
+}

--- a/types/node/v14/tty.d.ts
+++ b/types/node/v14/tty.d.ts
@@ -64,3 +64,6 @@ declare module 'tty' {
         isTTY: boolean;
     }
 }
+declare module 'node:tty' {
+    export * from 'tty';
+}

--- a/types/node/v14/url.d.ts
+++ b/types/node/v14/url.d.ts
@@ -114,3 +114,6 @@ declare module 'url' {
         [Symbol.iterator](): IterableIterator<[string, string]>;
     }
 }
+declare module 'node:url' {
+    export * from 'url';
+}

--- a/types/node/v14/util.d.ts
+++ b/types/node/v14/util.d.ts
@@ -211,3 +211,6 @@ declare module 'util' {
         encodeInto(input: string, output: Uint8Array): EncodeIntoResult;
     }
 }
+declare module 'node:util' {
+    export * from 'util';
+}

--- a/types/node/v14/v8.d.ts
+++ b/types/node/v14/v8.d.ts
@@ -185,3 +185,6 @@ declare module 'v8' {
      */
     function deserialize(data: NodeJS.TypedArray): any;
 }
+declare module 'node:v8' {
+    export * from 'v8';
+}

--- a/types/node/v14/vm.d.ts
+++ b/types/node/v14/vm.d.ts
@@ -150,3 +150,6 @@ declare module 'vm' {
      */
     function measureMemory(options?: MeasureMemoryOptions): Promise<MemoryMeasurement>;
 }
+declare module 'node:vm' {
+    export * from 'vm';
+}

--- a/types/node/v14/wasi.d.ts
+++ b/types/node/v14/wasi.d.ts
@@ -84,3 +84,6 @@ declare module 'wasi' {
         readonly wasiImport: NodeJS.Dict<any>; // TODO: Narrow to DOM types
     }
 }
+declare module 'node:wasi' {
+    export * from 'wasi';
+}

--- a/types/node/v14/worker_threads.d.ts
+++ b/types/node/v14/worker_threads.d.ts
@@ -236,3 +236,6 @@ declare module 'worker_threads' {
      */
     function receiveMessageOnPort(port: MessagePort): { message: any } | undefined;
 }
+declare module 'node:worker_threads' {
+    export * from 'worker_threads';
+}

--- a/types/node/v14/zlib.d.ts
+++ b/types/node/v14/zlib.d.ts
@@ -359,3 +359,6 @@ declare module 'zlib' {
     /** @deprecated */
     const Z_DEFLATED: number;
 }
+declare module 'node:zlib' {
+    export * from 'zlib';
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/nodejs/node/pull/37246
  - https://nodejs.org/ca/blog/release/v14.18.0/
  - https://nodejs.org/api/modules.html#core-modules
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

I've painstakingly coped each block as to exactly match what's being done in the 16.x version, so if any changes should be made we should probably make them in both.

The tests was simply switched over to use the `node:`-prefix, because that's what's done in the v16.x version.
