### PR TITLE
[ssh2] export the `SessionAcceptReject` type

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1116,7 +1116,7 @@ export interface SocketBindInfo {
     socketPath: string;
 }
 
-type SessionAcceptReject = (() => boolean) | undefined
+export type SessionAcceptReject = (() => boolean) | undefined
 
 export interface Session extends events.EventEmitter {
     // Session events


### PR DESCRIPTION
This PR exposes a type (SessionAcceptReject) that is used in the current type definitions but is not currently exported.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. (This doesn't change the shape of the exported types, just adds an export to an existing type)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See the commit message

