### PR TITLE
Added `@example` JSDoc tags for code examples

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -9590,7 +9590,6 @@ interface NativeModulesStatic {
  * Native Modules written in ObjectiveC/Swift/Java exposed via the RCTBridge
  * Define lazy getters for each module. These will return the module if already loaded, or load it if not.
  * See https://reactnative.dev/docs/native-modules-ios
- * Use:
  * @example
  * const MyModule = NativeModules.ModuleName
  */
@@ -9731,7 +9730,6 @@ declare global {
 
     /**
      * This variable is set to true when react-native is running in Dev mode
-     * Typical usage:
      * @example
      * if (__DEV__) console.log('Running in dev mode')
      */

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -9591,7 +9591,8 @@ interface NativeModulesStatic {
  * Define lazy getters for each module. These will return the module if already loaded, or load it if not.
  * See https://reactnative.dev/docs/native-modules-ios
  * Use:
- * <code>const MyModule = NativeModules.ModuleName</code>
+ * @example
+ * const MyModule = NativeModules.ModuleName
  */
 export const NativeModules: NativeModulesStatic;
 export const Platform:
@@ -9731,7 +9732,8 @@ declare global {
     /**
      * This variable is set to true when react-native is running in Dev mode
      * Typical usage:
-     * <code> if (__DEV__) console.log('Running in dev mode')</code>
+     * @example
+     * if (__DEV__) console.log('Running in dev mode')
      */
     const __DEV__: boolean;
 


### PR DESCRIPTION
In VS Code, I noticed that `__DEV__` and `NativeModules` had some weird JSDoc descriptions. They seemed cut off:

<img width="430" alt="Screen Shot 2021-12-09 at 16 42 11" src="https://user-images.githubusercontent.com/34488374/145491009-db75e7db-7abc-4e50-9caf-23a9c354ba0a.png">
<img width="460" alt="Screen Shot 2021-12-09 at 16 42 17" src="https://user-images.githubusercontent.com/34488374/145491010-c4f79055-864b-4814-80f3-3c3456736bea.png">

I then noticed they had some code examples documented with `<code>` instead of what JSDoc recommends which is `@example`: https://jsdoc.app/tags-example.html. In somewhat more recently added code, I see `@example` is being used instead of `<code>`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/90b2fb878e3c8c541ded9224c2f724d8154f021d/types/react-native/index.d.ts#L8814 

That is the reason for my changes. This is what VS Code shows after the changes:

<img width="500" alt="Screen Shot 2021-12-09 at 17 27 24" src="https://user-images.githubusercontent.com/34488374/145491634-a2563358-5385-422e-8fbe-eb69a79701f1.png">
<img width="620" alt="Screen Shot 2021-12-09 at 16 59 48" src="https://user-images.githubusercontent.com/34488374/145491277-7d4d8fa6-b243-4d39-b178-7e1388e3a11a.png">


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* https://jsdoc.app/tags-example.html
* https://github.com/DefinitelyTyped/DefinitelyTyped/blob/90b2fb878e3c8c541ded9224c2f724d8154f021d/types/react-native/index.d.ts#L232
* https://github.com/DefinitelyTyped/DefinitelyTyped/blob/90b2fb878e3c8c541ded9224c2f724d8154f021d/types/react-native/index.d.ts#L8814
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
