### PR TITLE
http-proxy. Response can actually be http.ServerResponse or net.Socket in emit('error') callback

### DIFF
--- a/types/http-proxy/index.d.ts
+++ b/types/http-proxy/index.d.ts
@@ -218,7 +218,7 @@ declare namespace Server {
     type ErrorCallback = (
         err: Error,
         req: http.IncomingMessage,
-        res: http.ServerResponse,
+        res: http.ServerResponse | net.Socket,
         target?: ProxyTargetUrl,
     ) => void;
 }

--- a/types/http-proxy/index.d.ts
+++ b/types/http-proxy/index.d.ts
@@ -218,7 +218,7 @@ declare namespace Server {
     type ErrorCallback = (
         err: Error,
         req: http.IncomingMessage,
-        res: http.ServerResponse | net.Socket,
+        resOrSocket: http.ServerResponse | net.Socket,
         target?: ProxyTargetUrl,
     ) => void;
 }

--- a/types/http-proxy/index.d.ts
+++ b/types/http-proxy/index.d.ts
@@ -218,7 +218,7 @@ declare namespace Server {
     type ErrorCallback = (
         err: Error,
         req: http.IncomingMessage,
-        resOrSocket: http.ServerResponse | net.Socket,
+        res: http.ServerResponse | net.Socket,
         target?: ProxyTargetUrl,
     ) => void;
 }


### PR DESCRIPTION
As illustrated

Here
https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/passes/web-incoming.js#L165
and
https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/passes/ws-incoming.js#L157