### PR TITLE
vexflow: add parameters to openGroup() in contexts

### DIFF
--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -32,6 +32,10 @@ declare namespace Vex {
         constructor(code: string, message: string);
     }
 
+    interface GroupAttributes {
+        pointerBBox: boolean;
+    }
+
     /**
      * Helper interface for handling the different rendering contexts (i.e. CanvasContext, RaphaelContext, SVGContext). Not part of VexFlow!
      */
@@ -71,7 +75,7 @@ declare namespace Vex {
         fillText(text: string, x: number, y: number): IRenderContext;
         save(): IRenderContext;
         restore(): IRenderContext;
-        openGroup(): Node | undefined;
+        openGroup(cls?: string, id?: string, attrs?: GroupAttributes): Node | undefined;
         closeGroup(): void;
 
         /**
@@ -479,7 +483,7 @@ declare namespace Vex {
             fillText(text: string, x: number, y: number): void;
             save(): void;
             restore(): void;
-            openGroup(): undefined;
+            openGroup(cls?: string, id?: string, attrs?: GroupAttributes): undefined;
             closeGroup(): void;
         }
 
@@ -1069,7 +1073,7 @@ declare namespace Vex {
             fillText(text: string, x: number, y: number): RaphaelContext;
             save(): RaphaelContext;
             restore(): RaphaelContext;
-            openGroup(): undefined;
+            openGroup(cls?: string, id?: string, attrs?: GroupAttributes): undefined;
             closeGroup(): void;
         }
 
@@ -1765,7 +1769,7 @@ declare namespace Vex {
             fillText(text: string, x: number, y: number): SVGContext;
             save(): SVGContext;
             restore(): SVGContext;
-            openGroup(): Node;
+            openGroup(cls?: string, id?: string, attrs?: GroupAttributes): Node;
             closeGroup(): void;
         }
 

--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for VexFlow v3.0.9
+// Type definitions for VexFlow v3.0.9, compatible with v1.2.93
 // Project: http://vexflow.com
 // Definitions by: Roman Quiring <https://github.com/rquiring>
 //                 Sebastian Haas <https://github.com/sebastianhaas>

--- a/types/vexflow/vexflow-tests.ts
+++ b/types/vexflow/vexflow-tests.ts
@@ -1,5 +1,5 @@
 var canvas = document.getElementById('canvas');
-var renderer = new Vex.Flow.Renderer(canvas, Vex.Flow.Renderer.Backends.CANVAS);
+var renderer = new Vex.Flow.Renderer(canvas, Vex.Flow.Renderer.Backends.SVG);
 var ctx = renderer.getContext();
 
 // Add a treble clef and time signature

--- a/types/vexflow/vexflow-tests.ts
+++ b/types/vexflow/vexflow-tests.ts
@@ -53,7 +53,9 @@ var formatter = new Vex.Flow.Formatter({softmaxFactor: null, maxIterations: 2})
 stave.draw();
 
 // Render voices
+ctx.openGroup("voice", "voice1");
 voice1.draw(ctx, stave);
+ctx.closeGroup();
 voice2.draw(ctx, stave);
 
 // Render beam


### PR DESCRIPTION
The parameters to this function were missing. Especially the non-optional `cls` parameter missing caused problems.

Implementation Note:
cls has to be optional even though it is seemingly mandatory in svgcontext.js in Vexflow 3.0.9,
because the other contexts implement IRenderContext in these definitions,
which they don't do in Vexflow 3.0.9, and they don't have these arguments including cls.
And IRenderContext is used in many places in these definitions, so it's also not easy to change.
Also, the cls argument is actually optional even though Vexflow says it isn't. Vexflow checks for undefined.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/0xfe/vexflow/blob/3.0.9/src/svgcontext.js
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (it doesn't)
