### PR TITLE
Add ToolbarGroup to @wordpress/components

### DIFF
--- a/types/wordpress__components/dropdown-menu/index.d.ts
+++ b/types/wordpress__components/dropdown-menu/index.d.ts
@@ -55,7 +55,7 @@ declare namespace DropdownMenu {
         /**
          * Dashicon icon slug.
          */
-        icon: Dashicon.Icon;
+        icon: Dashicon.Icon | JSX.Element;
         /**
          * Human-readable title for the control.
          */
@@ -67,7 +67,7 @@ declare namespace DropdownMenu {
         /**
          * Function to invoke when the option is selected.
          */
-        onClick(): void;
+        onClick?: () => void;
     }
     type Props = PropsWithChildren | PropsWithControls;
 }

--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -81,6 +81,7 @@ export { default as TextareaControl } from './textarea-control';
 export { default as ToggleControl } from './toggle-control';
 export { default as Toolbar } from './toolbar';
 export { default as ToolbarButton } from './toolbar-button';
+export { default as ToolbarGroup } from './toolbar-group';
 export { default as Tooltip } from './tooltip';
 export { default as TreeSelect } from './tree-select';
 export { default as IsolatedEventContainer } from './isolated-event-container';

--- a/types/wordpress__components/toolbar-group/index.d.ts
+++ b/types/wordpress__components/toolbar-group/index.d.ts
@@ -1,0 +1,29 @@
+import { ComponentType, HTMLProps } from 'react';
+
+import DropdownMenu from '../dropdown-menu';
+import ToolbarButton from '../toolbar-button';
+
+interface ToolbarGroupProps
+    extends Omit<HTMLProps<HTMLDivElement>, 'controls' | 'label'>,
+        Partial<Pick<DropdownMenu.Props, 'icon' | 'label'>> {
+    /**
+     * ARIA label for dropdown menu if is collapsed.
+     */
+    title?: string | undefined;
+    /**
+     * Class to set on the container div.
+     */
+    className?: string | undefined;
+    /**
+     * Turns ToolbarGroup into a dropdown menu.
+     */
+    isCollapsed?: boolean | undefined;
+    /**
+     * The controls to render in this toolbar.
+     */
+    controls?: readonly Control[] | ReadonlyArray<readonly Control[]> | undefined;
+}
+type Control = ToolbarButton.Props;
+declare const ToolbarGroup: ComponentType<ToolbarGroupProps>;
+
+export default ToolbarGroup;

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -891,6 +891,23 @@ const kbshortcuts = {
 <C.ToolbarButton>Text</C.ToolbarButton>;
 
 //
+// toolbar-group
+//
+<C.ToolbarGroup
+    isCollapsed
+    icon={ undefined }
+    label="More rich text controls"
+    controls={ [
+        { icon: <div>icon</div>, title: 'Inline code' },
+        { icon: <div>icon</div>, title: 'Inline image' },
+        {
+            icon: <div>icon</div>,
+            title: 'Strikethrough',
+        },
+    ] }
+/>;
+
+//
 // tooltip
 //
 <C.Tooltip>


### PR DESCRIPTION
This PR adds types for `ToolbarGroup` to the `@wordpress/components` package.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/e9f242a2c85d33721e8be5271d822b759b6270b5/packages/components/src/toolbar-group/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (the current definition claims to be for version 14 which was released in 2021, and this component [was added in 2019](https://github.com/WordPress/gutenberg/pull/18534)).