### PR TITLE
fix formidable types

### DIFF
--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -11,6 +11,7 @@ import {
     Options,
     PersistentFile,
     VolatileFile,
+    Part
 } from "formidable";
 import * as http from "http";
 
@@ -28,6 +29,11 @@ const options: Options = {
     minFileSize: 1,
     multiples: false,
     uploadDir: "/dir",
+    filter: (part) => {
+        // $ExpectType Part
+        part;
+        return true;
+    }
 };
 
 const file: File = {
@@ -40,7 +46,7 @@ const file: File = {
     size: 20,
     mimetype: "json",
     toJSON: () => ({
-        newFilename: file.newFilename!,
+        newFilename: file.newFilename,
         length: 10,
         mimetype: file.mimetype,
         mtime: file.mtime!,

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -176,9 +176,11 @@ declare namespace formidable {
          *
          * @default undefined
          */
-        filename?: (name: string, ext: string, part: string, form: string) => string | undefined;
+        filename?: (name: string, ext: string, part: Part, form: Formidable) => string;
 
         enabledPlugins?: string[] | undefined;
+
+        filter?: (part: Part) => boolean;
     }
 
     interface Fields {
@@ -189,10 +191,9 @@ declare namespace formidable {
     }
 
     interface Part extends Stream {
-        filename?: string | undefined;
-        headers: Record<string, string>;
-        mime?: string | undefined;
-        name: string;
+        name: string | null;
+        originalFilename: string | null;
+        mimetype: string | null;
     }
 
     /**
@@ -225,7 +226,7 @@ declare namespace formidable {
         /**
          * Calculated based on options provided
          */
-        newFilename: string | null;
+        newFilename: string;
 
         /**
          * The mime type of this file, according to the uploading client.


### PR DESCRIPTION
This PR make following changes.

* add `options.filter`
  * this option available on formidable v2.0.0
  * https://github.com/node-formidable/formidable/tree/1c30ec67648eb7ddcf50e548b0cd8bed384fde40
* fix argument (`part` and `form`) and return value types of  `options.filename`
  * https://github.com/node-formidable/formidable/tree/1c30ec67648eb7ddcf50e548b0cd8bed384fde40#optionsfilename--function-function-name-ext-part-form---string 
* fix `File.newFilename` type
  * According to the [documentation](https://github.com/node-formidable/formidable/tree/1c30ec67648eb7ddcf50e548b0cd8bed384fde40#file) it can be null. but as far as I read the implementation, it seems that there are no cases where it becomes null. If anyone knows about it, please let me know.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
