### PR TITLE
[node] Allow Http2ServerRequest url to be mutable.

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -1349,7 +1349,7 @@ declare module 'http2' {
          * ```
          * @since v8.4.0
          */
-        readonly url: string;
+        url: string;
         /**
          * Sets the `Http2Stream`'s timeout value to `msecs`. If a callback is
          * provided, then it is added as a listener on the `'timeout'` event on

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -277,6 +277,7 @@ import { URL } from 'node:url';
         let socket: Socket | TLSSocket = request.socket;
         let stream: ServerHttp2Stream = request.stream;
         const url: string = request.url;
+        request.url = "new url";
 
         request.setTimeout(0, () => {});
         request.on('aborted', (hadError: boolean, code: number) => {});

--- a/types/node/v12/http2.d.ts
+++ b/types/node/v12/http2.d.ts
@@ -588,7 +588,7 @@ declare module 'http2' {
         readonly socket: net.Socket | tls.TLSSocket;
         readonly stream: ServerHttp2Stream;
         readonly trailers: IncomingHttpHeaders;
-        readonly url: string;
+        url: string;
 
         setTimeout(msecs: number, callback?: () => void): void;
         read(size?: number): Buffer | string | null;

--- a/types/node/v12/test/http2.ts
+++ b/types/node/v12/test/http2.ts
@@ -272,6 +272,7 @@ import { URL } from 'url';
         let socket: Socket | TLSSocket = request.socket;
         let stream: ServerHttp2Stream = request.stream;
         const url: string = request.url;
+        request.url = "new url";
 
         request.setTimeout(0, () => {});
         request.on('aborted', (hadError: boolean, code: number) => {});

--- a/types/node/v14/http2.d.ts
+++ b/types/node/v14/http2.d.ts
@@ -594,7 +594,7 @@ declare module 'http2' {
         readonly socket: net.Socket | tls.TLSSocket;
         readonly stream: ServerHttp2Stream;
         readonly trailers: IncomingHttpHeaders;
-        readonly url: string;
+        url: string;
 
         setTimeout(msecs: number, callback?: () => void): void;
         read(size?: number): Buffer | string | null;

--- a/types/node/v14/test/http2.ts
+++ b/types/node/v14/test/http2.ts
@@ -273,6 +273,7 @@ import { URL } from 'node:url';
         let socket: Socket | TLSSocket = request.socket;
         let stream: ServerHttp2Stream = request.stream;
         const url: string = request.url;
+        request.url = "new url";
 
         request.setTimeout(0, () => {});
         request.on('aborted', (hadError: boolean, code: number) => {});

--- a/types/node/v16/http2.d.ts
+++ b/types/node/v16/http2.d.ts
@@ -1349,7 +1349,7 @@ declare module 'http2' {
          * ```
          * @since v8.4.0
          */
-        readonly url: string;
+        url: string;
         /**
          * Sets the `Http2Stream`'s timeout value to `msecs`. If a callback is
          * provided, then it is added as a listener on the `'timeout'` event on

--- a/types/node/v16/test/http2.ts
+++ b/types/node/v16/test/http2.ts
@@ -277,6 +277,7 @@ import { URL } from 'node:url';
         let socket: Socket | TLSSocket = request.socket;
         let stream: ServerHttp2Stream = request.stream;
         const url: string = request.url;
+        request.url = "new url";
 
         request.setTimeout(0, () => {});
         request.on('aborted', (hadError: boolean, code: number) => {});


### PR DESCRIPTION
It has both a get and a set method defined for it. This is a backwards
compatible change, since it only compiles more programs than before.

We do not need to worry about this changing from an earlier version of
Node, since the first commit that introduced this class back around the
time of Node 8 and 9 already defined the setter.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/nodejs/node/blob/master/lib/internal/http2/compat.js#L430
