### PR TITLE
add(webp-in-css): new definition

### DIFF
--- a/types/webp-in-css/index.d.ts
+++ b/types/webp-in-css/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for webp-in-css 0.7
+// Project: https://www.npmjs.com/package/webp-in-css
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+// tslint:disable-next-line  no-declare-current-package keeping it simple
+declare module 'webp-in-css/polyfill' {
+    // nothing here, global script
+}
+
+// tslint:disable-next-line  no-declare-current-package keeping it simple
+declare module 'webp-in-css/plugin' {
+    import { Declaration, PluginCreator } from 'postcss';
+
+    namespace webpInCss {
+        interface Options {
+            /** @default false */
+            modules?: boolean | undefined;
+            /** @default 'webp' */
+            webpClass?: string | undefined;
+            /** @default 'no-webp' */
+            noWebpClass?: string | undefined;
+            /** @default true */
+            addNoJs?: boolean | undefined;
+            /** @default 'no-js' */
+            noJsClass?: string | undefined;
+            /** @default decl => /\.(jpe?g|png)(?!(\.webp|.*[&?]format=webp))/i.test(decl.value) */
+            check?: (decl: Declaration) => boolean;
+            /** @default oldName => oldName.replace(/\.(jpe?g|png)/gi, '.webp') */
+            rename?: (url: string) => string;
+        }
+
+        type Plugin = PluginCreator<Options>;
+    }
+
+    const webpInCss: webpInCss.Plugin;
+
+    export = webpInCss;
+}

--- a/types/webp-in-css/package.json
+++ b/types/webp-in-css/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.4.4"
+    }
+}

--- a/types/webp-in-css/tsconfig.json
+++ b/types/webp-in-css/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webp-in-css-tests.ts"
+    ]
+}

--- a/types/webp-in-css/tslint.json
+++ b/types/webp-in-css/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/webp-in-css/webp-in-css-tests.ts
+++ b/types/webp-in-css/webp-in-css-tests.ts
@@ -1,0 +1,16 @@
+// tslint:disable-next-line no-var-requires testing polyfill inclusion
+require('webp-in-css/polyfill');
+import plugin = require('webp-in-css/plugin');
+
+plugin.postcss; // $ExpectType true
+plugin();
+plugin({});
+plugin({
+    modules: true,
+    webpClass: 'webp',
+    noWebpClass: 'no-webp',
+    addNoJs: true,
+    noJsClass: 'no-js',
+    check: decl => /\.jpg/.test(decl.value) && !decl.value.includes('as=webp'),
+    rename: url => url.replace('.jpg', '.jpg?as=webp'),
+});


### PR DESCRIPTION
PostCSS plugin:
https://github.com/ai/webp-in-css

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.