### PR TITLE
react-native-htmlview: Fix, update & improve typedefs (v0.16.0)

### DIFF
--- a/types/react-native-htmlview/index.d.ts
+++ b/types/react-native-htmlview/index.d.ts
@@ -1,34 +1,47 @@
-// Type definitions for react-native-htmlview 0.12
+// Type definitions for react-native-htmlview 0.16
 // Project: https://github.com/jsdf/react-native-htmlview
-// Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
+// Definitions by: Ifiok Jr. <https://github.com/ifiokjr>, Kiruse <https://github.com/Kiruse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { Component, ComponentType, ReactNode } from 'react';
+import { ComponentType, ReactNode } from 'react';
 import {
     StyleProp,
-    TextProperties,
-    ViewProperties,
+    TextProps,
+    ViewProps,
     TextStyle,
     ViewStyle,
     ImageStyle,
 } from 'react-native';
 
+type Nullish = null | undefined;
+
+interface GenericAttribs {
+    [key: string]: string;
+}
+interface SpecificAttribs {
+    style: StyleProp<ViewStyle | TextStyle | ImageStyle>;
+}
+
 export interface HTMLViewNode {
     data?: string | undefined;
     type?: string | undefined;
     name?: string | undefined;
-    attribs: { [key: string]: string };
+    attribs: GenericAttribs & SpecificAttribs;
+    children: HTMLViewNode[];
 }
+
 export interface HTMLViewProps {
     /**
      * a string of HTML content to render
      */
     value: string;
 
-    stylesheet?: {
-        [key: string]: StyleProp<ViewStyle | TextStyle | ImageStyle>;
-    } | undefined;
+    stylesheet?:
+        | {
+            [key: string]: StyleProp<ViewStyle | TextStyle | ImageStyle>;
+          }
+        | undefined;
 
     onLinkPress?(url: string): void;
 
@@ -52,9 +65,9 @@ export interface HTMLViewProps {
     renderNode?(
         node: HTMLViewNode,
         index: number,
-        siblings: HTMLViewNode,
+        siblings: HTMLViewNode[],
         parent: HTMLViewNode,
-        defaultRenderer: (node: HTMLViewNode, parent: HTMLViewNode) => ReactNode
+        defaultRenderer: HTMLViewNodeRenderer,
     ): ReactNode;
 
     /**
@@ -85,7 +98,7 @@ export interface HTMLViewProps {
     /*
      * Properties for the RootComponent, can be used independently from RootComponent
      */
-    rootComponentProps?: ViewProperties | undefined;
+    rootComponentProps?: ViewProps | undefined;
 
     /*
      * The component used for rendering HTML element nodes
@@ -95,7 +108,7 @@ export interface HTMLViewProps {
     /*
      * Properties for the NodeComponent, can be used independently from NodeComponent
      */
-    nodeComponentProps?: TextProperties | undefined;
+    nodeComponentProps?: TextProps | undefined;
 
     /*
      * The component used for rendering text element nodes
@@ -105,7 +118,13 @@ export interface HTMLViewProps {
     /*
      * Properties for the TextComponent, can be used independently from TextComponent
      */
-    textComponentProps?: TextProperties | undefined;
+    textComponentProps?: TextProps | undefined;
 }
 
-export default class HTMLView extends Component<HTMLViewProps> {}
+export type HTMLViewNodeRenderer = (
+    node: HTMLViewNode[],
+    parent: HTMLViewNode | Nullish,
+) => ReactNode;
+
+declare const HTMLView: ComponentType<HTMLViewProps>;
+export default HTMLView;

--- a/types/react-native-htmlview/react-native-htmlview-tests.tsx
+++ b/types/react-native-htmlview/react-native-htmlview-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import HTMLView from 'react-native-htmlview';
+import HTMLView, { HTMLViewProps } from 'react-native-htmlview';
 
 const styles = StyleSheet.create({
   strong: {},
@@ -51,7 +51,34 @@ class Simple extends React.Component {
         rootComponentProps={defaultRootProps}
         TextComponent={Text}
         textComponentProps={defaultTextProps}
+        renderNode={renderNode}
       />
     );
   }
 }
+
+const renderNode: HTMLViewProps['renderNode'] = (
+  node,
+  index,
+  siblings,
+  parent,
+  defaultRenderer,
+) => {
+  if (node.name === 'p') {
+    const { numberOfLines } = node.attribs;
+
+    return (
+      <Text
+        style={[
+          { color: '#acacac' },
+          node.attribs.style
+        ]}
+        numberOfLines={numberOfLines ? Number(numberOfLines) : undefined}
+      >
+        {defaultRenderer(node.children, node)}
+      </Text>
+    );
+  } else {
+    return defaultRenderer([node], parent);
+  }
+};


### PR DESCRIPTION
Changes based on `react-native-htmlview` documentation found in [README.md](https://github.com/jsdf/react-native-htmlview/blob/dd2d9a06a46da5591ab92179794f954848ca1191/README.md).

- Update to v0.16.0 of `react-native-htmlview`
- Improve `HTMLViewNode.attribs` by adding specialized attributes
- Replace deprecated Text/ViewProperties with appropriate Text/ViewProps
- Fix incorrect `defaultRenderer` typing
- Fix incorrect `siblings` argument typing of `renderNode`