### PR TITLE
Feature/57662 LevelUp interface is missing properties `status` & `isOperational()` #57662

### DIFF
--- a/types/abstract-leveldown/abstract-leveldown-tests.ts
+++ b/types/abstract-leveldown/abstract-leveldown-tests.ts
@@ -16,6 +16,23 @@ test(new AbstractLevelDOWN<any, string>('here'));
 // $ExpectType void
 test(AbstractLevelDOWN<any, string>('there'));
 
+const testMany = (levelDown: AbstractLevelDOWN<any, string>) => {
+    levelDown.put("first", "this is the first value", (err?) => { });
+    levelDown.put("second", "this is the second value", (err?) => { });
+    levelDown.put("third", "this is the third value", (err?) => { });
+
+    levelDown.getMany(["first", "second", "third"], (err?, value?) => { });
+    levelDown.getMany(["first", "second", "third"], { something: true }, (err?, value?) => { });
+  };
+  // $ExpectType void
+  testMany(new AbstractLevelDOWN('here'));
+  // $ExpectType void
+  testMany(AbstractLevelDOWN('there'));
+  // $ExpectType void
+  testMany(new AbstractLevelDOWN<any, string>('here'));
+  // $ExpectType void
+  testMany(AbstractLevelDOWN<any, string>('there'));
+
 // Init db (in order to test properties/methods)
 const db = new AbstractLevelDOWN('here');
 

--- a/types/abstract-leveldown/abstract-leveldown-tests.ts
+++ b/types/abstract-leveldown/abstract-leveldown-tests.ts
@@ -15,3 +15,12 @@ test(AbstractLevelDOWN('there'));
 test(new AbstractLevelDOWN<any, string>('here'));
 // $ExpectType void
 test(AbstractLevelDOWN<any, string>('there'));
+
+// Init db (in order to test properties/methods)
+const db = new AbstractLevelDOWN('here');
+
+// $ExpectType "new" | "opening" | "open" | "closing" | "closed"
+db.status;
+
+// $ExpectType boolean
+db.isOperational();

