### PR TITLE
[react-virtualized] Stricter `registerChild` types

### DIFF
--- a/types/react-virtualized/dist/es/CellMeasurer.d.ts
+++ b/types/react-virtualized/dist/es/CellMeasurer.d.ts
@@ -48,7 +48,7 @@ export type MeasuredCellParent = {
 
 export type CellMeasurerChildProps = {
     measure: () => void,
-    registerChild?: (element?: React.ReactNode) => void
+    registerChild?: (element?: Element) => void
 }
 
 export type CellMeasurerProps = {

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -344,7 +344,7 @@ export class DynamicHeightList extends PureComponent<any> {
         return (
             <CellMeasurer cache={this._cache} columnIndex={0} key={key} rowIndex={index} parent={parent}>
                 {({ measure, registerChild }) => (
-                    <div ref={registerChild} className={classNames} style={style}>
+                    <div ref={registerChild as React.Ref<HTMLDivElement>} className={classNames} style={style}>
                         <img
                             onLoad={measure}
                             src={source}


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210