### PR TITLE
[react-router] Fix children render props test using `match`

### DIFF
--- a/types/react-router/test/examples-from-react-router-website/CustomLink.tsx
+++ b/types/react-router/test/examples-from-react-router-website/CustomLink.tsx
@@ -24,7 +24,7 @@ interface OldSchoolMenuLinkProps extends LinkProps {
 }
 
 const OldSchoolMenuLink: React.FC<OldSchoolMenuLinkProps> = ({ label, to, activeOnlyWhenExact }) => (
-  <Route path={to as string} exact={activeOnlyWhenExact} children={(params: { match: boolean }) => (
+  <Route path={to as string} exact={activeOnlyWhenExact} children={(params) => (
     <div className={params.match ? 'active' : ''}>
       {params.match ? '> ' : ''}<Link to={to}>{label}</Link>
     </div>

--- a/types/react-router/ts4.0/test/examples-from-react-router-website/CustomLink.tsx
+++ b/types/react-router/ts4.0/test/examples-from-react-router-website/CustomLink.tsx
@@ -24,7 +24,7 @@ interface OldSchoolMenuLinkProps extends LinkProps {
 }
 
 const OldSchoolMenuLink: React.FC<OldSchoolMenuLinkProps> = ({ label, to, activeOnlyWhenExact }) => (
-  <Route path={to as string} exact={activeOnlyWhenExact} children={(params: { match: boolean }) => (
+  <Route path={to as string} exact={activeOnlyWhenExact} children={(params) => (
     <div className={params.match ? 'active' : ''}>
       {params.match ? '> ' : ''}<Link to={to}>{label}</Link>
     </div>


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210

https://v5.reactrouter.com/web/api/match
https://v5.reactrouter.com/web/api/Route/children-func
