### PR TITLE
[ramda] Allow `number` and `symbol` as keys for `mapObjIndexed`

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1209,18 +1209,18 @@ export function mapAccumRight<T, U, TResult>(fn: (acc: U, value: T) => [U, TResu
 type PartialRecord<K extends keyof any, T> = {
     [P in K]?: T;
 };
-export function mapObjIndexed<T, TResult, TKey extends string>(
+export function mapObjIndexed<T, TResult, TKey extends string | number | symbol>(
     fn: (value: T, key: TKey, obj?: Record<TKey, T>) => TResult,
     obj: Record<TKey, T>
 ): Record<TKey, TResult>;
-export function mapObjIndexed<T, TResult, TKey extends string>(
+export function mapObjIndexed<T, TResult, TKey extends string | number | symbol>(
     fn: (value: T, key: TKey, obj?: Record<TKey, T>) => TResult,
     obj: PartialRecord<TKey, T>
 ): PartialRecord<TKey, TResult>;
-export function mapObjIndexed<T, TResult, TKey extends string>(
+export function mapObjIndexed<T, TResult, TKey extends string | number | symbol>(
     fn: (value: T, key: TKey, obj?: Record<TKey, T>) => TResult
 ): (obj: Record<TKey, T>) => Record<TKey, TResult>;
-export function mapObjIndexed<T, TResult, TKey extends string>(
+export function mapObjIndexed<T, TResult, TKey extends string | number | symbol>(
     fn: (value: T, key: TKey, obj?: PartialRecord<TKey, T>) => TResult
 ): (obj: Record<TKey, T>) => PartialRecord<TKey, TResult>;
 export function mapObjIndexed<T, TResult>(


### PR DESCRIPTION
- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test ramda`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [MDN - Working with objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects)
     > Please note that all keys in the square bracket notation are converted to string unless they're Symbols, since JavaScript object property names (keys) can only be strings or Symbols
