### PR TITLE
[jira-client] add `expand` param to `getBoardIssuesForSprint`

### DIFF
--- a/types/jira-client/index.d.ts
+++ b/types/jira-client/index.d.ts
@@ -8,8 +8,8 @@
 
 /// <reference types="node" />
 
-import { CoreOptions, RequestResponse } from "request";
-import { ReadStream } from "fs";
+import { CoreOptions, RequestResponse } from 'request';
+import { ReadStream } from 'fs';
 
 declare class JiraApi {
     private protocol: string;
@@ -38,7 +38,7 @@ declare class JiraApi {
         expand?: string,
         fields?: string,
         properties?: string,
-        fieldsByKeys?: boolean
+        fieldsByKeys?: boolean,
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -99,7 +99,7 @@ declare class JiraApi {
      * Get details about a Sprint
      * @param sprintId - the id for the sprint view
      */
-     getSprint(sprintId: string): Promise<JiraApi.JsonResponse>;
+    getSprint(sprintId: string): Promise<JiraApi.JsonResponse>;
 
     /**
      * Add an issue to the project's current sprint
@@ -175,7 +175,7 @@ declare class JiraApi {
     deleteVersion(
         versionId: string,
         moveFixIssuesToId: string,
-        moveAffectedIssuesToId: string
+        moveAffectedIssuesToId: string,
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -284,7 +284,11 @@ declare class JiraApi {
      * @param issueUpdate - update Object as specified by the rest api
      * @param query - adds parameters to the query string
      */
-    updateIssue(issueId: string, issueUpdate: JiraApi.IssueObject, query?: JiraApi.Query): Promise<JiraApi.JsonResponse>;
+    updateIssue(
+        issueId: string,
+        issueUpdate: JiraApi.IssueObject,
+        query?: JiraApi.Query,
+    ): Promise<JiraApi.JsonResponse>;
 
     /**
      * List Components
@@ -362,7 +366,8 @@ declare class JiraApi {
     upsertFieldOption(
         fieldKey: string,
         optionId: string,
-        option: JiraApi.FieldOptionObject): Promise<JiraApi.JsonResponse>;
+        option: JiraApi.FieldOptionObject,
+    ): Promise<JiraApi.JsonResponse>;
 
     /**
      * Returns an option for a select list issue field.
@@ -455,7 +460,12 @@ declare class JiraApi {
      * @param comment - string containing new comment
      * @param [options={}] - extra options
      */
-    updateComment(issueId: string, commentId: string, comment: string, options?: JiraApi.CommentOptions): Promise<JiraApi.JsonResponse>;
+    updateComment(
+        issueId: string,
+        commentId: string,
+        comment: string,
+        options?: JiraApi.CommentOptions,
+    ): Promise<JiraApi.JsonResponse>;
 
     /**
      * Get Comments by IssueId.
@@ -492,7 +502,7 @@ declare class JiraApi {
         issueId: string,
         worklog: JiraApi.WorklogObject,
         newEstimate?: JiraApi.EstimateObject,
-        options?: JiraApi.WorklogOptions
+        options?: JiraApi.WorklogOptions,
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -649,7 +659,7 @@ declare class JiraApi {
         maxResults?: number,
         type?: string,
         name?: string,
-        projectKeyOrId?: string
+        projectKeyOrId?: string,
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -690,7 +700,7 @@ declare class JiraApi {
         maxResults?: number,
         jql?: string,
         validateQuery?: boolean,
-        fields?: string
+        fields?: string,
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -717,7 +727,7 @@ declare class JiraApi {
         maxResults?: number,
         jql?: string,
         validateQuery?: boolean,
-        fields?: string
+        fields?: string,
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -733,7 +743,7 @@ declare class JiraApi {
         boardId: string,
         startAt?: number,
         maxResults?: number,
-        done?: "true" | "false"
+        done?: 'true' | 'false',
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -756,7 +766,7 @@ declare class JiraApi {
         maxResults?: number,
         jql?: string,
         validateQuery?: boolean,
-        fields?: string
+        fields?: string,
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -839,7 +849,7 @@ declare class JiraApi {
         boardId: string,
         startAt?: number,
         maxResults?: number,
-        state?: "future" | "active" | "closed"
+        state?: 'future' | 'active' | 'closed',
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -863,7 +873,7 @@ declare class JiraApi {
         jql?: string,
         validateQuery?: boolean,
         fields?: string,
-        expand?: string
+        expand?: string,
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -880,7 +890,7 @@ declare class JiraApi {
         boardId: string,
         startAt?: number,
         maxResults?: number,
-        released?: "true" | "false"
+        released?: 'true' | 'false',
     ): Promise<JiraApi.JsonResponse>;
 
     /**
@@ -917,7 +927,14 @@ declare class JiraApi {
      * Default: true.
      * @param [fields] - The list of fields to return for each issue.
      */
-    getIssuesForEpic(epicId: string, startAt?: number, maxResults?: number, jql?: string, validateQuery?: boolean, fields?: string): Promise<JiraApi.JsonResponse>;
+    getIssuesForEpic(
+        epicId: string,
+        startAt?: number,
+        maxResults?: number,
+        jql?: string,
+        validateQuery?: boolean,
+        fields?: string,
+    ): Promise<JiraApi.JsonResponse>;
 
     /**
      * Move Issues to Epic
@@ -961,7 +978,7 @@ declare class JiraApi {
      * [Jira Doc](https://docs.atlassian.com/jira-software/REST/cloud/2/)
      * @param endpoint - Rest API endpoint
      */
-     genericAgileGet(endpoint: string): Promise<JiraApi.JsonResponse>;
+    genericAgileGet(endpoint: string): Promise<JiraApi.JsonResponse>;
 
     private makeRequestHeader(uri: string, options?: JiraApi.UriOptions);
 

--- a/types/jira-client/index.d.ts
+++ b/types/jira-client/index.d.ts
@@ -853,6 +853,7 @@ declare class JiraApi {
      * @param [validateQuery] - Specifies whether to validate the JQL query or not.
      * Default: true.
      * @param [fields] - The list of fields to return for each issue.
+     * @param [expand] - A comma-separated list of the parameters to expand.
      */
     getBoardIssuesForSprint(
         boardId: string,
@@ -861,7 +862,8 @@ declare class JiraApi {
         maxResults?: number,
         jql?: string,
         validateQuery?: boolean,
-        fields?: string
+        fields?: string,
+        expand?: string
     ): Promise<JiraApi.JsonResponse>;
 
     /**

--- a/types/jira-client/jira-client-tests.ts
+++ b/types/jira-client/jira-client-tests.ts
@@ -2,39 +2,30 @@ import * as JiraApi from 'jira-client';
 
 // Initialize
 const jira = new JiraApi({
-  protocol: 'https',
-  host: 'jira.somehost.com',
-  username: 'username',
-  password: 'password',
-  apiVersion: '2',
-  strictSSL: true
+    protocol: 'https',
+    host: 'jira.somehost.com',
+    username: 'username',
+    password: 'password',
+    apiVersion: '2',
+    strictSSL: true,
 });
 
-const issueNumber = "123";
+const issueNumber = '123';
 
 jira.findIssue(issueNumber)
-  .then(issue => {
-    console.log(`Status: ${issue.fields.status.name}`);
-  })
-  .catch(err => {
-    console.error(err);
-  });
+    .then(issue => {
+        console.log(`Status: ${issue.fields.status.name}`);
+    })
+    .catch(err => {
+        console.error(err);
+    });
 async function logIssueName() {
-  try {
-    const issue = await jira.findIssue(issueNumber);
-    console.log(`Status: ${issue.fields.status.name}`);
-  } catch (err) {
-    console.error(err);
-  }
+    try {
+        const issue = await jira.findIssue(issueNumber);
+        console.log(`Status: ${issue.fields.status.name}`);
+    } catch (err) {
+        console.error(err);
+    }
 }
 
-jira.getBoardIssuesForSprint(
-  '123',
-  '456',
-  undefined,
-  undefined,
-  undefined,
-  undefined,
-  undefined,
-  'changelog'
-);
+jira.getBoardIssuesForSprint('123', '456', undefined, undefined, undefined, undefined, undefined, 'changelog');

--- a/types/jira-client/jira-client-tests.ts
+++ b/types/jira-client/jira-client-tests.ts
@@ -27,3 +27,14 @@ async function logIssueName() {
     console.error(err);
   }
 }
+
+jira.getBoardIssuesForSprint(
+  '123',
+  '456',
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  'changelog'
+);


### PR DESCRIPTION
The `expand` paramter was added to the lib on https://github.com/jira-node/node-jira-client/pull/328 but documentation was only properly fixed at https://github.com/jira-node/node-jira-client/commit/b85af64de0f9ac19c7baafd31e2abe52a33844d7.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jira-node/node-jira-client/blob/master/src/jira.js#L1972
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.