### PR TITLE
Add walk-asyncgen v0.0.5 types

### DIFF
--- a/types/walk-asyncgen/index.d.ts
+++ b/types/walk-asyncgen/index.d.ts
@@ -1,38 +1,37 @@
-// Type definitions for walk-asyncgen 0.0.5
+// Type definitions for walk-asyncgen 0.0
 // Project: https://bitbucket.org/ShoemakerSteve/walk-asyncgen
 // Definitions by: PythonCoderAS <https://github.com/PythonCoderAS>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
-export interface Options {
+interface Options {
     /**
      * A regex of which directories to exclude.
      */
-    excludeDirs?: false | RegExp,
+    excludeDirs?: false | RegExp;
     /**
      * A regex of which files to exclude.
      */
-    excludeFiles?: false | RegExp,
+    excludeFiles?: false | RegExp;
     /**
      * A regex of which extensions to exclude.
      */
-    excludeExt?: false | RegExp,
+    excludeExt?: false | RegExp;
     /**
      * A regex of which directories to include. If provided, only directories matching this regex will be walked.
      */
-    includeDirs?: false | RegExp,
+    includeDirs?: false | RegExp;
     /**
      * A regex of which files to include. If provided, only files matching this regex will be walked.
      */
-    includeFiles?: false | RegExp,
+    includeFiles?: false | RegExp;
     /**
      * A regex of which extensions to include. If provided, only files with extensions matching this regex will be walked.
      */
-    includeExt?: false | RegExp,
+    includeExt?: false | RegExp;
     /**
      * Whether to print the directory that is initially walked.
      */
-    printDirs?: boolean,
+    printDirs?: boolean;
 }
 
 /**
@@ -40,4 +39,6 @@ export interface Options {
  * @param dir The directory to start at. Defaults to the current working directory.
  * @param options Optional settings for the walk.
  */
-export default function pathsGenerator(dir?: string, options?: Options): AsyncGenerator<string, void, void>;
+declare function pathsGenerator(dir?: string, options?: Options): AsyncGenerator<string, void, void>;
+
+export = pathsGenerator;

--- a/types/walk-asyncgen/index.d.ts
+++ b/types/walk-asyncgen/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for walk-asyncgen 0.0.5
+// Project: https://bitbucket.org/ShoemakerSteve/walk-asyncgen
+// Definitions by: PythonCoderAS <https://github.com/PythonCoderAS>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
+export interface Options {
+    /**
+     * A regex of which directories to exclude.
+     */
+    excludeDirs?: false | RegExp,
+    /**
+     * A regex of which files to exclude.
+     */
+    excludeFiles?: false | RegExp,
+    /**
+     * A regex of which extensions to exclude.
+     */
+    excludeExt?: false | RegExp,
+    /**
+     * A regex of which directories to include. If provided, only directories matching this regex will be walked.
+     */
+    includeDirs?: false | RegExp,
+    /**
+     * A regex of which files to include. If provided, only files matching this regex will be walked.
+     */
+    includeFiles?: false | RegExp,
+    /**
+     * A regex of which extensions to include. If provided, only files with extensions matching this regex will be walked.
+     */
+    includeExt?: false | RegExp,
+    /**
+     * Whether to print the directory that is initially walked.
+     */
+    printDirs?: boolean,
+}
+
+/**
+ * Walk a directory asynchronously and returns every file found.
+ * @param dir The directory to start at. Defaults to the current working directory.
+ * @param options Optional settings for the walk.
+ */
+export default function pathsGenerator(dir?: string, options?: Options): AsyncGenerator<string, void, void>;

--- a/types/walk-asyncgen/tsconfig.json
+++ b/types/walk-asyncgen/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "es2018"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "walk-asyncgen-tests.ts"
+    ]
+}

--- a/types/walk-asyncgen/tslint.json
+++ b/types/walk-asyncgen/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/walk-asyncgen/tslint.json
+++ b/types/walk-asyncgen/tslint.json
@@ -1,1 +1,1 @@
-{ "extends": "dtslint/dt.json" }
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/walk-asyncgen/walk-asyncgen-tests.ts
+++ b/types/walk-asyncgen/walk-asyncgen-tests.ts
@@ -1,0 +1,29 @@
+import pathsGenerator  from "./"
+
+// $ExpectType AsyncGenerator<string, void, void>
+const generator = pathsGenerator(".")
+
+// $ExpectType Options
+const excludeOptions = {
+    excludeFiles: /tslint.\S+/,
+    excludeDirs: /node_modules/,
+    excludeExt: /mp3$/
+}
+
+// $ExpectType Options
+const includeFilesoptions = {
+    includeFiles: /tslint.\S+/,
+    includeExt: /json/,
+    printDirs: false
+}
+
+// $ExpectError
+const errorOptions = {
+    excludeFiles: "",
+    excludeDirs: "",
+    excludeExt: ".mp3"
+}
+
+// $ExpectError
+
+pathsGenerator(".", {includeDirs: true})

--- a/types/walk-asyncgen/walk-asyncgen-tests.ts
+++ b/types/walk-asyncgen/walk-asyncgen-tests.ts
@@ -1,29 +1,27 @@
-import pathsGenerator  from "./"
+import pathsGenerator = require("walk-asyncgen");
 
 // $ExpectType AsyncGenerator<string, void, void>
-const generator = pathsGenerator(".")
+pathsGenerator(".");
 
-// $ExpectType Options
-const excludeOptions = {
+// $ExpectType AsyncGenerator<string, void, void>
+pathsGenerator(".", {
     excludeFiles: /tslint.\S+/,
     excludeDirs: /node_modules/,
     excludeExt: /mp3$/
-}
+});
 
-// $ExpectType Options
-const includeFilesoptions = {
+// $ExpectType AsyncGenerator<string, void, void>
+pathsGenerator(".", {
     includeFiles: /tslint.\S+/,
     includeExt: /json/,
     printDirs: false
-}
+});
 
-// $ExpectError
-const errorOptions = {
+pathsGenerator(".", {
+    // $ExpectError
     excludeFiles: "",
+    // $ExpectError
     excludeDirs: "",
+    // $ExpectError
     excludeExt: ".mp3"
-}
-
-// $ExpectError
-
-pathsGenerator(".", {includeDirs: true})
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
