### PR TITLE
Fix typo "defaul"

### DIFF
--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -146,7 +146,7 @@ declare module 'process' {
                 /**
                  * If true, a diagnostic report is generated when the process
                  * receives the signal specified by process.report.signal.
-                 * @defaul false
+                 * @default false
                  */
                 reportOnSignal: boolean;
                 /**

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -802,7 +802,7 @@ declare namespace NodeJS {
         /**
          * If true, a diagnostic report is generated when the process
          * receives the signal specified by process.report.signal.
-         * @defaul false
+         * @default false
          */
         reportOnSignal: boolean;
 

--- a/types/node/v14/process.d.ts
+++ b/types/node/v14/process.d.ts
@@ -120,7 +120,7 @@ declare module 'process' {
                 /**
                  * If true, a diagnostic report is generated when the process
                  * receives the signal specified by process.report.signal.
-                 * @defaul false
+                 * @default false
                  */
                 reportOnSignal: boolean;
 

--- a/types/node/v16/process.d.ts
+++ b/types/node/v16/process.d.ts
@@ -146,7 +146,7 @@ declare module 'process' {
                 /**
                  * If true, a diagnostic report is generated when the process
                  * receives the signal specified by process.report.signal.
-                 * @defaul false
+                 * @default false
                  */
                 reportOnSignal: boolean;
                 /**

--- a/types/p5/lib/addons/p5.sound.d.ts
+++ b/types/p5/lib/addons/p5.sound.d.ts
@@ -1551,7 +1551,7 @@ declare module '../../index' {
          *   that sound. The p5.Delay can produce different
          *   effects depending on the delayTime, feedback,
          *   filter, and type. In the example below, a feedback
-         *   of 0.5 (the defaul value) will produce a looping
+         *   of 0.5 (the default value) will produce a looping
          *   delay that decreases in volume by 50% each repeat.
          *   A filter will cut out the high frequencies so that
          *   the delay does not sound as piercing as the

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -936,7 +936,7 @@ async function test_schema(
     schema.addArray("arrayField", { defaultValue: notArray });
 
     /**
-     * @todo Enable type check for defaul value
+     * @todo Enable type check for default value
      */
     schema.addField("defaultFieldString");
     schema.addField("defaultFieldString", "String", { defaultValue: anyField });


### PR DESCRIPTION
Typos are not usually something I aim to fix, except in instances where functionality is impacted. And the `@default` keyword very much does not tolerate typos to work as intended.

Filled-out template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- n/a Test the change in your own code. (Compile and run.)
- n/a [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- n/a [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] Fixes existing definitions.