### PR TITLE
Add definition types for 'delegates' npm package

### DIFF
--- a/types/delegates/delegates-tests.ts
+++ b/types/delegates/delegates-tests.ts
@@ -1,0 +1,39 @@
+import delegates from 'delegates';
+
+class Animal {
+    private _age = 0
+
+    private _options = {}
+
+    get options() {
+        return this._options;
+    }
+
+    set options(value = {}) {
+        this._options = value;
+    }
+
+    get age() {
+        return this._age;
+    }
+
+    set age(value: number) {
+        this._age = value;
+    }
+
+    getFood() {}
+}
+
+class AnimalAPI {
+    constructor() {
+        delegates(this, '_animal')
+        .access('age')
+        .method('getFood')
+        .getter('options')
+        .setter('options')
+    }
+
+    private _animal = new Animal();
+}
+
+new AnimalAPI();

--- a/types/delegates/index.d.ts
+++ b/types/delegates/index.d.ts
@@ -1,0 +1,10 @@
+declare module 'delegates' {
+    function Delegate(proto: Object, target: string): Delegate;
+    interface Delegate {
+        method(name: string): Delegate
+        access(name: string): Delegate
+        getter(name: string): Delegate
+        setter(name: string): Delegate
+    }
+    export default Delegate;
+}

--- a/types/delegates/tsconfig.json
+++ b/types/delegates/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "delegates-tests.ts"
+    ]
+}

--- a/types/delegates/tslint.json
+++ b/types/delegates/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

