### PR TITLE
fix(@rdfjs/express-handler): req methods are optional

### DIFF
--- a/types/rdfjs__express-handler/index.d.ts
+++ b/types/rdfjs__express-handler/index.d.ts
@@ -9,8 +9,8 @@ import formats = require('@rdfjs/formats-common');
 
 declare module 'express-serve-static-core' {
     interface Request {
-        dataset(parserOptions?: any): Promise<DatasetCore>;
-        quadStream(parserOptions?: any): Stream;
+        dataset?(parserOptions?: any): Promise<DatasetCore>;
+        quadStream?(parserOptions?: any): Stream;
     }
 
     interface Response {

--- a/types/rdfjs__express-handler/rdfjs__express-handler-tests.ts
+++ b/types/rdfjs__express-handler/rdfjs__express-handler-tests.ts
@@ -32,21 +32,25 @@ app.use(rdfHandler({
 }));
 
 async function streams(req: express.Request, res: express.Response) {
-    let stream: Stream = req.quadStream();
-    stream = req.quadStream({
-        baseIRI: 'foo'
-    });
+    if (req.quadStream) {
+        let stream: Stream = req.quadStream();
+        stream = req.quadStream({
+            baseIRI: 'foo'
+        });
 
-    await res.quadStream(stream);
+        await res.quadStream(stream);
+    }
 }
 
 async function datasets(req: express.Request, res: express.Response) {
-    let dataset: DatasetCore = await req.dataset();
-    dataset = await req.dataset({
-        baseIRI: 'foo'
-    });
+    if (req.dataset) {
+        let dataset: DatasetCore = await req.dataset();
+        dataset = await req.dataset({
+            baseIRI: 'foo'
+        });
 
-    await res.dataset(dataset);
+        await res.dataset(dataset);
+    }
 }
 
 async function attach(req: express.Request, res: express.Response) {


### PR DESCRIPTION
From the package's readme

> The req.dataset() and req.quadStream() methods can be used for this. **But the methods are only attached if the request contains content in a type supported by one of the parsers.**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[<url here>](https://github.com/rdfjs-base/express-handler#request)>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
