### PR TITLE
[react-table] Fix tests when `ReactFragment` does  not include `{}`

### DIFF
--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -645,10 +645,10 @@ const Component = (props: {}) => {
                     // then sum any of those counts if they are
                     // aggregated further
                     aggregate: 'count',
-                    Aggregated: ({ cell: { value } }: CellProps<Data>) => `${value} Names`,
+                    Aggregated: ({ cell: { value } }: CellProps<Data>) => <>{value} Names</>,
                     Cell: ({ value }) => {
                         const v = value; // $ExpectType string
-                        return value;
+                        return <>{value}</>;
                     },
                 },
                 {
@@ -661,7 +661,7 @@ const Component = (props: {}) => {
                     // being aggregated, then sum those counts if
                     // they are aggregated further
                     aggregate: 'uniqueCount',
-                    Aggregated: ({ cell: { value } }: CellProps<Data>) => `${value} Unique Names`,
+                    Aggregated: ({ cell: { value } }: CellProps<Data>) => <>{value} Unique Names</>,
                 },
             ],
         },
@@ -675,11 +675,11 @@ const Component = (props: {}) => {
                     filter: 'equals',
                     // Aggregate the average age of visitors
                     aggregate: 'average',
-                    Aggregated: ({ cell: { value } }: CellProps<Data>) => `${value} (avg)`,
+                    Aggregated: ({ cell: { value } }: CellProps<Data>) => <>{value} (avg)</>,
                     disableGlobalFilter: true,
                     Cell: ({ value }) => {
                         const v = value; // $ExpectType number
-                        return value;
+                        return <>{value}</>;
                     },
                 },
                 {
@@ -689,7 +689,7 @@ const Component = (props: {}) => {
                     filter: 'between',
                     // Aggregate the sum of all visits
                     aggregate: 'sum',
-                    Aggregated: ({ cell: { value } }: CellProps<Data>) => `${value} (total)`,
+                    Aggregated: ({ cell: { value } }: CellProps<Data>) => <>{value} (total)</>,
                 },
                 {
                     Header: 'Status',
@@ -704,7 +704,7 @@ const Component = (props: {}) => {
                     filter: filterGreaterThan,
                     // Use our custom roundedMedian aggregator
                     aggregate: roundedMedian,
-                    Aggregated: ({ cell: { value } }: CellProps<Data>) => `${value} (med)`,
+                    Aggregated: ({ cell: { value } }: CellProps<Data>) => <>{value} (med)</>,
                 },
             ],
         },
@@ -720,10 +720,10 @@ const Component = (props: {}) => {
             // then sum any of those counts if they are
             // aggregated further
             aggregate: 'count',
-            Aggregated: ({ cell: { value } }: CellProps<Data>) => `${value} Names`,
+            Aggregated: ({ cell: { value } }: CellProps<Data>) => <>{value} Names</>,
             Cell: ({ value }) => {
                 const v = value; // $ExpectType string
-                return value;
+                return <>{value}</>;
             },
         },
         {
@@ -733,11 +733,11 @@ const Component = (props: {}) => {
             filter: 'equals',
             // Aggregate the average age of visitors
             aggregate: 'average',
-            Aggregated: ({ cell: { value } }: CellProps<Data>) => `${value} (avg)`,
+            Aggregated: ({ cell: { value } }: CellProps<Data>) => <>{value} (avg)</>,
             disableGlobalFilter: true,
             Cell: ({ value }) => {
                 const v = value; // $ExpectType number
-                return value;
+                return <>{value}</>;
             },
         },
         {
@@ -747,7 +747,7 @@ const Component = (props: {}) => {
             filter: 'between',
             // Aggregate the sum of all visits
             aggregate: 'sum',
-            Aggregated: ({ cell: { value } }: CellProps<Data>) => `${value} (total)`,
+            Aggregated: ({ cell: { value } }: CellProps<Data>) => <>{value} (total)</>,
         },
         {
             Header: 'Sub Rows',
@@ -755,7 +755,7 @@ const Component = (props: {}) => {
             Cell: ({ value }) => {
                 const v = value; // $ExpectType Data[] | undefined
                 const l = value!.length; // $ExpectType number
-                return l;
+                return <>{l}</>;
             },
         },
     ];
@@ -810,7 +810,7 @@ const Component = (props: {}) => {
                     accessor: 'firstName',
                     Cell: ({ value }) => {
                         const v = value; // $ExpectType string
-                        return value;
+                        return <>{value}</>;
                     },
                 },
             ]}


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210