### PR TITLE
Update ImapFlow class -> added close():void method

### DIFF
--- a/types/imapflow/index.d.ts
+++ b/types/imapflow/index.d.ts
@@ -31,6 +31,7 @@ export class ImapFlow extends EventEmitter {
 
     connect(): Promise<void>;
     logout(): Promise<void>;
+    close(): void;
     download(
         range: SequenceString,
         part?: string,


### PR DESCRIPTION
exported class ImapFlow misses method close() now

https://imapflow.com/module-imapflow-ImapFlow.html#close

The method was there since the beginning of the lib (v. 1.0.0)

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
