### PR TITLE
feat(wistia-player-browser): Add type declarations

### DIFF
--- a/types/wistia-player-browser/index.d.ts
+++ b/types/wistia-player-browser/index.d.ts
@@ -1,0 +1,228 @@
+// Type definitions for non-npm package wistia-player-browser 1.0
+// Project: https://wistia.com/support/developers/player-api
+// Definitions by: Kelly Littlepage <https://github.com/klittlepage>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace WistiaPlayer {
+    interface Chapter {
+        title: string;
+        time: number;
+    }
+
+    interface TurnStyleOptions {
+        allowSkip?: boolean;
+        alwaysShow?: boolean;
+        askName?: boolean;
+        bottomText?: string;
+        buttonBackground?: string;
+        errorColor?: string;
+        validDomains?: string;
+        invalidDomains?: string;
+        emailExampleText?: string;
+        firstNameExampleText?: string;
+        lastNameExampleText?: string;
+        sectionIndex?: number;
+        time?: number;
+        topText?: string;
+        videoIndex?: number;
+    }
+
+    interface PostRollOptions {
+        autoSize?: boolean;
+        backgroundOpacity?: number;
+        image?: number;
+        link?: string;
+        on?: boolean;
+        raw?: string;
+        rewatch?: boolean;
+        text?: string;
+        time?: number;
+    }
+
+    interface Annotation {
+        time: number;
+        duration: number;
+        text: string;
+        url?: string;
+    }
+
+    interface AnnotationOptions {
+        links?: false | Annotation[];
+    }
+
+    interface ShareOptions {
+        channels?: string;
+        pageTitle?: string;
+        overrideUrl?: boolean;
+        pageUrl?: string;
+        downloadType?: 'sd_mp4' | 'hd_mp4' | 'original';
+        tweetText?: string;
+    }
+
+    interface CaptionOptions {
+        onByDefault?: boolean;
+        language?: string;
+        subtitlesScale?: number;
+    }
+
+    interface PluginOptions {
+        videoThumbnail?: { clickToPlayButton: boolean };
+        'requireEmail-v1?'?: TurnStyleOptions;
+        'postRoll-v1'?: PostRollOptions;
+        'midrollLink-v1'?: AnnotationOptions;
+        share?: ShareOptions;
+        'captions-v1'?: CaptionOptions;
+    }
+
+    type PlaybackQuality = 224 | 360 | 540 | 720 | 1080 | 3840;
+
+    interface PlayerOptions {
+        autoPlay?: boolean | 'muted';
+        chaptersOn?: boolean;
+        chapterList?: Chapter[];
+        controlsVisibleOnLoad?: boolean;
+        copyLinkAndThumbnailEnabled?: boolean;
+        doNotTrack?: boolean;
+        email?: string;
+        endVideoBehavior?: 'default' | 'reset' | 'loop';
+        fakeFullscreen?: boolean;
+        fullscreenButton?: boolean;
+        fullscreenOnRotateToLandscape?: boolean;
+        googleAnalytics?: boolean;
+        muted?: boolean;
+        playbackRateControl?: boolean;
+        playbar?: boolean;
+        playButton?: boolean;
+        playerColor?: string;
+        playlistLinks?: string;
+        playlistLoop?: string;
+        playsinline?: boolean;
+        playSuspendedOffScreen?: boolean;
+        plugin?: PluginOptions;
+        preload?: boolean | 'metadata' | 'auto' | 'none';
+        qualityControl?: boolean;
+        qualityMax?: PlaybackQuality;
+        qualityMin?: PlaybackQuality;
+        resumable?: boolean | 'auto';
+        seo?: boolean;
+        settingsControl?: boolean;
+        silentAutoPlay?: boolean | 'allow';
+        smallPlayButton?: boolean;
+        stillUrl?: string;
+        time?: string;
+        videoFoam?:
+            | boolean
+            | {
+                  minWidth?: number;
+                  maxWidth?: number;
+                  minHeight?: number;
+                  maxHeight?: number;
+              };
+        volume?: number;
+        volumeControl?: boolean;
+        wmode?: 'transparent' | 'flash';
+    }
+
+    type PlayState = 'beforeplay' | 'playing' | 'paused' | 'ended';
+
+    interface VideoDimensionOptions {
+        constrain: boolean;
+    }
+
+    type BindCallback = () => void;
+    type WithinIntervalCallback = (withinInterval: boolean) => void;
+    type CaptionsChangeCallback = (details: { visible: boolean; language: string }) => void;
+    type ConversionCallback = (
+        type: 'pre-roll-email' | 'mid-roll-email' | 'post-roll-email',
+        email: string,
+        firstName: string,
+        lastName: string,
+    ) => void;
+    type PercentWatchedCallback = (percent: number, lastPercent: number) => void;
+    type PlaybackRateCallback = (playbackRate: number) => void;
+    type SecondChangeCallback = (time: number) => void;
+    type SeekCallback = (currentTime: number, lastTime: number) => void;
+    type SilentPlaybackModeCallback = (isSilentPlaybackMode: boolean) => void;
+    type TimeChangeCallback = (time: number) => void;
+    type VolumeChangeCallback = (volume: number) => void;
+
+    interface Player {
+        addToPlaylist(
+            hashId: string,
+            options?: PlayerOptions,
+            position?: { before?: string; after?: string; index?: number },
+        ): void;
+        aspect(): number;
+        bind(name: 'betweentimes', start: number, end: number, callback: WithinIntervalCallback): void;
+        bind(name: 'captionschange', callback: CaptionsChangeCallback): void;
+        bind(name: 'conversion', callback: ConversionCallback): void;
+        bind(name: 'crosstime', time: number, callback: BindCallback): void;
+        bind(
+            name:
+                | 'beforeremove'
+                | 'beforereplace'
+                | 'heightchange'
+                | 'widthchange'
+                | 'lookchange'
+                | 'mutechange'
+                | 'play'
+                | 'pause'
+                | 'end',
+            callback: BindCallback,
+        ): void;
+        bind(name: 'percentwatchedchanged', callback: PercentWatchedCallback): void;
+        bind(name: 'playbackratechange', callback: PlaybackRateCallback): void;
+        bind(name: 'secondchange', callback: SecondChangeCallback): void;
+        bind(name: 'seek', callback: SeekCallback): void;
+        bind(name: 'silentplaybackmodechange', callback: SilentPlaybackModeCallback): void;
+        bind(name: 'timechange', callback: TimeChangeCallback): void;
+        bind(name: 'volumechange', callback: VolumeChangeCallback): void;
+        duration(): number;
+        email(email?: string): string | null;
+        embedded(): boolean;
+        eventKey(): string;
+        hasData(): boolean;
+        hashedId(): string;
+        height(height: number, options?: VideoDimensionOptions): number;
+        isMuted(): boolean;
+        look(view?: {
+            heading?: number;
+            pitch?: number;
+            fov?: number;
+        }): { heading?: number; pitch?: number; fov?: number } | undefined;
+        mute(): void;
+        name(): string;
+        pause(): void;
+        percentWatched(): number;
+        play(): void;
+        playbackRate(rate: number): void;
+        ready(): boolean;
+        remove(): void;
+        replaceWith(hashId: string, options?: PlayerOptions): void;
+        secondsWatched(): number;
+        secondsWatchedVector(): number[];
+        state(): PlayState;
+        time(time?: number): number;
+        unbind(name: 'captionschange', callback: BindCallback | CaptionsChangeCallback): void;
+        unbind(name: 'conversion', callback: BindCallback | ConversionCallback): void;
+        unbind(name: 'crosstime', time: number, callback: BindCallback): void;
+        unbind(
+            name: 'heightchange' | 'lookchange' | 'mutechange' | 'play' | 'pause' | 'end',
+            callback: BindCallback,
+        ): void;
+        unbind(name: 'percentwatchedchanged', callback: BindCallback | PercentWatchedCallback): void;
+        unbind(name: 'playbackratechange', callback: BindCallback | PlaybackRateCallback): void;
+        unbind(name: 'secondchange', callback: BindCallback | SecondChangeCallback): void;
+        unbind(name: 'seek', callback: BindCallback | SeekCallback): void;
+        unbind(name: 'silentplaybackmodechange', callback: BindCallback | SilentPlaybackModeCallback): void;
+        unbind(name: 'timechange', callback: BindCallback | TimeChangeCallback): void;
+        unbind(name: 'volumechange', callback: BindCallback | VolumeChangeCallback): void;
+        unbind(name: 'widthchange', callback: BindCallback | BindCallback): void;
+        unmute(): void;
+        videoHeight(height: number, options?: VideoDimensionOptions): number;
+        videoWidth(width: number, options?: VideoDimensionOptions): number;
+        visitorKey(): string;
+        volume(volume: number): number;
+        width(width: number, options?: VideoDimensionOptions): number;
+    }
+}

