### PR TITLE
[gestalt] Fix tests assuming `onDismissStart` would be a valid child

### DIFF
--- a/types/gestalt/gestalt-tests.tsx
+++ b/types/gestalt/gestalt-tests.tsx
@@ -169,7 +169,7 @@ const CheckUseReducedMotion = () => {
     }}
 />;
 <Checkbox id={'1'} onChange={() => {}} />;
-<Collage columns={1} height={1} renderImage={({ height, index, width }) => () => {}} width={1} />;
+<Collage columns={1} height={1} renderImage={({ height, index, width }) => null} width={1} />;
 <ColorSchemeProvider colorScheme="dark" id="docsExample" />;
 <Column span={1} />;
 <Container />;
@@ -250,7 +250,11 @@ const CheckUseReducedMotion = () => {
     onDismiss={() => {}}
     footer={<Heading>Footer</Heading>}
 >
-    {({ onDismissStart }) => <Heading>Content {onDismissStart}</Heading>}
+    {({ onDismissStart }) => (
+        <Heading>
+            Content <button onClick={onDismissStart} />
+        </Heading>
+    )}
 </Sheet>;
 <Spinner show={true} accessibilityLabel="Example spinner" />;
 <Stack alignItems="center" gap={2}>


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210