### PR TITLE
@ungap/structured-clone - Add types

### DIFF
--- a/types/ungap__structured-clone/index.d.ts
+++ b/types/ungap__structured-clone/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for @ungap/structured-clone 0.3
+// Project: https://www.npmjs.com/package/@ungap/structured-clone#:~:text=github.com/ungap/structured%2Dclone%23readme
+// Definitions by: Flavian Hautbois <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace structuredClone;
+
+/**
+ * Returns a clone of the input value.
+ * @param any a serializable value.
+ * @param options an object with a `lossy` property that,
+ *  if `true`, will not throw errors on incompatible types, and behave more
+ *  like JSON stringify would behave. Symbol and Function will be discarded.
+ * @returns a clone of the input value
+ */
+declare function structuredClone<T>(any: T, options?: { lossy?: boolean }): T;
+export = structuredClone;
+
+declare namespace structuredClone {
+    type SerializedRecordIndex = [number, any] | SerializedRecordIndex[];
+    type SerializedRecord = [SerializedRecordIndex[], ...[number, any][]];
+
+    /**
+     * Serialize the input.
+     * @param serializable a serializable value.
+     * @param options an object with a `lossy` property that,
+     *  if `true`, will not throw errors on incompatible types, and behave more
+     *  like JSON stringify would behave. Symbol and Function will be discarded.
+     * @returns an array of SerializedRecord
+     */
+    function serialize(serializable: any, options?: { lossy?: boolean }): SerializedRecord;
+
+    /**
+     * Deserialize the output.
+     * @param serialized a previously serialized value.
+     * @returns Deserialized output
+     */
+    function deserialize(serialized: SerializedRecord): any;
+}

--- a/types/ungap__structured-clone/tsconfig.json
+++ b/types/ungap__structured-clone/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ungap/*": [
+                "ungap__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ungap__structured-clone-tests.ts"
+    ]
+}

--- a/types/ungap__structured-clone/tslint.json
+++ b/types/ungap__structured-clone/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "array-type": false
+    }
+}

--- a/types/ungap__structured-clone/ungap__structured-clone-tests.ts
+++ b/types/ungap__structured-clone/ungap__structured-clone-tests.ts
@@ -1,0 +1,15 @@
+import structuredClone = require('@ungap/structured-clone');
+
+interface AnyRecord {
+    any: string;
+}
+const serializable: AnyRecord = { any: 'serializable' };
+
+structuredClone(serializable); // $ExpectType AnyRecord
+structuredClone.serialize({ any: 'serializable' }); // $ExpectType SerializedRecord
+// prettier-ignore
+structuredClone.deserialize([ // $ExpectType any
+    [2, [[1, 2]]],
+    [0, 'any'],
+    [0, 'serializable'],
+] as structuredClone.SerializedRecord);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules. => **I had to use an additional rule `array-type: false` here. The reason is that without it, I have to write**
```typescript
// Tigger array-type, but test structuredClone.serialize({ any: 'serializable' }); // $ExpectType SerializedRecord passes
type SerializedRecord = [SerializedRecordIndex[], ...[number, any][]];  

// Makes array-type happy, but test structuredClone.serialize({ any: 'serializable' }); // $ExpectType SerializedRecord fails
type SerializedRecord = [SerializedRecordIndex[], ...Array<[number, any]>];  
/** Reason: 
* expect  TypeScript@4.6 expected type to be:
*   structuredClone.SerializedRecord
* got:
*   [SerializedRecordIndex[], ...[number, any][]]
*/
```
 
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.