### PR TITLE
[@types/ws]The first argument [of send(data, ...)] must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object

### DIFF
--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -1,3 +1,21 @@
-export { createWebSocketStream, WebSocket, WebSocketServer, RawData, Data, CertMeta, VerifyClientCallbackSync, VerifyClientCallbackAsync, ClientOptions, PerMessageDeflateOptions, Event, ErrorEvent, CloseEvent, MessageEvent, EventListenerOptions, ServerOptions, AddressInfo } from "./index.js";
-import WebSocket = require("./index.js");
+export {
+    createWebSocketStream,
+    WebSocket,
+    WebSocketServer,
+    RawData,
+    Data,
+    CertMeta,
+    VerifyClientCallbackSync,
+    VerifyClientCallbackAsync,
+    ClientOptions,
+    PerMessageDeflateOptions,
+    Event,
+    ErrorEvent,
+    CloseEvent,
+    MessageEvent,
+    EventListenerOptions,
+    ServerOptions,
+    AddressInfo,
+} from './index.js';
+import WebSocket = require('./index.js');
 export default WebSocket;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -11,7 +11,7 @@
 
 /// <reference types="node" />
 
-import { EventEmitter } from "events";
+import { EventEmitter } from 'events';
 import {
     Agent,
     ClientRequest,
@@ -19,12 +19,12 @@ import {
     IncomingMessage,
     OutgoingHttpHeaders,
     Server as HTTPServer,
-} from "http";
-import { Server as HTTPSServer } from "https";
-import { Duplex, DuplexOptions } from "stream";
-import { SecureContextOptions } from "tls";
-import { URL } from "url";
-import { ZlibOptions } from "zlib";
+} from 'http';
+import { Server as HTTPSServer } from 'https';
+import { Duplex, DuplexOptions } from 'stream';
+import { SecureContextOptions } from 'tls';
+import { URL } from 'url';
+import { ZlibOptions } from 'zlib';
 
 // WebSocket socket.
 declare class WebSocket extends EventEmitter {
@@ -37,7 +37,7 @@ declare class WebSocket extends EventEmitter {
     /** The connection is closed. */
     static readonly CLOSED: 3;
 
-    binaryType: "nodebuffer" | "arraybuffer" | "fragments";
+    binaryType: 'nodebuffer' | 'arraybuffer' | 'fragments';
     readonly bufferedAmount: number;
     readonly extensions: string;
     readonly protocol: string;
@@ -88,88 +88,88 @@ declare class WebSocket extends EventEmitter {
 
     // HTML5 WebSocket events
     addEventListener(
-        method: "message",
+        method: 'message',
         cb: (event: WebSocket.MessageEvent) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
     addEventListener(
-        method: "close",
+        method: 'close',
         cb: (event: WebSocket.CloseEvent) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
     addEventListener(
-        method: "error",
+        method: 'error',
         cb: (event: WebSocket.ErrorEvent) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
     addEventListener(
-        method: "open",
+        method: 'open',
         cb: (event: WebSocket.Event) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
 
-    removeEventListener(method: "message", cb: (event: WebSocket.MessageEvent) => void): void;
-    removeEventListener(method: "close", cb: (event: WebSocket.CloseEvent) => void): void;
-    removeEventListener(method: "error", cb: (event: WebSocket.ErrorEvent) => void): void;
-    removeEventListener(method: "open", cb: (event: WebSocket.Event) => void): void;
+    removeEventListener(method: 'message', cb: (event: WebSocket.MessageEvent) => void): void;
+    removeEventListener(method: 'close', cb: (event: WebSocket.CloseEvent) => void): void;
+    removeEventListener(method: 'error', cb: (event: WebSocket.ErrorEvent) => void): void;
+    removeEventListener(method: 'open', cb: (event: WebSocket.Event) => void): void;
 
     // Events
-    on(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
-    on(event: "error", listener: (this: WebSocket, err: Error) => void): this;
-    on(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
-    on(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
-    on(event: "open", listener: (this: WebSocket) => void): this;
-    on(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    on(event: 'close', listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
+    on(event: 'error', listener: (this: WebSocket, err: Error) => void): this;
+    on(event: 'upgrade', listener: (this: WebSocket, request: IncomingMessage) => void): this;
+    on(event: 'message', listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
+    on(event: 'open', listener: (this: WebSocket) => void): this;
+    on(event: 'ping' | 'pong', listener: (this: WebSocket, data: Buffer) => void): this;
     on(
-        event: "unexpected-response",
+        event: 'unexpected-response',
         listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
     ): this;
     on(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
-    once(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
-    once(event: "error", listener: (this: WebSocket, err: Error) => void): this;
-    once(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
-    once(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
-    once(event: "open", listener: (this: WebSocket) => void): this;
-    once(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    once(event: 'close', listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
+    once(event: 'error', listener: (this: WebSocket, err: Error) => void): this;
+    once(event: 'upgrade', listener: (this: WebSocket, request: IncomingMessage) => void): this;
+    once(event: 'message', listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
+    once(event: 'open', listener: (this: WebSocket) => void): this;
+    once(event: 'ping' | 'pong', listener: (this: WebSocket, data: Buffer) => void): this;
     once(
-        event: "unexpected-response",
+        event: 'unexpected-response',
         listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
     ): this;
     once(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
-    off(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
-    off(event: "error", listener: (this: WebSocket, err: Error) => void): this;
-    off(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
-    off(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
-    off(event: "open", listener: (this: WebSocket) => void): this;
-    off(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    off(event: 'close', listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
+    off(event: 'error', listener: (this: WebSocket, err: Error) => void): this;
+    off(event: 'upgrade', listener: (this: WebSocket, request: IncomingMessage) => void): this;
+    off(event: 'message', listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
+    off(event: 'open', listener: (this: WebSocket) => void): this;
+    off(event: 'ping' | 'pong', listener: (this: WebSocket, data: Buffer) => void): this;
     off(
-        event: "unexpected-response",
+        event: 'unexpected-response',
         listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
     ): this;
     off(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
-    addListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
-    addListener(event: "error", listener: (err: Error) => void): this;
-    addListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
-    addListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
-    addListener(event: "open", listener: () => void): this;
-    addListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
+    addListener(event: 'close', listener: (code: number, reason: Buffer) => void): this;
+    addListener(event: 'error', listener: (err: Error) => void): this;
+    addListener(event: 'upgrade', listener: (request: IncomingMessage) => void): this;
+    addListener(event: 'message', listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
+    addListener(event: 'open', listener: () => void): this;
+    addListener(event: 'ping' | 'pong', listener: (data: Buffer) => void): this;
     addListener(
-        event: "unexpected-response",
+        event: 'unexpected-response',
         listener: (request: ClientRequest, response: IncomingMessage) => void,
     ): this;
     addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-    removeListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
-    removeListener(event: "error", listener: (err: Error) => void): this;
-    removeListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
-    removeListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
-    removeListener(event: "open", listener: () => void): this;
-    removeListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
+    removeListener(event: 'close', listener: (code: number, reason: Buffer) => void): this;
+    removeListener(event: 'error', listener: (err: Error) => void): this;
+    removeListener(event: 'upgrade', listener: (request: IncomingMessage) => void): this;
+    removeListener(event: 'message', listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
+    removeListener(event: 'open', listener: () => void): this;
+    removeListener(event: 'ping' | 'pong', listener: (data: Buffer) => void): this;
     removeListener(
-        event: "unexpected-response",
+        event: 'unexpected-response',
         listener: (request: ClientRequest, response: IncomingMessage) => void,
     ): this;
     removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -234,7 +234,8 @@ declare namespace WebSocket {
         clientNoContextTakeover?: boolean | undefined;
         serverMaxWindowBits?: number | undefined;
         clientMaxWindowBits?: number | undefined;
-        zlibDeflateOptions?: {
+        zlibDeflateOptions?:
+        | {
             flush?: number | undefined;
             finishFlush?: number | undefined;
             chunkSize?: number | undefined;
@@ -244,7 +245,8 @@ declare namespace WebSocket {
             strategy?: number | undefined;
             dictionary?: Buffer | Buffer[] | DataView | undefined;
             info?: boolean | undefined;
-        } | undefined;
+        }
+        | undefined;
         zlibInflateOptions?: ZlibOptions | undefined;
         threshold?: number | undefined;
         concurrencyLimit?: number | undefined;
@@ -320,34 +322,34 @@ declare namespace WebSocket {
         shouldHandle(request: IncomingMessage): boolean | Promise<boolean>;
 
         // Events
-        on(event: "connection", cb: (this: Server, socket: WebSocket, request: IncomingMessage) => void): this;
-        on(event: "error", cb: (this: Server, error: Error) => void): this;
-        on(event: "headers", cb: (this: Server, headers: string[], request: IncomingMessage) => void): this;
-        on(event: "close" | "listening", cb: (this: Server) => void): this;
+        on(event: 'connection', cb: (this: Server, socket: WebSocket, request: IncomingMessage) => void): this;
+        on(event: 'error', cb: (this: Server, error: Error) => void): this;
+        on(event: 'headers', cb: (this: Server, headers: string[], request: IncomingMessage) => void): this;
+        on(event: 'close' | 'listening', cb: (this: Server) => void): this;
         on(event: string | symbol, listener: (this: Server, ...args: any[]) => void): this;
 
-        once(event: "connection", cb: (this: Server, socket: WebSocket, request: IncomingMessage) => void): this;
-        once(event: "error", cb: (this: Server, error: Error) => void): this;
-        once(event: "headers", cb: (this: Server, headers: string[], request: IncomingMessage) => void): this;
-        once(event: "close" | "listening", cb: (this: Server) => void): this;
+        once(event: 'connection', cb: (this: Server, socket: WebSocket, request: IncomingMessage) => void): this;
+        once(event: 'error', cb: (this: Server, error: Error) => void): this;
+        once(event: 'headers', cb: (this: Server, headers: string[], request: IncomingMessage) => void): this;
+        once(event: 'close' | 'listening', cb: (this: Server) => void): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        off(event: "connection", cb: (this: Server, socket: WebSocket, request: IncomingMessage) => void): this;
-        off(event: "error", cb: (this: Server, error: Error) => void): this;
-        off(event: "headers", cb: (this: Server, headers: string[], request: IncomingMessage) => void): this;
-        off(event: "close" | "listening", cb: (this: Server) => void): this;
+        off(event: 'connection', cb: (this: Server, socket: WebSocket, request: IncomingMessage) => void): this;
+        off(event: 'error', cb: (this: Server, error: Error) => void): this;
+        off(event: 'headers', cb: (this: Server, headers: string[], request: IncomingMessage) => void): this;
+        off(event: 'close' | 'listening', cb: (this: Server) => void): this;
         off(event: string | symbol, listener: (this: Server, ...args: any[]) => void): this;
 
-        addListener(event: "connection", cb: (client: WebSocket, request: IncomingMessage) => void): this;
-        addListener(event: "error", cb: (err: Error) => void): this;
-        addListener(event: "headers", cb: (headers: string[], request: IncomingMessage) => void): this;
-        addListener(event: "close" | "listening", cb: () => void): this;
+        addListener(event: 'connection', cb: (client: WebSocket, request: IncomingMessage) => void): this;
+        addListener(event: 'error', cb: (err: Error) => void): this;
+        addListener(event: 'headers', cb: (headers: string[], request: IncomingMessage) => void): this;
+        addListener(event: 'close' | 'listening', cb: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        removeListener(event: "connection", cb: (client: WebSocket) => void): this;
-        removeListener(event: "error", cb: (err: Error) => void): this;
-        removeListener(event: "headers", cb: (headers: string[], request: IncomingMessage) => void): this;
-        removeListener(event: "close" | "listening", cb: () => void): this;
+        removeListener(event: 'connection', cb: (client: WebSocket) => void): this;
+        removeListener(event: 'error', cb: (err: Error) => void): this;
+        removeListener(event: 'headers', cb: (headers: string[], request: IncomingMessage) => void): this;
+        removeListener(event: 'close' | 'listening', cb: () => void): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -70,13 +70,18 @@ declare class WebSocket extends EventEmitter {
         options?: WebSocket.ClientOptions | ClientRequestArgs,
     );
 
-    close(code?: number, data?: string | Buffer): void;
-    ping(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
-    pong(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
-    send(data: any, cb?: (err?: Error) => void): void;
+    close(code?: number, data?: WebSocket.Data): void;
+    ping(data?: WebSocket.Data | number, mask?: boolean, cb?: (err: Error) => void): void;
+    pong(data?: WebSocket.Data | number, mask?: boolean, cb?: (err: Error) => void): void;
+    send(data: WebSocket.Data | number | ArrayLike<any>, cb?: (err?: Error) => void): void;
     send(
-        data: any,
-        options: { mask?: boolean | undefined; binary?: boolean | undefined; compress?: boolean | undefined; fin?: boolean | undefined },
+        data: WebSocket.Data | number | ArrayLike<any>,
+        options: {
+            mask?: boolean | undefined;
+            binary?: boolean | undefined;
+            compress?: boolean | undefined;
+            fin?: boolean | undefined;
+        },
         cb?: (err?: Error) => void,
     ): void;
     terminate(): void;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -1,19 +1,19 @@
-import WebSocket = require("ws");
-import * as http from "http";
-import * as https from "https";
-import * as url from "url";
-import * as wslib from "ws";
+import WebSocket = require('ws');
+import * as http from 'http';
+import * as https from 'https';
+import * as url from 'url';
+import * as wslib from 'ws';
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
-    ws.on("open", () => ws.send("something"));
-    ws.on("message", data => {});
+    const ws = new WebSocket('ws://www.host.com/path');
+    ws.on('open', () => ws.send('something'));
+    ws.on('message', data => {});
 }
 
 {
-    const addr = new url.URL("ws://www.host.com/path");
+    const addr = new url.URL('ws://www.host.com/path');
     const ws = new WebSocket(addr);
-    ws.on("open", () => {
+    ws.on('open', () => {
         const array = new Float32Array(5);
         for (let i = 0; i < array.length; ++i) array[i] = i / 2;
         ws.send(array, { binary: true, mask: true });
@@ -21,7 +21,7 @@ import * as wslib from "ws";
 }
 
 {
-    const ws: wslib.WebSocket = new wslib.WebSocket("ws://www.host.com/path");
+    const ws: wslib.WebSocket = new wslib.WebSocket('ws://www.host.com/path');
 }
 
 {
@@ -30,17 +30,17 @@ import * as wslib from "ws";
 
 {
     const wss = new WebSocket.Server({ port: 8081 });
-    wss.on("connection", (ws, req) => {
-        ws.on("message", message => console.log("received: %s", message));
-        ws.send("something");
-        ws.send("something", (error?: Error) => {});
-        ws.send("something", {}, (error?: Error) => {});
+    wss.on('connection', (ws, req) => {
+        ws.on('message', message => console.log('received: %s', message));
+        ws.send('something');
+        ws.send('something', (error?: Error) => {});
+        ws.send('something', {}, (error?: Error) => {});
     });
-    wss.once("connection", (ws, req) => {
-        ws.send("something");
+    wss.once('connection', (ws, req) => {
+        ws.send('something');
     });
-    wss.off("connection", (ws, req) => {
-        ws.send("something");
+    wss.off('connection', (ws, req) => {
+        ws.send('something');
     });
 }
 
@@ -53,15 +53,15 @@ import * as wslib from "ws";
 }
 
 {
-    const wsc = new WebSocket("ws://echo.websocket.org/");
+    const wsc = new WebSocket('ws://echo.websocket.org/');
 
-    wsc.on("open", () => wsc.send(Date.now().toString(), { mask: true }));
-    wsc.on("close", () => console.log("disconnected"));
-    wsc.on("error", error => {
+    wsc.on('open', () => wsc.send(Date.now().toString(), { mask: true }));
+    wsc.on('close', () => console.log('disconnected'));
+    wsc.on('error', error => {
         console.log(`unexpected response: ${error}`);
     });
 
-    wsc.on("message", (data) => {
+    wsc.on('message', data => {
         console.log(`Roundtrip time: ${Date.now() - parseInt(data.toString(), 10)} ms`);
         setTimeout(() => {
             wsc.send(Date.now().toString(), { mask: true });
@@ -88,7 +88,7 @@ import * as wslib from "ws";
         perMessageDeflate: true,
     });
 
-    wsv.on("connection", function connection(ws) {
+    wsv.on('connection', function connection(ws) {
         console.log(ws.protocol);
     });
 }
@@ -96,7 +96,7 @@ import * as wslib from "ws";
 {
     const wss = new WebSocket.Server();
 
-    wss.addListener("connection", (client, request) => {
+    wss.addListener('connection', (client, request) => {
         request.socket.remoteAddress;
 
         // $ExpectError
@@ -127,7 +127,7 @@ import * as wslib from "ws";
                 level: 0,
                 memLevel: 0,
                 strategy: 0,
-                dictionary: new Buffer("test"),
+                dictionary: new Buffer('test'),
                 info: false,
             },
             zlibInflateOptions: {
@@ -135,21 +135,21 @@ import * as wslib from "ws";
             },
         },
         verifyClient: (info: any, cb: any) => {
-            cb(true, 123, "message", { Upgrade: "websocket" });
+            cb(true, 123, 'message', { Upgrade: 'websocket' });
         },
     });
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path", {
+    const ws = new WebSocket('ws://www.host.com/path', {
         timeout: 5000,
         maxPayload: 10 * 1024 * 1024,
     });
-    ws.on("open", () => ws.send("something assume to be really long"));
+    ws.on('open', () => ws.send('something assume to be really long'));
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
     ws.onopen = (event: WebSocket.Event) => {
         console.log(event.target, event.type);
     };
@@ -165,7 +165,7 @@ import * as wslib from "ws";
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
 
     const duplex = WebSocket.createWebSocketStream(ws, {
         allowHalfOpen: true,
@@ -176,7 +176,7 @@ import * as wslib from "ws";
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
 
     const duplex = WebSocket.createWebSocketStream(ws);
 
@@ -185,15 +185,15 @@ import * as wslib from "ws";
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
     // $ExpectError
-    ws.addEventListener("other", () => {});
+    ws.addEventListener('other', () => {});
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
     ws.addEventListener(
-        "message",
+        'message',
         (event: WebSocket.MessageEvent) => {
             console.log(event.data, event.target, event.type);
         },
@@ -202,17 +202,17 @@ import * as wslib from "ws";
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
     const eventHandler: Parameters<typeof ws.once>[1] = () => {};
-    const event = "";
+    const event = '';
     const errorHandler = (err: Error) => {
         ws.off(event, eventHandler);
     };
-    ws.once("error", errorHandler);
+    ws.once('error', errorHandler);
 }
 
 function f() {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
 
     // $ExpectError
     const a: 5 = ws.readyState;
@@ -247,7 +247,7 @@ function f() {
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
 
     // $ExpectError
     ws.CONNECTING = 123;
@@ -263,22 +263,22 @@ function f() {
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
 
-    ws.binaryType = "arraybuffer";
-    ws.binaryType = "fragments";
-    ws.binaryType = "nodebuffer";
+    ws.binaryType = 'arraybuffer';
+    ws.binaryType = 'fragments';
+    ws.binaryType = 'nodebuffer';
 
     // $ExpectError
-    ws.binaryType = "";
+    ws.binaryType = '';
     // $ExpectError
     ws.binaryType = true;
     // $ExpectError
-    ws.binaryType = "invalid-value";
+    ws.binaryType = 'invalid-value';
 }
 
 {
-    const ws = new WebSocket("ws://www.host.com/path");
+    const ws = new WebSocket('ws://www.host.com/path');
 
     // $ExpectType number
     ws.bufferedAmount;
@@ -293,12 +293,12 @@ function f() {
     ws.bufferedAmount = true;
 
     // $ExpectError
-    ws.extensions = "a-value";
+    ws.extensions = 'a-value';
     // $ExpectError
     ws.extensions = true;
 
     // $ExpectError
-    ws.protocol = "a-value";
+    ws.protocol = 'a-value';
     // $ExpectError
     ws.protocol = true;
 }
@@ -308,7 +308,7 @@ function f() {
     const server = new http.Server();
     server.on('upgrade', (request, socket, head) => {
         if (request.url === '/path') {
-            webSocketServer.handleUpgrade(request, socket, head, (ws) => {
+            webSocketServer.handleUpgrade(request, socket, head, ws => {
                 webSocketServer.emit('connection', ws, request);
             });
         }


### PR DESCRIPTION
Continuation of #57607 . I had forgotten about this PR when I cleaned up my forks and repos.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [?] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Closes #56554
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
