### PR TITLE
[node] Add `Blob` typings to v14

### DIFF
--- a/types/node/v14/buffer.d.ts
+++ b/types/node/v14/buffer.d.ts
@@ -1,4 +1,5 @@
 declare module 'buffer' {
+    import { BinaryLike } from 'node:crypto';
     export const INSPECT_MAX_BYTES: number;
     export const kMaxLength: number;
     export const kStringMaxLength: number;
@@ -17,6 +18,69 @@ declare module 'buffer' {
         new(size: number): Buffer;
         prototype: Buffer;
     };
+    /**
+     * @experimental
+     */
+    export interface BlobOptions {
+        /**
+         * @default 'utf8'
+         */
+        encoding?: BufferEncoding | undefined;
+        /**
+         * The Blob content-type. The intent is for `type` to convey
+         * the MIME media type of the data, however no validation of the type format
+         * is performed.
+         */
+        type?: string | undefined;
+    }
+    /**
+     * A [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) encapsulates immutable, raw data that can be safely shared across
+     * multiple worker threads.
+     * @since v14.18.0
+     * @experimental
+     */
+    export class Blob {
+        /**
+         * The total size of the `Blob` in bytes.
+         * @since v14.18.0
+         */
+        readonly size: number;
+        /**
+         * The content-type of the `Blob`.
+         * @since v14.18.0
+         */
+        readonly type: string;
+        /**
+         * Creates a new `Blob` object containing a concatenation of the given sources.
+         *
+         * {ArrayBuffer}, {TypedArray}, {DataView}, and {Buffer} sources are copied into
+         * the 'Blob' and can therefore be safely modified after the 'Blob' is created.
+         *
+         * String sources are also copied into the `Blob`.
+         */
+        constructor(sources: Array<BinaryLike | Blob>, options?: BlobOptions);
+        /**
+         * Returns a promise that fulfills with an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) containing a copy of
+         * the `Blob` data.
+         * @since v14.18.0
+         */
+        arrayBuffer(): Promise<ArrayBuffer>;
+        /**
+         * Creates and returns a new `Blob` containing a subset of this `Blob` objects
+         * data. The original `Blob` is not altered.
+         * @since v14.18.0
+         * @param start The starting index.
+         * @param end The ending index.
+         * @param type The content-type for the new `Blob`
+         */
+        slice(start?: number, end?: number, type?: string): Blob;
+        /**
+         * Returns a promise that fulfills with the contents of the `Blob` decoded as a
+         * UTF-8 string.
+         * @since v14.18.0
+         */
+        text(): Promise<string>;
+    }
 
     export { BuffType as Buffer };
 }

--- a/types/node/v14/test/buffer.ts
+++ b/types/node/v14/test/buffer.ts
@@ -7,6 +7,7 @@ import {
     constants,
     kMaxLength,
     kStringMaxLength,
+    Blob,
 } from 'node:buffer';
 
 const utf8Buffer = new Buffer('test');
@@ -262,3 +263,21 @@ b.fill('a').fill('b');
     const target: TranscodeEncoding = 'ascii';
     transcode(Buffer.from('€'), source, target); // $ExpectType Buffer
 }
+
+// Blob
+async () => {
+    const blob = new Blob(['asd', Buffer.from('test'), new Blob(['dummy'])], {
+        type: 'application/javascript',
+        encoding: 'base64',
+    });
+
+    blob.size; // $ExpectType number
+    blob.type; // $ExpectType string
+
+    blob.arrayBuffer(); // $ExpectType Promise<ArrayBuffer>
+    blob.text(); // $ExpectType Promise<string>
+    blob.slice(); // $ExpectType Blob
+    blob.slice(1); // $ExpectType Blob
+    blob.slice(1, 2); // $ExpectType Blob
+    blob.slice(1, 2, 'other'); // $ExpectType Blob
+};


### PR DESCRIPTION
Node.js has supported `Blob` in v14 since [`14.18.0`][1]. This change
reads across the `Blob` class from v16, with the notable exception of
`blob.stream()`, which was only added in [`16.7.0`][2]

[1]: https://nodejs.org/api/buffer.html#class-blob
[2]: https://nodejs.org/api/buffer.html#blobstream

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
