### PR TITLE
[luxon] Correct `toX` return types

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -936,13 +936,13 @@ export class DateTime {
      * Get the short human name for the zone's current offset, for example "EST" or "EDT".
      * Defaults to the system's locale if no locale has been specified
      */
-    get offsetNameShort(): string;
+    get offsetNameShort(): string | null;
 
     /**
      * Get the long human name for the zone's current offset, for example "Eastern Standard Time" or "Eastern Daylight Time".
      * Defaults to the system's locale if no locale has been specified
      */
-    get offsetNameLong(): string;
+    get offsetNameLong(): string | null;
 
     /**
      * Get whether this zone's offset ever changes, as in a DST.
@@ -1223,7 +1223,7 @@ export class DateTime {
      * @example
      * DateTime.now().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
      */
-    toISO(opts?: ToISOTimeOptions): string;
+    toISO(opts?: ToISOTimeOptions): string | null;
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime's date component
@@ -1236,7 +1236,7 @@ export class DateTime {
      * @example
      * DateTime.utc(1982, 5, 25).toISODate({ format: 'basic' }) //=> '19820525'
      */
-    toISODate(opts?: ToISODateOptions): string;
+    toISODate(opts?: ToISODateOptions): string | null;
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime's week date
@@ -1244,7 +1244,7 @@ export class DateTime {
      * @example
      * DateTime.utc(1982, 5, 25).toISOWeekDate() //=> '1982-W21-2'
      */
-    toISOWeekDate(): string;
+    toISOWeekDate(): string | null;
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime's time component
@@ -1265,7 +1265,7 @@ export class DateTime {
      * @example
      * DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime({ includePrefix: true }) //=> 'T07:34:19.361Z'
      */
-    toISOTime(ops?: ToISOTimeOptions): string;
+    toISOTime(ops?: ToISOTimeOptions): string | null;
 
     /**
      * Returns an RFC 2822-compatible string representation of this DateTime, always in UTC
@@ -1275,7 +1275,7 @@ export class DateTime {
      * @example
      * DateTime.local(2014, 7, 13).toRFC2822() //=> 'Sun, 13 Jul 2014 00:00:00 -0400'
      */
-    toRFC2822(): string;
+    toRFC2822(): string | null;
 
     /**
      * Returns a string representation of this DateTime appropriate for use in HTTP headers.
@@ -1287,7 +1287,7 @@ export class DateTime {
      * @example
      * DateTime.utc(2014, 7, 13, 19).toHTTP() //=> 'Sun, 13 Jul 2014 19:00:00 GMT'
      */
-    toHTTP(): string;
+    toHTTP(): string | null;
 
     /**
      * Returns a string representation of this DateTime appropriate for use in SQL Date
@@ -1295,7 +1295,7 @@ export class DateTime {
      * @example
      * DateTime.utc(2014, 7, 13).toSQLDate() //=> '2014-07-13'
      */
-    toSQLDate(): string;
+    toSQLDate(): string | null;
 
     /**
      * Returns a string representation of this DateTime appropriate for use in SQL Time
@@ -1313,7 +1313,7 @@ export class DateTime {
      * @example
      * DateTime.now().toSQL({ includeZone: false }) //=> '05:15:16.345 America/New_York'
      */
-    toSQLTime(opts?: ToSQLOptions): string;
+    toSQLTime(opts?: ToSQLOptions): string | null;
 
     /**
      * Returns a string representation of this DateTime appropriate for use in SQL DateTime
@@ -1331,7 +1331,7 @@ export class DateTime {
      * @example
      * DateTime.local(2014, 7, 13).toSQL({ includeZone: true }) //=> '2014-07-13 00:00:00.000 America/New_York'
      */
-    toSQL(opts?: ToSQLOptions): string;
+    toSQL(opts?: ToSQLOptions): string | null;
 
     /**
      * Returns a string representation of this DateTime appropriate for debugging
@@ -1356,7 +1356,7 @@ export class DateTime {
     /**
      * Returns an ISO 8601 representation of this DateTime appropriate for use in JSON.
      */
-    toJSON(): string;
+    toJSON(): string | null;
 
     /**
      * Returns a BSON serializable equivalent to this DateTime.

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -263,7 +263,7 @@ export class Duration {
      * @example
      * Duration.fromObject({ milliseconds: 6 }).toISO() //=> 'PT0.006S'
      */
-    toISO(): string;
+    toISO(): string | null;
 
     /**
      * Returns an ISO 8601-compliant string representation of this Duration, formatted as a time of day.
@@ -286,7 +286,7 @@ export class Duration {
      * @example
      * Duration.fromObject({ hours: 11 }).toISOTime({ format: 'basic' }) //=> '110000.000'
      */
-    toISOTime(opts?: ToISOTimeDurationOptions): string;
+    toISOTime(opts?: ToISOTimeDurationOptions): string | null;
 
     /**
      * Returns an ISO 8601 representation of this Duration appropriate for use in JSON.

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -97,16 +97,16 @@ getters.ordinal; // $ExpectType number
 getters.isInLeapYear; // $ExpectType boolean
 
 dt.toBSON(); // $ExpectType Date
-dt.toHTTP(); // $ExpectType string
-dt.toISO(); // $ExpectType string
-dt.toISO({ includeOffset: true, format: 'extended' }); // $ExpectType string
-dt.toISODate(); // $ExpectType string
-dt.toISODate({ format: 'basic' }); // $ExpectType string
-dt.toISOTime(); // $ExpectType string
-dt.toISOTime({ format: 'basic' }); // $ExpectType string
-dt.toISOWeekDate(); // $ExpectType string
+dt.toHTTP(); // $ExpectType string | null
+dt.toISO(); // $ExpectType string | null
+dt.toISO({ includeOffset: true, format: 'extended' }); // $ExpectType string | null
+dt.toISODate(); // $ExpectType string | null
+dt.toISODate({ format: 'basic' }); // $ExpectType string | null
+dt.toISOTime(); // $ExpectType string | null
+dt.toISOTime({ format: 'basic' }); // $ExpectType string | null
+dt.toISOWeekDate(); // $ExpectType string | null
 dt.toJSDate(); // $ExpectType Date
-dt.toJSON(); // $ExpectType string
+dt.toJSON(); // $ExpectType string | null
 dt.toLocaleParts(); // $ExpectType DateTimeFormatPart[]
 dt.toLocaleParts()[0].type; // $ExpectType DateTimeFormatPartTypes
 dt.toLocaleParts()[0].value; // $ExpectType string
@@ -118,13 +118,13 @@ dt.toMillis(); // $ExpectType number
 dt.toMillis(); // $ExpectType number
 dt.toRelative(); // $ExpectType string | null
 dt.toRelativeCalendar(); // $ExpectType string | null
-dt.toRFC2822(); // $ExpectType string
+dt.toRFC2822(); // $ExpectType string | null
 dt.toSeconds(); // $ExpectType number
-dt.toSQL(); // $ExpectType string
-dt.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string
-dt.toSQLDate(); // $ExpectType string
-dt.toSQLTime(); // $ExpectType string
-dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
+dt.toSQL(); // $ExpectType string | null
+dt.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string | null
+dt.toSQLDate(); // $ExpectType string | null
+dt.toSQLTime(); // $ExpectType string | null
+dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string | null
 dt.valueOf(); // $ExpectType number
 dt.toObject(); // $ExpectType ToObjectOutput
 dt.toObject({ includeConfig: true }); // $ExpectType ToObjectOutput
@@ -214,8 +214,8 @@ dur.set({ hour: 2, minutes: 15 }); // $ExpectType Duration
 
 dur.as('seconds'); // $ExpectType number
 dur.toObject();
-dur.toISO(); // $ExpectType string
-dur.toISOTime(); // $ExpectType string
+dur.toISO(); // $ExpectType string | null
+dur.toISOTime(); // $ExpectType string | null
 dur.normalize(); // $ExpectType Duration
 dur.toMillis(); // $ExpectType number
 dur.mapUnits((x, u) => (u === 'hours' ? x * 2 : x)); // $ExpectType Duration
@@ -328,7 +328,7 @@ DateTime.fromFormat('2017-05-15T09:10:23 Europe/Paris', "yyyy-MM-dd'T'HH:mm:ss z
 
 /* Calendars */
 // prettier-ignore
-DateTime.fromISO('2017-W23-3').plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $ExpectType string
+DateTime.fromISO('2017-W23-3').plus({ weeks: 1, days: 2 }).toISOWeekDate(); // $ExpectType string | null
 
 const dtHebrew = DateTime.local().reconfigure({ outputCalendar: 'hebrew' });
 dtHebrew.outputCalendar; // $ExpectType string
@@ -383,7 +383,7 @@ dur.toObject().day; // $ExpectError
 dur.as('minutes'); // $ExpectType number
 dur.shiftTo('minutes').toObject().minutes; // $ExpectType number | undefined
 // prettier-ignore
-DateTime.fromISO('2017-05-15').plus(dur).toISO(); // $ExpectType string
+DateTime.fromISO('2017-05-15').plus(dur).toISO(); // $ExpectType string | null
 
 const end = DateTime.fromISO('2017-03-13');
 const start = DateTime.fromISO('2017-02-13');

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -166,8 +166,8 @@ dt.endOf('hour');
 dt.zone;
 dt.zoneName; // $ExpectType string
 dt.offset; // $ExpectType number
-dt.offsetNameShort; // $ExpectType string
-dt.offsetNameLong; // $ExpectType string
+dt.offsetNameShort; // $ExpectType string | null
+dt.offsetNameLong; // $ExpectType string | null
 dt.isOffsetFixed; // $ExpectType boolean
 dt.isInDST; // $ExpectType boolean
 


### PR DESCRIPTION
Many `toX` functions return `null` if the date is invalid. These were not included in the types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`DateTime` definition](https://github.com/moment/luxon/blob/master/src/datetime.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
