### PR TITLE
[aws-lambda] Fix SQSMessageAttribute required types

### DIFF
--- a/types/aws-lambda/test/sqs-tests.ts
+++ b/types/aws-lambda/test/sqs-tests.ts
@@ -47,6 +47,11 @@ const event: SQSEvent = {
                     binaryListValues: [],
                     dataType: 'Number',
                 },
+                testAttr2: {
+                    stringValue: '100',
+                    binaryValue: 'base64Str',
+                    dataType: 'Number',
+                },
             },
             md5OfBody: '9bb58f26192e4ba00f01e2e7b136bbd8',
             eventSource: 'aws:sqs',

--- a/types/aws-lambda/trigger/sqs.d.ts
+++ b/types/aws-lambda/trigger/sqs.d.ts
@@ -37,8 +37,8 @@ export type SQSMessageAttributeDataType = 'String' | 'Number' | 'Binary' | strin
 export interface SQSMessageAttribute {
     stringValue?: string | undefined;
     binaryValue?: string | undefined;
-    stringListValues: never[]; // Not implemented. Reserved for future use.
-    binaryListValues: never[]; // Not implemented. Reserved for future use.
+    stringListValues?: string[] | undefined; // Not implemented. Reserved for future use.
+    binaryListValues?: string[] | undefined; // Not implemented. Reserved for future use.
     dataType: SQSMessageAttributeDataType;
 }
 


### PR DESCRIPTION
Closes #57720

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test aws-lambda`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html#API_MessageAttributeValue_Contents>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
