### PR TITLE
Meteor: use modern namespace for local modules

### DIFF
--- a/types/meteor/accounts-base.d.ts
+++ b/types/meteor/accounts-base.d.ts
@@ -14,7 +14,7 @@ declare module 'meteor/accounts-base' {
         html?: ((user: Meteor.User, url: string) => string) | undefined;
     }
 
-    module Accounts {
+    namespace Accounts {
         var urls: URLS;
 
         function user(options?: { fields?: Mongo.FieldSpecifier | undefined }): Meteor.User | null;
@@ -56,7 +56,7 @@ declare module 'meteor/accounts-base' {
         function onPageLoadLogin(func: Function): void;
     }
 
-    module Accounts {
+    namespace Accounts {
         function changePassword(
             oldPassword: string,
             newPassword: string,
@@ -116,7 +116,7 @@ declare module 'meteor/accounts-base' {
         verifyEmail: EmailFields;
     }
 
-    module Accounts {
+    namespace Accounts {
         var emailTemplates: EmailTemplates;
 
         function addEmail(userId: string, newEmail: string, verified?: boolean): void;
@@ -179,15 +179,15 @@ declare module 'meteor/accounts-base' {
         }
     }
 
-    module Accounts {
+    namespace Accounts {
         function onLogout(func: Function): void;
     }
 
-    module Accounts {
+    namespace Accounts {
         function onLogout(func: (options: { user: Meteor.User; connection: Meteor.Connection }) => void): void;
     }
 
-    module Accounts {
+    namespace Accounts {
         interface LoginMethodOptions {
             /**
              * The method to call (default 'login')
@@ -274,7 +274,7 @@ declare module 'meteor/accounts-base' {
         function _checkPassword(user: Meteor.User, password: Password): { userId: string; error?: any };
     }
 
-    module Accounts {
+    namespace Accounts {
         type StampedLoginToken = {
             token: string;
             when: Date;

--- a/types/meteor/blaze.d.ts
+++ b/types/meteor/blaze.d.ts
@@ -3,7 +3,7 @@ import * as $ from 'jquery';
 import { Tracker } from 'meteor/tracker';
 import { Meteor } from 'meteor/meteor';
 declare module 'meteor/blaze' {
-    module Blaze {
+    namespace Blaze {
         var View: ViewStatic;
 
         interface ViewStatic {

--- a/types/meteor/browser-policy-common.d.ts
+++ b/types/meteor/browser-policy-common.d.ts
@@ -1,5 +1,5 @@
 declare module 'meteor/browser-policy-common' {
-    module BrowserPolicy {
+    namespace BrowserPolicy {
         var framing: {
             disallow(): void;
             restrictToOrigin(origin: string): void;

--- a/types/meteor/check.d.ts
+++ b/types/meteor/check.d.ts
@@ -2,7 +2,7 @@ declare module 'meteor/check' {
     /**
      * The namespace for all Match types and methods.
      */
-    module Match {
+    namespace Match {
         interface Matcher<T> {
             _meteorCheckMatcherBrand: void;
         }

--- a/types/meteor/ddp-rate-limiter.d.ts
+++ b/types/meteor/ddp-rate-limiter.d.ts
@@ -1,5 +1,5 @@
 declare module 'meteor/ddp-rate-limiter' {
-    module DDPRateLimiter {
+    namespace DDPRateLimiter {
         interface Matcher {
             type?: string | ((type: string) => boolean) | undefined;
             name?: string | ((name: string) => boolean) | undefined;

--- a/types/meteor/ddp.d.ts
+++ b/types/meteor/ddp.d.ts
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 declare module 'meteor/ddp' {
-    module DDP {
+    namespace DDP {
         interface DDPStatic {
             subscribe(name: string, ...rest: any[]): Meteor.SubscriptionHandle;
             call(method: string, ...parameters: any[]): any;
@@ -27,7 +27,7 @@ declare module 'meteor/ddp' {
         function connect(url: string): DDPStatic;
     }
 
-    module DDPCommon {
+    namespace DDPCommon {
         interface MethodInvocationOptions {
             userId: string | null;
             setUserId?: ((newUserId: string) => void) | undefined;

--- a/types/meteor/ejson.d.ts
+++ b/types/meteor/ejson.d.ts
@@ -26,7 +26,7 @@ declare module 'meteor/ejson' {
     }
     interface EJSON extends EJSONable {}
 
-    module EJSON {
+    namespace EJSON {
         function addType(name: string, factory: (val: JSONable) => EJSONableCustomType): void;
 
         function clone<T>(val: T): T;

--- a/types/meteor/email.d.ts
+++ b/types/meteor/email.d.ts
@@ -1,5 +1,5 @@
 declare module 'meteor/email' {
-    module Email {
+    namespace Email {
         function send(options: {
             from?: string | undefined;
             to?: string | string[] | undefined;

--- a/types/meteor/globals/accounts-base.d.ts
+++ b/types/meteor/globals/accounts-base.d.ts
@@ -11,7 +11,7 @@ declare interface EmailFields {
     html?: ((user: Meteor.User, url: string) => string) | undefined;
 }
 
-declare module Accounts {
+declare namespace Accounts {
     var urls: URLS;
 
     function user(options?: { fields?: Mongo.FieldSpecifier | undefined }): Meteor.User | null;
@@ -53,7 +53,7 @@ declare module Accounts {
     function onPageLoadLogin(func: Function): void;
 }
 
-declare module Accounts {
+declare namespace Accounts {
     function changePassword(
         oldPassword: string,
         newPassword: string,
@@ -110,7 +110,7 @@ declare interface EmailTemplates {
     verifyEmail: EmailFields;
 }
 
-declare module Accounts {
+declare namespace Accounts {
     var emailTemplates: EmailTemplates;
 
     function addEmail(userId: string, newEmail: string, verified?: boolean): void;
@@ -173,15 +173,15 @@ declare module Accounts {
     }
 }
 
-declare module Accounts {
+declare namespace Accounts {
     function onLogout(func: Function): void;
 }
 
-declare module Accounts {
+declare namespace Accounts {
     function onLogout(func: (options: { user: Meteor.User; connection: Meteor.Connection }) => void): void;
 }
 
-declare module Accounts {
+declare namespace Accounts {
     interface LoginMethodOptions {
         /**
          * The method to call (default 'login')
@@ -268,7 +268,7 @@ declare module Accounts {
     function _checkPassword(user: Meteor.User, password: Password): { userId: string; error?: any };
 }
 
-declare module Accounts {
+declare namespace Accounts {
     type StampedLoginToken = {
         token: string;
         when: Date;

--- a/types/meteor/globals/blaze.d.ts
+++ b/types/meteor/globals/blaze.d.ts
@@ -1,4 +1,4 @@
-declare module Blaze {
+declare namespace Blaze {
     var View: ViewStatic;
 
     interface ViewStatic {

--- a/types/meteor/globals/browser-policy-common.d.ts
+++ b/types/meteor/globals/browser-policy-common.d.ts
@@ -1,4 +1,4 @@
-declare module BrowserPolicy {
+declare namespace BrowserPolicy {
     var framing: {
         disallow(): void;
         restrictToOrigin(origin: string): void;

--- a/types/meteor/globals/check.d.ts
+++ b/types/meteor/globals/check.d.ts
@@ -1,7 +1,7 @@
 /**
  * The namespace for all Match types and methods.
  */
-declare module Match {
+declare namespace Match {
     interface Matcher<T> {
         _meteorCheckMatcherBrand: void;
     }

--- a/types/meteor/globals/ddp-rate-limiter.d.ts
+++ b/types/meteor/globals/ddp-rate-limiter.d.ts
@@ -1,4 +1,4 @@
-declare module DDPRateLimiter {
+declare namespace DDPRateLimiter {
     interface Matcher {
         type?: string | ((type: string) => boolean) | undefined;
         name?: string | ((name: string) => boolean) | undefined;

--- a/types/meteor/globals/ddp.d.ts
+++ b/types/meteor/globals/ddp.d.ts
@@ -1,4 +1,4 @@
-declare module DDP {
+declare namespace DDP {
     interface DDPStatic {
         subscribe(name: string, ...rest: any[]): Meteor.SubscriptionHandle;
         call(method: string, ...parameters: any[]): any;
@@ -25,7 +25,7 @@ declare module DDP {
     function connect(url: string): DDPStatic;
 }
 
-declare module DDPCommon {
+declare namespace DDPCommon {
     interface MethodInvocationOptions {
         userId: string | null;
         setUserId?: ((newUserId: string) => void) | undefined;

--- a/types/meteor/globals/ejson.d.ts
+++ b/types/meteor/globals/ejson.d.ts
@@ -25,7 +25,7 @@ declare interface JSONable {
 }
 declare interface EJSON extends EJSONable {}
 
-declare module EJSON {
+declare namespace EJSON {
     function addType(name: string, factory: (val: JSONable) => EJSONableCustomType): void;
 
     function clone<T>(val: T): T;

--- a/types/meteor/globals/email.d.ts
+++ b/types/meteor/globals/email.d.ts
@@ -1,4 +1,4 @@
-declare module Email {
+declare namespace Email {
     function send(options: {
         from?: string | undefined;
         to?: string | string[] | undefined;

--- a/types/meteor/globals/http.d.ts
+++ b/types/meteor/globals/http.d.ts
@@ -1,4 +1,4 @@
-declare module HTTP {
+declare namespace HTTP {
     interface HTTPRequest {
         content?: string | undefined;
         data?: any;

--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -1,5 +1,5 @@
 declare type global_Error = Error;
-declare module Meteor {
+declare namespace Meteor {
     /** Global props **/
     /** True if running in client environment. */
     var isClient: boolean;
@@ -251,7 +251,7 @@ declare module Meteor {
     /** Pub/Sub **/
 }
 
-declare module Meteor {
+declare namespace Meteor {
     /** Login **/
     interface LoginWithExternalServiceOptions {
         requestPermissions?: ReadonlyArray<string> | undefined;
@@ -378,7 +378,7 @@ declare module Meteor {
     /** Pub/Sub **/
 }
 
-declare module Meteor {
+declare namespace Meteor {
     /** Connection **/
     interface Connection {
         id: string;
@@ -454,7 +454,7 @@ declare interface Subscription {
     userId: string | null;
 }
 
-declare module Meteor {
+declare namespace Meteor {
     /** Global props **/
     /** True if running in development environment. */
     var isDevelopment: boolean;

--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -1,7 +1,7 @@
 // Based on https://github.com/microsoft/TypeScript/issues/28791#issuecomment-443520161
 declare type UnionOmit<T, K extends keyof any> = T extends T ? Pick<T, Exclude<keyof T, K>> : never;
 
-declare module Mongo {
+declare namespace Mongo {
     // prettier-ignore
     type BsonType = 1 | "double" |
         2 | "string" |
@@ -385,7 +385,7 @@ declare module Mongo {
     function setConnectionOptions(options: any): void;
 }
 
-declare module Mongo {
+declare namespace Mongo {
     interface AllowDenyOptions {
         insert?: ((userId: string, doc: any) => boolean) | undefined;
         update?: ((userId: string, doc: any, fieldNames: string[], modifier: any) => boolean) | undefined;

--- a/types/meteor/globals/random.d.ts
+++ b/types/meteor/globals/random.d.ts
@@ -1,4 +1,4 @@
-declare module Random {
+declare namespace Random {
     function id(numberOfChars?: number): string;
 
     function secret(numberOfChars?: number): string;

--- a/types/meteor/globals/session.d.ts
+++ b/types/meteor/globals/session.d.ts
@@ -1,4 +1,4 @@
-declare module Session {
+declare namespace Session {
     /**
      * Test if a session variable is equal to a value. If inside a
      * reactive computation, invalidate the computation the next

--- a/types/meteor/globals/tiny-test.d.ts
+++ b/types/meteor/globals/tiny-test.d.ts
@@ -29,7 +29,7 @@ declare interface ITinytestAssertions {
     _stringEqual(actual: string, expected: string, msg?: string): void;
 }
 
-declare module Tinytest {
+declare namespace Tinytest {
     function add(description: string, func: (test: ITinytestAssertions) => void): void;
 
     function addAsync(description: string, func: (test: ITinytestAssertions) => void): void;

--- a/types/meteor/globals/tools.d.ts
+++ b/types/meteor/globals/tools.d.ts
@@ -1,4 +1,4 @@
-declare module App {
+declare namespace App {
     function accessRule(
         pattern: string,
         options?: {
@@ -49,7 +49,7 @@ declare function execFileSync(
     },
 ): String;
 
-declare module Assets {
+declare namespace Assets {
     function getBinary(assetPath: string, asyncCallback?: Function): EJSON | undefined;
 
     function getText(assetPath: string, asyncCallback?: Function): string | undefined;
@@ -57,11 +57,11 @@ declare module Assets {
     function absoluteFilePath(assetPath: string): string;
 }
 
-declare module Cordova {
+declare namespace Cordova {
     function depends(dependencies: { [id: string]: string }): void;
 }
 
-declare module Npm {
+declare namespace Npm {
     function depends(dependencies: { [id: string]: string }): void;
 
     function require(name: string): any;

--- a/types/meteor/globals/tracker.d.ts
+++ b/types/meteor/globals/tracker.d.ts
@@ -1,7 +1,7 @@
 /**
  * The namespace for Tracker-related methods.
  */
-declare module Tracker {
+declare namespace Tracker {
     function Computation(): void;
     /**
      * A Computation object represents code that is repeatedly rerun

--- a/types/meteor/http.d.ts
+++ b/types/meteor/http.d.ts
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 declare module 'meteor/http' {
-    module HTTP {
+    namespace HTTP {
         interface HTTPRequest {
             content?: string | undefined;
             data?: any;

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -4,7 +4,7 @@ import { Blaze } from 'meteor/blaze';
 import { DDP } from 'meteor/ddp';
 declare module 'meteor/meteor' {
     type global_Error = Error;
-    module Meteor {
+    namespace Meteor {
         /** Global props **/
         /** True if running in client environment. */
         var isClient: boolean;
@@ -258,7 +258,7 @@ declare module 'meteor/meteor' {
         /** Pub/Sub **/
     }
 
-    module Meteor {
+    namespace Meteor {
         /** Login **/
         interface LoginWithExternalServiceOptions {
             requestPermissions?: ReadonlyArray<string> | undefined;
@@ -385,7 +385,7 @@ declare module 'meteor/meteor' {
         /** Pub/Sub **/
     }
 
-    module Meteor {
+    namespace Meteor {
         /** Connection **/
         interface Connection {
             id: string;
@@ -461,7 +461,7 @@ declare module 'meteor/meteor' {
         userId: string | null;
     }
 
-    module Meteor {
+    namespace Meteor {
         /** Global props **/
         /** True if running in development environment. */
         var isDevelopment: boolean;

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -7,7 +7,7 @@ declare module 'meteor/mongo' {
     // Based on https://github.com/microsoft/TypeScript/issues/28791#issuecomment-443520161
     type UnionOmit<T, K extends keyof any> = T extends T ? Pick<T, Exclude<keyof T, K>> : never;
 
-    module Mongo {
+    namespace Mongo {
         // prettier-ignore
         type BsonType = 1 | "double" |
             2 | "string" |
@@ -401,7 +401,7 @@ declare module 'meteor/mongo' {
         function setConnectionOptions(options: any): void;
     }
 
-    module Mongo {
+    namespace Mongo {
         interface AllowDenyOptions {
             insert?: ((userId: string, doc: any) => boolean) | undefined;
             update?: ((userId: string, doc: any, fieldNames: string[], modifier: any) => boolean) | undefined;

--- a/types/meteor/random.d.ts
+++ b/types/meteor/random.d.ts
@@ -1,5 +1,5 @@
 declare module 'meteor/random' {
-    module Random {
+    namespace Random {
         function id(numberOfChars?: number): string;
 
         function secret(numberOfChars?: number): string;

--- a/types/meteor/session.d.ts
+++ b/types/meteor/session.d.ts
@@ -1,6 +1,6 @@
 import { EJSONable } from 'meteor/ejson';
 declare module 'meteor/session' {
-    module Session {
+    namespace Session {
         /**
          * Test if a session variable is equal to a value. If inside a
          * reactive computation, invalidate the computation the next

--- a/types/meteor/tiny-test.d.ts
+++ b/types/meteor/tiny-test.d.ts
@@ -30,7 +30,7 @@ declare module 'meteor/tiny-test' {
         _stringEqual(actual: string, expected: string, msg?: string): void;
     }
 
-    module Tinytest {
+    namespace Tinytest {
         function add(description: string, func: (test: ITinytestAssertions) => void): void;
 
         function addAsync(description: string, func: (test: ITinytestAssertions) => void): void;

--- a/types/meteor/tools.d.ts
+++ b/types/meteor/tools.d.ts
@@ -1,6 +1,6 @@
 import { EJSON } from 'meteor/ejson';
 declare module 'meteor/tools' {
-    module App {
+    namespace App {
         function accessRule(
             pattern: string,
             options?: {
@@ -51,7 +51,7 @@ declare module 'meteor/tools' {
         },
     ): String;
 
-    module Assets {
+    namespace Assets {
         function getBinary(assetPath: string, asyncCallback?: Function): EJSON | undefined;
 
         function getText(assetPath: string, asyncCallback?: Function): string | undefined;
@@ -59,11 +59,11 @@ declare module 'meteor/tools' {
         function absoluteFilePath(assetPath: string): string;
     }
 
-    module Cordova {
+    namespace Cordova {
         function depends(dependencies: { [id: string]: string }): void;
     }
 
-    module Npm {
+    namespace Npm {
         function depends(dependencies: { [id: string]: string }): void;
 
         function require(name: string): any;

--- a/types/meteor/tracker.d.ts
+++ b/types/meteor/tracker.d.ts
@@ -2,7 +2,7 @@ declare module 'meteor/tracker' {
     /**
      * The namespace for Tracker-related methods.
      */
-    module Tracker {
+    namespace Tracker {
         function Computation(): void;
         /**
          * A Computation object represents code that is repeatedly rerun


### PR DESCRIPTION
Switch from old-style local `module` to `namespace`, as [recommended since TypeScript 1.5](https://www.typescriptlang.org/docs/handbook/namespaces.html).

(Originally part of #58014)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. No additional tests needed.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/namespaces.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. Not applicable.
