### PR TITLE
fix(sax): add missing events

### DIFF
--- a/types/sax/index.d.ts
+++ b/types/sax/index.d.ts
@@ -97,8 +97,7 @@ export class SAXStream extends stream.Duplex {
     on(event: "doctype", listener: (this: this, doctype: string) => void): this;
     on(event: "processinginstruction", listener: (this: this, node: { name: string; body: string }) => void): this;
     on(event: "sgmldeclaration", listener: (this: this, sgmlDecl: string) => void): this;
-    on(event: "opentag", listener: (this: this, tag: Tag | QualifiedTag) => void): this;
-    on(event: "opentagstart", listener: (this: this, tag: Tag | QualifiedTag) => void): this;
+    on(event: "opentag" | "opentagstart", listener: (this: this, tag: Tag | QualifiedTag) => void): this;
     on(event: "closetag", listener: (this: this, tagName: string) => void): this;
     on(event: "attribute", listener: (this: this, attr: { name: string; value: string }) => void): this;
     on(event: "comment", listener: (this: this, comment: string) => void): this;

--- a/types/sax/index.d.ts
+++ b/types/sax/index.d.ts
@@ -72,7 +72,9 @@ export class SAXParser {
     ontext(t: string): void;
     ondoctype(doctype: string): void;
     onprocessinginstruction(node: { name: string; body: string }): void;
+    onsgmldeclaration(sgmlDecl: string): void;
     onopentag(tag: Tag | QualifiedTag): void;
+    onopentagstart(tag: Tag | QualifiedTag): void;
     onclosetag(tagName: string): void;
     onattribute(attr: { name: string; value: string }): void;
     oncomment(comment: string): void;
@@ -94,7 +96,9 @@ export class SAXStream extends stream.Duplex {
     on(event: "text", listener: (this: this, text: string) => void): this;
     on(event: "doctype", listener: (this: this, doctype: string) => void): this;
     on(event: "processinginstruction", listener: (this: this, node: { name: string; body: string }) => void): this;
+    on(event: "sgmldeclaration", listener: (this: this, sgmlDecl: string) => void): this;
     on(event: "opentag", listener: (this: this, tag: Tag | QualifiedTag) => void): this;
+    on(event: "opentagstart", listener: (this: this, tag: Tag | QualifiedTag) => void): this;
     on(event: "closetag", listener: (this: this, tagName: string) => void): this;
     on(event: "attribute", listener: (this: this, attr: { name: string; value: string }) => void): this;
     on(event: "comment", listener: (this: this, comment: string) => void): this;

--- a/types/sax/sax-tests.ts
+++ b/types/sax/sax-tests.ts
@@ -33,6 +33,10 @@ import fs = require("fs");
             const attrValue: string = attr.value;
         }
     };
+    
+    parser.onopentagstart = (tag: sax.QualifiedTag) => {};
+
+    parser.onsgmldeclaration = (sgmlDecl: string) => {};
 
     parser.onattribute = (attr: { name: string; value: string; }) => {};
 
@@ -60,6 +64,16 @@ import fs = require("fs");
     saxStream.on("opentag", tag => {
         // $ExpectType Tag | QualifiedTag
         tag;
+    });
+
+    saxStream.on("opentagstart", tag => {
+        // $ExpectType Tag | QualifiedTag
+        tag;
+    });
+
+    saxStream.on("sgmldeclaration", sgmlDecl => {
+        // $ExpectType string
+        sgmlDecl;
     });
 
     saxStream.on("closetag", tagName => {

--- a/types/sax/sax-tests.ts
+++ b/types/sax/sax-tests.ts
@@ -33,7 +33,7 @@ import fs = require("fs");
             const attrValue: string = attr.value;
         }
     };
-    
+
     parser.onopentagstart = (tag: sax.QualifiedTag) => {};
 
     parser.onsgmldeclaration = (sgmlDecl: string) => {};


### PR DESCRIPTION
Adds `opentagstart` and `sgmldeclaration` events to the API.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/isaacs/sax-js/blob/5aee2163d55cff24b817bbf550bac44841f9df45/README.md?plain=1#L166-L174
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
