### PR TITLE
[luxon] add Interval constructor definition

### DIFF
--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -6,6 +6,10 @@ export interface IntervalObject {
     end?: DateTime | undefined;
 }
 
+export interface IntervalConfig extends IntervalObject {
+    invalid?: boolean;
+}
+
 export type DateInput = DateTime | DateObjectUnits | Date;
 
 /**
@@ -25,6 +29,8 @@ export type DateInput = DateTime | DateObjectUnits | Date;
  * * {@link Interval#toFormat}, and {@link Interval#toDuration}.
  */
 export class Interval {
+    constructor(config: IntervalConfig);
+
     /**
      * Create an invalid Interval.
      *

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -252,6 +252,8 @@ if (Interval.isInterval(anything)) {
 Interval.invalid(); // $ExpectError
 Interval.invalid('code', 'because I said so'); // $ExpectType Interval
 Interval.isInterval(0 as unknown); // $ExpectType boolean
+new Interval(); // $ExpectError
+new Interval({}); // $ExpectType Interval
 
 /* Info */
 Info.months();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Luxon Interval constructor](https://github.com/moment/luxon/blob/master/src/interval.js#L41-L58)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (did not change header since I'm not sure of other needed changes to update to 2.3.0; this change is good for 2.0 through current master branch)
