### PR TITLE
[sinon] allow to specify argument and return value types for fake methods

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -8,6 +8,7 @@
 //                 John Wood <https://github.com/johnjesse>
 //                 Alec Flett <https://github.com/alecf>
 //                 Simon Schick <https://github.com/SimonSchick>
+//                 Mathias Schreck <https://github.com/lo1tuma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as FakeTimers from "@sinonjs/fake-timers";
@@ -1479,43 +1480,48 @@ declare namespace Sinon {
         /**
          * Creates a basic fake, with no behavior
          */
-        (): SinonSpy;
+        <TArgs extends any[] = any[], TReturnValue = any>(): SinonSpy<TArgs, TReturnValue>;
         /**
          * Wraps an existing Function to record all interactions, while leaving it up to the func to provide the behavior.
          * This is useful when complex behavior not covered by the sinon.fake.* methods is required or when wrapping an existing function or method.
          */
-        (fn: Function): SinonSpy;
+        <TArgs extends any[] = any[], TReturnValue = any>(fn: (...args: TArgs) => TReturnValue): SinonSpy<
+            TArgs,
+            TReturnValue
+        >;
         /**
          * Creates a fake that returns the val argument
          * @param val Returned value
          */
-        returns(val: any): SinonSpy;
+        returns<TArgs extends any[] = any[], TReturnValue = any>(val: TReturnValue): SinonSpy<TArgs, TReturnValue>;
         /**
          * Creates a fake that throws an Error with the provided value as the message property.
          * If an Error is passed as the val argument, then that will be the thrown value. If any other value is passed, then that will be used for the message property of the thrown Error.
          * @param val Returned value or throw value if an Error
          */
-        throws(val: Error | string): SinonSpy;
+        throws<TArgs extends any[] = any[], TReturnValue = any>(val: Error | string): SinonSpy<TArgs, TReturnValue>;
         /**
          * Creates a fake that returns a resolved Promise for the passed value.
          * @param val Resolved promise
          */
-        resolves(val: any): SinonSpy;
+        resolves<TArgs extends any[] = any[], TReturnValue = any>(
+            val: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : any,
+        ): SinonSpy<TArgs, TReturnValue>;
         /**
          * Creates a fake that returns a rejected Promise for the passed value.
          * If an Error is passed as the value argument, then that will be the value of the promise.
          * If any other value is passed, then that will be used for the message property of the Error returned by the promise.
          * @param val Rejected promise
          */
-        rejects(val: any): SinonSpy;
+        rejects<TArgs extends any[] = any[], TReturnValue = any>(val: any): SinonSpy<TArgs, TReturnValue>;
         /**
          * fake expects the last argument to be a callback and will invoke it with the given arguments.
          */
-        yields(...args: any[]): SinonSpy;
+        yields<TArgs extends any[] = any[], TReturnValue = any>(...args: any[]): SinonSpy<TArgs, TReturnValue>;
         /**
          * fake expects the last argument to be a callback and will invoke it asynchronously with the given arguments.
          */
-        yieldsAsync(...args: any[]): SinonSpy;
+        yieldsAsync<TArgs extends any[] = any[], TReturnValue = any>(...args: any[]): SinonSpy<TArgs, TReturnValue>;
     }
 
     interface SinonSandbox {

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -298,18 +298,52 @@ function testMatch() {
 
 function testFake() {
     const fn = () => {};
-    let fake = sinon.fake();
+    const fake1 = sinon.fake();
 
-    fake = sinon.fake(() => true);
-    fake = sinon.fake.returns(5);
-    fake = sinon.fake.throws("foo");
-    fake = sinon.fake.throws(new Error("foo"));
-    fake = sinon.fake.resolves("foo");
-    fake = sinon.fake.rejects("foo");
-    fake = sinon.fake.yields(1, 2, fn);
-    fake = sinon.fake.yieldsAsync(1, 2, fn);
+    fake1.args; // $ExpectType any[][]
+    fake1.firstCall.returnValue; // $ExpectType any
 
-    fake.calledWith("foo");
+    const fake2 = sinon.fake(() => true);
+
+    fake2.args; // $ExpectType [][]
+    fake2.firstCall.returnValue; // $ExpectType boolean
+
+    const fake3 = sinon.fake.returns(5);
+
+    fake3.args; // $ExpectType any[][]
+    fake3.firstCall.returnValue; // $ExpectType number
+
+    const fake4 = sinon.fake.throws('foo');
+
+    fake4.args; // $ExpectType any[][]
+    fake4.firstCall.returnValue; // $ExpectType any
+
+    const fake5 = sinon.fake.throws(new Error('foo'));
+
+    fake5.args; // $ExpectType any[][]
+    fake5.firstCall.returnValue; // $ExpectType any
+
+    const fake6 = sinon.fake.resolves('foo');
+
+    fake6.args; // $ExpectType any[][]
+    fake6.firstCall.returnValue; // $ExpectType any
+
+    const fake7 = sinon.fake.rejects('foo');
+
+    fake7.args; // $ExpectType any[][]
+    fake7.firstCall.returnValue; // $ExpectType any
+
+    const fake8 = sinon.fake.yields(1, 2, fn);
+
+    fake8.args; // $ExpectType any[][]
+    fake8.firstCall.returnValue; // $ExpectType any
+
+    const fake9 = sinon.fake.yieldsAsync(1, 2, fn);
+
+    fake9.args; // $ExpectType any[][]
+    fake9.firstCall.returnValue; // $ExpectType any
+
+    fake9.calledWith('foo');
 }
 
 function testAssert() {
@@ -753,4 +787,75 @@ async function testPromises() {
     const executor2 = sinon.promise<string>((resolve, reject) => {
         reject('some error');
     });
+}
+
+async function testTypedFake() {
+    const fake1: sinon.SinonSpy<[number, string], boolean> = sinon.fake((arg1, arg2) => {
+        arg1; // $ExpectType number
+        arg2; // $ExpectType string
+        return true;
+    });
+    fake1(42, ''); // $ExpectType boolean
+    fake1.firstCall.args; // $ExpectType [number, string]
+    fake1.firstCall.returnValue; // $ExpectType boolean
+    fake1.calledWith(21, 'foo');
+    fake1.calledWith(true, 21); // $ExpectError
+
+    const fake2 = sinon.fake<[boolean, string], number>();
+
+    fake2.args; // $ExpectType [boolean, string][]
+    fake2.firstCall.returnValue; // $ExpectType number
+
+    const fake3 = sinon.fake.returns<[boolean, string], number>(42);
+
+    fake3.args; // $ExpectType [boolean, string][]
+    fake3.firstCall.returnValue; // $ExpectType number
+
+    const fake4 = sinon.fake.throws<[boolean, string], number>('');
+
+    fake4.args; // $ExpectType [boolean, string][]
+    fake4.firstCall.returnValue; // $ExpectType number
+
+    const fake5 = sinon.fake.resolves<[boolean, string], Promise<number>>(42);
+
+    fake5.args; // $ExpectType [boolean, string][]
+    fake5.firstCall.returnValue; // $ExpectType Promise<number>
+    await fake5(true, ''); // $ExpectType number
+
+    const fake6 = sinon.fake.rejects<[boolean, string], Promise<number>>('');
+
+    fake6.args; // $ExpectType [boolean, string][]
+    fake6.firstCall.returnValue; // $ExpectType Promise<number>
+    await fake6(true, ''); // $ExpectType number
+
+    const fake7 = sinon.fake.yields<[boolean, string], number>();
+
+    fake7.args; // $ExpectType [boolean, string][]
+    fake7.firstCall.returnValue; // $ExpectType number
+
+    const fake8 = sinon.fake.yieldsAsync<[boolean, string], number>();
+
+    fake8.args; // $ExpectType [boolean, string][]
+    fake8.firstCall.returnValue; // $ExpectType number
+
+    const fake9 = sinon.fake.returns('foo');
+
+    fake9.args; // $ExpectType any[][]
+    fake9.firstCall.returnValue; // $ExpectType string
+
+    const fake10 = sinon.fake.resolves('foo');
+
+    fake10.args; // $ExpectType any[][]
+    fake10.firstCall.returnValue; // $ExpectType any
+
+    const typedFn = (...args: [number, string]): boolean => {
+        return true;
+    };
+
+    const fake11 = sinon.fake(typedFn);
+
+    fake11.firstCall.args; // $ExpectType [number, string]
+    fake11.firstCall.returnValue; // $ExpectType boolean
+
+    sinon.fake<[boolean, string], number>(typedFn); // $ExpectError
 }

--- a/types/sinon/tslint.json
+++ b/types/sinon/tslint.json
@@ -2,6 +2,7 @@
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
         "ban-types": false,
-        "unified-signatures": false
+        "unified-signatures": false,
+        "no-unnecessary-generics": false
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/v12.0.1/fakes/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---------------------------

This change allows to define the generic type parameters of `SinonSpy`, which is returned by all `sinon.fake` methods, so we don’t need to rely on the `any` default type.
