### PR TITLE
[firefox-webext-browser] Add missing methods for bookmarks

### DIFF
--- a/types/firefox-webext-browser/firefox-webext-browser-tests.ts
+++ b/types/firefox-webext-browser/firefox-webext-browser-tests.ts
@@ -22,7 +22,18 @@ port.onMessage.addListener((response) => {
     console.log('Received: ' + response);
 });
 
+browser.bookmarks.create({ title: 'Mozilla Developer Network (MDN)' });
+browser.bookmarks.get('bookmarkId');
+browser.bookmarks.get(['bookmarkId_1', 'bookmarkId_2']);
+browser.bookmarks.getChildren('bookmarkId');
+browser.bookmarks.getRecent(2);
+browser.bookmarks.getSubTree('bookmarkId');
 browser.bookmarks.getTree();
+browser.bookmarks.move('bookmarkId', { index: 0 });
+browser.bookmarks.remove('bookmarkId');
+browser.bookmarks.removeTree('bookmarkId');
+browser.bookmarks.search({});
+browser.bookmarks.update('bookmarkId', { title: 'Mozilla Developer Network (MDN)' });
 
 browser.proxy.onError.addListener((error) => {
     console.error(`Proxy error: ${error.message}`);

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -6005,6 +6005,16 @@ declare namespace browser.bookmarks {
      */
     function update(id: string, changes: _UpdateChanges): Promise<BookmarkTreeNode>;
 
+    /**
+     * Removes a bookmark or an empty bookmark folder, given the node's ID.
+     */
+    function remove(id: string): Promise<BookmarkTreeNode>;
+
+    /**
+     * Recursively removes a bookmark folder; that is, given the ID of a folder node, removes that node and all its descendants.
+     */
+    function removeTree(id: string): Promise<BookmarkTreeNode>;
+
     /* bookmarks events */
     /** Fired when a bookmark or folder is created. */
     const onCreated: WebExtEvent<(id: string, bookmark: BookmarkTreeNode) => void>;


### PR DESCRIPTION
Discussion: #57890
Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test firefox-webext-browser`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.