### PR TITLE
fix(enzyme): Syntax error

### DIFF
--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -102,7 +102,7 @@ export interface CommonWrapper<P = {}, S = {}, C = Component<P, S>> {
     /**
      * Invokes a function prop.
      * @param invokePropName The function prop to call.
-     * @param ...args The argments to the invokePropName function
+     * @param ...args The arguments to the invokePropName function
      * @returns The value of the function.
      */
     invoke<


### PR DESCRIPTION
This PR fixes the syntax error in JSDoc of Enzyme types