### PR TITLE
[use-persisted-state] Push type param to createPersistedState

### DIFF
--- a/types/use-persisted-state/index.d.ts
+++ b/types/use-persisted-state/index.d.ts
@@ -3,9 +3,12 @@
 // Definitions by: Karol Majewski <https://github.com/karol-majewski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
-import { useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 
-declare function createPersistedState(key: string, provider?: Pick<Storage, 'getItem' | 'setItem'>): typeof useState;
+declare function createPersistedState<S>(key: string, provider?: Pick<Storage, 'getItem' | 'setItem'>): {
+    (initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
+    (): [S | undefined, Dispatch<SetStateAction<S | undefined>>];
+};
 
 export as namespace createPersistedState;
 export default createPersistedState;

--- a/types/use-persisted-state/use-persisted-state-tests.ts
+++ b/types/use-persisted-state/use-persisted-state-tests.ts
@@ -43,3 +43,15 @@ createPersistedState(undefined);       // $ExpectError
 createPersistedState('myKey', { });                               // $ExpectError
 createPersistedState('myKey', { getItem: localStorage.getItem }); // $ExpectError
 createPersistedState('myKey', { setItem: localStorage.setItem }); // $ExpectError
+
+/**
+ * createPersistedState takes an optional type parameter, which carries through
+ * to the returned hook
+ *
+ * (based on the README example)
+ */
+const useCounterState = createPersistedState<number>('count');
+const initialCount = 1;
+const [count, setCount] = useCounterState(initialCount);
+count; // $ExpectType number
+setCount; // $ExpectType Dispatch<SetStateAction<number>>


### PR DESCRIPTION
It seems a bit odd to declare the type of your state variable every time
you invoke the hook, when it's shared across multiple invocations. This
better matches the way that I would expect to use use-persisted-state.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A - purely a typing change
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
