### PR TITLE
[Memoizee] Added string as a possible type to options/promise

### DIFF
--- a/types/memoizee/index.d.ts
+++ b/types/memoizee/index.d.ts
@@ -11,7 +11,7 @@ declare namespace memoizee {
     maxAge?: number | undefined;
     max?: number | undefined;
     preFetch?: number | true | undefined;
-    promise?: boolean | undefined;
+    promise?: boolean | string | undefined;
     dispose?(value: any): void;
     async?: boolean | undefined;
     primitive?: boolean | undefined;

--- a/types/memoizee/index.d.ts
+++ b/types/memoizee/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for memoizee 0.4.6
+// Type definitions for memoizee 0.4
 // Project: https://github.com/medikoo/memoizee
 // Definitions by: Juan Picado <https://github.com/juanpicado>
 //                 Patrick Muff <https://github.com/dislick>

--- a/types/memoizee/index.d.ts
+++ b/types/memoizee/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for memoizee 0.4
+// Type definitions for memoizee 0.4.6
 // Project: https://github.com/medikoo/memoizee
 // Definitions by: Juan Picado <https://github.com/juanpicado>
 //                 Patrick Muff <https://github.com/dislick>

--- a/types/memoizee/index.d.ts
+++ b/types/memoizee/index.d.ts
@@ -11,7 +11,7 @@ declare namespace memoizee {
     maxAge?: number | undefined;
     max?: number | undefined;
     preFetch?: number | true | undefined;
-    promise?: boolean | string | undefined;
+    promise?: boolean | "then" | "done" | "done:finally" | undefined;
     dispose?(value: any): void;
     async?: boolean | undefined;
     primitive?: boolean | undefined;

--- a/types/memoizee/memoizee-tests.ts
+++ b/types/memoizee/memoizee-tests.ts
@@ -42,19 +42,19 @@ memoized(String({ toString() { return "12"; } }), Number({}));
     const afn = (a: number, b: number) => {
         return new Promise(res => { res(a + b); });
     };
-    const memoized = memoize(afn, { promise: true });
+    let memoized = memoize(afn, { promise: true });
     memoized(3, 7);
     memoized(3, 7);
 
-    const memoized = memoize(afn, { promise: 'then' });
+    memoized = memoize(afn, { promise: 'then' });
     memoized(2, 7);
     memoized(2, 7);
     
-    const memoized = memoize(afn, { promise: 'done' });
+    memoized = memoize(afn, { promise: 'done' });
     memoized(5, 7);
     memoized(5, 7);
     
-    const memoized = memoize(afn, { promise: 'done:finally' });
+    memoized = memoize(afn, { promise: 'done:finally' });
     memoized(8, 7);
     memoized(8, 7);
 }

--- a/types/memoizee/memoizee-tests.ts
+++ b/types/memoizee/memoizee-tests.ts
@@ -45,19 +45,18 @@ memoized(String({ toString() { return "12"; } }), Number({}));
     const memoized = memoize(afn, { promise: true });
     memoized(3, 7);
     memoized(3, 7);
-}
 
-{
-    const afn = (a: number) => {
-        return new Promise(res => { 
-            if (a != 1) {
-                throw new Error('A is not 1!')
-            }
-        });
-    };
+    const memoized = memoize(afn, { promise: 'then' });
+    memoized(2, 7);
+    memoized(2, 7);
+    
+    const memoized = memoize(afn, { promise: 'done' });
+    memoized(5, 7);
+    memoized(5, 7);
+    
     const memoized = memoize(afn, { promise: 'done:finally' });
-    memoized(2);
-    memoized(2);
+    memoized(8, 7);
+    memoized(8, 7);
 }
 
 memoized = memoize(fn, { maxAge: 1000, preFetch: 0.6 });

--- a/types/memoizee/memoizee-tests.ts
+++ b/types/memoizee/memoizee-tests.ts
@@ -47,6 +47,19 @@ memoized(String({ toString() { return "12"; } }), Number({}));
     memoized(3, 7);
 }
 
+{
+    const afn = (a: number) => {
+        return new Promise(res => { 
+            if (a != 1) {
+                throw new Error('A is not 1!')
+            }
+        });
+    };
+    const memoized = memoize(afn, { promise: 'done:finally' });
+    memoized(2);
+    memoized(2);
+}
+
 memoized = memoize(fn, { maxAge: 1000, preFetch: 0.6 });
 
 memoized('foo', 3);

--- a/types/memoizee/memoizee-tests.ts
+++ b/types/memoizee/memoizee-tests.ts
@@ -49,11 +49,11 @@ memoized(String({ toString() { return "12"; } }), Number({}));
     memoized = memoize(afn, { promise: 'then' });
     memoized(2, 7);
     memoized(2, 7);
-    
+
     memoized = memoize(afn, { promise: 'done' });
     memoized(5, 7);
     memoized(5, 7);
-    
+
     memoized = memoize(afn, { promise: 'done:finally' });
     memoized(8, 7);
     memoized(8, 7);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR modifies the types for [Memoizee](https://github.com/medikoo/memoizee). While recently using the types I noticed that the types for the [Memoizee Options](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/memoizee/index.d.ts#L14) is missing the string declaration for the Promise option. 

In their documentation one can see that promise can be `boolean`, `string` or `undefined`.
https://github.com/medikoo/memoizee#memoizing-asynchronous-functions (Can be found under supported modes).

This PR adds the possibility to use different promise modes to Memoizee.