### PR TITLE
Added Type definitions for WordPress admin window global

### DIFF
--- a/types/wordpress__admin/components/media-models.d.ts
+++ b/types/wordpress__admin/components/media-models.d.ts
@@ -1,0 +1,209 @@
+import * as Backbone from 'backbone';
+import { MemoizedFunction } from 'lodash';
+
+export type AttachmentOptions = {
+    context: Record<string, unknown>;
+    data: AttachmentOptionsData;
+};
+
+export type AttachmentOptionsData = {
+    action?: string;
+    id?: number;
+    nonce?: string;
+    post_id?: number;
+    changes?: { [key: string]: string };
+};
+
+export type AttachmentsOptions = {
+    props: {
+        order: string;
+        orderby: string;
+        query: string;
+        observe: string;
+        filters: string;
+    };
+};
+
+/**
+ * Media Model Attachment
+ */
+export type Attachment = Backbone.Model & {
+    id: number;
+
+    /**
+     * Triggered when attachment details change
+     * Overrides Backbone.Model.sync
+     */
+    sync: (method: string, model: Attachment, options: any) => unknown; // Returns wp.media.ajax;
+
+    /**
+     * Convert date strings into Date objects.
+     *
+     * @param  resp The raw response object, typically returned by fetch()
+     * @return      The modified response object, which is the attributes hash
+     *              to be set on the model.
+     */
+    parse: (response: Record<string, unknown>) => Record<string, unknown>;
+
+    saveCompat: (data: AttachmentOptionsData, options: Record<string, unknown>) => Promise<any>;
+
+    /**
+     * Create a new model on the static 'all' attachments collection and return it.
+     */
+    create: (attrs: Record<string, unknown>) => Attachment;
+
+    get: <T extends Backbone.Model>(id: string, attachment: Backbone.Model | undefined) => T & MemoizedFunction;
+};
+
+/**
+ * A collection of attachments.
+ *
+ * This collection has no persistence with the server without supplying
+ * 'options.props.query = true', which will mirror the collection
+ */
+export type Attachments = Backbone.Collection<Attachment> & {
+    model: Attachment;
+
+    validateDestroyed: boolean;
+
+    initialize: (models: Attachment[], options: AttachmentsOptions) => void;
+
+    /**
+     * Checks whether an attachment is valid.
+     */
+    validator: (attachment: Attachment) => boolean;
+
+    /**
+     * Add or remove an attachment to the collection depending on its validity.
+     */
+    validate: (attachment: Attachment, options: Backbone.Silenceable) => Attachments;
+
+    /**
+     * Add or remove all attachments from another collection depending on each one's validity.
+     */
+    validateAll: (attachments: Attachment[], options: Backbone.Silenceable) => Attachments;
+
+    /**
+     * Start observing another attachments collection change events
+     * and replicate them on this collection.
+     */
+    observe: (attachments: Attachment[]) => Attachments;
+
+    /**
+     * Stop replicating collection change events from another attachments collection.
+     */
+    unobserve: (attachments: Attachment[]) => Attachments;
+
+    /**
+     * Start mirroring another attachments collection, clearing out any models already
+     * in the collection.
+     */
+    mirror: (attachments: Attachment[]) => Attachments;
+
+    /**
+     * Stop mirroring another attachments collection.
+     */
+    unmirror: () => void;
+
+    /**
+     * Retrieve more attachments from the server for the collection.
+     *
+     * Only works if the collection is mirroring a Query Attachments collection,
+     * and forwards to its `more` method. This collection class doesn't have
+     * server persistence by itself.
+     */
+    more: (options: any) => Promise<any>;
+
+    /**
+     * Whether there are more attachments that haven't been sync'd from the server
+     * that match the collection's query.
+     *
+     * Only works if the collection is mirroring a Query Attachments collection,
+     * and forwards to its `hasMore` method. This collection class doesn't have
+     * server persistence by itself.
+     */
+    hasMore: () => boolean;
+
+    /**
+     * Gets the total number of attachments.
+     */
+    getTotalAttachments: () => number;
+
+    /**
+     * A custom Ajax-response parser.
+     *
+     * See trac ticket #24753.
+     *
+     * Called automatically by Backbone whenever a collection's models are returned
+     * by the server, in fetch. The default implementation is a no-op, simply
+     * passing through the JSON response. We override this to add attributes to
+     * the collection items.
+     */
+    parse: (response: Record<string, unknown>, xhr: unknown) => Record<string, unknown>;
+
+    /**
+     * If this collection is sorted by `menuOrder`, recalculates and saves
+     * the menu order to the database.
+     */
+    saveMenuOrder: () => unknown; // returns wp.media.post;
+
+    /**
+     * A function to compare two attachment models in an attachments collection.
+     *
+     * Used as the default comparator for instances of wp.media.model.Attachments
+     * and its subclasses.
+     */
+    comparator(a: Backbone.Model, b: Backbone.Model, options: Record<string, unknown>): number;
+
+    filters: AttachmentFilters;
+};
+
+export type Selection = Attachments & {
+    /**
+     * Refresh the `single` model whenever the selection changes.
+     * Binds `single` instead of using the context argument to ensure
+     * it receives no parameters.
+     */
+    initialize: (models: Attachment[], options: any) => void;
+
+    /**
+     * If the workflow does not support multi-select, clear out the selection
+     * before adding a new attachment to it.
+     */
+    add: (models: Attachment[], options: any) => Attachment[];
+
+    /**
+     * Fired when toggling (clicking on) an attachment in the modal.
+     */
+    single: (model: Attachment | boolean | undefined) => Attachment[];
+};
+
+export type AttachmentFilters = {
+    search: (attachment: Attachment) => boolean;
+    type: (attachment: Attachment) => boolean;
+    uploadedTo: (attachment: Attachment) => boolean;
+    status: (attachment: Attachment) => boolean;
+};
+
+export type Query = Attachments & {
+    initialize: (models: Attachment[], options: any) => void;
+    hasMore: () => boolean;
+    more: (options: any) => Promise<any>;
+    sync: (method: string, model: Backbone.Model, options: any) => unknown;
+    get: (props: any, options: any) => Query;
+};
+
+export type PostImageAttributes = {
+    attachment_id: number;
+    [key: string]: any;
+};
+
+export type PostImage = Backbone.Model & {
+    initialize: (attributes: PostImageAttributes) => void;
+    bindAttachmentListeners: () => void;
+    changeAttachment: (attachment: Attachment, props: any) => void;
+    setLinkTypeFromUrl: () => void;
+    updateLinkUrl: () => void;
+    updateSize: () => void;
+    setAspectRatio: () => void;
+};

