### PR TITLE
fix(chrome): added missing properties to declarativeNetRequest

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10989,6 +10989,18 @@ declare namespace chrome.declarativeNetRequest {
     /** Ruleset ID for the session-scoped rules added by the extension. */
     export const SESSION_RULESET_ID: string;
 
+    /** This describes the HTTP request method of a network request.  */
+    export enum RequestMethod {
+        CONNECT = "connect",
+        DELETE = "delete",
+        GET = "get",
+        HEAD = "head",
+        OPTIONS = "options",
+        PATCH = "patch",
+        POST = "post",
+        PUT = "put"
+    }
+
     /** This describes the resource type of the network request. */
     export enum ResourceType {
         MAIN_FRAME = "main_frame",
@@ -11114,13 +11126,15 @@ declare namespace chrome.declarativeNetRequest {
         type: RuleActionType;
     }
 
-    export interface RuleCondition {
-        /** Specifies whether the network request is first-party or third-party to the domain from which it originated.
+    export type RuleCondition = {
+        /**
+         * Specifies whether the network request is first-party or third-party to the domain from which it originated.
          * If omitted, all requests are accepted.
          */
         domainType?: DomainType | undefined;
 
-        /** The rule will only match network requests originating from the list of domains.
+        /**
+         * The rule will only match network requests originating from the list of domains.
          * If the list is omitted, the rule is applied to requests from all domains.
          * An empty list is not allowed.
          *
@@ -11132,7 +11146,8 @@ declare namespace chrome.declarativeNetRequest {
          */
         domains?: string[] | undefined;
 
-        /** The rule will not match network requests originating from the list of excludedDomains.
+        /**
+         * The rule will not match network requests originating from the list of excludedDomains.
          * If the list is empty or omitted, no domains are excluded.
          * This takes precedence over domains.
          *
@@ -11144,11 +11159,27 @@ declare namespace chrome.declarativeNetRequest {
          */
         excludedDomains?: string[] | undefined;
 
-        /** List of resource types which the rule won't match.
-         * Only one of resourceTypes and excludedResourceTypes should be specified.
+        /**
+         * List of request methods which the rule won't match.
+         * Only one of requestMethods and excludedRequestMethods should be specified.
+         * If neither of them is specified, all request methods are matched.
+         */
+        excludedRequestMethods?: RequestMethod[] | undefined;
+
+        /**
+         * List of resource types which the rule won't match.
+         * Only one of {@link chrome.declarativeNetRequest.RuleCondition.resourceTypes}
+         * and {@link chrome.declarativeNetRequest.RuleCondition.excludedResourceTypes} should be specified.
          * If neither of them is specified, all resource types except "main_frame" are blocked.
          */
         excludedResourceTypes?: ResourceType[] | undefined;
+
+        /**
+         * List of {@link chrome.tabs.Tab.id} which the rule should not match.
+         * An ID of {@link chrome.tabs.TAB_ID_NONE} excludes requests which don't originate from a tab.
+         * Only supported for session-scoped rules.
+         */
+        excludedTabIds?: number[] | undefined;
 
         /**
          * Whether the urlFilter or regexFilter (whichever is specified) is case sensitive.
@@ -11156,7 +11187,8 @@ declare namespace chrome.declarativeNetRequest {
          */
         isUrlFilterCaseSensitive?: boolean | undefined;
 
-        /** Regular expression to match against the network request url.
+        /**
+         * Regular expression to match against the network request url.
          * This follows the RE2 syntax.
          *
          * Note: Only one of urlFilter or regexFilter can be specified.
@@ -11166,14 +11198,22 @@ declare namespace chrome.declarativeNetRequest {
          */
         regexFilter?: string | undefined;
 
-        /** List of resource types which the rule can match.
-         * An empty list is not allowed.
-         *
-         * Note: this must be specified for allowAllRequests rules and may only include the sub_frame and main_frame resource types.
+        /**
+         * List of HTTP request methods which the rule can match. An empty list is not allowed.
+         * Note: Specifying a {@link chrome.declarativeNetRequest.RuleCondition.requestMethods} rule condition will also exclude non-HTTP(s) requests,
+         * whereas specifying {@link chrome.declarativeNetRequest.RuleCondition.excludedRequestMethods} will not.
          */
-        resourceTypes?: ResourceType[] | undefined;
+        requestMethods?: RequestMethod[];
 
-        /** The pattern which is matched against the network request url.
+        /**
+         * List of {@link chrome.tabs.Tab.id} which the rule should not match.
+         * An ID of {@link chrome.tabs.TAB_ID_NONE} excludes requests which don't originate from a tab.
+         * An empty list is not allowed. Only supported for session-scoped rules.
+         */
+        tabIds?: number | undefined;
+
+        /**
+         * The pattern which is matched against the network request url.
          * Supported constructs:
          *
          * '*' : Wildcard: Matches any number of characters.
@@ -11198,7 +11238,26 @@ declare namespace chrome.declarativeNetRequest {
          * For example, when the request url is http://abc.рф?q=ф, the urlFilter will be matched against the url http://abc.xn--p1ai/?q=%D1%84.
          */
         urlFilter?: string | undefined;
-    }
+    } & (
+        | {
+              /**
+               * List of resource types which the rule won't match.
+               * Only one of {@link chrome.declarativeNetRequest.RuleCondition.resourceTypes}
+               * and {@link chrome.declarativeNetRequest.RuleCondition.excludedResourceTypes} should be specified.
+               * If neither of them is specified, all resource types except "main_frame" are blocked.
+               */
+              excludedResourceTypes?: ResourceType[] | undefined;
+          }
+        | {
+              /**
+               * List of resource types which the rule can match.
+               * An empty list is not allowed.
+               *
+               * Note: this must be specified for allowAllRequests rules and may only include the sub_frame and main_frame resource types.
+               */
+              resourceTypes?: ResourceType[] | undefined;
+          }
+    );
 
     export interface MatchedRule {
         /** A matching rule's ID. */
@@ -11368,7 +11427,8 @@ declare namespace chrome.declarativeNetRequest {
         /** Rules to add. */
         addRules?: Rule[] | undefined;
 
-        /** IDs of the rules to remove.
+        /**
+         * IDs of the rules to remove.
          * Any invalid IDs will be ignored.
          */
         removeRuleIds?: number[] | undefined;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1070,6 +1070,20 @@ async function testDeclarativeNetRequestForPromise() {
     await chrome.declarativeNetRequest.updateSessionRules({});
 }
 
+async function testDynamicRules() {
+    await chrome.declarativeNetRequest.updateDynamicRules({});
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      addRules: [{
+        action: {
+          type: chrome.declarativeNetRequest.RuleActionType.ALLOW,
+        },
+        condition: {},
+        id: 2,
+        priority: 3,
+      }],
+    });
+}
+
 // https://developer.chrome.com/docs/extensions/reference/storage
 function testStorageForPromise() {
     chrome.storage.sync.getBytesInUse().then(() => {});


### PR DESCRIPTION
@nev-sc pointed out in #57759 that chrome.declarativeNetRequest.RuleCondition was missing a few properties. This PR adds the missing properties.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#type-RuleCondition
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.