### PR TITLE
[@types/three] Fix OBB.intersectsOBB argument not being optional

### DIFF
--- a/types/three/examples/jsm/math/OBB.d.ts
+++ b/types/three/examples/jsm/math/OBB.d.ts
@@ -14,7 +14,7 @@ export class OBB {
     containsPoint(point: Vector3): boolean;
     intersectsBox3(box3: Box3): boolean;
     intersectsSphere(sphere: Sphere): boolean;
-    intersectsOBB(obb: OBB, epsilon: number): boolean;
+    intersectsOBB(obb: OBB, epsilon?: number): boolean;
     intersectsPlane(plane: Plane): boolean;
     intersectRay(ray: Ray, result: Vector3): Vector3 | null;
     intersectsRay(ray: Ray): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

There are no tests for /math/*, so i have not updated/added any.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/mrdoob/three.js/blob/dev/examples/jsm/math/OBB.js#L150>
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~