### PR TITLE
react-elemental's source npm package has been unpublished.

### DIFF
--- a/types/react-elemental/index.d.ts
+++ b/types/react-elemental/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React Elemental 1.2
+// Type definitions for non-npm package React Elemental 1.2
 // Project: https://github.com/LINKIWI/react-elemental
 // Definitions by: Fernando Chen <https://github.com/wzfc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Both react-elemental and @types/react-elemental are little used, so it
might be better to delete the directory and mark it as not needed
instead. However, even that would leave @types/react-elemental still
accessible, unlike react-elemental itself.
