### PR TITLE
[react-native] Correctly extend `ViewProps` in `PressableProps`

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -453,7 +453,7 @@ export interface PressableAndroidRippleConfig {
     foreground?: null | boolean | undefined;
 }
 
-export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'style' | 'hitSlop'> {
+export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'children' | 'style' | 'hitSlop'> {
     /**
      * Called when a single tap gesture is detected.
      */

--- a/types/react-native/v0.63/index.d.ts
+++ b/types/react-native/v0.63/index.d.ts
@@ -478,7 +478,7 @@ export interface PressableAndroidRippleConfig {
     radius?: null | number;
 }
 
-export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'style' | 'hitSlop'> {
+export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'children' | 'style' | 'hitSlop'> {
     /**
      * Called when a single tap gesture is detected.
      */

--- a/types/react-native/v0.64/index.d.ts
+++ b/types/react-native/v0.64/index.d.ts
@@ -450,7 +450,7 @@ export interface PressableAndroidRippleConfig {
     radius?: null | number | undefined;
 }
 
-export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'style' | 'hitSlop'> {
+export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'children' | 'style' | 'hitSlop'> {
     /**
      * Called when a single tap gesture is detected.
      */

--- a/types/react-native/v0.65/index.d.ts
+++ b/types/react-native/v0.65/index.d.ts
@@ -454,7 +454,7 @@ export interface PressableAndroidRippleConfig {
     foreground?: null | boolean | undefined;
 }
 
-export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'style' | 'hitSlop'> {
+export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'children' | 'style' | 'hitSlop'> {
     /**
      * Called when a single tap gesture is detected.
      */


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

The changes all fix intersections of `ReactNode` with render-props. This only passed because render-props were assignable to `{}`.

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210