### PR TITLE
[make-fetch-happen] Remove reference to dom

### DIFF
--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -4,7 +4,7 @@
 //                 Trevor Scheer <https://github.com/trevor-scheer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
-/// <reference lib="dom" />
+
 import { ClientRequestArgs, AgentOptions } from 'http';
 import { CommonConnectionOptions, SecureContextOptions } from 'tls';
 import { URL as NodeURL } from 'url';


### PR DESCRIPTION
This reference includes DOM typings across the entire project when this is a Node package. This will make TypeScript think that it can use `window.fetch`, `atob`, etc. and compile those successfully, only to fail with a ReferenceError at runtime since those are not Node APIs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
