### PR TITLE
[@types/pg] Add missing options config

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -31,6 +31,7 @@ export interface ClientConfig {
     application_name?: string | undefined;
     connectionTimeoutMillis?: number | undefined;
     types?: CustomTypesConfig | undefined;
+    options?: string | undefined;
 }
 
 export type ConnectionConfig = ClientConfig;


### PR DESCRIPTION
This fixes a missing `options` config for `pg`

This is not in documentation, but was added in 8.3.0 via https://github.com/brianc/node-postgres/pull/2216