### PR TITLE
Pin storybook-addon-jsx dependencies

### DIFF
--- a/types/storybook-addon-jsx/package.json
+++ b/types/storybook-addon-jsx/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@storybook/addons": "^5.2.4",
-        "@storybook/react": "^5.2.4"
+        "@storybook/addons": "5.2.4",
+        "@storybook/react": "5.2.4"
     }
 }


### PR DESCRIPTION
@storybook/addons has nearly unusable types for adding to StoryApi -- its index signature is a union of a string and a call signature -- but for some reason storybook-addon-jsx's intersection type works with 5.2.4 and 5.3.21 but fails with the new 5.3.22.

I don't know why, so for now I pinned the dependencies to 5.2.4 explicitly; I think the types in 6.* are significantly different so upgrading to that will probably work around this problem.
