### PR TITLE
[draft-js] Add a few `DraftEditor` member types

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -80,6 +80,10 @@ class RichEditorExample extends React.Component<{}, { editorState: EditorState }
     }
     state = RichEditorExample.initState()
 
+    editor: Editor;
+    editorElement: HTMLElement;
+    editorContainer: HTMLElement;
+
     onChange: (editorState: EditorState) => void = (editorState: EditorState) => this.setState({ editorState });
 
     keyBindingFn(e: SyntheticKeyboardEvent): string {
@@ -101,6 +105,18 @@ class RichEditorExample extends React.Component<{}, { editorState: EditorState }
         }
 
         return getDefaultKeyBinding(e);
+    }
+
+    getEditorKey = (): string => this.editor.getEditorKey();
+
+    focus = (): void => this.editor.focus();
+
+    blur = (): void => this.editor.blur();
+
+    handleEditorRef = (editor: Editor | null) => {
+        this.editor = editor;
+        this.editorElement = this.editor?.editor;
+        this.editorContainer = this.editor?.editorContainer;
     }
 
     handleKeyCommand = (command: EditorCommand, editorState: EditorState, eventTimeStamp: number) => {
@@ -196,7 +212,7 @@ class RichEditorExample extends React.Component<{}, { editorState: EditorState }
                         handleKeyCommand={this.handleKeyCommand}
                         onChange={this.onChange}
                         placeholder="Tell a story..."
-                        ref="editor"
+                        ref={this.handleEditorRef}
                         spellCheck={true}
                         preserveSelectionOnBlur={false}
                     />

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -53,6 +53,10 @@ declare namespace Draft {
              * state of the editor. See `DraftEditorProps` for details.
              */
             class DraftEditor extends React.Component<DraftEditorProps, {}> {
+                editor: HTMLElement | null | undefined;
+                editorContainer: HTMLElement | null | undefined;
+                getEditorKey: () => string;
+
                 /** Force focus back onto the editor node. */
                 focus(): void;
                 /** Remove focus from the editor node. */

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -55,7 +55,7 @@ declare namespace Draft {
             class DraftEditor extends React.Component<DraftEditorProps, {}> {
                 editor: HTMLElement | null | undefined;
                 editorContainer: HTMLElement | null | undefined;
-                getEditorKey: () => string;
+                getEditorKey(): string;
 
                 /** Force focus back onto the editor node. */
                 focus(): void;


### PR DESCRIPTION
### Changes

Add types for the following `DraftEditor` members:
- `getEditorKey`
- `editor`
- `editorContainer`

You can see the original flow types in the draft-js code here: https://github.com/facebook/draft-js/blob/d974abb0c2844bf99724aba9448df42a63291e0e/src/component/base/DraftEditor.react.js#L187-L189.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/draft-js/blob/d974abb0c2844bf99724aba9448df42a63291e0e/src/component/base/DraftEditor.react.js#L187-L189
