### PR TITLE
[Node v17, v16, v14] replace "dom" in compilerOptions.lib with appropriate selections

### DIFF
--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -397,7 +397,5 @@ buff.writeDoubleBE(123.123);
 buff.writeDoubleBE(123.123, 0);
 
 {
-    // The 'as any' is to make sure the Global DOM Blob does not clash with the
-    //  local "Blob" which comes with node.
-    resolveObjectURL(URL.createObjectURL(new Blob(['']) as any)); // $ExpectType Blob | undefined
+    resolveObjectURL("hello"); // $ExpectType Blob | undefined
 }

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -530,7 +530,7 @@ async function testReadableStream() {
 
     const stream = new ReadableStream<number>({
         async start(controller) {
-            for await (const _ of every(SECOND)) controller.enqueue(performance.now());
+            for await (const _ of every(SECOND)) controller.enqueue(1.1);
         },
     });
 

--- a/types/node/test/wasi.ts
+++ b/types/node/test/wasi.ts
@@ -12,8 +12,10 @@ import * as fs from 'node:fs';
     const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
     (async () => {
-        const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
-        const instance = await WebAssembly.instantiate(wasm, importObject);
+        // TODO: WebAssembly types don't exist in @types/node
+        // const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
+        // const instance = await WebAssembly.instantiate(wasm, importObject);
+        const instance = {};
 
         wasi.start(instance);
     })();

--- a/types/node/tsconfig.json
+++ b/types/node/tsconfig.json
@@ -7,7 +7,7 @@
         "module": "commonjs",
         "target": "esnext",
         "lib": [
-            "dom"
+            "es2021"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/node/v14/test/wasi.ts
+++ b/types/node/v14/test/wasi.ts
@@ -12,8 +12,10 @@ import * as fs from 'node:fs';
     const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
     (async () => {
-        const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
-        const instance = await WebAssembly.instantiate(wasm, importObject);
+        // TODO: WebAssembly types don't exist in @types/node
+        // const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
+        // const instance = await WebAssembly.instantiate(wasm, importObject);
+        const instance = {};
 
         wasi.start(instance);
     })();

--- a/types/node/v14/tsconfig.json
+++ b/types/node/v14/tsconfig.json
@@ -7,7 +7,7 @@
         "module": "commonjs",
         "target": "esnext",
         "lib": [
-            "dom"
+            "es2020"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/node/v16/test/buffer.ts
+++ b/types/node/v16/test/buffer.ts
@@ -397,7 +397,5 @@ buff.writeDoubleBE(123.123);
 buff.writeDoubleBE(123.123, 0);
 
 {
-    // The 'as any' is to make sure the Global DOM Blob does not clash with the
-    //  local "Blob" which comes with node.
-    resolveObjectURL(URL.createObjectURL(new Blob(['']) as any)); // $ExpectType Blob | undefined
+    resolveObjectURL("hello"); // $ExpectType Blob | undefined
 }

--- a/types/node/v16/test/stream.ts
+++ b/types/node/v16/test/stream.ts
@@ -530,7 +530,7 @@ async function testReadableStream() {
 
     const stream = new ReadableStream<number>({
         async start(controller) {
-            for await (const _ of every(SECOND)) controller.enqueue(performance.now());
+            for await (const _ of every(SECOND)) controller.enqueue(1.1);
         },
     });
 

--- a/types/node/v16/test/wasi.ts
+++ b/types/node/v16/test/wasi.ts
@@ -12,8 +12,10 @@ import * as fs from 'node:fs';
     const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
     (async () => {
-        const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
-        const instance = await WebAssembly.instantiate(wasm, importObject);
+        // TODO: WebAssembly types don't exist in @types/node
+        // const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
+        // const instance = await WebAssembly.instantiate(wasm, importObject);
+        const instance = {};
 
         wasi.start(instance);
     })();

--- a/types/node/v16/tsconfig.json
+++ b/types/node/v16/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "commonjs",
     "target": "esnext",
     "lib": [
-      "dom"
+      "es2021"
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
  - [x] `npm test node`
  - [x] `npm test node/v16`
  - [x] `npm test node/v14`

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://github.com/tsconfig/bases/blob/53131a972d30993ecc98eec8cb3946d9d843833d/bases/node14.json#L6
   - https://github.com/tsconfig/bases/blob/53131a972d30993ecc98eec8cb3946d9d843833d/bases/node16.json#L6

---

At some point, `"dom"` was added to `compilerOptions.lib` (it used to just be `"es6"`). This causes tests to _pass_ which should _fail_ if they reference items defined in `lib.dom.d.ts` but missing in `@types/node`. For instance, I was working on tests for AbortSignal and they all passed even though `@types/node` only has partial types!

This PR:
- Sets `compilerOptions.lib` according to [tsconfig bases](https://github.com/tsconfig/bases/tree/main/bases) back to v14; this _removes_ `"dom"` from current, v16, and v14. (I didn't touch v12 due to its age, but can do so if requested.)
- Modifies existing tests that relied on `"dom"` being in lib. Most of these are inconsequential, but perhaps not `wasi` (I commented out the actual use of the WebAssembly types).
  - I tried a different approach—providing the actual WebAssembly types for NodeJS—but couldn't get them to merge cleanly with those already in `"dom"`, causing failures in _many other packages_.