### PR TITLE
@types/ckeditor4 - Added definition for insertHtmlIntoRange

### DIFF
--- a/types/ckeditor4/ckeditor4-tests.ts
+++ b/types/ckeditor4/ckeditor4-tests.ts
@@ -546,6 +546,8 @@ function test_editable() {
     editable.insertHtml('data');
     editable.insertHtml('data', 'mode');
     editable.insertHtml('data', 'mode', range);
+    editable.insertHtmlIntoRange('data', range);
+    editable.insertHtmlIntoRange('data', range, 'mode');
     editable.insertText(new CKEDITOR.dom.text('text'));
 
     const inline: boolean = editable.isInline();

--- a/types/ckeditor4/index.d.ts
+++ b/types/ckeditor4/index.d.ts
@@ -1073,6 +1073,7 @@ declare namespace CKEDITOR {
         changeAttr(attr: string, val: string): void;
         detach(): void;
         insertElement(element: dom.element, range?: dom.range): void;
+        insertHtmlIntoRange(data: string, range: CKEDITOR.dom.range, mode?: string): void;
         insertHtml(data: string, mode?: string, range?: dom.range): void;
         insertText(text: dom.text): void;
         isInline(): boolean;


### PR DESCRIPTION
Added the `insertHtmlIntoRange` definition from the API doc: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editable.html#method-insertHtmlIntoRange

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

