### PR TITLE
[htmlhint] Add type definition for version 1.1.0

### DIFF
--- a/types/htmlhint/htmlhint-tests.ts
+++ b/types/htmlhint/htmlhint-tests.ts
@@ -1,0 +1,34 @@
+import { HTMLHint } from 'htmlhint';
+import { Rule, Ruleset } from 'htmlhint/types';
+
+const htmlHintRules: Ruleset = {
+    'tagname-lowercase': true,
+    'attr-lowercase': true,
+    'attr-value-double-quotes': true,
+    'doctype-first': true,
+    'tag-pair': true,
+    'spec-char-escape': true,
+    'id-unique': true,
+    'src-not-empty': true,
+    'attr-no-duplication': true,
+    'title-require': true,
+    'space-tab-mixed-disabled': 'tab',
+};
+
+const rule: Rule = {
+    id: 'custom-rule',
+    description: 'Custom rule',
+    link: '../custom-rule',
+    init(parser, reporter) {
+        parser; // $ExpectType HTMLParser
+        reporter; // $ExpectType Reporter
+    },
+};
+
+HTMLHint.addRule(rule); // $ExpectType void
+
+// $ExpectType Hint[]
+const result = HTMLHint.verify('<span></span>', htmlHintRules);
+
+// $ExpectType string[]
+const formatted = HTMLHint.format(result, { indent: 2 });

