### PR TITLE
jest-when: updates for 3.5.0

### DIFF
--- a/types/jest-when/example-module.ts
+++ b/types/jest-when/example-module.ts
@@ -1,1 +1,1 @@
-export const toBeMocked = (hello = "world") => hello;
+export const toBeMocked = (hello = 'world') => hello;

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -26,6 +26,10 @@ export interface WhenMock<T = any, Y extends any[] = any>
   mockRejectedValueOnce(value: jest.RejectedValue<T>): this;
   mockImplementation(fn: (...args: Y) => T): this;
   mockImplementationOnce(fn?: (...args: Y) => T): this;
+  defaultReturnValue(value: T): this;
+  defaultResolvedValue(value: jest.ResolvedValue<T>): this;
+  defaultRejectedValue(value: jest.RejectedValue<T>): this;
+  defaultImplementation(fn: (...args: Y) => T): this;
 }
 
 export interface AllArgsMatcher<Y> {

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -14,7 +14,9 @@ export type ArgumentOrMatcher<ArgTypes extends any[]> = { [Index in keyof ArgTyp
 
 export interface WhenMock<T = any, Y extends any[] = any>
   extends jest.MockInstance<T, Y> {
+  calledWith(allArgsMatcher: AllArgsMatcher<Y>): this;
   calledWith(...matchers: ArgumentOrMatcher<Y>): this;
+  expectCalledWith(allArgsMatcher: AllArgsMatcher<Y>): this;
   expectCalledWith(...matchers: ArgumentOrMatcher<Y>): this;
   mockReturnValue(value: T): this;
   mockReturnValueOnce(value: T): this;
@@ -26,7 +28,18 @@ export interface WhenMock<T = any, Y extends any[] = any>
   mockImplementationOnce(fn?: (...args: Y) => T): this;
 }
 
-export type When = <T, Y extends any[]>(fn: ((...args: Y) => T) | jest.MockInstance<T, Y>) => WhenMock<T, Y>;
+export interface AllArgsMatcher<Y> {
+  (args: Y, equals: jest.MatcherUtils['equals']): boolean;
+  // Internal, but needed to distinguish from normal callables
+  _isAllArgsFunctionMatcher: true;
+  _isFunctionMatcher: true;
+}
+
+export interface When {
+  <T, Y extends any[]>(fn: ((...args: Y) => T) | jest.MockInstance<T, Y>): WhenMock<T, Y>;
+
+  allArgs<Y extends any[]>(matcher: (args: Y, equals: jest.MatcherUtils['equals']) => boolean): AllArgsMatcher<Y>;
+}
 
 export const when: When;
 export function resetAllWhenMocks(): void;

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -10,10 +10,12 @@
 
 /// <reference types="jest" />
 
+export type ArgumentOrMatcher<ArgTypes extends any[]> = { [Index in keyof ArgTypes]: ArgTypes[Index] | WhenMock<boolean, [ArgTypes[Index]]> };
+
 export interface WhenMock<T = any, Y extends any[] = any>
   extends jest.MockInstance<T, Y> {
-  calledWith(...matchers: Y): this;
-  expectCalledWith(...matchers: Y): this;
+  calledWith(...matchers: ArgumentOrMatcher<Y>): this;
+  expectCalledWith(...matchers: ArgumentOrMatcher<Y>): this;
   mockReturnValue(value: T): this;
   mockReturnValueOnce(value: T): this;
   mockResolvedValue(value: jest.ResolvedValue<T>): this;

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -10,39 +10,40 @@
 
 /// <reference types="jest" />
 
-export type ArgumentOrMatcher<ArgTypes extends any[]> = { [Index in keyof ArgTypes]: ArgTypes[Index] | WhenMock<boolean, [ArgTypes[Index]]> };
+export type ArgumentOrMatcher<ArgTypes extends any[]> = {
+    [Index in keyof ArgTypes]: ArgTypes[Index] | WhenMock<boolean, [ArgTypes[Index]]>;
+};
 
-export interface WhenMock<T = any, Y extends any[] = any>
-  extends jest.MockInstance<T, Y> {
-  calledWith(allArgsMatcher: AllArgsMatcher<Y>): this;
-  calledWith(...matchers: ArgumentOrMatcher<Y>): this;
-  expectCalledWith(allArgsMatcher: AllArgsMatcher<Y>): this;
-  expectCalledWith(...matchers: ArgumentOrMatcher<Y>): this;
-  mockReturnValue(value: T): this;
-  mockReturnValueOnce(value: T): this;
-  mockResolvedValue(value: jest.ResolvedValue<T>): this;
-  mockResolvedValueOnce(value: jest.ResolvedValue<T>): this;
-  mockRejectedValue(value: jest.RejectedValue<T>): this;
-  mockRejectedValueOnce(value: jest.RejectedValue<T>): this;
-  mockImplementation(fn: (...args: Y) => T): this;
-  mockImplementationOnce(fn?: (...args: Y) => T): this;
-  defaultReturnValue(value: T): this;
-  defaultResolvedValue(value: jest.ResolvedValue<T>): this;
-  defaultRejectedValue(value: jest.RejectedValue<T>): this;
-  defaultImplementation(fn: (...args: Y) => T): this;
+export interface WhenMock<T = any, Y extends any[] = any> extends jest.MockInstance<T, Y> {
+    calledWith(allArgsMatcher: AllArgsMatcher<Y>): this;
+    calledWith(...matchers: ArgumentOrMatcher<Y>): this;
+    expectCalledWith(allArgsMatcher: AllArgsMatcher<Y>): this;
+    expectCalledWith(...matchers: ArgumentOrMatcher<Y>): this;
+    mockReturnValue(value: T): this;
+    mockReturnValueOnce(value: T): this;
+    mockResolvedValue(value: jest.ResolvedValue<T>): this;
+    mockResolvedValueOnce(value: jest.ResolvedValue<T>): this;
+    mockRejectedValue(value: jest.RejectedValue<T>): this;
+    mockRejectedValueOnce(value: jest.RejectedValue<T>): this;
+    mockImplementation(fn: (...args: Y) => T): this;
+    mockImplementationOnce(fn?: (...args: Y) => T): this;
+    defaultReturnValue(value: T): this;
+    defaultResolvedValue(value: jest.ResolvedValue<T>): this;
+    defaultRejectedValue(value: jest.RejectedValue<T>): this;
+    defaultImplementation(fn: (...args: Y) => T): this;
 }
 
 export interface AllArgsMatcher<Y> {
-  (args: Y, equals: jest.MatcherUtils['equals']): boolean;
-  // Internal, but needed to distinguish from normal callables
-  _isAllArgsFunctionMatcher: true;
-  _isFunctionMatcher: true;
+    (args: Y, equals: jest.MatcherUtils['equals']): boolean;
+    // Internal, but needed to distinguish from normal callables
+    _isAllArgsFunctionMatcher: true;
+    _isFunctionMatcher: true;
 }
 
 export interface When {
-  <T, Y extends any[]>(fn: ((...args: Y) => T) | jest.MockInstance<T, Y>): WhenMock<T, Y>;
+    <T, Y extends any[]>(fn: ((...args: Y) => T) | jest.MockInstance<T, Y>): WhenMock<T, Y>;
 
-  allArgs<Y extends any[]>(matcher: (args: Y, equals: jest.MatcherUtils['equals']) => boolean): AllArgsMatcher<Y>;
+    allArgs<Y extends any[]>(matcher: (args: Y, equals: jest.MatcherUtils['equals']) => boolean): AllArgsMatcher<Y>;
 }
 
 export const when: When;

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jest-when 2.7
+// Type definitions for jest-when 3.5
 // Project: https://github.com/timkindberg/jest-when#readme
 // Definitions by: Alden Taylor <https://github.com/aldentaylor>,
 //                 Trung Dang <https://github.com/immanuel192>,

--- a/types/jest-when/jest-when-tests.ts
+++ b/types/jest-when/jest-when-tests.ts
@@ -5,253 +5,214 @@ jest.mock('./example-module');
 
 describe('mock-when test', () => {
     it('basic usage:', () => {
-      const fn = jest.fn();
-      when(fn)
-        .calledWith(1)
-        .mockReturnValue('yay!');
+        const fn = jest.fn();
+        when(fn).calledWith(1).mockReturnValue('yay!');
 
-      const result = fn(1);
-      expect(result).toEqual('yay!');
+        const result = fn(1);
+        expect(result).toEqual('yay!');
     });
 
     it('Supports multiple args:', () => {
-      const fn = jest.fn();
-      when(fn)
-        .calledWith(1, true, 'foo')
-        .mockReturnValue('yay!');
+        const fn = jest.fn();
+        when(fn).calledWith(1, true, 'foo').mockReturnValue('yay!');
 
-      const result = fn(1, true, 'foo');
-      expect(result).toEqual('yay!');
+        const result = fn(1, true, 'foo');
+        expect(result).toEqual('yay!');
     });
 
     it('Supports jest matchers:', () => {
-      const fn = jest.fn();
-      when(fn)
-        .calledWith(
-          expect.anything(),
-          expect.any(Number),
-          expect.arrayContaining([false]),
-        )
-        .mockReturnValue('yay!');
+        const fn = jest.fn();
+        when(fn)
+            .calledWith(expect.anything(), expect.any(Number), expect.arrayContaining([false]))
+            .mockReturnValue('yay!');
 
-      const result = fn('whatever', 100, [true, false]);
-      expect(result).toEqual('yay!');
+        const result = fn('whatever', 100, [true, false]);
+        expect(result).toEqual('yay!');
     });
 
     it('Supports compound declarations:', () => {
-      const fn = jest.fn();
-      when(fn)
-        .calledWith(1)
-        .mockReturnValueOnce('no')
-        .mockReturnValue('yes');
-      when(fn)
-        .calledWith(2)
-        .mockReturnValue('way?');
-      when(fn)
-        .calledWith(3)
-        .mockResolvedValueOnce('no');
-      when(fn)
-        .calledWith(3)
-        .mockResolvedValue('yes');
-      when(fn)
-        .calledWith(4)
-        .mockRejectedValueOnce('no');
-      when(fn)
-        .calledWith(4)
-        .mockRejectedValue('yes');
+        const fn = jest.fn();
+        when(fn).calledWith(1).mockReturnValueOnce('no').mockReturnValue('yes');
+        when(fn).calledWith(2).mockReturnValue('way?');
+        when(fn).calledWith(3).mockResolvedValueOnce('no');
+        when(fn).calledWith(3).mockResolvedValue('yes');
+        when(fn).calledWith(4).mockRejectedValueOnce('no');
+        when(fn).calledWith(4).mockRejectedValue('yes');
 
-      expect(fn(1)).toEqual('no');
-      expect(fn(1)).toEqual('yes');
-      expect(fn(2)).toEqual('way?');
-      expect(fn(3)).resolves.toEqual('no');
-      expect(fn(3)).resolves.toEqual('yes');
-      expect(fn(4)).rejects.toEqual('no');
-      expect(fn(4)).rejects.toEqual('yes');
+        expect(fn(1)).toEqual('no');
+        expect(fn(1)).toEqual('yes');
+        expect(fn(2)).toEqual('way?');
+        expect(fn(3)).resolves.toEqual('no');
+        expect(fn(3)).resolves.toEqual('yes');
+        expect(fn(4)).rejects.toEqual('no');
+        expect(fn(4)).rejects.toEqual('yes');
     });
 
     it('Supports chained calls:', () => {
-      const fn = jest.fn();
-      when(fn)
-        .calledWith(1)
-        .mockReturnValue('no')
-        .calledWith(2)
-        .mockReturnValue('way?')
-        .calledWith(3)
-        .mockReturnValue('yes')
-        .calledWith(4)
-        .mockReturnValue('way!');
+        const fn = jest.fn();
+        when(fn)
+            .calledWith(1)
+            .mockReturnValue('no')
+            .calledWith(2)
+            .mockReturnValue('way?')
+            .calledWith(3)
+            .mockReturnValue('yes')
+            .calledWith(4)
+            .mockReturnValue('way!');
 
-      expect(fn(1)).toEqual('no');
-      expect(fn(2)).toEqual('way?');
-      expect(fn(3)).toEqual('yes');
-      expect(fn(4)).toEqual('way!');
-      expect(fn(5)).toEqual(undefined);
+        expect(fn(1)).toEqual('no');
+        expect(fn(2)).toEqual('way?');
+        expect(fn(3)).toEqual('yes');
+        expect(fn(4)).toEqual('way!');
+        expect(fn(5)).toEqual(undefined);
     });
 
     it('Supports chained calls with defaults:', () => {
-      const fn = jest.fn();
-      when(fn)
-        .mockReturnValue('nice')
-        .calledWith(1)
-        .mockReturnValue('no')
-        .calledWith(2)
-        .mockReturnValue('way?')
-        .calledWith(3)
-        .mockReturnValue('yes')
-        .calledWith(4)
-        .mockReturnValue('way!');
+        const fn = jest.fn();
+        when(fn)
+            .mockReturnValue('nice')
+            .calledWith(1)
+            .mockReturnValue('no')
+            .calledWith(2)
+            .mockReturnValue('way?')
+            .calledWith(3)
+            .mockReturnValue('yes')
+            .calledWith(4)
+            .mockReturnValue('way!');
 
-      expect(fn(1)).toEqual('no');
-      expect(fn(2)).toEqual('way?');
-      expect(fn(3)).toEqual('yes');
-      expect(fn(4)).toEqual('way!');
-      expect(fn(5)).toEqual('nice');
+        expect(fn(1)).toEqual('no');
+        expect(fn(2)).toEqual('way?');
+        expect(fn(3)).toEqual('yes');
+        expect(fn(4)).toEqual('way!');
+        expect(fn(5)).toEqual('nice');
     });
 
     it('Assert the args:', () => {
-      const fn = jest.fn();
-      when(fn)
-        .expectCalledWith(1)
-        .mockReturnValue('x');
-      let testPassed = false;
-      try {
-        fn(2); // Will throw a helpful jest assertion error with args diff
-      } catch (e) {
-        testPassed = true;
-      }
-      expect(testPassed).toBeTruthy();
+        const fn = jest.fn();
+        when(fn).expectCalledWith(1).mockReturnValue('x');
+        let testPassed = false;
+        try {
+            fn(2); // Will throw a helpful jest assertion error with args diff
+        } catch (e) {
+            testPassed = true;
+        }
+        expect(testPassed).toBeTruthy();
     });
 
     it('should support for mockImplementation', () => {
-      const fn = jest.fn();
-      const expectValue = { a: 1, b: 2 };
-      when(fn)
-        .calledWith(expect.anything())
-        .mockImplementation(() => expectValue);
+        const fn = jest.fn();
+        const expectValue = { a: 1, b: 2 };
+        when(fn)
+            .calledWith(expect.anything())
+            .mockImplementation(() => expectValue);
 
-      const result = fn('whatever');
-      expect(result).toMatchObject(expectValue);
+        const result = fn('whatever');
+        expect(result).toMatchObject(expectValue);
     });
 
     it('should support for mockImplementationOnce', () => {
-      const fn = jest.fn();
-      const expectValue = { a: 1, b: 2 };
-      when(fn)
-        .calledWith(expect.anything())
-        .mockImplementationOnce(() => expectValue);
+        const fn = jest.fn();
+        const expectValue = { a: 1, b: 2 };
+        when(fn)
+            .calledWith(expect.anything())
+            .mockImplementationOnce(() => expectValue);
 
-      const result = fn('whatever');
-      const result2 = fn('whatever');
-      expect(result).toMatchObject(expectValue);
-      expect(result2).toEqual(undefined);
+        const result = fn('whatever');
+        const result2 = fn('whatever');
+        expect(result).toMatchObject(expectValue);
+        expect(result2).toEqual(undefined);
     });
 
     it('should support resetAllWhenMocks', () => {
-      const fn = jest.fn(_ => 'initial');
+        const fn = jest.fn(_ => 'initial');
 
-      when(fn)
-        .expectCalledWith(1)
-        .mockReturnValueOnce('x');
+        when(fn).expectCalledWith(1).mockReturnValueOnce('x');
 
-      resetAllWhenMocks();
+        resetAllWhenMocks();
 
-      expect(fn(1)).toEqual('initial');
+        expect(fn(1)).toEqual('initial');
     });
 
     it('should supper verifyAllWhenMocksCalled', () => {
-      const fn1 = jest.fn();
-      const fn2 = jest.fn();
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
 
-      when(fn1)
-        .expectCalledWith(1)
-        .mockReturnValue('z');
-      when(fn2)
-        .expectCalledWith(1)
-        .mockReturnValueOnce('x');
-      when(fn2)
-        .expectCalledWith(1)
-        .mockReturnValueOnce('y');
-      when(fn2)
-        .expectCalledWith(1)
-        .mockReturnValue('z');
+        when(fn1).expectCalledWith(1).mockReturnValue('z');
+        when(fn2).expectCalledWith(1).mockReturnValueOnce('x');
+        when(fn2).expectCalledWith(1).mockReturnValueOnce('y');
+        when(fn2).expectCalledWith(1).mockReturnValue('z');
 
-      fn1(1);
-      fn2(1);
-      fn2(1);
-      fn2(1);
+        fn1(1);
+        fn2(1);
+        fn2(1);
+        fn2(1);
 
-      expect(verifyAllWhenMocksCalled).not.toThrow();
+        expect(verifyAllWhenMocksCalled).not.toThrow();
     });
 
     it('allows mocked modules', () => {
-      when(toBeMocked)
-        .calledWith('another one')
-        .mockReturnValue('another one');
+        when(toBeMocked).calledWith('another one').mockReturnValue('another one');
 
-      expect(toBeMocked('another one')).toEqual('another one');
+        expect(toBeMocked('another one')).toEqual('another one');
     });
 
     it('supports function matchers', () => {
-      const fn = jest.fn<string, [{[key: string]: boolean}, number]>();
-      const allValuesTrue = when((arg: {[key: string]: boolean}) => Object.keys(arg).map((k) => arg[k]).every(Boolean));
-      const numberDivisibleBy3 = when((arg: number) => arg % 3 === 0);
+        const fn = jest.fn<string, [{ [key: string]: boolean }, number]>();
+        const allValuesTrue = when((arg: { [key: string]: boolean }) =>
+            Object.keys(arg)
+                .map(k => arg[k])
+                .every(Boolean),
+        );
+        const numberDivisibleBy3 = when((arg: number) => arg % 3 === 0);
 
-      when(fn)
-      .calledWith(allValuesTrue, numberDivisibleBy3)
-      .mockReturnValue('yay!');
+        when(fn).calledWith(allValuesTrue, numberDivisibleBy3).mockReturnValue('yay!');
 
-      expect(fn({ foo: true, bar: true }, 9)).toEqual('yay!');
-      expect(fn({ foo: true, bar: false }, 9)).toEqual(undefined);
-      expect(fn({ foo: true, bar: false }, 13)).toEqual(undefined);
+        expect(fn({ foo: true, bar: true }, 9)).toEqual('yay!');
+        expect(fn({ foo: true, bar: false }, 9)).toEqual(undefined);
+        expect(fn({ foo: true, bar: false }, 13)).toEqual(undefined);
 
-      when(fn)
-        .calledWith('foo', 123)  // $ExpectError
-        .mockReturnValue('nay!');
+        when(fn)
+            .calledWith('foo', 123) // $ExpectError
+            .mockReturnValue('nay!');
 
-      const badMatcher = when((arg: string) => arg.length === 5);
-      when(fn)
-        .calledWith(badMatcher, numberDivisibleBy3)  // $ExpectError
-        .mockReturnValue('nay!');
+        const badMatcher = when((arg: string) => arg.length === 5);
+        when(fn)
+            .calledWith(badMatcher, numberDivisibleBy3) // $ExpectError
+            .mockReturnValue('nay!');
     });
 
     it('supports allArgs', () => {
-      const fn = jest.fn<string, [] | [number] | [number, number]>();
-      const allArgsMatcher = when.allArgs((args: number[]) => args.length === 1);
+        const fn = jest.fn<string, [] | [number] | [number, number]>();
+        const allArgsMatcher = when.allArgs((args: number[]) => args.length === 1);
 
-      when(fn)
-        .calledWith(allArgsMatcher)
-        .mockReturnValue('yay!');
+        when(fn).calledWith(allArgsMatcher).mockReturnValue('yay!');
 
-      expect(fn()).toBe(undefined);
-      expect(fn(123)).toBe('yay!');
-      expect(fn(123, 456)).toBe(undefined);
+        expect(fn()).toBe(undefined);
+        expect(fn(123)).toBe('yay!');
+        expect(fn(123, 456)).toBe(undefined);
 
-      // allArgs matcher should be the only argument to calledWith/expectCalledWith
-      when(fn)
-        .calledWith(allArgsMatcher, 456)  // $ExpectError
-        .mockReturnValue('nay!');
+        // allArgs matcher should be the only argument to calledWith/expectCalledWith
+        when(fn)
+            .calledWith(allArgsMatcher, 456) // $ExpectError
+            .mockReturnValue('nay!');
 
-      when.allArgs((args: number) => args > 0); // $ExpectError
+        when.allArgs((args: number) => args > 0); // $ExpectError
 
-      when.allArgs((args: number[], equals) => args.length > 0 && equals(args, expect.arrayContaining([123])));
+        when.allArgs((args: number[], equals) => args.length > 0 && equals(args, expect.arrayContaining([123])));
     });
 
     it('supports default methods', () => {
-      const fn = jest.fn<string, [string]>();
+        const fn = jest.fn<string, [string]>();
 
-      when(fn)
-        .calledWith('foo').mockReturnValue('special')
-        .defaultReturnValue('default');
+        when(fn).calledWith('foo').mockReturnValue('special').defaultReturnValue('default');
 
-      expect(fn('foo')).toEqual('special');
-      expect(fn('bar')).toEqual('default');
+        expect(fn('foo')).toEqual('special');
+        expect(fn('bar')).toEqual('default');
 
-      function unsupportedCallError(...args: any[]): never {
-        throw new Error(`Wrong args: ${JSON.stringify(args, null, 2)}`);
-      }
+        function unsupportedCallError(...args: any[]): never {
+            throw new Error(`Wrong args: ${JSON.stringify(args, null, 2)}`);
+        }
 
-      when(fn)
-        .calledWith('foo').mockReturnValue('bar')
-        .defaultImplementation(unsupportedCallError);
+        when(fn).calledWith('foo').mockReturnValue('bar').defaultImplementation(unsupportedCallError);
     });
 });

--- a/types/jest-when/jest-when-tests.ts
+++ b/types/jest-when/jest-when-tests.ts
@@ -235,4 +235,23 @@ describe('mock-when test', () => {
 
       when.allArgs((args: number[], equals) => args.length > 0 && equals(args, expect.arrayContaining([123])));
     });
+
+    it('supports default methods', () => {
+      const fn = jest.fn<string, [string]>();
+
+      when(fn)
+        .calledWith('foo').mockReturnValue('special')
+        .defaultReturnValue('default');
+
+      expect(fn('foo')).toEqual('special');
+      expect(fn('bar')).toEqual('default');
+
+      function unsupportedCallError(...args: any[]): never {
+        throw new Error(`Wrong args: ${JSON.stringify(args, null, 2)}`);
+      }
+
+      when(fn)
+        .calledWith('foo').mockReturnValue('bar')
+        .defaultImplementation(unsupportedCallError);
+    });
 });

--- a/types/jest-when/jest-when-tests.ts
+++ b/types/jest-when/jest-when-tests.ts
@@ -190,4 +190,27 @@ describe('mock-when test', () => {
 
       expect(toBeMocked('another one')).toEqual('another one');
     });
+
+    it('supports function matchers', () => {
+      const fn = jest.fn<string, [{[key: string]: boolean}, number]>();
+      const allValuesTrue = when((arg: {[key: string]: boolean}) => Object.keys(arg).map((k) => arg[k]).every(Boolean));
+      const numberDivisibleBy3 = when((arg: number) => arg % 3 === 0);
+
+      when(fn)
+      .calledWith(allValuesTrue, numberDivisibleBy3)
+      .mockReturnValue('yay!');
+
+      expect(fn({ foo: true, bar: true }, 9)).toEqual('yay!');
+      expect(fn({ foo: true, bar: false }, 9)).toEqual(undefined);
+      expect(fn({ foo: true, bar: false }, 13)).toEqual(undefined);
+
+      when(fn)
+        .calledWith('foo', 123)  // $ExpectError
+        .mockReturnValue('nay!');
+
+      const badMatcher = when((arg: string) => arg.length === 5);
+      when(fn)
+        .calledWith(badMatcher, numberDivisibleBy3)  // $ExpectError
+        .mockReturnValue('nay!');
+    });
 });

--- a/types/jest-when/jest-when-tests.ts
+++ b/types/jest-when/jest-when-tests.ts
@@ -213,4 +213,26 @@ describe('mock-when test', () => {
         .calledWith(badMatcher, numberDivisibleBy3)  // $ExpectError
         .mockReturnValue('nay!');
     });
+
+    it('supports allArgs', () => {
+      const fn = jest.fn<string, [] | [number] | [number, number]>();
+      const allArgsMatcher = when.allArgs((args: number[]) => args.length === 1);
+
+      when(fn)
+        .calledWith(allArgsMatcher)
+        .mockReturnValue('yay!');
+
+      expect(fn()).toBe(undefined);
+      expect(fn(123)).toBe('yay!');
+      expect(fn(123, 456)).toBe(undefined);
+
+      // allArgs matcher should be the only argument to calledWith/expectCalledWith
+      when(fn)
+        .calledWith(allArgsMatcher, 456)  // $ExpectError
+        .mockReturnValue('nay!');
+
+      when.allArgs((args: number) => args > 0); // $ExpectError
+
+      when.allArgs((args: number[], equals) => args.length > 0 && equals(args, expect.arrayContaining([123])));
+    });
 });