--- a/types/wistia-player-browser/tsconfig.json
+++ b/types/wistia-player-browser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "wistia-player-browser-tests.ts"
+    ]
+}

--- a/types/wistia-player-browser/tslint.json
+++ b/types/wistia-player-browser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/wistia-player-browser/wistia-player-browser-tests.ts
+++ b/types/wistia-player-browser/wistia-player-browser-tests.ts
@@ -1,0 +1,42 @@
+{
+    const chapter: WistiaPlayer.Chapter = {
+        title: 'test',
+        time: 0,
+    };
+}
+
+{
+    const options: WistiaPlayer.TurnStyleOptions = { allowSkip: true };
+}
+
+{
+    const options: WistiaPlayer.PostRollOptions = { autoSize: true };
+}
+
+{
+    const annotation: WistiaPlayer.Annotation = { time: 0, duration: 0, text: 'test' };
+    const options: WistiaPlayer.AnnotationOptions = { links: [annotation] };
+}
+
+{
+    const options: WistiaPlayer.ShareOptions = { channels: 'test' };
+}
+
+{
+    const options: WistiaPlayer.CaptionOptions = { onByDefault: true };
+}
+
+{
+    const options: WistiaPlayer.PluginOptions = { videoThumbnail: { clickToPlayButton: true } };
+}
+
+{
+    const options: WistiaPlayer.PlayerOptions = { autoPlay: 'muted' };
+}
+
+declare var mockPlayer: WistiaPlayer.Player;
+
+{
+    mockPlayer.addToPlaylist('test');
+    mockPlayer.bind('beforeremove', () => undefined);
+}


### PR DESCRIPTION
Contributing type declarations for the Wistia JavaScript Player API:
https://wistia.com/support/developers/player-api

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
