### PR TITLE
[mongoose-paginate-v2] fix(custom-labels): can be false to be excluded from response

### DIFF
--- a/types/mongoose-paginate-v2/index.d.ts
+++ b/types/mongoose-paginate-v2/index.d.ts
@@ -10,18 +10,18 @@
 // Minimum TypeScript Version: 4.1
 
 declare module 'mongoose' {
-    interface CustomLabels {
-        totalDocs?: string | undefined;
-        docs?: string | undefined;
-        limit?: string | undefined;
-        page?: string | undefined;
-        nextPage?: string | undefined;
-        prevPage?: string | undefined;
-        hasNextPage?: string | undefined;
-        hasPrevPage?: string | undefined;
-        totalPages?: string | undefined;
-        pagingCounter?: string | undefined;
-        meta?: string | undefined;
+    interface CustomLabels<T = string | undefined | boolean> {
+        totalDocs?: T;
+        docs?: T;
+        limit?: T;
+        page?: T;
+        nextPage?: T;
+        prevPage?: T;
+        hasNextPage?: T;
+        hasPrevPage?: T;
+        totalPages?: T;
+        pagingCounter?: T;
+        meta?: T;
     }
 
     interface ReadOptions {

--- a/types/mongoose-paginate-v2/mongoose-paginate-v2-tests.ts
+++ b/types/mongoose-paginate-v2/mongoose-paginate-v2-tests.ts
@@ -68,6 +68,7 @@ router.get('/users.json', async (req: Request, res: Response) => {
         docs: 'docsCustom',
         nextPage: 'nextPageCustom',
         prevPage: 'prevPageCustom',
+        pagingCounter: false,
     };
     options.pagination = false;
     options.useEstimatedCount = true;
@@ -90,6 +91,7 @@ router.get('/users.json', async (req: Request, res: Response) => {
         console.log('prevPage: ' + value.prevPageCustom);
         console.log('totalPages: ' + value.totalPagesCustom);
         console.log('offset: ' + value.offset);
+        console.log('pagingCounter: ' + value.pagingCounter);
         console.log('docs: ');
         console.dir(value.docsCustom);
         const user = value.docs[0];


### PR DESCRIPTION
Each custom label can be set to false to later be excluded from the paginated response.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/mongoose-paginate-v2

