### PR TITLE
[ioredis] OverloadedListCommand should also accept a single key in a promise

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -18,6 +18,7 @@
 //                 Michael Salaverry <https://github.com/barakplasma>
 //                 Hannes Van De Vreken <https://github.com/hannesvdvreken>
 //                 T.J. Tarazevits <https://github.com/venku122>
+//                 Michiel De Mey <https://github.com/michieldemey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -108,7 +109,7 @@ declare namespace IORedis {
         (arg1: T, arg2: T, cb: Callback<U>): void;
         (arg1: T | T[], cb: Callback<U>): void;
         (...args: T[]): Promise<U>;
-        (arg1: T[]): Promise<U>;
+        (arg1: T | T[]): Promise<U>;
     }
 
     interface OverloadedBlockingListCommand<T, U> {

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -26,6 +26,7 @@ redis.getrangeBuffer("foo", 0, 1).then(b => cb(null, b));
 redis.del('foo', 'bar').then(result => result * 1);
 
 // Test OverloadedListCommand
+redis.del('foo').then(result => result * 1);
 redis.del(['foo', 'bar']).then(result => result * 1);
 redis.del('foo', 'bar', cbNumber);
 redis.del(['foo', 'bar'], cbNumber);


### PR DESCRIPTION
Not sure why the promise version is not allowed to use a single key instead of an array, the same as its callback-based counterpart.

I might be grossly overlooking something though.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis/blob/master/examples/basic_operations.js#L29
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
