### PR TITLE
[ndarray-ops] Allow non-numeric arrays for ndarray-ops assign

### DIFF
--- a/types/ndarray-ops/index.d.ts
+++ b/types/ndarray-ops/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Adam Zerella <https://github.com/adamzerella>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { NdArray } from "ndarray";
+import { Data, NdArray } from 'ndarray';
 
 ////////////////
 /// Assignment operations
@@ -212,7 +212,7 @@ export function inf(array: NdArray): boolean;
 export function argmin(index: number, array: NdArray, shape: NdArray): boolean;
 export function argmax(index: number, array: NdArray, shape: NdArray): boolean;
 export function random(array: NdArray): NdArray;
-export function assign(array: NdArray, array2: NdArray): NdArray;
+export function assign<D extends Data = Data<number>>(array: NdArray<D>, array2: NdArray<D>): NdArray<D>;
 export function assigns(array: NdArray, scalar: number): NdArray;
 export function equals(array1: NdArray, array2: NdArray): boolean;
 

--- a/types/ndarray-ops/ndarray-ops-tests.ts
+++ b/types/ndarray-ops/ndarray-ops-tests.ts
@@ -1,5 +1,5 @@
 import ndarray = require('ndarray');
-import ops = require("ndarray-ops");
+import ops = require('ndarray-ops');
 
 const data = new Int32Array(2 * 2 * 2 + 10);
 const arr1 = ndarray(data, [2, 2, 2], [1, 2, 4], 5);
@@ -161,3 +161,9 @@ ops.random(arr2);
 ops.assign(arr2, arr2);
 ops.assigns(arr2, 2);
 ops.equals(arr1, arr2);
+
+// Not-numeric arrays
+const source = ndarray(['a', 'b', 'c', 'd', 'e', 'f'], [2, 3]);
+const dest: ndarray.NdArray<string[]> = ndarray([], [2, 3]);
+
+ops.assign(dest, source);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

### Some context:
`ndarray-ops` can be used on `ndarray` that contain non-numeric data. The typings of `ndarray-ops` prevent this as they enforce the use of `NdArray` which is the shorthand for `NdArray<number[]>`.

For some operation, such as `add` or `sub`, it makes sense. For others such as `assign`, the only need is to have compliant data between the source and the destination (even non-numeric).

This PR adds generics for `assign` so that the typings allow its use with ndarray containing non-numeric data. Note that other operations could fall into the same category so I might update others when I encounter the usecase. 

