### PR TITLE
Fix export signature

### DIFF
--- a/types/lru-cache/index.d.ts
+++ b/types/lru-cache/index.d.ts
@@ -190,4 +190,4 @@ declare namespace LRUCache {
     }
 }
 
-export = LRUCache;
+export default LRUCache;


### PR DESCRIPTION
In the JS, it does `module.exports = LRUCache` which is translated to a default export.

https://github.com/isaacs/node-lru-cache/blob/master/index.js#L334

Doing `exports = LRUCache` breaks default imports when they should not be, and forces you to do `import * as LRUCache` which is actually incorrect.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
