### PR TITLE
fix(prosemirror-view): add option `destroy` to `WidgetDecorationSpec`

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -77,6 +77,10 @@ export interface WidgetDecorationSpec {
      * different keys.
      */
     key?: string | null | undefined;
+    /**
+     * Called when the widget decoration is removed as a result of mapping
+     */
+    destroy?: (node: Node) => void;
 }
 /**
  * The `spec` for the inline decoration.

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -15,6 +15,7 @@ const widgetDecoration = Decoration.widget<{ a: number }>(0, x => x.dom, { a: 1 
 widgetDecoration.spec.a; // $ExpectType number
 widgetDecoration.spec.stopEvent; // $ExpectType ((event: Event) => boolean) | null | undefined
 widgetDecoration.spec.ignoreSelection; // $ExpectType boolean | undefined
+widgetDecoration.spec.destroy; // $ExpectType ((event: Node) => void) | undefined
 
 Decoration.node<{ a: number }>(0, 10, {}, { a: '' }); // $ExpectError
 const nodeDecoration = Decoration.node<{ a: number }>(0, 10, {}, { a: 1 });

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -15,7 +15,7 @@ const widgetDecoration = Decoration.widget<{ a: number }>(0, x => x.dom, { a: 1 
 widgetDecoration.spec.a; // $ExpectType number
 widgetDecoration.spec.stopEvent; // $ExpectType ((event: Event) => boolean) | null | undefined
 widgetDecoration.spec.ignoreSelection; // $ExpectType boolean | undefined
-widgetDecoration.spec.destroy; // $ExpectType ((event: Node) => void) | undefined
+widgetDecoration.spec.destroy; // $ExpectType ((node: Node) => void) | undefined
 
 Decoration.node<{ a: number }>(0, 10, {}, { a: '' }); // $ExpectError
 const nodeDecoration = Decoration.node<{ a: number }>(0, 10, {}, { a: 1 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Docs: https://prosemirror.net/docs/ref/#view.Decoration^widget^spec.destroy
  - Changelog: https://github.com/ProseMirror/prosemirror-view/blob/master/CHANGELOG.md#1220-2021-11-08
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
 