### PR TITLE
[node-red__editor-client] Accessible node instance properties

### DIFF
--- a/types/node-red__editor-client/index.d.ts
+++ b/types/node-red__editor-client/index.d.ts
@@ -38,7 +38,9 @@ declare namespace editorClient {
      * Read more: https://nodered.org/docs/creating-nodes/properties
      */
     type NodePropertiesDef<TProps extends NodeProperties, TInstProps extends TProps = TProps> = {
-        [K in keyof TProps]: NodePropertyDef<TProps[K], TInstProps>;
+        [K in keyof TProps]: K extends NodeReservedProperties
+            ? never
+            : NodePropertyDef<TProps[K], TInstProps>;
     };
 
     /**
@@ -47,94 +49,65 @@ declare namespace editorClient {
      */
     interface NodeProperties {
         name?: string | undefined;
-        /** If a node wants to allow the number of outputs it provides to be configurable then outputs may be included. */
-        outputs?: number | undefined;
-
-        /** Reserved name for properties that MUST NOT BE USED. */
-        changed?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        dirty?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        icon?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        id?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        info?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        inputLabels?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        inputs?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        outputLabels?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        ports?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        selected?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        type?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        valid?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        validationErrors?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        wires?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        a?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        b?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        c?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        d?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        e?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        f?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        g?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        h?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        i?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        j?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        k?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        l?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        m?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        n?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        o?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        p?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        q?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        r?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        s?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        t?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        u?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        v?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        w?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        x?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        y?: never | undefined;
-        /** Reserved name for properties that MUST NOT BE USED. */
-        z?: never | undefined;
     }
 
-    type NodeInstance<TProps extends NodeProperties = NodeProperties> = TProps & {
-        _: I18nTFunction;
-    };
+    /** Reserved name for properties that MUST NOT BE USED. */
+    type NodeReservedProperties =
+        | 'changed'
+        | 'dirty'
+        | 'icon'
+        | 'id'
+        | 'info'
+        | 'inputLabels'
+        | 'inputs'
+        | 'outputLabels'
+        | 'ports'
+        | 'selected'
+        | 'type'
+        | 'valid'
+        | 'validationErrors'
+        | 'wires'
+        | 'a'
+        | 'b'
+        | 'c'
+        | 'd'
+        | 'e'
+        | 'f'
+        | 'g'
+        | 'h'
+        | 'i'
+        | 'j'
+        | 'k'
+        | 'l'
+        | 'm'
+        | 'n'
+        | 'o'
+        | 'p'
+        | 'q'
+        | 'r'
+        | 's'
+        | 't'
+        | 'u'
+        | 'v'
+        | 'w'
+        | 'x'
+        | 'y'
+        | 'z';
+
+    type NodeInstance<TProps extends NodeProperties = NodeProperties> =
+        Omit<TProps, NodeReservedProperties> &
+        Readonly<{
+            _: I18nTFunction;
+            id: string;
+            type: string;
+            inputs: 0 | 1;
+            outputs: number;
+            h: number;
+            w: number;
+            x: number;
+            y: number;
+            z: string;
+        }>;
 
     type NodeCredentials<T> = {
         [K in keyof T]: NodeCredential;

--- a/types/node-red__editor-client/node-red__editor-client-tests.ts
+++ b/types/node-red__editor-client/node-red__editor-client-tests.ts
@@ -4,6 +4,7 @@ import editorClient = require('@node-red/editor-client');
 
 function redTests(RED: editorClient.RED) {
     interface MyNodeProperties extends editorClient.NodeProperties {
+        x: string;
         key: string;
     }
     interface MyNodeCredentials {
@@ -15,6 +16,10 @@ function redTests(RED: editorClient.RED) {
     }
 
     function nodeInstanceTests(nodeInstance: editorClient.NodeInstance<MyNodeInstanceProperties>) {
+        // $ExpectType string
+        nodeInstance.id;
+        // $ExpectType number
+        nodeInstance.x;
         // $ExpectType string
         nodeInstance.instanceProp;
         // $ExpectError
@@ -211,6 +216,18 @@ function redTests(RED: editorClient.RED) {
                   return 'label';
               },
     };
+
+    const defWithReserved: editorClient.NodeDef<MyNodeProperties, MyNodeCredentials, MyNodeInstanceProperties> = {
+        category: 'category',
+        defaults: {
+            // $ExpectError
+            x: {},
+            key: {
+                value: '',
+            }
+        }
+    };
+
     RED.nodes.registerType('my-node', myNodeDef);
     RED.nodes.registerType<MyNodeProperties, MyNodeCredentials>('my-node', {
         category: 'category',


### PR DESCRIPTION
Currently its not possible to access node instance properties from editor client. Being able to access these properties would allow node developers to access the node element from document and render custom components around said node.

Caveat of these changes is that it requires user to know about reserved properties. It will still throw error if user tries to define them in `defaults` object but its a bit more vague.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
