### PR TITLE
[htmlhint] Revert htmlhint definition

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -1817,10 +1817,6 @@
             "libraryName": "html2canvas",
             "asOfVersion": "1.0.0"
         },
-        "htmlhint": {
-            "libraryName": "htmlhint",
-            "asOfVersion": "1.0.0"
-        },
         "http-graceful-shutdown": {
             "libraryName": "http-graceful-shutdown",
             "asOfVersion": "2.3.0"

--- a/types/htmlhint/htmlhint-tests.ts
+++ b/types/htmlhint/htmlhint-tests.ts
@@ -1,0 +1,25 @@
+import { HTMLHint, LintResult, Rule, RuleSet } from 'htmlhint';
+
+const htmlHintRules: RuleSet = {
+    'tagname-lowercase': true,
+    'attr-lowercase': true,
+    'attr-value-double-quotes': true,
+    'doctype-first': true,
+    'tag-pair': true,
+    'spec-char-escape': true,
+    'id-unique': true,
+    'src-not-empty': true,
+    'attr-no-duplication': true,
+    'title-require': true,
+    'space-tab-mixed-disabled': 'tab',
+};
+
+const rule: Rule = {
+    id: 'custom-rule',
+    description: 'Custom rule',
+    link: '../custom-rule',
+};
+HTMLHint.addRule(rule);
+
+const result: LintResult[] = HTMLHint.verify('<span></span>', htmlHintRules);
+const formatted: string[] = HTMLHint.format(result, { indent: 2 });

--- a/types/htmlhint/index.d.ts
+++ b/types/htmlhint/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for HTMLHint 0.9
+// Project: https://github.com/yaniswang/HTMLHint
+// Definitions by: Alan Agius <https://github.com/alan-agius4/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface LintResult {
+    evidence: string;
+    line: number;
+    col: number;
+    message: string;
+    rule: Rule;
+}
+
+export interface FormatOptions {
+    indent?: number | undefined;
+    colors?: boolean | undefined;
+}
+
+export interface Rule {
+    id: string;
+    description: string;
+    link: string;
+}
+
+export interface RuleSet {
+    [id: string]: boolean | string;
+}
+
+export namespace HTMLHint {
+    function addRule(rule: Rule): void;
+    function verify(fileContent: string, ruleSet?: RuleSet): LintResult[];
+    function format(arrMessages: LintResult[], options?: FormatOptions): string[];
+}

--- a/types/htmlhint/tsconfig.json
+++ b/types/htmlhint/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "htmlhint-tests.ts"
+    ]
+}

--- a/types/htmlhint/tslint.json
+++ b/types/htmlhint/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Revert htmlhint definition based on this issue https://github.com/htmlhint/HTMLHint/issues/633

After merging my PR https://github.com/htmlhint/HTMLHint/pull/865 to fix the issue I remove the types from this repository

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test htmlhint`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).