### PR TITLE
@types/prosemirror-markdown: Add missing type definitions and fix incorrect definition for "render"

### DIFF
--- a/types/prosemirror-markdown/index.d.ts
+++ b/types/prosemirror-markdown/index.d.ts
@@ -191,10 +191,36 @@ export let defaultMarkdownSerializer: MarkdownSerializer;
  * node and mark serialization methods (see `toMarkdown`).
  */
 export class MarkdownSerializerState<S extends Schema = any> {
+    constructor(
+        nodes: {
+            [name: string]: (state: MarkdownSerializerState, node: ProsemirrorNode<S>) => void;
+        },
+        marks: {
+            [key: string]: MarkSerializerConfig;
+        },
+    );
+    /**
+     * The node serializer
+     * functions for this serializer.
+     */
+    nodes: {
+        [name: string]: (state: MarkdownSerializerState, node: ProsemirrorNode<S>) => void;
+    };
+    /**
+     * The mark serializer info.
+     */
+    marks: { [key: string]: any };
+    delim: string;
+    out: string;
+    closed: boolean;
+    inTightList: boolean;
     /**
      * The options passed to the serializer.
      */
     options: { tightLists?: boolean | null | undefined };
+
+    flushClose(size: number): void;
+
     /**
      * Render a block, prefixing each line with `delim`, and the first
      * line in `firstDelim`. `node` should be the node that is closed at
@@ -202,6 +228,8 @@ export class MarkdownSerializerState<S extends Schema = any> {
      * content of the block.
      */
     wrapBlock(delim: string, firstDelim: string | undefined, node: ProsemirrorNode<S>, f: () => void): void;
+
+    atBlank(): boolean;
     /**
      * Ensure the current content ends with a newline.
      */
@@ -225,7 +253,7 @@ export class MarkdownSerializerState<S extends Schema = any> {
     /**
      * Render the given node as a block.
      */
-    render(node: ProsemirrorNode<S>): void;
+    render(node: ProsemirrorNode<S>, parent: ProsemirrorNode<S>, index: number): void;
 
     /**
      * Render the contents of `parent` as block nodes.
@@ -256,6 +284,11 @@ export class MarkdownSerializerState<S extends Schema = any> {
      * Repeat the given string `n` times.
      */
     repeat(str: string, n: number): string;
+
+    /**
+     * Get the markdown string for a given opening or closing mark.
+     */
+    markString(mark: Mark, open: boolean, parent?: Node, index?: number): string;
 
     /**
      * Get leading and trailing whitespace from a string. Values of

--- a/types/prosemirror-markdown/prosemirror-markdown-tests.ts
+++ b/types/prosemirror-markdown/prosemirror-markdown-tests.ts
@@ -178,99 +178,23 @@ function backticksFor(node: ProsemirrorNode, side: Side) {
 }
 
 const stateTest = () => {
-    const state = new MarkdownSerializerState(
-        {
-            blockquote(state, node) {
-                state.wrapBlock('> ', undefined, node, () => state.renderContent(node));
-            },
-            codeBlock(state, node) {
-                // tslint:disable-next-line: prefer-template
-                state.write('```' + (node.attrs.language || '') + '\n');
-                state.text(node.textContent, false);
-                state.ensureNewLine();
-                state.write('```');
-                state.closeBlock(node);
-            },
-            heading(state, node) {
-                state.write(state.repeat('#', node.attrs.level) + ' ');
-                state.renderInline(node);
-                state.closeBlock(node);
-            },
-            horizontalRule(state, node) {
-                state.write(node.attrs.markup || '---');
-                state.closeBlock(node);
-            },
-            bulletList(state, node) {
-                state.renderList(node, '  ', () => (node.attrs.bullet || '*') + ' ');
-            },
-            orderedList(state, node) {
-                const start = node.attrs.order || 1;
-                const maxW = String(start + node.childCount - 1).length;
-                const space = state.repeat(' ', maxW + 2);
-                state.renderList(node, space, i => {
-                    const nStr = String(start + i);
-                    // tslint:disable-next-line: prefer-template
-                    return state.repeat(' ', maxW - nStr.length) + nStr + '. ';
-                });
-            },
-            listItem(state, node) {
-                state.renderContent(node);
-            },
-            paragraph(state, node) {
-                console.log(state, node);
-                state.renderInline(node);
-                state.closeBlock(node);
-            },
-            image(state, node) {
-                state.write(
-                    // tslint:disable-next-line: prefer-template
-                    '![' +
-                        state.esc(node.attrs.alt || '') +
-                        '](' +
-                        state.esc(node.attrs.src) +
-                        (node.attrs.title ? ' ' + state.quote(node.attrs.title) : '') +
-                        ')',
-                );
-            },
-            hardBreak(state, node) {
-                state.write('\\\n');
-            },
-            text(state, node) {
-                if (!node.text) {
-                    return;
-                }
-                state.text(node.text);
-            },
+    const state = new MarkdownSerializerState({
+        paragraph(state, node) {
+            state.renderInline(node);
+            state.closeBlock(node);
         },
-        {
-            italic: { open: '*', close: '*', mixable: true, expelEnclosingWhitespace: true },
-            bold: { open: '**', close: '**', mixable: true, expelEnclosingWhitespace: true },
-            link: {
-                open(_state, mark, parent, index) {
-                    return isPlainURL(mark, parent, index, 1) ? '<' : '[';
-                },
-                close(state, mark, parent, index) {
-                    return isPlainURL(mark, parent, index, -1)
-                        ? '>'
-                        : // tslint:disable-next-line: prefer-template
-                          '](' +
-                              state.esc(mark.attrs.href) +
-                              (mark.attrs.title ? ' ' + state.quote(mark.attrs.title) : '') +
-                              ')';
-                },
-            },
-            code: {
-                open(_state, _mark, parent, index) {
-                    return backticksFor(parent.child(index), -1);
-                },
-                close(_state, _mark, parent, index) {
-                    return backticksFor(parent.child(index - 1), 1);
-                },
-                escape: false,
-            },
-        });
+        text(state, node) {
+            if (!node.text) {
+                return;
+            }
+            state.text(node.text);
+        },
+    }, {
+        italic: { open: '*', close: '*', mixable: true, expelEnclosingWhitespace: true },
+        bold: { open: '**', close: '**', mixable: true, expelEnclosingWhitespace: true },
+    });
 
-    const {marks, nodes, delim, out, closed, inTightList} = state;
+    const { marks, nodes, delim, out, closed, inTightList } = state;
 
     state.atBlank();
     state.flushClose(2);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.