### PR TITLE
Improve @wordpress/components types for Animate, DropdownMenu, ResizableBox, and ToolbarButton

### DIFF
--- a/types/wordpress__components/animate/index.d.ts
+++ b/types/wordpress__components/animate/index.d.ts
@@ -2,7 +2,7 @@ import { ComponentType, ReactNode } from 'react';
 
 declare namespace Animate {
     interface BaseProps {
-        type: 'appear' | 'slide-in';
+        type: 'appear' | 'slide-in' | 'loading';
         children(props: { className: string }): ReactNode;
     }
 
@@ -20,7 +20,11 @@ declare namespace Animate {
         } | undefined;
     }
 
-    type Props = AppearProps | SlideInProps;
+    interface LoadingProps extends BaseProps {
+        type: 'loading';
+    }
+
+    type Props = AppearProps | SlideInProps | LoadingProps;
 }
 declare const Animate: ComponentType<Animate.Props>;
 

--- a/types/wordpress__components/dropdown-menu/index.d.ts
+++ b/types/wordpress__components/dropdown-menu/index.d.ts
@@ -10,7 +10,7 @@ declare namespace DropdownMenu {
          * The Dashicon icon slug to be shown in the collapsed menu button.
          * @defaultValue "menu"
          */
-        icon?: Dashicon.Icon | undefined;
+        icon?: Dashicon.Icon | JSX.Element | undefined;
         /**
          * A human-readable label to present as accessibility text on the
          * focused collapsed menu button.

--- a/types/wordpress__components/resizable-box/index.d.ts
+++ b/types/wordpress__components/resizable-box/index.d.ts
@@ -1,8 +1,12 @@
-import { ComponentType } from 'react';
+import { ComponentType, ReactNode } from 'react';
 import { ResizableProps } from 're-resizable';
 
 declare namespace ResizableBox {
-    type Props = ResizableProps;
+    type Props = ResizableProps & {
+        className?: string;
+        children?: ReactNode;
+        showHandle?: boolean;
+    };
 }
 declare const ResizableBox: ComponentType<ResizableBox.Props>;
 

--- a/types/wordpress__components/toolbar-button/index.d.ts
+++ b/types/wordpress__components/toolbar-button/index.d.ts
@@ -2,6 +2,7 @@ import { ComponentType, ReactNode } from 'react';
 
 import DropdownMenu from '../dropdown-menu';
 import IconButton from '../icon-button';
+import Button from '../button';
 
 declare namespace ToolbarButton {
     interface Props extends DropdownMenu.Control, Pick<IconButton.Props, 'shortcut'> {
@@ -31,6 +32,6 @@ declare namespace ToolbarButton {
         subscript?: string | undefined;
     }
 }
-declare const ToolbarButton: ComponentType<ToolbarButton.Props>;
+declare const ToolbarButton: ComponentType<ToolbarButton.Props|Button.Props>;
 
 export default ToolbarButton;

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -887,6 +887,8 @@ const kbshortcuts = {
     title="Toolbar Button"
     onClick={() => console.log('clicked')}
 />;
+<C.ToolbarButton icon={ <span>click</span> } label="Paragraph" />;
+<C.ToolbarButton>Text</C.ToolbarButton>;
 
 //
 // tooltip

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -280,7 +280,7 @@ const buttonGroupRef = createRef<HTMLDivElement>();
     )}
 </C.DropdownMenu>;
 <C.DropdownMenu
-    icon="move"
+    icon={<span>icon</span>}
     label="Select a direction"
     controls={[
         {

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -662,6 +662,26 @@ const kbshortcuts = {
         topLeft: false,
     }}
 />;
+<C.ResizableBox
+    showHandle
+    className="testing"
+    size={{
+        height: 100,
+        width: 100,
+    }}
+    minHeight="50"
+    minWidth={50}
+    enable={{
+        top: false,
+        right: true,
+        bottom: true,
+        left: false,
+        topRight: false,
+        bottomRight: true,
+        bottomLeft: false,
+        topLeft: false,
+    }}
+><div>hello</div></C.ResizableBox>;
 
 //
 // responsive-wrapper

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -24,6 +24,9 @@ import { createRef, MouseEvent as ReactMouseEvent } from 'react';
 <C.Animate type="appear" options={{ origin: 'top left' }}>
     {({ className }) => <h1 className={className}>Hello World</h1>}
 </C.Animate>;
+<C.Animate type="loading">
+    {({ className }) => <h1 className={className}>Hello World</h1>}
+</C.Animate>;
 
 //
 // autocomplete


### PR DESCRIPTION
This PR updates the types for the `@wordpress/components` package to fix some omissions which I've noticed in [wp-calypso](https://github.com/Automattic/wp-calypso/) usage. Specifically:

- Adds `type: 'loading'` to `Animate`. (See the option [here](https://github.com/WordPress/gutenberg/blob/43d950788629daaf588c80a2a56173124f112c60/packages/components/src/animate/index.js#L11), added in https://github.com/WordPress/gutenberg/pull/17106).
- Allows`icon: JSX.Element` to be used by `DropdownMenu`. (It passes it through to `Icon` which [has allowed elements](https://github.com/WordPress/gutenberg/blob/43d950788629daaf588c80a2a56173124f112c60/packages/components/src/icon/index.tsx#L24), added in https://github.com/WordPress/gutenberg/pull/10651.)
- Adds missing props like `showHandle` to `ResizableBox`. (See the [definitions here](https://github.com/WordPress/gutenberg/blob/43d950788629daaf588c80a2a56173124f112c60/packages/components/src/resizable-box/index.tsx#L92-L94), added in https://github.com/WordPress/gutenberg/pull/18097.)
- Allows using `ToolbarButton` like `Button`. (See the [explanation here](https://github.com/WordPress/gutenberg/blob/04c0dd302246d893211c1a61e900686004a15150/packages/components/src/toolbar-button/index.js#L63-L65), added, I believe, in https://github.com/WordPress/gutenberg/pull/18931.)

For more details about the reasons for each of these changes, including additional links to the code, see the relevant commits.

The latest of these changes is from around version 8.1 of `@wordpress/components` and the type definitions claim to be accurate for version 14.0, so I have not changed the version number.

Note that there are some type errors in the npm tests for this package, but they are all pre-existing and none were added by this PR.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see above for each change)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
