### PR TITLE
Prosemirror-Model: Adds missing optional target argument to serializeFragment function

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -1426,7 +1426,7 @@ export class DOMSerializer<S extends Schema = any> {
      * document, should be passed so that the serializer can create
      * nodes.
      */
-    serializeFragment(fragment: Fragment<S>, options?: { [key: string]: any }): DocumentFragment;
+    serializeFragment(fragment: Fragment<S>, options?: { [key: string]: any }, target?: Node): DocumentFragment;
     /**
      * Serialize this node to a DOM node. This can be useful when you
      * need to serialize a part of a document, as opposed to the whole

--- a/types/prosemirror-model/prosemirror-model-tests.ts
+++ b/types/prosemirror-model/prosemirror-model-tests.ts
@@ -119,3 +119,26 @@ const fragmentTests = () => {
     // $ExpectType string
     const textBetweenSeparatorAndNullLeafArgs = prosemirrorFragment.textBetween(1, 2, 'separator', null);
 };
+
+const serializeFragmentTests = () => {
+    const target = window.document.createElement('div');
+    const schema = new model.Schema({
+        nodes: nodeSpec
+    });
+
+    const node = model.Node.fromJSON(schema, {
+        type: 'doc',
+        content: {},
+        marks: []
+    });
+
+    // $ExpectType DocumentFragment
+    const resWithTarget = model.DOMSerializer
+        .fromSchema(schema)
+        .serializeFragment(node.content, {}, target);
+
+    // $ExpectType DocumentFragment
+    const resWithoutTarget = model.DOMSerializer
+        .fromSchema(schema)
+        .serializeFragment(node.content, {});
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source Code](https://github.com/ProseMirror/prosemirror-model/blob/master/src/to_dom.js#L44)

This function definition hasn't changed in 5 years, so it looks like this type was just incorrect.