### PR TITLE
[react-simple-maps] Stricter type for  `children` renderProps

### DIFF
--- a/types/react-simple-maps/index.d.ts
+++ b/types/react-simple-maps/index.d.ts
@@ -90,7 +90,7 @@ interface GeographiesChildrenArgument {
     projection: GeoProjection;
 }
 
-export interface GeographiesProps extends React.SVGAttributes<SVGGElement> {
+export interface GeographiesProps extends Omit<React.SVGAttributes<SVGGElement>, 'children'> {
     parseGeographies?: ((features: Array<Feature<any, any>>) => Array<Feature<any, any>>) | undefined;
     geography?: string | Record<string, any> | string[] | undefined;
     children?: ((data: GeographiesChildrenArgument) => void) | undefined;


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210