### PR TITLE
update(onfleet__node-onfleet): add GetTaskResult in Task Type

### DIFF
--- a/types/onfleet__node-onfleet/Resources/Tasks.d.ts
+++ b/types/onfleet__node-onfleet/Resources/Tasks.d.ts
@@ -9,7 +9,7 @@ declare class Task {
   create(task: Task.CreateTaskProps): Promise<Task.OnfleetTask>;
   deleteOne(id: string): Promise<number>;
   forceComplete(id: string): Promise<void>;
-  get(queryOrId: string, queryKey?: Task.TaskQueryKey): Promise<Task.OnfleetTask>;
+  get(queryOrId: string, queryKey?: Task.TaskQueryKey): Promise<Task.GetTaskResult>;
   get(queryParams?: Task.TaskQueryParam): Promise<Task.OnfleetTask[]>;
   matchMetadata: MatchMetadata<Task.OnfleetTask['metadata']>;
   update(id: string, task: Partial<Task.CreateTaskProps>): Promise<Task.UpdateTaskResult>;
@@ -155,6 +155,12 @@ declare namespace Task {
       recipients?: OnfleetRecipient | OnfleetRecipient[] | undefined;
       serviceTime?: number | undefined;
     } | undefined;
+  }
+
+  interface GetTaskResult extends OnfleetTask {
+    estimatedCompletionTime: number | null;
+    eta: number | null;
+    trackingViewed: boolean;
   }
 
   interface UpdateTaskResult extends OnfleetTask {

--- a/types/onfleet__node-onfleet/onfleet__node-onfleet-tests.ts
+++ b/types/onfleet__node-onfleet/onfleet__node-onfleet-tests.ts
@@ -34,7 +34,12 @@ const testAddress = {
 
 async function testTasks(onfleet: Onfleet) {
     // test tasks.get
-    await onfleet.tasks.get('fake_task_id');
+    const task = await onfleet.tasks.get('fake_task_id');
+    // test tasks.get GetTaskResult props
+    task.estimatedCompletionTime;
+    task.eta;
+    task.trackingViewed;
+
     await onfleet.tasks.get({ from: 1455072025000 });
     await onfleet.tasks.get({ from: 145507202500, lastId: 'fake_task_id' });
     await onfleet.tasks.get('fake_task_id', 'shortId');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.onfleet.com/reference#get-single-task>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
