### PR TITLE
[jasmine] Use ThisType<> to make spy this type-safe

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -1149,12 +1149,12 @@ declare namespace jasmine {
         /** Set this spy to do a shallow clone of arguments passed to each invocation. */
         saveArgumentsByValue(): void;
         /** Get the "this" object that was passed to a specific invocation of this spy. */
-        thisFor(index: number): any;
+        thisFor(index: number): ThisType<Fn>;
     }
 
     interface CallInfo<Fn extends Func> {
         /** The context (the this) for the call */
-        object: any;
+        object: ThisType<Fn>;
         /** All arguments passed to the call */
         args: Parameters<Fn>;
         /** The return value of the call */

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1939,19 +1939,21 @@ describe("Custom async matcher: 'toBeEight'", () => {
 
 describe("better typed spys", () => {
     describe("a typed spy", () => {
-        const spy = jasmine.createSpy("spy", (num: number, str: string): string => {
+        const spy = jasmine.createSpy("spy", function(this: Date, num: number, str: string): string {
             return `${num} and ${str}`;
         });
         it("has a typed returnValue", () => {
-            // $ExpectType (val: string) => Spy<(num: number, str: string) => string>
+            // $ExpectType (val: string) => Spy<(this: Date, num: number, str: string) => string>
             spy.and.returnValue;
         });
         it("has a typed calls property", () => {
             spy.calls.first().args; // $ExpectType [number, string] || [num: number, str: string]
             spy.calls.first().returnValue; // $ExpectType string
+            spy.calls.first().object; // $ExpectType ThisType<(this: Date, num: number, str: string) => string>
+            spy.calls.thisFor(0); // $ExpectType ThisType<(this: Date, num: number, str: string) => string>
         });
         it("has a typed callFake", () => {
-            // $ExpectType (fn: (num: number, str: string) => string) => Spy<(num: number, str: string) => string>
+            // $ExpectType (fn: (this: Date, num: number, str: string) => string) => Spy<(this: Date, num: number, str: string) => string>
             spy.and.callFake;
         });
     });


### PR DESCRIPTION
This makes `spy.calls.thisFor()` and `call...().object` strongly-typed instead of `any`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://jasmine.github.io/api/edge/Spy.html)
