### PR TITLE
[react] remove implicit `children` prop from `ForwardRefRenderFunction`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -26,6 +26,7 @@
 //                 Victor Magalhães <https://github.com/vhfmag>
 //                 Dale Tan <https://github.com/hellatan>
 //                 Priyanshu Rav <https://github.com/priyanshurav>
+//                 Romain Francez <https://github.com/thefrenchjosh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -807,7 +808,7 @@ declare namespace React {
         propTypes?: WeakValidationMap<P> | undefined;
     }
 
-    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithChildren<PropsWithoutRef<P>> & RefAttributes<T>>;
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -568,7 +568,7 @@ declare namespace React {
     type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
 
     interface ForwardRefRenderFunction<T, P = {}> {
-        (props: PropsWithChildren<P>, ref: ForwardedRef<T>): ReactElement | null;
+        (props: P, ref: ForwardedRef<T>): ReactElement | null;
         displayName?: string | undefined;
         // explicit rejected with `never` required due to
         // https://github.com/microsoft/TypeScript/issues/36826
@@ -808,7 +808,7 @@ declare namespace React {
         propTypes?: WeakValidationMap<P> | undefined;
     }
 
-    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithChildren<PropsWithoutRef<P>> & RefAttributes<T>>;
+    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -342,6 +342,39 @@ const divRef = React.createRef<HTMLDivElement>();
 <ForwardRef2 ref={divRef}/>;
 <ForwardRef2 ref='string'/>; // $ExpectError
 
+const ForwardRefTyping = React.forwardRef<HTMLDivElement>((props, ref) => (
+    <div {...props} ref={ref}>{
+        props.children // $ExpectError
+    }</div>
+));
+<ForwardRefTyping>Children</ForwardRefTyping>; // $ExpectError
+
+interface ForwardRefTypingProps {
+    foo: string;
+}
+const ForwardRefTypingWithProps = React.forwardRef<HTMLDivElement, ForwardRefTypingProps>((props, ref) => (
+    <div {...props} ref={ref}>{
+        // $ExpectType ForwardRefTypingProps
+        props
+    }</div>
+));
+<ForwardRefTypingWithProps foo='string'/>;
+<ForwardRefTypingWithProps foo='string'>Children</ForwardRefTypingWithProps>; // $ExpectError
+
+interface ForwardRefTypingPropsWithRef {
+    foo: string;
+    ref: string;
+}
+const ForwardRefTypingWithPropsWithRef = React.forwardRef<HTMLDivElement, ForwardRefTypingPropsWithRef>((props, ref) => (
+    <div {...props} ref={ref}>{
+        // $ExpectType ForwardRefTypingPropsWithRef
+        props
+    }</div>
+));
+<ForwardRefTypingWithPropsWithRef foo='string'/>;
+<ForwardRefTypingWithPropsWithRef foo='string' ref='string'/>; // $ExpectError
+<ForwardRefTypingWithPropsWithRef foo='string'>Children</ForwardRefTypingWithPropsWithRef>; // $ExpectError
+
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef}/>;
 <NewContext ref='string'/>;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -332,6 +332,7 @@ class NewContext extends React.Component {
 
 const ForwardRef = React.forwardRef((props: JSX.IntrinsicElements['div'], ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}/>);
 const ForwardRef2 = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <ForwardRef {...props} ref={ref}/>);
+const ForwardRefChildren = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}>{props.children}</div>);
 const divFnRef = (ref: HTMLDivElement|null) => { /* empty */ };
 const divRef = React.createRef<HTMLDivElement>();
 
@@ -341,6 +342,8 @@ const divRef = React.createRef<HTMLDivElement>();
 <ForwardRef2 ref={divFnRef}/>;
 <ForwardRef2 ref={divRef}/>;
 <ForwardRef2 ref='string'/>; // $ExpectError
+<ForwardRefChildren ref={divFnRef}>Child</ForwardRefChildren>;
+<ForwardRefChildren ref={divRef}>Child</ForwardRefChildren>;
 
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef}/>;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -332,7 +332,6 @@ class NewContext extends React.Component {
 
 const ForwardRef = React.forwardRef((props: JSX.IntrinsicElements['div'], ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}/>);
 const ForwardRef2 = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <ForwardRef {...props} ref={ref}/>);
-const ForwardRefChildren = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}>{props.children}</div>);
 const divFnRef = (ref: HTMLDivElement|null) => { /* empty */ };
 const divRef = React.createRef<HTMLDivElement>();
 
@@ -342,8 +341,6 @@ const divRef = React.createRef<HTMLDivElement>();
 <ForwardRef2 ref={divFnRef}/>;
 <ForwardRef2 ref={divRef}/>;
 <ForwardRef2 ref='string'/>; // $ExpectError
-<ForwardRefChildren ref={divFnRef}>Child</ForwardRefChildren>;
-<ForwardRefChildren ref={divRef}>Child</ForwardRefChildren>;
 
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef}/>;

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -26,7 +26,6 @@
 //                 Victor Magalhães <https://github.com/vhfmag>
 //                 Dale Tan <https://github.com/hellatan>
 //                 Priyanshu Rav <https://github.com/priyanshurav>
