### PR TITLE
types: jsonwebtoken - improve return types

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -12,6 +12,7 @@
 //                 Ivan Sieder <https://github.com/ivansieder>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Nandor Kraszlan <https://github.com/nandi95>
+//                 Indian Ocean Roleplay <https://github.com/oceanroleplay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -130,9 +131,9 @@ export interface JwtPayload {
     jti?: string | undefined;
 }
 
-export interface Jwt {
+export interface Jwt<T = JwtPayload> {
     header: JwtHeader;
-    payload: JwtPayload;
+    payload: T;
     signature: string;
 }
 
@@ -198,8 +199,24 @@ export function sign(
  * [options] - Options for the verification
  * returns - The decoded token.
  */
-export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt | string;
-export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): JwtPayload | string;
+export function verify<T>(
+    token: string,
+    secretOrPublicKey: Secret,
+    options: VerifyOptions & { complete: true }
+): T extends string
+    ? string
+    : T extends object
+    ? Jwt<T & JwtPayload>
+    : string | Jwt<T & JwtPayload>;
+export function verify<T>(
+    token: string,
+    secretOrPublicKey: Secret,
+    options?: VerifyOptions
+): T extends string
+    ? string
+    : T extends object
+    ? T & JwtPayload
+    : string | (T & JwtPayload);
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token
@@ -210,22 +227,40 @@ export function verify(token: string, secretOrPublicKey: Secret, options?: Verif
  * [options] - Options for the verification
  * callback - Callback to get the decoded token on
  */
-export function verify(
-    token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
-    callback?: VerifyCallback,
+export function verify<T>(
+  token: string,
+  secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+  callback?: VerifyCallback<
+    T extends string
+      ? string
+      : T extends object
+      ? T & JwtPayload
+      : string | (T & JwtPayload)
+  >
 ): void;
-export function verify(
-    token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
-    options?: VerifyOptions & { complete: true },
-    callback?: VerifyCallback<Jwt>,
+export function verify<T>(
+  token: string,
+  secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+  options?: VerifyOptions & { complete: true },
+  callback?: VerifyCallback<
+    T extends string
+      ? string
+      : T extends object
+      ? Jwt<T & JwtPayload>
+      : string | Jwt<T & JwtPayload>
+  >
 ): void;
-export function verify(
-    token: string,
-    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
-    options?: VerifyOptions,
-    callback?: VerifyCallback,
+export function verify<T>(
+  token: string,
+  secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+  options?: VerifyOptions,
+  callback?: VerifyCallback<
+    T extends string
+      ? string
+      : T extends object
+      ? T & JwtPayload
+      : string | (T & JwtPayload)
+  >
 ): void;
 
 /**
@@ -234,6 +269,23 @@ export function verify(
  * [options] - Options for decoding
  * returns - The decoded Token
  */
-export function decode(token: string, options: DecodeOptions & { complete: true }): null | Jwt;
-export function decode(token: string, options: DecodeOptions & { json: true }): null | JwtPayload;
-export function decode(token: string, options?: DecodeOptions): null | JwtPayload | string;
+export function decode<T>(
+  token: string,
+  options: DecodeOptions & { complete: true }
+): T extends string
+  ? null | string
+  : T extends object
+  ? null | Jwt<T & JwtPayload>
+  : null | string | Jwt<T & JwtPayload>;
+export function decode<T = { [key: string]: any }>(
+  token: string,
+  options: DecodeOptions & { json: true }
+): T extends object ? null | (T & JwtPayload) : null | JwtPayload;
+export function decode<T>(
+  token: string,
+  options?: DecodeOptions
+): T extends string
+  ? null | string
+  : T extends object
+  ? null | (T & JwtPayload)
+  : null | string | (T & JwtPayload);

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -14,6 +14,8 @@ interface TestObject {
     foo: string;
 }
 
+type DecodedTestObject =  TestObject & jwt.JwtPayload;
+
 const testObject = { foo: "bar" };
 
 /**
@@ -62,36 +64,36 @@ jwt.sign(testObject, cert, { algorithm: "RS256" }, (
  * https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback
  */
 // verify a token symmetric
-jwt.verify(token, "shhhhh", (err, decoded) => {
-    const result = decoded as TestObject;
+jwt.verify<TestObject>(token, "shhhhh", (err, decoded) => {
+    const result = decoded as DecodedTestObject;
 
     console.log(result.foo); // bar
 });
 
 // use external time for verifying
-jwt.verify(token, 'shhhhh', { clockTimestamp: 1 }, (err, decoded) => {
-    const result = decoded as TestObject;
+jwt.verify<TestObject>(token, 'shhhhh', { clockTimestamp: 1 }, (err, decoded) => {
+    const result = decoded as DecodedTestObject;
 
     console.log(result.foo); // bar
 });
 
 // invalid token
-jwt.verify(token, "wrong-secret", (err, decoded) => {
+jwt.verify<TestObject>(token, "wrong-secret", (err, decoded) => {
     // err
     // decoded undefined
 });
 
 // verify with encrypted RSA SHA256 private key
-jwt.verify(token, secret, (err, decoded) => {
-    const result = decoded as TestObject;
+jwt.verify<TestObject>(token, secret, (err, decoded) => {
+    const result = decoded as DecodedTestObject;
 
     console.log(result.foo); // bar
 });
 
 // verify a token asymmetric
 cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, (err, decoded) => {
-    const result = decoded as TestObject;
+jwt.verify<TestObject>(token, cert, (err, decoded) => {
+    const result = decoded as DecodedTestObject;
 
     console.log(result.foo); // bar
 });
@@ -103,18 +105,18 @@ function getKey(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
     callback(null, cert);
 }
 
-jwt.verify(token, getKey, (err, decoded) => {
-    const result = decoded as TestObject;
+jwt.verify<TestObject>(token, getKey, (err, decoded) => {
+    const result = decoded as DecodedTestObject;
 
     console.log(result.foo); // bar
 });
 
 // verify audience
 cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, { audience: "urn:foo" }, (err, decoded) => {
+jwt.verify<TestObject>(token, cert, { audience: "urn:foo" }, (err, decoded) => {
     // if audience mismatch, err == invalid audience
 });
-jwt.verify(token, cert, { audience: /urn:f[o]{2}/ }, (err, decoded) => {
+jwt.verify<TestObject>(token, cert, { audience: /urn:f[o]{2}/ }, (err, decoded) => {
     // if audience mismatch, err == invalid audience
 });
 jwt.verify(token, cert, { audience: [/urn:f[o]{2}/, "urn:bar"] }, (err, decoded) => {
@@ -123,7 +125,7 @@ jwt.verify(token, cert, { audience: [/urn:f[o]{2}/, "urn:bar"] }, (err, decoded)
 
 // verify issuer
 cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, { audience: "urn:foo", issuer: "urn:issuer" }, (
+jwt.verify<TestObject>(token, cert, { audience: "urn:foo", issuer: "urn:issuer" }, (
     err,
     decoded,
 ) => {
@@ -132,62 +134,62 @@ jwt.verify(token, cert, { audience: "urn:foo", issuer: "urn:issuer" }, (
 
 // verify algorithm
 cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, { algorithms: ["RS256"] }, (err, decoded) => {
+jwt.verify<TestObject>(token, cert, { algorithms: ["RS256"] }, (err, decoded) => {
     // if algorithm mismatch, err == invalid algorithm
 });
 
 // verify without expiration check
 cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, { ignoreExpiration: true }, (err, decoded) => {
+jwt.verify<TestObject>(token, cert, { ignoreExpiration: true }, (err, decoded) => {
     // if ignoreExpration == false and token is expired, err == expired token
 });
 
 cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, (_err, payload) => {
+jwt.verify<TestObject>(token, cert, (_err, payload) => {
     if (payload) {
-        // $ExpectType JwtPayload
+        // $ExpectType TestObject & JwtPayload
         payload;
     }
 });
 
 cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, {}, (_err, payload) => {
+jwt.verify<TestObject>(token, cert, {}, (_err, payload) => {
     if (payload) {
-        // $ExpectType JwtPayload
+        // $ExpectType TestObject & JwtPayload
         payload;
     }
 });
 
 cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, { complete: true }, (_err, payload) => {
+jwt.verify<TestObject>(token, cert, { complete: true }, (_err, payload) => {
     if (payload) {
-        // $ExpectType Jwt
+        // $ExpectType Jwt<TestObject & JwtPayload>
         payload;
     }
 });
 
 cert = fs.readFileSync("public.pem"); // get public key
-const verified = jwt.verify(token, cert);
+const verified = jwt.verify<TestObject>(token, cert);
 
 if (typeof verified !== 'string') {
-    // $ExpectType JwtPayload
+    // $ExpectType TestObject & JwtPayload
     verified;
 }
 
 cert = fs.readFileSync("public.pem"); // get public key
-const verified2 = jwt.verify(token, cert, { complete: true });
+const verified2 = jwt.verify<TestObject>(token, cert, { complete: true });
 
 if (typeof verified2 !== 'string') {
-    // $ExpectType Jwt
+    // $ExpectType Jwt<TestObject & JwtPayload>
     verified2;
 }
 
 // This tests creates a token with iat as now, verifies with maxAge=now()+3600sec
 cert = fs.readFileSync("public.pem"); // get public key
-const verified3 = jwt.verify(token, cert, {maxAge: 3600});
+const verified3 = jwt.verify<TestObject>(token, cert, {maxAge: 3600});
 
 if (typeof verified3 !== 'string') {
-    // $ExpectType JwtPayload
+    // $ExpectType TestObject & JwtPayload
     verified3;
 }
 
@@ -195,23 +197,23 @@ if (typeof verified3 !== 'string') {
  * jwt.decode
  * https://github.com/auth0/node-jsonwebtoken#jwtdecodetoken
  */
-// $ExpectType string | JwtPayload | null
-jwt.decode(token);
+// $ExpectType (TestObject & JwtPayload) | null
+jwt.decode<TestObject>(token);
 
-// $ExpectType string | JwtPayload | null
-jwt.decode(token, { complete: false });
+// $ExpectType (TestObject & JwtPayload) | null
+jwt.decode<TestObject>(token, { complete: false });
 
-// $ExpectType string | JwtPayload | null
-jwt.decode(token, { json: false });
+// $ExpectType (TestObject & JwtPayload) | null
+jwt.decode<TestObject>(token, { json: false });
 
-// $ExpectType string | JwtPayload | null
-jwt.decode(token, { complete: false, json: false });
+// $ExpectType (TestObject & JwtPayload) | null
+jwt.decode<TestObject>(token, { complete: false, json: false });
 
-// $ExpectType JwtPayload | null
-jwt.decode(token, { json: true });
+// $ExpectType (TestObject & JwtPayload) | null
+jwt.decode<TestObject>(token, { json: true });
 
-// $ExpectType Jwt | null
-jwt.decode(token, { complete: true });
+// $ExpectType Jwt<TestObject & JwtPayload> | null
+jwt.decode<TestObject>(token, { complete: true });
 
-// $ExpectType Jwt | null
-jwt.decode(token, { complete: true, json: true });
+// $ExpectType Jwt<TestObject & JwtPayload> | null
+jwt.decode<TestObject>(token, { complete: true, json: true });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation](https://github.com/auth0/node-jsonwebtoken#usage)

# Brief

I have been using `jsonwebtoken` for quite some time, but I sometimes find typing either confusing or irritating. Based on the end user's experience, I've modified the return type.  

Note: There are no breaking changes in this PR.

## Testings

An example of final usage with the revised typings.

![image](https://user-images.githubusercontent.com/43092101/145244294-47a6b74e-12b4-484d-baae-d07f56cf6c0a.png)


## Note to maintainers

Another pull request is closed by this pull request: #57616

## Thank you

Feel free to share your reviews or ask questions in the comments.