### PR TITLE
[react-form] Correctly extend FieldProps in RadioGroup

### DIFF
--- a/types/react-form/v2/index.d.ts
+++ b/types/react-form/v2/index.d.ts
@@ -157,7 +157,7 @@ export interface RadioGroupContext {
 
 export class RadioGroup
     extends React.Component<
-        FieldProps & { children?: ((props: FieldApi) => RenderReturn) | RenderReturn | undefined }
+        Omit<FieldProps, 'children'> & { children?: ((props: FieldApi) => RenderReturn) | RenderReturn | undefined }
         >
     implements React.ChildContextProvider<RadioGroupContext> {
     getChildContext(): {
@@ -184,7 +184,7 @@ export const StyledRadio: React.FunctionComponent<StyledProps & React.InputHTMLA
 
 export class StyledRadioGroup
     extends React.Component<
-        StyledProps & { children?: ((props: FieldApi) => RenderReturn) | RenderReturn | undefined }
+        Omit<StyledProps, 'children'> & { children?: ((props: FieldApi) => RenderReturn) | RenderReturn | undefined }
         >
     implements React.ChildContextProvider<RadioGroupContext> {
     getChildContext(): {


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210