### PR TITLE
bull: addBulk repeat option is not supported

### DIFF
--- a/types/bull/bull-tests.tsx
+++ b/types/bull/bull-tests.tsx
@@ -103,10 +103,15 @@ imageQueue.process((job, done) => {
 
 videoQueue.add({ video: 'http://example.com/video1.mov' });
 audioQueue.add({ audio: 'http://example.com/audio1.mp3' });
-imageQueue.add({ image: 'http://example.com/image1.tiff' });
+imageQueue.add({ image: 'http://example.com/image1.tiff' }, { repeat: { cron: "00 06 * * 1", tz: "America/New_York" } });
 videoQueue.addBulk([
     { name: 'frame1', data: { video: 'http://example.com/video1.mov' }, opts: { attempts: 6 } },
     { data: { audio: 'http://example.com/video1.mov' } },
+    {
+      opts: {
+        repeat: { cron: "00 06 * * 1", tz: "America/New_York" } // $ExpectError
+      }
+    }
 ]);
 
 //////////////////////////////////////////////////////////////////////////////////

--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -591,8 +591,9 @@ declare namespace Bull {
      * Adds an array of jobs to the queue.
      * If the queue is empty the jobs will be executed directly,
      * otherwise they will be placed in the queue and executed as soon as possible.
+     * 'repeat' option is not supported in addBulk https://github.com/OptimalBits/bull/issues/1731
      */
-    addBulk(jobs: Array<{name?: string | undefined, data: T, opts?: JobOptions | undefined}>): Promise<Array<Job<T>>>;
+     addBulk(jobs: Array<{name?: string | undefined, data: T, opts?: Omit<JobOptions, "repeat"> | undefined}>): Promise<Array<Job<T>>>;
 
     /**
      * Returns a promise that resolves when the queue is paused.


### PR DESCRIPTION
I innocently tried to use addBulk to add a bunch of jobs with repeat options and was confused why it didn't work.
Turns out it's simply not supported as concluded in https://github.com/OptimalBits/bull/issues/1731
Hopefully this little update to the typings avoids someone else hitting the same issue I did

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OptimalBits/bull/issues/1731
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
