### PR TITLE
Add typing for useBlockProps for @wordpress/block-editor

### DIFF
--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -61,3 +61,4 @@ export { default as BlockEditorProvider } from './provider';
  * Hooks
  */
 export { useBlockProps } from './use-block-props';
+export * as UseBlockProps from './use-block-props';

--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -60,4 +60,4 @@ export { default as BlockEditorProvider } from './provider';
 /*
  * Hooks
  */
-export * from './use-block-props';
+export { useBlockProps } from './use-block-props';

--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -56,3 +56,8 @@ export { default as WritingFlow } from './writing-flow';
  * State Related Components
  */
 export { default as BlockEditorProvider } from './provider';
+
+/*
+ * Hooks
+ */
+export * from './use-block-props';

--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -61,4 +61,3 @@ export { default as BlockEditorProvider } from './provider';
  * Hooks
  */
 export { useBlockProps } from './use-block-props';
-export * as UseBlockProps from './use-block-props';

--- a/types/wordpress__block-editor/components/use-block-props.d.ts
+++ b/types/wordpress__block-editor/components/use-block-props.d.ts
@@ -1,0 +1,24 @@
+import { Ref } from 'react';
+
+export type UseBlockPropsProps<Props extends Record<PropertyKey, unknown>, R = unknown> = { ref?: Ref<R> } & Props;
+
+export type UseBlockPropsOut<Props extends Record<PropertyKey, unknown>> = Props &
+    Ref<unknown> & {
+        id: string;
+        tabIndex: 0;
+        role: 'document';
+        'aria-label': string;
+        'data-block': string;
+        'data-type': string;
+        'data-title': string;
+        className: string;
+        style: Record<string, unknown>;
+    };
+
+export function useBlockProps<Props extends Record<PropertyKey, unknown>>(
+    props?: UseBlockPropsProps<Props>,
+): UseBlockPropsOut<Props>;
+
+export namespace useBlockProps {
+    function save(props?: Record<PropertyKey, unknown>): unknown;
+}

--- a/types/wordpress__block-editor/components/use-block-props.d.ts
+++ b/types/wordpress__block-editor/components/use-block-props.d.ts
@@ -21,7 +21,7 @@ export interface UseBlockProps {
         props?: Props & {
             [K in keyof Props]: K extends keyof Reserved ? never : Props[K];
         } & { ref?: Ref<unknown> },
-    ): Omit<Props, 'ref'> & Merged & Reserved;
+    ): Pick<Props, Exclude<keyof Props, 'ref'>> & Merged & Reserved;
 
     save: (props?: Record<string, unknown>) => Record<string, unknown>;
 }

--- a/types/wordpress__block-editor/components/use-block-props.d.ts
+++ b/types/wordpress__block-editor/components/use-block-props.d.ts
@@ -1,24 +1,25 @@
-import { Ref } from 'react';
-
-export type UseBlockPropsProps<Props extends Record<string, unknown>, R = unknown> = { ref?: Ref<R> } & Props;
-
-export type UseBlockPropsOut<Props extends Record<string, unknown>> = Props &
-    Ref<unknown> & {
-        id: string;
-        tabIndex: 0;
-        role: 'document';
-        'aria-label': string;
-        'data-block': string;
-        'data-type': string;
-        'data-title': string;
-        className: string;
-        style: Record<string, unknown>;
-    };
-
-export function useBlockProps<Props extends Record<string, unknown>>(
-    props?: UseBlockPropsProps<Props>,
-): UseBlockPropsOut<Props>;
-
-export namespace useBlockProps {
-    function save(props?: Record<string, unknown>): unknown;
+export interface Reserved {
+    id: string;
+    role: 'document';
+    tabIndex: 0;
+    'aria-label': string;
+    'data-block': string;
+    'data-type': string;
+    'data-title': string;
 }
+
+export interface Merged {
+    className: string;
+    style: Record<string, unknown>;
+    ref: (value: unknown) => void;
+}
+
+export interface UseBlockProps {
+    <Props extends Record<string, unknown>>(
+        props?: Props & { [K in keyof Props]: K extends keyof Reserved ? never : Props[K] },
+    ): Props & Merged & Reserved;
+
+    save: (props?: Record<string, unknown>) => unknown;
+}
+
+export const useBlockProps: UseBlockProps;

--- a/types/wordpress__block-editor/components/use-block-props.d.ts
+++ b/types/wordpress__block-editor/components/use-block-props.d.ts
@@ -21,7 +21,7 @@ export interface UseBlockProps {
         props?: Props & {
             [K in keyof Props]: K extends keyof Reserved ? never : Props[K];
         } & { ref?: Ref<unknown> },
-    ): Pick<Props, Exclude<keyof Props, 'ref'>> & Merged & Reserved;
+    ): Omit<Props, 'ref'> & Merged & Reserved;
 
     save: (props?: Record<string, unknown>) => Record<string, unknown>;
 }

