### PR TITLE
[gapi.auth2] Fix error TS1062 when awaiting GoogleAuth

### DIFF
--- a/types/gapi.auth2/gapi.auth2-tests.ts
+++ b/types/gapi.auth2/gapi.auth2-tests.ts
@@ -160,3 +160,10 @@ function makeApiCall() {
     document.getElementById('content').appendChild(p);
   });
 }
+
+async function test_await() {
+  // This used to result in TS1062: "Type is referenced directly or indirectly in the fulfillment callback of its own 'then' method"
+  // tslint:disable-next-line: await-promise Bug in tslint: https://github.com/palantir/tslint/issues/3997
+  const auth = await gapi.auth2.getAuthInstance();
+  console.log(auth.isSignedIn.get());
+}

--- a/types/gapi.auth2/index.d.ts
+++ b/types/gapi.auth2/index.d.ts
@@ -12,16 +12,18 @@ declare namespace gapi.auth2 {
    * get the user's current sign-in status, get specific data from the user's Google profile,
    * request additional scopes, and sign out from the current account.
    */
-  class GoogleAuth {
-    isSignedIn: IsSignedIn;
-
-    currentUser: CurrentUser;
-
+  class GoogleAuth extends GoogleAuthBase {
     /**
      * Calls the onInit function when the GoogleAuth object is fully initialized, or calls the onFailure function if
      * initialization fails.
      */
-    then(onInit: (googleAuth: GoogleAuth) => any, onFailure?: (reason: {error: string, details: string}) => any): any;
+    then(onInit: (googleAuth: GoogleAuthBase) => any, onFailure?: (reason: {error: string, details: string}) => any): any;
+  }
+
+  class GoogleAuthBase {
+    isSignedIn: IsSignedIn;
+
+    currentUser: CurrentUser;
 
     /**
      * Signs in the user using the specified options.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/54299128/type-is-referenced-directly-or-indirectly-in-the-fulfillment-callback-of-its-own/59655446#comment124321335_59655446

To provide more context: the types used to accurately reflect the implementation (which meant you couldn't call `await gapi.auth2.getAuthInstance()` or you'd get infinite recursion), but at some point Google fixed the implementation.

AFAICT the source isn't published anywhere so I can't say exactly when they fixed it. This updates the types to reflect Google's fix.