--- a/types/abstract-leveldown/index.d.ts
+++ b/types/abstract-leveldown/index.d.ts
@@ -38,6 +38,9 @@ export interface AbstractLevelDOWN<K = any, V = any> extends AbstractOptions {
   del(key: K, cb: ErrorCallback): void;
   del(key: K, options: AbstractOptions, cb: ErrorCallback): void;
 
+  getMany(key: K[], cb: ErrorValueCallback<V[]>): void;
+  getMany(key: K[], options: AbstractGetOptions, cb: ErrorValueCallback<V[]>): void;
+
   batch(): AbstractChainedBatch<K, V>;
   batch(array: ReadonlyArray<AbstractBatch<K, V>>, cb: ErrorCallback): AbstractChainedBatch<K, V>;
   batch(

--- a/types/abstract-leveldown/index.d.ts
+++ b/types/abstract-leveldown/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for abstract-leveldown 5.0
+// Type definitions for abstract-leveldown 7.2
 // Project: https://github.com/Level/abstract-leveldown
 // Definitions by: Meirion Hughes <https://github.com/MeirionHughes>
 //                 Daniel Byrne <https://github.com/danwbyrne>
+//                 Steffen Park <https://github.com/istherepie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 4.6
 
 export interface AbstractOptions {
   readonly [k: string]: any;

--- a/types/abstract-leveldown/index.d.ts
+++ b/types/abstract-leveldown/index.d.ts
@@ -4,7 +4,7 @@
 //                 Daniel Byrne <https://github.com/danwbyrne>
 //                 Steffen Park <https://github.com/istherepie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.6
+// TypeScript Version: 2.3
 
 export interface AbstractOptions {
   readonly [k: string]: any;

--- a/types/abstract-leveldown/index.d.ts
+++ b/types/abstract-leveldown/index.d.ts
@@ -46,6 +46,9 @@ export interface AbstractLevelDOWN<K = any, V = any> extends AbstractOptions {
   ): AbstractChainedBatch<K, V>;
 
   iterator(options?: AbstractIteratorOptions<K>): AbstractIterator<K, V>;
+
+  readonly status: "new" | "opening" | "open" | "closing" | "closed";
+  isOperational(): boolean;
 }
 
 export interface AbstractLevelDOWNConstructor {

--- a/types/level-ttl/level-ttl-tests.ts
+++ b/types/level-ttl/level-ttl-tests.ts
@@ -1,4 +1,4 @@
-import levelup from 'levelup';
+import { LevelUp as levelup } from 'levelup';
 import { AbstractLevelDOWN } from 'abstract-leveldown';
 import ttl, { LevelTTL, LevelTTLOptions } from 'level-ttl';
 

--- a/types/levelup/index.d.ts
+++ b/types/levelup/index.d.ts
@@ -87,6 +87,9 @@ export interface LevelUp<DB = AbstractLevelDOWN, Iterator = AbstractIterator<any
     isOpen(): boolean;
     isClosed(): boolean;
 
+    readonly status: "new" | "opening" | "open" | "closing" | "closed";
+    isOperational(): boolean;
+
     createReadStream(options?: AbstractIteratorOptions): NodeJS.ReadableStream;
     createKeyStream(options?: AbstractIteratorOptions): NodeJS.ReadableStream;
     createValueStream(options?: AbstractIteratorOptions): NodeJS.ReadableStream;

--- a/types/levelup/index.d.ts
+++ b/types/levelup/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for levelup 4.3
+// Type definitions for levelup 5.1
 // Project: https://github.com/Level/levelup
 // Definitions by: Meirion Hughes <https://github.com/MeirionHughes>
 //                 Daniel Byrne <https://github.com/danwbyrne>
 //                 Carson Farmer <https://github.com/carsonfarmer>
+//                 Steffen Park <https://github.com/istherepie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 4.6
 
 /// <reference types="node" />
 

--- a/types/levelup/index.d.ts
+++ b/types/levelup/index.d.ts
@@ -5,7 +5,7 @@
 //                 Carson Farmer <https://github.com/carsonfarmer>
 //                 Steffen Park <https://github.com/istherepie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.6
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/levelup/index.d.ts
+++ b/types/levelup/index.d.ts
@@ -169,5 +169,6 @@ export interface LevelUpChain<K = any, V = any> {
 
 export const errors: LevelUpConstructor["errors"];
 
-declare const LevelUp: LevelUpConstructor;
-export default LevelUp;
+export const LevelUp: LevelUpConstructor;
+
+export {};

--- a/types/levelup/index.d.ts
+++ b/types/levelup/index.d.ts
@@ -23,6 +23,11 @@ type LevelUpGet<K, V, O> =
     ((key: K, options: O, callback: ErrorValueCallback<V>) => void) &
     ((key: K, options?: O) => Promise<V>);
 
+type LevelUpGetMany<K, V, O> =
+    ((keys: K[], callback: ErrorValueCallback<V[]>) => void) &
+    ((keys: K[], options: O, callback: ErrorValueCallback<V[]>) => void) &
+    ((keys: K[], options?: O) => Promise<V[]>);
+
 type LevelUpDel<K, O> =
     ((key: K, callback: ErrorCallback) => void) &
     ((key: K, options: O, callback: ErrorCallback) => void) &
@@ -47,6 +52,11 @@ type InferDBGet<DB> =
     DB extends { get: (key: infer K, options: infer O, callback: ErrorValueCallback<infer V>) => void } ?
     LevelUpGet<K, V, O> :
     LevelUpGet<any, any, AbstractGetOptions>;
+
+type InferDBGetMany<DB> =
+    DB extends { getMany: (keys: Array<infer K>, options: infer O, callback: ErrorValueCallback<Array<infer V>>) => void } ?
+    LevelUpGetMany<K, V, O> :
+    LevelUpGetMany<any, any, AbstractGetOptions>;
 
 type InferDBDel<DB> =
     DB extends { del: (key: infer K, options: infer O, callback: ErrorCallback) => void } ?
@@ -77,6 +87,7 @@ export interface LevelUp<DB = AbstractLevelDOWN, Iterator = AbstractIterator<any
     get: InferDBGet<DB>;
     del: InferDBDel<DB>;
     clear: InferDBClear<DB>;
+    getMany: InferDBGetMany<DB>;
 
     batch(array: AbstractBatch[], options?: any): Promise<void>;
     batch(array: AbstractBatch[], options: any, callback: (err?: any) => any): void;

--- a/types/levelup/levelup-tests.ts
+++ b/types/levelup/levelup-tests.ts
@@ -57,6 +57,12 @@ db.isOpen();
 // $ExpectType boolean
 db.isClosed();
 
+// $ExpectType "new" | "opening" | "open" | "closing" | "closed"
+db.status;
+
+// $ExpectType boolean
+db.isOperational();
+
 db.createReadStream()
     .on('data', (data: any) => {
       console.log(data.key, '=', data.value);

--- a/types/levelup/levelup-tests.ts
+++ b/types/levelup/levelup-tests.ts
@@ -1,4 +1,4 @@
-import levelup from 'levelup';
+import { LevelUp as levelup } from 'levelup';
 import { AbstractLevelDOWN } from 'abstract-leveldown';
 
 interface StringEncoding {

--- a/types/levelup/levelup-tests.ts
+++ b/types/levelup/levelup-tests.ts
@@ -38,6 +38,10 @@ db.del("key", (error) => {});
 db.del("key", {keyEncoding: "json"}, (error) => {});
 db.del("key", {sync: true}, (error) => {});
 
+db.getMany(["key1", "key2"], {keyEncoding: "json"}, (error, values) => {});
+db.getMany(["key1", "key2"], {fillCache: true}, (error, values) => {});
+db.getMany(["key1", "key2"], (error, values) => {});
+
 db.batch([{
     type          : 'put'
     , key           : ([1, 2, 3])

--- a/types/levelup/tslint.json
+++ b/types/levelup/tslint.json
@@ -8,10 +8,6 @@
                     [
                         "NeedsExportEquals",
                         false
-                    ],
-                    [
-                        "NoDefaultExport",
-                        false
                     ]
                 ],
                 "mode": "code"

--- a/types/levelup/tslint.json
+++ b/types/levelup/tslint.json
@@ -8,6 +8,10 @@
                     [
                         "NeedsExportEquals",
                         false
+                    ],
+                    [
+                        "NoDefaultExport",
+                        false
                     ]
                 ],
                 "mode": "code"

--- a/types/subleveldown/subleveldown-tests.ts
+++ b/types/subleveldown/subleveldown-tests.ts
@@ -1,4 +1,4 @@
-import levelup from 'levelup';
+import { LevelUp as levelup } from 'levelup';
 import sub from 'subleveldown';
 import { AbstractLevelDOWN } from 'abstract-leveldown';
 


### PR DESCRIPTION
Related to discussion #57662 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/57662)>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

