### PR TITLE
[bootstrap] fix toggleEnabled property

### DIFF
--- a/types/bootstrap/js/dist/popover.d.ts
+++ b/types/bootstrap/js/dist/popover.d.ts
@@ -77,7 +77,7 @@ declare class Popover extends BaseComponent {
     /**
      * Toggles the ability for an element’s popover to be shown or hidden.
      */
-    toggleEnable(): void;
+    toggleEnabled(): void;
 
     /**
      * Updates the position of an element’s popover.
@@ -153,7 +153,7 @@ declare namespace Popover {
             | 'toggle'
             | 'enable'
             | 'disable'
-            | 'toggleEnable'
+            | 'toggleEnabled'
             | 'update'
             | 'dispose',
     ) => void;

--- a/types/bootstrap/test/popover-tests.ts
+++ b/types/bootstrap/test/popover-tests.ts
@@ -81,5 +81,5 @@ $('.alert').popover('hide'); // $ExpectType void
 $('.alert').popover('toggle'); // $ExpectType void
 $('.alert').popover('enable'); // $ExpectType void
 $('.alert').popover('disable'); // $ExpectType void
-$('.alert').popover('toggleEnable'); // $ExpectType void
+$('.alert').popover('toggleEnabled'); // $ExpectType void
 $('.alert').popover('update'); // $ExpectType void


### PR DESCRIPTION
The property to enable/disable toggle is called "toggleEnabled", not "toggleEnable".

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test bootstrap`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://getbootstrap.com/docs/5.1/components/popovers/#toggleenabled)

