### PR TITLE
pacote: add missing `packumentCache` option

### DIFF
--- a/types/pacote/index.d.ts
+++ b/types/pacote/index.d.ts
@@ -249,6 +249,16 @@ export interface PacoteOptions {
      * time is part of the extended packument metadata.
      */
     fullMetadata?: boolean | undefined;
+
+    /**
+     * you usually don't want to fetch the same packument multiple times in
+     * the span of a given script or command, no matter how many pacote calls
+     * are made, so this lets us avoid doing that.  It's only relevant for
+     * registry fetchers, because other types simulate their packument from
+     * the manifest, which they memoize on this.package, so it's very cheap
+     * already.
+     */
+    packumentCache?: Map<string, Packument> | undefined;
 }
 
 export type Options = PacoteOptions & npmFetch.Options;

--- a/types/pacote/pacote-tests.ts
+++ b/types/pacote/pacote-tests.ts
@@ -1,5 +1,6 @@
 import logger = require('npmlog');
 import pacote = require('pacote');
+import type { Packument } from 'pacote';
 import { Integrity } from 'ssri';
 
 const opts: pacote.Options = {
@@ -16,6 +17,7 @@ const opts: pacote.Options = {
     defaultTag: 'latest',
     registry: 'https://registry.npmjs.org',
     fullMetadata: false,
+    packumentCache: new Map<string, Packument>(),
 };
 
 pacote.resolve('pacote'); // $ExpectType Promise<string>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/pacote/blob/80cce46e807026e7d4ad750620c00e62539b0e46/lib/registry.js#L24-L30