### PR TITLE
[chai]: add be and oneOf to deep interface

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1373,6 +1373,14 @@ function oneOf() {
     expect('Today is sunny').to.contain.oneOf(['sunny', 'cloudy']);
 }
 
+function deepOneOf() {
+    expect({z: 3}).to.be.deep.oneOf([{z: 3}]);
+    expect({z: 3}).to.deep.be.oneOf([{z: 3}]);
+
+    expect({z: 3}).to.not.be.deep.oneOf([{x: 1}, {y: 2}]);
+    expect({z: 3}).to.not.deep.be.oneOf([{x: 1}, {y: 2}]);
+}
+
 function testInspectType() {
     const x: string = util.inspect([1, 2, 3], false, 4, false);
     expect(x).to.be.equal('[ 1, 2, 3 ]');

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for chai 4.2
+// Type definitions for chai 4.3
 // Project: http://chaijs.com/
 // Definitions by: Jed Mao <https://github.com/jedmao>,
 //                 Bart van der Schoor <https://github.com/Bartvds>,
@@ -313,6 +313,7 @@ declare namespace Chai {
     }
 
     interface Deep extends KeyFilter {
+        be: Assertion;
         equal: Equal;
         equals: Equal;
         eq: Equal;
@@ -323,6 +324,7 @@ declare namespace Chai {
         property: Property;
         ordered: Ordered;
         nested: Nested;
+        oneOf: OneOf;
         own: Own;
     }
 


### PR DESCRIPTION
Chai assertions support using `oneOf` with `deep` comparisons. This allows users to assert that an object is deeply equivalent to another in an array of objects. The feature was added in chai@4.3.1. I confirmed its use locally in a project depending on this behavior.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [chaijs pull request](https://github.com/chaijs/chai/pull/1334/files)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