--- a/types/htmlhint/htmlparser.d.ts
+++ b/types/htmlhint/htmlparser.d.ts
@@ -25,6 +25,10 @@ export type Listener = (event: Block) => void;
 export default class HTMLParser {
     lastEvent: Partial<Block> | null;
 
+    private _listeners: { [type: string]: Listener[] };
+    private _mapCdataTags: { [tagName: string]: boolean };
+    private _arrBlocks: Array<Partial<Block>>;
+
     constructor();
 
     makeMap(

--- a/types/htmlhint/htmlparser.d.ts
+++ b/types/htmlhint/htmlparser.d.ts
@@ -1,0 +1,51 @@
+export interface Attr {
+    name: string;
+    value: string;
+    quote: string;
+    index: number;
+    raw: string;
+}
+
+export interface Block {
+    tagName: string;
+    attrs: Attr[];
+    type: string;
+    raw: string;
+    pos: number;
+    line: number;
+    col: number;
+    content: string;
+    long: boolean;
+    close: string;
+    lastEvent?: Partial<Block>;
+}
+
+export type Listener = (event: Block) => void;
+
+export default class HTMLParser {
+    lastEvent: Partial<Block> | null;
+
+    constructor();
+
+    makeMap(
+        str: string,
+    ): {
+        [key: string]: boolean;
+    };
+    parse(html: string): void;
+    addListener(types: string, listener: Listener): void;
+    fire(type: string, data?: Partial<Block>): void;
+    removeListener(type: string, listener: Listener): void;
+    fixPos(
+        event: Block,
+        index: number,
+    ): {
+        line: number;
+        col: number;
+    };
+    getMapAttrs(
+        arrAttrs: Attr[],
+    ): {
+        [name: string]: string;
+    };
+}

--- a/types/htmlhint/index.d.ts
+++ b/types/htmlhint/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for HTMLHint 1.1
+// Project: https://github.com/yaniswang/HTMLHint
+// Definitions by: Alan Agius <https://github.com/alan-agius4/>
+//                 Martin Badin <https://github.com/martin-badin/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import HTMLParser from './htmlparser';
+import Reporter from './reporter';
+import * as HTMLRules from './rules';
+import { Hint, Rule, Ruleset } from './types';
+
+export as namespace HTMLHint;
+
+export interface FormatOptions {
+    colors?: boolean;
+    indent?: number;
+}
+
+declare class HTMLHintCore {
+    rules: { [id: string]: Rule };
+    readonly defaultRuleset: Ruleset;
+
+    addRule(rule: Rule): void;
+    verify(html: string, ruleset?: Ruleset): Hint[];
+    format(arrMessages: Hint[], options?: FormatOptions): string[];
+}
+
+export const HTMLHint: HTMLHintCore;
+
+export { HTMLRules, Reporter, HTMLParser };

--- a/types/htmlhint/reporter.d.ts
+++ b/types/htmlhint/reporter.d.ts
@@ -1,4 +1,4 @@
-import { Hint, Rule, Ruleset } from './types';
+import { Hint, Rule, Ruleset, ReportType } from './types';
 
 export default class Reporter {
     html: string;
@@ -12,4 +12,5 @@ export default class Reporter {
     info(message: string, line: number, col: number, rule: Rule, raw: string): void;
     warn(message: string, line: number, col: number, rule: Rule, raw: string): void;
     error(message: string, line: number, col: number, rule: Rule, raw: string): void;
+    private report(type: ReportType, message: string, line: number, col: number, rule: Rule, raw: string): void;
 }

--- a/types/htmlhint/reporter.d.ts
+++ b/types/htmlhint/reporter.d.ts
@@ -1,0 +1,15 @@
+import { Hint, Rule, Ruleset } from './types';
+
+export default class Reporter {
+    html: string;
+    lines: string[];
+    brLen: number;
+    ruleset: Ruleset;
+    messages: Hint[];
+
+    constructor(html: string, ruleset: Ruleset);
+
+    info(message: string, line: number, col: number, rule: Rule, raw: string): void;
+    warn(message: string, line: number, col: number, rule: Rule, raw: string): void;
+    error(message: string, line: number, col: number, rule: Rule, raw: string): void;
+}

--- a/types/htmlhint/rules.d.ts
+++ b/types/htmlhint/rules.d.ts
@@ -1,0 +1,5 @@
+import { Rule } from './types';
+
+declare const Rules: Rule[];
+
+export default Rules;

--- a/types/htmlhint/tsconfig.json
+++ b/types/htmlhint/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "htmlhint-tests.ts"
+    ]
+}

--- a/types/htmlhint/tslint.json
+++ b/types/htmlhint/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/htmlhint/types.d.ts
+++ b/types/htmlhint/types.d.ts
@@ -1,0 +1,72 @@
+import { HTMLParser, Reporter } from './';
+
+export interface Rule {
+    id: string;
+    description: string;
+    link?: string;
+    init(parser: HTMLParser, reporter: Reporter, options: unknown): void;
+}
+
+export interface Ruleset {
+    'alt-require'?: boolean;
+    'attr-lowercase'?: boolean | Array<string | RegExp>;
+    'attr-no-duplication'?: boolean;
+    'attr-no-unnecessary-whitespace'?: boolean;
+    'attr-sorted'?: boolean;
+    'attr-unsafe-chars'?: boolean;
+    'attr-value-double-quotes'?: boolean;
+    'attr-value-not-empty'?: boolean;
+    'attr-value-single-quotes'?: boolean;
+    'attr-whitespace'?: boolean;
+    'doctype-first'?: boolean;
+    'doctype-html5'?: boolean;
+    'empty-tag-not-self-closed'?: boolean;
+    'head-script-disabled'?: boolean;
+    'href-abs-or-rel'?: 'abs' | 'rel';
+    'id-class-ad-disabled'?: boolean;
+    'id-class-value'?: 'underline' | 'dash' | 'hump' | { regId: RegExp; message: string };
+    'id-unique'?: boolean;
+    'inline-script-disabled'?: boolean;
+    'inline-style-disabled'?: boolean;
+    'input-requires-label'?: boolean;
+    'script-disabled'?: boolean;
+    'space-tab-mixed-disabled'?:
+        | boolean
+        | 'space'
+        | 'space1'
+        | 'space2'
+        | 'space3'
+        | 'space4'
+        | 'space5'
+        | 'space6'
+        | 'space7'
+        | 'space8'
+        | 'tab';
+    'spec-char-escape'?: boolean;
+    'src-not-empty'?: boolean;
+    'style-disabled'?: boolean;
+    'tag-pair'?: boolean;
+    'tag-self-close'?: boolean;
+    'tagname-lowercase'?: boolean;
+    'tagname-specialchars'?: boolean;
+    'tags-check'?: { [tagName: string]: Record<string, unknown> };
+    'title-require'?: boolean;
+    // There may be other unknown rules
+    [ruleId: string]: unknown;
+}
+
+export enum ReportType {
+    error = 'error',
+    warning = 'warning',
+    info = 'info',
+}
+
+export interface Hint {
+    type: ReportType;
+    message: string;
+    raw: string;
+    evidence: string;
+    line: number;
+    col: number;
+    rule: Rule;
+}


### PR DESCRIPTION
These types are copies of existing types from the original repository because types aren't exported for now.

Documentation: https://github.com/htmlhint/HTMLHint

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test htmlhint`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.