### PR TITLE
Remove htmlhint from notNeededPackages.json

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -1821,10 +1821,6 @@
             "libraryName": "html2canvas",
             "asOfVersion": "1.0.0"
         },
-        "htmlhint": {
-            "libraryName": "htmlhint",
-            "asOfVersion": "1.0.0"
-        },
         "http-graceful-shutdown": {
             "libraryName": "http-graceful-shutdown",
             "asOfVersion": "2.3.0"


### PR DESCRIPTION
Should have been done with #58181, but DT's tests didn't catch the problem.