### PR TITLE
meteor: Add new useSubscribe and useFind methods

### DIFF
--- a/types/meteor/react-meteor-data.d.ts
+++ b/types/meteor/react-meteor-data.d.ts
@@ -11,3 +11,17 @@ export function withTracker<TDataProps, TOwnProps>(
  * Requires react-meteor-data 2.0.0 or later
  */
 export function useTracker<TDataProps>(getMeteorData: () => TDataProps, deps?: React.DependencyList): TDataProps;
+
+/**
+ * Requires react-meteor-data 2.4.0 or later
+ */
+export function useSubscribe(name?: string, ...args: any[]): () => boolean;
+// If the factory is non-nullable, it will always return a list
+export function useFind<T>(
+    factory: () => Mongo.Cursor<T>,
+    deps?: React.DependencyList,
+): T[];
+export function useFind<T>(
+    factory: () => (Mongo.Cursor<T> | undefined | null),
+    deps?: React.DependencyList,
+): T[] | null;

--- a/types/meteor/test/react-meteor-data-tests.tsx
+++ b/types/meteor/test/react-meteor-data-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withTracker, useTracker } from 'meteor/react-meteor-data';
+import { withTracker, useTracker, useSubscribe, useFind } from 'meteor/react-meteor-data';
 
 interface DemoComponentContainerProps {
     status: string;
@@ -34,3 +34,37 @@ const RootComponent = () => (
         <HooksDemoComponentContainer status="ok" />
     </>
 );
+
+interface Post {
+    _id: string;
+    title: string;
+    groupId: string;
+};
+const Posts = new Mongo.Collection<Post>('posts');
+
+const UseSubscribeComponent = ({ groupId, skip }: { groupId: string, skip: boolean }) => {
+    // Note: isLoading is a function!
+    const isLoading = useSubscribe('posts', groupId);
+    const posts = useFind(() => Posts.find({ groupId }), [groupId]);
+
+    // $ExpectType Post[]
+    posts;
+
+    const optionalPosts = useFind(() => {
+        if (skip) {
+            return null;
+        }
+        return Posts.find({ groupId });
+    }, [skip]);
+
+    // $ExpectType Post[] | null
+    optionalPosts;
+
+    if (isLoading()) {
+        return <div>Loading...</div>
+    } else {
+        return <ul>
+            {posts.map(post => <li key={post._id}>{post.title}</li>)}
+        </ul>
+    }
+}


### PR DESCRIPTION
New methods in the recent 2.4.0 release of react-meteor-data (a
Meteor-internal package). These type declarations are mostly taken
directly from the code for react-meteor-data (which is in Typescript).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/meteor/react-packages/tree/master/packages/react-meteor-data#usesubscribesubname-args-a-convenient-wrapper-for-subscriptions)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
