### PR TITLE
update(webpack-assets-manifest): v5.1 and `extra` option

### DIFF
--- a/types/webpack-assets-manifest/index.d.ts
+++ b/types/webpack-assets-manifest/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for webpack-assets-manifest 5.0
+// Type definitions for webpack-assets-manifest 5.1
 // Project: https://github.com/webdeveric/webpack-assets-manifest
 // Definitions by: Franklin Tse <https://github.com/FranklinWhale>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
 
 /// <reference types="node" />
+
 import { Asset, Compilation, Compiler, LoaderContext, Module, Stats, WebpackPluginInstance } from 'webpack';
 import { AsyncSeriesHook, SyncHook, SyncWaterfallHook } from 'tapable';
 
@@ -235,6 +235,11 @@ declare namespace WebpackAssetsManifest {
 
         /** https://github.com/webdeveric/webpack-assets-manifest#integritypropertyname */
         integrityPropertyName?: string | undefined;
+        /**
+         * A place to put your arbitrary data
+         * @default {}
+         */
+        extra?: Record<string, unknown> | undefined;
     }
 
     interface Entry {
@@ -242,9 +247,7 @@ declare namespace WebpackAssetsManifest {
         value: string;
     }
 
-    interface Assets {
-        [key: string]: unknown;
-    }
+    interface Assets extends Record<string, unknown> {}
 }
 
 export = WebpackAssetsManifest;

--- a/types/webpack-assets-manifest/webpack-assets-manifest-tests.ts
+++ b/types/webpack-assets-manifest/webpack-assets-manifest-tests.ts
@@ -11,6 +11,7 @@ new WebpackAssetsManifest({
             value: asset && asset.info.integrity,
         };
     },
+    extra: {},
 });
 
 /** https://github.com/webdeveric/webpack-assets-manifest/blob/master/examples/aws-s3-data-integrity.js */
@@ -25,6 +26,9 @@ new WebpackAssetsManifest({
             key: entry.value,
             value: asset && asset.info.md5.substr(4),
         };
+    },
+    extra: {
+        test: true,
     },
 });
 


### PR DESCRIPTION
- `extra` options property
- version bump
- unified interface for objects `Record<string, unknown>`

https://github.com/webdeveric/webpack-assets-manifest/releases/tag/v5.1.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.