### PR TITLE
Fix Meteor server-render method signatures

### DIFF
--- a/types/meteor/server-render.d.ts
+++ b/types/meteor/server-render.d.ts
@@ -1,22 +1,30 @@
 import * as http from 'http';
 declare module 'meteor/server-render' {
+    // NodeJS.ReadableStream only works on server.
+    // HTMLElement only works on client.
+    type Content = string | Content[] | NodeJS.ReadableStream | HTMLElement;
+
     interface Sink {
-        request?: http.IncomingMessage | undefined;
-        arch?: string | undefined;
-        head?: string | undefined;
-        body?: string | undefined;
-        htmlById?: { [key: string]: string } | undefined;
-        maybeMadeChanges?: boolean | undefined;
-        appendToHead?(html: string): void;
-        appendToBody?(html: string): void;
-        appendToElementById?(id: string, html: string): void;
-        renderIntoElementById?(id: string, html: string): void;
-        renderIntoElementById?(id: string, html: NodeJS.ReadableStream): void;
-        redirect?(location: string, code?: number): void;
-        setStatusCode?(code: number): void;
-        setHeader?(key: string, value: number | string | string[]): void;
-        getHeaders?(): http.IncomingHttpHeaders;
-        getCookies?(): { [key: string]: string };
+        // Server-only:
+        request?: http.IncomingMessage;
+        arch?: string;
+        head?: string;
+        body?: string;
+        htmlById?: { [key: string]: string };
+        maybeMadeChanges?: boolean;
+
+        // Client and server. Only client
+        appendToHead(html: Content): void;
+        appendToBody(html: Content): void;
+        appendToElementById(id: string, html: Content): void;
+        renderIntoElementById(id: string, html: Content): void;
+        redirect(location: string, code?: number): void;
+
+        // Server-only, but error-raising stubs provided to client:
+        setStatusCode(code: number): void;
+        setHeader(key: string, value: number | string | string[]): void;
+        getHeaders(): http.IncomingHttpHeaders;
+        getCookies(): { [key: string]: string };
     }
 
     type Callback = (sink: Sink) => Promise<any> | any;

--- a/types/meteor/server-render.d.ts
+++ b/types/meteor/server-render.d.ts
@@ -4,15 +4,7 @@ declare module 'meteor/server-render' {
     // HTMLElement only works on client.
     type Content = string | Content[] | NodeJS.ReadableStream | HTMLElement;
 
-    interface Sink {
-        // Server-only:
-        request?: http.IncomingMessage;
-        arch?: string;
-        head?: string;
-        body?: string;
-        htmlById?: { [key: string]: string };
-        maybeMadeChanges?: boolean;
-
+    interface ClientSink {
         // Client and server. Only client
         appendToHead(html: Content): void;
         appendToBody(html: Content): void;
@@ -27,6 +19,17 @@ declare module 'meteor/server-render' {
         getCookies(): { [key: string]: string };
     }
 
+    interface ServerSink extends ClientSink {
+        // Server-only:
+        request: http.IncomingMessage;
+        arch: string;
+        head: string;
+        body: string;
+        htmlById: { [key: string]: string };
+        maybeMadeChanges: boolean;
+    }
+
+    type Sink = ClientSink | ServerSink;
     type Callback = (sink: Sink) => Promise<any> | any;
     export function onPageLoad<T extends Callback>(callback: T): T;
 }

--- a/types/meteor/test/server-render.tsx
+++ b/types/meteor/test/server-render.tsx
@@ -1,4 +1,4 @@
-import { onPageLoad } from "meteor/server-render";
+import { onPageLoad, ServerSink } from "meteor/server-render";
 import * as React from 'react';
 import { renderToString, renderToNodeStream } from 'react-dom/server';
 import { hydrate } from 'react-dom';
@@ -21,7 +21,7 @@ onPageLoad(async () => {
 onPageLoad(sink => {
   const sheet = new ServerStyleSheet();
   const html = renderToString(sheet.collectStyles(
-    <div data-location={sink.request!.url} />
+    <div data-location={(sink as ServerSink).request.url} />
   ));
 
   sink.renderIntoElementById("app", html);
@@ -35,4 +35,8 @@ onPageLoad(sink => {
   sink.setStatusCode(200);
   sink.redirect('/');
   sink.redirect('/', 301);
+
+  if ('request' in sink) { // ServerSink
+    console.log(sink.arch + sink.head + sink.body);
+  }
 });

--- a/types/meteor/test/server-render.tsx
+++ b/types/meteor/test/server-render.tsx
@@ -1,34 +1,38 @@
 import { onPageLoad } from "meteor/server-render";
 import * as React from 'react';
 import { renderToString, renderToNodeStream } from 'react-dom/server';
+import { hydrate } from 'react-dom';
+import { ServerStyleSheet } from "styled-components";
+
+// Based on https://docs.meteor.com/packages/server-render.html
 
 onPageLoad(sink => {
-  if (sink.renderIntoElementById) {
-    sink.renderIntoElementById("app", renderToString(<div>Hello World</div>));
-  }
+  sink.renderIntoElementById("app", renderToString(<div>Hello World</div>));
 });
 
 onPageLoad(sink => {
-  if (sink.renderIntoElementById) {
-    sink.renderIntoElementById("app", renderToNodeStream(<div>Hello World</div>));
-  }
+  sink.renderIntoElementById("app", renderToNodeStream(<div>Hello World</div>));
+});
+
+onPageLoad(async () => {
+  hydrate(<div>Hello World</div>, document.getElementById("app"));
 });
 
 onPageLoad(sink => {
-  if (sink.getCookies) {
-    sink.getCookies(); // $ExpectType { [key: string]: string; }
-  }
-  if (sink.getHeaders) {
-    sink.getHeaders(); // $ExpectType IncomingHttpHeaders
-  }
-  if (sink.setHeader) {
-    sink.setHeader('cache-control', 'no-cache');
-  }
-  if (sink.setStatusCode) {
-    sink.setStatusCode(200);
-  }
-  if (sink.redirect) {
-    sink.redirect('/');
-    sink.redirect('/', 301);
-  }
+  const sheet = new ServerStyleSheet();
+  const html = renderToString(sheet.collectStyles(
+    <div data-location={sink.request!.url} />
+  ));
+
+  sink.renderIntoElementById("app", html);
+  sink.appendToHead(sheet.getStyleTags());
+});
+
+onPageLoad(sink => {
+  sink.getCookies(); // $ExpectType { [key: string]: string; }
+  sink.getHeaders(); // $ExpectType IncomingHttpHeaders
+  sink.setHeader('cache-control', 'no-cache');
+  sink.setStatusCode(200);
+  sink.redirect('/');
+  sink.redirect('/', 301);
 });


### PR DESCRIPTION
* Methods in server-render, both [client code](https://github.com/meteor/meteor/blob/devel/packages/server-render/client-sink.js) and [server code](https://github.com/meteor/meteor/blob/devel/packages/server-render/server-sink.js) are always present, but were marked as optional for some reason.

* From inspecting the code, all `html` arguments get passed to the same `appendContent` function, which takes `NodeJS.ReadableStream` on server and `HTMLElement` on client. Previously, only the former was allowed in only one of the API calls, but it should be allowed in all. I don't expect there will be confusion of calling with the wrong type on server vs. client.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/meteor/meteor/tree/devel/packages/server-render and https://docs.meteor.com/packages/server-render.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.  [server-render last changed in Meteor 1.6.1]
