### PR TITLE
Fix return type of verify function in jsonwebtoken

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -95,7 +95,7 @@ export type VerifyErrors =
     | JsonWebTokenError
     | NotBeforeError
     | TokenExpiredError;
-export type VerifyCallback<T = JwtPayload> = (
+export type VerifyCallback<T = unknown> = (
     err: VerifyErrors | null,
     decoded: T | undefined,
 ) => void;
@@ -118,21 +118,9 @@ export interface JwtHeader {
     x5c?: string | string[] | undefined;
 }
 
-// standard claims https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
-export interface JwtPayload {
-    [key: string]: any;
-    iss?: string | undefined;
-    sub?: string | undefined;
-    aud?: string | string[] | undefined;
-    exp?: number | undefined;
-    nbf?: number | undefined;
-    iat?: number | undefined;
-    jti?: string | undefined;
-}
-
 export interface Jwt {
     header: JwtHeader;
-    payload: JwtPayload;
+    payload: unknown;
     signature: string;
 }
 
@@ -199,7 +187,7 @@ export function sign(
  * returns - The decoded token.
  */
 export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
-export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): any;
+export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): unknown;
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token
@@ -235,5 +223,5 @@ export function verify(
  * returns - The decoded Token
  */
 export function decode(token: string, options: DecodeOptions & { complete: true }): null | Jwt;
-export function decode(token: string, options: DecodeOptions & { json: true }): null | JwtPayload;
-export function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
+export function decode(token: string, options: DecodeOptions & { json: true }): unknown;
+export function decode(token: string, options?: DecodeOptions): unknown;

--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -198,8 +198,8 @@ export function sign(
  * [options] - Options for the verification
  * returns - The decoded token.
  */
-export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt | string;
-export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): JwtPayload | string;
+export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
+export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): any;
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -88,10 +88,6 @@ jwt.verify(token, secret, (err, decoded) => {
     console.log(result.foo); // bar
 });
 
-// verify without a callback
-const decoded = jwt.verify(token, secret);
-console.log(decoded.foo);
-
 // verify a token asymmetric
 cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, (err, decoded) => {
@@ -149,7 +145,7 @@ jwt.verify(token, cert, { ignoreExpiration: true }, (err, decoded) => {
 cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, (_err, payload) => {
     if (payload) {
-        // $ExpectType JwtPayload
+        // $ExpectType unknown
         payload;
     }
 });
@@ -157,7 +153,7 @@ jwt.verify(token, cert, (_err, payload) => {
 cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, {}, (_err, payload) => {
     if (payload) {
-        // $ExpectType JwtPayload
+        // $ExpectType unknown
         payload;
     }
 });
@@ -174,7 +170,7 @@ cert = fs.readFileSync("public.pem"); // get public key
 const verified = jwt.verify(token, cert);
 
 if (typeof verified !== 'string') {
-    // $ExpectType any
+    // $ExpectType unknown
     verified;
 }
 
@@ -191,7 +187,7 @@ cert = fs.readFileSync("public.pem"); // get public key
 const verified3 = jwt.verify(token, cert, {maxAge: 3600});
 
 if (typeof verified3 !== 'string') {
-    // $ExpectType any
+    // $ExpectType unknown
     verified3;
 }
 
@@ -199,19 +195,19 @@ if (typeof verified3 !== 'string') {
  * jwt.decode
  * https://github.com/auth0/node-jsonwebtoken#jwtdecodetoken
  */
-// $ExpectType string | JwtPayload | null
+// $ExpectType unknown
 jwt.decode(token);
 
-// $ExpectType string | JwtPayload | null
+// $ExpectType unknown
 jwt.decode(token, { complete: false });
 
-// $ExpectType string | JwtPayload | null
+// $ExpectType unknown
 jwt.decode(token, { json: false });
 
-// $ExpectType string | JwtPayload | null
+// $ExpectType unknown
 jwt.decode(token, { complete: false, json: false });
 
-// $ExpectType JwtPayload | null
+// $ExpectType unknown
 jwt.decode(token, { json: true });
 
 // $ExpectType Jwt | null

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -88,6 +88,10 @@ jwt.verify(token, secret, (err, decoded) => {
     console.log(result.foo); // bar
 });
 
+// verify without a callback
+const decoded = jwt.verify(token, secret);
+console.log(decoded.foo);
+
 // verify a token asymmetric
 cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, (err, decoded) => {

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -191,7 +191,7 @@ cert = fs.readFileSync("public.pem"); // get public key
 const verified3 = jwt.verify(token, cert, {maxAge: 3600});
 
 if (typeof verified3 !== 'string') {
-    // $ExpectType JwtPayload
+    // $ExpectType any
     verified3;
 }
 

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -174,7 +174,7 @@ cert = fs.readFileSync("public.pem"); // get public key
 const verified = jwt.verify(token, cert);
 
 if (typeof verified !== 'string') {
-    // $ExpectType JwtPayload
+    // $ExpectType any
     verified;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The verify function returns either an object or a string. There is no way to determine which one from the arguments provided to the function. The previous return type was ```string | JwtPayload```. This seems to be a misunderstanding of the concept of union types. ```JwtPayload``` is defined as having all properties. This means the union of the two types is just the properties of the string type. This is wrong as the decoded payload may be an object with any properties.