### PR TITLE
Fix return type of yog's BigPipe.destroy

### DIFF
--- a/types/yog-bigpipe/index.d.ts
+++ b/types/yog-bigpipe/index.d.ts
@@ -63,7 +63,7 @@ declare namespace yogBigpipe {
 
         renderPagelet(pagelet: Pagelet): void;
 
-        destroy(): void;
+        destroy(): this;
 
         _onPageletDone(pagelet: Pagelet): void;
 


### PR DESCRIPTION
It overrides Readable.destroy, so it needs to have the same return type: `this`.