### PR TITLE
[chrome]: Made the options for chrome.notifications.create stricter

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5414,19 +5414,7 @@ declare namespace chrome.notifications {
         message: string;
     }
 
-    export interface NotificationOptions {
-        /** Optional. Which type of notification to display. Required for notifications.create method. */
-        type?: string | undefined;
-        /**
-         * Optional.
-         * A URL to the sender's avatar, app icon, or a thumbnail for image notifications.
-         * URLs can be a data URL, a blob URL, or a URL relative to a resource within this extension's .crx file Required for notifications.create method.
-         */
-        iconUrl?: string | undefined;
-        /** Optional. Title of the notification (e.g. sender name for email). Required for notifications.create method. */
-        title?: string | undefined;
-        /** Optional. Main notification content. Required for notifications.create method. */
-        message?: string | undefined;
+    export type NotificationOptions<T extends boolean = false> = {
         /**
          * Optional.
          * Alternate notification content with a lower-weight font.
@@ -5473,7 +5461,32 @@ declare namespace chrome.notifications {
          * @since Chrome 70
          */
         silent?: boolean | undefined;
-    }
+    } & (T extends true ? {
+        /**
+         * A URL to the sender's avatar, app icon, or a thumbnail for image notifications.
+         * URLs can be a data URL, a blob URL, or a URL relative to a resource within this extension's .crx file. Required for notifications.create method.
+         */
+        iconUrl: string;
+        /** Main notification content. Required for notifications.create method. */
+        message: string;
+        /** Which type of notification to display. Required for notifications.create method. */
+        type: string;
+        /** Title of the notification (e.g. sender name for email). Required for notifications.create method. */
+        title: string;
+    } : {
+        /**
+         * Optional.
+         * A URL to the sender's avatar, app icon, or a thumbnail for image notifications.
+         * URLs can be a data URL, a blob URL, or a URL relative to a resource within this extension's .crx file. Required for notifications.create method.
+         */
+        iconUrl?: string | undefined;
+        /** Optional. Main notification content. Required for notifications.create method. */
+        message?: string | undefined;
+        /** Optional. Which type of notification to display. Required for notifications.create method. */
+        type?: string | undefined;
+        /** Optional. Title of the notification (e.g. sender name for email). Required for notifications.create method. */
+        title?: string | undefined;
+    })
 
     export interface NotificationClosedEvent
         extends chrome.events.Event<(notificationId: string, byUser: boolean) => void> { }
