### PR TITLE
Add lineColor to @react-verticle-timeline-component VerticalTimelineProps

### DIFF
--- a/types/react-vertical-timeline-component/index.d.ts
+++ b/types/react-vertical-timeline-component/index.d.ts
@@ -12,6 +12,7 @@ export interface VerticalTimelineProps {
     children?: React.ReactNode;
     className?: string | undefined;
     layout?: '1-column' | '2-columns' | undefined;
+    lineColor?: string | undefined;
 }
 
 export interface VerticalTimelineElementProps {

--- a/types/react-vertical-timeline-component/react-vertical-timeline-component-tests.tsx
+++ b/types/react-vertical-timeline-component/react-vertical-timeline-component-tests.tsx
@@ -4,7 +4,7 @@ import { VerticalTimeline, VerticalTimelineElement } from "react-vertical-timeli
 export default class ReactVerticalTimelineComponentTests extends React.Component {
     render() {
         return (
-            <VerticalTimeline animate={false} className="vertical-timeline--red" layout='2-columns'>
+            <VerticalTimeline animate={false} className="vertical-timeline--red" layout='2-columns' lineColor='black'>
                 <VerticalTimelineElement
                     iconOnClick={() => console.info('icon has been clicked')}
                     className="vertical-timeline-element--work"


### PR DESCRIPTION
This PR updates the types for the @react-verticle-timeline-component package to fix a prop missing from the VerticalTimelineProps. Specifically:

Adds type: 'lineColor' to VerticalTimelineProps. 
lineColor is used here: https://github.com/stephane-monnot/react-vertical-timeline/blob/a4685ca0fd703bddc277d32d193d5ce4e8403c56/src/VerticalTimeline.js#L9

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
