### PR TITLE
[google-map-react] add optional mapId to MapOptions

### DIFF
--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -12,6 +12,7 @@ const client: BootstrapURLKeys = { client: 'my-client-identifier', v: '3.28' , l
 const options: MapOptions = {
     zoomControl: false,
     gestureHandling: 'cooperative',
+    mapId: '123456789',
     styles: [
         {
             featureType: "administrative",

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -38,6 +38,7 @@ declare namespace googleMapReact {
         gestureHandling?: string | undefined;
         heading?: number | undefined;
         keyboardShortcuts?: boolean | undefined;
+        mapId?: string | undefined;
         mapTypeControl?: boolean | undefined;
         mapTypeControlOptions?: any;
         mapTypeId?: string | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Adding missing type to the MapOptions interface as defined here https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.mapId
