### PR TITLE
[@types/google-apps-script] Improve Analytics Types

### DIFF
--- a/types/google-apps-script/apis/analytics_v3.d.ts
+++ b/types/google-apps-script/apis/analytics_v3.d.ts
@@ -407,7 +407,7 @@ declare namespace GoogleAppsScript {
         customDataImportUids?: string[] | undefined;
       }
       interface Column {
-        attributes?: any | undefined;
+        attributes?: any;
         id?: string | undefined;
         kind?: string | undefined;
       }
@@ -765,7 +765,7 @@ declare namespace GoogleAppsScript {
         /** The maximum number of rows to include in the response. */
         'max-results'?: number;
         /** The desired output type for the Analytics data returned in the response. Acceptable values are json and dataTable. Default: json. */
-        output?: 'json' | 'dataTable'
+        output?: 'json' | 'dataTable';
         /** Selector specifying a subset of fields to include in the response. */
         fields?: string;
         /** Returns response with indentations and line breaks. Default false. */

--- a/types/google-apps-script/apis/analytics_v3.d.ts
+++ b/types/google-apps-script/apis/analytics_v3.d.ts
@@ -758,28 +758,10 @@ declare namespace GoogleAppsScript {
          * HIGHER_PRECISION — Returns a more accurate response using a large sample size, but this may result in the response being slower.
          */
         samplingLevel?: 'DEFAULT' | 'FASTER' | 'HIGHER_PRECISION';
-        /** Defaults to true; if set to false, rows where all metric values are zero will be omitted from the response. */
-        'include-empty-rows'?: boolean;
         /** The first row of data to retrieve, starting at 1. Use this parameter as a pagination mechanism along with the max-results parameter. */
         'start-index'?: number;
         /** The maximum number of rows to include in the response. */
         'max-results'?: number;
-        /** The desired output type for the Analytics data returned in the response. Acceptable values are json and dataTable. Default: json. */
-        output?: 'json' | 'dataTable';
-        /** Selector specifying a subset of fields to include in the response. */
-        fields?: string;
-        /** Returns response with indentations and line breaks. Default false. */
-        prettyPrint?: string;
-        /** Specifies IP address of the end user for whom the API call is being made. Used to cap usage per IP. */
-        userIp?: string;
-        /** Alternative to userIp in cases when the user's IP address is unknown. */
-        quotaUser?: string;
-        /** One possible way to provide an OAuth 2.0 token. */
-        access_token?: string;
-        /** Name of the JavaScript callback function that handles the response. Used in JavaScript JSON-P requests. */
-        callback?: string;
-        /** Used for OAuth 1.0a authorization to specify your application to get quota. For example: key=AldefliuhSFADSfasdfasdfASdf. */
-        key?: string;
       }
       interface Goal {
         accountId?: string | undefined;

--- a/types/google-apps-script/apis/analytics_v3.d.ts
+++ b/types/google-apps-script/apis/analytics_v3.d.ts
@@ -741,17 +741,51 @@ declare namespace GoogleAppsScript {
         webPropertyId?: string | undefined;
       }
       interface GaDataQuery {
-        dimensions?: string | undefined;
-        end_date?: string | undefined;
-        filters?: string | undefined;
-        ids?: string | undefined;
-        max_results?: number | undefined;
-        metrics?: string[] | undefined;
-        samplingLevel?: string | undefined;
-        segment?: string | undefined;
-        sort?: string[] | undefined;
-        start_date?: string | undefined;
-        start_index?: number | undefined;
+        /** The unique table ID of the form ga:XXXX, where XXXX is the Analytics view (profile) ID for which the query will retrieve the data. */
+        ids?: string;
+        /** Start date for fetching Analytics data. Requests can specify a start date formatted as YYYY-MM-DD, or as a relative date (e.g., today, yesterday, or NdaysAgo where N is a positive integer). */
+        'start-date'?: string;
+        /** End date for fetching Analytics data. Request can specify an end date formatted as YYYY-MM-DD, or as a relative date (e.g., today, yesterday, or NdaysAgo where N is a positive integer). */
+        'end-date'?: string;
+        /** A list of comma-separated metrics, such as ga:sessions,ga:bounces. */
+        metrics?: string;
+        /** A list of comma-separated dimensions for your Analytics data, such as ga:browser,ga:city. */
+        dimensions?: string;
+        /** A list of comma-separated dimensions and metrics indicating the sorting order and sorting direction for the returned data. */
+        sort?: string;
+        /** Dimension or metric filters that restrict the data returned for your request. */
+        filters?: string;
+        /** Segments the data returned for your request. */
+        segment?: string;
+        /**
+         * The desired sampling level. Allowed Values:
+         * DEFAULT — Returns response with a sample size that balances speed and accuracy.
+         * FASTER — Returns a fast response with a smaller sample size.
+         * HIGHER_PRECISION — Returns a more accurate response using a large sample size, but this may result in the response being slower.
+         */
+        samplingLevel?: 'DEFAULT' | 'FASTER' | 'HIGHER_PRECISION';
+        /** Defaults to true; if set to false, rows where all metric values are zero will be omitted from the response. */
+        'include-empty-rows'?: boolean;
+        /** The first row of data to retrieve, starting at 1. Use this parameter as a pagination mechanism along with the max-results parameter. */
+        'start-index'?: number;
+        /** The maximum number of rows to include in the response. */
+        'max-results'?: number;
+        /** The desired output type for the Analytics data returned in the response. Acceptable values are json and dataTable. Default: json. */
+        output?: 'json' | 'dataTable'
+        /** Selector specifying a subset of fields to include in the response. */
+        fields?: string;
+        /** Returns response with indentations and line breaks. Default false. */
+        prettyPrint?: string;
+        /** Specifies IP address of the end user for whom the API call is being made. Used to cap usage per IP. */
+        userIp?: string;
+        /** Alternative to userIp in cases when the user's IP address is unknown. */
+        quotaUser?: string;
+        /** One possible way to provide an OAuth 2.0 token. */
+        access_token?: string;
+        /** Name of the JavaScript callback function that handles the response. Used in JavaScript JSON-P requests. */
+        callback?: string;
+        /** Used for OAuth 1.0a authorization to specify your application to get quota. For example: key=AldefliuhSFADSfasdfasdfASdf. */
+        key?: string;
       }
       interface Goal {
         accountId?: string | undefined;

--- a/types/google-apps-script/apis/analytics_v3.d.ts
+++ b/types/google-apps-script/apis/analytics_v3.d.ts
@@ -710,7 +710,7 @@ declare namespace GoogleAppsScript {
         sampleSpace?: string | undefined;
         selfLink?: string | undefined;
         totalResults?: number | undefined;
-        totalsForAllResults?: any | undefined;
+        totalsForAllResults?: Record<string, string> | undefined;
       }
       interface GaDataColumnHeaders {
         columnType?: string | undefined;
@@ -863,7 +863,7 @@ declare namespace GoogleAppsScript {
         sampleSpace?: string | undefined;
         selfLink?: string | undefined;
         totalResults?: number | undefined;
-        totalsForAllResults?: any | undefined;
+        totalsForAllResults?: Record<string, string> | undefined;
       }
       interface McfDataColumnHeaders {
         columnType?: string | undefined;
@@ -991,7 +991,7 @@ declare namespace GoogleAppsScript {
         rows?: string[][] | undefined;
         selfLink?: string | undefined;
         totalResults?: number | undefined;
-        totalsForAllResults?: any | undefined;
+        totalsForAllResults?: Record<string, string> | undefined;
       }
       interface RealtimeDataColumnHeaders {
         columnType?: string | undefined;

--- a/types/google-apps-script/apis/analytics_v3.d.ts
+++ b/types/google-apps-script/apis/analytics_v3.d.ts
@@ -572,7 +572,7 @@ declare namespace GoogleAppsScript {
         kind?: string | undefined;
         minimumExperimentLengthInDays?: number | undefined;
         name?: string | undefined;
-        anyiveMetric?: string | undefined;
+        objectiveMetric?: string | undefined;
         optimizationType?: string | undefined;
         parentLink?: Analytics.Schema.ExperimentParentLink | undefined;
         profileId?: string | undefined;

--- a/types/google-apps-script/apis/analytics_v3.d.ts
+++ b/types/google-apps-script/apis/analytics_v3.d.ts
@@ -11,19 +11,19 @@ declare namespace GoogleAppsScript {
           // Returns Analytics data for a view (profile).
           get(ids: string, start_date: string, end_date: string, metrics: string): Analytics.Schema.GaData;
           // Returns Analytics data for a view (profile).
-          get(ids: string, start_date: string, end_date: string, metrics: string, optionalArgs: object): Analytics.Schema.GaData;
+          get(ids: string, start_date: string, end_date: string, metrics: string, optionalArgs: any): Analytics.Schema.GaData;
         }
         interface McfCollection {
           // Returns Analytics Multi-Channel Funnels data for a view (profile).
           get(ids: string, start_date: string, end_date: string, metrics: string): Analytics.Schema.McfData;
           // Returns Analytics Multi-Channel Funnels data for a view (profile).
-          get(ids: string, start_date: string, end_date: string, metrics: string, optionalArgs: object): Analytics.Schema.McfData;
+          get(ids: string, start_date: string, end_date: string, metrics: string, optionalArgs: any): Analytics.Schema.McfData;
         }
         interface RealtimeCollection {
           // Returns real time data for a view (profile).
           get(ids: string, metrics: string): Analytics.Schema.RealtimeData;
           // Returns real time data for a view (profile).
-          get(ids: string, metrics: string, optionalArgs: object): Analytics.Schema.RealtimeData;
+          get(ids: string, metrics: string, optionalArgs: any): Analytics.Schema.RealtimeData;
         }
       }
       namespace Management {
@@ -31,7 +31,7 @@ declare namespace GoogleAppsScript {
           // Lists account summaries (lightweight tree comprised of accounts/properties/profiles) to which the user has access.
           list(): Analytics.Schema.AccountSummaries;
           // Lists account summaries (lightweight tree comprised of accounts/properties/profiles) to which the user has access.
-          list(optionalArgs: object): Analytics.Schema.AccountSummaries;
+          list(optionalArgs: any): Analytics.Schema.AccountSummaries;
         }
         interface AccountUserLinksCollection {
           // Adds a new user to the given account.
@@ -39,7 +39,7 @@ declare namespace GoogleAppsScript {
           // Lists account-user links for a given account.
           list(accountId: string): Analytics.Schema.EntityUserLinks;
           // Lists account-user links for a given account.
-          list(accountId: string, optionalArgs: object): Analytics.Schema.EntityUserLinks;
+          list(accountId: string, optionalArgs: any): Analytics.Schema.EntityUserLinks;
           // Removes a user from the given account.
           remove(accountId: string, linkId: string): void;
           // Updates permissions for an existing user on the given account.
@@ -49,7 +49,7 @@ declare namespace GoogleAppsScript {
           // Lists all accounts to which the user has access.
           list(): Analytics.Schema.Accounts;
           // Lists all accounts to which the user has access.
-          list(optionalArgs: object): Analytics.Schema.Accounts;
+          list(optionalArgs: any): Analytics.Schema.Accounts;
         }
         interface ClientIdCollection {
           // Hashes the given Client ID.
@@ -59,7 +59,7 @@ declare namespace GoogleAppsScript {
           // List custom data sources to which the user has access.
           list(accountId: string, webPropertyId: string): Analytics.Schema.CustomDataSources;
           // List custom data sources to which the user has access.
-          list(accountId: string, webPropertyId: string, optionalArgs: object): Analytics.Schema.CustomDataSources;
+          list(accountId: string, webPropertyId: string, optionalArgs: any): Analytics.Schema.CustomDataSources;
         }
         interface CustomDimensionsCollection {
           // Get a custom dimension to which the user has access.
@@ -69,15 +69,15 @@ declare namespace GoogleAppsScript {
           // Lists custom dimensions to which the user has access.
           list(accountId: string, webPropertyId: string): Analytics.Schema.CustomDimensions;
           // Lists custom dimensions to which the user has access.
-          list(accountId: string, webPropertyId: string, optionalArgs: object): Analytics.Schema.CustomDimensions;
+          list(accountId: string, webPropertyId: string, optionalArgs: any): Analytics.Schema.CustomDimensions;
           // Updates an existing custom dimension. This method supports patch semantics.
           patch(resource: Schema.CustomDimension, accountId: string, webPropertyId: string, customDimensionId: string): Analytics.Schema.CustomDimension;
           // Updates an existing custom dimension. This method supports patch semantics.
-          patch(resource: Schema.CustomDimension, accountId: string, webPropertyId: string, customDimensionId: string, optionalArgs: object): Analytics.Schema.CustomDimension;
+          patch(resource: Schema.CustomDimension, accountId: string, webPropertyId: string, customDimensionId: string, optionalArgs: any): Analytics.Schema.CustomDimension;
           // Updates an existing custom dimension.
           update(resource: Schema.CustomDimension, accountId: string, webPropertyId: string, customDimensionId: string): Analytics.Schema.CustomDimension;
           // Updates an existing custom dimension.
-          update(resource: Schema.CustomDimension, accountId: string, webPropertyId: string, customDimensionId: string, optionalArgs: object): Analytics.Schema.CustomDimension;
+          update(resource: Schema.CustomDimension, accountId: string, webPropertyId: string, customDimensionId: string, optionalArgs: any): Analytics.Schema.CustomDimension;
         }
         interface CustomMetricsCollection {
           // Get a custom metric to which the user has access.
@@ -87,15 +87,15 @@ declare namespace GoogleAppsScript {
           // Lists custom metrics to which the user has access.
           list(accountId: string, webPropertyId: string): Analytics.Schema.CustomMetrics;
           // Lists custom metrics to which the user has access.
-          list(accountId: string, webPropertyId: string, optionalArgs: object): Analytics.Schema.CustomMetrics;
+          list(accountId: string, webPropertyId: string, optionalArgs: any): Analytics.Schema.CustomMetrics;
           // Updates an existing custom metric. This method supports patch semantics.
           patch(resource: Schema.CustomMetric, accountId: string, webPropertyId: string, customMetricId: string): Analytics.Schema.CustomMetric;
           // Updates an existing custom metric. This method supports patch semantics.
-          patch(resource: Schema.CustomMetric, accountId: string, webPropertyId: string, customMetricId: string, optionalArgs: object): Analytics.Schema.CustomMetric;
+          patch(resource: Schema.CustomMetric, accountId: string, webPropertyId: string, customMetricId: string, optionalArgs: any): Analytics.Schema.CustomMetric;
           // Updates an existing custom metric.
           update(resource: Schema.CustomMetric, accountId: string, webPropertyId: string, customMetricId: string): Analytics.Schema.CustomMetric;
           // Updates an existing custom metric.
-          update(resource: Schema.CustomMetric, accountId: string, webPropertyId: string, customMetricId: string, optionalArgs: object): Analytics.Schema.CustomMetric;
+          update(resource: Schema.CustomMetric, accountId: string, webPropertyId: string, customMetricId: string, optionalArgs: any): Analytics.Schema.CustomMetric;
         }
         interface ExperimentsCollection {
           // Returns an experiment to which the user has access.
@@ -105,7 +105,7 @@ declare namespace GoogleAppsScript {
           // Lists experiments to which the user has access.
           list(accountId: string, webPropertyId: string, profileId: string): Analytics.Schema.Experiments;
           // Lists experiments to which the user has access.
-          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: object): Analytics.Schema.Experiments;
+          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: any): Analytics.Schema.Experiments;
           // Update an existing experiment. This method supports patch semantics.
           patch(resource: Schema.Experiment, accountId: string, webPropertyId: string, profileId: string, experimentId: string): Analytics.Schema.Experiment;
           // Delete an experiment.
@@ -121,7 +121,7 @@ declare namespace GoogleAppsScript {
           // Lists all filters for an account
           list(accountId: string): Analytics.Schema.Filters;
           // Lists all filters for an account
-          list(accountId: string, optionalArgs: object): Analytics.Schema.Filters;
+          list(accountId: string, optionalArgs: any): Analytics.Schema.Filters;
           // Updates an existing filter. This method supports patch semantics.
           patch(resource: Schema.Filter, accountId: string, filterId: string): Analytics.Schema.Filter;
           // Delete a filter.
@@ -137,7 +137,7 @@ declare namespace GoogleAppsScript {
           // Lists goals to which the user has access.
           list(accountId: string, webPropertyId: string, profileId: string): Analytics.Schema.Goals;
           // Lists goals to which the user has access.
-          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: object): Analytics.Schema.Goals;
+          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: any): Analytics.Schema.Goals;
           // Updates an existing goal. This method supports patch semantics.
           patch(resource: Schema.Goal, accountId: string, webPropertyId: string, profileId: string, goalId: string): Analytics.Schema.Goal;
           // Updates an existing goal.
@@ -151,7 +151,7 @@ declare namespace GoogleAppsScript {
           // Lists all profile filter links for a profile.
           list(accountId: string, webPropertyId: string, profileId: string): Analytics.Schema.ProfileFilterLinks;
           // Lists all profile filter links for a profile.
-          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: object): Analytics.Schema.ProfileFilterLinks;
+          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: any): Analytics.Schema.ProfileFilterLinks;
           // Update an existing profile filter link. This method supports patch semantics.
           patch(resource: Schema.ProfileFilterLink, accountId: string, webPropertyId: string, profileId: string, linkId: string): Analytics.Schema.ProfileFilterLink;
           // Delete a profile filter link.
@@ -165,7 +165,7 @@ declare namespace GoogleAppsScript {
           // Lists profile-user links for a given view (profile).
           list(accountId: string, webPropertyId: string, profileId: string): Analytics.Schema.EntityUserLinks;
           // Lists profile-user links for a given view (profile).
-          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: object): Analytics.Schema.EntityUserLinks;
+          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: any): Analytics.Schema.EntityUserLinks;
           // Removes a user from the given view (profile).
           remove(accountId: string, webPropertyId: string, profileId: string, linkId: string): void;
           // Updates permissions for an existing user on the given view (profile).
@@ -179,7 +179,7 @@ declare namespace GoogleAppsScript {
           // Lists views (profiles) to which the user has access.
           list(accountId: string, webPropertyId: string): Analytics.Schema.Profiles;
           // Lists views (profiles) to which the user has access.
-          list(accountId: string, webPropertyId: string, optionalArgs: object): Analytics.Schema.Profiles;
+          list(accountId: string, webPropertyId: string, optionalArgs: any): Analytics.Schema.Profiles;
           // Updates an existing view (profile). This method supports patch semantics.
           patch(resource: Schema.Profile, accountId: string, webPropertyId: string, profileId: string): Analytics.Schema.Profile;
           // Deletes a view (profile).
@@ -195,7 +195,7 @@ declare namespace GoogleAppsScript {
           // Lists remarketing audiences to which the user has access.
           list(accountId: string, webPropertyId: string): Analytics.Schema.RemarketingAudiences;
           // Lists remarketing audiences to which the user has access.
-          list(accountId: string, webPropertyId: string, optionalArgs: object): Analytics.Schema.RemarketingAudiences;
+          list(accountId: string, webPropertyId: string, optionalArgs: any): Analytics.Schema.RemarketingAudiences;
           // Updates an existing remarketing audience. This method supports patch semantics.
           patch(resource: Schema.RemarketingAudience, accountId: string, webPropertyId: string, remarketingAudienceId: string): Analytics.Schema.RemarketingAudience;
           // Delete a remarketing audience.
@@ -207,7 +207,7 @@ declare namespace GoogleAppsScript {
           // Lists segments to which the user has access.
           list(): Analytics.Schema.Segments;
           // Lists segments to which the user has access.
-          list(optionalArgs: object): Analytics.Schema.Segments;
+          list(optionalArgs: any): Analytics.Schema.Segments;
         }
         interface UnsampledReportsCollection {
           // Returns a single unsampled report.
@@ -217,7 +217,7 @@ declare namespace GoogleAppsScript {
           // Lists unsampled reports to which the user has access.
           list(accountId: string, webPropertyId: string, profileId: string): Analytics.Schema.UnsampledReports;
           // Lists unsampled reports to which the user has access.
-          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: object): Analytics.Schema.UnsampledReports;
+          list(accountId: string, webPropertyId: string, profileId: string, optionalArgs: any): Analytics.Schema.UnsampledReports;
           // Deletes an unsampled report.
           remove(accountId: string, webPropertyId: string, profileId: string, unsampledReportId: string): void;
         }
@@ -229,7 +229,7 @@ declare namespace GoogleAppsScript {
           // List uploads to which the user has access.
           list(accountId: string, webPropertyId: string, customDataSourceId: string): Analytics.Schema.Uploads;
           // List uploads to which the user has access.
-          list(accountId: string, webPropertyId: string, customDataSourceId: string, optionalArgs: object): Analytics.Schema.Uploads;
+          list(accountId: string, webPropertyId: string, customDataSourceId: string, optionalArgs: any): Analytics.Schema.Uploads;
           // Upload data for a custom data source.
           uploadData(accountId: string, webPropertyId: string, customDataSourceId: string): Analytics.Schema.Upload;
           // Upload data for a custom data source.
@@ -243,7 +243,7 @@ declare namespace GoogleAppsScript {
           // Lists webProperty-Google Ads links for a given web property.
           list(accountId: string, webPropertyId: string): Analytics.Schema.EntityAdWordsLinks;
           // Lists webProperty-Google Ads links for a given web property.
-          list(accountId: string, webPropertyId: string, optionalArgs: object): Analytics.Schema.EntityAdWordsLinks;
+          list(accountId: string, webPropertyId: string, optionalArgs: any): Analytics.Schema.EntityAdWordsLinks;
           // Updates an existing webProperty-Google Ads link. This method supports patch semantics.
           patch(resource: Schema.EntityAdWordsLink, accountId: string, webPropertyId: string, webPropertyAdWordsLinkId: string): Analytics.Schema.EntityAdWordsLink;
           // Deletes a web property-Google Ads link.
@@ -259,7 +259,7 @@ declare namespace GoogleAppsScript {
           // Lists web properties to which the user has access.
           list(accountId: string): Analytics.Schema.Webproperties;
           // Lists web properties to which the user has access.
-          list(accountId: string, optionalArgs: object): Analytics.Schema.Webproperties;
+          list(accountId: string, optionalArgs: any): Analytics.Schema.Webproperties;
           // Updates an existing web property. This method supports patch semantics.
           patch(resource: Schema.Webproperty, accountId: string, webPropertyId: string): Analytics.Schema.Webproperty;
           // Updates an existing web property.
@@ -271,7 +271,7 @@ declare namespace GoogleAppsScript {
           // Lists webProperty-user links for a given web property.
           list(accountId: string, webPropertyId: string): Analytics.Schema.EntityUserLinks;
           // Lists webProperty-user links for a given web property.
-          list(accountId: string, webPropertyId: string, optionalArgs: object): Analytics.Schema.EntityUserLinks;
+          list(accountId: string, webPropertyId: string, optionalArgs: any): Analytics.Schema.EntityUserLinks;
           // Removes a user from the given web property.
           remove(accountId: string, webPropertyId: string, linkId: string): void;
           // Updates permissions for an existing user on the given web property.
@@ -413,7 +413,7 @@ declare namespace GoogleAppsScript {
         customDataImportUids?: string[] | undefined;
       }
       interface Column {
-        attributes?: object | undefined;
+        attributes?: any | undefined;
         id?: string | undefined;
         kind?: string | undefined;
       }
@@ -578,7 +578,7 @@ declare namespace GoogleAppsScript {
         kind?: string | undefined;
         minimumExperimentLengthInDays?: number | undefined;
         name?: string | undefined;
-        objectiveMetric?: string | undefined;
+        anyiveMetric?: string | undefined;
         optimizationType?: string | undefined;
         parentLink?: Analytics.Schema.ExperimentParentLink | undefined;
         profileId?: string | undefined;
@@ -710,7 +710,7 @@ declare namespace GoogleAppsScript {
         sampleSpace?: string | undefined;
         selfLink?: string | undefined;
         totalResults?: number | undefined;
-        totalsForAllResults?: object | undefined;
+        totalsForAllResults?: any | undefined;
       }
       interface GaDataColumnHeaders {
         columnType?: string | undefined;
@@ -863,7 +863,7 @@ declare namespace GoogleAppsScript {
         sampleSpace?: string | undefined;
         selfLink?: string | undefined;
         totalResults?: number | undefined;
-        totalsForAllResults?: object | undefined;
+        totalsForAllResults?: any | undefined;
       }
       interface McfDataColumnHeaders {
         columnType?: string | undefined;
@@ -991,7 +991,7 @@ declare namespace GoogleAppsScript {
         rows?: string[][] | undefined;
         selfLink?: string | undefined;
         totalResults?: number | undefined;
-        totalsForAllResults?: object | undefined;
+        totalsForAllResults?: any | undefined;
       }
       interface RealtimeDataColumnHeaders {
         columnType?: string | undefined;
@@ -1095,7 +1095,7 @@ declare namespace GoogleAppsScript {
       }
       interface UnsampledReportCloudStorageDownloadDetails {
         bucketId?: string | undefined;
-        objectId?: string | undefined;
+        anyId?: string | undefined;
       }
       interface UnsampledReportDriveDownloadDetails {
         documentId?: string | undefined;

--- a/types/google-apps-script/apis/analytics_v3.d.ts
+++ b/types/google-apps-script/apis/analytics_v3.d.ts
@@ -9,21 +9,15 @@ declare namespace GoogleAppsScript {
       namespace Data {
         interface GaCollection {
           // Returns Analytics data for a view (profile).
-          get(ids: string, start_date: string, end_date: string, metrics: string): Analytics.Schema.GaData;
-          // Returns Analytics data for a view (profile).
-          get(ids: string, start_date: string, end_date: string, metrics: string, optionalArgs: any): Analytics.Schema.GaData;
+          get(ids: string, start_date: string, end_date: string, metrics: string, optionalArgs?: Analytics.Schema.GaDataQuery): Analytics.Schema.GaData;
         }
         interface McfCollection {
           // Returns Analytics Multi-Channel Funnels data for a view (profile).
-          get(ids: string, start_date: string, end_date: string, metrics: string): Analytics.Schema.McfData;
-          // Returns Analytics Multi-Channel Funnels data for a view (profile).
-          get(ids: string, start_date: string, end_date: string, metrics: string, optionalArgs: any): Analytics.Schema.McfData;
+          get(ids: string, start_date: string, end_date: string, metrics: string, optionalArgs?: Analytics.Schema.GaDataQuery): Analytics.Schema.McfData;
         }
         interface RealtimeCollection {
           // Returns real time data for a view (profile).
-          get(ids: string, metrics: string): Analytics.Schema.RealtimeData;
-          // Returns real time data for a view (profile).
-          get(ids: string, metrics: string, optionalArgs: any): Analytics.Schema.RealtimeData;
+          get(ids: string, metrics: string, optionalArgs?: any): Analytics.Schema.RealtimeData;
         }
       }
       namespace Management {

--- a/types/google-apps-script/apis/analytics_v3.d.ts
+++ b/types/google-apps-script/apis/analytics_v3.d.ts
@@ -1105,7 +1105,7 @@ declare namespace GoogleAppsScript {
       }
       interface UnsampledReportCloudStorageDownloadDetails {
         bucketId?: string | undefined;
-        anyId?: string | undefined;
+        objectId?: string | undefined;
       }
       interface UnsampledReportDriveDownloadDetails {
         documentId?: string | undefined;

--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -589,3 +589,21 @@ const handleScopeAction = () => {
 
     return serialized;
 };
+
+// Analytics Test
+const requestAnalyticsData = (): string => {
+    const gaData = Analytics.Data.Ga.get(
+        'An Id',
+        '2022-01-18',
+        '2022-01-18',
+        'Some metrics',
+        {
+            dimensions: 'Some dimensions',
+        },
+    );
+
+    const totalsForAllResults = gaData.totalsForAllResults;
+    const totalSessions = totalsForAllResults['ga:sessions'];
+
+    return totalSessions;
+};


### PR DESCRIPTION
Just a few changes to improve the Analytics types within Google Apps Script.

Summary of changes:

- Replaced object type with any type
- Changed `totalsForAllResults` to Record type
Example of `totalsForAllResults`...

```javascript
{
  totalsForAllResults: {
    'ga:itemRevenue': '7995839.46',
    'ga:productDetailViews': '2159798',
    'ga:uniquePurchases': '74012'
  }
}
```
- Updated GaDataQuery type to match [documentation](https://developers.google.com/analytics/devguides/reporting/core/v3/reference#q_summary)
- Set optionalArgs type to GaDataQuery (From any/object)


---


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://developers.google.com/analytics/devguides/reporting/core/v3/reference](https://developers.google.com/analytics/devguides/reporting/core/v3/reference)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
