### PR TITLE
Add missing buffered parameter in node/perf_hooks.d.ts

### DIFF
--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -397,9 +397,11 @@ declare module 'perf_hooks' {
             options:
                 | {
                       entryTypes: ReadonlyArray<EntryType>;
+                      buffered?: boolean | undefined;
                   }
                 | {
                       type: EntryType;
+                      buffered?: boolean | undefined;
                   }
         ): void;
     }

--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -62,9 +62,11 @@ const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => 
 const obs = new PerformanceObserver(performanceObserverCallback);
 obs.observe({
     entryTypes: ['gc'],
+    buffered: true,
 });
 obs.observe({
     type: 'gc',
+    buffered: true,
 });
 
 const monitor: IntervalHistogram = monitorEventLoopDelay({

--- a/types/node/v16/perf_hooks.d.ts
+++ b/types/node/v16/perf_hooks.d.ts
@@ -397,9 +397,11 @@ declare module 'perf_hooks' {
             options:
                 | {
                       entryTypes: ReadonlyArray<EntryType>;
+                      buffered?: boolean | undefined;
                   }
                 | {
                       type: EntryType;
+                      buffered?: boolean | undefined;
                   }
         ): void;
     }

--- a/types/node/v16/test/perf_hooks.ts
+++ b/types/node/v16/test/perf_hooks.ts
@@ -62,9 +62,11 @@ const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => 
 const obs = new PerformanceObserver(performanceObserverCallback);
 obs.observe({
     entryTypes: ['gc'],
+    buffered: true,
 });
 obs.observe({
     type: 'gc',
+    buffered: true,
 });
 
 const monitor: IntervalHistogram = monitorEventLoopDelay({


### PR DESCRIPTION
`options` parameter in `performanceObserver.observe(options)` was missing `buffered` property. This is probably because the buffered option was removed for Node v16.0.0 and added back for v16.7.0. For more information please see [Node documentation](https://nodejs.org/docs/latest-v17.x/api/perf_hooks.html#performanceobserverobserveoptions) for `observe`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.