### PR TITLE
Node.js TCP Socket - remove obsolete timeout option and add abortController

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -620,7 +620,6 @@ declare module 'net' {
     interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
         timeout?: number | undefined;
     }
-
     type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
     /**
      * Creates a new TCP or `IPC` server.

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -27,6 +27,7 @@ declare module 'net' {
         allowHalfOpen?: boolean | undefined;
         readable?: boolean | undefined;
         writable?: boolean | undefined;
+        signal?: AbortSignal;
     }
     interface OnReadOpts {
         buffer: Uint8Array | (() => Uint8Array);
@@ -613,12 +614,9 @@ declare module 'net' {
         check(address: SocketAddress): boolean;
         check(address: string, type?: IPVersion): boolean;
     }
-    interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number | undefined;
-    }
-    interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number | undefined;
-    }
+    interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {}
+    interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {}
+
     type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
     /**
      * Creates a new TCP or `IPC` server.

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -614,8 +614,12 @@ declare module 'net' {
         check(address: SocketAddress): boolean;
         check(address: string, type?: IPVersion): boolean;
     }
-    interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {}
-    interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {}
+    interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
+        timeout?: number | undefined;
+    }
+    interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
+        timeout?: number | undefined;
+    }
 
     type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
     /**

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -3,12 +3,13 @@ import { LookupOneOptions } from 'node:dns';
 import { Socket } from 'node:dgram';
 
 {
+    const abort = new AbortController();
     const connectOpts: net.NetConnectOpts = {
         allowHalfOpen: true,
         family: 4,
         host: "localhost",
         port: 443,
-        timeout: 10E3
+        signal: abort.signal
     };
     const socket: net.Socket = net.createConnection(connectOpts, (): void => {
         // nothing

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -9,7 +9,8 @@ import { Socket } from 'node:dgram';
         family: 4,
         host: "localhost",
         port: 443,
-        signal: abort.signal
+        signal: abort.signal,
+        timeout: 10E3
     };
     const socket: net.Socket = net.createConnection(connectOpts, (): void => {
         // nothing

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -620,7 +620,6 @@ declare module 'net' {
     interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
         timeout?: number | undefined;
     }
-
     type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
     /**
      * Creates a new TCP or `IPC` server.

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -27,6 +27,7 @@ declare module 'net' {
         allowHalfOpen?: boolean | undefined;
         readable?: boolean | undefined;
         writable?: boolean | undefined;
+        signal?: AbortSignal;
     }
     interface OnReadOpts {
         buffer: Uint8Array | (() => Uint8Array);
@@ -613,12 +614,9 @@ declare module 'net' {
         check(address: SocketAddress): boolean;
         check(address: string, type?: IPVersion): boolean;
     }
-    interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number | undefined;
-    }
-    interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
-        timeout?: number | undefined;
-    }
+    interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {}
+    interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {}
+
     type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
     /**
      * Creates a new TCP or `IPC` server.

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -614,8 +614,12 @@ declare module 'net' {
         check(address: SocketAddress): boolean;
         check(address: string, type?: IPVersion): boolean;
     }
-    interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {}
-    interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {}
+    interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
+        timeout?: number | undefined;
+    }
+    interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
+        timeout?: number | undefined;
+    }
 
     type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
     /**

--- a/types/node/v16/test/net.ts
+++ b/types/node/v16/test/net.ts
@@ -3,12 +3,13 @@ import { LookupOneOptions } from 'node:dns';
 import { Socket } from 'node:dgram';
 
 {
+    const abort = new AbortController();
     const connectOpts: net.NetConnectOpts = {
         allowHalfOpen: true,
         family: 4,
         host: "localhost",
         port: 443,
-        timeout: 10E3
+        signal: abort.signal
     };
     const socket: net.Socket = net.createConnection(connectOpts, (): void => {
         // nothing

--- a/types/node/v16/test/net.ts
+++ b/types/node/v16/test/net.ts
@@ -9,7 +9,8 @@ import { Socket } from 'node:dgram';
         family: 4,
         host: "localhost",
         port: 443,
-        signal: abort.signal
+        signal: abort.signal,
+        timeout: 10E3
     };
     const socket: net.Socket = net.createConnection(connectOpts, (): void => {
         // nothing


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Node.js TCP socket options](https://nodejs.org/docs/latest-v16.x/api/net.html#new-netsocketoptions)
