### PR TITLE
react-pdf needs to target es2015

### DIFF
--- a/types/react-pdf/tsconfig.json
+++ b/types/react-pdf/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "target": "es2015",
         "lib": [
             "es6",
             "dom"


### PR DESCRIPTION
A dependency, pdfjs-dist, uses #private which requires ES2015.