### PR TITLE
[react-aria-menubutton] Correctly extend HTMLProps in MenuProps

### DIFF
--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -80,7 +80,7 @@ export interface ButtonProps<T extends HTMLElement>
 export const Button: React.ForwardRefExoticComponent<ButtonProps<HTMLElement>>;
 
 export interface MenuProps<T extends HTMLElement>
-    extends React.HTMLProps<T> {
+    extends Omit<React.HTMLProps<T>, 'children'> {
     /**
      * The HTML tag for this element. Default: 'div'.
      */


### PR DESCRIPTION
We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210