### PR TITLE
update(write-file-atomic): v4 bump and missing `tmpfileCreated`

### DIFF
--- a/types/write-file-atomic/index.d.ts
+++ b/types/write-file-atomic/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for write-file-atomic 3.0
+// Type definitions for write-file-atomic 4.0
 // Project: https://github.com/npm/write-file-atomic
 // Definitions by: BendingBender <https://github.com/BendingBender>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
@@ -8,23 +8,35 @@
 
 export = writeFile;
 
-declare function writeFile(filename: string, data: string | Buffer, options: writeFile.Options | BufferEncoding, callback: (error?: Error) => void): void;
+declare function writeFile(
+    filename: string,
+    data: string | Buffer,
+    options: writeFile.Options | BufferEncoding,
+    callback: (error?: Error) => void,
+): void;
 declare function writeFile(filename: string, data: string | Buffer, callback: (error?: Error) => void): void;
-declare function writeFile(filename: string, data: string | Buffer, options?: writeFile.Options | BufferEncoding): Promise<void>;
+declare function writeFile(
+    filename: string,
+    data: string | Buffer,
+    options?: writeFile.Options | BufferEncoding,
+): Promise<void>;
 
 declare namespace writeFile {
     function sync(filename: string, data: string | Buffer, options?: Options | BufferEncoding): void;
 
     interface Options {
-        chown?: {
-            uid: number;
-            gid: number;
-        } | undefined;
+        chown?:
+            | {
+                  uid: number;
+                  gid: number;
+              }
+            | undefined;
         /**
          * @default 'utf8'
          */
         encoding?: BufferEncoding | undefined;
         fsync?: boolean | undefined;
         mode?: number | undefined;
+        tmpfileCreated?: ((tmpfile: string) => void) | undefined;
     }
 }

--- a/types/write-file-atomic/write-file-atomic-tests.ts
+++ b/types/write-file-atomic/write-file-atomic-tests.ts
@@ -2,18 +2,29 @@ import writeFileAtomic = require('write-file-atomic');
 
 writeFileAtomic('message.txt', 'Hello Node', err => {});
 
-writeFileAtomic('message.txt', 'Hello Node', {chown: {uid: 100, gid: 50}}, err => {});
-writeFileAtomic('message.txt', 'Hello Node', {fsync: false}, err => {});
-writeFileAtomic('message.txt', 'Hello Node', {mode: 123}, err => {});
+writeFileAtomic('message.txt', 'Hello Node', { chown: { uid: 100, gid: 50 } }, err => {});
+writeFileAtomic('message.txt', 'Hello Node', { fsync: false }, err => {});
+writeFileAtomic('message.txt', 'Hello Node', { mode: 123 }, err => {});
 writeFileAtomic('message.txt', 'Hello Node', 'utf8', err => {});
 
-writeFileAtomic('message.txt', 'Hello Node').then(() => {}).catch(() => {});
-writeFileAtomic('message.txt', 'Hello Node', {mode: 123}).then(() => {}).catch(() => {});
-writeFileAtomic('message.txt', 'Hello Node', 'utf8').then(() => {}).catch(() => {});
+writeFileAtomic('message.txt', 'Hello Node')
+    .then(() => {})
+    .catch(() => {});
+writeFileAtomic('message.txt', 'Hello Node', { mode: 123 })
+    .then(() => {})
+    .catch(() => {});
+writeFileAtomic('message.txt', 'Hello Node', 'utf8')
+    .then(() => {})
+    .catch(() => {});
 
 writeFileAtomic.sync('message.txt', 'Hello Node');
 
-writeFileAtomic.sync('message.txt', 'Hello Node', {chown: {uid: 100, gid: 50}});
-writeFileAtomic.sync('message.txt', 'Hello Node', {fsync: false});
-writeFileAtomic.sync('message.txt', 'Hello Node', {mode: 123});
+writeFileAtomic.sync('message.txt', 'Hello Node', { chown: { uid: 100, gid: 50 } });
+writeFileAtomic.sync('message.txt', 'Hello Node', { fsync: false });
+writeFileAtomic.sync('message.txt', 'Hello Node', { mode: 123 });
+writeFileAtomic.sync('message.txt', 'Hello Node', {
+    tmpfileCreated(tmpfile) {
+        tmpfile; // $ExpectType string
+    },
+});
 writeFileAtomic.sync('message.txt', 'Hello Node', 'utf8');


### PR DESCRIPTION
- added missing `tmpfileCreated` callback option
- version bump to v4
- DT formatting applied

https://github.com/npm/write-file-atomic/releases/tag/v4.0.0
https://github.com/npm/write-file-atomic#option://github.com/npm/write-file-atomic#options

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.