### PR TITLE
fix(url-parse): tune type definitions

### DIFF
--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -42,7 +42,7 @@ interface URLParse<Query> {
     readonly slashes: boolean;
     readonly username: string;
     set<Part extends URLParse.URLPart>(part: Part, value: URLParse<string>[Part] | undefined, fn?: false): URLParse<string>;
-    set<Part extends URLParse.URLPart, T>(part: Part, value: URLParse<T>[Part] | undefined, fn: URLParse.QueryParser<T>): URLParse<T>;
+    set<Part extends URLParse.URLPart, T>(part: Part, value: URLParse<T>[Part] | undefined, fn?: URLParse.QueryParser<T>): URLParse<T>;
     toString(stringify?: URLParse.StringifyQuery): string;
 }
 

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -70,6 +70,7 @@ declare const URLParse: {
         parse: URLParse.QueryParser;
         stringify: URLParse.StringifyQuery;
     };
+    trimLeft(url: string): string;
 };
 
 export = URLParse;

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -32,6 +32,9 @@ url4.query.has(3);
 const url2 = new URL('foo/bar', 'https://github.com/');
 url2.set('protocol', 'http://');
 url2.set('slashes', true);
+url2.set('query', 'bar=foo')
+url2.set('query', {queryParameterName: 'queryParameterValue'});
+url2.set('query', {queryParameterName: 'queryParameterValue'}, () => '');
 
 URL.extractProtocol('https://github.com/foo/bar');
 URL.location('https://github.com/foo/bar');

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -37,4 +37,5 @@ url2.set('query', {queryParameterName: 'queryParameterValue'});
 
 URL.extractProtocol('https://github.com/foo/bar');
 URL.location('https://github.com/foo/bar');
+URL.trimLeft('   https://github.com/foo/bar');
 URL.qs.parse('a=b');

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -32,7 +32,7 @@ url4.query.has(3);
 const url2 = new URL('foo/bar', 'https://github.com/');
 url2.set('protocol', 'http://');
 url2.set('slashes', true);
-url2.set('query', 'bar=foo')
+url2.set('query', 'bar=foo');
 url2.set('query', {queryParameterName: 'queryParameterValue'});
 
 URL.extractProtocol('https://github.com/foo/bar');

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -34,7 +34,6 @@ url2.set('protocol', 'http://');
 url2.set('slashes', true);
 url2.set('query', 'bar=foo')
 url2.set('query', {queryParameterName: 'queryParameterValue'});
-url2.set('query', {queryParameterName: 'queryParameterValue'}, () => '');
 
 URL.extractProtocol('https://github.com/foo/bar');
 URL.location('https://github.com/foo/bar');


### PR DESCRIPTION
1) actually there is no ability to pass custom parser (third argument) for the case, when `Record<string, string>` is passed as a second argument of `url.set('query', ...)`, so making third argument optional for now;
2) add missing `trimLeft` definition.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/unshiftio/url-parse/blob/master/index.js#L408>>. Also tests, that shows such usage: <<https://github.com/unshiftio/url-parse/blob/master/test/test.js#L914>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
