### PR TITLE
Add Guide to @wordpress/components

### DIFF
--- a/types/wordpress__components/guide/index.d.ts
+++ b/types/wordpress__components/guide/index.d.ts
@@ -1,19 +1,19 @@
 import type { ComponentType, ReactNode } from 'react';
 
 interface GuidePage {
-		content: ReactNode;
-		image?: ReactNode;
+    content: ReactNode;
+    image?: ReactNode;
 }
 
 interface GuideProps {
-		className?: string;
-		contentLabel?: string;
-		finishButtonText?: ReactNode;
-		onFinish?: () => void;
-		pages?: GuidePage[];
+    className?: string;
+    contentLabel?: string;
+    finishButtonText?: ReactNode;
+    onFinish?: () => void;
+    pages?: GuidePage[];
 
-		/* @deprecated */
-		children?: ReactNode;
+    /* @deprecated */
+    children?: ReactNode;
 }
 
 declare const Guide: ComponentType<GuideProps>;

--- a/types/wordpress__components/guide/index.d.ts
+++ b/types/wordpress__components/guide/index.d.ts
@@ -12,7 +12,10 @@ interface GuideProps {
     onFinish?: () => void;
     pages?: GuidePage[];
 
-    /* @deprecated */
+    /**
+     * @deprecated use the `pages` prop instead
+     * @since 5.5
+     */
     children?: ReactNode;
 }
 

--- a/types/wordpress__components/guide/index.d.ts
+++ b/types/wordpress__components/guide/index.d.ts
@@ -1,0 +1,20 @@
+import type { ComponentType, ReactNode } from 'react';
+
+interface GuidePage {
+		content: ReactNode;
+		image?: ReactNode;
+}
+
+interface GuideProps {
+		className?: string;
+		contentLabel?: string;
+		finishButtonText?: ReactNode;
+		onFinish?: () => void;
+		pages?: GuidePage[];
+
+		/* @deprecated */
+		children?: ReactNode;
+}
+
+declare const Guide: ComponentType<GuideProps>;
+export default Guide;

--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -48,6 +48,7 @@ export { default as FontSizePicker } from './font-size-picker';
 export { default as FormFileUpload } from './form-file-upload';
 export { default as FormToggle } from './form-toggle';
 export { default as FormTokenField } from './form-token-field';
+export { default as Guide } from './guide';
 export { default as Icon } from './icon';
 export { default as IconButton } from './icon-button';
 export { default as KeyboardShortcuts } from './keyboard-shortcuts';

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -405,6 +405,23 @@ const buttonGroupRef = createRef<HTMLDivElement>();
 />;
 
 //
+// guide
+//
+<C.Guide
+    finishButtonText="Finish"
+    contentLabel="Guide title"
+    onFinish={ () => {
+        console.log('finished');
+    } }
+    pages={ [
+        {
+            content: <h1>My Page</h1>,
+            image: <h1>My Page Image</h1>,
+        }
+    ] }
+/>;
+
+//
 // icon
 //
 <C.Icon />;


### PR DESCRIPTION
This PR adds types for `Guide` to the `@wordpress/components` package.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/e9f242a2c85d33721e8be5271d822b759b6270b5/packages/components/src/guide/index.js#L22
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header (the current definition claims to be for version 14 which was released in 2021, and this component [was added in 2019](https://github.com/WordPress/gutenberg/pull/18041)).
