### PR TITLE
[chec/commercejs] Fix get shipping method response

### DIFF
--- a/types/chec__commerce.js/features/checkout.d.ts
+++ b/types/chec__commerce.js/features/checkout.d.ts
@@ -116,10 +116,18 @@ export class Checkout {
         token: string,
         data: { shipping_option_id: string; country: string; region?: string | undefined },
     ): Promise<CheckShippingOptionResponse>;
-    getShippingOptions(token: string, data: { country: string; region?: string | undefined }): Promise<GetShippingOptionsResponse>;
+    getShippingOptions(
+        token: string,
+        data: { country: string; region?: string | undefined },
+    ): Promise<GetShippingOptionsResponse[]>;
     setTaxZone(
         token: string,
-        data: { ip_address?: string | undefined; country?: string | undefined; region?: string | undefined; postal_zip_code?: string | undefined },
+        data: {
+            ip_address?: string | undefined;
+            country?: string | undefined;
+            region?: string | undefined;
+            postal_zip_code?: string | undefined;
+        },
     ): Promise<SetTaxZoneResponse>;
     checkQuantity(token: string, lineItemId: string, data: object): Promise<CheckQuantityResponse>;
     helperValidation(token: string): Promise<HelperValidationResponse>;

--- a/types/chec__commerce.js/test/checkout.ts
+++ b/types/chec__commerce.js/test/checkout.ts
@@ -259,7 +259,7 @@ commerce.checkout.checkGiftcard(checkoutTokenId, {
 // $ExpectType Promise<HelperValidationResponse>
 commerce.checkout.helperValidation(checkoutTokenId);
 
-// $ExpectType Promise<GetShippingOptionsResponse>
+// $ExpectType Promise<GetShippingOptionsResponse[]>
 commerce.checkout.getShippingOptions(checkoutTokenId, {
     country,
     region,


### PR DESCRIPTION
Updates the `getShippingOptions` checkout helper function to return **an array**, per the documentation: https://commercejs.com/docs/api/#get-available-shipping-methods. Note that the commit show another code diff, but this was just from some IDE auto-formatting.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://commercejs.com/docs/api/#get-available-shipping-methods
