### PR TITLE
[gulp-changed]: Replace deprecated `compareSha1Digest` with `compareContents`

### DIFF
--- a/types/gulp-changed/gulp-changed-tests.ts
+++ b/types/gulp-changed/gulp-changed-tests.ts
@@ -10,6 +10,6 @@ gulp.src("*.html")
 
 // With some options
 gulp.src("*.html")
-    .pipe(changed("build", { hasChanged: changed.compareSha1Digest }))
+    .pipe(changed("build", { hasChanged: changed.compareContents }))
     .pipe(minifyHtml())
     .pipe(gulp.dest("build"));

--- a/types/gulp-changed/index.d.ts
+++ b/types/gulp-changed/index.d.ts
@@ -12,11 +12,10 @@ import File = require("vinyl");
 interface IComparator {
     /**
      * @param stream Should be used to queue sourceFile if it passes some comparison
-     * @param callback Should be called when done
      * @param sourceFile File to operate on
      * @param destPath Destination for sourceFile as an absolute path
      */
-    (stream: Transform, callback: Function, sourceFile: File, destPath: string): void;
+    (stream: Transform, sourceFile: File, destPath: string): void;
 }
 
 interface IDestination {
@@ -51,7 +50,7 @@ interface IGulpChanged {
     (destination: string | IDestination, options?: IOptions): NodeJS.ReadWriteStream;
 
     compareLastModifiedTime: IComparator;
-    compareSha1Digest: IComparator;
+    compareContents: IComparator;
 }
 
 declare const changed: IGulpChanged;


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/sindresorhus/gulp-changed/blob/main/index.js >
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
