### PR TITLE
@ember/object Fix and/or computed property types to any instead of boolean

### DIFF
--- a/types/ember/test/computed.ts
+++ b/types/ember/test/computed.ts
@@ -131,7 +131,7 @@ const objectWithComputedProperties = Ember.Object.extend({
     intersect: Ember.computed.intersect('foo', 'bar', 'baz', 'qux'),
     lt: Ember.computed.lt('foo', 3),
     lte: Ember.computed.lte('foo', 3),
-    map: Ember.computed.map('foo', (item, index) => item.bar),
+    map: Ember.computed.map('foo', (item, index) => item),
     mapBy: Ember.computed.mapBy('foo', 'bar'),
     match: Ember.computed.match('foo', /^tom.ter$/),
     max: Ember.computed.max('foo'),
@@ -146,22 +146,47 @@ const objectWithComputedProperties = Ember.Object.extend({
     setDiff: Ember.computed.setDiff('foo', 'bar'),
     sort1: Ember.computed.sort('foo', 'bar'),
     sort2: Ember.computed.sort('foo', (itemA, itemB) => {
-        if (itemA < itemB) {
-            return -1;
-        } else if (itemA > itemB) {
-            return 1;
-        } else {
-            return 0;
-        }
+        return `${itemA}`.length - `${itemB}`.length;
     }),
     sum: Ember.computed.sum('foo'),
     union: Ember.computed.union('foo', 'bar', 'baz', 'qux'),
     uniq: Ember.computed.uniq('foo'),
     uniqBy: Ember.computed.uniqBy('foo', 'bar'),
-});
-
-const component2 = Component.extend({
-    isAnimal: or('isDog', 'isCat'),
 }).create();
 
-assertType<boolean>(component2.get('isAnimal'));
+assertType<unknown>(objectWithComputedProperties.get('alias'));
+assertType<unknown>(objectWithComputedProperties.get('and'));
+assertType<boolean>(objectWithComputedProperties.get('bool'));
+assertType<unknown[]>(objectWithComputedProperties.get('collect'));
+assertType<unknown>(objectWithComputedProperties.get('deprecatingAlias'));
+assertType<boolean>(objectWithComputedProperties.get('empty'));
+assertType<boolean>(objectWithComputedProperties.get('equalNumber'));
+assertType<boolean>(objectWithComputedProperties.get('equalString'));
+assertType<boolean>(objectWithComputedProperties.get('equalObject'));
+assertType<unknown[]>(objectWithComputedProperties.get('filter'));
+assertType<unknown[]>(objectWithComputedProperties.get('filterBy1'));
+assertType<unknown[]>(objectWithComputedProperties.get('filterBy2'));
+assertType<boolean>(objectWithComputedProperties.get('gt'));
+assertType<boolean>(objectWithComputedProperties.get('gte'));
+assertType<unknown[]>(objectWithComputedProperties.get('intersect'));
+assertType<boolean>(objectWithComputedProperties.get('lt'));
+assertType<boolean>(objectWithComputedProperties.get('lte'));
+assertType<unknown[]>(objectWithComputedProperties.get('map'));
+assertType<unknown[]>(objectWithComputedProperties.get('mapBy'));
+assertType<boolean>(objectWithComputedProperties.get('match'));
+assertType<number>(objectWithComputedProperties.get('max'));
+assertType<number>(objectWithComputedProperties.get('min'));
+assertType<boolean>(objectWithComputedProperties.get('none'));
+assertType<boolean>(objectWithComputedProperties.get('not'));
+assertType<boolean>(objectWithComputedProperties.get('notEmpty'));
+assertType<unknown>(objectWithComputedProperties.get('oneWay'));
+assertType<unknown>(objectWithComputedProperties.get('or'));
+assertType<unknown>(objectWithComputedProperties.get('readOnly'));
+assertType<unknown>(objectWithComputedProperties.get('reads'));
+assertType<unknown[]>(objectWithComputedProperties.get('setDiff'));
+assertType<unknown[]>(objectWithComputedProperties.get('sort1'));
+assertType<unknown[]>(objectWithComputedProperties.get('sort2'));
+assertType<number>(objectWithComputedProperties.get('sum'));
+assertType<unknown[]>(objectWithComputedProperties.get('union'));
+assertType<unknown[]>(objectWithComputedProperties.get('uniq'));
+assertType<unknown[]>(objectWithComputedProperties.get('uniqBy'));

--- a/types/ember/v2/index.d.ts
+++ b/types/ember/v2/index.d.ts
@@ -2468,12 +2468,12 @@ declare module 'ember' {
              * A computed property that performs a logical `and` on the
              * original values for the provided dependent properties.
              */
-            and(...dependentKeys: string[]): ComputedProperty<boolean>;
+            and(...dependentKeys: string[]): ComputedProperty<any>;
             /**
              * A computed property which performs a logical `or` on the
              * original values for the provided dependent properties.
              */
-            or(...dependentKeys: string[]): ComputedProperty<boolean>;
+            or(...dependentKeys: string[]): ComputedProperty<any>;
             /**
              * Creates a new property that is an alias for another property
              * on an object. Calls to `get` or `set` this property behave as

--- a/types/ember/v2/index.d.ts
+++ b/types/ember/v2/index.d.ts
@@ -2443,7 +2443,7 @@ declare module 'ember' {
              * A computed property that returns true if the provided dependent property
              * is equal to the given value.
              */
-            equal(dependentKey: string, value: any): ComputedProperty<boolean>;
+            equal(dependentKey: string, value: unknown): ComputedProperty<boolean>;
             /**
              * A computed property that returns true if the provided dependent property
              * is greater than the provided value.
@@ -2468,18 +2468,18 @@ declare module 'ember' {
              * A computed property that performs a logical `and` on the
              * original values for the provided dependent properties.
              */
-            and(...dependentKeys: string[]): ComputedProperty<any>;
+            and(...dependentKeys: string[]): ComputedProperty<unknown>;
             /**
              * A computed property which performs a logical `or` on the
              * original values for the provided dependent properties.
              */
-            or(...dependentKeys: string[]): ComputedProperty<any>;
+            or(...dependentKeys: string[]): ComputedProperty<unknown>;
             /**
              * Creates a new property that is an alias for another property
              * on an object. Calls to `get` or `set` this property behave as
              * though they were called on the original property.
              */
-            alias(dependentKey: string): ComputedProperty<any>;
+            alias(dependentKey: string): ComputedProperty<unknown>;
             /**
              * Where `computed.alias` aliases `get` and `set`, and allows for bidirectional
              * data flow, `computed.oneWay` only provides an aliased `get`. The `set` will
@@ -2487,29 +2487,29 @@ declare module 'ember' {
              * become the value set. This causes the downstream property to permanently
              * diverge from the upstream property.
              */
-            oneWay(dependentKey: string): ComputedProperty<any>;
+            oneWay(dependentKey: string): ComputedProperty<unknown>;
             /**
              * This is a more semantically meaningful alias of `computed.oneWay`,
              * whose name is somewhat ambiguous as to which direction the data flows.
              */
-            reads(dependentKey: string): ComputedProperty<any>;
+            reads(dependentKey: string): ComputedProperty<unknown>;
             /**
              * Where `computed.oneWay` provides oneWay bindings, `computed.readOnly` provides
              * a readOnly one way binding. Very often when using `computed.oneWay` one does
              * not also want changes to propagate back up, as they will replace the value.
              */
-            readOnly(dependentKey: string): ComputedProperty<any>;
+            readOnly(dependentKey: string): ComputedProperty<unknown>;
             /**
              * Creates a new property that is an alias for another property
              * on an object. Calls to `get` or `set` this property behave as
              * though they were called on the original property, but also
              * print a deprecation warning.
              */
-            deprecatingAlias(dependentKey: string, options: DeprecationOptions): ComputedProperty<any>;
+            deprecatingAlias(dependentKey: string, options: DeprecationOptions): ComputedProperty<unknown>;
             /**
              * @deprecated Missing deprecation options: https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options
              */
-            deprecatingAlias(dependentKey: string, options?: Partial<DeprecationOptions>): ComputedProperty<any>;
+            deprecatingAlias(dependentKey: string, options?: Partial<DeprecationOptions>): ComputedProperty<unknown>;
             /**
              * A computed property that returns the sum of the values
              * in the dependent array.
@@ -2532,54 +2532,54 @@ declare module 'ember' {
              */
             map<U>(
                 dependentKey: string,
-                callback: (value: any, index: number, array: any[]) => U,
+                callback: (value: unknown, index: number, array: unknown[]) => U,
             ): ComputedProperty<U[]>;
             /**
              * Returns an array mapped to the specified key.
              */
-            mapBy(dependentKey: string, propertyKey: string): ComputedProperty<any[]>;
+            mapBy(dependentKey: string, propertyKey: string): ComputedProperty<unknown[]>;
             /**
              * Filters the array by the callback.
              */
             filter(
                 dependentKey: string,
-                callback: (value: any, index: number, array: any[]) => boolean,
-            ): ComputedProperty<any[]>;
+                callback: (value: unknown, index: number, array: unknown[]) => boolean,
+            ): ComputedProperty<unknown[]>;
             /**
              * Filters the array by the property and value
              */
-            filterBy(dependentKey: string, propertyKey: string, value?: any): ComputedProperty<any[]>;
+            filterBy(dependentKey: string, propertyKey: string, value?: unknown): ComputedProperty<unknown[]>;
             /**
              * A computed property which returns a new array with all the unique
              * elements from one or more dependent arrays.
              */
-            uniq(propertyKey: string): ComputedProperty<any[]>;
+            uniq(propertyKey: string): ComputedProperty<unknown[]>;
             /**
              * A computed property which returns a new array with all the unique
              * elements from an array, with uniqueness determined by specific key.
              */
-            uniqBy(dependentKey: string, propertyKey: string): ComputedProperty<any[]>;
+            uniqBy(dependentKey: string, propertyKey: string): ComputedProperty<unknown[]>;
             /**
              * A computed property which returns a new array with all the unique
              * elements from one or more dependent arrays.
              */
-            union(...propertyKeys: string[]): ComputedProperty<any[]>;
+            union(...propertyKeys: string[]): ComputedProperty<unknown[]>;
             /**
              * A computed property which returns a new array with all the elements
              * two or more dependent arrays have in common.
              */
-            intersect(...propertyKeys: string[]): ComputedProperty<any[]>;
+            intersect(...propertyKeys: string[]): ComputedProperty<unknown[]>;
             /**
              * A computed property which returns a new array with all the
              * properties from the first dependent array that are not in the second
              * dependent array.
              */
-            setDiff(setAProperty: string, setBProperty: string): ComputedProperty<any[]>;
+            setDiff(setAProperty: string, setBProperty: string): ComputedProperty<unknown[]>;
             /**
              * A computed property that returns the array of values
              * for the provided dependent properties.
              */
-            collect(...dependentKeys: string[]): ComputedProperty<any[]>;
+            collect(...dependentKeys: string[]): ComputedProperty<unknown[]>;
             /**
              * A computed property which returns a new array with all the
              * properties from the first dependent array sorted based on a property
@@ -2587,8 +2587,8 @@ declare module 'ember' {
              */
             sort(
                 itemsKey: string,
-                sortDefinition: string | ((itemA: any, itemB: any) => number),
-            ): ComputedProperty<any[]>;
+                sortDefinition: string | ((itemA: unknown, itemB: unknown) => number),
+            ): ComputedProperty<unknown[]>;
         };
         const run: {
             /**

--- a/types/ember/v2/test/computed.ts
+++ b/types/ember/v2/test/computed.ts
@@ -158,10 +158,41 @@ const objectWithComputedProperties = Ember.Object.extend({
     union: Ember.computed.union('foo', 'bar', 'baz', 'qux'),
     uniq: Ember.computed.uniq('foo'),
     uniqBy: Ember.computed.uniqBy('foo', 'bar'),
-});
-
-const component2 = Component.extend({
-    isAnimal: or('isDog', 'isCat'),
 }).create();
 
-assertType<boolean>(component2.get('isAnimal'));
+assertType<any>(objectWithComputedProperties.get('alias'));
+assertType<any>(objectWithComputedProperties.get('and'));
+assertType<boolean>(objectWithComputedProperties.get('bool'));
+assertType<any[]>(objectWithComputedProperties.get('collect'));
+assertType<any>(objectWithComputedProperties.get('deprecatingAlias'));
+assertType<boolean>(objectWithComputedProperties.get('empty'));
+assertType<boolean>(objectWithComputedProperties.get('equalNumber'));
+assertType<boolean>(objectWithComputedProperties.get('equalString'));
+assertType<boolean>(objectWithComputedProperties.get('equalObject'));
+assertType<any[]>(objectWithComputedProperties.get('filter'));
+assertType<any[]>(objectWithComputedProperties.get('filterBy1'));
+assertType<any[]>(objectWithComputedProperties.get('filterBy2'));
+assertType<boolean>(objectWithComputedProperties.get('gt'));
+assertType<boolean>(objectWithComputedProperties.get('gte'));
+assertType<any[]>(objectWithComputedProperties.get('intersect'));
+assertType<boolean>(objectWithComputedProperties.get('lt'));
+assertType<boolean>(objectWithComputedProperties.get('lte'));
+assertType<any[]>(objectWithComputedProperties.get('map'));
+assertType<any[]>(objectWithComputedProperties.get('mapBy'));
+assertType<boolean>(objectWithComputedProperties.get('match'));
+assertType<number>(objectWithComputedProperties.get('max'));
+assertType<number>(objectWithComputedProperties.get('min'));
+assertType<boolean>(objectWithComputedProperties.get('none'));
+assertType<boolean>(objectWithComputedProperties.get('not'));
+assertType<boolean>(objectWithComputedProperties.get('notEmpty'));
+assertType<any>(objectWithComputedProperties.get('oneWay'));
+assertType<any>(objectWithComputedProperties.get('or'));
+assertType<any>(objectWithComputedProperties.get('readOnly'));
+assertType<any>(objectWithComputedProperties.get('reads'));
+assertType<any[]>(objectWithComputedProperties.get('setDiff'));
+assertType<any[]>(objectWithComputedProperties.get('sort1'));
+assertType<any[]>(objectWithComputedProperties.get('sort2'));
+assertType<number>(objectWithComputedProperties.get('sum'));
+assertType<any[]>(objectWithComputedProperties.get('union'));
+assertType<any[]>(objectWithComputedProperties.get('uniq'));
+assertType<any[]>(objectWithComputedProperties.get('uniqBy'));

--- a/types/ember/v2/test/computed.ts
+++ b/types/ember/v2/test/computed.ts
@@ -131,7 +131,7 @@ const objectWithComputedProperties = Ember.Object.extend({
     intersect: Ember.computed.intersect('foo', 'bar', 'baz', 'qux'),
     lt: Ember.computed.lt('foo', 3),
     lte: Ember.computed.lte('foo', 3),
-    map: Ember.computed.map('foo', (item, index) => item.bar),
+    map: Ember.computed.map('foo', (item, index) => item),
     mapBy: Ember.computed.mapBy('foo', 'bar'),
     match: Ember.computed.match('foo', /^tom.ter$/),
     max: Ember.computed.max('foo'),
@@ -146,13 +146,7 @@ const objectWithComputedProperties = Ember.Object.extend({
     setDiff: Ember.computed.setDiff('foo', 'bar'),
     sort1: Ember.computed.sort('foo', 'bar'),
     sort2: Ember.computed.sort('foo', (itemA, itemB) => {
-        if (itemA < itemB) {
-            return -1;
-        } else if (itemA > itemB) {
-            return 1;
-        } else {
-            return 0;
-        }
+        return `${itemA}`.length - `${itemB}`.length;
     }),
     sum: Ember.computed.sum('foo'),
     union: Ember.computed.union('foo', 'bar', 'baz', 'qux'),
@@ -160,39 +154,39 @@ const objectWithComputedProperties = Ember.Object.extend({
     uniqBy: Ember.computed.uniqBy('foo', 'bar'),
 }).create();
 
-assertType<any>(objectWithComputedProperties.get('alias'));
-assertType<any>(objectWithComputedProperties.get('and'));
+assertType<unknown>(objectWithComputedProperties.get('alias'));
+assertType<unknown>(objectWithComputedProperties.get('and'));
 assertType<boolean>(objectWithComputedProperties.get('bool'));
-assertType<any[]>(objectWithComputedProperties.get('collect'));
-assertType<any>(objectWithComputedProperties.get('deprecatingAlias'));
+assertType<unknown[]>(objectWithComputedProperties.get('collect'));
+assertType<unknown>(objectWithComputedProperties.get('deprecatingAlias'));
 assertType<boolean>(objectWithComputedProperties.get('empty'));
 assertType<boolean>(objectWithComputedProperties.get('equalNumber'));
 assertType<boolean>(objectWithComputedProperties.get('equalString'));
 assertType<boolean>(objectWithComputedProperties.get('equalObject'));
-assertType<any[]>(objectWithComputedProperties.get('filter'));
-assertType<any[]>(objectWithComputedProperties.get('filterBy1'));
-assertType<any[]>(objectWithComputedProperties.get('filterBy2'));
+assertType<unknown[]>(objectWithComputedProperties.get('filter'));
+assertType<unknown[]>(objectWithComputedProperties.get('filterBy1'));
+assertType<unknown[]>(objectWithComputedProperties.get('filterBy2'));
 assertType<boolean>(objectWithComputedProperties.get('gt'));
 assertType<boolean>(objectWithComputedProperties.get('gte'));
-assertType<any[]>(objectWithComputedProperties.get('intersect'));
+assertType<unknown[]>(objectWithComputedProperties.get('intersect'));
 assertType<boolean>(objectWithComputedProperties.get('lt'));
 assertType<boolean>(objectWithComputedProperties.get('lte'));
-assertType<any[]>(objectWithComputedProperties.get('map'));
-assertType<any[]>(objectWithComputedProperties.get('mapBy'));
+assertType<unknown[]>(objectWithComputedProperties.get('map'));
+assertType<unknown[]>(objectWithComputedProperties.get('mapBy'));
 assertType<boolean>(objectWithComputedProperties.get('match'));
 assertType<number>(objectWithComputedProperties.get('max'));
 assertType<number>(objectWithComputedProperties.get('min'));
 assertType<boolean>(objectWithComputedProperties.get('none'));
 assertType<boolean>(objectWithComputedProperties.get('not'));
 assertType<boolean>(objectWithComputedProperties.get('notEmpty'));
-assertType<any>(objectWithComputedProperties.get('oneWay'));
-assertType<any>(objectWithComputedProperties.get('or'));
-assertType<any>(objectWithComputedProperties.get('readOnly'));
-assertType<any>(objectWithComputedProperties.get('reads'));
-assertType<any[]>(objectWithComputedProperties.get('setDiff'));
-assertType<any[]>(objectWithComputedProperties.get('sort1'));
-assertType<any[]>(objectWithComputedProperties.get('sort2'));
+assertType<unknown>(objectWithComputedProperties.get('oneWay'));
+assertType<unknown>(objectWithComputedProperties.get('or'));
+assertType<unknown>(objectWithComputedProperties.get('readOnly'));
+assertType<unknown>(objectWithComputedProperties.get('reads'));
+assertType<unknown[]>(objectWithComputedProperties.get('setDiff'));
+assertType<unknown[]>(objectWithComputedProperties.get('sort1'));
+assertType<unknown[]>(objectWithComputedProperties.get('sort2'));
 assertType<number>(objectWithComputedProperties.get('sum'));
-assertType<any[]>(objectWithComputedProperties.get('union'));
-assertType<any[]>(objectWithComputedProperties.get('uniq'));
-assertType<any[]>(objectWithComputedProperties.get('uniqBy'));
+assertType<unknown[]>(objectWithComputedProperties.get('union'));
+assertType<unknown[]>(objectWithComputedProperties.get('uniq'));
+assertType<unknown[]>(objectWithComputedProperties.get('uniqBy'));

--- a/types/ember/v2/test/computed.ts
+++ b/types/ember/v2/test/computed.ts
@@ -154,11 +154,15 @@ const objectWithComputedProperties = Ember.Object.extend({
     uniqBy: Ember.computed.uniqBy('foo', 'bar'),
 }).create();
 
-assertType<unknown>(objectWithComputedProperties.get('alias'));
-assertType<unknown>(objectWithComputedProperties.get('and'));
+// There isn't a good way to assert that something's type is unknown.
+// The best way is to assert that it is Anything, and verify that it gets an error.
+type Anything = {} | undefined | null;
+
+assertType<Anything>(objectWithComputedProperties.get('alias')) // $ExpectError;
+assertType<Anything>(objectWithComputedProperties.get('and')); // $ExpectError;
 assertType<boolean>(objectWithComputedProperties.get('bool'));
 assertType<unknown[]>(objectWithComputedProperties.get('collect'));
-assertType<unknown>(objectWithComputedProperties.get('deprecatingAlias'));
+assertType<Anything>(objectWithComputedProperties.get('deprecatingAlias')); // $ExpectError;
 assertType<boolean>(objectWithComputedProperties.get('empty'));
 assertType<boolean>(objectWithComputedProperties.get('equalNumber'));
 assertType<boolean>(objectWithComputedProperties.get('equalString'));
@@ -179,10 +183,10 @@ assertType<number>(objectWithComputedProperties.get('min'));
 assertType<boolean>(objectWithComputedProperties.get('none'));
 assertType<boolean>(objectWithComputedProperties.get('not'));
 assertType<boolean>(objectWithComputedProperties.get('notEmpty'));
-assertType<unknown>(objectWithComputedProperties.get('oneWay'));
-assertType<unknown>(objectWithComputedProperties.get('or'));
-assertType<unknown>(objectWithComputedProperties.get('readOnly'));
-assertType<unknown>(objectWithComputedProperties.get('reads'));
+assertType<Anything>(objectWithComputedProperties.get('oneWay')); // $ExpectError;
+assertType<Anything>(objectWithComputedProperties.get('or')); // $ExpectError;
+assertType<Anything>(objectWithComputedProperties.get('readOnly')); // $ExpectError;
+assertType<Anything>(objectWithComputedProperties.get('reads')); // $ExpectError;
 assertType<unknown[]>(objectWithComputedProperties.get('setDiff'));
 assertType<unknown[]>(objectWithComputedProperties.get('sort1'));
 assertType<unknown[]>(objectWithComputedProperties.get('sort2'));

--- a/types/ember/v2/test/computed.ts
+++ b/types/ember/v2/test/computed.ts
@@ -158,11 +158,11 @@ const objectWithComputedProperties = Ember.Object.extend({
 // The best way is to assert that it is Anything, and verify that it gets an error.
 type Anything = {} | undefined | null;
 
-assertType<Anything>(objectWithComputedProperties.get('alias')) // $ExpectError;
-assertType<Anything>(objectWithComputedProperties.get('and')); // $ExpectError;
+assertType<Anything>(objectWithComputedProperties.get('alias')); // $ExpectError
+assertType<Anything>(objectWithComputedProperties.get('and')); // $ExpectError
 assertType<boolean>(objectWithComputedProperties.get('bool'));
 assertType<unknown[]>(objectWithComputedProperties.get('collect'));
-assertType<Anything>(objectWithComputedProperties.get('deprecatingAlias')); // $ExpectError;
+assertType<Anything>(objectWithComputedProperties.get('deprecatingAlias')); // $ExpectError
 assertType<boolean>(objectWithComputedProperties.get('empty'));
 assertType<boolean>(objectWithComputedProperties.get('equalNumber'));
 assertType<boolean>(objectWithComputedProperties.get('equalString'));
@@ -183,10 +183,10 @@ assertType<number>(objectWithComputedProperties.get('min'));
 assertType<boolean>(objectWithComputedProperties.get('none'));
 assertType<boolean>(objectWithComputedProperties.get('not'));
 assertType<boolean>(objectWithComputedProperties.get('notEmpty'));
-assertType<Anything>(objectWithComputedProperties.get('oneWay')); // $ExpectError;
-assertType<Anything>(objectWithComputedProperties.get('or')); // $ExpectError;
-assertType<Anything>(objectWithComputedProperties.get('readOnly')); // $ExpectError;
-assertType<Anything>(objectWithComputedProperties.get('reads')); // $ExpectError;
+assertType<Anything>(objectWithComputedProperties.get('oneWay')); // $ExpectError
+assertType<Anything>(objectWithComputedProperties.get('or')); // $ExpectError
+assertType<Anything>(objectWithComputedProperties.get('readOnly')); // $ExpectError
+assertType<Anything>(objectWithComputedProperties.get('reads')); // $ExpectError
 assertType<unknown[]>(objectWithComputedProperties.get('setDiff'));
 assertType<unknown[]>(objectWithComputedProperties.get('sort1'));
 assertType<unknown[]>(objectWithComputedProperties.get('sort2'));

--- a/types/ember__object/computed.d.ts
+++ b/types/ember__object/computed.d.ts
@@ -53,7 +53,7 @@ export function alias(
  */
 export function and(
     ...dependentKeys: string[]
-): ComputedProperty<boolean>;
+): ComputedProperty<any>;
 /**
  * A computed property that converts the provided dependent property
  * into a boolean value.
@@ -261,7 +261,7 @@ export function oneWay(
  */
 export function or(
     ...dependentKeys: string[]
-): ComputedProperty<boolean>;
+): ComputedProperty<any>;
 /**
  * Where `computed.oneWay` provides oneWay bindings, `computed.readOnly` provides
  * a readOnly one way binding. Very often when using `computed.oneWay` one does

--- a/types/ember__object/computed.d.ts
+++ b/types/ember__object/computed.d.ts
@@ -46,14 +46,14 @@ export default interface ComputedProperty<Get, Set = Get>
  */
 export function alias(
     dependentKey: string
-): ComputedProperty<any>;
+): ComputedProperty<unknown>;
 /**
  * A computed property that performs a logical `and` on the
  * original values for the provided dependent properties.
  */
 export function and(
     ...dependentKeys: string[]
-): ComputedProperty<any>;
+): ComputedProperty<unknown>;
 /**
  * A computed property that converts the provided dependent property
  * into a boolean value.
@@ -68,7 +68,7 @@ export function bool(
  */
 export function collect(
     ...dependentKeys: string[]
-): ComputedProperty<any[]>;
+): ComputedProperty<unknown[]>;
 
 /**
  * Creates a new property that is an alias for another property
@@ -79,14 +79,14 @@ export function collect(
 export function deprecatingAlias(
     dependentKey: string,
     options: { id: string; until: string }
-): ComputedProperty<any>;
+): ComputedProperty<unknown>;
 /**
  * @deprecated Missing deprecation options: https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options
  */
 export function deprecatingAlias(
     dependentKey: string,
     options?: { id?: string | undefined; until?: string | undefined }
-): ComputedProperty<any>;
+): ComputedProperty<unknown>;
 
 /**
  * A computed property that returns true if the value of the dependent
@@ -101,7 +101,7 @@ export function empty(
  */
 export function equal(
     dependentKey: string,
-    value: any
+    value: unknown
 ): ComputedProperty<boolean>;
 /**
  * Expands `pattern`, invoking `callback` for each expansion.
@@ -116,8 +116,8 @@ export function expandProperties(
  */
 export function filter(
     dependentKey: string,
-    callback: (value: any, index: number, array: any[]) => boolean
-): ComputedProperty<any[]>;
+    callback: (value: unknown, index: number, array: unknown[]) => boolean
+): ComputedProperty<unknown[]>;
 
 /**
  * Filters the array by the callback and an array of additional dependent keys.
@@ -125,8 +125,8 @@ export function filter(
 export function filter(
     dependentKey: string,
     additionalDependentKeys: string[],
-    callback: (value: any, index: number, array: any[]) => boolean
-): ComputedProperty<any[]>;
+    callback: (value: unknown, index: number, array: unknown[]) => boolean
+): ComputedProperty<unknown[]>;
 
 /**
  * Filters the array by the property and value
@@ -134,8 +134,8 @@ export function filter(
 export function filterBy(
     dependentKey: string,
     propertyKey: string,
-    value?: any
-): ComputedProperty<any[]>;
+    value?: unknown
+): ComputedProperty<unknown[]>;
 
 /**
  * A computed property that returns true if the provided dependent property
@@ -160,7 +160,7 @@ export function gte(
  */
 export function intersect(
     ...propertyKeys: string[]
-): ComputedProperty<any[]>;
+): ComputedProperty<unknown[]>;
 
 /**
  * A computed property that returns true if the provided dependent property
@@ -184,7 +184,7 @@ export function lte(
  */
 export function map<U>(
     dependentKey: string,
-    callback: (value: any, index: number, array: any[]) => U
+    callback: (value: unknown, index: number, array: unknown[]) => U
 ): ComputedProperty<U[]>;
 
 /**
@@ -193,7 +193,7 @@ export function map<U>(
 export function mapBy(
     dependentKey: string,
     propertyKey: string
-): ComputedProperty<any[]>;
+): ComputedProperty<unknown[]>;
 
 /**
  * A computed property which matches the original value for the
@@ -254,14 +254,14 @@ export function notEmpty(
  */
 export function oneWay(
     dependentKey: string
-): ComputedProperty<any>;
+): ComputedProperty<unknown>;
 /**
  * A computed property which performs a logical `or` on the
  * original values for the provided dependent properties.
  */
 export function or(
     ...dependentKeys: string[]
-): ComputedProperty<any>;
+): ComputedProperty<unknown>;
 /**
  * Where `computed.oneWay` provides oneWay bindings, `computed.readOnly` provides
  * a readOnly one way binding. Very often when using `computed.oneWay` one does
@@ -269,14 +269,14 @@ export function or(
  */
 export function readOnly(
     dependentKey: string
-): ComputedProperty<any>;
+): ComputedProperty<unknown>;
 /**
  * This is a more semantically meaningful alias of `computed.oneWay`,
  * whose name is somewhat ambiguous as to which direction the data flows.
  */
 export function reads(
     dependentKey: string
-): ComputedProperty<any>;
+): ComputedProperty<unknown>;
 
 /**
  * A computed property which returns a new array with all the
@@ -286,7 +286,7 @@ export function reads(
 export function setDiff(
     setAProperty: string,
     setBProperty: string
-): ComputedProperty<any[]>;
+): ComputedProperty<unknown[]>;
 
 /**
  * A computed property which returns a new array with all the
@@ -298,8 +298,8 @@ export function setDiff(
  */
 export function sort(
     itemsKey: string,
-    sortDefinition: string | ((itemA: any, itemB: any) => number)
-): ComputedProperty<any[]>;
+    sortDefinition: string | ((itemA: unknown, itemB: unknown) => number)
+): ComputedProperty<unknown[]>;
 
 /**
  * A computed property which returns a new array with all the
@@ -311,8 +311,8 @@ export function sort(
 export function sort(
     itemsKey: string,
     dependentKeys: string[],
-    sortDefinition: string | ((itemA: any, itemB: any) => number)
-): ComputedProperty<any[]>;
+    sortDefinition: string | ((itemA: unknown, itemB: unknown) => number)
+): ComputedProperty<unknown[]>;
 
 /**
  * A computed property that returns the sum of the values
@@ -328,7 +328,7 @@ export function sum(
  */
 export function uniq(
     propertyKey: string
-): ComputedProperty<any[]>;
+): ComputedProperty<unknown[]>;
 
 /**
  * A computed property which returns a new array with all the unique
@@ -336,7 +336,7 @@ export function uniq(
  */
 export function union(
     ...propertyKeys: string[]
-): ComputedProperty<any[]>;
+): ComputedProperty<unknown[]>;
 
 /**
  * A computed property which returns a new array with all the unique

--- a/types/ember__object/test/computed.ts
+++ b/types/ember__object/test/computed.ts
@@ -164,7 +164,7 @@ const objectWithComputedProperties = EmberObject.extend({
     intersect: intersect('foo', 'bar', 'baz', 'qux'),
     lt: lt('foo', 3),
     lte: lte('foo', 3),
-    map: map('foo', (item, index) => item.bar),
+    map: map('foo', (item, index) => item),
     mapBy: mapBy('foo', 'bar'),
     match: match('foo', /^tom.ter$/),
     max: max('foo'),
@@ -179,22 +179,10 @@ const objectWithComputedProperties = EmberObject.extend({
     setDiff: setDiff('foo', 'bar'),
     sort1: sort('foo', 'bar'),
     sort2: sort('foo', (itemA, itemB) => {
-        if (itemA < itemB) {
-            return -1;
-        } else if (itemA > itemB) {
-            return 1;
-        } else {
-            return 0;
-        }
+      return `${itemA}`.length - `${itemB}`.length;
     }),
     sort3: sort('foo', ['bar', 'baz'], (itemA, itemB) => {
-        if (itemA < itemB) {
-            return -1;
-        } else if (itemA > itemB) {
-            return 1;
-        } else {
-            return 0;
-        }
+      return `${itemA}`.length - `${itemB}`.length;
     }),
 
     sum: sum('foo'),
@@ -203,41 +191,41 @@ const objectWithComputedProperties = EmberObject.extend({
     uniqBy: uniqBy('foo', 'bar'),
 }).create();
 
-assertType<any>(objectWithComputedProperties.get('alias'));
-assertType<any>(objectWithComputedProperties.get('and'));
+assertType<unknown>(objectWithComputedProperties.get('alias'));
+assertType<unknown>(objectWithComputedProperties.get('and'));
 assertType<boolean>(objectWithComputedProperties.get('bool'));
-assertType<any[]>(objectWithComputedProperties.get('collect'));
-assertType<any>(objectWithComputedProperties.get('deprecatingAlias'));
+assertType<unknown[]>(objectWithComputedProperties.get('collect'));
+assertType<unknown>(objectWithComputedProperties.get('deprecatingAlias'));
 assertType<boolean>(objectWithComputedProperties.get('empty'));
 assertType<boolean>(objectWithComputedProperties.get('equalNumber'));
 assertType<boolean>(objectWithComputedProperties.get('equalString'));
 assertType<boolean>(objectWithComputedProperties.get('equalObject'));
-assertType<any[]>(objectWithComputedProperties.get('filter1'));
-assertType<any[]>(objectWithComputedProperties.get('filter2'));
-assertType<any[]>(objectWithComputedProperties.get('filterBy1'));
-assertType<any[]>(objectWithComputedProperties.get('filterBy2'));
+assertType<unknown[]>(objectWithComputedProperties.get('filter1'));
+assertType<unknown[]>(objectWithComputedProperties.get('filter2'));
+assertType<unknown[]>(objectWithComputedProperties.get('filterBy1'));
+assertType<unknown[]>(objectWithComputedProperties.get('filterBy2'));
 assertType<boolean>(objectWithComputedProperties.get('gt'));
 assertType<boolean>(objectWithComputedProperties.get('gte'));
-assertType<any[]>(objectWithComputedProperties.get('intersect'));
+assertType<unknown[]>(objectWithComputedProperties.get('intersect'));
 assertType<boolean>(objectWithComputedProperties.get('lt'));
 assertType<boolean>(objectWithComputedProperties.get('lte'));
-assertType<any[]>(objectWithComputedProperties.get('map'));
-assertType<any[]>(objectWithComputedProperties.get('mapBy'));
+assertType<unknown[]>(objectWithComputedProperties.get('map'));
+assertType<unknown[]>(objectWithComputedProperties.get('mapBy'));
 assertType<boolean>(objectWithComputedProperties.get('match'));
 assertType<number>(objectWithComputedProperties.get('max'));
 assertType<number>(objectWithComputedProperties.get('min'));
 assertType<boolean>(objectWithComputedProperties.get('none'));
 assertType<boolean>(objectWithComputedProperties.get('not'));
 assertType<boolean>(objectWithComputedProperties.get('notEmpty'));
-assertType<any>(objectWithComputedProperties.get('oneWay'));
-assertType<any>(objectWithComputedProperties.get('or'));
-assertType<any>(objectWithComputedProperties.get('readOnly'));
-assertType<any>(objectWithComputedProperties.get('reads'));
-assertType<any[]>(objectWithComputedProperties.get('setDiff'));
-assertType<any[]>(objectWithComputedProperties.get('sort1'));
-assertType<any[]>(objectWithComputedProperties.get('sort2'));
-assertType<any[]>(objectWithComputedProperties.get('sort3'));
+assertType<unknown>(objectWithComputedProperties.get('oneWay'));
+assertType<unknown>(objectWithComputedProperties.get('or'));
+assertType<unknown>(objectWithComputedProperties.get('readOnly'));
+assertType<unknown>(objectWithComputedProperties.get('reads'));
+assertType<unknown[]>(objectWithComputedProperties.get('setDiff'));
+assertType<unknown[]>(objectWithComputedProperties.get('sort1'));
+assertType<unknown[]>(objectWithComputedProperties.get('sort2'));
+assertType<unknown[]>(objectWithComputedProperties.get('sort3'));
 assertType<number>(objectWithComputedProperties.get('sum'));
-assertType<any[]>(objectWithComputedProperties.get('union'));
-assertType<any[]>(objectWithComputedProperties.get('uniq'));
-assertType<any[]>(objectWithComputedProperties.get('uniqBy'));
+assertType<unknown[]>(objectWithComputedProperties.get('union'));
+assertType<unknown[]>(objectWithComputedProperties.get('uniq'));
+assertType<unknown[]>(objectWithComputedProperties.get('uniqBy'));

--- a/types/ember__object/test/computed.ts
+++ b/types/ember__object/test/computed.ts
@@ -201,10 +201,43 @@ const objectWithComputedProperties = EmberObject.extend({
     union: union('foo', 'bar', 'baz', 'qux'),
     uniq: uniq('foo'),
     uniqBy: uniqBy('foo', 'bar'),
-});
-
-const component2 = EmberObject.extend({
-    isAnimal: or('isDog', 'isCat'),
 }).create();
 
-assertType<boolean>(component2.get('isAnimal'));
+assertType<any>(objectWithComputedProperties.get('alias'));
+assertType<any>(objectWithComputedProperties.get('and'));
+assertType<boolean>(objectWithComputedProperties.get('bool'));
+assertType<any[]>(objectWithComputedProperties.get('collect'));
+assertType<any>(objectWithComputedProperties.get('deprecatingAlias'));
+assertType<boolean>(objectWithComputedProperties.get('empty'));
+assertType<boolean>(objectWithComputedProperties.get('equalNumber'));
+assertType<boolean>(objectWithComputedProperties.get('equalString'));
+assertType<boolean>(objectWithComputedProperties.get('equalObject'));
+assertType<any[]>(objectWithComputedProperties.get('filter1'));
+assertType<any[]>(objectWithComputedProperties.get('filter2'));
+assertType<any[]>(objectWithComputedProperties.get('filterBy1'));
+assertType<any[]>(objectWithComputedProperties.get('filterBy2'));
+assertType<boolean>(objectWithComputedProperties.get('gt'));
+assertType<boolean>(objectWithComputedProperties.get('gte'));
+assertType<any[]>(objectWithComputedProperties.get('intersect'));
+assertType<boolean>(objectWithComputedProperties.get('lt'));
+assertType<boolean>(objectWithComputedProperties.get('lte'));
+assertType<any[]>(objectWithComputedProperties.get('map'));
+assertType<any[]>(objectWithComputedProperties.get('mapBy'));
+assertType<boolean>(objectWithComputedProperties.get('match'));
+assertType<number>(objectWithComputedProperties.get('max'));
+assertType<number>(objectWithComputedProperties.get('min'));
+assertType<boolean>(objectWithComputedProperties.get('none'));
+assertType<boolean>(objectWithComputedProperties.get('not'));
+assertType<boolean>(objectWithComputedProperties.get('notEmpty'));
+assertType<any>(objectWithComputedProperties.get('oneWay'));
+assertType<any>(objectWithComputedProperties.get('or'));
+assertType<any>(objectWithComputedProperties.get('readOnly'));
+assertType<any>(objectWithComputedProperties.get('reads'));
+assertType<any[]>(objectWithComputedProperties.get('setDiff'));
+assertType<any[]>(objectWithComputedProperties.get('sort1'));
+assertType<any[]>(objectWithComputedProperties.get('sort2'));
+assertType<any[]>(objectWithComputedProperties.get('sort3'));
+assertType<number>(objectWithComputedProperties.get('sum'));
+assertType<any[]>(objectWithComputedProperties.get('union'));
+assertType<any[]>(objectWithComputedProperties.get('uniq'));
+assertType<any[]>(objectWithComputedProperties.get('uniqBy'));

--- a/types/ember__object/test/octane.ts
+++ b/types/ember__object/test/octane.ts
@@ -109,9 +109,9 @@ class Bar extends EmberObject {
     @filter filterTest1: string[]; // $ExpectError
     @filter() filterTest2: string[]; // $ExpectError
     @filter('firstName') filterTest3: string[]; // $ExpectError
-    @filter('firstName', x => Boolean(x)) filterTest4: string[];
-    @filter('firstName', 'secondName', x => Boolean(x)) filterTest5: string[]; // $ExpectError
-    @filter('firstName', ['secondName'], x => Boolean(x)) filterTest6: string[];
+    @filter('firstName', Boolean) filterTest4: string[];
+    @filter('firstName', 'secondName', Boolean) filterTest5: string[]; // $ExpectError
+    @filter('firstName', ['secondName'], Boolean) filterTest6: string[];
 
     @filterBy filterByTest1: any[]; // $ExpectError
     @filterBy() filterByTest2: any[]; // $ExpectError

--- a/types/ember__object/test/octane.ts
+++ b/types/ember__object/test/octane.ts
@@ -109,9 +109,9 @@ class Bar extends EmberObject {
     @filter filterTest1: string[]; // $ExpectError
     @filter() filterTest2: string[]; // $ExpectError
     @filter('firstName') filterTest3: string[]; // $ExpectError
-    @filter('firstName', x => x) filterTest4: string[];
-    @filter('firstName', 'secondName', x => x) filterTest5: string[]; // $ExpectError
-    @filter('firstName', ['secondName'], x => x) filterTest6: string[];
+    @filter('firstName', x => Boolean(x)) filterTest4: string[];
+    @filter('firstName', 'secondName', x => Boolean(x)) filterTest5: string[]; // $ExpectError
+    @filter('firstName', ['secondName'], x => Boolean(x)) filterTest6: string[];
 
     @filterBy filterByTest1: any[]; // $ExpectError
     @filterBy() filterByTest2: any[]; // $ExpectError
@@ -214,10 +214,10 @@ class Bar extends EmberObject {
     @sort('values') sortTest3: number; // $ExpectError
     @sort('values', 'id') sortTest4: number;
     @sort('values', 'id', 'a') sortTest5: number; // $ExpectError
-    @sort('values', (a, b) => a - b) sortTest6: number;
-    @sort('values', ['id'], (a, b) => a - b) sortTest7: number;
-    @sort('values', 'id', (a, b) => a - b) sortTest8: number; // $ExpectError
-    @sort(['id'], (a, b) => a - b) sortTest9: number; // $ExpectError
+    @sort('values', (a, b) => Number(a) - Number(b)) sortTest6: number;
+    @sort('values', ['id'], (a, b) => Number(a) - Number(b)) sortTest7: number;
+    @sort('values', 'id', (a, b) => Number(a) - Number(b)) sortTest8: number; // $ExpectError
+    @sort(['id'], (a, b) => Number(a) - Number(b)) sortTest9: number; // $ExpectError
 
     @sum sumTest1: number; // $ExpectError
     @sum() sumTest2: number; // $ExpectError


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.emberjs.com/ember/3.28/functions/@ember%2Fobject%2Fcomputed/and (the example is not returning a boolean)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
