### PR TITLE
[lodash-es] Add missing `chain` export

### DIFF
--- a/types/lodash-es/chain.d.ts
+++ b/types/lodash-es/chain.d.ts
@@ -1,0 +1,2 @@
+import { chain } from "lodash";
+export default chain;

--- a/types/lodash-es/index.d.ts
+++ b/types/lodash-es/index.d.ts
@@ -21,6 +21,7 @@ export { default as camelCase } from "./camelCase";
 export { default as capitalize } from "./capitalize";
 export { default as castArray } from "./castArray";
 export { default as ceil } from "./ceil";
+export { default as chain } from "./chain";
 export { default as chunk } from "./chunk";
 export { default as clamp } from "./clamp";
 export { default as clone } from "./clone";

--- a/types/lodash-es/lodash-es-tests.ts
+++ b/types/lodash-es/lodash-es-tests.ts
@@ -15,6 +15,7 @@ import camelCase from "lodash-es/camelCase";
 import capitalize from "lodash-es/capitalize";
 import castArray from "lodash-es/castArray";
 import ceil from "lodash-es/ceil";
+import chain from "lodash-es/chain";
 import chunk from "lodash-es/chunk";
 import clamp from "lodash-es/clamp";
 import clone from "lodash-es/clone";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lodash/lodash/blob/4.17.21-es/lodash.js#L27

---

Adds a missing `chain` export. Note, the export is not new- it has been exported since `lodash-es` v4.13 (DefinitelyTyped header currently points at 4.14).

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52919