### PR TITLE
[video.js] Add type definition for player.audioTracks() and AudioTrackList

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -654,7 +654,7 @@ declare namespace videojs {
          * Add a {@link VideojsAudioTrack} to the `AudioTrackList`
          *
          * @param track
-         *        The text track to add to the list.
+         *        The audio track to add to the list.
          *
          * @fires TrackList#addtrack
          */

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -633,13 +633,32 @@ declare namespace videojs {
         new (player: Player, options?: AudioTrackMenuItemOptions): AudioTrackMenuItem;
     };
 
-    interface VideojsAudioTrack {
+    interface VideojsAudioTrack extends Track {
         enabled: boolean;
         readonly id: string;
         kind: string;
         readonly label: string;
         language: string;
         readonly sourceBuffer: SourceBuffer | null;
+    }
+
+    /**
+     * The current list of {@link VideojsAudioTrack} for a media file.
+     *
+     * @see [Spec]{@link https://html.spec.whatwg.org/multipage/media.html#audiotracklist}
+     */
+     interface AudioTrackList extends TrackList {
+        [index: number]: VideojsAudioTrack;
+
+        /**
+         * Add a {@link VideojsAudioTrack} to the `AudioTrackList`
+         *
+         * @param track
+         *        The text track to add to the list.
+         *
+         * @fires TrackList#addtrack
+         */
+        addTrack(track: VideojsAudioTrack): void;
     }
 
     interface AudioTrackMenuItemOptions extends MenuItemOptions {
@@ -6096,6 +6115,12 @@ export interface VideoJsPlayer extends videojs.Component {
      * @return The current remote text track list
      */
     textTracks(): TextTrackList;
+
+    /**
+     * Get the remote {@link videojs.AudioTrackList}
+     * @return The current remote text track list
+     */
+    audioTracks(): videojs.AudioTrackList;
 
     /**
      * Get the remote {@link TextTrackList}

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -6118,7 +6118,7 @@ export interface VideoJsPlayer extends videojs.Component {
 
     /**
      * Get the remote {@link videojs.AudioTrackList}
-     * @return The current remote text track list
+     * @return The current remote audio track list
      */
     audioTracks(): videojs.AudioTrackList;
 

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -182,6 +182,8 @@ videojs('example_video_1', playerOptions).ready(function playerReady() {
 
     // $ExpectType CanPlayTypeResult
     this.canPlayType('video/mp4');
+
+    testTracks(this);
 });
 
 function testEvents(player: videojs.Player) {
@@ -320,4 +322,12 @@ function testTech() {
     );
     // $ExpectType CanPlayTypeResult
     videojs.Tech.canPlayType('video/mp4');
+}
+
+function testTracks(player: VideoJsPlayer) {
+    // $ExpectType AudioTrackList
+    player.audioTracks();
+
+    // $ExpectType TextTrackList
+    player.textTracks();
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [video.js audio tracks tutorial](https://docs.videojs.com/tutorial-audio-tracks.html)
  - In the second code snippet, `player.audioTracks()` would be typed as `any` with the current configuration
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