--- a/types/wordpress__admin/components/media-models.d.ts
+++ b/types/wordpress__admin/components/media-models.d.ts
@@ -1,20 +1,20 @@
 import * as Backbone from 'backbone';
 import { MemoizedFunction } from 'lodash';
 
-export type AttachmentOptions = {
+export interface AttachmentOptions {
     context: Record<string, unknown>;
     data: AttachmentOptionsData;
-};
+}
 
-export type AttachmentOptionsData = {
+export interface AttachmentOptionsData {
     action?: string;
     id?: number;
     nonce?: string;
     post_id?: number;
     changes?: { [key: string]: string };
-};
+}
 
-export type AttachmentsOptions = {
+export interface AttachmentsOptions {
     props: {
         order: string;
         orderby: string;
@@ -22,7 +22,7 @@ export type AttachmentsOptions = {
         observe: string;
         filters: string;
     };
-};
+}
 
 /**
  * Media Model Attachment
@@ -52,7 +52,7 @@ export type Attachment = Backbone.Model & {
      */
     create: (attrs: Record<string, unknown>) => Attachment;
 
-    get: <T extends Backbone.Model>(id: string, attachment: Backbone.Model | undefined) => T & MemoizedFunction;
+    get: (id: string, attachment: Backbone.Model | undefined) => any & MemoizedFunction;
 };
 
 /**
@@ -178,12 +178,12 @@ export type Selection = Attachments & {
     single: (model: Attachment | boolean | undefined) => Attachment[];
 };
 
-export type AttachmentFilters = {
+export interface AttachmentFilters {
     search: (attachment: Attachment) => boolean;
     type: (attachment: Attachment) => boolean;
     uploadedTo: (attachment: Attachment) => boolean;
     status: (attachment: Attachment) => boolean;
-};
+}
 
 export type Query = Attachments & {
     initialize: (models: Attachment[], options: any) => void;
@@ -193,10 +193,10 @@ export type Query = Attachments & {
     get: (props: any, options: any) => Query;
 };
 
-export type PostImageAttributes = {
+export interface PostImageAttributes {
     attachment_id: number;
     [key: string]: any;
-};
+}
 
 export type PostImage = Backbone.Model & {
     initialize: (attributes: PostImageAttributes) => void;

--- a/types/wordpress__admin/components/media-views.d.ts
+++ b/types/wordpress__admin/components/media-views.d.ts
@@ -4,18 +4,18 @@ import { WpBackboneSubviews, WpBackBoneView, WpBackboneViewList } from './wp-bac
 
 export type FrameType = 'select' | 'post' | 'manage' | 'image' | 'audio' | 'video' | 'edit-attachments';
 
-export type FrameClasses = {
+export interface FrameClasses {
     select: MediaFrameSelect;
-};
+}
 
-export type FrameOptions = {
+export interface FrameOptions {
     title?: string;
     button?: {
         text?: string;
     };
     // frame?: FrameType;
     multiple?: boolean;
-};
+}
 
 export type View = WpBackBoneView & {
     constructor: (options?: { [key: string]: any }) => void;
@@ -64,7 +64,7 @@ export type Region = Backbone.Model & {
     /**
      * Trigger regional view events on the frame.
      */
