### PR TITLE
[formidable] Fix incorrect return type of fileWriteStreamHandler

### DIFF
--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -67,6 +67,8 @@ Formidable.DEFAULT_OPTIONS;
 defaultOptions;
 defaultOptions.enabledPlugins; // $ExpectType EnabledPlugins
 
+options.fileWriteStreamHandler; // $ExpectType (() => Writable) | undefined
+
 // $ExpectType EnabledPlugins
 enabledPlugins;
 

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="node" />
 
-import { Stream } from "stream";
+import { Stream, Writable } from "stream";
 import Formidable = require("./Formidable");
 import parsers = require("./parsers/index");
 import PersistentFile = require("./PersistentFile");
@@ -159,7 +159,7 @@ declare namespace formidable {
          *
          * @default null
          */
-        fileWriteStreamHandler?: (() => void) | undefined;
+        fileWriteStreamHandler?: (() => Writable) | undefined;
 
         /**
          * when you call the .parse method, the files argument (of the callback) will contain arrays of


### PR DESCRIPTION
- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-formidable/formidable/issues/802
- [ x ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
