### PR TITLE
meteor: Add runtime config methods in Webapp

### DIFF
--- a/types/meteor/globals/webapp.d.ts
+++ b/types/meteor/globals/webapp.d.ts
@@ -27,6 +27,16 @@ declare module WebApp {
     var connectApp: connect.Server;
     function suppressConnectErrors(): void;
     function onListening(callback: Function): void;
+
+    type RuntimeConfigHookCallback = (options: {
+        arch: 'web.browser' | 'web.browser.legacy' | 'web.cordova';
+        request: http.IncomingMessage;
+        encodedCurrentConfig: string;
+        updated: boolean;
+    }) => string | undefined | null | false;
+    function addRuntimeConfigHook(callback: RuntimeConfigHookCallback): void;
+    function decodeRuntimeConfig(rtimeConfigString: string): unknown;
+    function encodeRuntimeConfig(rtimeConfig: unknown): string;
 }
 declare module WebAppInternals {
     var NpmModules: {

--- a/types/meteor/test/meteor-tests-module-only.ts
+++ b/types/meteor/test/meteor-tests-module-only.ts
@@ -35,3 +35,30 @@ MeteorPromise.await(bar());
 
 // $ExpectType number[]
 MeteorPromise.awaitAll([bar()]);
+
+/**
+ * From Webapp
+ */
+// Listen to incoming HTTP requests (can only be used on the server).
+WebApp.connectHandlers.use('/hello', (req, res, next) => {
+    res.writeHead(200);
+    res.end(`Hello world from: ${Meteor.release}`);
+});
+
+WebApp.addRuntimeConfigHook(({arch, request, encodedCurrentConfig, updated}) => {
+    // check the request to see if this is a request that requires
+    // modifying the runtime configuration
+    if (request.headers.domain === 'calling.domain') {
+        // make changes to the config for this domain
+        // decode the current runtime config string into an object
+        const config = WebApp.decodeRuntimeConfig(encodedCurrentConfig) as { newVar?: string, oldVar?: string };
+        // make your changes
+        config.newVar = 'some value';
+        config.oldVar = 'new value';
+        // encode the modified object to the runtime config string
+        // and return it
+        return WebApp.encodeRuntimeConfig(config);
+    }
+    // Not modifying other domains so return undefined
+    return undefined;
+});

--- a/types/meteor/webapp.d.ts
+++ b/types/meteor/webapp.d.ts
@@ -28,6 +28,16 @@ declare module 'meteor/webapp' {
         var connectApp: connect.Server;
         function suppressConnectErrors(): void;
         function onListening(callback: Function): void;
+
+        type RuntimeConfigHookCallback = (options: {
+            arch: 'web.browser' | 'web.browser.legacy' | 'web.cordova';
+            request: http.IncomingMessage;
+            encodedCurrentConfig: string;
+            updated: boolean;
+        }) => string | undefined | null | false;
+        function addRuntimeConfigHook(callback: RuntimeConfigHookCallback): void;
+        function decodeRuntimeConfig(rtimeConfigString: string): unknown;
+        function encodeRuntimeConfig(rtimeConfig: unknown): string;
     }
     module WebAppInternals {
         var NpmModules: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://docs.meteor.com/packages/webapp.html#Dynamic-Runtime-Configuration)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
