### PR TITLE
[ref-struct-di] improved typing for constructor args

### DIFF
--- a/types/ref-struct-di/index.d.ts
+++ b/types/ref-struct-di/index.d.ts
@@ -162,12 +162,16 @@ declare namespace struct {
      */
     interface StructType<TDefinition extends StructTypeDefinitionBase = any> extends ref.Type<StructObject<StructObjectProperties<TDefinition>>> {
         /** Pass it an existing Buffer instance to use that as the backing buffer. */
-        new (arg: Buffer, data?: Partial<StructObjectProperties<TDefinition>>): StructObject<StructObjectProperties<TDefinition>>;
-        new (data?: Partial<StructObjectProperties<TDefinition>>): StructObject<StructObjectProperties<TDefinition>>;
+        new (
+            arg?: Buffer | Partial<StructObjectProperties<TDefinition>>,
+            data?: Partial<StructObjectProperties<TDefinition>>
+        ): StructObject<StructObjectProperties<TDefinition>>;
 
         /** Pass it an existing Buffer instance to use that as the backing buffer. */
-        (arg: Buffer, data?: Partial<StructObjectProperties<TDefinition>>): StructObject<StructObjectProperties<TDefinition>>;
-        (data?: Partial<StructObjectProperties<TDefinition>>): StructObject<StructObjectProperties<TDefinition>>;
+        (
+            arg?: Buffer | Partial<StructObjectProperties<TDefinition>>,
+            data?: Partial<StructObjectProperties<TDefinition>>
+        ): StructObject<StructObjectProperties<TDefinition>>;
 
         fields: StructFields<TDefinition>;
 

--- a/types/ref-struct-di/ts4.1/index.d.ts
+++ b/types/ref-struct-di/ts4.1/index.d.ts
@@ -27,12 +27,16 @@ declare namespace struct {
      */
     interface StructType extends ref.Type {
         /** Pass it an existing Buffer instance to use that as the backing buffer. */
-        new (arg: Buffer, data?: Record<string, any>): Record<string, any>;
-        new (data?: Record<string, any>): Record<string, any>;
+        new (
+            arg?: Buffer | Record<string, any>,
+            data?: Record<string, any>
+        ): Record<string, any>;
 
         /** Pass it an existing Buffer instance to use that as the backing buffer. */
-        (arg: Buffer, data?: Record<string, any>): Record<string, any>;
-        (data?: Record<string, any>): Record<string, any>;
+        (
+            arg?: Buffer | Record<string, any>,
+            data?: Record<string, any>
+        ): Record<string, any>;
 
         fields: Record<string, Field>;
 


### PR DESCRIPTION
- fixing an issue where typescript wouldn't pick up the second overload
  due to overlapping between Buffer and StructObjectProperties

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-ffi-napi/ref-struct-di/blob/master/lib/struct.js#L81
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
