### PR TITLE
Update koa-graphql's express-graphql dependency

### DIFF
--- a/types/koa-graphql/package.json
+++ b/types/koa-graphql/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "dependencies": {
     "graphql": "^15.1.0",
-    "express-graphql": "^0.9.0"
+    "express-graphql": "^0.10.0"
   }
 }


### PR DESCRIPTION
express-graphql has a peer dependency on graphql. The current version, 0.9.0, has a conflicting dependency on graphql@14. I updated it to the earliest version, 0.10.0, that has a peer dependency on 14 || 15.