### PR TITLE
[pino-datadog] Create eu option

### DIFF
--- a/types/pino-datadog/index.d.ts
+++ b/types/pino-datadog/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino-datadog 2.0.2
+// Type definitions for pino-datadog 2.0
 // Project: https://github.com/ovhemert/pino-datadog
 // Definitions by: czystyl <https://github.com/czystyl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pino-datadog/index.d.ts
+++ b/types/pino-datadog/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino-datadog 2.0
+// Type definitions for pino-datadog 2.0.2
 // Project: https://github.com/ovhemert/pino-datadog
 // Definitions by: czystyl <https://github.com/czystyl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pino-datadog/index.d.ts
+++ b/types/pino-datadog/index.d.ts
@@ -34,6 +34,10 @@ export interface Options {
      * Keep the msg attribute in the log record. Used to allow a Datadog facet on the message.
      */
     keepMsg?: boolean;
+    /**
+     * Use Datadog EU site
+     */
+    eu?: boolean;
 }
 
 /**

--- a/types/pino-datadog/pino-datadog-tests.ts
+++ b/types/pino-datadog/pino-datadog-tests.ts
@@ -8,6 +8,7 @@ const options: datadog.Options = {
     service: 'service',
     hostname: 'host',
     keepMsg: true,
+    eu: true,
 };
 
 // $ExpectType Promise<WritableStream>


### PR DESCRIPTION
Changed an existing definition, because source code has `eu` option, but the typing does not.

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: [source with eu option](https://github.com/ovhemert/pino-datadog/blob/08ee4977995bffcdfa6ca1e98a079565bdd5f012/src/datadog.js#L17)
