### PR TITLE
[node/v14] fix return type of outgoingMessage.setHeader()

### DIFF
--- a/types/node/v14/http.d.ts
+++ b/types/node/v14/http.d.ts
@@ -237,7 +237,7 @@ declare module 'http' {
         constructor();
 
         setTimeout(msecs: number, callback?: () => void): this;
-        setHeader(name: string, value: number | string | ReadonlyArray<string>): void;
+        setHeader(name: string, value: number | string | ReadonlyArray<string>): this;
         getHeader(name: string): number | string | string[] | undefined;
         getHeaders(): OutgoingHttpHeaders;
         getHeaderNames(): string[];

--- a/types/node/v14/test/http.ts
+++ b/types/node/v14/test/http.ts
@@ -57,7 +57,7 @@ import * as dns from 'node:dns';
     const res: http.ServerResponse = new http.ServerResponse(incoming);
 
     // test headers
-    res.setHeader('Content-Type', 'text/plain');
+    res.setHeader('Content-Type', 'text/plain').setHeader('Access-Control-Allow-Origin', '*');
     const bool: boolean = res.hasHeader('Content-Type');
     const headers: string[] = res.getHeaderNames();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Doc: https://nodejs.org/docs/latest-v14.x/api/http.html#http_outgoingmessage_setheader_name_value
  - Source: https://github.com/nodejs/node/blob/v14.18.2/lib/_http_outgoing.js#L571
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.