### PR TITLE
[xml] Fix xml function overload

### DIFF
--- a/types/xml/index.d.ts
+++ b/types/xml/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for xml 1.0
 // Project: https://github.com/dylang/node-xml
 // Definitions by: Jianrong Yu <https://github.com/YuJianrong>
+//                 Semyon Fomin <https://github.com/semyonf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -53,7 +54,7 @@ declare namespace xml {
 
 declare function xml(
     xmlObject: xml.XmlObject | xml.XmlObject[],
-    options: { stream: true; indent?: string | undefined },
+    options: { stream: true } & xml.Option,
 ): NodeJS.ReadableStream;
 declare function xml(xmlObject?: xml.XmlObject | xml.XmlObject[], options?: boolean | string | xml.Option): string;
 

--- a/types/xml/xml-tests.ts
+++ b/types/xml/xml-tests.ts
@@ -162,3 +162,25 @@ test('xml declaration options', t => {
     t.is(xml([{a: 'test'}], {declaration: true, indent: '\n'}), '<?xml version="1.0" encoding="UTF-8"?>\n<a>test</a>');
     t.is(xml([{a: 'test'}], {}), '<a>test</a>');
 });
+
+const xmlElement = xml.element({_attr: {xmlns: 'http://www.w3.org/1999/xhtml'}});
+
+// $ExpectType ReadableStream
+xml(
+    { 'd:foo': xmlElement },
+    {
+        stream: true,
+        indent: '\t',
+        declaration: true,
+    },
+);
+
+// $ExpectType string
+const xmlStream = xml(
+    { 'd:foo': xmlElement },
+    {
+        stream: false,
+        indent: '\t',
+        declaration: true,
+    },
+);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/xml#options

## Changes

Setting `declaration` option was causing function's return type to be `string`, no matter whether the `stream` option was enabled or not.