### PR TITLE
[styled-components] Fix union type of props being lost

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -50,14 +50,14 @@ export type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
 type Defaultize<P, D> = P extends any
     ? string extends keyof P
         ? P
-        : Pick<P, Exclude<keyof P, keyof D>> &
-              Partial<Pick<P, Extract<keyof P, keyof D>>> &
-              Partial<Pick<D, Exclude<keyof D, keyof P>>>
+        : PickU<P, Exclude<keyof P, keyof D>> &
+              Partial<PickU<P, Extract<keyof P, keyof D>>> &
+              Partial<PickU<D, Exclude<keyof D, keyof P>>>
     : never;
 
 type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
 
-type MakeAttrsOptional<C extends string | React.ComponentType<any>, O extends object, A extends keyof any> = Omit<
+type MakeAttrsOptional<C extends string | React.ComponentType<any>, O extends object, A extends keyof any> = OmitU<
     ReactDefaultizedProps<
         C,
         React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never>
@@ -66,7 +66,7 @@ type MakeAttrsOptional<C extends string | React.ComponentType<any>, O extends ob
     A
 > &
     Partial<
-        Pick<React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never> & O, A>
+        PickU<React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never> & O, A>
     >;
 
 export type StyledComponentProps<
@@ -130,11 +130,11 @@ export interface GlobalStyleComponent<P, T> extends React.ComponentClass<ThemedG
 
 // remove the call signature from StyledComponent so Interpolation can still infer InterpolationFunction
 type StyledComponentInterpolation =
-    | Pick<StyledComponentBase<any, any, any, any>, keyof StyledComponentBase<any, any>>
-    | Pick<StyledComponentBase<any, any, any>, keyof StyledComponentBase<any, any>>;
+    | PickU<StyledComponentBase<any, any, any, any>, keyof StyledComponentBase<any, any>>
+    | PickU<StyledComponentBase<any, any, any>, keyof StyledComponentBase<any, any>>;
 
 // abuse Pick to strip the call signature from ForwardRefExoticComponent
-type ForwardRefExoticBase<P> = Pick<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>;
+type ForwardRefExoticBase<P> = PickU<React.ForwardRefExoticComponent<P>, keyof React.ForwardRefExoticComponent<any>>;
 
 // Config to be used with withConfig
 export interface StyledConfig<O extends object = {}> {
@@ -303,8 +303,10 @@ export interface BaseThemedCssFunction<T extends object> {
 export type ThemedCssFunction<T extends object> = BaseThemedCssFunction<AnyIfEmpty<T>>;
 
 // Helper type operators
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type WithOptionalTheme<P extends { theme?: T | undefined }, T> = Omit<P, 'theme'> & {
+// Pick that distributes over union types
+export type PickU<T, K extends keyof T> = T extends any ? {[P in K]: T[P]} : never;
+export type OmitU<T, K extends keyof T> = T extends any ? PickU<T, Exclude<keyof T, K>> : never;
+type WithOptionalTheme<P extends { theme?: T | undefined }, T> = OmitU<P, 'theme'> & {
     theme?: T | undefined;
 };
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -1220,8 +1220,7 @@ function unionTest() {
         font-size: ${props => (props.kind === 'book' ? 16 : 14)};
     `;
 
-    // undesired, fix was reverted because of https://github.com/Microsoft/TypeScript/issues/30663
-    <StyledReadable kind="book" author="Hejlsberg" />; // $ExpectError
+    <StyledReadable kind="book" author="Hejlsberg" />;
     <StyledReadable kind="magazine" author="Hejlsberg" />; // $ExpectError
 }
 


### PR DESCRIPTION
Reapplied #33061

This changed was reverted by #34499 due to Microsoft/TypeScript#30663.
But because this issue was fixed in TS 3.5 and TS 3.4 is already EOF, I think it is able to reapply this change now.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
  - This is an internal change to the typings
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
