### PR TITLE
Update @types/eslint-scope to solve issue with matching version 3.7.2

### DIFF
--- a/types/eslint-scope/eslint-scope-tests.ts
+++ b/types/eslint-scope/eslint-scope-tests.ts
@@ -1,13 +1,13 @@
 import * as eslint from "eslint";
 import * as estree from "estree";
-import * as escope from "eslint-scope";
+import * as eslintScope from "eslint-scope";
 
 declare const program: estree.Program;
-declare const scope: escope.Scope;
-declare const variable: escope.Variable;
-declare const reference: escope.Reference;
+declare const scope: eslintScope.Scope;
+declare const variable: eslintScope.Variable;
+declare const reference: eslintScope.Reference;
 
-const manager1: escope.ScopeManager = escope.analyze(
+const manager1: eslintScope.ScopeManager = eslintScope.analyze(
     program,
     {
         directive: false,
@@ -22,7 +22,7 @@ const manager1: escope.ScopeManager = escope.analyze(
         sourceType: "module"
     }
 );
-const manager2: escope.ScopeManager = escope.analyze(
+const manager2: eslintScope.ScopeManager = eslintScope.analyze(
     program,
     {
         ecmaVersion: 5,
@@ -33,9 +33,9 @@ const manager2: escope.ScopeManager = escope.analyze(
         sourceType: "script"
     }
 );
-const manager3: escope.ScopeManager = escope.analyze(program);
+const manager3: eslintScope.ScopeManager = eslintScope.analyze(program);
 
-const managerInterface: eslint.Scope.ScopeManager = manager1;
-const scopeInterface: eslint.Scope.Scope = scope;
-const variableInterface: eslint.Scope.Variable = variable;
-const referenceInterface: eslint.Scope.Reference = reference;
+const managerInterface = manager1; // $ExpectType ScopeManager
+const scopeInterface = scope; // $ExpectType Scope
+const variableInterface = variable; // $ExpectType Variable
+const referenceInterface = reference; // $ExpectType Reference

--- a/types/eslint-scope/index.d.ts
+++ b/types/eslint-scope/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/eslint/eslint-scope
 // Definitions by: Toru Nagashima <https://github.com/mysticatea>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 3.8
 import * as eslint from "eslint";
 import * as estree from "estree";
 
@@ -51,14 +51,14 @@ export class Reference implements eslint.Scope.Reference {
 }
 
 export interface AnalysisOptions {
-    optimistic?: boolean | undefined;
-    directive?: boolean | undefined;
-    ignoreEval?: boolean | undefined;
-    nodejsScope?: boolean | undefined;
-    impliedStrict?: boolean | undefined;
-    fallback?: string | ((node: {}) => string[]) | undefined;
-    sourceType?: "script" | "module" | undefined;
-    ecmaVersion?: number | undefined;
+    optimistic?: boolean;
+    directive?: boolean;
+    ignoreEval?: boolean;
+    nodejsScope?: boolean;
+    impliedStrict?: boolean;
+    fallback?: string | ((node: {}) => string[]);
+    sourceType?: "script" | "module";
+    ecmaVersion?: number;
 }
 
 export function analyze(ast: {}, options?: AnalysisOptions): ScopeManager;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code that provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Version 3.7.2 is a no-go due to a security issue introduced.
Some repositories have a filter to block this version (which includes the types) from being installed/replicated.

These changes remove the unnecessary `undefined` in the types as a way to bump the version and solve the issue.

References:
- https://github.com/webpack/webpack/issues/15059
- https://eslint.org/blog/2018/07/postmortem-for-malicious-package-publishes