### PR TITLE
[react-router] Fix test assuming applyRouterMiddleWare returns a ReactNode

### DIFF
--- a/types/react-router/v3/react-router-tests.tsx
+++ b/types/react-router/v3/react-router-tests.tsx
@@ -222,16 +222,20 @@ match({ history, routes }, (error, redirectLocation, renderProps) => {
     renderToString(<RouterContext {...renderProps} />);
 });
 
-ReactDOM.render((
+ReactDOM.render(
     <Router
         history={history}
         routes={routes}
-        render={applyRouterMiddleware({
-            renderRouteComponent: child => child
-        })}
-    >
-    </Router>
-), document.body);
+        render={props => {
+            const Context = applyRouterMiddleware({
+                renderRouteComponent: child => child,
+            })(props);
+
+            return <Context></Context>;
+        }}
+    ></Router>,
+    document.body,
+);
 
 const matchedPattern = matchPattern("/foo", "/foo/bar");
 


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210