### PR TITLE
wrong types in @types/identicon.js

### DIFF
--- a/types/identicon.js/index.d.ts
+++ b/types/identicon.js/index.d.ts
@@ -38,15 +38,15 @@ export interface PNGlib {
 
 export interface Svg {
     size: number;
-    foreground: Color;
-    background: Color;
+    foreground: string;
+    background: string;
     rectangles: [
         {
             x: number;
             y: number;
             width: number;
             height: number;
-            color: Color;
+            color: string;
         }
     ];
 
@@ -105,7 +105,7 @@ export default class Identicon {
         y: number,
         w: number,
         h: number,
-        color: Color,
+        color: string | Color,
         image: Svg | PNGlib
     ): void;
 


### PR DESCRIPTION
`Svg.color` returns string so if format is svg foreground and background will be string as well as rectangle color property
see https://github.com/stewartlord/identicon.js/blob/master/identicon.js#L144

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](https://github.com/stewartlord/identicon.js/blob/master/identicon.js#L144)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
