### PR TITLE
[backbone] add hashChange to HistoryOptions

### DIFF
--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -360,6 +360,7 @@ function test_collection() {
 //////////
 
 Backbone.history.start();
+Backbone.history.start({hashChange: false});
 Backbone.History.started;
 Backbone.history.loadUrl();
 Backbone.history.loadUrl('12345');

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -41,6 +41,7 @@ declare namespace Backbone {
     interface HistoryOptions extends Silenceable {
         pushState?: boolean | undefined;
         root?: string | undefined;
+        hashChange?: boolean | undefined;
     }
 
     interface NavigateOptions {


### PR DESCRIPTION
This adds in the hashChange option to HistoryOptions, which is used by Backbone to here: https://github.com/jashkenas/backbone/blob/master/backbone.js#L1839