### PR TITLE
Update events.d.ts

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -154,8 +154,8 @@ declare module 'events' {
          * ```
          * @since v11.13.0, v10.16.0
          */
-        static once(emitter: NodeEventTarget, eventName: string | symbol, options?: StaticEventEmitterOptions): Promise<any[]>;
-        static once(emitter: DOMEventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
+        static once<T extends any[]=any[]>(emitter: NodeEventTarget, eventName: string | symbol, options?: StaticEventEmitterOptions): Promise<T>;
+        static once<T extends any[]=any[]>(emitter: DOMEventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<T>;
         /**
          * ```js
          * const { on, EventEmitter } = require('events');


### PR DESCRIPTION
Optional type for event payload. It is full backwards compatible and allow to inline event data type:
```ts
const [response] = await once<[Response]>( request, 'response' );
```

