### PR TITLE
add loggingOut source to accounts-base

### DIFF
--- a/types/meteor/accounts-base.d.ts
+++ b/types/meteor/accounts-base.d.ts
@@ -87,6 +87,8 @@ declare module 'meteor/accounts-base' {
 
         function loggingIn(): boolean;
 
+        function loggingOut(): boolean;
+
         function logout(callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void): void;
 
         function logoutOtherClients(callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void): void;

--- a/types/meteor/globals/accounts-base.d.ts
+++ b/types/meteor/globals/accounts-base.d.ts
@@ -81,6 +81,8 @@ declare module Accounts {
 
     function loggingIn(): boolean;
 
+    function loggingOut(): boolean;
+
     function logout(callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void): void;
 
     function logoutOtherClients(callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void): void;

--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -298,8 +298,6 @@ declare module Meteor {
         callback?: (error?: global_Error | Meteor.Error | Meteor.TypedError) => void,
     ): void;
 
-    function loggingIn(): boolean;
-
     function loginWith<ExternalService>(
         options?: {
             requestPermissions?: ReadonlyArray<string> | undefined;
@@ -322,6 +320,8 @@ declare module Meteor {
         token: string,
         callback?: (error?: global_Error | Meteor.Error | Meteor.TypedError) => void,
     ): void;
+
+    function loggingIn(): boolean;
 
     function loggingOut(): boolean;
 

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -305,8 +305,6 @@ declare module 'meteor/meteor' {
             callback?: (error?: global_Error | Meteor.Error | Meteor.TypedError) => void,
         ): void;
 
-        function loggingIn(): boolean;
-
         function loginWith<ExternalService>(
             options?: {
                 requestPermissions?: ReadonlyArray<string> | undefined;
@@ -329,6 +327,8 @@ declare module 'meteor/meteor' {
             token: string,
             callback?: (error?: global_Error | Meteor.Error | Meteor.TypedError) => void,
         ): void;
+
+        function loggingIn(): boolean;
 
         function loggingOut(): boolean;
 

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -579,6 +579,9 @@ namespace MeteorTests {
         },
     );
 
+    Accounts.loggingIn(); // $ExpectType boolean
+    Accounts.loggingOut(); // $ExpectType boolean
+
     Meteor.loggingIn(); // $ExpectType boolean
     Meteor.loggingOut(); // $ExpectType boolean
 

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -579,6 +579,7 @@ namespace MeteorTests {
         },
     );
 
+    Meteor.loggingIn(); // $ExpectType boolean
     Meteor.loggingOut(); // $ExpectType boolean
 
     Meteor.user();

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -594,6 +594,9 @@ namespace MeteorTests {
         },
     );
 
+    Accounts.loggingIn(); // $ExpectType boolean
+    Accounts.loggingOut(); // $ExpectType boolean
+
     Meteor.loggingIn(); // $ExpectType boolean
     Meteor.loggingOut(); // $ExpectType boolean
 

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -594,6 +594,7 @@ namespace MeteorTests {
         },
     );
 
+    Meteor.loggingIn(); // $ExpectType boolean
     Meteor.loggingOut(); // $ExpectType boolean
 
     Meteor.user();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Accounts.loggingOut source code](https://github.com/meteor/meteor/blob/devel/packages/accounts-base/accounts_client.js#L60-L66)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

While `loggingOut` was already documented under the `Meteor` module scope, it was not under `Accounts`. Tests were added covering both `(Meteor|Accounts).logging(In|Out)` where only `Meteor.loggingOut` was tested prior. I also moved the declarations to be side-by-side in the `Meteor` module file instead of interrupting `loginWith*` functions (I think this improves readability -- I thought it was missing there as well on first glance).

In order to get the tests running, I had to add `"@types/node": "^14.18.2"` to `types/meteor/package.json` dependencies. This solved an error appearing for me about conflicting versions when running `npm test meteor` -- [gist here](https://gist.github.com/WilliamKelley/57c0fc93f47a4fd19785e584fc90054c). I'm not sure if it's a symptom of me doing something wrong, but I can add it to the changes as well.
