### PR TITLE
[react] Upgrade useInsertionEffect to next

### DIFF
--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -93,12 +93,4 @@ declare module '.' {
      * @see https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist
      */
     export const SuspenseList: ExoticComponent<SuspenseListProps>;
-
-    /**
-     * @param effect Imperative function that can return a cleanup function
-     * @param deps If present, effect will only activate if the values in the list change.
-     *
-     * @see https://github.com/facebook/react/pull/21913
-     */
-     export function unstable_useInsertionEffect(effect: EffectCallback, deps?: DependencyList): void;
 }

--- a/types/react/next.d.ts
+++ b/types/react/next.d.ts
@@ -126,6 +126,14 @@ declare module '.' {
     export function unstable_useMutableSource<T, TResult extends unknown>(MutableSource: MutableSource<T>, getSnapshot: (source: T) => TResult, subscribe: MutableSourceSubscribe<T>): TResult;
 
     /**
+     * @param effect Imperative function that can return a cleanup function
+     * @param deps If present, effect will only activate if the values in the list change.
+     *
+     * @see https://github.com/facebook/react/pull/21913
+     */
+     export function useInsertionEffect(effect: EffectCallback, deps?: DependencyList): void;
+
+    /**
      * @param subscribe
      * @param getSnapshot
      *

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -2,16 +2,6 @@
 
 import React = require('react');
 
-function useExperimentalHooks() {
-    const [toggle, setToggle] = React.useState(false);
-
-    React.unstable_useInsertionEffect(() => {});
-    React.unstable_useInsertionEffect(() => {}, []);
-    React.unstable_useInsertionEffect(() => {
-        return () => {};
-    }, [toggle]);
-}
-
 // Unsupported `revealOrder` triggers a runtime warning
 // $ExpectError
 <React.SuspenseList revealOrder="something">

--- a/types/react/test/next.tsx
+++ b/types/react/test/next.tsx
@@ -53,6 +53,12 @@ function useExperimentalHooks() {
     // $ExpectType string
     const pathName = React.unstable_useMutableSource(locationSource, getSnapshot, subscribe);
 
+    React.useInsertionEffect(() => {});
+    React.useInsertionEffect(() => {}, []);
+    React.useInsertionEffect(() => {
+        return () => {};
+    }, [toggle]);
+
     return () => {
         startTransition(() => {
             setToggle(toggle => !toggle);


### PR DESCRIPTION
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/57554

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://github.com/facebook/react/pull/22589
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

