### PR TITLE
Add types for ComboboxControl to @wordpress/components

### DIFF
--- a/types/wordpress__components/combobox-control/index.d.ts
+++ b/types/wordpress__components/combobox-control/index.d.ts
@@ -1,0 +1,19 @@
+import { ComponentType, ReactNode } from 'react';
+
+declare namespace ComboboxControl {
+    interface Props {
+        value: string | number;
+        label?: ReactNode | undefined;
+        options: { label: string | number; value: string }[];
+        onChange: (value: string | null) => void;
+        onFilterValueChange?: (value: string) => void;
+        hideLabelFromVision?: boolean | undefined;
+        help?: ReactNode | undefined;
+        allowReset?: boolean;
+        className?: string;
+        messages?: { selected: string };
+    }
+}
+declare const ComboboxControl: ComponentType<ComboboxControl.Props>;
+
+export default ComboboxControl;

--- a/types/wordpress__components/combobox-control/index.d.ts
+++ b/types/wordpress__components/combobox-control/index.d.ts
@@ -2,9 +2,9 @@ import { ComponentType, ReactNode } from 'react';
 
 declare namespace ComboboxControl {
     interface Props {
-        value: string | number;
-        label?: ReactNode | undefined;
-        options: Array<{ label: string | number; value: string }>;
+        value: string;
+        label?: string;
+        options: Array<{ label: string; value: string }>;
         onChange: (value: string | null) => void;
         onFilterValueChange?: (value: string) => void;
         hideLabelFromVision?: boolean | undefined;

--- a/types/wordpress__components/combobox-control/index.d.ts
+++ b/types/wordpress__components/combobox-control/index.d.ts
@@ -4,7 +4,7 @@ declare namespace ComboboxControl {
     interface Props {
         value: string | number;
         label?: ReactNode | undefined;
-        options: { label: string | number; value: string }[];
+        options: Array<{ label: string | number; value: string }>;
         onChange: (value: string | null) => void;
         onFilterValueChange?: (value: string) => void;
         hideLabelFromVision?: boolean | undefined;

--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -29,6 +29,7 @@ export { default as ClipboardButton } from './clipboard-button';
 export { default as ColorIndicator } from './color-indicator';
 export { default as ColorPalette } from './color-palette';
 export { default as ColorPicker } from './color-picker';
+export { default as ComboboxControl } from './combobox-control';
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
 export { DateTimePicker, DatePicker, TimePicker } from './date-time';

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -202,6 +202,23 @@ const buttonGroupRef = createRef<HTMLDivElement>();
 <C.ColorPicker onChangeComplete={color => console.log(color.hex)} disableAlpha />;
 
 //
+// combobox-control
+//
+<C.ComboboxControl
+    label={'Region'}
+    value={'UK'}
+    onChange={value => {
+        console.log(value);
+    }}
+    options={[
+        {
+            label: 'test',
+            value: 'test',
+        },
+    ]}
+/>;
+
+//
 // custom-select-control
 //
 <C.CustomSelectControl


### PR DESCRIPTION
This adds types for `ComboboxControl` to the `@wordpress/components` package.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/0135921bcb72ceec629fa8f9e755891afab747b9/packages/components/src/combobox-control/index.js#L44
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header (this definition claims to be for version 14 which was released in 2021, but this component [was added](https://github.com/WordPress/gutenberg/pull/25442) in 2020).
