### PR TITLE
fix(jsonfile): fix wrong type

### DIFF
--- a/types/jsonfile/index.d.ts
+++ b/types/jsonfile/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jsonfile 6.0
+// Type definitions for jsonfile 6.1
 // Project: https://github.com/jprichardson/node-jsonfile#readme
 // Definitions by: Daniel Bowring <https://github.com/dbowring>
 //                 BendingBender <https://github.com/BendingBender>

--- a/types/jsonfile/jsonfile-tests.ts
+++ b/types/jsonfile/jsonfile-tests.ts
@@ -70,4 +70,4 @@ jsonfile.writeFileSync(file, obj, { flag: 'a' });
 // $ExpectType string
 stripBom('content');
 // $ExpectType string
-stringify(obj, { flag: 'a' });
+stringify(obj, { finalEOL: true, EOL: '\r\n', spaces: 2, replacer: (key, value) => value });

--- a/types/jsonfile/utils/index.d.ts
+++ b/types/jsonfile/utils/index.d.ts
@@ -1,4 +1,3 @@
-
 export function stringify(
     obj: any,
     options?: {

--- a/types/jsonfile/utils/index.d.ts
+++ b/types/jsonfile/utils/index.d.ts
@@ -1,4 +1,12 @@
 import { JFWriteOptions } from '../';
 
-export function stringify(obj: any, options?: JFWriteOptions): string;
+export function stringify(
+    obj: any,
+    options?: {
+        EOL?: string | undefined;
+        finalEOL?: boolean | undefined;
+        replacer?: ((key: string, value: any) => any) | undefined;
+        spaces?: string | number | undefined;
+    },
+): string;
 export function stripBom(content: string): string;

--- a/types/jsonfile/utils/index.d.ts
+++ b/types/jsonfile/utils/index.d.ts
@@ -1,4 +1,4 @@
-import { JFReadOptions } from '../';
+import { JFWriteOptions } from '../';
 
-export function stringify(obj: any, options?: JFReadOptions): string;
+export function stringify(obj: any, options?: JFWriteOptions): string;
 export function stripBom(content: string): string;

--- a/types/jsonfile/utils/index.d.ts
+++ b/types/jsonfile/utils/index.d.ts
@@ -1,4 +1,3 @@
-import { JFWriteOptions } from '../';
 
 export function stringify(
     obj: any,


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
