### PR TITLE
[node/v14] Add `AbortController` and `AbortSignal` to v14

### DIFF
--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -75,6 +75,49 @@ type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" 
 
 type WithImplicitCoercion<T> = T | { valueOf(): T };
 
+//#region borrowed
+// from https://github.com/microsoft/TypeScript/blob/38da7c600c83e7b31193a62495239a0fe478cb67/lib/lib.webworker.d.ts#L633 until moved to separate lib
+/**
+ * A controller object that allows you to abort one or more DOM requests as and when desired.
+ * @since v14.7.0
+ */
+interface AbortController {
+    /**
+     * Returns the AbortSignal object associated with this object.
+     * @since v14.7.0
+     */
+    readonly signal: AbortSignal;
+    /**
+     * Invoking this method will set this object's AbortSignal's aborted flag and signal to any observers that the associated activity is to be aborted.
+     * @since v14.7.0
+     */
+    abort(): void;
+}
+
+/**
+ * A signal object that allows you to communicate with a DOM request (such as a Fetch) and abort it if required via an AbortController object.
+ * @since v14.7.0
+ */
+interface AbortSignal {
+    /**
+     * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
+     * @since v14.7.0
+     */
+    readonly aborted: boolean;
+}
+
+declare var AbortController: {
+    prototype: AbortController;
+    new(): AbortController;
+};
+
+declare var AbortSignal: {
+    prototype: AbortSignal;
+    new(): AbortSignal;
+    // TODO: Add abort() static
+};
+//#endregion borrowed
+
 /**
  * Raw data is stored in instances of the Buffer class.
  * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.

--- a/types/node/v14/test/globals.ts
+++ b/types/node/v14/test/globals.ts
@@ -10,3 +10,6 @@
 }
 
 declare var RANDOM_GLOBAL_VARIABLE: true;
+
+const abortController = new global.AbortController();
+abortController.signal; // $ExpectType AbortSignal


### PR DESCRIPTION
Node.js has supported [`AbortController`][1] and [`AbortSignal`][2] in
v14 since `14.7.0. This change reads across these classes from v16.

[1]: https://nodejs.org/api/globals.html#class-abortcontroller
[2]: https://nodejs.org/api/globals.html#class-abortsignal

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
