### PR TITLE
[superagent] remove `dom` typings

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -15,7 +15,6 @@
 // TypeScript Version: 3.0
 
 /// <reference types="node" />
-/// <reference lib="dom" />
 
 import * as fs from "fs";
 import * as http from "http";
@@ -127,7 +126,7 @@ declare namespace request {
         text: string;
         type: string;
         unauthorized: boolean;
-        xhr: XMLHttpRequest;
+        xhr: any;
         redirects: string[];
     }
 

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -219,7 +219,7 @@ request.get("http://example.com/search").retry(2, callback).end(callback);
 })();
 
 // Attaching files
-const blob: Blob = new File([], "thor.png");
+const blob = {} as unknown as Blob;
 request
     .post("/upload")
     .attach("avatar", "path/to/tobi.png", "user.png")
@@ -282,8 +282,7 @@ request
     .get("/blob")
     .responseType("blob")
     .end((err, res) => {
-        assert(res.xhr instanceof XMLHttpRequest);
-        assert(res.xhr.response instanceof Blob);
+        console.log(res.xhr.response);
     });
 
 // HTTPS request, from: https://github.com/visionmedia/superagent/commit/6158efbf42cb93d77c1a70887284be783dd7dabe

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -219,7 +219,7 @@ request.get("http://example.com/search").retry(2, callback).end(callback);
 })();
 
 // Attaching files
-const blob = {} as unknown as Blob;
+declare const blob: Blob;
 request
     .post("/upload")
     .attach("avatar", "path/to/tobi.png", "user.png")
@@ -282,7 +282,8 @@ request
     .get("/blob")
     .responseType("blob")
     .end((err, res) => {
-        console.log(res.xhr.response);
+        res.xhr; // $ExpectType any
+        res.xhr.response; // $ExpectType any
     });
 
 // HTTPS request, from: https://github.com/visionmedia/superagent/commit/6158efbf42cb93d77c1a70887284be783dd7dabe

--- a/types/superagent/tsconfig.json
+++ b/types/superagent/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/55382

Picks up from https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41425#issuecomment-730017992

At the moment, the `@types/superagent` library silently includes `dom`
typings, even in Node-only projects. This is *very* surprising.

This change sets the problematic `Response.xhr` property to `any`.

The `xhr` property is for [browser-only use][1], so it doesn't really
make sense for this browser-only property to exist on `Response`,
which currently [extends a `NodeJS.ReadableStream`][2], where you would
never expect access to DOM types.

[1]: https://github.com/visionmedia/superagent/blob/048cf185d954028b1dccde0717d2488b2284c297/src/client.js#L88
[2]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/59b04cbc8e5570ca2b8717e1cb054cfbbea01e01/types/superagent/index.d.ts#L103

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.