### PR TITLE
fix(node): fixed broken markdown link for tsdoc in `http`

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -778,7 +778,7 @@ declare module 'http' {
          * The `message.aborted` property will be `true` if the request has
          * been aborted.
          * @since v10.1.0
-         * @deprecated Since v17.0.0 - Check `message.destroyed` from <a href="stream.html#class-streamreadable" class="type">stream.Readable</a>.
+         * @deprecated Since v17.0.0 - Check `message.destroyed` from [stream.Readable](https://nodejs.org/dist/latest-v17.x/docs/api/stream.html#class-streamreadable).
          */
         aborted: boolean;
         /**


### PR DESCRIPTION
The old link wasn't showing up as a link at all in VSCode IntelliSense. I have also never seen HTML anchor links working anywhere at all. It should be either a `[markdown](link)` or `{@link ...}` afaik. Anyway I opted for the former because it works just about everywhere.

I discovered this bug when my Docusaurus generated website failed on this line trying to find `stream.html` in my own files. I had to temporarily toggle typedoc's `excludeExterrnal` to solve this issue.

<details><summary>Expand to show the logs in which I was alerted of this issue</summary>

```
Unable to build website for locale "en".
Error: Docusaurus found broken links!
Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
Exhaustive list of all broken links found:
- On source page path = /docs/Documentation/api-plugins/classes/sapphire_plugin_api.ApiRequest:
   -> linking to stream.html#class-streamreadable (resolved as: /docs/Documentation/api-plugins/classes/stream.html)
    at reportMessage (/vercel/path0/node_modules/@docusaurus/utils/lib/index.js:306:19)
    at handleBrokenLinks (/vercel/path0/node_modules/@docusaurus/core/lib/server/brokenLinks.js:138:35)
    at async buildLocale (/vercel/path0/node_modules/@docusaurus/core/lib/commands/build.js:157:5)
    at async tryToBuildLocale (/vercel/path0/node_modules/@docusaurus/core/lib/commands/build.js:34:20)
    at async mapAsyncSequencial (/vercel/path0/node_modules/@docusaurus/utils/lib/index.js:262:24)
    at async build (/vercel/path0/node_modules/@docusaurus/core/lib/commands/build.js:70:25)
Error: Command "yarn vercel-build" exited with 1
```

</details>

The old code produced this IntelliSense in VSCode: ![image](https://user-images.githubusercontent.com/4019718/146675548-e169f19f-b983-402e-875a-edb280f9fc68.png)

The new code produces this IntelliSense in VSCode: 
![image](https://user-images.githubusercontent.com/4019718/146675606-60e06169-9d8c-4ee0-a039-c94fc7706f8d.png)

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N.A.