### PR TITLE
(eslint) Add `hasSuggestions` to Rule.RuleMetaData

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -365,6 +365,20 @@ rule = {
     },
     meta: { type: "layout" },
 };
+rule = {
+    create(context) {
+        return {};
+    },
+    meta: {
+        docs: {
+            description: "disallow the use of `console`",
+            category: "Possible Errors",
+            recommended: true,
+            url: "https://eslint.org/docs/rules/no-console",
+        },
+        hasSuggestions: true,
+    },
+};
 
 rule = {
     create(context) {

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -567,6 +567,8 @@ export namespace Rule {
         schema?: JSONSchema4 | JSONSchema4[] | undefined;
         deprecated?: boolean | undefined;
         type?: "problem" | "suggestion" | "layout" | undefined;
+        /** specifies whether rules can return suggestions (defaults to false if omitted) */
+        hasSuggestions?: boolean | undefined;
     }
 
     interface RuleContext {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [eslint v8 migration guide](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#rules-require-metahassuggestions-to-provide-suggestions)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

In ESLint v8, `meta.docs.suggestions` has been removed.But it has not been removed in this PR because it would be a breaking change.