### PR TITLE
[http-errors] Make the status code a generic

### DIFF
--- a/types/http-errors/http-errors-tests.ts
+++ b/types/http-errors/http-errors-tests.ts
@@ -15,79 +15,92 @@ app.use((req, res, next) => {
 /* Examples taken from https://github.com/jshttp/http-errors/blob/1.6.2/test/test.js */
 
 // create(status)
-let err = create(404);
-err; // $ExpectType HttpError
+const err = create(404);
+err; // $ExpectType HttpError<404>
 err.name; // $ExpectType string
 err.message; // $ExpectType string
-err.status; // $ExpectType number
-err.statusCode; // $ExpectType number
+err.status; // $ExpectType 404
+err.statusCode; // $ExpectType 404
 err.expose; // $ExpectType boolean
 err.headers; // $ExpectType { [key: string]: string; } | undefined
 
 // create(status, msg)
-err = create(404, 'LOL');
+// $ExpectType HttpError<404>
+create(404, 'LOL');
 
 // create(status, props)
-err = create(404, {id: 1});
+// $ExpectType HttpError<404>
+create(404, {id: 1});
 
 // create(status, props) with status prop
-err = create(404, {
+// $ExpectType HttpError<404>
+create(404, {
     id: 1,
     status: 500
 });
 
 // create(status, props) with statusCode prop
-err = create(404, {
+// $ExpectType HttpError<404>
+create(404, {
     id: 1,
     statusCode: 500
 });
 
 // create(props)
-err = create({id: 1});
+// $ExpectType HttpError<number>
+create({id: 1});
 // $ExpectType any
 err.id;
 
 // create(msg, status)
-err = create('LOL', 404);
+// $ExpectType HttpError<number>
+create('LOL', 404);
 
 // create(msg)
-err = create('LOL');
+// $ExpectType HttpError<number>
+create('LOL');
 
 // create(msg, props)
-err = create('LOL', {id: 1});
+// $ExpectType HttpError<number>
+create('LOL', {id: 1});
 
 // create(err)
-err = create(new Error('LOL'));
+// $ExpectType HttpError<number>
+create(new Error('LOL'));
 
 // create(err, props)
-err = create(new Error('LOL'), {id: 1});
+// $ExpectType HttpError<number>
+create(new Error('LOL'), {id: 1});
 
 // create(status, err, props)
-err = create(404, new Error('LOL'), {id: 1});
+// $ExpectType HttpError<404>
+create(404, new Error('LOL'), {id: 1});
 
 // create(status, msg, props)
-err = create(404, 'LOL', {id: 1});
+// $ExpectType HttpError<404>
+create(404, 'LOL', {id: 1});
 
 // create(status, msg, { expose: false })
-err = create(404, 'LOL', {expose: false});
+// $ExpectType HttpError<404>
+create(404, 'LOL', {expose: false});
 
-err = new create.NotFound();
-err = new create.InternalServerError();
-err = new create[404]();
-err = new create['404']();
+new create.NotFound(); // $ExpectType HttpError<404>
+new create.InternalServerError(); // $ExpectType HttpError<500>
+new create[404](); // $ExpectType HttpError<404>
+new create['404'](); // $ExpectType HttpError<404>
 
 create['404'](); // $ExpectError
 new create(); // $ExpectError
 
 // Error messages can have custom messages
-err = new create.NotFound('This might be a problem');
-err = new create[404]('This might be a problem');
+new create.NotFound('This might be a problem'); // $ExpectType HttpError<404>
+new create[404]('This might be a problem'); // $ExpectType HttpError<404>
 
 // 1.5.0 supports 421 - Misdirected Request
-err = new create.MisdirectedRequest();
-err = new create.MisdirectedRequest('Where should this go?');
+new create.MisdirectedRequest(); // $ExpectType HttpError<421>
+new create.MisdirectedRequest('Where should this go?'); // $ExpectType HttpError<421>
 
-// $ExpectType HttpError
+// $ExpectType HttpError<number>
 new create.HttpError();
 
 // $ExpectType boolean

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -12,9 +12,9 @@ declare const createHttpError: createHttpError.CreateHttpError & createHttpError
 };
 
 declare namespace createHttpError {
-    interface HttpError extends Error {
-        status: number;
-        statusCode: number;
+    interface HttpError<N extends number = number> extends Error {
+        status: N;
+        statusCode: N;
         expose: boolean;
         headers?: {
             [key: string]: string;
@@ -24,95 +24,56 @@ declare namespace createHttpError {
 
     type UnknownError = Error | string | number | { [key: string]: any };
 
-    type HttpErrorConstructor = new (msg?: string) => HttpError;
+    type HttpErrorConstructor<N extends number = number> = new (msg?: string) => HttpError<N>;
 
-    type CreateHttpError = (...args: UnknownError[]) => HttpError;
+    type CreateHttpError = <N extends UnknownError>(arg: N, ...rest: UnknownError[]) => HttpError<N extends number ? N : number>;
 
     type IsHttpError = (error: unknown) => error is HttpError;
 
     type NamedConstructors = {
         [code: string]: HttpErrorConstructor;
         HttpError: HttpErrorConstructor;
-    } & Record<'BadRequest' |
-        'Unauthorized' |
-        'PaymentRequired' |
-        'Forbidden' |
-        'NotFound' |
-        'MethodNotAllowed' |
-        'NotAcceptable' |
-        'ProxyAuthenticationRequired' |
-        'RequestTimeout' |
-        'Conflict' |
-        'Gone' |
-        'LengthRequired' |
-        'PreconditionFailed' |
-        'PayloadTooLarge' |
-        'URITooLong' |
-        'UnsupportedMediaType' |
-        'RangeNotSatisfiable' |
-        'ExpectationFailed' |
-        'ImATeapot' |
-        'MisdirectedRequest' |
-        'UnprocessableEntity' |
-        'Locked' |
-        'FailedDependency' |
-        'UnorderedCollection' |
-        'UpgradeRequired' |
-        'PreconditionRequired' |
-        'TooManyRequests' |
-        'RequestHeaderFieldsTooLarge' |
-        'UnavailableForLegalReasons' |
-        'InternalServerError' |
-        'NotImplemented' |
-        'BadGateway' |
-        'ServiceUnavailable' |
-        'GatewayTimeout' |
-        'HTTPVersionNotSupported' |
-        'VariantAlsoNegotiates' |
-        'InsufficientStorage' |
-        'LoopDetected' |
-        'BandwidthLimitExceeded' |
-        'NotExtended' |
-        'NetworkAuthenticationRequire' |
-        '400' |
-        '401' |
-        '402' |
-        '403' |
-        '404' |
-        '405' |
-        '406' |
-        '407' |
-        '408' |
-        '409' |
-        '410' |
-        '411' |
-        '412' |
-        '413' |
-        '414' |
-        '415' |
-        '416' |
-        '417' |
-        '418' |
-        '421' |
-        '422' |
-        '423' |
-        '424' |
-        '425' |
-        '426' |
-        '428' |
-        '429' |
-        '431' |
-        '451' |
-        '500' |
-        '501' |
-        '502' |
-        '503' |
-        '504' |
-        '505' |
-        '506' |
-        '507' |
-        '508' |
-        '509' |
-        '510' |
-        '511', HttpErrorConstructor>;
+    }
+    & Record<'BadRequest' | '400', HttpErrorConstructor<400>>
+    & Record<'Unauthorized' | '401', HttpErrorConstructor<401>>
+    & Record<'PaymentRequired' | '402', HttpErrorConstructor<402>>
+    & Record<'Forbidden' | '403', HttpErrorConstructor<403>>
+    & Record<'NotFound' | '404', HttpErrorConstructor<404>>
+    & Record<'MethodNotAllowed' | '405', HttpErrorConstructor<405>>
+    & Record<'NotAcceptable' | '406', HttpErrorConstructor<406>>
+    & Record<'ProxyAuthenticationRequired' | '407', HttpErrorConstructor<407>>
+    & Record<'RequestTimeout' | '408', HttpErrorConstructor<408>>
+    & Record<'Conflict' | '409', HttpErrorConstructor<409>>
+    & Record<'Gone' | '410', HttpErrorConstructor<410>>
+    & Record<'LengthRequired' | '411', HttpErrorConstructor<411>>
+    & Record<'PreconditionFailed' | '412', HttpErrorConstructor<412>>
+    & Record<'PayloadTooLarge' | '413', HttpErrorConstructor<413>>
+    & Record<'URITooLong' | '414', HttpErrorConstructor<414>>
+    & Record<'UnsupportedMediaType' | '415', HttpErrorConstructor<415>>
+    & Record<'RangeNotSatisfiable' | '416', HttpErrorConstructor<416>>
+    & Record<'ExpectationFailed' | '417', HttpErrorConstructor<417>>
+    & Record<'ImATeapot' | '418', HttpErrorConstructor<418>>
+    & Record<'MisdirectedRequest' | '421', HttpErrorConstructor<421>>
+    & Record<'UnprocessableEntity' | '422', HttpErrorConstructor<422>>
+    & Record<'Locked' | '423', HttpErrorConstructor<423>>
+    & Record<'FailedDependency' | '424', HttpErrorConstructor<424>>
+    & Record<'UnorderedCollection' | '425', HttpErrorConstructor<425>>
+    & Record<'UpgradeRequired' | '426', HttpErrorConstructor<426>>
+    & Record<'PreconditionRequired' | '428', HttpErrorConstructor<428>>
+    & Record<'TooManyRequests' | '429', HttpErrorConstructor<429>>
+    & Record<'RequestHeaderFieldsTooLarge' | '431', HttpErrorConstructor<431>>
+    & Record<'UnavailableForLegalReasons' | '451', HttpErrorConstructor<451>>
+    & Record<'InternalServerError' | '500', HttpErrorConstructor<500>>
+    & Record<'NotImplemented' | '501', HttpErrorConstructor<501>>
+    & Record<'BadGateway' | '502', HttpErrorConstructor<502>>
+    & Record<'ServiceUnavailable' | '503', HttpErrorConstructor<500>>
+    & Record<'GatewayTimeout' | '504', HttpErrorConstructor<504>>
+    & Record<'HTTPVersionNotSupported' | '505', HttpErrorConstructor<505>>
+    & Record<'VariantAlsoNegotiates' | '506', HttpErrorConstructor<506>>
+    & Record<'InsufficientStorage' | '507', HttpErrorConstructor<507>>
+    & Record<'LoopDetected' | '508', HttpErrorConstructor<508>>
+    & Record<'BandwidthLimitExceeded' | '509', HttpErrorConstructor<509>>
+    & Record<'NotExtended' | '510', HttpErrorConstructor<510>>
+    & Record<'NetworkAuthenticationRequire' | '511', HttpErrorConstructor<511>>
+    ;
 }


### PR DESCRIPTION
I've found it useful to know if an error is of a specific type, this can be achieved with a generic.

This only works if the status code is the first argument (and matches the [behaviour in v2](https://github.com/jshttp/http-errors/blob/master/HISTORY.md#200--2021-12-17)).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.