@@ -5516,7 +5529,7 @@ declare namespace chrome.notifications {
      */
     export function create(
         notificationId: string,
-        options: NotificationOptions,
+        options: NotificationOptions<true>,
         callback?: (notificationId: string) => void,
     ): void;
     /**
@@ -5529,7 +5542,7 @@ declare namespace chrome.notifications {
      * If you specify the callback parameter, it should be a function that looks like this:
      * function(string notificationId) {...};
      */
-    export function create(options: NotificationOptions, callback?: (notificationId: string) => void): void;
+    export function create(options: NotificationOptions<true>, callback?: (notificationId: string) => void): void;
     /**
      * Updates an existing notification.
      * @param notificationId The id of the notification to be updated. This is returned by notifications.create method.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5402,6 +5402,8 @@ declare namespace chrome.networking.config {
  * @since Chrome 28.
  */
 declare namespace chrome.notifications {
+    export type TemplateType = "basic" | "image" | "list" | "progress";
+
     export interface ButtonOptions {
         title: string;
         iconUrl?: string | undefined;
@@ -5470,7 +5472,7 @@ declare namespace chrome.notifications {
         /** Main notification content. Required for notifications.create method. */
         message: string;
         /** Which type of notification to display. Required for notifications.create method. */
-        type: string;
+        type: TemplateType;
         /** Title of the notification (e.g. sender name for email). Required for notifications.create method. */
         title: string;
     } : {
@@ -5483,7 +5485,7 @@ declare namespace chrome.notifications {
         /** Optional. Main notification content. Required for notifications.create method. */
         message?: string | undefined;
         /** Optional. Which type of notification to display. Required for notifications.create method. */
-        type?: string | undefined;
+        type?: TemplateType | undefined;
         /** Optional. Title of the notification (e.g. sender name for email). Required for notifications.create method. */
         title?: string | undefined;
     })

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -305,32 +305,11 @@ function proxySettings() {
 
 function testNotificationCreation() {
 	chrome.notifications.create("id", {}); // $ExpectError
-	chrome.notifications.create("id", {
-		message: "",
-		type: "",
-		title: "",
-	}); // $ExpectError
-	chrome.notifications.create("id", {
-		iconUrl: "",
-		type: "",
-		title: "",
-	}); // $ExpectError
-	chrome.notifications.create("id", {
-		iconUrl: "",
-		message: "",
-		title: "",
-	}); // $ExpectError
-	chrome.notifications.create("id", {
-		iconUrl: "",
-		message: "",
-		type: "",
-	}); // $ExpectError
-	chrome.notifications.create("id", {
-		iconUrl: "",
-		message: "",
-		type: "",
-		title: "",
-	});
+	chrome.notifications.create("id", { message: "", type: "", title: "", }); // $ExpectError
+	chrome.notifications.create("id", { iconUrl: "", type: "", title: "", }); // $ExpectError
+	chrome.notifications.create("id", { iconUrl: "", message: "", title: "", }); // $ExpectError
+	chrome.notifications.create("id", { iconUrl: "", message: "", type: "", }); // $ExpectError
+	chrome.notifications.create("id", { iconUrl: "", message: "", type: "", title: "", });
 }
 
 // https://developer.chrome.com/extensions/examples/api/contentSettings/popup.js

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -304,12 +304,12 @@ function proxySettings() {
 }
 
 function testNotificationCreation() {
-	chrome.notifications.create("id", {}); // $ExpectError
-	chrome.notifications.create("id", { message: "", type: "", title: "", }); // $ExpectError
-	chrome.notifications.create("id", { iconUrl: "", type: "", title: "", }); // $ExpectError
-	chrome.notifications.create("id", { iconUrl: "", message: "", title: "", }); // $ExpectError
-	chrome.notifications.create("id", { iconUrl: "", message: "", type: "", }); // $ExpectError
-	chrome.notifications.create("id", { iconUrl: "", message: "", type: "", title: "", });
+    chrome.notifications.create("id", {}); // $ExpectError
+    chrome.notifications.create("id", { message: "", type: "", title: "", }); // $ExpectError
+    chrome.notifications.create("id", { iconUrl: "", type: "", title: "", }); // $ExpectError
+    chrome.notifications.create("id", { iconUrl: "", message: "", title: "", }); // $ExpectError
+    chrome.notifications.create("id", { iconUrl: "", message: "", type: "", }); // $ExpectError
+    chrome.notifications.create("id", { iconUrl: "", message: "", type: "", title: "", });
 }
 
 // https://developer.chrome.com/extensions/examples/api/contentSettings/popup.js

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -303,6 +303,36 @@ function proxySettings() {
     chrome.proxy.settings.clear({ scope: 'regular' });
 }
 
+function testNotificationCreation() {
+	chrome.notifications.create("id", {}); // $ExpectError
+	chrome.notifications.create("id", {
+		message: "",
+		type: "",
+		title: "",
+	}); // $ExpectError
+	chrome.notifications.create("id", {
+		iconUrl: "",
+		type: "",
+		title: "",
+	}); // $ExpectError
+	chrome.notifications.create("id", {
+		iconUrl: "",
+		message: "",
+		title: "",
+	}); // $ExpectError
+	chrome.notifications.create("id", {
+		iconUrl: "",
+		message: "",
+		type: "",
+	}); // $ExpectError
+	chrome.notifications.create("id", {
+		iconUrl: "",
+		message: "",
+		type: "",
+		title: "",
+	});
+}
+
 // https://developer.chrome.com/extensions/examples/api/contentSettings/popup.js
 function contentSettings() {
     var incognito;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -309,7 +309,8 @@ function testNotificationCreation() {
     chrome.notifications.create("id", { iconUrl: "", type: "", title: "", }); // $ExpectError
     chrome.notifications.create("id", { iconUrl: "", message: "", title: "", }); // $ExpectError
     chrome.notifications.create("id", { iconUrl: "", message: "", type: "", }); // $ExpectError
-    chrome.notifications.create("id", { iconUrl: "", message: "", type: "", title: "", });
+    chrome.notifications.create("id", { iconUrl: "", message: "", type: "", title: "", }); // $ExpectError
+    chrome.notifications.create("id", { iconUrl: "", message: "", type: "basic", title: "", });
 }
 
 // https://developer.chrome.com/extensions/examples/api/contentSettings/popup.js


### PR DESCRIPTION
Some properties are required in chrome.notifications.create at runtime, but not in the typings. This PR enforces those options. This was pointed out by @wfk007 in #57548.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/notifications/#type-NotificationOptions
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.