### PR TITLE
fix(styled-components): avoid quadratic union distribution

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -55,17 +55,14 @@ type Defaultize<P, D> = P extends any
 
 type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
 
-type MakeAttrsOptional<C extends string | React.ComponentType<any>, O extends object, A extends keyof any> = OmitU<
-    ReactDefaultizedProps<
-        C,
-        React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never>
-    > &
-        O,
-    A
-> &
-    Partial<
-        PickU<React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never> & O, A>
-    >;
+type MakeAttrsOptional<
+    C extends string | React.ComponentType<any>,
+    O extends object,
+    A extends keyof P,
+    P = React.ComponentPropsWithRef<C extends IntrinsicElementsKeys | React.ComponentType<any> ? C : never>,
+> =
+    // Distribute unions early to avoid quadratic expansion
+    P extends any ? OmitU<ReactDefaultizedProps<C, P> & O, A> & Partial<PickU<P & O, A>> : never;
 
 export type StyledComponentProps<
     // The Component from whose props are derived


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57684
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

----

After the introduction of union distribution in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57684, it started to consume a lot of memory and cause tsc to hang in a project I'm working on. It was caused by the following pattern:

```typescript
OmitU<ReactDefaultizedProps<C, P> & O, A> & Partial<PickU<P & O>, A>
```

When `P` is a union, it expands to a quadratically large union and that seems to be the cause of the memory consumption.

This PR changes `MakeAttrsOptional` so that the unions are distributed beforehand to reduce computation.