### PR TITLE
[gulp-muxml] Add type definition for gulp-muxml

### DIFF
--- a/types/gulp-muxml/gulp-muxml-tests.ts
+++ b/types/gulp-muxml/gulp-muxml-tests.ts
@@ -1,0 +1,9 @@
+import gulp = require('gulp');
+import muxml = require('gulp-muxml');
+
+gulp.task('default', () => {
+    return gulp
+        .src('src/*')
+        .pipe(muxml({ strict: true }))
+        .pipe(gulp.dest('dist'));
+});

--- a/types/gulp-muxml/index.d.ts
+++ b/types/gulp-muxml/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for gulp-muxml 2.0
+// Project: https://github.com/t1st3/gulp-muxml
+// Definitions by: Martin Badin <https://github.com/martin-badin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Transform } from 'stream';
+import * as muxml from 'muxml';
+
+declare function gulpMuxml(opts: muxml.Options): Transform;
+
+export = gulpMuxml;

--- a/types/gulp-muxml/tsconfig.json
+++ b/types/gulp-muxml/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "gulp-muxml-tests.ts"
+    ]
+}

--- a/types/gulp-muxml/tslint.json
+++ b/types/gulp-muxml/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/muxml/index.d.ts
+++ b/types/muxml/index.d.ts
@@ -1,0 +1,102 @@
+// Type definitions for muxml 2.0
+// Project: https://github.com/t1st3/muxml
+// Definitions by: Martin Badin <https://github.com/martin-badin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Transform } from 'stream';
+import * as sax from 'sax';
+
+declare namespace muxml {
+    interface Options {
+        /**
+         * @default true
+         */
+        strict?: boolean | undefined;
+
+        /**
+         * Prettify the output. If true, output has newlines and indentation.
+         *
+         * @default true
+         */
+        pretty?: boolean | undefined;
+
+        /**
+         * When pretty is set to true, indent with either spaces or tabs.
+         *
+         * @default 'spaces'
+         */
+        indentStyle?: 'spaces' | 'tabs' | undefined;
+
+        /**
+         * When pretty is set to true and indentStyle is set to spaces, then indent with this number of spaces.
+         *
+         * @default 2
+         */
+        indentSpaces?: number | undefined;
+
+        /**
+         * When pretty is set to true and indentStyle is set to tabs, then indent with this number of tabs.
+         *
+         * @default 1
+         */
+        indentTabs?: number | undefined;
+
+        /**
+         * Filter XML with tags with name matching the filter.
+         *
+         * @default null
+         */
+        filter?: string | null | undefined;
+
+        /**
+         * Strip attributes from tags.
+         *
+         * @default false
+         */
+        stripAttributes?: boolean | undefined;
+
+        /**
+         * Strip CDATA tags.
+         *
+         * @default true
+         */
+        stripCdata?: boolean | undefined;
+
+        /**
+         * Strip XML comments.
+         *
+         * @default true
+         */
+        stripComments?: boolean | undefined;
+
+        /**
+         * Strip <!DOCTYPE declarations.
+         *
+         * @default true
+         */
+        stripDoctype?: boolean | undefined;
+
+        /**
+         * Strip processing instruction (like <?xml foo="blerg" ?>) tags.
+         *
+         * @default true
+         */
+        stripInstruction?: boolean | undefined;
+
+        /**
+         * @default {}
+         */
+        saxOptions?: sax.SAXOptions | undefined;
+
+        /**
+         * @default null
+         */
+        tagFilter?: string | null;
+    }
+}
+
+declare function muxml(options?: muxml.Options): Transform;
+
+export = muxml;

--- a/types/muxml/muxml-tests.ts
+++ b/types/muxml/muxml-tests.ts
@@ -1,0 +1,54 @@
+import muxml = require('muxml');
+import concatStream = require('concat-stream');
+import assert = require('assert');
+
+const mux = muxml({
+    indentSpaces: 4,
+    indentStyle: 'tabs',
+    indentTabs: 2,
+    pretty: false,
+    stripAttributes: true,
+    stripCdata: false,
+    stripComments: false,
+    stripDoctype: false,
+    stripInstruction: false,
+    tagFilter: 'b',
+});
+
+const expected = '<a id="aa"><b><c>d</c></b></a>';
+const xml = [
+    '<a id="aa">',
+    '<b>',
+    '<c>',
+    '<a>',
+    '<b>',
+    '<c>d</c>',
+    '</b>',
+    '</a>',
+    '</c>',
+    '</b>',
+    '<b>',
+    '<e>f</e>',
+    '</b>',
+    '<g>',
+    '<b attr="foo">h</b>',
+    '</g>',
+    '</a>',
+].join('\n');
+
+mux.on('data', () => {})
+    .on('opentag', tag => {})
+    .on('closetag', tag => {})
+    .on('comment', comment => {})
+    .on('doctype', doctype => {})
+    .on('instruction', instruction => {})
+    .on('opencdata', () => {})
+    .on('closecdata', () => {})
+    .on('cdata', text => {})
+    .on('attribute', attr => {})
+    .pipe(
+        concatStream({ encoding: 'string' }, data => {
+            assert.strictEqual(data, expected);
+        }),
+    )
+    .end(xml);

--- a/types/muxml/tsconfig.json
+++ b/types/muxml/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "muxml-tests.ts"
+    ]
+}

--- a/types/muxml/tslint.json
+++ b/types/muxml/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Documentation: https://github.com/t1st3/gulp-muxml
Discussion: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58111

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test gulp-muxml`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.