### PR TITLE
Declare JSON.parse() accepts as buffer in node

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -13,6 +13,17 @@ interface ErrorConstructor {
     stackTraceLimit: number;
 }
 
+// Declare JSON.parse accepts a buffer
+interface JSON {
+    /**
+     * Converts a JavaScript Object Notation (JSON) string into an object.
+     * @param buffer A buffer containing a valid JSON string.
+     * @param reviver A function that transforms the results. This function is called for each member of the object.
+     * If a member contains nested objects, the nested objects are transformed before the parent object is.
+     */
+    parse(buffer: Buffer, reviver?: (this: any, key: string, value: any) => any): any;
+}
+
 /*-----------------------------------------------*
  *                                               *
  *                   GLOBAL                      *
@@ -243,7 +254,7 @@ declare namespace NodeJS {
     }
 
     interface RequireResolve {
-        (id: string, options?: { paths?: string[] | undefined; }): string;
+        (id: string, options?: { paths?: string[] | undefined }): string;
         paths(request: string): string[] | null;
     }
 

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -8,6 +8,8 @@
     const accessibleToGlobalThisMembers: true = global.RANDOM_GLOBAL_VARIABLE;
 }
 
+JSON.parse(Buffer.from('{}'));
+
 declare var RANDOM_GLOBAL_VARIABLE: true;
 
 // global aliases for compatibility

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -142,6 +142,17 @@ interface ErrorConstructor {
     stackTraceLimit: number;
 }
 
+// Declare JSON.parse accepts a buffer
+interface JSON {
+    /**
+     * Converts a JavaScript Object Notation (JSON) string into an object.
+     * @param buffer A buffer containing a valid JSON string.
+     * @param reviver A function that transforms the results. This function is called for each member of the object.
+     * If a member contains nested objects, the nested objects are transformed before the parent object is.
+     */
+    parse(buffer: Buffer, reviver?: (this: any, key: string, value: any) => any): any;
+}
+
 interface SymbolConstructor {
     readonly observable: symbol;
 }

--- a/types/node/v12/test/globals.ts
+++ b/types/node/v12/test/globals.ts
@@ -9,4 +9,6 @@
     const accessibleToGlobalThisMembers: true = global.RANDOM_GLOBAL_VARIABLE;
 }
 
+JSON.parse(Buffer.from('{}'));
+
 declare var RANDOM_GLOBAL_VARIABLE: true;

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -13,6 +13,17 @@ interface ErrorConstructor {
     stackTraceLimit: number;
 }
 
+// Declare JSON.parse accepts a buffer
+interface JSON {
+    /**
+     * Converts a JavaScript Object Notation (JSON) string into an object.
+     * @param buffer A buffer containing a valid JSON string.
+     * @param reviver A function that transforms the results. This function is called for each member of the object.
+     * If a member contains nested objects, the nested objects are transformed before the parent object is.
+     */
+    parse(buffer: Buffer, reviver?: (this: any, key: string, value: any) => any): any;
+}
+
 // Node.js ESNEXT support
 interface String {
     /** Removes whitespace from the left end of a string. */

--- a/types/node/v14/test/globals.ts
+++ b/types/node/v14/test/globals.ts
@@ -9,4 +9,6 @@
     const accessibleToGlobalThisMembers: true = global.RANDOM_GLOBAL_VARIABLE;
 }
 
+JSON.parse(Buffer.from('{}'));
+
 declare var RANDOM_GLOBAL_VARIABLE: true;

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -13,6 +13,17 @@ interface ErrorConstructor {
     stackTraceLimit: number;
 }
 
+// Declare JSON.parse accepts a buffer
+interface JSON {
+    /**
+     * Converts a JavaScript Object Notation (JSON) string into an object.
+     * @param buffer A buffer containing a valid JSON string.
+     * @param reviver A function that transforms the results. This function is called for each member of the object.
+     * If a member contains nested objects, the nested objects are transformed before the parent object is.
+     */
+    parse(buffer: Buffer, reviver?: (this: any, key: string, value: any) => any): any;
+}
+
 /*-----------------------------------------------*
  *                                               *
  *                   GLOBAL                      *

--- a/types/node/v16/test/globals.ts
+++ b/types/node/v16/test/globals.ts
@@ -8,6 +8,8 @@
     const accessibleToGlobalThisMembers: true = global.RANDOM_GLOBAL_VARIABLE;
 }
 
+JSON.parse(Buffer.from('{}'));
+
 declare var RANDOM_GLOBAL_VARIABLE: true;
 
 // global aliases for compatibility


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](https://nodejs.org/api/)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The [Node.js docs](https://nodejs.org/api/) docs show various examples of `JSON.parse()` accepting a buffer, but I can’t find an official statement that this is allowed.

The following code works and can be run from the repl:

```js
JSON.parse(Buffer.from('{}'))
```

sindresorhus/eslint-plugin-unicorn#1676 add an ESLint rule which disallows to specify an encoding when reading and parsing a JSON file, because `JSON.parse()` can handle buffers.