### PR TITLE
fix(node-cron): add missing parameter

### DIFF
--- a/types/node-cron/index.d.ts
+++ b/types/node-cron/index.d.ts
@@ -8,7 +8,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 import EventEmitter = require('events');
 
-export function schedule(cronExpression: string, func: () => void, options?: ScheduleOptions): ScheduledTask;
+export function schedule(cronExpression: string, func: (now: Date) => void, options?: ScheduleOptions): ScheduledTask;
 
 export function validate(cronExpression: string): boolean;
 

--- a/types/node-cron/node-cron-tests.ts
+++ b/types/node-cron/node-cron-tests.ts
@@ -4,8 +4,13 @@ import cron = require('node-cron');
 
 const log = console.log;
 
-cron.schedule('* * * * *', () => {
+cron.schedule('* * * * *', now => {
     log('running a task every minute');
+    if (now.getTime() === Date.now()) {
+        log('task ran at the predicted time');
+    } else {
+        log('Task ran with a delay');
+    }
 });
 
 cron.schedule('1-5 * * * *', () => {


### PR DESCRIPTION
This PR adds a missing type to the schedule function on node-cron which is a Date object corresponding to the date at which the task was executed and which is passed every time this happens. This missing type actually caused an error in my code which prompted me to investigate the package and find this out. This may be a bug but, until the parameter is removed, I think it's best to add this here

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-cron/node-cron/blob/fbc403930ab3165ffef7d53387a29af92670dfea/src/task.js#L14-L17
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
