### PR TITLE
Google apps script

### DIFF
--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -571,3 +571,17 @@ const makeGrid = ({ items, ...options}: GridOptions) => {
 
     return grid;
 };
+
+const handleScopeAction = () => {
+    // $ExpectType EditorFileScopeActionResponseBuilder
+    const builder = CardService.newEditorFileScopeActionResponseBuilder();
+    builder.requestFileScopeForActiveDocument();
+
+    // $ExpectType EditorFileScopeActionResponse
+    const response = builder.build();
+
+    // $ExpectType string
+    const serialized = response.printJson();
+
+    return serialized;
+};

--- a/types/google-apps-script/google-apps-script.card-service.d.ts
+++ b/types/google-apps-script/google-apps-script.card-service.d.ts
@@ -283,6 +283,10 @@ declare namespace GoogleAppsScript {
       newDecoratedText(): DecoratedText;
       newDivider(): Divider;
       newDriveItemsSelectedActionResponseBuilder(): DriveItemsSelectedActionResponseBuilder;
+      /**
+       * Creates a new EditorFileScopeActionResponseBuilder.
+       */
+      newEditorFileScopeActionResponseBuilder(): EditorFileScopeActionResponseBuilder;
       newFixedFooter(): FixedFooter;
       newIconImage(): IconImage;
       /**
@@ -1068,6 +1072,29 @@ declare namespace GoogleAppsScript {
      */
     interface DriveItemsSelectedActionResponse {
       printJson(): string;
+    }
+
+    /**
+     * Makes changes to an Editor, such as Google Docs, Sheets, or Slides in reaction to an action taken in the UI.
+     */
+    interface EditorFileScopeActionResponse {
+        /**
+         * Prints the JSON representation of this object.
+         */
+        printJson(): string;
+    }
+    /**
+     * A builder for EditorFileScopeActionResponse objects.
+     */
+    interface EditorFileScopeActionResponseBuilder {
+        /**
+         * Builds the current Editor action response.
+         */
+        build(): EditorFileScopeActionResponse;
+        /**
+         * Requests the drive.file scope for the current active Editor document.
+         */
+        requestFileScopeForActiveDocument(): EditorFileScopeActionResponseBuilder;
     }
 
     /**


### PR DESCRIPTION
This PR adds missing type definitions for the `EditoFileScopeAction*` family of interfaces and methods:

- [`CardService#newEditorFileScopeActionResponseBuilder`](https://developers.google.com/apps-script/reference/card-service/card-service#neweditorfilescopeactionresponsebuilder)
- [`EditorFileScopeActionResponseBuilder`](https://developers.google.com/apps-script/reference/card-service/editor-file-scope-action-response-builder)
- [`EditorFileScopeActionResponse`](https://developers.google.com/apps-script/reference/card-service/editor-file-scope-action-response)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/apps-script/reference/card-service/editor-file-scope-action-response-builder>>