### PR TITLE
Add allowExitOnIdle option to PoolConfig.

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -50,6 +50,7 @@ export interface PoolConfig extends ClientConfig {
     idleTimeoutMillis?: number | undefined;
     log?: ((...messages: any[]) => void) | undefined;
     Promise?: PromiseConstructorLike | undefined;
+    allowExitOnIdle?: boolean | undefined;
 }
 
 export interface QueryConfig<I extends any[] = any[]> {

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -290,6 +290,9 @@ pool.end().then(() => console.log('pool has ended'));
     client.release();
 })();
 
+// Set allowExitOnIdle on pool constructor
+const poolExitOnIdle = new Pool({ allowExitOnIdle: true });
+
 // client constructor tests
 // client config object tested above
 let c = new Client(); // empty constructor allowed


### PR DESCRIPTION
This changes update the PoolConfig options parameter to include the option `allowExitOnIdle` that was missing. The documentation for it is available [here](https://node-postgres.com/api/pool)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://node-postgres.com/api/pool)>>
