### PR TITLE
Meteor: scripts/generate-globals updates

### DIFF
--- a/types/meteor/globals/accounts-base.d.ts
+++ b/types/meteor/globals/accounts-base.d.ts
@@ -71,7 +71,10 @@ declare module Accounts {
         callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void,
     ): void;
 
-    function verifyEmail(token: string, callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void): void;
+    function verifyEmail(
+        token: string,
+        callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void,
+    ): void;
 
     function onEmailVerificationLink(callback: Function): void;
 

--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -141,7 +141,9 @@ declare module Meteor {
         args: ReadonlyArray<EJSONable | EJSONableProperty>,
         options?: {
             wait?: boolean | undefined;
-            onResultReceived?: ((error: global_Error | Meteor.Error | undefined, result?: Result) => void) | undefined;
+            onResultReceived?:
+                | ((error: global_Error | Meteor.Error | undefined, result?: Result) => void)
+                | undefined;
             /**
              * (Client only) if true, don't send this method again on reload, simply call the callback an error with the error code 'invocation-failed'.
              */

--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -197,7 +197,12 @@ declare module Mongo {
         allow<Fn extends Transform<T> = undefined>(options: {
             insert?: ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean) | undefined;
             update?:
-                | ((userId: string, doc: DispatchTransform<Fn, T, U>, fieldNames: string[], modifier: any) => boolean)
+                | ((
+                      userId: string,
+                      doc: DispatchTransform<Fn, T, U>,
+                      fieldNames: string[],
+                      modifier: any,
+                  ) => boolean)
                 | undefined;
             remove?: ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean) | undefined;
             fetch?: string[] | undefined;
@@ -207,7 +212,12 @@ declare module Mongo {
         deny<Fn extends Transform<T> = undefined>(options: {
             insert?: ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean) | undefined;
             update?:
-                | ((userId: string, doc: DispatchTransform<Fn, T, U>, fieldNames: string[], modifier: any) => boolean)
+                | ((
+                      userId: string,
+                      doc: DispatchTransform<Fn, T, U>,
+                      fieldNames: string[],
+                      modifier: any,
+                  ) => boolean)
                 | undefined;
             remove?: ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean) | undefined;
             fetch?: string[] | undefined;
@@ -404,4 +414,9 @@ declare function defaultRemoteCollectionDriver(): {
     mongo: MongoConnection;
 };
 
-declare var NpmModules: any;
+declare var NpmModules: {
+    mongodb: {
+        version: string,
+        module: any
+    }
+};

--- a/types/meteor/globals/templating.d.ts
+++ b/types/meteor/globals/templating.d.ts
@@ -2,7 +2,8 @@ declare var Template: TemplateStatic & {
     [index: string]: any | Blaze.Template;
 };
 
-declare interface TemplateStatic<D = any, T = Blaze.TemplateInstance<D>> extends Blaze.TemplateStatic<D, T> {
+declare interface TemplateStatic<D = any, T = Blaze.TemplateInstance<D>>
+    extends Blaze.TemplateStatic<D, T> {
     new (viewName?: string, renderFunction?: Function): Blaze.Template;
     body: Blaze.Template;
 }

--- a/types/meteor/scripts/generate-globals
+++ b/types/meteor/scripts/generate-globals
@@ -13,6 +13,22 @@ the modules that also have globals) by hand, and this script generates
 
 Usage: scripts/generate-globals
 
+Note that the output needs some hand editing after the script runs.
+In general, because `import`s need to be removed, some imported types need
+to be replaced by `any`.  Specifically:
+
+* In `globals/mongo.d.ts`, imported Mongo types `IndexOptions`,
+  `MongoCollection`, `MongoDb`, `MongoClient`, and `typeof MongoNpmModule`
+  need to be replaced by `any`.
+* In `globals/server-render.d.ts`, imported types `http.IncomingMessage` and
+  `http.IncomingHttpHeaders` need to be replaced by `any`.
+* In `globals/meteor-tests.ts`:
+  * `declare module 'meteor/meteor' { ... }` should be removed
+    (as it is nonfunctional).
+  * In the `Rooms.rawDatabase().stats().then` callback,
+    `stats` and `error` need to be typed `: any`.
+  * `user.dexterity` needs to be cast as `(user as any).dexterity`.
+
 This script may be used by Meteor typings packages in DefinitelyTyped other than
 `meteor` itself.
 
@@ -74,9 +90,9 @@ for (let outFile of files) {
             } else {
                 let m2;
                 // Capture any line with a comment
-                if ((m2 = /^    (\/\/.*)$/.exec(l)) != null) return m2[1];
-
-                if ((m2 = /^    ([^} ].*)$/.exec(l)) != null) return "declare " + m2[1];
+                if ((m2 = /^    (\/[\/\*].*)$/.exec(l)) != null) return m2[1];
+                if ((m2 = /^    ((import|export [\{\*]).*)$/.exec(l)) != null) return m2[1];
+                if ((m2 = /^    ([^})> ].*)$/.exec(l)) != null) return "declare " + m2[1].replace(/^export /, '');
                 if ((m2 = /^    (.*)$/.exec(l)) != null) return m2[1];
                 if (l == "") return l;
                 return null;  // Strip `declare module "..." {` and `}`.

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -11,15 +11,6 @@
 
 /*********************************** Begin setup for tests ******************************/
 
-declare module 'meteor/meteor' {
-    namespace Meteor {
-        interface User {
-            // One of the tests assigns a new property to the user so it has to be typed
-            dexterity?: number | undefined;
-        }
-    }
-}
-
 // Avoid conflicts between `meteor-tests.ts` and `globals/meteor-tests.ts`.
 namespace MeteorTests {
     interface RoomDAO {
@@ -663,6 +654,10 @@ namespace MeteorTests {
      * From Accounts, Accounts.onCreateUser section
      */
     Accounts.onCreateUser(function (options: { profile: any }, user) {
+        var d6 = function () {
+            return Math.floor(Math.random() * 6) + 1;
+        };
+        (user as any).dexterity = d6() + d6() + d6();
         // We still want the default hook's 'profile' behavior.
         if (options.profile) user.profile = options.profile;
         return user;


### PR DESCRIPTION
Changes:
* Bring `globals` into sync with source files by running `scripts/generate-globals`
* Improve `scripts/generate-globals` to require less hand-editing after running the script
* Document what hand-editing is needed after running `scripts/generate-globals`. (To check this, run the script again and check out `git diff`.)
  * Obviously I'm not a fan of the hand-editing required, but for now just trying to document what's been done in the past (based on the code that's already here).

See [this discussion](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58014#discussion_r779860028) for why `declare module 'meteor/meteor'` got removed from `types/meteor/test/globals/meteor-tests.ts`.

(Originally part of #58014)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: n/a
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
