### PR TITLE
Adding missing handleReturn to EditorProps v1.13.4

### DIFF
--- a/types/react-draft-wysiwyg/index.d.ts
+++ b/types/react-draft-wysiwyg/index.d.ts
@@ -76,6 +76,10 @@ export interface EditorProps {
         editorState: EditorState,
         onChange: (editorState: EditorState) => void,
     ): boolean;
+    handleReturn?(
+        e: SyntheticKeyboardEvent,
+        editorState: EditorState
+    ): boolean;
     customStyleMap?: object | undefined;
 }
 


### PR DESCRIPTION
Fixing https://github.com/jpuri/react-draft-wysiwyg/issues/1148 by adding a simple missing interface option.

This option is [visible here](https://github.com/jpuri/react-draft-wysiwyg/blob/f59ee8419cdbd45aab3bdfdf1995f112b09bbb6a/src/Editor/index.js#L369) and similar to adjacent ones that already exist such as `handlePastedText`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) 
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/jpuri/react-draft-wysiwyg/blob/f59ee8419cdbd45aab3bdfdf1995f112b09bbb6a/src/Editor/index.js#L369)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

^ Note, it's been an option since the beginning but for some reason is missing, so just a patch bump is fine.
 