--- a/types/wordpress__block-editor/components/use-block-props.d.ts
+++ b/types/wordpress__block-editor/components/use-block-props.d.ts
@@ -1,3 +1,5 @@
+import { Ref } from 'react';
+
 export interface Reserved {
     id: string;
     role: 'document';
@@ -16,10 +18,12 @@ export interface Merged {
 
 export interface UseBlockProps {
     <Props extends Record<string, unknown>>(
-        props?: Props & { [K in keyof Props]: K extends keyof Reserved ? never : Props[K] },
-    ): Props & Merged & Reserved;
+        props?: Props & {
+            [K in keyof Props]: K extends keyof Reserved ? never : Props[K];
+        } & { ref?: Ref<unknown> },
+    ): Omit<Props, 'ref'> & Merged & Reserved;
 
-    save: (props?: Record<string, unknown>) => unknown;
+    save: (props?: Record<string, unknown>) => Record<string, unknown>;
 }
 
 export const useBlockProps: UseBlockProps;

--- a/types/wordpress__block-editor/components/use-block-props.d.ts
+++ b/types/wordpress__block-editor/components/use-block-props.d.ts
@@ -1,8 +1,8 @@
 import { Ref } from 'react';
 
-export type UseBlockPropsProps<Props extends Record<PropertyKey, unknown>, R = unknown> = { ref?: Ref<R> } & Props;
+export type UseBlockPropsProps<Props extends Record<string, unknown>, R = unknown> = { ref?: Ref<R> } & Props;
 
-export type UseBlockPropsOut<Props extends Record<PropertyKey, unknown>> = Props &
+export type UseBlockPropsOut<Props extends Record<string, unknown>> = Props &
     Ref<unknown> & {
         id: string;
         tabIndex: 0;
@@ -15,10 +15,10 @@ export type UseBlockPropsOut<Props extends Record<PropertyKey, unknown>> = Props
         style: Record<string, unknown>;
     };
 
-export function useBlockProps<Props extends Record<PropertyKey, unknown>>(
+export function useBlockProps<Props extends Record<string, unknown>>(
     props?: UseBlockPropsProps<Props>,
 ): UseBlockPropsOut<Props>;
 
 export namespace useBlockProps {
-    function save(props?: Record<PropertyKey, unknown>): unknown;
+    function save(props?: Record<string, unknown>): unknown;
 }

--- a/types/wordpress__block-editor/components/use-block-props.d.ts
+++ b/types/wordpress__block-editor/components/use-block-props.d.ts
@@ -1,4 +1,4 @@
-import { Ref } from 'react';
+import { Ref, RefCallback } from 'react';
 
 export interface Reserved {
     id: string;
@@ -13,7 +13,7 @@ export interface Reserved {
 export interface Merged {
     className: string;
     style: Record<string, unknown>;
-    ref: (value: unknown) => void;
+    ref: RefCallback<unknown>;
 }
 
 export interface UseBlockProps {

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -536,13 +536,13 @@ select('core/block-editor').getAdjacentBlockClientId('foo');
 select('core/block-editor').getAdjacentBlockClientId('foo', -1);
 select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
-// $ExpectType Pick<Record<string, unknown>, string> & Merged & Reserved
+// $ExpectType Omit<Record<string, unknown>, "ref"> & Merged & Reserved
 be.useBlockProps();
 
-// $ExpectType Pick<{ foo: string; }, "foo"> & Merged & Reserved
+// $ExpectType Omit<{ foo: string; }, "ref"> & Merged & Reserved
 be.useBlockProps({ foo: "bar" });
 
-// $ExpectType Pick<{ ref: MutableRefObject<string>; }, never> & Merged & Reserved
+// $ExpectType Omit<{ ref: MutableRefObject<string>; }, "ref"> & Merged & Reserved
 be.useBlockProps({ ref: useRef("test") });
 
 // $ExpectType Record<string, unknown>

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -534,3 +534,15 @@ select('core/block-editor').getAdjacentBlockClientId();
 select('core/block-editor').getAdjacentBlockClientId('foo');
 select('core/block-editor').getAdjacentBlockClientId('foo', -1);
 select('core/block-editor').getAdjacentBlockClientId('foo', 1);
+
+// $ExpectType UseBlockPropsOut<Record<PropertyKey, unknown>>
+be.useBlockProps();
+
+// $ExpectType UseBlockPropsOut<{ foo: string; }>
+be.useBlockProps({ foo: "bar" });
+
+// $ExpectType unknown
+be.useBlockProps.save();
+
+// $ExpectType unknown
+be.useBlockProps.save({ foo: "bar" });

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -1,5 +1,6 @@
 import { BlockInstance } from '@wordpress/blocks';
 import * as be from '@wordpress/block-editor';
+import * as UseBlockProps from '@wordpress/block-editor/components/use-block-props';
 import { dispatch, select } from '@wordpress/data';
 import { useRef } from 'react';
 
@@ -536,33 +537,22 @@ select('core/block-editor').getAdjacentBlockClientId('foo');
 select('core/block-editor').getAdjacentBlockClientId('foo', -1);
 select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
-const _reserved: be.UseBlockProps.Reserved = {
-    id: 'test',
-    role: 'document',
-    tabIndex: 0,
-    'aria-label': 'aria-label',
-    'data-block': 'data-block',
-    'data-type': 'data-type',
-    'data-title': 'data-title',
-};
+{
+  const blockProps: UseBlockProps.Merged & UseBlockProps.Reserved = be.useBlockProps();
+  blockProps;
+}
 
-const _merged: be.UseBlockProps.Merged = {
-    className: 'test',
-    style: {
-        hello: 'world',
-        other: { whatherver: true },
-    },
-    ref: () => useRef({ hello: { world: true } }),
-};
+{
+  const blockProps = be.useBlockProps({ foo: "bar" });
+  // $ExpectType string
+  blockProps.foo;
+}
 
-// $ExpectType Omit<Record<string, unknown>, "ref"> & Merged & Reserved
-be.useBlockProps();
-
-// $ExpectType Omit<{ foo: string; }, "ref"> & Merged & Reserved
-be.useBlockProps({ foo: "bar" });
-
-// $ExpectType Omit<{ ref: MutableRefObject<string>; }, "ref"> & Merged & Reserved
-be.useBlockProps({ ref: useRef("test") });
+{
+  const blockProps = be.useBlockProps({ ref: useRef("test") });
+  // $ExpectType (instance: unknown) => void
+  blockProps.ref;
+}
 
 // $ExpectType Record<string, unknown>
 be.useBlockProps.save();

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -535,7 +535,7 @@ select('core/block-editor').getAdjacentBlockClientId('foo');
 select('core/block-editor').getAdjacentBlockClientId('foo', -1);
 select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
-// $ExpectType UseBlockPropsOut<Record<PropertyKey, unknown>>
+// $ExpectType UseBlockPropsOut<Record<string, unknown>>
 be.useBlockProps();
 
 // $ExpectType UseBlockPropsOut<{ foo: string; }>

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -1,6 +1,7 @@
 import { BlockInstance } from '@wordpress/blocks';
 import * as be from '@wordpress/block-editor';
 import { dispatch, select } from '@wordpress/data';
+import { useRef } from 'react';
 
 declare const BLOCK_INSTANCE: BlockInstance;
 
@@ -535,14 +536,17 @@ select('core/block-editor').getAdjacentBlockClientId('foo');
 select('core/block-editor').getAdjacentBlockClientId('foo', -1);
 select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
-// $ExpectType Record<string, unknown> & Merged & Reserved
+// $ExpectType Omit<Record<string, unknown>, "ref"> & Merged & Reserved
 be.useBlockProps();
 
-// $ExpectType { foo: string; } & Merged & Reserved
+// $ExpectType Omit<{ foo: string; }, "ref"> & Merged & Reserved
 be.useBlockProps({ foo: "bar" });
 
-// $ExpectType unknown
+// $ExpectType Omit<{ ref: MutableRefObject<string>; }, "ref"> & Merged & Reserved
+be.useBlockProps({ ref: useRef("test") });
+
+// $ExpectType Record<string, unknown>
 be.useBlockProps.save();
 
-// $ExpectType unknown
+// $ExpectType Record<string, unknown>
 be.useBlockProps.save({ foo: "bar" });

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -535,10 +535,10 @@ select('core/block-editor').getAdjacentBlockClientId('foo');
 select('core/block-editor').getAdjacentBlockClientId('foo', -1);
 select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
-// $ExpectType UseBlockPropsOut<Record<string, unknown>>
+// $ExpectType Record<string, unknown> & Merged & Reserved
 be.useBlockProps();
 
-// $ExpectType UseBlockPropsOut<{ foo: string; }>
+// $ExpectType { foo: string; } & Merged & Reserved
 be.useBlockProps({ foo: "bar" });
 
 // $ExpectType unknown

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -536,6 +536,25 @@ select('core/block-editor').getAdjacentBlockClientId('foo');
 select('core/block-editor').getAdjacentBlockClientId('foo', -1);
 select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
+const _reserved: be.UseBlockProps.Reserved = {
+    id: 'test',
+    role: 'document',
+    tabIndex: 0,
+    'aria-label': 'aria-label',
+    'data-block': 'data-block',
+    'data-type': 'data-type',
+    'data-title': 'data-title',
+};
+
+const _merged: be.UseBlockProps.Merged = {
+    className: 'test',
+    style: {
+        hello: 'world',
+        other: { whatherver: true },
+    },
+    ref: () => useRef({ hello: { world: true } }),
+};
+
 // $ExpectType Omit<Record<string, unknown>, "ref"> & Merged & Reserved
 be.useBlockProps();
 

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -536,13 +536,13 @@ select('core/block-editor').getAdjacentBlockClientId('foo');
 select('core/block-editor').getAdjacentBlockClientId('foo', -1);
 select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
-// $ExpectType Omit<Record<string, unknown>, "ref"> & Merged & Reserved
+// $ExpectType Pick<Record<string, unknown>, string> & Merged & Reserved
 be.useBlockProps();
 
-// $ExpectType Omit<{ foo: string; }, "ref"> & Merged & Reserved
+// $ExpectType Pick<{ foo: string; }, "foo"> & Merged & Reserved
 be.useBlockProps({ foo: "bar" });
 
-// $ExpectType Omit<{ ref: MutableRefObject<string>; }, "ref"> & Merged & Reserved
+// $ExpectType Pick<{ ref: MutableRefObject<string>; }, never> & Merged & Reserved
 be.useBlockProps({ ref: useRef("test") });
 
 // $ExpectType Record<string, unknown>


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/59dce7546f86abece759066769d8c60b139cca31/packages/block-editor/src/components/block-list/use-block-props/index.js#L46-L169
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

---

I am a bit unsure about the version: `useBlockProps` was already available in @wordpress/block-editor@6.0.0 (now this at 8.0.13), therefore it should be sufficient to bump the patch version of the package.

Moreover, I extracted the types looking at the code, just let me know if it could be better to use just `Record`s instead of specific type intersections.

Credits: this PR has been sponsored by [Thirdfloor SRL](http://www.thirdfloor.it)