### PR TITLE
Export internal interface from is-hotkey

### DIFF
--- a/types/is-hotkey/index.d.ts
+++ b/types/is-hotkey/index.d.ts
@@ -4,7 +4,7 @@
 //                 Alex Kondratyuk <https://github.com/lynxtaa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface KeyboardEventLike {
+export interface KeyboardEventLike {
     key: string;
     which: number;
     altKey: boolean;


### PR DESCRIPTION
Fixes the error `Exported variable 'x' has or is using name 'KeyboardEventLike' from external module "@types/is-hotkey/index" but cannot be named.`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
