### PR TITLE
[jsts] Fix GeoJSONReader constructor

### DIFF
--- a/types/jsts/index.d.ts
+++ b/types/jsts/index.d.ts
@@ -2322,7 +2322,7 @@ declare namespace jsts {
         }
 
         export class GeoJSONReader {
-            constructor();
+            constructor(geometryFactory?: jsts.geom.GeometryFactory);
 
             /**
              * Converts a GeoJSON to its <code>Geometry</code> representation.

--- a/types/jsts/jsts-tests.ts
+++ b/types/jsts/jsts-tests.ts
@@ -164,6 +164,9 @@ n = poly.getNumInteriorRing();
 var gjw: jsts.io.GeoJSONWriter = new jsts.io.GeoJSONWriter();
 obj = gjw.write(g);
 
+var gjr: jsts.io.GeoJSONReader = new jsts.io.GeoJSONReader(factory);
+g = gjr.read(obj);
+
 var wr: jsts.io.WKTReader = new jsts.io.WKTReader();
 g = wr.read(str);
 wr.reducePrecision(g);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
I couldn't find the documentation for the GeoJSONReader class in the JTS doc even though the class seems to exist in the repository :
https://github.com/locationtech/jts/blob/master/modules/io/common/src/main/java/org/locationtech/jts/io/geojson/GeoJsonReader.java
So the modification is based on the fact that the factory is an optional parameter in the JSTS code (which seems coherent with the fact that the java class has 2 constructors, one with the parameter, one without) :
https://github.com/bjornharrtell/jsts/blob/master/src/org/locationtech/jts/io/GeoJSONReader.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
