### PR TITLE
[@types/node] Header array on http.OutgoingMessage can include numbers

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -110,7 +110,7 @@ declare module 'http' {
         'www-authenticate'?: string | undefined;
     }
     // outgoing headers allows numbers (as they are converted internally to strings)
-    type OutgoingHttpHeader = number | string | string[];
+    type OutgoingHttpHeader = number | string | (number|string)[];
     interface OutgoingHttpHeaders extends NodeJS.Dict<OutgoingHttpHeader> {}
     interface ClientRequestArgs {
         abort?: AbortSignal | undefined;
@@ -372,7 +372,7 @@ declare module 'http' {
          * @since v0.4.0
          * @param name Name of header
          */
-        getHeader(name: string): number | string | string[] | undefined;
+        getHeader(name: string): number | string | (number|string)[] | undefined;
         /**
          * Returns a shallow copy of the current outgoing headers. Since a shallow
          * copy is used, array values may be mutated without additional calls to


### PR DESCRIPTION
Simple test:

```js
> http = require('http')
> o = new http.OutgoingMessage()
> o.setHeader('foo', [5, 6, "hello"])
> o.getHeader('foo')
[ 5, 6, 'hello' ]
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/http.html#requestgetheadername
