### PR TITLE
fix(piwik-react-router): make modifier optional

### DIFF
--- a/types/piwik-react-router/index.d.ts
+++ b/types/piwik-react-router/index.d.ts
@@ -29,7 +29,7 @@ interface PiwikReactRouter {
     trackError: (e: PiwikReactRouterTrackErrorEvent, eventName: string) => void;
     connectToHistory: (
         history: PiwikReactRouterHistory,
-        modifier: (history: PiwikReactRouterHistory) => void,
+        modifier?: (history: PiwikReactRouterHistory) => void,
     ) => PiwikReactRouterHistory;
     disconnectFromHistory: () => boolean;
 }

--- a/types/piwik-react-router/piwik-react-router-tests.ts
+++ b/types/piwik-react-router/piwik-react-router-tests.ts
@@ -10,3 +10,5 @@ piwik.setUserId('userId');
 piwik.push({ arg1: 1, arg2: 2 });
 
 piwik.trackError({ message: 'message', filename: 'filename', lineno: 'lineno' }, 'EventName');
+
+piwik.connectToHistory({ location: 'tst' });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/canserkanuren/DefinitelyTyped
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This is a simple fix from the first version that I did yesterday. 
Seen in the link above, the function `connectToHistory` has only one mandatory parameter, the other one is optional, hence my actual pull request