### PR TITLE
monday-sdk-js: Added variables as an optional parameter of type 'object' on the 'api' method of MondayServerSdk

### DIFF
--- a/types/monday-sdk-js/index.d.ts
+++ b/types/monday-sdk-js/index.d.ts
@@ -200,7 +200,7 @@ interface MondayClientSdk {
 interface MondayServerSdk {
     setToken(token: string): void;
 
-    api(query: string, options?: Partial<{ token: string }>): Promise<any>;
+    api(query: string, options?: Partial<{ token: string, variables?: object} >): Promise<any>;
 
     oauthToken(code: string, clientId: string, clientSecret: string): Promise<any>;
 }

--- a/types/monday-sdk-js/index.d.ts
+++ b/types/monday-sdk-js/index.d.ts
@@ -200,7 +200,7 @@ interface MondayClientSdk {
 interface MondayServerSdk {
     setToken(token: string): void;
 
-    api(query: string, options?: Partial<{ token: string, variables?: object} >): Promise<any>;
+    api(query: string, options?: Partial<{ token: string, variables: object} >): Promise<any>;
 
     oauthToken(code: string, clientId: string, clientSecret: string): Promise<any>;
 }

--- a/types/monday-sdk-js/test/monday-sdk-js-global.test.ts
+++ b/types/monday-sdk-js/test/monday-sdk-js-global.test.ts
@@ -18,4 +18,7 @@ const mondayServer = mondaySdk({ token: '123' });
 
 mondayServer.setToken('123'); // $ExpectType void
 mondayServer.api('test'); // $ExpectType Promise<any>
+mondayServer.api('test', { token: 'test' }); // $ExpectType Promise<any>
+mondayServer.api('test', { variables: { variable1: 'test' } }); // $ExpectType Promise<any>
+mondayServer.api('test', { token: 'test', variables: { variable1: 'test' } }); // $ExpectType Promise<any>
 mondayServer.oauthToken('test', 'test', 'test'); // $ExpectType Promise<any>

--- a/types/monday-sdk-js/test/monday-sdk-js-module.test.ts
+++ b/types/monday-sdk-js/test/monday-sdk-js-module.test.ts
@@ -19,4 +19,7 @@ const mondayServer = mondaySdk({ token: '123' });
 
 mondayServer.setToken('123'); // $ExpectType void
 mondayServer.api('test'); // $ExpectType Promise<any>
+mondayServer.api('test', { token: 'test' }); // $ExpectType Promise<any>
+mondayServer.api('test', { variables: { variable1: 'test' } }); // $ExpectType Promise<any>
+mondayServer.api('test', { token: 'test', variables: { variable1: 'test' } }); // $ExpectType Promise<any>
 mondayServer.oauthToken('test', 'test', 'test'); // $ExpectType Promise<any>


### PR DESCRIPTION
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/aalnussairi/DefinitelyTyped/blob/master/types/monday-sdk-js/index.d.ts)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

### Description
The node.js sdk for monday.com (monday-sdk-js) supports the passing of GraphQL variables as a second parameter of the .api method. This works as follows:

```
const itemId = 1234567890;
const columnId = "text";

const query = `query($itemId: [Int], $columnId: [String]) {
        items (ids: $itemId) {
          column_values(ids:$columnId) {
            value
          }
        }
      }`;

const variables = { columnId, itemId };

const response = await mondayClient.api(query, { variables });
```