### PR TITLE
@types/luxon: Add more specific number types

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -18,7 +18,7 @@ export type MonthNumbers = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 export type WeekdayNumbers = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
 export type DayNumbers =
-    1
+    | 1
     | 2
     | 3
     | 4
@@ -51,7 +51,7 @@ export type DayNumbers =
     | 31;
 
 export type SecondNumbers =
-    0
+    | 0
     | 1
     | 2
     | 3
@@ -115,7 +115,7 @@ export type SecondNumbers =
 export type MinuteNumbers = SecondNumbers;
 
 export type HourNumbers =
-    0
+    | 0
     | 1
     | 2
     | 3
@@ -141,7 +141,7 @@ export type HourNumbers =
     | 23;
 
 export type WeekNumbers =
-    1
+    | 1
     | 2
     | 3
     | 4
@@ -193,8 +193,7 @@ export type WeekNumbers =
     | 50
     | 51
     | 52
-    | 53
-    ;
+    | 53;
 
 export type QuarterNumbers = 1 | 2 | 3 | 4;
 

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -14,6 +14,194 @@ import { Interval } from './interval';
 export type DateTimeUnit = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second' | 'millisecond';
 export type ToRelativeUnit = 'years' | 'quarters' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds';
 
+export type MonthNumbers = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type WeekdayNumbers = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export type DayNumbers =
+    1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20
+    | 21
+    | 22
+    | 23
+    | 24
+    | 25
+    | 26
+    | 27
+    | 28
+    | 29
+    | 30
+    | 31;
+
+export type SecondNumbers =
+    0
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20
+    | 21
+    | 22
+    | 23
+    | 24
+    | 25
+    | 26
+    | 27
+    | 28
+    | 29
+    | 30
+    | 31
+    | 32
+    | 33
+    | 34
+    | 35
+    | 36
+    | 37
+    | 38
+    | 39
+    | 40
+    | 41
+    | 42
+    | 43
+    | 44
+    | 45
+    | 46
+    | 47
+    | 48
+    | 49
+    | 50
+    | 51
+    | 52
+    | 53
+    | 54
+    | 55
+    | 56
+    | 57
+    | 58
+    | 59;
+
+export type MinuteNumbers = SecondNumbers;
+
+export type HourNumbers =
+    0
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20
+    | 21
+    | 22
+    | 23;
+
+export type WeekNumbers =
+    1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | 13
+    | 14
+    | 15
+    | 16
+    | 17
+    | 18
+    | 19
+    | 20
+    | 21
+    | 22
+    | 23
+    | 24
+    | 25
+    | 26
+    | 27
+    | 28
+    | 29
+    | 30
+    | 31
+    | 32
+    | 33
+    | 34
+    | 35
+    | 36
+    | 37
+    | 38
+    | 39
+    | 40
+    | 41
+    | 42
+    | 43
+    | 44
+    | 45
+    | 46
+    | 47
+    | 48
+    | 49
+    | 50
+    | 51
+    | 52
+    | 53
+    ;
+
+export type QuarterNumbers = 1 | 2 | 3 | 4;
+
+export type PossibleDaysInMonth = 28 | 29 | 30 | 31;
+export type PossibleDaysInYear = 365 | 366;
+export type PossibleWeeksInYear = 52 | 53;
+
 export interface ToObjectOutput extends DateTimeJSOptions {
     year: number;
     month: number;
@@ -103,6 +291,7 @@ export interface LocaleOptions {
     outputCalendar?: CalendarSystem | undefined;
     numberingSystem?: NumberingSystem | undefined;
 }
+
 export type ResolvedLocaleOptions = Required<LocaleOptions>;
 
 export interface DateTimeOptions extends LocaleOptions {
@@ -615,28 +804,28 @@ export class DateTime {
      *
      * @example DateTime.local(2017, 5, 25).quarter //=> 2
      */
-    get quarter(): number;
+    get quarter(): QuarterNumbers;
 
     /**
      * Get the month (1-12).
      *
      * @example DateTime.local(2017, 5, 25).month //=> 5
      */
-    get month(): number;
+    get month(): MonthNumbers;
 
     /**
      * Get the day of the month (1-30ish).
      *
      * @example DateTime.local(2017, 5, 25).day //=> 25
      */
-    get day(): number;
+    get day(): DayNumbers;
 
     /**
      * Get the hour of the day (0-23).
      *
      * @example DateTime.local(2017, 5, 25, 9).hour //=> 9
      */
-    get hour(): number;
+    get hour(): HourNumbers;
 
     /**
      * Get the minute of the hour (0-59).
@@ -644,7 +833,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25, 9, 30).minute //=> 30
      */
-    get minute(): number;
+    get minute(): MinuteNumbers;
 
     /**
      * Get the second of the minute (0-59).
@@ -652,7 +841,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25, 9, 30, 52).second //=> 52
      */
-    get second(): number;
+    get second(): SecondNumbers;
 
     /**
      * Get the millisecond of the second (0-999).
@@ -678,7 +867,7 @@ export class DateTime {
      * @example
      * DateTime.local(2017, 5, 25).weekNumber //=> 21
      */
-    get weekNumber(): number;
+    get weekNumber(): WeekNumbers;
 
     /**
      * Get the day of the week.
@@ -688,7 +877,7 @@ export class DateTime {
      * @example
      * DateTime.local(2014, 11, 31).weekday //=> 4
      */
-    get weekday(): number;
+    get weekday(): WeekdayNumbers;
 
     /**
      * Get the ordinal (meaning the day of the year)
@@ -784,7 +973,7 @@ export class DateTime {
      * @example
      * DateTime.local(2016, 3).daysInMonth //=> 31
      */
-    get daysInMonth(): number;
+    get daysInMonth(): PossibleDaysInMonth;
 
     /**
      * Returns the number of days in this DateTime's year
@@ -794,7 +983,7 @@ export class DateTime {
      * @example
      * DateTime.local(2013).daysInYear //=> 365
      */
-    get daysInYear(): number;
+    get daysInYear(): PossibleDaysInYear;
 
     /**
      * Returns the number of weeks in this DateTime's year
@@ -805,7 +994,7 @@ export class DateTime {
      * @example
      * DateTime.local(2013).weeksInWeekYear //=> 52
      */
-    get weeksInWeekYear(): number;
+    get weeksInWeekYear(): PossibleWeeksInYear;
 
     /**
      * Returns the resolved Intl options for this DateTime.

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -83,13 +83,16 @@ DateTime.local().toString(); // => '2017-09-14T03:20:34.091-04:00'
 
 const getters = DateTime.local();
 getters.year; // $ExpectType number
-getters.month; // $ExpectType number
-getters.day; // $ExpectType number
-getters.second; // $ExpectType number
-getters.weekday; // $ExpectType number
+getters.month; // $ExpectType MonthNumbers
+getters.day; // $ExpectType DayNumbers
+getters.minute; // $ExpectType SecondNumbers
+getters.second; // $ExpectType SecondNumbers
+getters.weekday; // $ExpectType WeekdayNumbers
 getters.zoneName; // $ExpectType string
 getters.offset; // $ExpectType number
-getters.daysInMonth; // $ExpectType number
+getters.daysInMonth; // $ExpectType PossibleDaysInMonth
+getters.daysInYear; // $ExpectType PossibleDaysInYear
+getters.weeksInWeekYear; // $ExpectType PossibleWeeksInYear
 getters.ordinal; // $ExpectType number
 getters.isInLeapYear; // $ExpectType boolean
 
@@ -168,7 +171,7 @@ dt.offsetNameLong; // $ExpectType string
 dt.isOffsetFixed; // $ExpectType boolean
 dt.isInDST; // $ExpectType boolean
 
-dt.set({ hour: 3 }).hour; // $ExpectType number
+dt.set({ hour: 3 }).hour; // $ExpectType HourNumbers
 
 const f: { month: 'long'; day: 'numeric' } = { month: 'long', day: 'numeric' };
 dt.setLocale('fr').toLocaleString(f);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Certain methods will always return a range of numbers. For example, `DateTime.month` will always be in the range `1 <= month <= 12`, `DateTime.weekday` will always be in the range `1 <= weekday <= 7`, and so on. If the TypeScript declarations returned these exact possible values, it would be really helpful, especially for switch functions. This is a basic attempt of implementing something like this, and I feel there is a better way to do this, but that way is currently unknown to this.