-//                 Romain Francez <https://github.com/thefrenchjosh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -559,7 +558,7 @@ declare namespace React {
     }
 
     interface ForwardRefRenderFunction<T, P = {}> {
-        (props: PropsWithChildren<P>, ref: ((instance: T | null) => void) | MutableRefObject<T | null> | null): ReactElement | null;
+        (props: P, ref: ((instance: T | null) => void) | MutableRefObject<T | null> | null): ReactElement | null;
         displayName?: string | undefined;
         // explicit rejected with `never` required due to
         // https://github.com/microsoft/TypeScript/issues/36826
@@ -799,7 +798,7 @@ declare namespace React {
         propTypes?: WeakValidationMap<P> | undefined;
     }
 
-    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithChildren<PropsWithoutRef<P>> & RefAttributes<T>>;
+    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -26,6 +26,7 @@
 //                 Victor Magalhães <https://github.com/vhfmag>
 //                 Dale Tan <https://github.com/hellatan>
 //                 Priyanshu Rav <https://github.com/priyanshurav>
+//                 Romain Francez <https://github.com/thefrenchjosh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -798,7 +799,7 @@ declare namespace React {
         propTypes?: WeakValidationMap<P> | undefined;
     }
 
-    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithChildren<PropsWithoutRef<P>> & RefAttributes<T>>;
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =

--- a/types/react/v16/test/tsx.tsx
+++ b/types/react/v16/test/tsx.tsx
@@ -342,6 +342,39 @@ const divRef = React.createRef<HTMLDivElement>();
 <ForwardRef2 ref={divRef}/>;
 <ForwardRef2 ref='string'/>; // $ExpectError
 
+const ForwardRefTyping = React.forwardRef<HTMLDivElement>((props, ref) => (
+    <div {...props} ref={ref}>{
+        props.children // $ExpectError
+    }</div>
+));
+<ForwardRefTyping>Children</ForwardRefTyping>; // $ExpectError
+
+interface ForwardRefTypingProps {
+    foo: string;
+}
+const ForwardRefTypingWithProps = React.forwardRef<HTMLDivElement, ForwardRefTypingProps>((props, ref) => (
+    <div {...props} ref={ref}>{
+        // $ExpectType ForwardRefTypingProps
+        props
+    }</div>
+));
+<ForwardRefTypingWithProps foo='string'/>;
+<ForwardRefTypingWithProps foo='string'>Children</ForwardRefTypingWithProps>; // $ExpectError
+
+interface ForwardRefTypingPropsWithRef {
+    foo: string;
+    ref: string;
+}
+const ForwardRefTypingWithPropsWithRef = React.forwardRef<HTMLDivElement, ForwardRefTypingPropsWithRef>((props, ref) => (
+    <div {...props} ref={ref}>{
+        // $ExpectType ForwardRefTypingPropsWithRef
+        props
+    }</div>
+));
+<ForwardRefTypingWithPropsWithRef foo='string'/>;
+<ForwardRefTypingWithPropsWithRef foo='string' ref='string'/>; // $ExpectError
+<ForwardRefTypingWithPropsWithRef foo='string'>Children</ForwardRefTypingWithPropsWithRef>; // $ExpectError
+
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef}/>;
 <NewContext ref='string'/>;

--- a/types/react/v16/test/tsx.tsx
+++ b/types/react/v16/test/tsx.tsx
@@ -332,6 +332,7 @@ class NewContext extends React.Component {
 
 const ForwardRef = React.forwardRef((props: JSX.IntrinsicElements['div'], ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}/>);
 const ForwardRef2 = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <ForwardRef {...props} ref={ref}/>);
+const ForwardRefChildren = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}>{props.children}</div>);
 const divFnRef = (ref: HTMLDivElement|null) => { /* empty */ };
 const divRef = React.createRef<HTMLDivElement>();
 
@@ -341,6 +342,8 @@ const divRef = React.createRef<HTMLDivElement>();
 <ForwardRef2 ref={divFnRef}/>;
 <ForwardRef2 ref={divRef}/>;
 <ForwardRef2 ref='string'/>; // $ExpectError
+<ForwardRefChildren ref={divFnRef}>Child</ForwardRefChildren>;
+<ForwardRefChildren ref={divRef}>Child</ForwardRefChildren>;
 
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef}/>;

--- a/types/react/v16/test/tsx.tsx
+++ b/types/react/v16/test/tsx.tsx
@@ -332,7 +332,6 @@ class NewContext extends React.Component {
 
 const ForwardRef = React.forwardRef((props: JSX.IntrinsicElements['div'], ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}/>);
 const ForwardRef2 = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <ForwardRef {...props} ref={ref}/>);
-const ForwardRefChildren = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}>{props.children}</div>);
 const divFnRef = (ref: HTMLDivElement|null) => { /* empty */ };
 const divRef = React.createRef<HTMLDivElement>();
 
@@ -342,8 +341,6 @@ const divRef = React.createRef<HTMLDivElement>();
 <ForwardRef2 ref={divFnRef}/>;
 <ForwardRef2 ref={divRef}/>;
 <ForwardRef2 ref='string'/>; // $ExpectError
-<ForwardRefChildren ref={divFnRef}>Child</ForwardRefChildren>;
-<ForwardRefChildren ref={divRef}>Child</ForwardRefChildren>;
 
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef}/>;


### PR DESCRIPTION
Checklist:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Forwarding Refs - React](https://reactjs.org/docs/forwarding-refs.html)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

Context:
1) `ForwardRefRenderFunction` defines type as `PropsWithChildren<P>`
2) I can use the children prop inside my function component as it was added with `PropsWithChildren`
3) I can't use children when calling my component

This PR aligns the props types

Example:
```
const ForwardRefTyping = React.forwardRef((props, ref?: React.Ref<HTMLDivElement>) => (
    <div {...props} ref={ref}>
        {props.children} // This works
    </div>)
);
<ForwardRefTyping>Children</ForwardRefTyping> // This doesn't
```
