### PR TITLE
[node] Add missing aliases `node:path/posix` and `node:path/win32`

### DIFF
--- a/types/node/path.d.ts
+++ b/types/node/path.d.ts
@@ -170,3 +170,11 @@ declare module 'node:path' {
     import path = require('path');
     export = path;
 }
+declare module 'node:path/posix' {
+    import path = require('path/posix');
+    export = path;
+}
+declare module 'node:path/win32' {
+    import path = require('path/win32');
+    export = path;
+}

--- a/types/node/test/path.ts
+++ b/types/node/test/path.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
-import * as win32Path from 'path/win32';
-import * as posixPath from 'path/posix';
+import * as win32Path from 'node:path/win32';
+import * as posixPath from 'node:path/posix';
 
 path.normalize('/foo/bar//baz/asdf/quux/..');
 

--- a/types/node/v16/path.d.ts
+++ b/types/node/v16/path.d.ts
@@ -170,3 +170,11 @@ declare module 'node:path' {
     import path = require('path');
     export = path;
 }
+declare module 'node:path/posix' {
+    import path = require('path/posix');
+    export = path;
+}
+declare module 'node:path/win32' {
+    import path = require('path/win32');
+    export = path;
+}

--- a/types/node/v16/test/path.ts
+++ b/types/node/v16/test/path.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
-import * as win32Path from 'path/win32';
-import * as posixPath from 'path/posix';
+import * as win32Path from 'node:path/win32';
+import * as posixPath from 'node:path/posix';
 
 path.normalize('/foo/bar//baz/asdf/quux/..');
 


### PR DESCRIPTION
Please fill in this template.

Related discussion: #57816.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Node.JS documentation for `node:` prefix in [`cjs`] and [`esm`].
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

[`cjs`]: https://nodejs.org/docs/latest-v16.x/api/modules.html#core-modules
[`esm`]: https://nodejs.org/docs/latest-v16.x/api/esm.html#node-imports
