### PR TITLE
[jsdoc-to-markdown] Fix JsdocOptions noCache prop name

### DIFF
--- a/types/jsdoc-to-markdown/index.d.ts
+++ b/types/jsdoc-to-markdown/index.d.ts
@@ -77,7 +77,7 @@ export interface JsdocOptions {
      * By default results are cached to speed up repeat invocations.
      * Set to true to disable this.
      */
-    noCache?: boolean | undefined;
+    'no-cache'?: boolean | undefined;
     /**
      * One or more filenames to process.
      * Accepts globs (e.g. *.js). Either files, source or data must be supplied.

--- a/types/jsdoc-to-markdown/jsdoc-to-markdown-tests.ts
+++ b/types/jsdoc-to-markdown/jsdoc-to-markdown-tests.ts
@@ -5,7 +5,7 @@ const output = jsdoc2md.renderSync({ files: 'lib/*.js' });
 
 const JsdocDataOptions: jsdoc2md.JsdocOptions = {
     files: 'file.js',
-    noCache: true,
+    'no-cache': true,
 };
 
 const RenderOptions: jsdoc2md.RenderOptions = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsdoc2md/jsdoc-to-markdown/blob/master/docs/API.md#jsdoc2mdgetjsdocdataoptions--promise
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.