### PR TITLE
fix: exchange params max and min of zrevrangebylex

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -740,20 +740,20 @@ declare namespace IORedis {
             callback: Callback<Buffer[]>,
         ): void;
 
-        zrevrangebylex(key: KeyType, min: string, max: string): Promise<string[]>;
+        zrevrangebylex(key: KeyType, max: string, min: string): Promise<string[]>;
         zrevrangebylex(
             key: KeyType,
-            min: string,
             max: string,
+            min: string,
             limit: 'LIMIT',
             offset: number,
             count: number,
         ): Promise<string[]>;
-        zrevrangebylex(key: KeyType, min: string, max: string, callback: Callback<string[]>): void;
+        zrevrangebylex(key: KeyType, max: string, min: string, callback: Callback<string[]>): void;
         zrevrangebylex(
             key: KeyType,
-            min: string,
             max: string,
+            min: string,
             limit: 'LIMIT',
             offset: number,
             count: number,


### PR DESCRIPTION
redis official signature of zrevrangebylex is 
ZREVRANGEBYLEX key max min [LIMIT offset count]

I noticed it that in types/ioredis, the definition of zrevrangebylex misplaced the position of max and min. 
It confused me at the very beginning, I thought it might be a new implementation of official method. 
But after testing, I found it is just a simple mistake.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://redis.io/commands/zrevrangebylex)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

