### PR TITLE
edit-json-file: add options argument for set

### DIFF
--- a/types/edit-json-file/edit-json-file-tests.ts
+++ b/types/edit-json-file/edit-json-file-tests.ts
@@ -3,6 +3,7 @@ import * as editJsonFile from 'edit-json-file';
 const jsonEditor: editJsonFile.JsonEditor = editJsonFile('1.json'); // $ExpectType JsonEditor
 jsonEditor.set('a', 2); // $ExpectType JsonEditor
 jsonEditor.set('b', []); // $ExpectType JsonEditor
+jsonEditor.set('devDependencies.@types/jest', '^27.4.0', { preservePaths: false }); // $ExpectType JsonEditor
 jsonEditor.append('a', 'b'); // $ExpectType JsonEditor
 jsonEditor.pop('a'); // $ExpectType JsonEditor
 jsonEditor.unset('b'); // $ExpectType JsonEditor

--- a/types/edit-json-file/index.d.ts
+++ b/types/edit-json-file/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for edit-json-file 1.6
+// Type definitions for edit-json-file 1.7
 // Project: https://github.com/IonicaBizau/edit-json-file#readme
 // Definitions by: Twixes <https://github.com/Twixes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,6 +6,9 @@
 /// <reference types= "node" />
 
 import { NoParamCallback } from 'fs';
+import * as set from 'set-value';
+
+type SetValueOptions = Parameters<typeof set>[3]; // Type of the 3rd parameter of `set()` which is the options hash.
 
 declare namespace editJsonFile {
     /** JSON file editor options. */
@@ -22,7 +25,7 @@ declare namespace editJsonFile {
         /** Get value at path. */
         get(path?: string): any;
         /** Set value at path. */
-        set(path: string, value: any): JsonEditor;
+        set(path: string, value: any, options?: SetValueOptions): JsonEditor;
         /** Appends a value/object to a specific path. */
         append(path: string, value: any): JsonEditor;
         /** Pop an array from a specific path. */

--- a/types/edit-json-file/index.d.ts
+++ b/types/edit-json-file/index.d.ts
@@ -8,8 +8,6 @@
 import { NoParamCallback } from 'fs';
 import * as set from 'set-value';
 
-type SetValueOptions = Parameters<typeof set>[3]; // Type of the 3rd parameter of `set()` which is the options hash.
-
 declare namespace editJsonFile {
     /** JSON file editor options. */
     interface Options {
@@ -25,7 +23,7 @@ declare namespace editJsonFile {
         /** Get value at path. */
         get(path?: string): any;
         /** Set value at path. */
-        set(path: string, value: any, options?: SetValueOptions): JsonEditor;
+        set(path: string, value: any, options?: set.Options): JsonEditor;
         /** Appends a value/object to a specific path. */
         append(path: string, value: any): JsonEditor;
         /** Pop an array from a specific path. */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `set` function supports a new options argument. I imported the types for this object from `set-value` since the options are just passed through to that package.

* https://github.com/IonicaBizau/edit-json-file/pull/51
* https://github.com/IonicaBizau/edit-json-file/releases/tag/1.7.0
* https://github.com/IonicaBizau/edit-json-file#setpath-value-options
* https://github.com/jonschlinkert/set-value#options

CC: @flucivja @lukasMega @IonicaBizau @tamslinn
