### PR TITLE
nodegit: Added `Refspec.parse` and `Refspec#string` methods.

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -171,6 +171,6 @@ Git.Refspec.parse('+refs/heads/*:refs/remotes/origin/*', 0).then(refspec => {
     refspec.dstMatches('+refs/heads/*'); // $ExpectType number
     refspec.force(); // $ExpectType number
     refspec.src(); // $ExpectType string
-    refspec.srcMatches(); // $ExpectType number
+    refspec.srcMatches('refs/remotes/origin/*'); // $ExpectType number
     refspec.string(); // $ExpectType string
 });

--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -164,3 +164,13 @@ Git.Worktree.openFromRepository(repo).then(worktree => {
     worktree.name(); // $ExpectType string
     worktree.path(); // $ExpectType string
 });
+
+Git.Refspec.parse('+refs/heads/*:refs/remotes/origin/*', 0).then(refspec => {
+    refspec.direction(); // $ExpectType number
+    refspec.dst(); // $ExpectType string
+    refspec.dstMatches('+refs/heads/*'); // $ExpectType number
+    refspec.force(); // $ExpectType number
+    refspec.src(); // $ExpectType string
+    refspec.srcMatches(); // $ExpectType number
+    refspec.string(); // $ExpectType string
+});

--- a/types/nodegit/ref-spec.d.ts
+++ b/types/nodegit/ref-spec.d.ts
@@ -1,5 +1,5 @@
 export class Refspec {
-    static parse(input: string, is_fetch: number): Promise<nodeGit.Refspec>;
+    static parse(input: string, is_fetch: number): Promise<Refspec>;
     direction(): number;
     dst(): string;
     dstMatches(refname: string): number;

--- a/types/nodegit/ref-spec.d.ts
+++ b/types/nodegit/ref-spec.d.ts
@@ -1,8 +1,10 @@
 export class Refspec {
+    static parse(input: string, is_fetch: number): Promise<nodeGit.Refspec>;
     direction(): number;
     dst(): string;
     dstMatches(refname: string): number;
     force(): number;
     src(): string;
     srcMatches(refname: string): number;
+    string(): string;
 }


### PR DESCRIPTION
Added methods to nodegit types corresponding to documentation
https://www.nodegit.org/api/refspec/#parse and https://www.nodegit.org/api/refspec/#string

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.nodegit.org/api/refspec/#parse and https://www.nodegit.org/api/refspec/#string
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
