### PR TITLE
aws-lambda: mutual TLS authentication structure

### DIFF
--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -152,6 +152,7 @@ let proxyHandler: APIGatewayProxyHandler = async (event, context, callback) => {
 };
 
 const proxyHandlerV2: APIGatewayProxyHandlerV2 = async (event, context, callback) => {
+    str = event.version;
     strOrUndefined = event.body;
     str = event.headers['example']!;
     str = event.routeKey;
@@ -175,6 +176,12 @@ const proxyHandlerV2: APIGatewayProxyHandlerV2 = async (event, context, callback
     str = event.requestContext.requestId;
     str = event.requestContext.time;
     num = event.requestContext.timeEpoch;
+
+    str = event.requestContext.authentication!.clientCert.clientCertPem;
+    str = event.requestContext.authentication!.clientCert.issuerDN;
+    str = event.requestContext.authentication!.clientCert.subjectDN;
+    str = event.requestContext.authentication!.clientCert.validity.notAfter;
+    str = event.requestContext.authentication!.clientCert.validity.notBefore;
 
     const result = createProxyResultV2();
 

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -177,11 +177,14 @@ const proxyHandlerV2: APIGatewayProxyHandlerV2 = async (event, context, callback
     str = event.requestContext.time;
     num = event.requestContext.timeEpoch;
 
-    str = event.requestContext.authentication!.clientCert.clientCertPem;
-    str = event.requestContext.authentication!.clientCert.issuerDN;
-    str = event.requestContext.authentication!.clientCert.subjectDN;
-    str = event.requestContext.authentication!.clientCert.validity.notAfter;
-    str = event.requestContext.authentication!.clientCert.validity.notBefore;
+    if (event.requestContext.authentication) {
+        str = event.requestContext.authentication.clientCert.clientCertPem;
+        str = event.requestContext.authentication.clientCert.issuerDN;
+        str = event.requestContext.authentication.clientCert.serialNumber;
+        str = event.requestContext.authentication.clientCert.subjectDN;
+        str = event.requestContext.authentication.clientCert.validity.notAfter;
+        str = event.requestContext.authentication.clientCert.validity.notBefore;
+    }
 
     const result = createProxyResultV2();
 

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -142,7 +142,8 @@ export interface APIGatewayProxyEventV2 {
             clientCert: {
                 clientCertPem: string;
                 issuerDN: string;
-                serialNumber: string;
+                // not documented, so omitting:
+                // serialNumber: string;
                 subjectDN: string;
                 validity: {
                     notBefore: string;

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -138,6 +138,18 @@ export interface APIGatewayProxyEventV2 {
                 scopes: string[];
             };
         } | undefined;
+        authentication?: {
+            clientCert: {
+                clientCertPem: string;
+                issuerDN: string;
+                serialNumber: string;
+                subjectDN: string;
+                validity: {
+                    notBefore: string;
+                    notAfter: string;
+                };
+            };
+        };
         domainName: string;
         domainPrefix: string;
         http: {

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -1,4 +1,5 @@
 import {
+    APIGatewayEventClientCertificate,
     APIGatewayEventDefaultAuthorizerContext,
     APIGatewayEventRequestContextWithAuthorizer,
 } from "../common/api-gateway";
@@ -139,17 +140,7 @@ export interface APIGatewayProxyEventV2 {
             };
         } | undefined;
         authentication?: {
-            clientCert: {
-                clientCertPem: string;
-                issuerDN: string;
-                // not documented, so omitting:
-                // serialNumber: string;
-                subjectDN: string;
-                validity: {
-                    notBefore: string;
-                    notAfter: string;
-                };
-            };
+            clientCert: APIGatewayEventClientCertificate;
         };
         domainName: string;
         domainPrefix: string;


### PR DESCRIPTION
This adds the structure as documented:

https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

for the client certificate TLS authentication of the HTTP API of AWS APIGateway.
