### PR TITLE
rsync: Update types for build method when method doesn't take an argument

### DIFF
--- a/types/rsync/index.d.ts
+++ b/types/rsync/index.d.ts
@@ -26,8 +26,8 @@ interface Rsync {
 
     unset(option: string): Rsync;
 
+    flags(...args: Array<string | boolean>): Rsync;
     flags(flags: string | string[] | Flag, set?: boolean): Rsync;
-    flags(...args: any[]): Rsync;
 
     isSet(option: string): boolean;
 
@@ -82,7 +82,16 @@ interface Rsync {
 interface RsyncStatic {
     new (): Rsync;
 
-    build: (options: Partial<{ [ Property in keyof Rsync ]: Parameters<Rsync[Property]>[0] }>) => Rsync;
+    // The `build` method will take an arguments object where the key is an rsync method and the value is the first paramater to that argument.
+    // If the method doesn't take an argument (e.g. `archive`, `progress`) then the value should be "true".
+    // Technically speaking, the value can be anything if the method doesn't take an argument, but it may as well be typed consistently here.
+    build: (
+        options: Partial<{
+            [Property in keyof Rsync]: [Parameters<Rsync[Property]>[0]] extends [undefined]
+                ? true
+                : Parameters<Rsync[Property]>[0];
+        }>,
+    ) => Rsync;
 }
 
 declare const e: RsyncStatic;

--- a/types/rsync/rsync-tests.ts
+++ b/types/rsync/rsync-tests.ts
@@ -168,3 +168,9 @@ Rsync.build({
 Rsync.build({
   flags: [ 'avz', '123' ],
 })
+
+// Static build for methods that don't take arguments
+Rsync.build({
+    progress: true,
+    archive: true
+});


### PR DESCRIPTION
The `build` method will take an arguments object where the key is an rsync method and the value is the first parameter to that argument.
If the method doesn't take an argument (e.g. `archive`, `progress`) then the value should be "true".
Technically speaking, the value can be anything if the method doesn't take an argument, but it may as well be typed consistently here.
See the source code [here](https://github.com/mattijs/node-rsync/blob/master/rsync.js#L90)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
