### PR TITLE
[amplitude-js] remove myself as author

### DIFF
--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for Amplitude SDK 8.0
 // Project: https://github.com/amplitude/Amplitude-Javascript
-// Definitions by: Arvydas Sidorenko <https://github.com/Asido>
-//                 Dan Manastireanu <https://github.com/danmana>
+// Definitions by: Dan Manastireanu <https://github.com/danmana>
 //                 Kimmo Hintikka <https://github.com/HintikkaKimmo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/amplitude-js/v4/index.d.ts
+++ b/types/amplitude-js/v4/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for Amplitude SDK 4.4.0
 // Project: https://github.com/amplitude/Amplitude-Javascript
-// Definitions by: Arvydas Sidorenko <https://github.com/Asido>
-//                 Dan Manastireanu <https://github.com/danmana>
+// Definitions by: Dan Manastireanu <https://github.com/danmana>
 //                 Kimmo Hintikka <https://github.com/HintikkaKimmo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/amplitude-js/v5/index.d.ts
+++ b/types/amplitude-js/v5/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for Amplitude SDK 5.11
 // Project: https://github.com/amplitude/Amplitude-Javascript
-// Definitions by: Arvydas Sidorenko <https://github.com/Asido>
-//                 Dan Manastireanu <https://github.com/danmana>
+// Definitions by: Dan Manastireanu <https://github.com/danmana>
 //                 Kimmo Hintikka <https://github.com/HintikkaKimmo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 


### PR DESCRIPTION
The patch removes me as `amplitude-js` author to stop email notifications.