### PR TITLE
fixing config js extendDeep signature

### DIFF
--- a/types/config/config-tests.ts
+++ b/types/config/config-tests.ts
@@ -14,6 +14,7 @@ var has: boolean = config.has("");
 // util tests:
 var extended1: any = config.util.extendDeep({}, {});
 var extended2: any = config.util.extendDeep({}, {}, 20);
+var extended3: any = config.util.extendDeep({}, {}, {}, 20);
 
 var clone1: any = config.util.cloneDeep({});
 var clone2: any = config.util.cloneDeep({}, 20);

--- a/types/config/index.d.ts
+++ b/types/config/index.d.ts
@@ -16,7 +16,7 @@ declare namespace c {
     // see https://github.com/lorenwest/node-config/wiki/Using-Config-Utilities
     interface IUtil {
         // Extend an object (and any object it contains) with one or more objects (and objects contained in them).
-        extendDeep(mergeInto: any, mergeFrom: any, depth?: number): any;
+        extendDeep(mergeInto: any, ...mergeFrom: any): any;
 
         // Return a deep copy of the specified object.
         cloneDeep(copyFrom: any, depth?: number): any;
@@ -41,7 +41,7 @@ declare namespace c {
 
         // Return the sources for the configurations
         getConfigSources(): IConfigSource[];
-        
+
         // Returns a new deep copy of the current config object, or any part of the config if provided.
         toObject(config?: any): any;
 

--- a/types/config/index.d.ts
+++ b/types/config/index.d.ts
@@ -16,6 +16,8 @@ declare namespace c {
     // see https://github.com/lorenwest/node-config/wiki/Using-Config-Utilities
     interface IUtil {
         // Extend an object (and any object it contains) with one or more objects (and objects contained in them).
+        extendDeep(mergeInto: any, mergeFrom: any, depth?: number): any;
+        extendDeep(mergeInto: any, mergeFrom1: any, mergeFrom2: any, depth?: number): any;
         extendDeep(mergeInto: any, ...mergeFrom: any): any;
 
         // Return a deep copy of the specified object.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [extendDeep](https://github.com/lorenwest/node-config/blob/master/lib/config.js#L1263)](https://github.com/lorenwest/node-config/blob/master/lib/config.js#L1263)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

Method signature for util.extendDeep was not correct and did not support adding multiple mergeFrom objects. Unfortunately, you cannot have ...rest processing of arguments in the middle of a method signature; the ...rest must be the last element. While the type and the function are compatible with this fix, the IntelliSense documentation won't prompt for the depth parameter. The user will have to look at the node-config documentation to understand all the options. Perhaps future versions of node-config will fix this ambiguity in some way.