### PR TITLE
[react-netlify-form] `recaptcha` is an element

### DIFF
--- a/types/react-netlify-form/index.d.ts
+++ b/types/react-netlify-form/index.d.ts
@@ -11,7 +11,7 @@ export interface NetlifyFormState {
     error: boolean;
     success: boolean;
     recaptchaError?: boolean | undefined;
-    recaptcha?: Recaptcha | undefined;
+    recaptcha?: React.ReactElement | undefined;
 }
 
 export interface NetlifyFormProps {


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210

https://github.com/escaladesports/react-netlify-form/blob/f8008ace44d1c2bb9f27b199d36a3822d31367d3/src/export/index.js#L61-L68
https://github.com/escaladesports/react-netlify-form/blob/f8008ace44d1c2bb9f27b199d36a3822d31367d3/README.md#recaptcha-v2
