### PR TITLE
add(karma-image-snapshot): new definition

### DIFF
--- a/types/karma-image-snapshot/index.d.ts
+++ b/types/karma-image-snapshot/index.d.ts
@@ -1,0 +1,129 @@
+// Type definitions for karma-image-snapshot 0.0
+// Project: https://github.com/maksimr/karma-image-snapshot
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import 'karma';
+import 'jasmine';
+import { PixelmatchOptions } from 'pixelmatch';
+import { Options as SSIMOptions } from 'ssim.js';
+
+export interface MatchImageSnapshotOptions {
+    /**
+     * If set to true, the build will not fail when the screenshots to compare have different sizes.
+     * @default false
+     */
+    allowSizeMismatch?: boolean | undefined;
+    /**
+     * Custom config passed to 'pixelmatch' or 'ssim'
+     */
+    customDiffConfig?: PixelmatchOptions | Partial<SSIMOptions> | undefined;
+    /**
+     * The method by which images are compared.
+     * `pixelmatch` does a pixel by pixel comparison, whereas `ssim` does a structural similarity comparison.
+     * @default 'pixelmatch'
+     */
+    comparisonMethod?: 'pixelmatch' | 'ssim' | undefined;
+    /**
+     * Custom snapshots directory.
+     * Absolute path of a directory to keep the snapshot in.
+     */
+    customSnapshotsDir?: string | undefined;
+    /**
+     * A custom absolute path of a directory to keep this diff in
+     */
+    customDiffDir?: string | undefined;
+    /**
+     * A custom name to give this snapshot. If not provided, one is computed automatically. When a function is provided
+     * it is called with an object containing testPath, currentTestName, counter and defaultIdentifier as its first
+     * argument. The function must return an identifier to use for the snapshot.
+     */
+    customSnapshotIdentifier?:
+        | ((parameters: {
+              testPath: string;
+              currentTestName: string;
+              counter: number;
+              defaultIdentifier: string;
+          }) => string)
+        | string
+        | undefined;
+    /**
+     * Changes diff image layout direction.
+     * @default 'horizontal'
+     */
+    diffDirection?: 'horizontal' | 'vertical' | undefined;
+    /**
+     * Will output base64 string of a diff image to console in case of failed tests (in addition to creating a diff image).
+     * This string can be copy-pasted to a browser address string to preview the diff for a failed test.
+     * @default false
+     */
+    dumpDiffToConsole?: boolean | undefined;
+    /**
+     * Will output the image to the terminal using iTerm's Inline Images Protocol.
+     * If the term is not compatible, it does the same thing as `dumpDiffToConsole`.
+     * @default false
+     */
+    dumpInlineDiffToConsole?: boolean | undefined;
+    /**
+     * Removes coloring from the console output, useful if storing the results to a file.
+     * @default false.
+     */
+    noColors?: boolean | undefined;
+    /**
+     * Sets the threshold that would trigger a test failure based on the failureThresholdType selected. This is different
+     * to the customDiffConfig.threshold above - the customDiffConfig.threshold is the per pixel failure threshold, whereas
+     * this is the failure threshold for the entire comparison.
+     * @default 0.
+     */
+    failureThreshold?: number | undefined;
+    /**
+     * Sets the type of threshold that would trigger a failure.
+     * @default 'pixel'.
+     */
+    failureThresholdType?: 'pixel' | 'percent' | undefined;
+    /**
+     * Updates a snapshot even if it passed the threshold against the existing one.
+     * @default false.
+     */
+    updatePassedSnapshot?: boolean | undefined;
+    /**
+     * Applies Gaussian Blur on compared images, accepts radius in pixels as value. Useful when you have noise after
+     * scaling images per different resolutions on your target website, usually setting its value to 1-2 should be
+     * enough to solve that problem.
+     * @default 0.
+     */
+    blur?: number | undefined;
+    /**
+     * Runs the diff in process without spawning a child process.
+     * @default false.
+     */
+    runInProcess?: boolean | undefined;
+}
+
+declare global {
+    interface Window {
+        /** @async */
+        screenshot(): Promise<string | Buffer>;
+        setViewport(options: { width: number; height: number }): Promise<void>;
+        toMatchImageSnapshot(options?: MatchImageSnapshotOptions): Promise<void>;
+    }
+
+    namespace jasmine {
+        interface AsyncMatchers<T, U> {
+            toMatchImageSnapshot(options?: MatchImageSnapshotOptions): Promise<void>;
+        }
+    }
+}
+
+declare module 'karma' {
+    interface ConfigOptions {
+        reporters?: Array<'outdated-snapshot' | string> | undefined;
+
+        /**
+         * @default undefined
+         */
+        snapshot?: MatchImageSnapshotOptions;
+    }
+}

--- a/types/karma-image-snapshot/karma-image-snapshot-tests.ts
+++ b/types/karma-image-snapshot/karma-image-snapshot-tests.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'karma';
+
+it('should compare image snapshots', async () => {
+    const image = await window.screenshot();
+    await expectAsync(image).toMatchImageSnapshot();
+});
+
+module.exports = (config: Config) => {
+    config.set({
+        reporters: ['outdated-snapshot'],
+        snapshot: {
+            allowSizeMismatch: true,
+            blur: 2,
+            comparisonMethod: 'pixelmatch',
+        },
+    });
+};

--- a/types/karma-image-snapshot/package.json
+++ b/types/karma-image-snapshot/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "ssim.js": "^3.1.1"
+    }
+}

--- a/types/karma-image-snapshot/tsconfig.json
+++ b/types/karma-image-snapshot/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "karma-image-snapshot-tests.ts"
+    ]
+}

--- a/types/karma-image-snapshot/tslint.json
+++ b/types/karma-image-snapshot/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Declaration file for Jasmine port of 'jest-image-snapshot' for Karma
runner.
Note that DT purpose is to provide 'karma-image-snapshots' changes for
Karma configuration, DOM global object methods and for Jasmine custom
matcher, which are public APIs to be used when 'karma-image-snapshot' is
added to a project, not direct usage of 'karma-image-snapshot' module
exports (which are used by Karma dependency resolution for plugins).

'jest' related declaration have to be manually ported into DT file,
otherwise 'jest' and 'jasmine' are non-compatible in single definition,
resulting in errros which cannot be resolved on DT.

https://www.npmjs.com/package/karma-image-snapshot
https://github.com/maksimr/karma-image-snapshot#readme

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.