### PR TITLE
connect-timeout accepts numbers for delay

### DIFF
--- a/types/connect-timeout/connect-timeout-tests.ts
+++ b/types/connect-timeout/connect-timeout-tests.ts
@@ -21,3 +21,13 @@ function haltOnTimedout(req: express.Request, res: express.Response, next: Funct
 }
 
 app.listen(3000);
+
+// check use of number as delay
+var app2 = express();
+app2.use(timeout(500));
+app2.use(bodyParser());
+app2.use(haltOnTimedout);
+app2.use(cookieParser());
+app2.use(haltOnTimedout);
+
+app2.listen(3001);

--- a/types/connect-timeout/index.d.ts
+++ b/types/connect-timeout/index.d.ts
@@ -37,6 +37,9 @@ declare module "connect-timeout" {
         }
     }
 
-    function e(timeout: number | string, options?: e.TimeoutOptions): express.RequestHandler;
+    /**
+     * @summary Returns middleware that times out in time milliseconds. time can also be a string accepted by the ms module. On timeout, req will emit "timeout".
+     */
+    function e(time: number | string, options?: e.TimeoutOptions): express.RequestHandler;
     export = e;
 }

--- a/types/connect-timeout/index.d.ts
+++ b/types/connect-timeout/index.d.ts
@@ -37,6 +37,6 @@ declare module "connect-timeout" {
         }
     }
 
-    function e(timeout: string, options?: e.TimeoutOptions): express.RequestHandler;
+    function e(timeout: number | string, options?: e.TimeoutOptions): express.RequestHandler;
     export = e;
 }


### PR DESCRIPTION
The function exported by the `connect-timeout` package can accept either a number (as a representation of milliseconds) or a string for the first argument, but currently it is only typed as a string. This PR changes the type of said parameter to a union type `number | string`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Parameter documentation](https://github.com/expressjs/timeout#timeouttime-options)
  - [Parameter use in code](https://github.com/expressjs/timeout/blob/master/index.js#L40)
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~