### PR TITLE
[serverless] add architecture attribute in provider

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -61,6 +61,7 @@ declare namespace Aws {
         cfnRole?: string | undefined;
         iam?: IamSettings | undefined;
         versionFunctions?: boolean | undefined;
+        architecture?: 'x86_64' | 'arm64' | undefined;
         environment?: Environment | string | undefined;
         endpointType?: 'regional' | 'edge' | 'private' | undefined;
         apiKeys?: string[] | undefined;

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -174,6 +174,7 @@ const awsServerless: Aws.Serverless = {
         rolePermissionsBoundary: 'testrolePermissionsBoundary',
         cfnRole: 'testcfnRole',
         versionFunctions: true,
+        architecture: 'x86_64',
         environment: {
             testenvironmentkey: 'testenvironmentvalue'
         },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/serverless/serverless/blob/452e4d8279802ab2ce1ca300ab2c75ec8588a9e8/docs/providers/aws/guide/serverless.yml.md?plain=1#L103
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
