### PR TITLE
Updates for Relay 13

### DIFF
--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-relay 11.0
+// Type definitions for react-relay 13.0
 // Project: https://github.com/facebook/relay, https://relay.dev
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 Marais Rossouw <https://github.com/maraisr>

--- a/types/react-relay/relay-hooks/MatchContainer.d.ts
+++ b/types/react-relay/relay-hooks/MatchContainer.d.ts
@@ -72,7 +72,7 @@ type TypenameOnlyPointer = Readonly<{ __typename: string }>;
 export type MatchPointer = Readonly<{
     __fragmentPropName?: string | null | undefined;
     __module_component?: unknown | undefined;
-    ' $fragmentRefs': unknown;
+    ' $fragmentSpreads': unknown;
 }>;
 
 export type MatchContainerProps<TProps = {}, TFallback = ReactNode> = Readonly<{

--- a/types/react-relay/relay-hooks/helpers.d.ts
+++ b/types/react-relay/relay-hooks/helpers.d.ts
@@ -2,18 +2,13 @@
 A TS file to help with the construction of the official Relay (flow) types.
  */
 
-import { FragmentReference } from 'relay-runtime';
+import { FragmentType } from 'relay-runtime';
 import { EntryPoint } from './EntryPointTypes';
 
-export type KeyType<TData = unknown> = Readonly<
-    | {
-        ' $data'?: TData | undefined;
-        ' $fragmentRefs': FragmentReference;
-    }
-    | {
-        ' $data'?: TData | undefined;
-        ' $fragmentSpreads': FragmentReference;
-    }>;
+export type KeyType<TData = unknown> = Readonly<{
+    ' $data'?: TData | undefined;
+    ' $fragmentSpreads': FragmentType;
+}>;
 
 export type KeyTypeData<TKey extends KeyType<TData>, TData = unknown> = Required<TKey>[' $data'];
 

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -163,7 +163,7 @@ type Story_story = {
     readonly id: string;
     readonly text: string;
     readonly isPublished: boolean;
-    readonly ' $refType': 'Story_story';
+    readonly ' $fragmentType': 'Story_story';
 };
 
 const Story = (() => {
@@ -295,15 +295,15 @@ type FeedStories_feed = {
     readonly edges: ReadonlyArray<{
         readonly node: {
             readonly id: string;
-            readonly ' $fragmentRefs': FragmentRefs<'Story_story' | 'FeedStories_feed'>;
+            readonly ' $fragmentSpreads': FragmentRefs<'Story_story' | 'FeedStories_feed'>;
         };
-        readonly ' $fragmentRefs': FragmentRefs<'FeedStory_edges'>;
+        readonly ' $fragmentSpreads': FragmentRefs<'FeedStory_edges'>;
     }>;
-    readonly ' $refType': 'FeedStories_feed';
+    readonly ' $fragmentType': 'FeedStories_feed';
 };
 type FeedStory_edges = ReadonlyArray<{
     readonly publishedAt: string;
-    readonly ' $refType': 'FeedStory_edges';
+    readonly ' $fragmentType': 'FeedStory_edges';
 }>;
 
 const Feed = (() => {
@@ -414,9 +414,9 @@ type UserFeed_user = {
             readonly endCursor?: string | null | undefined;
             readonly hasNextPage: boolean;
         };
-        readonly ' $fragmentRefs': FragmentRefs<'FeedStories_feed'>;
+        readonly ' $fragmentSpreads': FragmentRefs<'FeedStories_feed'>;
     };
-    readonly ' $refType': 'UserFeed_user';
+    readonly ' $fragmentType': 'UserFeed_user';
 };
 () => {
     interface Props {

--- a/types/react-relay/test/relay-hooks-tests.tsx
+++ b/types/react-relay/test/relay-hooks-tests.tsx
@@ -185,14 +185,14 @@ interface UserComponent_user {
     readonly profile_picture: {
         readonly uri: string;
     };
-    readonly ' $refType': 'UserComponent_user';
+    readonly ' $fragmentType': 'UserComponent_user';
 }
 
 type UserComponent_user$data = UserComponent_user;
 
 interface UserComponent_user$key {
     readonly ' $data'?: UserComponent_user$data | undefined;
-    readonly ' $fragmentRefs': FragmentRefs<'UserComponent_user'>;
+    readonly ' $fragmentSpreads': FragmentRefs<'UserComponent_user'>;
 }
 
 function NonNullableFragment() {
@@ -246,12 +246,12 @@ type UserComponent_users = ReadonlyArray<{
     readonly profile_picture: {
         readonly uri: string;
     };
-    readonly ' $refType': 'UserComponent_users';
+    readonly ' $fragmentType': 'UserComponent_users';
 }>;
 type UserComponent_users$data = UserComponent_users;
 type UserComponent_users$key = ReadonlyArray<{
     readonly ' $data'?: UserComponent_users$data | undefined;
-    readonly ' $fragmentRefs': FragmentRefs<'UserComponent_users'>;
+    readonly ' $fragmentSpreads': FragmentRefs<'UserComponent_users'>;
 }>;
 
 function NonNullableArrayFragment() {
@@ -353,7 +353,7 @@ function RefetchableFragment() {
 
     interface CommentBodyRefetchQueryResponse {
         readonly node: {
-            readonly ' $fragmentRefs': FragmentRefs<'CommentBody_comment'>;
+            readonly ' $fragmentSpreads': FragmentRefs<'CommentBody_comment'>;
         } | null;
     }
 
@@ -367,14 +367,14 @@ function RefetchableFragment() {
             readonly text: string;
         } | null;
         readonly id: string | null;
-        readonly ' $refType': 'CommentBody_comment';
+        readonly ' $fragmentType': 'CommentBody_comment';
     }
 
     type CommentBody_comment$data = CommentBody_comment;
 
     interface CommentBody_comment$key {
         readonly ' $data'?: CommentBody_comment$data | undefined;
-        readonly ' $fragmentRefs': FragmentRefs<'CommentBody_comment'>;
+        readonly ' $fragmentSpreads': FragmentRefs<'CommentBody_comment'>;
     }
 
     interface Props {
@@ -429,7 +429,7 @@ function PaginationFragment() {
 
     interface FriendsListPaginationQueryResponse {
         readonly node: {
-            readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+            readonly ' $fragmentSpreads': FragmentRefs<'FriendsListComponent_user'>;
         };
     }
 
@@ -449,14 +449,14 @@ function PaginationFragment() {
             }>;
         };
         readonly id: string;
-        readonly ' $refType': 'FriendsListComponent_user';
+        readonly ' $fragmentType': 'FriendsListComponent_user';
     }
 
     type FriendsListComponent_user$data = FriendsListComponent_user;
 
     interface FriendsListComponent_user$key {
         readonly ' $data'?: FriendsListComponent_user$data | undefined;
-        readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+        readonly ' $fragmentSpreads': FragmentRefs<'FriendsListComponent_user'>;
     }
 
     interface Props {
@@ -515,7 +515,7 @@ function PaginationFragment_WithNonNullUserProp() {
 
     interface FriendsListPaginationQueryResponse {
         readonly node: {
-            readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+            readonly ' $fragmentSpreads': FragmentRefs<'FriendsListComponent_user'>;
         };
     }
 
@@ -535,14 +535,14 @@ function PaginationFragment_WithNonNullUserProp() {
             }>;
         };
         readonly id: string;
-        readonly ' $refType': 'FriendsListComponent_user';
+        readonly ' $fragmentType': 'FriendsListComponent_user';
     }
 
     type FriendsListComponent_user$data = FriendsListComponent_user;
 
     interface FriendsListComponent_user$key {
         readonly ' $data'?: FriendsListComponent_user$data | undefined;
-        readonly ' $fragmentRefs': FragmentRefs<'FriendsListComponent_user'>;
+        readonly ' $fragmentSpreads': FragmentRefs<'FriendsListComponent_user'>;
     }
 
     interface Props {

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for relay-runtime 12.0
+// Type definitions for relay-runtime 13.0
 // Project: https://github.com/facebook/relay, https://facebook.github.io/relay
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 Stephen Pittman <https://github.com/Stephen2>
@@ -58,7 +58,9 @@ export {
     Environment as IEnvironment,
     FragmentMap,
     FragmentPointer,
-    FragmentReference,
+    // DEPRECATED: use FragmentType instead of FragmentReference
+    FragmentType as FragmentReference,
+    FragmentType,
     FragmentSpecResolver,
     HandleFieldPayload,
     InvalidationState,
@@ -216,21 +218,13 @@ export const __internal: Internal;
  * relay-compiler-language-typescript support for fragment references
  */
 
-export type _RefType<Ref extends string> =
-    | {
-        ' $refType': Ref;
-    }
-    | {
-        ' $fragmentType': Ref
-    };
+export interface _RefType<Ref extends string> {
+    ' $fragmentType': Ref;
+}
 
-export type _FragmentRefs<Refs extends string> =
-    | {
-        ' $fragmentRefs': FragmentRefs<Refs>;
-    }
-    | {
-        ' $fragmentSpreads': FragmentRefs<Refs>;
-    };
+export interface _FragmentRefs<Refs extends string> {
+    ' $fragmentSpreads': FragmentRefs<Refs>;
+}
 
 // This is used in the actual artifacts to define the various fragment references a container holds.
 export type FragmentRefs<Refs extends string> = {

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -21,7 +21,7 @@ import { RelayOperationTracker } from './RelayOperationTracker';
 import { RecordState } from './RelayRecordState';
 import { InvalidationState } from './RelayModernStore';
 
-export type FragmentReference = unknown;
+export type FragmentType = unknown;
 export type OperationTracker = RelayOperationTracker;
 
 /*
@@ -733,7 +733,7 @@ export interface FragmentPointer {
 export interface ModuleImportPointer {
     readonly __fragmentPropName: string | null | undefined;
     readonly __module_component: unknown;
-    readonly $fragmentRefs: unknown;
+    readonly $fragmentSpreads: unknown;
 }
 
 /**

--- a/types/relay-runtime/lib/store/readInlineData.d.ts
+++ b/types/relay-runtime/lib/store/readInlineData.d.ts
@@ -1,9 +1,9 @@
-import { FragmentReference } from './RelayStoreTypes';
+import { FragmentType } from './RelayStoreTypes';
 import { GraphQLTaggedNode } from '../query/RelayModernGraphQLTag';
 
 export type KeyType<TData = unknown> = Readonly<{
     ' $data'?: TData | undefined;
-    ' $fragmentRefs': FragmentReference;
+    ' $fragmentSpreads': FragmentType;
 }>;
 
 export type KeyTypeData<TKey extends KeyType<TData>, TData = unknown> = Required<TKey>[' $data'];

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -428,12 +428,12 @@ const nodeFragment: ReaderFragment = {
 
 interface Module_data {
     readonly id: string;
-    readonly ' $refType': 'Module_data';
+    readonly ' $fragmentType': 'Module_data';
 }
 type Module_data$data = Module_data;
 interface Module_data$key {
     readonly ' $data'?: Module_data$data;
-    readonly ' $fragmentRefs': FragmentRefs<'Module_data'>;
+    readonly ' $fragmentSpreads': FragmentRefs<'Module_data'>;
 }
 
 function readData(


### PR DESCRIPTION
In Relay v13 `$refType` was renamed to `$fragmentType` and `$fragmentRefs` was renamed to `$fragmentSpreads`. A previous PR updated a few places with type unions to remain backwards compatible with relay 12, but there were several places that still needed to be updated.

This PR updates the headers in `@types/react-relay` and `@types/relay-runtime`, so I think it will be published as v13.0.0. I removed the type aliases and only attempt to support relay v13 in this version.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://github.com/facebook/relay/commit/4556f53985334e3543f02d6ebc0b95591da486d1
    - https://github.com/facebook/relay/commit/0a487b60eb314c4241e25d5c1ad3cb2dbd2a65af
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
