### PR TITLE
nodegit: Fix Signature.default return type

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -84,6 +84,12 @@ signature.name();
 signature.email();
 signature.when();
 
+Git.Signature.default(repo).then(defaultSigniture => {
+    defaultSigniture.name();
+    defaultSigniture.email();
+    defaultSigniture.when();
+});
+
 repo.createBlobFromBuffer(Buffer.from('test')).then((oid: Git.Oid) => oid.cpy());
 repo.commondir();
 

--- a/types/nodegit/signature.d.ts
+++ b/types/nodegit/signature.d.ts
@@ -2,7 +2,7 @@ import { Repository } from './repository';
 import { Time } from './time';
 
 export class Signature {
-    static default(repo: Repository): Signature;
+    static default(repo: Repository): Promise<Signature>;
     static create(name: string, email: string, time: number, offset: number): Signature;
     static now(name: string, email: string): Signature;
     static fromBuffer(buf: string): Promise<Signature>;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.nodegit.org/api/signature/ looks like this changed https://github.com/nodegit/nodegit.github.com/commit/11dc4bac08b06ab9866467c60ef0c4942750531c
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header: I don't think it does, I think it just fixes a bug with the version, types/nodegit/index.d.ts lists the library version as 0.27, in which this function is async
