### PR TITLE
Add type definitions for node dmx library

### DIFF
--- a/types/dmx/dmx-tests.ts
+++ b/types/dmx/dmx-tests.ts
@@ -1,0 +1,23 @@
+import DMX, { Animation } from 'dmx';
+
+const dmx = new DMX();
+const channelMap = {
+    1: 255,
+    2: 0,
+};
+const universe = dmx.addUniverse('universe-1', 'enttec-usb-dmx-pro', '/dev/cu.usbserial-EN086119');
+dmx.update('universe-1', channelMap);
+dmx.devices['rgb-led'] && dmx.devices['rgb-led'].channels;
+dmx.devices['rgb-led'] && dmx.devices['rgb-led'].extraInfo1;
+
+universe.update(channelMap);
+
+const animation = new Animation().add(channelMap, 100).add(channelMap, 100, { easing: 'linear' });
+
+animation.run(universe);
+animation.stop();
+animation.run(universe, () => {});
+animation.stop();
+animation.runLoop(universe, () => {}, 1);
+animation.delay(300);
+animation.reset(0);

--- a/types/dmx/index.d.ts
+++ b/types/dmx/index.d.ts
@@ -1,0 +1,95 @@
+// Type definitions for dmx 0.2
+// Project: https://github.com/node-dmx/dmx
+// Definitions by: Ryan Price <https://github.com/ryprice>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace DMX {
+    interface DMX {
+        addUniverse(name: string, driver: string, deviceId: string, options?: object): Universe;
+        update(universe: string, channels: ChannelMap, extraData?: object): void;
+        devices: Devices;
+    }
+
+    interface Universe {
+        update(channels: ChannelMap): void;
+    }
+
+    interface Devices {
+      [deviceName: string]: Device;
+    }
+
+    interface Device {
+        channels: string[];
+        // Extends Object because it may have other arbitrary properties
+        [name: string]: any;
+    }
+
+    interface Animation {
+        add(to: ChannelMap, duration: number, options?: AnimationStepOptions): Animation;
+        delay(duration: number): Animation;
+        reset(startTime: number): void;
+        run(universe: Universe, onFinish?: () => void): Animation;
+        runLoop(universe: Universe, onFinish?: () => void, loops?: number): void;
+        stop(): void;
+    }
+
+    interface AnimationConstructor {
+        new (options?: AnimationOptions): Animation;
+    }
+
+    interface AnimationOptions {
+        loop?: number;
+        filter?: (completedAnimationStatesToSet: any) => boolean;
+    }
+
+    interface AnimationStepOptions {
+        easing?: EasingTypes;
+    }
+
+    type EasingTypes =
+        | 'linear'
+        | 'inQuad'
+        | 'outQuad'
+        | 'inOutQuad'
+        | 'inCubic'
+        | 'outCubic'
+        | 'inOutCubic'
+        | 'inQuart'
+        | 'outQuart'
+        | 'inOutQuart'
+        | 'inQuint'
+        | 'outQuint'
+        | 'inOutQuint'
+        | 'inSine'
+        | 'outSine'
+        | 'inOutSine'
+        | 'inExpo'
+        | 'outExpo'
+        | 'inOutExpo'
+        | 'inCirc'
+        | 'outCirc'
+        | 'inOutCirc'
+        | 'inElastic'
+        | 'outElastic'
+        | 'inOutElastic'
+        | 'inBack'
+        | 'outBack'
+        | 'inOutBack'
+        | 'inBounce'
+        | 'outBounce'
+        | 'inOutBounce';
+
+    interface ChannelMap {
+      [channel: number]: number;
+    }
+
+    interface DMXStatic {
+        new (): DMX;
+        Animation: AnimationConstructor;
+        devices: Devices;
+    }
+
+    const DMXStatic: DMXStatic;
+}
+
+export = DMX.DMXStatic;

--- a/types/dmx/tsconfig.json
+++ b/types/dmx/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6"
+      ],
+      "esModuleInterop": true,
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "index.d.ts",
+      "dmx-tests.ts"
+  ]
+}

--- a/types/dmx/tslint.json
+++ b/types/dmx/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@definitelytyped/dtslint/dt.json"
+}


### PR DESCRIPTION
This is for the npm [dmx](https://github.com/node-dmx/dmx) package, a library for controlling theater lights via DMX controllers. This PR intends to get completely coverage of the library's api. Aside from writing tests, I have verified that the types work with my own project.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
