### PR TITLE
Fixing ArrayBufferView namespace incosistency in node.js fs/promise types.

### DIFF
--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -42,11 +42,11 @@ declare module 'fs/promises' {
         mode?: Mode | undefined;
         flag?: OpenMode | undefined;
     }
-    interface FileReadResult<T extends ArrayBufferView> {
+    interface FileReadResult<T extends NodeJS.ArrayBufferView> {
         bytesRead: number;
         buffer: T;
     }
-    interface FileReadOptions<T extends ArrayBufferView = Buffer> {
+    interface FileReadOptions<T extends NodeJS.ArrayBufferView = Buffer> {
         /**
          * @default `Buffer.alloc(0xffff)`
          */
@@ -207,8 +207,8 @@ declare module 'fs/promises' {
          * integer, the current file position will remain unchanged.
          * @return Fulfills upon success with an object with two properties:
          */
-        read<T extends ArrayBufferView>(buffer: T, offset?: number | null, length?: number | null, position?: number | null): Promise<FileReadResult<T>>;
-        read<T extends ArrayBufferView = Buffer>(options?: FileReadOptions<T>): Promise<FileReadResult<T>>;
+        read<T extends NodeJS.ArrayBufferView>(buffer: T, offset?: number | null, length?: number | null, position?: number | null): Promise<FileReadResult<T>>;
+        read<T extends NodeJS.ArrayBufferView = Buffer>(options?: FileReadOptions<T>): Promise<FileReadResult<T>>;
         /**
          * Asynchronously reads the entire contents of a file.
          *

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -440,6 +440,9 @@ async () => {
         length: 3,
     })).buffer; // $ExpectType Uint32Array
 
+    await handle.read(new Uint32Array(), 1, 2, 3);
+    await handle.read(Buffer.from('hurr'));
+
     await handle.write('hurr', 0, 'utf-8');
     await handle.write(Buffer.from('hurr'), 0, 42, 10);
 };


### PR DESCRIPTION
Most of the file already uses the correct type `NodeJS.ArrayBufferView`. For some reason, these 4 types don't. It makes the types incorrectly resolve to `node_modules\typescript\lib\lib.es5.d.ts` which contains `ArrayBufferView` that is incompatible. I am making the change to bring consistency across the file. By adding the correct namespace the type resolves to `ArrayBufferView` in file `types\node\globals.d.ts` in this repository. The breaking change was done as part of #54330. We found out about it by upgrading our types and suddenly not being compatible with  `FileHandle` interface. Eventually, I've got it to work by adding NodeJS namespace on our part. Nevertheless clicking on the type in VSCode in node_modules still resolves incorrectly.

Thank you for looking into it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. 
> I've added the tests specifically for buffer and array. Nevertheless, they don't fail on master. I am not sure why but it seems it's only when the module is published in node modules.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [fs/promises > read](https://nodejs.org/dist/latest-v16.x/docs/api/fs.html#filehandlereadbuffer-offset-length-position)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - N/A

