### PR TITLE
Update webpack-shell-plugin's webpack-dev-server dependency

### DIFF
--- a/types/webpack-shell-plugin/package.json
+++ b/types/webpack-shell-plugin/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@types/webpack-dev-server": "3"
+    }
+}

--- a/types/webpack-shell-plugin/webpack-shell-plugin-tests.ts
+++ b/types/webpack-shell-plugin/webpack-shell-plugin-tests.ts
@@ -1,4 +1,4 @@
-/// <reference types="webpack-dev-server/v3" />
+/// <reference types="webpack-dev-server" />
 import WebpackShellPlugin = require('webpack-shell-plugin');
 import path = require('path');
 import { Configuration, Plugin } from 'webpack';


### PR DESCRIPTION
It's now an external dependency. Missed in #57808