### PR TITLE
[spotify-web-api-node] Improve `after` property type

### DIFF
--- a/types/spotify-web-api-node/index.d.ts
+++ b/types/spotify-web-api-node/index.d.ts
@@ -581,8 +581,8 @@ declare class SpotifyWebApi {
      *          otherwise an error. Not returned if a callback is given. Note that the response will be empty
      *          in case the user has enabled private session.
      */
-    getMyRecentlyPlayedTracks(options: BeforeOptions | AfterOptions, callback: Callback<SpotifyApi.UsersRecentlyPlayedTracksResponse>): void;
-    getMyRecentlyPlayedTracks(options?: BeforeOptions | AfterOptions): Promise<Response<SpotifyApi.UsersRecentlyPlayedTracksResponse>>;
+    getMyRecentlyPlayedTracks(options: BeforeOptions | AfterOptions<number>, callback: Callback<SpotifyApi.UsersRecentlyPlayedTracksResponse>): void;
+    getMyRecentlyPlayedTracks(options?: BeforeOptions | AfterOptions<number>): Promise<Response<SpotifyApi.UsersRecentlyPlayedTracksResponse>>;
 
     /**
      * Add track or episode to device queue
@@ -789,8 +789,8 @@ declare class SpotifyWebApi {
      * @returns A promise that if successful, resolves to an object containing a paging object which contains
      * album objects. Not returned if a callback is given.
      */
-    getFollowedArtists(options: AfterOptions, callback: Callback<SpotifyApi.UsersFollowedArtistsResponse>): void;
-    getFollowedArtists(options?: AfterOptions): Promise<Response<SpotifyApi.UsersFollowedArtistsResponse>>;
+    getFollowedArtists(options: AfterOptions<string>, callback: Callback<SpotifyApi.UsersFollowedArtistsResponse>): void;
+    getFollowedArtists(options?: AfterOptions<string>): Promise<Response<SpotifyApi.UsersFollowedArtistsResponse>>;
 
     /**
      * Check if users are following a playlist.
@@ -1089,8 +1089,8 @@ interface BeforeOptions extends LimitOptions {
     before?: number | undefined;
 }
 
-interface AfterOptions extends LimitOptions {
-    after?: string | undefined;
+interface AfterOptions<T extends number | string> extends LimitOptions {
+    after?: T | undefined;
 }
 
 interface LocaleOptions extends CountryOptions {


### PR DESCRIPTION
I changed the type of the shared `after` property used for cursor-based pagination in two different endpoints. One requires string and the other one requires number. At the end it does not really matter as it is passed in a query string, but to make it consistent with the `before` property it and to avoid unnecessary `toString()` conversion I extended the `AfterOptions` interface.

Here are links to the documentation of those both endpoints:
- https://developer.spotify.com/documentation/web-api/reference/#/operations/get-followed
- https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recently-played

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
