### PR TITLE
[dompurify] Added missing ALLOW_ARIA_ATTR config

### DIFF
--- a/types/dompurify/index.d.ts
+++ b/types/dompurify/index.d.ts
@@ -49,6 +49,7 @@ declare namespace DOMPurify {
         ADD_DATA_URI_TAGS?: string[] | undefined;
         ADD_TAGS?: string[] | undefined;
         ADD_URI_SAFE_ATTR?: string[] | undefined;
+        ALLOW_ARIA_ATTR?: boolean | undefined;
         ALLOW_DATA_ATTR?: boolean | undefined;
         ALLOW_UNKNOWN_PROTOCOLS?: boolean | undefined;
         ALLOWED_ATTR?: string[] | undefined;

--- a/types/dompurify/test/dompurify-tests.ts
+++ b/types/dompurify/test/dompurify-tests.ts
@@ -17,6 +17,7 @@ DOMPurify.sanitize(dirty, { ADD_ATTR: ['my-attr'] }); // $ExpectType string
 DOMPurify.sanitize(dirty, { ADD_DATA_URI_TAGS: ['a', 'area'] }); // $ExpectType string
 DOMPurify.sanitize(dirty, { ADD_TAGS: ['my-tag'] }); // $ExpectType string
 DOMPurify.sanitize(dirty, { ADD_URI_SAFE_ATTR: ['my-attr'] }); // $ExpectType string
+DOMPurify.sanitize(dirty, { ALLOW_ARIA_ATTR: false }); // $ExpectType string
 DOMPurify.sanitize(dirty, { ALLOW_DATA_ATTR: false }); // $ExpectType string
 DOMPurify.sanitize(dirty, { ALLOWED_TAGS: ['b', 'q'], ALLOWED_ATTR: ['style'] }); // $ExpectType string
 DOMPurify.sanitize(dirty, { ALLOWED_TAGS: ['b'] }); // $ExpectType string


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test dompurify`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cure53/DOMPurify/blob/45ee75572a9e1c04b031133796eda49a516c81bb/src/purify.js#L410
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

<hr>

This just adds the missing DOMPurify `ALLOW_ARIA_ATTR` property which is allowed per https://github.com/cure53/DOMPurify/blob/45ee75572a9e1c04b031133796eda49a516c81bb/src/purify.js#L410 and has been there for many years looking at the git blame.

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58135
