### PR TITLE
@types/react-datepicker: fix onChange prop value type depending on selectsRange prop value

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -50,7 +50,7 @@ export interface ReactDatePickerCustomHeaderProps {
     nextYearButtonDisabled: boolean;
 }
 
-export interface ReactDatePickerProps<CustomModifierNames extends string = never> {
+export interface ReactDatePickerProps<CustomModifierNames extends string = never, WithRange extends boolean | undefined = undefined> {
     adjustDateOnChange?: boolean | undefined;
     allowSameDay?: boolean | undefined;
     ariaDescribedBy?: string | undefined;
@@ -114,7 +114,7 @@ export interface ReactDatePickerProps<CustomModifierNames extends string = never
     onCalendarClose?(): void;
     onCalendarOpen?(): void;
     onChange(
-        date: Date | [Date | null, Date | null] | /* for selectsRange */ null,
+        date: (WithRange extends false | undefined ? Date | null : [Date | null, Date | null]),
         event: React.SyntheticEvent<any> | undefined,
     ): void;
     onChangeRaw?(event: React.FocusEvent<HTMLInputElement>): void;
@@ -156,7 +156,7 @@ export interface ReactDatePickerProps<CustomModifierNames extends string = never
     selected?: Date | null | undefined;
     selectsEnd?: boolean | undefined;
     selectsStart?: boolean | undefined;
-    selectsRange?: boolean | undefined;
+    selectsRange?: WithRange;
     shouldCloseOnSelect?: boolean | undefined;
     showDisabledMonthNavigation?: boolean | undefined;
     showFullMonthYearPicker?: boolean | undefined;
@@ -198,8 +198,8 @@ export interface ReactDatePickerProps<CustomModifierNames extends string = never
     yearItemNumber?: number | undefined;
 }
 
-export class ReactDatePicker<CustomModifierNames extends string = never> extends React.Component<
-    ReactDatePickerProps<CustomModifierNames>
+export class ReactDatePicker<CustomModifierNames extends string = never, WithRange extends boolean | undefined = undefined> extends React.Component<
+    ReactDatePickerProps<CustomModifierNames, WithRange>
 > {
     readonly setBlur: () => void;
     readonly setFocus: () => void;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -241,11 +241,10 @@ const DatePickerCustomHeader = ({
     nextMonthButtonDisabled,
     prevYearButtonDisabled,
     nextYearButtonDisabled,
-}: ReactDatePickerCustomHeaderProps) => (
-    <div></div>
-);
+}: ReactDatePickerCustomHeaderProps) => <div></div>;
 
-<DatePicker
-    onChange={() => {}}
-    renderCustomHeader={(props) => <DatePickerCustomHeader {...props} />}
-/>;
+<DatePicker onChange={() => {}} renderCustomHeader={props => <DatePickerCustomHeader {...props} />} />;
+
+<DatePicker selectsRange onChange={([start]) => start?.getHours()} />;
+
+<DatePicker onChange={date => date?.toISOString()} />;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Hacker0x01/react-datepicker/blob/18302ebb2cb6b98ae9064e195d73bc25e96eb6a9/docs-site/src/examples/selectsRange.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
