### PR TITLE
[uuid] fix: Add package.json to package's exports

### DIFF
--- a/types/uuid/package.json
+++ b/types/uuid/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "exports": {
+        "./package.json": "./package.json",
         ".": {
             "types": {
                 "import": "./index.d.mts",


### PR DESCRIPTION
Adds the `package.json` to the `package.json` exports to fix an [invalid package configuration warning](https://github.com/react-native-community/cli/issues/1168) encountered when using the `react-native` cli.

Note: this change has previously been made to the [uuid package](https://github.com/uuidjs/uuid/commit/be1c8fe9a3206c358e0059b52fafd7213aa48a52) also.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/uuidjs/uuid/commit/be1c8fe9a3206c358e0059b52fafd7213aa48a52
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
