### PR TITLE
jest-environment-puppeteer: bump jest to 27

### DIFF
--- a/types/jest-environment-puppeteer/index.d.ts
+++ b/types/jest-environment-puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jest-environment-puppeteer 4.4
+// Type definitions for jest-environment-puppeteer 5.0.4
 // Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-environment-puppeteer
 // Definitions by: Josh Goldberg <https://github.com/joshuakgoldberg>
 //                 Ifiok Jr. <https://github.com/ifiokjr>
@@ -56,7 +56,7 @@ interface Global extends GlobalType.Global {
 
 /** Note: TestEnvironment is sandboxed. Each test suite will trigger setup/teardown in their own TestEnvironment. */
 declare class PuppeteerEnvironment extends NodeEnvironment {
-  global: Global;
+    global: Global;
 }
 
 declare global {

--- a/types/jest-environment-puppeteer/index.d.ts
+++ b/types/jest-environment-puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jest-environment-puppeteer 5.0.4
+// Type definitions for jest-environment-puppeteer 5.0
 // Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-environment-puppeteer
 // Definitions by: Josh Goldberg <https://github.com/joshuakgoldberg>
 //                 Ifiok Jr. <https://github.com/ifiokjr>

--- a/types/jest-environment-puppeteer/jest-environment-puppeteer-tests.ts
+++ b/types/jest-environment-puppeteer/jest-environment-puppeteer-tests.ts
@@ -1,7 +1,6 @@
 import { Browser, Page, BrowserContext } from 'puppeteer';
 import JestEnvironmentPuppeteer from 'jest-environment-puppeteer';
 import { Config, Circus } from '@jest/types';
-import { Script } from 'vm';
 
 const myBrowser: Browser = browser; // $ExpectType Browser
 const myPage: Page = page; // $ExpectType Page
@@ -24,10 +23,6 @@ class CustomJestEnvironment extends JestEnvironmentPuppeteer {
     async teardown() {
         await this.global.page.waitFor(2000);
         await super.teardown();
-    }
-
-    runScript(script: Script): any {
-        return super.runScript(script);
     }
 
     async handleTestEvent(event: Circus.Event, state: Circus.State) {

--- a/types/jest-environment-puppeteer/package.json
+++ b/types/jest-environment-puppeteer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@jest/types": ">=24 <=26",
-        "jest-environment-node": ">=24 <=26"
+        "@jest/types": ">=24 <=27",
+        "jest-environment-node": ">=24 <=27"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.



jest-environment-puppeteer has had a dependency on jest-environment-node 27.x since 5.0.4 [change](https://github.com/smooth-code/jest-puppeteer/compare/v5.0.3...v5.0.4#diff-2f06640d1e61c571f77b31657fff4c3aa14743d0ed3912a733ce8b7997c17311R27)
