### PR TITLE
@types/express-jwt: change type of user in interface Request to any | undefined

### DIFF
--- a/types/express-jwt/express-jwt-tests.ts
+++ b/types/express-jwt/express-jwt-tests.ts
@@ -80,4 +80,5 @@ app.use((err: any, req: express.Request, res: express.Response, next: express.Ne
 
 app.use((req, res) => {
     const user = req.user;
+    const username = req.user?.username;
 });

--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -67,7 +67,7 @@ declare global {
         interface User {}
 
         interface Request {
-            user?: User | undefined;
+            user?: any | undefined;
         }
     }
 }

--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -4,6 +4,7 @@
 //                 Sl1MBoy <https://github.com/Sl1MBoy>
 //                 Milan Mimra <https://github.com/milan-mimra>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Karl Beecken <https://github.com/karlbeecken>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import express = require('express');
@@ -64,10 +65,12 @@ declare namespace jwt {
 declare global {
     namespace Express {
         // tslint:disable-next-line:no-empty-interface
-        interface User {}
+        interface User {
+            [key: string]: any;
+        }
 
         interface Request {
-            user?: any | undefined;
+            user?: User | undefined;
         }
     }
 }


### PR DESCRIPTION
In [line 70](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/express-jwt/index.d.ts#L70) the `user` property of a request is declared the type `User`, the definition for this type is empty. In real-world-scenarios the `req.user` property will contain an object with the payload data, so I added a wildcard in the `User` interface to avoid errors when accessing a subproperty like `req.user.username`. As it is not possible to know what the payload contains, this is imo the best solution.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [auth0/express-jwt](https://github.com/auth0/express-jwt/blob/master/README.md#usage)
