### PR TITLE
[react-redux] Fix tests assuming Provider supports children render props

### DIFF
--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -479,7 +479,7 @@ const targetEl = document.getElementById('root');
 
 ReactDOM.render((
     <Provider store={store}>
-        {() => <App />}
+        <App />
     </Provider>
 ), targetEl);
 
@@ -511,7 +511,7 @@ declare var counterActionCreators: { [type: string]: (...args: any[]) => any; };
 
 ReactDOM.render(
     <Provider store={store}>
-        {() => <MyRootComponent />}
+        <MyRootComponent />
     </Provider>,
     document.body
 );

--- a/types/react-redux/v5/react-redux-tests.tsx
+++ b/types/react-redux/v5/react-redux-tests.tsx
@@ -359,7 +359,7 @@ const targetEl = document.getElementById('root');
 
 ReactDOM.render((
     <Provider store={store}>
-        {() => <App />}
+        <App />
     </Provider>
 ), targetEl);
 
@@ -392,7 +392,7 @@ declare var counterActionCreators: { [type: string]: (...args: any[]) => any; };
 
 ReactDOM.render(
     <Provider store={store}>
-        {() => <MyRootComponent />}
+        <MyRootComponent />
     </Provider>,
     document.body
 );

--- a/types/react-redux/v6/react-redux-tests.tsx
+++ b/types/react-redux/v6/react-redux-tests.tsx
@@ -434,7 +434,7 @@ const targetEl = document.getElementById('root');
 
 ReactDOM.render((
     <Provider store={store}>
-        {() => <App />}
+        <App />
     </Provider>
 ), targetEl);
 
@@ -466,7 +466,7 @@ declare var counterActionCreators: { [type: string]: (...args: any[]) => any; };
 
 ReactDOM.render(
     <Provider store={store}>
-        {() => <MyRootComponent />}
+        <MyRootComponent />
     </Provider>,
     document.body
 );


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210

https://github.com/reduxjs/react-redux/blob/v7.2.6/src/components/Provider.js#L34
