### PR TITLE
node-mailjet: Add delete method

### DIFF
--- a/types/node-mailjet/index.d.ts
+++ b/types/node-mailjet/index.d.ts
@@ -32,6 +32,8 @@ export namespace Email {
         put(action: string, options?: ConfigOptions): PutResource;
 
         post(action: string, options?: ConfigOptions): PostResource;
+
+        delete(action: string, option?: ConfigOptions): DeleteResource;
     }
 
     // resources
@@ -59,6 +61,12 @@ export namespace Email {
         request(params: object, callback?: (error: Error, res: PutResponse) => void): Promise<PutResponse>;
     }
 
+    interface DeleteResource {
+        id(value: string): DeleteResource;
+
+        request(params?: object, callback?: (error: Error, res: DeleteResponse) => void): Promise<DeleteResponse>;
+    }
+
     // responses
     interface Response {
         readonly body: object;
@@ -74,6 +82,10 @@ export namespace Email {
 
     interface PutResponse {
         readonly body: PutResponseData;
+    }
+
+    interface DeleteResponse {
+        readonly body: {};
     }
 
     // request params

--- a/types/node-mailjet/node-mailjet-tests.ts
+++ b/types/node-mailjet/node-mailjet-tests.ts
@@ -162,7 +162,7 @@ const mailJetDeleteResponse: Promise<void> = mailJetRequestDelete
         const responseBody: Email.DeleteResponse['body'] = res;
     })
     .catch((err: Error) => {
-        //ignore
+        // ignore
     });
 
 // *** SMS API *** //

--- a/types/node-mailjet/node-mailjet-tests.ts
+++ b/types/node-mailjet/node-mailjet-tests.ts
@@ -152,6 +152,19 @@ mailJetPutResponse
         // ignore
     });
 
+// delete parse route
+const mailJetRequestDelete: Email.DeleteResource = connection.delete('parseroute', { version: 'v3' }).id('fake-id');
+const mailJetDeleteResponse: Promise<void> = mailJetRequestDelete
+    .request({
+        SandboxMode: true,
+    })
+    .then((res) => {
+        const responseBody: Email.DeleteResponse['body'] = res;
+    })
+    .catch((err: Error) => {
+        //ignore
+    });
+
 // *** SMS API *** //
 
 // send SMS


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

The Mailjet API supports the delete method (for example, in the [Parse API](https://dev.mailjet.com/email/reference/parse#v3_delete_parseroute_parseroute_ID)). However, it was missing from the types.

