### PR TITLE
[nat-upnp] Fixed spelling mistake and an incorrect type

### DIFF
--- a/types/nat-upnp/index.d.ts
+++ b/types/nat-upnp/index.d.ts
@@ -15,14 +15,16 @@ export interface StandardOpts {
         | {
               port?: number | undefined;
               host?: string | undefined;
-          } | undefined;
+          }
+        | undefined;
     private?:
         | number
         | null
         | {
               port?: number | undefined;
               host?: string | undefined;
-          } | undefined;
+          }
+        | undefined;
     protocol?: string | undefined;
 }
 
@@ -75,7 +77,7 @@ export interface RawDevice {
 export interface Device {
     /**
      * Get the available services on the network device
-     * @param types List of service types to lookf or
+     * @param types List of service types to look for
      * @param callback
      */
     getService(
@@ -92,19 +94,17 @@ export interface Device {
      * @param info
      * @returns the available devices and services in array form
      */
-    parseDescription(info: {
-        device?: RawDevice | undefined;
-    }): {
+    parseDescription(info: { device?: RawDevice | undefined }): {
         services: RawService[];
         devices: RawDevice[];
     };
     /**
      * Perform a SSDP/UPNP request
      * @param action the action to perform
-     * @param args arguments of said action
+     * @param args key-value pair arguments of said action
      * @param callback Callback to be run when completed, or on error
      */
-    run(action: string, args: string[], callback: CB<RawResponse>): void;
+    run(action: string, args: Array<[string, string | number]>, callback: CB<RawResponse>): void;
 }
 
 // Note for the SSDP class/interface

--- a/types/nat-upnp/nat-upnp-tests.ts
+++ b/types/nat-upnp/nat-upnp-tests.ts
@@ -37,7 +37,7 @@ NATClient.findGateway((err, gatewayDevice) => {
         }
         console.log(service.service, service.SCPDURL, service.controlURL);
     });
-    gatewayDevice.run('action', ['arg'], (err2, res) => {
+    gatewayDevice.run('action', [['key', 'val']], (err2, res) => {
         if (err2 || res == null) {
             console.error(
                 'gatewayDevice.run',


### PR DESCRIPTION
Most of the changes were made by prettier formatting the code. 

I changed was the type second argument of the method Device.run at ```types/nat-upnp/index.d.ts:107``` from ```string[]``` to ```Array<[string, string | number]>```.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [implementation of Device.run](https://github.com/indutny/node-nat-upnp/blob/9c80722df962ce1984946038e702e8eaccd0e97a/lib/nat-upnp/client.js#L41)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The implementation in the source code has the second argument as a key-value pair array not string array.