### PR TITLE
fix(chrome): fix tabIds to a number array

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11210,7 +11210,7 @@ declare namespace chrome.declarativeNetRequest {
          * An ID of {@link chrome.tabs.TAB_ID_NONE} excludes requests which don't originate from a tab.
          * An empty list is not allowed. Only supported for session-scoped rules.
          */
-        tabIds?: number | undefined;
+        tabIds?: number[] | undefined;
 
         /**
          * The pattern which is matched against the network request url.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1077,7 +1077,10 @@ async function testDynamicRules() {
         action: {
           type: chrome.declarativeNetRequest.RuleActionType.ALLOW,
         },
-        condition: {},
+        condition: {
+            domains: ["www.example.com"],
+            tabIds: [2, 3, 76],
+        },
         id: 2,
         priority: 3,
       }],


### PR DESCRIPTION
In #57778, I mistakenly set tabIds to a single number, while the docs specify that tabIds should be an array of numbers.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#type-RuleCondition>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
