### PR TITLE
Fixed capabilities and mailbox types

### DIFF
--- a/types/imapflow/index.d.ts
+++ b/types/imapflow/index.d.ts
@@ -12,12 +12,12 @@ export type Readable = import('stream').Readable;
 export class ImapFlow extends EventEmitter {
     constructor(options: ImapFlowOptions);
     authenticated: string | boolean;
-    capabilities: string | boolean;
+    capabilities: Map<string, (boolean|number)>;
     emitLogs: boolean;
     enabled: Set<string>;
     id: string;
     idling: boolean;
-    mailbox: MailboxObject;
+    mailbox: MailboxObject | boolean;
     secureConnection: boolean;
     serverInfo: IdInfoObject;
     usable: boolean;


### PR DESCRIPTION
According to documentation https://imapflow.com/module-imapflow-ImapFlow.html#capabilities

capabilities is Map <string, (boolean|numer)>
and mailbox is MailboxObject | boolean

This types were like that like that from the very beginning

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
