### PR TITLE
[formidable] add missing options, extends class from EventEmitter

### DIFF
--- a/types/formidable/Formidable.d.ts
+++ b/types/formidable/Formidable.d.ts
@@ -1,6 +1,12 @@
-import { IncomingMessage } from "http";
-import { EmitData, EventData, Fields, File, Files, Options, Part, PluginFunction, DefaultOptions } from "./";
-declare class IncomingForm {
+/**
+ * Docs: https://github.com/node-formidable/formidable/blob/master/src/Formidable.js#L45
+ */
+
+import { IncomingMessage } from 'http';
+import { EventEmitter } from 'stream';
+import { EmitData, EventData, Fields, File, Files, Options, Part, PluginFunction, DefaultOptions } from './';
+
+declare class IncomingForm extends EventEmitter {
     static readonly DEFAULT_OPTIONS: DefaultOptions;
     constructor(options?: Partial<Options>);
 
@@ -12,17 +18,17 @@ declare class IncomingForm {
      */
     parse(request: IncomingMessage, callback: (err: any, fields: Fields, files: Files) => void): void;
 
-    once(name: "end", callback: () => void): void;
-    once(name: "error", callback: (err: any) => void): void;
+    once(eventName: 'end', listener: () => void): this;
+    once(eventName: 'error', listener: (err: any) => void): this;
 
-    on(name: "data", callback: (data: EventData) => void): void;
-    on(name: "error", callback: (err: any) => void): void;
-    on(name: "field", callback: (name: string, value: string) => void): void;
-    on(name: "fileBegin" | "file", callback: (formName: string, file: File) => void): void;
-    on(name: "progress", callback: (bytesReceived: number, bytesExpected: number) => void): void;
-    on(name: string, callback: () => void): void;
+    on(eventName: 'data', listener: (data: EventData) => void): this;
+    on(eventName: 'error', listener: (err: any) => void): this;
+    on(eventName: 'field', listener: (name: string, value: string) => void): this;
+    on(eventName: 'fileBegin' | 'file', listener: (formName: string, file: File) => void): this;
+    on(eventName: 'progress', listener: (bytesReceived: number, bytesExpected: number) => void): this;
+    on(eventName: string, listener: () => void): this;
 
-    emit(name: "data", data: EmitData): void;
+    emit(eventName: 'data', data: EmitData): boolean;
 
     /**
      * A method that allows you to extend the Formidable library. By default we include 4 plugins,

--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -11,7 +11,7 @@ import {
     Options,
     PersistentFile,
     VolatileFile,
-    Part
+    Part,
 } from "formidable";
 import * as http from "http";
 
@@ -25,7 +25,9 @@ const options: Options = {
     keepExtensions: false,
     maxFields: 1000,
     maxFieldsSize: 20 * 1024 * 1024,
+    maxFiles: Infinity,
     maxFileSize: 200 * 1024 * 1024,
+    maxTotalFileSize: 200 * 1024 * 1024,
     minFileSize: 1,
     multiples: false,
     uploadDir: "/dir",
@@ -33,7 +35,7 @@ const options: Options = {
         // $ExpectType Part
         part;
         return true;
-    }
+    },
 };
 
 const file: File = {
@@ -52,7 +54,7 @@ const file: File = {
         mtime: file.mtime!,
         originalFilename: file.originalFilename,
         filepath: file.filepath,
-        size: file.size
+        size: file.size,
     }),
     toString: () => `File: ${file.originalFilename}`,
 };
@@ -95,7 +97,7 @@ MultipartParser.stateToString;
 MultipartParser.STATES;
 
 const form = new Formidable(options);
-form.on("data", data => {
+form.on('data', data => {
     // $ExpectType EventData
     data;
 
@@ -115,51 +117,45 @@ form.on("data", data => {
     end;
     // $ExpectType string
     formname;
-});
+})
+    .on('fileBegin', (formname, file) => {
+        // $ExpectType string
+        formname;
+        // $ExpectType File
+        file;
 
-form.on("fileBegin", (formname, file) => {
-    // $ExpectType string
-    formname;
-    // $ExpectType File
-    file;
+        form.emit('data', { name: 'fileBegin', formname, value: file });
+    })
+    .on('file', (formname, file) => {
+        // $ExpectType string
+        formname;
+        // $ExpectType File
+        file;
 
-    form.emit("data", { name: "fileBegin", formname, value: file });
-});
-form.on("file", (formname, file) => {
-    // $ExpectType string
-    formname;
-    // $ExpectType File
-    file;
-
-    form.emit("data", { name: "file", formname, value: file });
-});
-
-form.on("progress", (bytesReceived, bytesExpected) => {
-    // $ExpectType number
-    bytesReceived;
-    // $ExpectType number
-    bytesExpected;
-});
-
-form.on("field", (name, value) => {
-    // $ExpectType string
-    name;
-    // $ExpectType string
-    value;
-});
-
-form.on("error", err => {
-    // $ExpectType any
-    err;
-});
-
-form.on("aborted", () => {});
-
-form.once("end", () => {});
-form.once("error", err => {
-    // $ExpectType any
-    err;
-});
+        form.emit('data', { name: 'file', formname, value: file });
+    })
+    .on('progress', (bytesReceived, bytesExpected) => {
+        // $ExpectType number
+        bytesReceived;
+        // $ExpectType number
+        bytesExpected;
+    })
+    .on('field', (name, value) => {
+        // $ExpectType string
+        name;
+        // $ExpectType string
+        value;
+    })
+    .on('error', err => {
+        // $ExpectType any
+        err;
+    })
+    .on('aborted', () => {})
+    .once('end', () => {})
+    .once('error', err => {
+        // $ExpectType any
+        err;
+    });
 
 form.use((self, options) => {
     // $ExpectType IncomingForm

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -120,11 +120,25 @@ declare namespace formidable {
         minFileSize?: number | undefined;
 
         /**
+         * limit the amount of uploaded files, set Infinity for unlimited
+         *
+         * @default Infinity
+         */
+        maxFiles?: number | undefined;
+
+        /**
          * limit the size of uploaded file
          *
          * @default 200 * 1024 * 1024
          */
         maxFileSize?: number | undefined;
+
+        /**
+         * limit the size of the batch of uploaded files
+         *
+         * @default options.maxFileSize
+         */
+        maxTotalFileSize?: number | undefined;
 
         /**
          * limit the number of fields, set 0 for unlimited


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test formidable`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/node-formidable/formidable#options>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.