### PR TITLE
react-native-video-player: inherit props from react-native-video

### DIFF
--- a/types/react-native-video-player/index.d.ts
+++ b/types/react-native-video-player/index.d.ts
@@ -1,22 +1,22 @@
 // Type definitions for react-native-video-player 0.10
 // Project: https://github.com/cornedor/react-native-video-player.git
 // Definitions by: Junseong Park <https://github.com/Kweiza>
+//                 mike castleman <https://github.com/mlc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as React from 'react';
 import { ImageSourcePropType, StyleProp, ViewStyle, TextStyle, ImageStyle } from 'react-native';
 import { VideoProperties } from 'react-native-video';
-import Icon from 'react-native-vector-icons/MaterialIcons';
 
-export interface VideoPlayerProps {
+export interface VideoPlayerProps extends Omit<VideoProperties, 'source'> {
     video?: { uri?: string | undefined, mainVer?: number | undefined, patchVer?: number | undefined } | number | undefined;
     thumbnail?: ImageSourcePropType | undefined;
     endThumbnail?: ImageSourcePropType | undefined;
     videoWidth?: number | undefined;
     videoHeight?: number | undefined;
     duration?: number | undefined;
+    showDuration?: boolean;
     autoplay?: boolean | undefined;
-    paused?: boolean | undefined;
     defaultMuted?: boolean | undefined;
     muted?: boolean | undefined;
     style?: StyleProp<ViewStyle> | undefined;
@@ -24,7 +24,6 @@ export interface VideoPlayerProps {
     disableControlsAutoHide?: boolean | undefined;
     disableFullscreen?: boolean | undefined;
     loop?: boolean | undefined;
-    resizeMode?: 'stretch' | 'contain' | 'cover' | 'none' | undefined;
     hideControlsOnStart?: boolean | undefined;
     endWithThumbnail?: boolean | undefined;
     disableSeek?: boolean | undefined;
@@ -49,9 +48,6 @@ export interface VideoPlayerProps {
         playButton?: StyleProp<ViewStyle> | undefined;
         playArrow?: StyleProp<TextStyle> | undefined;
     } | undefined;
-    onEnd?: ((event: any) => any) | undefined;
-    onProgress?: ((event: any) => any) | undefined;
-    onLoad?: ((event: any) => any) | undefined;
     onStart?: (() => any) | undefined;
     onPlayPress?: (() => any) | undefined;
     onHideControls?: (() => any) | undefined;

--- a/types/react-native-video-player/react-native-video-player-tests.tsx
+++ b/types/react-native-video-player/react-native-video-player-tests.tsx
@@ -7,4 +7,5 @@ import VideoPlayer from 'react-native-video-player';
     video={{ uri: 'sample.mp4' }}
     videoWidth={1280}
     videoHeight={720}
+    ignoreSilentSwitch="ignore"
 />;


### PR DESCRIPTION
This modifies the type definitions for `react-native-video-player` to inherit from `react-native-video`, so that any additional props can be used.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cornedor/react-native-video-player#props
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