--- a/types/jest-when/jest-when-tests.ts
+++ b/types/jest-when/jest-when-tests.ts
@@ -181,6 +181,20 @@ describe('mock-when test', () => {
             .mockReturnValue('nay!');
     });
 
+    it('supports mixing function matchers and bare matchers', () => {
+        const fn = jest.fn<string, [{ [key: string]: boolean }, number]>();
+        const allValuesTrue = when((arg: { [key: string]: boolean }) =>
+            Object.keys(arg)
+                .map(k => arg[k])
+                .every(Boolean),
+        );
+
+        when(fn).calledWith(allValuesTrue, 10).mockReturnValue('yay!');
+        when(fn).calledWith({ foo: true }, allValuesTrue); // $ExpectError
+        when(fn).calledWith(10, allValuesTrue); // $ExpectError
+        when(fn).calledWith(allValuesTrue, '10'); // $ExpectError
+    });
+
     it('supports allArgs', () => {
         const fn = jest.fn<string, [] | [number] | [number, number]>();
         const allArgsMatcher = when.allArgs((args: number[]) => args.length === 1);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [README](https://github.com/timkindberg/jest-when#readme), [v3.2.0](https://github.com/timkindberg/jest-when/releases/tag/v3.2.0), [v3.3.0](https://github.com/timkindberg/jest-when/releases/tag/v3.3.0), [v3.5.0](https://github.com/timkindberg/jest-when/releases/tag/v3.5.0). The other versions don't seem to change the interface.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

