### PR TITLE
 update: (pkg: sade) option API has description as an optional param

### DIFF
--- a/types/sade/index.d.ts
+++ b/types/sade/index.d.ts
@@ -40,7 +40,7 @@ declare namespace sade {
         alias(...names: string[]): Sade;
         command(str: string, desc?: string, opts?: Readonly<CommandOptions>): Sade;
         describe(str: string | ReadonlyArray<string>): Sade;
-        option(str: string, desc: string, val?: string | number | boolean): Sade;
+        option(str: string, desc?: string, val?: string | number | boolean): Sade;
         action(handler: Handler): Sade;
         example(str: string): Sade;
         version(str: string): Sade;

--- a/types/sade/sade-tests.ts
+++ b/types/sade/sade-tests.ts
@@ -5,6 +5,7 @@ const prog = sade('my-cli');
 const argv = ['sirv', 'build'];
 
 prog.version('1.0.5')
+    .option('--global, -g')
     .option('--global, -g', 'An example global flag')
     .option('-c, --config', 'Provide path to custom config', 'foo.config.js');
 


### PR DESCRIPTION
description param is optional

ref: https://www.npmjs.com/package/sade#progoptionflags-desc-value

- [x] Tested locally