### PR TITLE
jsonwebtoken: restore string payload functionality

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -95,7 +95,7 @@ export type VerifyErrors =
     | JsonWebTokenError
     | NotBeforeError
     | TokenExpiredError;
-export type VerifyCallback<T = JwtPayload> = (
+export type VerifyCallback<T = Jwt | JwtPayload | string> = (
     err: VerifyErrors | null,
     decoded: T | undefined,
 ) => void;
@@ -132,7 +132,7 @@ export interface JwtPayload {
 
 export interface Jwt {
     header: JwtHeader;
-    payload: JwtPayload;
+    payload: JwtPayload | string;
     signature: string;
 }
 
@@ -199,7 +199,8 @@ export function sign(
  * returns - The decoded token.
  */
 export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
-export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): JwtPayload;
+export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions & { complete?: false }): JwtPayload | string;
+export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): Jwt | JwtPayload | string;
 
 /**
  * Asynchronously verify given token using a secret or a public key to get a decoded token
@@ -213,13 +214,19 @@ export function verify(token: string, secretOrPublicKey: Secret, options?: Verif
 export function verify(
     token: string,
     secretOrPublicKey: Secret | GetPublicKeyOrSecret,
-    callback?: VerifyCallback,
+    callback?: VerifyCallback<JwtPayload | string>,
 ): void;
 export function verify(
     token: string,
     secretOrPublicKey: Secret | GetPublicKeyOrSecret,
-    options?: VerifyOptions & { complete: true },
+    options: VerifyOptions & { complete: true },
     callback?: VerifyCallback<Jwt>,
+): void;
+export function verify(
+    token: string,
+    secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+    options?: VerifyOptions & { complete?: false },
+    callback?: VerifyCallback<JwtPayload | string>,
 ): void;
 export function verify(
     token: string,

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -14,6 +14,7 @@ interface TestObject {
     foo: string;
 }
 
+const testBoolean = true as boolean;
 const testObject = { foo: "bar" };
 
 /**
@@ -142,39 +143,70 @@ jwt.verify(token, cert, { ignoreExpiration: true }, (err, decoded) => {
     // if ignoreExpration == false and token is expired, err == expired token
 });
 
-cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, (_err, payload) => {
-    if (payload) {
-        // $ExpectType JwtPayload
-        payload;
+jwt.verify(token, cert, (_err, decoded) => {
+    if (decoded) {
+        // $ExpectType string | JwtPayload
+        decoded;
     }
 });
 
-cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, {}, (_err, payload) => {
-    if (payload) {
-        // $ExpectType JwtPayload
-        payload;
+jwt.verify(token, cert, {}, (_err, decoded) => {
+    if (decoded) {
+        // $ExpectType string | JwtPayload
+        decoded;
     }
 });
 
-cert = fs.readFileSync("public.pem"); // get public key
-jwt.verify(token, cert, { complete: true }, (_err, payload) => {
-    if (payload) {
+jwt.verify(token, cert, { complete: true }, (_err, decoded) => {
+    if (decoded) {
         // $ExpectType Jwt
-        payload;
+        decoded;
+        // $ExpectType string | JwtPayload
+        decoded.payload;
     }
 });
 
-cert = fs.readFileSync("public.pem"); // get public key
-const verified = jwt.verify(token, cert);
+jwt.verify(token, cert, { complete: false }, (_err, decoded) => {
+    if (decoded) {
+        // $ExpectType string | JwtPayload
+        decoded;
+    }
+});
 
-cert = fs.readFileSync("public.pem"); // get public key
-const verified2 = jwt.verify(token, cert, { complete: true });
+jwt.verify(token, cert, { maxAge: 3600 }, (_err, decoded) => {
+    if (decoded) {
+        // $ExpectType string | JwtPayload
+        decoded;
+    }
+});
 
-// This tests creates a token with iat as now, verifies with maxAge=now()+3600sec
-cert = fs.readFileSync("public.pem"); // get public key
-const verified3 = jwt.verify(token, cert, {maxAge: 3600});
+jwt.verify(token, cert, { complete: testBoolean }, (_err, decoded) => {
+    if (decoded) {
+        // $ExpectType string | Jwt | JwtPayload
+        decoded;
+    }
+});
+
+// $ExpectType string | JwtPayload
+jwt.verify(token, cert);
+
+// $ExpectType string | JwtPayload
+jwt.verify(token, cert, {});
+
+// $ExpectType Jwt
+jwt.verify(token, cert, { complete: true });
+
+// $ExpectType string | JwtPayload
+jwt.verify(token, cert, { complete: true }).payload;
+
+// $ExpectType string | JwtPayload
+jwt.verify(token, cert, { complete: false });
+
+// $ExpectType string | JwtPayload
+jwt.verify(token, cert, { maxAge: 3600 });
+
+// $ExpectType string | Jwt | JwtPayload
+jwt.verify(token, cert, { complete: testBoolean });
 
 /**
  * jwt.decode


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://github.com/auth0/node-jsonwebtoken/blob/74d5719bd03993fcf71e3b176621f133eb6138c0/verify.js#L66-L69
    - https://github.com/auth0/node-jsonwebtoken/blob/74d5719bd03993fcf71e3b176621f133eb6138c0/decode.js#L9-L17
    - https://github.com/auth0/node-jsonwebtoken/blob/74d5719bd03993fcf71e3b176621f133eb6138c0/verify.js#L136
    - https://github.com/auth0/node-jsonwebtoken/blob/74d5719bd03993fcf71e3b176621f133eb6138c0/verify.js#L213-L223
- [n/a] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----

Follow up to #58126, context in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58126#issuecomment-1011857998

> I believe that this is because you don't necessarily have to store JSON in the payload, since the payload is application specific.
> 
> Since this library is used almost exclusively for security critical things, I think it's important that the return type is accurately reflected so that one is forced to handle the string case. Otherwise there might be an exploit lurking because the code assumes that the payload is an object.
> 
> There was still one problem with the old types though. When `complete: true` is given, it will be the `payload` that is a string, not the entire return value.

I have also added extensive tests that should cover all of the different ways you can call the verify function.

ping: @nwjsmith @nandi95 @peterblazejewicz

-----

On a personal note, I know that this might make it a bit harder to work with the API, but that is because the upstream API is very strange/non-strict. I think it's way more important that the code is correct, then that the types are easy to use but might break at runtime. Especially since this is a security related library...