### PR TITLE
fix: add type `isDestroyed` for `prosemirror-view`

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-view 1.19
+// Type definitions for prosemirror-view 1.23
 // Project: https://github.com/ProseMirror/prosemirror-view
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>
@@ -6,6 +6,7 @@
 //                 Patrick Simmelbauer <https://github.com/patsimm>
 //                 Ifiok Jr. <https://github.com/ifiokjr>
 //                 Mike Morearty <https://github.com/mmorearty>
+//                 Ocavue <https://github.com/ocavue>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -367,6 +368,12 @@ export class EditorView<S extends Schema = any> {
      * views](#view.NodeView).
      */
     destroy(): void;
+    /**
+     * This is true when the view has been
+     * [destroyed](#view.EditorView.destroy) (and thus should not be
+     * used anymore).
+     */
+    isDestroyed: boolean;
     /**
      * Dispatch a transaction. Will call
      * [`dispatchTransaction`](#view.DirectEditorProps.dispatchTransaction)


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Docs: https://prosemirror.net/docs/ref/#view.EditorView.isDestroyed
  - Source Code: https://github.com/ProseMirror/prosemirror-view/blob/128620ca6e68153f3e51ca13ceab358495767a0b/src/index.js#L380
  - Changlog: https://github.com/ProseMirror/prosemirror-view/blob/master/CHANGELOG.md#1230-2021-11-11
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
 