### PR TITLE
[ink-text-animation] Add implicit types for children

### DIFF
--- a/types/ink-text-animation/index.d.ts
+++ b/types/ink-text-animation/index.d.ts
@@ -3,9 +3,10 @@
 // Definitions by: Martin Badin <https://github.com/martin-badin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Component } from 'react';
+import { Component, ReactNode } from 'react';
 
 export interface InkTextAnimationProps {
+    children?: ReactNode;
     name?: 'rainbow' | 'pulse' | 'glitch' | 'radar' | 'neon';
     speed?: number;
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

Props documentation:
https://github.com/yardnsm/ink-text-animation/tree/51e7d6e3fc82eb2e564c1f9ba2e955e511299b1e#usage
