### PR TITLE
[@wordpress/components] Add explicit children for VisuallyHidden

### DIFF
--- a/types/wordpress__components/visually-hidden/index.d.ts
+++ b/types/wordpress__components/visually-hidden/index.d.ts
@@ -2,7 +2,7 @@ import { ComponentType, ReactNode } from 'react';
 import { WordPressComponentProps } from '../ui/context/wordpress-component';
 
 declare namespace VisuallyHidden {
-    type Props = WordPressComponentProps<ReactNode, 'div'>;
+    type Props = WordPressComponentProps<{ children?: ReactNode }, 'div'>;
 }
 declare const VisuallyHidden: ComponentType<VisuallyHidden.Props>;
 


### PR DESCRIPTION
Current typings break in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210: https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=120782&view=logs&j=8635df7d-ecde-52a7-c7a8-84b998e35690&t=c264d665-0b79-59b7-7e04-9965cbe74860&l=2403.
 