### PR TITLE
Add type definitions for node midi library

### DIFF
--- a/types/midi/index.d.ts
+++ b/types/midi/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for midi 2.0
+// Project: https://github.com/justinlatimer/node-midi
+// Definitions by: Ryan Price <https://github.com/ryprice>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace MIDI {
+    type MIDIMessage = [number, number, number];
+
+    type MIDIMessageHandler = (
+        deltaTime: number,
+        // [status, data1, data2]
+        message: MIDIMessage,
+    ) => void;
+
+    interface MIDIInput {
+        getPortCount(): number;
+        getPortName(port: number): string;
+        on(type: 'message', handler: MIDIMessageHandler): void;
+        openPort(port: number): void;
+        ignoreTypes(filterSysex: boolean, filterTiming: boolean, filterSensing: boolean): void;
+    }
+
+    interface MIDIInputConstructor {
+        new (): MIDIInput;
+    }
+
+    interface MIDIOutput {
+        getPortCount(): number;
+        getPortName(port: number): string;
+        openPort(port: number): void;
+        sendMessage(message: MIDIMessage): void;
+        closePort(): void;
+    }
+
+    interface MIDIOutputConstructor {
+        new(): MIDIOutput;
+    }
+
+    interface MIDIStatic {
+        Input: MIDIInputConstructor;
+        Output: MIDIOutputConstructor;
+    }
+
+    const MIDIStatic: MIDIStatic;
+}
+
+export = MIDI.MIDIStatic;

--- a/types/midi/midi-tests.ts
+++ b/types/midi/midi-tests.ts
@@ -1,0 +1,15 @@
+import midi from 'midi';
+
+const input = new midi.Input();
+input.getPortCount();
+input.getPortName(0);
+input.on('message', (deltaTime: number, message: number[]) => {});
+input.openPort(0);
+input.ignoreTypes(false, false, false);
+
+const output = new midi.Output();
+output.getPortCount();
+output.getPortName(0);
+output.openPort(0);
+output.sendMessage([176, 22, 1]);
+output.closePort();

--- a/types/midi/tsconfig.json
+++ b/types/midi/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6"
+      ],
+      "esModuleInterop": true,
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "index.d.ts",
+      "midi-tests.ts"
+  ]
+}

--- a/types/midi/tslint.json
+++ b/types/midi/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@definitelytyped/dtslint/dt.json"
+}


### PR DESCRIPTION
Adds type definitions for the [node midi library](https://github.com/justinlatimer/node-midi). I have only validated the input definitions with my code because my project is using a device that only outputs a midi signal (input to the computer), but it's a relatively simple api and I used the code snippets on node-midi's readme to write `midi-tests.ts`, so should be alright. There are additional parts to this library that I have not written definitions for.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

