### PR TITLE
Mark google-profanity-words as a non-npm package

### DIFF
--- a/types/google-profanity-words/index.d.ts
+++ b/types/google-profanity-words/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for google-profanity-words 1.0
+// Type definitions for non-npm package google-profanity-words 1.0
 // Project: https://github.com/RobertJGabriel/Google-profanity-words
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
The original was unpublished recently. Might be better to delete the types too since it's not much used.