### PR TITLE
Meteor hot-module-replacement types

### DIFF
--- a/types/meteor/README.md
+++ b/types/meteor/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-These are the definitions for version 1.4 of Meteor.  These definitions were generated from the same [Meteor data.js file](https://github.com/meteor/meteor/blob/devel/docs/client/data.js) that is used to generate the official [Meteor docs](http://docs.meteor.com/).  The code that generates these definitions can be found [here](https://github.com/meteor-typescript/meteor-typescript-libs/).
+These are the definitions for version 2.0 of Meteor.  These definitions were generated from the same [Meteor data.js file](https://github.com/meteor/meteor/blob/devel/docs/client/data.js) that is used to generate the official [Meteor docs](http://docs.meteor.com/).  The code that generates these definitions can be found [here](https://github.com/meteor-typescript/meteor-typescript-libs/).
 
 
 ## Meteor `typescript` package

--- a/types/meteor/globals/reactive-dict.d.ts
+++ b/types/meteor/globals/reactive-dict.d.ts
@@ -1,3 +1,4 @@
+
 declare class ReactiveDict<O = EJSONable> {
     /**
      * Constructor for a ReactiveDict, which represents a reactive dictionary of key/value pairs.

--- a/types/meteor/hot-module-replacement.d.ts
+++ b/types/meteor/hot-module-replacement.d.ts
@@ -1,14 +1,10 @@
-interface HotModuleReplacementData {
-    // user-defined attributes
-}
-
 declare namespace NodeJS {
     interface Module {
         readonly hot?: {
             accept(): void;
             decline(): void;
-            dispose(callback: (data: HotModuleReplacementData) => void): void;
-            data: HotModuleReplacementData | null;
+            dispose(callback: (data: object) => void): void;
+            data: object | null;
             onRequire<T>(callbacks: {
                 before?(requiredModule: Module, parentId: string): T;
                 after?(requiredModule: Module, data: T): void;

--- a/types/meteor/hot-module-replacement.d.ts
+++ b/types/meteor/hot-module-replacement.d.ts
@@ -1,0 +1,20 @@
+interface HotModuleReplacementData {
+    // user-defined attributes
+}
+
+declare namespace NodeJS {
+    interface Module {
+        readonly hot?: {
+            accept(): void;
+            decline(): void;
+            dispose(callback: (data: HotModuleReplacementData) => void): void;
+            data: HotModuleReplacementData | null;
+            onRequire<T>(callbacks: {
+                before?(requiredModule: Module, parentId: string): T;
+                after?(requiredModule: Module, data: T): void;
+            }): void;
+        }
+    }
+}
+
+declare var module: NodeJS.Module;

--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Meteor 1.4
+// Type definitions for Meteor 2.0
 // Project: http://www.meteor.com/
 // Definitions by: Alex Borodach <https://github.com/barbatus>
 //                 Dave Allen <https://github.com/fullflavedave>
@@ -17,6 +17,7 @@
 //                 Wojciech Adamek <https://github.com/wadamek65>
 //                 Maciej Stasieluk <https://github.com/MacRusher>
 //                 Markus Peloso <https://github.com/ToastHawaii>
+//                 Erik Demaine <https://github.com/edemaine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.7
 
@@ -39,6 +40,7 @@
 /// <reference path="./globals/email.d.ts" />
 /// <reference path="./http.d.ts" />
 /// <reference path="./globals/http.d.ts" />
+/// <reference path="./hot-module-replacement.d.ts" />
 /// <reference path="./meteor.d.ts" />
 /// <reference path="./globals/meteor.d.ts" />
 /// <reference path="./modern-browsers.d.ts" />

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -1166,11 +1166,11 @@ namespace MeteorTests {
     let color = 'blue';
     if (module.hot) {
         if (module.hot.data) {
-            color = module.hot.data.color;
+            color = (module.hot.data as any).color;
         }
 
         module.hot.dispose(data => {
-            data.color = color;
+            (data as any).color = color;
         });
     }
 

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -1150,6 +1150,67 @@ namespace MeteorTests {
     const collectionWithoutConnection = new Mongo.Collection<MonkeyDAO>('monkey', {
         connection: null,
     });
+
+    // hot-module-replacement
+    if (module.hot) {
+        module.hot.accept();
+    }
+
+    const computation = Tracker.autorun(() => null);
+    if (module.hot) {
+        module.hot.dispose(() => {
+            computation.stop();
+        });
+    }
+
+    let color = 'blue';
+    if (module.hot) {
+        if (module.hot.data) {
+            color = module.hot.data.color;
+        }
+
+        module.hot.dispose(data => {
+            data.color = color;
+        });
+    }
+
+    function canAcceptUpdates(module: NodeModule) {
+        return true;
+    }
+    if (module.hot) {
+        module.hot.onRequire<{
+            importedBy: string,
+            previouslyEvaluated: boolean,
+        }>({
+            // requiredModule is the same object available in the
+            // required module as `module`, including access to `module.hot`
+            // and `module.exports`
+            //
+            // parentId is a string with the path of the module that
+            // imported requiredModule.
+            before(requiredModule, parentId) {
+                // Anything returned here is available to the
+                // after callback as the data parameter.
+                return {
+                    importedBy: parentId,
+                    previouslyEvaluated: !requiredModule.loaded
+                }
+            },
+            after(requiredModule, data) {
+                if (!data.previouslyEvaluated) {
+                    console.log(`Finished evaluating ${requiredModule.id}`);
+                    console.log(`It was imported by ${data.importedBy}`);
+                    console.log(`Its exports are ${requiredModule.exports}`);
+                }
+
+                // canAcceptUpdates would look at the exports, and maybe the imports
+                // to check if this module can safely be updated with HMR.
+                if (requiredModule.hot && canAcceptUpdates(requiredModule)) {
+                    requiredModule.hot.accept();
+                }
+            }
+        });
+    }
 } // End of namespace
 
 // absoluteUrl

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -35,6 +35,13 @@ declare module 'meteor/meteor' {
     }
 }
 
+declare global {
+    interface HotModuleReplacementData {
+        // One of the tests assigns this property to HMR data object
+        color: string;
+    }
+}
+
 // Avoid conflicts between `meteor-tests.ts` and `globals/meteor-tests.ts`.
 namespace MeteorTests {
     interface RoomDAO {
@@ -1169,6 +1176,67 @@ namespace MeteorTests {
     const collectionWithoutConnection = new Mongo.Collection<MonkeyDAO>('monkey', {
         connection: null,
     });
+
+    // hot-module-replacement
+    if (module.hot) {
+        module.hot.accept();
+    }
+
+    const computation = Tracker.autorun(() => null);
+    if (module.hot) {
+        module.hot.dispose(() => {
+            computation.stop();
+        });
+    }
+
+    let color = 'blue';
+    if (module.hot) {
+        if (module.hot.data) {
+            color = module.hot.data.color;
+        }
+
+        module.hot.dispose(data => {
+            data.color = color;
+        });
+    }
+
+    function canAcceptUpdates(module: NodeModule) {
+        return true;
+    }
+    if (module.hot) {
+        module.hot.onRequire<{
+            importedBy: string,
+            previouslyEvaluated: boolean,
+        }>({
+            // requiredModule is the same object available in the
+            // required module as `module`, including access to `module.hot`
+            // and `module.exports`
+            //
+            // parentId is a string with the path of the module that
+            // imported requiredModule.
+            before(requiredModule, parentId) {
+                // Anything returned here is available to the
+                // after callback as the data parameter.
+                return {
+                    importedBy: parentId,
+                    previouslyEvaluated: !requiredModule.loaded
+                }
+            },
+            after(requiredModule, data) {
+                if (!data.previouslyEvaluated) {
+                    console.log(`Finished evaluating ${requiredModule.id}`);
+                    console.log(`It was imported by ${data.importedBy}`);
+                    console.log(`Its exports are ${requiredModule.exports}`);
+                }
+
+                // canAcceptUpdates would look at the exports, and maybe the imports
+                // to check if this module can safely be updated with HMR.
+                if (requiredModule.hot && canAcceptUpdates(requiredModule)) {
+                    requiredModule.hot.accept();
+                }
+            }
+        });
+    }
 } // End of namespace
 
 // absoluteUrl

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -35,13 +35,6 @@ declare module 'meteor/meteor' {
     }
 }
 
-declare global {
-    interface HotModuleReplacementData {
-        // One of the tests assigns this property to HMR data object
-        color: string;
-    }
-}
-
 // Avoid conflicts between `meteor-tests.ts` and `globals/meteor-tests.ts`.
 namespace MeteorTests {
     interface RoomDAO {
@@ -1192,11 +1185,11 @@ namespace MeteorTests {
     let color = 'blue';
     if (module.hot) {
         if (module.hot.data) {
-            color = module.hot.data.color;
+            color = (module.hot.data as any).color;
         }
 
         module.hot.dispose(data => {
-            data.color = color;
+            (data as any).color = color;
         });
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/packages/hot-module-replacement.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

# Changes

As discussed in https://github.com/meteor/meteor/discussions/11836, this defines types for the optional global `module.hot`, as defined by Meteor's [hot-module-replacement](https://docs.meteor.com/packages/hot-module-replacement.html). It includes all tests from that webpage.

I ended up having to extend the `NodeJS.Module` type so that the global `module` didn't get redefined as a different type.

I also cleaned up the code some [moved to other PRs].  `scripts/generate-globals` doesn't seem to have been run for a while, and the output requires a bunch of manual changes.  I improved it to require fewer manual changes, but it's still a bit of a mess. [moved to #58022]  I also changed from local `module`s to `interface` [as recommended since TypeScript 1.5](https://www.typescriptlang.org/docs/handbook/namespaces.html) [moved to #58020].