### PR TITLE
[spotify-web-api-node] fix wrong return type in getMySavedShows method

### DIFF
--- a/types/spotify-web-api-node/index.d.ts
+++ b/types/spotify-web-api-node/index.d.ts
@@ -932,7 +932,7 @@ declare class SpotifyWebApi {
      *          playlist show objects. Not returned if a callback is given.
      */
     getMySavedShows(options: PaginationMarketOptions, callback: Callback<SpotifyApi.UsersSavedShowsResponse>): void;
-    getMySavedShows(options?: PaginationMarketOptions): Promise<Response<SpotifyApi.SavedShowObject>>;
+    getMySavedShows(options?: PaginationMarketOptions): Promise<Response<SpotifyApi.UsersSavedShowsResponse>>;
 
     /**
      * Get the episodes of an show.

--- a/types/spotify-web-api-node/spotify-web-api-node-tests.ts
+++ b/types/spotify-web-api-node/spotify-web-api-node-tests.ts
@@ -674,6 +674,16 @@ spotifyApi.getMyTopTracks()
 
 /* Shows */
 
+// Get shows in the signed in user's Your Music library
+spotifyApi.getMySavedShows()
+  .then((data) => {
+    const shows = data.body.items;
+    console.log(shows);
+  }, (err) => {
+    console.log('Something went wrong!', err);
+  });
+
+// Get the episodes of a show.
 spotifyApi.getShowEpisodes('53TsTEHBmnGHUNTf5PIuSg')
   .then((data) => {
     const episodes = data.body.items;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