-    trigger: (event: any | Event) => Region;
+    trigger: (event: any) => Region;
 };
 
 /**
@@ -97,7 +97,7 @@ export type State = Backbone.Model & {
  *
  * States are stored as models in a Backbone collection.
  */
-export type StateMachine = {
+export interface StateMachine {
     (): { extend: typeof Backbone.Model.extend };
 
     /**
@@ -132,7 +132,7 @@ export type StateMachine = {
     on: (event: string, callback: (...args: any[]) => void) => StateMachine;
     off: (event: string, callback: (...args: any[]) => void) => StateMachine;
     trigger: (event: string, ...args: any[]) => StateMachine;
-};
+}
 
 // eslint-disable-next-line prettier/prettier
 export type Frame = StateMachine &
@@ -197,7 +197,7 @@ export type MediaFrame = Frame & {
 
     createMenu: (menu: any) => void;
 
-    toggleMenu: (event: any | Event) => void;
+    toggleMenu: (event: any) => void;
 
     createToolbar: (toolbar: any) => void;
 
@@ -263,12 +263,12 @@ export type MediaFrameSelect = MediaFrame & {
     createStates: () => void;
 
     /**
-     *Bind region mode event callbacks.
+     * Bind region mode event callbacks.
      */
     bindHandlers: () => void;
 
     /**
-     *Render callback for the router region in the `browse` mode.
+     * Render callback for the router region in the `browse` mode.
      */
     browseRouter: (routerView: any) => void; // RouterView => media.view.Router
 

--- a/types/wordpress__admin/components/media-views.d.ts
+++ b/types/wordpress__admin/components/media-views.d.ts
@@ -1,0 +1,286 @@
+import * as Backbone from 'backbone';
+import { TemplateExecutor } from 'lodash';
+import { WpBackboneSubviews, WpBackBoneView, WpBackboneViewList } from './wp-backbone';
+
+export type FrameType = 'select' | 'post' | 'manage' | 'image' | 'audio' | 'video' | 'edit-attachments';
+
+export type FrameClasses = {
+    select: MediaFrameSelect;
+};
+
+export type FrameOptions = {
+    title?: string;
+    button?: {
+        text?: string;
+    };
+    // frame?: FrameType;
+    multiple?: boolean;
+};
+
+export type View = WpBackBoneView & {
+    constructor: (options?: { [key: string]: any }) => void;
+    dispose: () => View;
+    remove: () => View;
+};
+
+/**
+ * A region is a persistent application layout area.
+ *
+ * A region assumes one mode at any time, and can be switched to another.
+ *
+ * When mode changes, events are triggered on the region's parent view.
+ * The parent view will listen to specific events and fill the region with an
+ * appropriate view depending on mode. For example, a frame listens for the
+ * 'browse' mode t be activated on the 'content' view and then fills the region
+ * with an AttachmentsBrowser view.
+ */
+export type Region = Backbone.Model & {
+    options?: {
+        id?: string;
+        view?: Backbone.View;
+        selector?: string;
+    };
+
+    /**
+     * Activate a mode.
+     */
+    mode: (mode: string) => Region;
+
+    /**
+     * Render a mode.
+     */
+    render: (mode: string) => Region;
+
+    /**
+     * Get the region's view.
+     */
+    get: () => View;
+
+    /**
+     * Set the region's view as a subview of the frame.
+     */
+    set: (views: WpBackboneViewList, options: any) => WpBackboneSubviews;
+
+    /**
+     * Trigger regional view events on the frame.
+     */
+    trigger: (event: any | Event) => Region;
+};
+
+/**
+ * wp.media.controller.State
+ *
+ * A state is a step in a workflow that when set will trigger the controllers
+ * for the regions to be updated as specified in the frame.
+ *
+ * A state has an event-driven lifecycle:
+ *
+ *     'ready'      triggers when a state is added to a state machine's collection.
+ *     'activate'   triggers when a state is activated by a state machine.
+ *     'deactivate' triggers when a state is deactivated by a state machine.
+ *     'reset'      is not triggered automatically. It should be invoked by the
+ *                  proper controller to reset the state to its default.
+ */
+export type State = Backbone.Model & {
+    constructor: () => void;
+    ready: () => void;
+    activate: () => void;
+    deactivate: () => void;
+    reset: () => void;
+};
+
+/**
+ * wp.media.controller.StateMachine
+ *
+ * A state machine keeps track of state. It is in one state at a time,
+ * and can change from one state to another.
+ *
+ * States are stored as models in a Backbone collection.
+ */
+export type StateMachine = {
+    (): { extend: typeof Backbone.Model.extend };
+
+    /**
+     * Fetch a state.
+     *
+     * If no `id` is provided, returns the active state.
+     *
+     * Implicitly creates states.
+     *
+     * Ensure that the `states` collection exists so the `StateMachine`
+     * can be used as a mixin.
+     */
+    state: (id?: string) => State;
+
+    /**
+     * Sets the active state.
+     *
+     * Bail if we're trying to select the current state, if we haven't
+     * created the `states` collection, or are trying to select a state
+     * that does not exist.
+     */
+    setState: (id: string) => StateMachine;
+
+    /**
+     * Returns the previous active state.
+     *
+     * Call the `state()` method with no parameters to retrieve the current
+     * active state.
+     */
+    lastState: () => State;
+
+    on: (event: string, callback: (...args: any[]) => void) => StateMachine;
+    off: (event: string, callback: (...args: any[]) => void) => StateMachine;
+    trigger: (event: string, ...args: any[]) => StateMachine;
+};
+
+// eslint-disable-next-line prettier/prettier
+export type Frame = StateMachine &
+    View & {
+        initialize: () => void;
+        /**
+         * Reset all states on the frame to their defaults.
+         */
+        reset: () => Frame;
+
+        triggerModeEvents: (
+            model: Backbone.Model,
+            collection: Backbone.Collection,
+            options: { [key: string]: string },
+        ) => void;
+
+        /**
+         * Activate a mode on the frame.
+         */
+        activateMode: (mode: string) => Frame;
+
+        /**
+         * Deactivate a mode on the frame.
+         */
+        deactivateMode: (mode: string) => Frame;
+
+        /**
+         * Check if a mode is enabled on the frame.
+         */
+        isModeActive: (mode: string) => boolean;
+    };
+
+/**
+ * The frame used to create the media modal.
+ */
+export type MediaFrame = Frame & {
+    // Object properties
+    className: string;
+    template: TemplateExecutor;
+    regions: string[];
+    events: { [key: string]: string };
+    modal: unknown;
+    options: {
+        [key: string]: unknown;
+    };
+    uploader: UploaderWindow;
+    // Object methods
+
+    /**
+     * Sets the attributes to be used on the menu ARIA tab panel.
+     */
+    setMenuTabPanelAriaAttributes: () => void;
+
+    /**
+     * Sets the attributes to be used on the router ARIA tab panel.
+     */
+    setRouterTabPanelAriaAttributes: () => void;
+
+    render: () => MediaFrame;
+
+    createTitle: (title: any) => void;
+
+    createMenu: (menu: any) => void;
+
+    toggleMenu: (event: any | Event) => void;
+
+    createToolbar: (toolbar: any) => void;
+
+    createRouter: (router: any) => void;
+
+    createIframeStates: (options: any) => void;
+
+    iframeContent: (content: any) => void;
+
+    iframeContentCleanup: () => void;
+
+    iframeMenu: (view: any) => void;
+
+    hijackThickbox: () => void;
+
+    restoreThickbox: () => void;
+
+    open: () => MediaFrame;
+
+    close: () => MediaFrame;
+
+    attach: () => MediaFrame;
+
+    detach: () => MediaFrame;
+
+    escape: () => MediaFrame;
+};
+
+export type UploaderWindow = View & {
+    tagName: string;
+    className: string;
+    template: TemplateExecutor;
+    options: {
+        uploader?: {
+            params?: { [key: string]: any };
+        };
+    };
+
+    initialize: () => void;
+    refresh: () => void;
+    ready: () => void;
+    show: () => void;
+    hide: () => void;
+};
+
+export type MediaFrameSelect = MediaFrame & {
+    initialize: () => void;
+
+    /**
+     * Attach a selection collection to the frame.
+     *
+     * A selection is a collection of attachments used for a specific purpose
+     * by a media frame. e.g. Selecting an attachment (or many) to insert into
+     * post content.
+     */
+    createSelection: () => void;
+
+    editImageContent: () => void;
+
+    /**
+     * Create the default states on the frame.
+     */
+    createStates: () => void;
+
+    /**
+     *Bind region mode event callbacks.
+     */
+    bindHandlers: () => void;
+
+    /**
+     *Render callback for the router region in the `browse` mode.
+     */
+    browseRouter: (routerView: any) => void; // RouterView => media.view.Router
+
+    /**
+     * Render callback for the content region in the `browse` mode.
+     */
+    browseContent: (contentRegion: Region) => void;
+
+    /**
+     * Render callback for the content region in the `upload` mode.
+     */
+    uploadContent: () => void;
+
+    createSelectToolbar: (toolbar: any, option: any) => void;
+};

--- a/types/wordpress__admin/components/wp-backbone.d.ts
+++ b/types/wordpress__admin/components/wp-backbone.d.ts
@@ -1,26 +1,26 @@
 import * as Backbone from 'backbone';
 import * as _ from 'lodash';
 
-export type WpBackboneViewList = Array<WpBackBoneView> | { [key: string]: WpBackBoneView[] };
+export type WpBackboneViewList = WpBackBoneView[] | { [key: string]: WpBackBoneView[] };
 
-export type WpBackBoneViewOptions = {
+export interface WpBackBoneViewOptions {
     template?: _.TemplateExecutor;
     [key: string]: any;
-};
+}
 
-export type WpSubViewSetOptions = {
+export interface WpSubViewSetOptions {
     silent?: boolean;
     add?: boolean;
     at?: number;
-};
+}
 
 /**
  * WordPress Backbone instance
  */
-export type WpBackbone = {
+export interface WpBackbone {
     View: WpBackBoneView;
     Subviews: WpBackboneSubviews;
-};
+}
 
 /**
  * A backbone subview manager.
@@ -125,7 +125,7 @@ export type WpBackboneSubviews = Backbone.Model & {
      *
      * Can be overridden in subclasses.
      */
-    replace: ($target: JQuery<HTMLElement>, els: string | HTMLElement | HTMLElement[]) => WpBackboneSubviews;
+    replace: ($target: JQuery, els: string | HTMLElement | HTMLElement[]) => WpBackboneSubviews;
 
     /**
      * Insert subviews into a selector.
@@ -135,7 +135,7 @@ export type WpBackboneSubviews = Backbone.Model & {
      * provided index.
      */
     insert: (
-        $target: JQuery<HTMLElement>,
+        $target: JQuery,
         els: string | HTMLElement | HTMLElement[],
         options: WpSubViewSetOptions,
     ) => WpBackboneSubviews;

--- a/types/wordpress__admin/components/wp-backbone.d.ts
+++ b/types/wordpress__admin/components/wp-backbone.d.ts
@@ -1,0 +1,186 @@
+import * as Backbone from 'backbone';
+import * as _ from 'lodash';
+
+export type WpBackboneViewList = Array<WpBackBoneView> | { [key: string]: WpBackBoneView[] };
+
+export type WpBackBoneViewOptions = {
+    template?: _.TemplateExecutor;
+    [key: string]: any;
+};
+
+export type WpSubViewSetOptions = {
+    silent?: boolean;
+    add?: boolean;
+    at?: number;
+};
+
+/**
+ * WordPress Backbone instance
+ */
+export type WpBackbone = {
+    View: WpBackBoneView;
+    Subviews: WpBackboneSubviews;
+};
+
+/**
+ * A backbone subview manager.
+ */
+export type WpBackboneSubviews = Backbone.Model & {
+    (view: WpBackBoneView, views: WpBackboneViewList): void;
+
+    /**
+     * Fetches all of the subviews.
+     */
+    all: () => WpBackBoneView[];
+
+    /**
+     * Fetches all subviews that match a given `selector`.
+     *
+     * If no `selector` is provided, it will grab all subviews attached
+     * to the view's root.
+     *
+     * @param selector A jQuery selector.
+     */
+    get: (selector: string) => WpBackBoneView | undefined;
+
+    /**
+     * Fetches the first subview that matches a given `selector`.
+     *
+     * If no `selector` is provided, it will grab the first subview attached to the
+     * view's root.
+     *
+     * Useful when a selector only has one subview at a time.
+     *
+     * @param selector A jQuery selector.
+     */
+    first: (selector: string) => WpBackBoneView | null;
+
+    /**
+     * Registers subview(s).
+     *
+     * Registers any number of `views` to a `selector`.
+     *
+     * When no `selector` is provided, the root selector (the empty string)
+     * is used. `views` accepts a `Backbone.View` instance or an array of
+     * `Backbone.View` instances.
+     */
+    set: (selector: string, views: WpBackboneViewList, options?: WpSubViewSetOptions) => WpBackboneSubviews;
+
+    /**
+     * Add subview(s) to existing subviews.
+     *
+     * An alias to `Views.set()`, which defaults `options.add` to true.
+     *
+     * Adds any number of `views` to a `selector`.
+     *
+     * When no `selector` is provided, the root selector (the empty string)
+     * is used. `views` accepts a `Backbone.View` instance or an array of
+     * `Backbone.View` instances.
+     */
+    add: (selector: string, views: WpBackboneViewList, options?: WpSubViewSetOptions) => WpBackboneSubviews;
+
+    /**
+     * Removes an added subview.
+     *
+     * Stops tracking `views` registered to a `selector`. If no `views` are
+     * set, then all of the `selector`'s subviews will be unregistered and
+     * removed.
+     */
+    unset: (selector: string, views: WpBackboneViewList, options?: WpSubViewSetOptions) => WpBackboneSubviews;
+
+    /**
+     * Detaches all subviews.
+     *
+     * Helps to preserve all subview events when re-rendering the master
+     * view. Used in conjunction with `Views.render()`.
+     */
+    detach: () => WpBackboneSubviews;
+
+    /**
+     * Renders all subviews.
+     *
+     * Used in conjunction with `Views.detach()`.
+     */
+    render: () => WpBackboneSubviews;
+
+    /**
+     * Removes all subviews.
+     *
+     * Triggers the `remove()` method on all subviews. Detaches the master
+     * view from its parent. Resets the internals of the views manager.
+     *
+     * Accepts an `options` object. If `options.silent` is set, `unset`
+     * will *not* be triggered on the master view's parent.
+     *
+     */
+    remove: (options: false | { silent: boolean }) => WpBackboneSubviews;
+
+    /**
+     * Replaces a selector's subviews
+     *
+     * By default, sets the `$target` selector's html to the subview `els`.
+     *
+     * @param $target Selector where to put the elements.
+     * @param els HTML or elements to put into the selector's HTML.
+     *
+     * Can be overridden in subclasses.
+     */
+    replace: ($target: JQuery<HTMLElement>, els: string | HTMLElement | HTMLElement[]) => WpBackboneSubviews;
+
+    /**
+     * Insert subviews into a selector.
+     *
+     * By default, appends the subview `els` to the end of the `$target`
+     * selector. If `options.at` is set, inserts the subview `els` at the
+     * provided index.
+     */
+    insert: (
+        $target: JQuery<HTMLElement>,
+        els: string | HTMLElement | HTMLElement[],
+        options: WpSubViewSetOptions,
+    ) => WpBackboneSubviews;
+
+    /**
+     * Triggers the ready event.
+     *
+     * Only use this method if you know what you're doing. For performance reasons,
+     * this method does not check if the view is actually attached to the DOM. It's
+     * taking your word for it.
+     *
+     * Fires the ready event on the current view and all attached subviews.
+     */
+    ready: () => WpBackboneSubviews;
+};
+
+/**
+ * The base view class.
+ *
+ * This extends the backbone view to have a build-in way to use subviews. This
+ * makes it easier to have nested views.
+ *
+ */
+export type WpBackBoneView = Backbone.View & {
+    Subviews: WpBackboneSubviews;
+    extend(): typeof Backbone.Model.extend;
+
+    constructor: (options: WpBackBoneViewOptions) => void;
+    /**
+     * Removes this view and all subviews.
+     */
+    remove: () => WpBackboneSubviews;
+
+    /**
+     * Renders this view and all subviews.
+     */
+    render: () => WpBackBoneView;
+
+    /**
+     * Returns the options for this view.
+     */
+    prepare: () => WpBackBoneViewOptions;
+
+    /**
+     * Method that is called when the ready event is triggered.
+     */
+    ready: () => void;
+};

--- a/types/wordpress__admin/index.d.ts
+++ b/types/wordpress__admin/index.d.ts
@@ -3,6 +3,9 @@
 // Definitions by: Sibin Grasic <https://github.com/oblakstudio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="backbone" />
+/// <reference types="lodash" />
+
 import { Attachment, Attachments, PostImage, Query } from './components/media-models';
 import { Frame, FrameOptions, MediaFrame, MediaFrameSelect, Region, State, StateMachine, View } from './components/media-views';
 import { WpBackbone } from './components/wp-backbone';

--- a/types/wordpress__admin/index.d.ts
+++ b/types/wordpress__admin/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for @wordpress/admin 5.8
+// Project: https://github.com/wordpress/wordpress
+// Definitions by: Sibin Grasic <https://github.com/oblakstudio>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Attachment, Attachments, PostImage, Query } from './components/media-models';
+import { Frame, FrameOptions, MediaFrame, MediaFrameSelect, Region, State, StateMachine, View } from './components/media-views';
+import { WpBackbone } from './components/wp-backbone';
+
+export type Media = {
+  (attributes: FrameOptions): MediaFrameSelect;
+  (attributes: FrameOptions & { frame: 'post' }): any;
+  controller: {
+    Region: Region;
+    StateMachine: StateMachine;
+    State: State;
+  };
+  model: {
+    Attachment: Attachment;
+    Attachments: Attachments;
+    PostImage: PostImage;
+    Query: Query;
+    Selection: Selection;
+  };
+  view: {
+    Frame: Frame;
+    MediaFrame: MediaFrame;
+  };
+  View: View;
+  frames: Record<string, unknown>;
+};
+
+export type WpAdmin = {
+  Backbone: WpBackbone;
+  media: Media;
+};
+
+declare global {
+  interface Window {
+    wp: WpAdmin;
+  }
+}

--- a/types/wordpress__admin/index.d.ts
+++ b/types/wordpress__admin/index.d.ts
@@ -7,7 +7,7 @@ import { Attachment, Attachments, PostImage, Query } from './components/media-mo
 import { Frame, FrameOptions, MediaFrame, MediaFrameSelect, Region, State, StateMachine, View } from './components/media-views';
 import { WpBackbone } from './components/wp-backbone';
 
-export type Media = {
+export interface Media {
   (attributes: FrameOptions): MediaFrameSelect;
   (attributes: FrameOptions & { frame: 'post' }): any;
   controller: {
@@ -28,12 +28,12 @@ export type Media = {
   };
   View: View;
   frames: Record<string, unknown>;
-};
+}
 
-export type WpAdmin = {
+export interface WpAdmin {
   Backbone: WpBackbone;
   media: Media;
-};
+}
 
 declare global {
   interface Window {

--- a/types/wordpress__admin/index.d.ts
+++ b/types/wordpress__admin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package WordPress Admin Dashboarsd - WP-Admin 5.8.3
+// Type definitions for non-npm package WordPress Admin Dashboarsd - WP-Admin 5.8
 // Project: https://github.com/wordpress/wordpress
 // Definitions by: Sibin Grasic <https://github.com/oblakstudio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__admin/index.d.ts
+++ b/types/wordpress__admin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/admin 5.8
+// Type definitions for non-npm package WordPress Admin Dashboarsd - WP-Admin 5.8.3
 // Project: https://github.com/wordpress/wordpress
 // Definitions by: Sibin Grasic <https://github.com/oblakstudio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__admin/tsconfig.json
+++ b/types/wordpress__admin/tsconfig.json
@@ -17,9 +17,6 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "paths": {
-            "jquery": [
-                "jquery/v3"
-            ],
             "lodash": [
                 "lodash/v3"
             ]

--- a/types/wordpress__admin/tsconfig.json
+++ b/types/wordpress__admin/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "backbone": [
+                "backbone/index"
+            ],
+            "jquery": [
+                "jquery/v3"
+            ],
+            "lodash": [
+                "lodash/v3"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "wordpress__admin-tests.ts"
+    ]
+}

--- a/types/wordpress__admin/tsconfig.json
+++ b/types/wordpress__admin/tsconfig.json
@@ -17,9 +17,6 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "paths": {
-            "backbone": [
-                "backbone"
-            ],
             "jquery": [
                 "jquery/v3"
             ],

--- a/types/wordpress__admin/tsconfig.json
+++ b/types/wordpress__admin/tsconfig.json
@@ -18,7 +18,7 @@
         "forceConsistentCasingInFileNames": true,
         "paths": {
             "backbone": [
-                "backbone/index"
+                "backbone"
             ],
             "jquery": [
                 "jquery/v3"

--- a/types/wordpress__admin/tslint.json
+++ b/types/wordpress__admin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/wordpress__admin/tslint.json
+++ b/types/wordpress__admin/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
+        "npm-naming": false,
         "export-just-namespace": false,
         "no-empty-interface": false,
         "no-namespace": false,

--- a/types/wordpress__admin/tslint.json
+++ b/types/wordpress__admin/tslint.json
@@ -1,1 +1,9 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "export-just-namespace": false,
+        "no-empty-interface": false,
+        "no-namespace": false,
+        "unified-signatures": false
+    }
+}

--- a/types/wordpress__admin/tslint.json
+++ b/types/wordpress__admin/tslint.json
@@ -2,9 +2,6 @@
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
         "npm-naming": false,
-        "export-just-namespace": false,
-        "no-empty-interface": false,
         "no-namespace": false,
-        "unified-signatures": false
     }
 }

--- a/types/wordpress__admin/tslint.json
+++ b/types/wordpress__admin/tslint.json
@@ -2,6 +2,6 @@
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
         "npm-naming": false,
-        "no-namespace": false,
+        "no-namespace": false
     }
 }

--- a/types/wordpress__admin/wordpress__admin-tests.ts
+++ b/types/wordpress__admin/wordpress__admin-tests.ts
@@ -1,0 +1,5 @@
+const frame = window.wp.media({
+    title: 'Media Library',
+});
+
+frame.on('select', () => alert('works'));


### PR DESCRIPTION

- [* ] Use a meaningful title for the pull request. Include the name of the package modified.
- [* ] Test the change in your own code. (Compile and run.)
- [* ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [*] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [*] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [*] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [*] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [*] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

I'd like to point out that writing these definitions is insanely hard, `window.wp` object is split over multiple files, and all object properties are build via `Backbone.extend`, so I needed to use any in a lot of places in order to make it work.
This is a work in progress, but I consider it a solid base which enables people to work with `window.wp` global in TypeScript
