### PR TITLE
[react-pdf] [fix] specify target to `es6` so that tests succeeds

### DIFF
--- a/types/react-pdf/tsconfig.json
+++ b/types/react-pdf/tsconfig.json
@@ -16,7 +16,8 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
-        "jsx": "react"
+        "jsx": "react",
+        "target": "es6"
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

This is fixing this error whilst running tests; `pdfs-dist` is using private identifiers that aren't available prior to es6.
```
Error: Errors in typescript@4.6 for external dependencies:
node_modules/pdfjs-dist/types/src/display/metadata.d.ts(10,5): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
```
