### PR TITLE
sharedb: context types now include a generic for the agent's type

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -231,41 +231,41 @@ declare namespace sharedb {
             submit: SubmitContext;
         }
 
-        interface BaseContext {
+        interface BaseContext<TAgentCustom = any> {
             action: keyof ActionContextMap;
-            agent: Agent;
+            agent: Agent<TAgentCustom>;
             backend: sharedb;
         }
 
-        interface ApplyContext extends BaseContext, SubmitRequest {
+        interface ApplyContext<TAgentCustom = any> extends BaseContext<TAgentCustom>, SubmitRequest {
         }
 
-        interface CommitContext extends BaseContext, SubmitRequest {
+        interface CommitContext<TAgentCustom = any> extends BaseContext<TAgentCustom>, SubmitRequest {
         }
 
-        interface ConnectContext extends BaseContext {
+        interface ConnectContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
             stream: any;
             req: any;  // Property always exists, value may be undefined
         }
 
-        interface DocContext extends BaseContext {
+        interface DocContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
             collection: string;
             id: string;
             snapshot: Snapshot;
         }
 
-        interface OpContext extends BaseContext {
+        interface OpContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
             collection: string;
             id: string;
             op: any;
         }
 
-        interface PresenceContext extends BaseContext {
+        interface PresenceContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
             presence: PresenceMessage;
             collection?: string;
         }
 
-        interface QueryContext extends BaseContext {
+        interface QueryContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
             index: string;
             collection: string;
             projection: ReadonlyProjection;
@@ -277,24 +277,24 @@ declare namespace sharedb {
             snapshotProjection: ReadonlyProjection | null;
         }
 
-        interface ReadSnapshotsContext extends BaseContext {
+        interface ReadSnapshotsContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
             collection: string;
             snapshots: Snapshot[];
             snapshotType: SnapshotType;
         }
 
-        interface ReceiveContext extends BaseContext {
+        interface ReceiveContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
             data: {[key: string]: any};  // ClientRequest, but before any validation
         }
 
-        interface ReplyContext extends BaseContext {
+        interface ReplyContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
             request: ShareDB.ClientRequest;
             reply: {[key: string]: any};
         }
 
         type SnapshotType = 'current' | 'byVersion' | 'byTimestamp';
 
-        interface SubmitContext extends BaseContext, SubmitRequest {
+        interface SubmitContext<TAgentCustom = any> extends BaseContext<TAgentCustom>, SubmitRequest {
         }
     }
 }
@@ -351,7 +351,7 @@ interface PresenceMessage {
 
 type BasicCallback = (err?: Error) => void;
 
-type ErrorHandler = (error: Error, context: ErrorHandlerContext) => void;
-interface ErrorHandlerContext {
-    agent?: Agent;
+type ErrorHandler<TAgentCustom = any> = (error: Error, context: ErrorHandlerContext<TAgentCustom>) => void;
+interface ErrorHandlerContext<TAgentCustom = any> {
+    agent?: Agent<TAgentCustom>;
 }

--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -243,29 +243,29 @@ declare namespace sharedb {
         interface CommitContext<TAgentCustom = any> extends BaseContext<TAgentCustom>, SubmitRequest {
         }
 
-        interface ConnectContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
+        interface ConnectContext<TAgentCustom = any> extends BaseContext<TAgentCustom> {
             stream: any;
             req: any;  // Property always exists, value may be undefined
         }
 
-        interface DocContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
+        interface DocContext<TAgentCustom = any> extends BaseContext<TAgentCustom> {
             collection: string;
             id: string;
             snapshot: Snapshot;
         }
 
-        interface OpContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
+        interface OpContext<TAgentCustom = any> extends BaseContext<TAgentCustom> {
             collection: string;
             id: string;
             op: any;
         }
 
-        interface PresenceContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
+        interface PresenceContext<TAgentCustom = any> extends BaseContext<TAgentCustom> {
             presence: PresenceMessage;
             collection?: string;
         }
 
-        interface QueryContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
+        interface QueryContext<TAgentCustom = any> extends BaseContext<TAgentCustom> {
             index: string;
             collection: string;
             projection: ReadonlyProjection;
@@ -277,17 +277,17 @@ declare namespace sharedb {
             snapshotProjection: ReadonlyProjection | null;
         }
 
-        interface ReadSnapshotsContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
+        interface ReadSnapshotsContext<TAgentCustom = any> extends BaseContext<TAgentCustom> {
             collection: string;
             snapshots: Snapshot[];
             snapshotType: SnapshotType;
         }
 
-        interface ReceiveContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
+        interface ReceiveContext<TAgentCustom = any> extends BaseContext<TAgentCustom> {
             data: {[key: string]: any};  // ClientRequest, but before any validation
         }
 
-        interface ReplyContext<TAgentCustom = any> extends BaseContext<TAgentCustom>{
+        interface ReplyContext<TAgentCustom = any> extends BaseContext<TAgentCustom> {
             request: ShareDB.ClientRequest;
             reply: {[key: string]: any};
         }

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -111,11 +111,11 @@ for (const action of submitRelatedActions) {
         callback();
     });
 }
-backend.use('connect', (context, callback) => {
+backend.use('connect', (context: ShareDB.middleware.ConnectContext<{ user: { id: any } }>, callback) => {
     // `context.req` is the HTTP / websocket request.
     // This assumes that some request middleware has handled auth and popuplated `req.userId`.
     if (context.req.userId) {
-        context.agent.custom.user = {id: context.req.userId};
+        context.agent.custom.user = { id: context.req.userId };
     }
     console.log(
         context.action,


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/sharedb/lib/agent.d.ts)

While the Agent type is already a generic, this generic wasn't used in the context definitions. The change allows you to have a static type in the `context.agent.custom` property through a generic:

```ts
context: ShareDB.middleware.ConnectContext<{ user: { id: any } }>
```

will make `context.agent.custom` of the type `{user: {id: any} }`.