### PR TITLE
TailwindCSS: Allow for string selector in TailwindConfig's important property

### DIFF
--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -513,6 +513,6 @@ export interface TailwindConfig {
     darkMode: false | 'media' | 'class';
     variantOrder?: TailwindVariant[];
     prefix?: string;
-    important?: boolean;
+    important?: boolean | string;
     separator?: string;
 }

--- a/types/tailwindcss/test/tailwindcss-tests.ts
+++ b/types/tailwindcss/test/tailwindcss-tests.ts
@@ -2614,8 +2614,10 @@ tailwindConfig.important;
 
 tailwindConfig.important = false;
 
-// @ts-expect-error should be boolean
-tailwindConfig.important = 'false';
+tailwindConfig.important = 'selector';
+
+// @ts-expect-error should be boolean or string
+tailwindConfig.important = 0;
 
 // $ExpectType string | undefined
 tailwindConfig.separator;

--- a/types/tailwindcss/test/tailwindcss-tests.ts
+++ b/types/tailwindcss/test/tailwindcss-tests.ts
@@ -2609,7 +2609,7 @@ tailwindConfig.prefix = 'tw-';
 // @ts-expect-error value should be string
 tailwindConfig.prefix = 1000;
 
-// $ExpectType boolean | undefined
+// $ExpectType string | boolean | undefined
 tailwindConfig.important;
 
 tailwindConfig.important = false;


### PR DESCRIPTION
TailwindConfig's `important` property should allow strings too, in order to allow for the [Selector strategy](https://tailwindcss.com/docs/configuration#selector-strategy).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
