### PR TITLE
[superagent] Fix `Blob` error

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -20,6 +20,7 @@ import * as fs from "fs";
 import * as http from "http";
 import * as stream from "stream";
 import * as cookiejar from "cookiejar";
+import { Blob } from "buffer";
 
 type CallbackHandler = (err: any, res: request.Response) => void;
 

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -3,6 +3,7 @@ import request = require("superagent");
 import * as fs from "fs";
 import assert = require("assert");
 import { Agent } from "https";
+import { Blob } from "buffer";
 
 // Examples taken from https://github.com/visionmedia/superagent/blob/gh-pages/docs/index.md
 // and https://github.com/visionmedia/superagent/blob/master/Readme.md
@@ -219,7 +220,7 @@ request.get("http://example.com/search").retry(2, callback).end(callback);
 })();
 
 // Attaching files
-declare const blob: Blob;
+const blob = new Blob([]);
 request
     .post("/upload")
     .attach("avatar", "path/to/tobi.png", "user.png")

--- a/types/superagent/tslint.json
+++ b/types/superagent/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "no-outside-dependencies": false
+    }
+}


### PR DESCRIPTION
At the moment, some users' builds fail, because `Blob` isn't defined as
a global in Node.js - it sits in the [`buffer`][1] package.

This change adds an import from `buffer` to fix this issue.

Note that I think the build was incorrectly passing before because of
a [leaky interface in `stream/consumers`][2].

Note that I've had to disable the linter's `no-outside-dependencies`
because of a [known false positive on `buffer`][3].

[1]: https://nodejs.org/api/buffer.html#class-blob
[2]: #55311 (comment)
[3]: microsoft/dtslint#315

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
