### PR TITLE
Fix Leaflet panInside which supports PanOptions and ZoomOptions

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1615,7 +1615,7 @@ export interface FitBoundsOptions extends ZoomOptions, PanOptions {
     maxZoom?: number | undefined;
 }
 
-export interface PanInsideOptions {
+export interface PanInsideOptions extends ZoomOptions, PanOptions {
     paddingTopLeft?: PointExpression | undefined;
     paddingBottomRight?: PointExpression | undefined;
     padding?: PointExpression | undefined;

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1615,7 +1615,7 @@ export interface FitBoundsOptions extends ZoomOptions, PanOptions {
     maxZoom?: number | undefined;
 }
 
-export interface PanInsideOptions extends ZoomOptions, PanOptions {
+export interface PanInsideOptions extends PanOptions {
     paddingTopLeft?: PointExpression | undefined;
     paddingBottomRight?: PointExpression | undefined;
     padding?: PointExpression | undefined;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -216,6 +216,7 @@ map.removeEventListener('dblclick', (_e: L.LeafletMouseEvent) => {});
 map.removeEventListener('locationerror', (_e: L.ErrorEvent) => {}, {});
 
 map.panInside(latLng, { padding: [50, 50], paddingBottomRight: point, paddingTopLeft: [100, 100] });
+map.panInside(latLng, { padding: [50, 50], paddingBottomRight: point, paddingTopLeft: [100, 100], animate: true, duration: 0.5 });
 
 // map.getRenderer
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js#L536 panInside calls pan and forwards the options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
