### PR TITLE
mixpanel-browser: method on Group type should be set_once instead of setOnce

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -133,7 +133,7 @@ export interface Group {
         to?: Prop extends string ? string : undefined,
         callback?: Callback,
     ): Group;
-    setOnce<Prop extends string | Dict>(
+    set_once<Prop extends string | Dict>(
         prop: Prop,
         to?: Prop extends string ? string : undefined,
         callback?: Callback,

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -314,7 +314,7 @@ mixpanel.get_group('test', 'id').set(
         }
     },
 );
-mixpanel.get_group('test', 'id').setOnce('prop', 'value', response => {
+mixpanel.get_group('test', 'id').set_once('prop', 'value', response => {
     if (response === 1) {
     } else if (response === 0) {
     } else if (response.status === 1 && response.error === null) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelgroupset_once
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -> Seems like a typo in the type definition, not because of a new version of mixpanel.
