### PR TITLE
Add minDate to @types/react-datetime-picker

### DIFF
--- a/types/react-datetime-picker/index.d.ts
+++ b/types/react-datetime-picker/index.d.ts
@@ -31,6 +31,7 @@ export interface DateTimePickerProps {
     locale?: string;
     maxDate?: Date;
     maxDetail?: 'hour' | 'minute' | 'second';
+    minDate?: Date;
     minDetail?: 'month' | 'year' | 'decade' | 'century';
     minuteAriaLabel?: string;
     minutePlaceholder?: string;

--- a/types/react-datetime-picker/react-datetime-picker-tests.tsx
+++ b/types/react-datetime-picker/react-datetime-picker-tests.tsx
@@ -31,6 +31,7 @@ function Test1() {
                 locale={'en-US'}
                 maxDate={new Date()}
                 maxDetail={'second'}
+                minDate={new Date()}
                 minDetail={'month'}
                 minuteAriaLabel={'Minute ARIA Label'}
                 minutePlaceholder={'Minute Placeholder'}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wojtekmaj/react-datetime-picker
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As the title states, just adding the `minDate` property to the props - I missed it in my initial creation.