### PR TITLE
Indy-sdk fix: createRevocationState parameter type issue

### DIFF
--- a/types/indy-sdk/index.d.ts
+++ b/types/indy-sdk/index.d.ts
@@ -239,7 +239,7 @@ export function verifierVerifyProof(
 
 export function createRevocationState(
     blobStorageReaderHandle: BlobReaderHandle,
-    revRegDef: RevRegDef,
+    revRegDef: RevocRegDef,
     revRegDelta: RevocRegDelta,
     timestamp: number,
     credRevId: CredRevocId,

--- a/types/indy-sdk/indy-sdk-tests.ts
+++ b/types/indy-sdk/indy-sdk-tests.ts
@@ -287,7 +287,20 @@ indy.proverCreateProof(
 
 indy.createRevocationState(
     10,
-    {},
+    {
+    id: '',
+    revocDefType: 'CL_ACCUM',
+    tag: '',
+    credDefId: '',
+    value: {
+        issuanceType: 'ISSUANCE_BY_DEFAULT',
+        maxCredNum: 0,
+        tailsHash: '',
+        tailsLocation: '',
+        publicKeys: []
+    },
+    ver: ''
+},
     {
         value: {
             prevAccum: 'prevAccum',


### PR DESCRIPTION
Fix issue with createRevocationState function's parameters requiring RevRegDef type instead of the proper RevocRegDef type

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [URL
](https://github.com/hyperledger/indy-sdk/blob/master/wrappers/nodejs/README.md#createrevocationstate--blobstoragereaderhandle-revregdef-revregdelta-timestamp-credrevid----revstate)