### PR TITLE
[react-relay] Preserve defaultProps optionality when using createFragmentContainer, createPaginationContainer and createRefetchContainer

### DIFF
--- a/types/react-relay/legacy.d.ts
+++ b/types/react-relay/legacy.d.ts
@@ -13,12 +13,7 @@ import {
     FetchPolicy,
 } from 'relay-runtime';
 
-export {
-    FragmentRef,
-    RelayPaginationProp,
-    RelayProp,
-    RelayRefetchProp,
-} from './ReactRelayTypes';
+export { FragmentRef, RelayPaginationProp, RelayProp, RelayRefetchProp } from './ReactRelayTypes';
 
 import { RelayProp, MappedFragmentProps, RelayRefetchProp, RelayPaginationProp } from './ReactRelayTypes';
 
@@ -60,12 +55,12 @@ declare class ReactRelayQueryRenderer<TOperation extends OperationType> extends 
         cacheConfig?: CacheConfig | null | undefined;
         fetchPolicy?: FetchPolicy | undefined;
     } & QueryRendererProps<TOperation>
-    > { }
+> {}
 export { ReactRelayQueryRenderer as QueryRenderer };
 
 declare class ReactRelayLocalQueryRenderer<TOperation extends OperationType> extends React.Component<
     QueryRendererProps<TOperation>
-    > { }
+> {}
 export { ReactRelayLocalQueryRenderer as LocalQueryRenderer };
 
 export { MutationTypes } from 'relay-runtime';
@@ -79,7 +74,9 @@ export { commitMutation } from 'relay-runtime';
 
 export type ContainerProps<Props> = MappedFragmentProps<Pick<Props, Exclude<keyof Props, 'relay'>>>;
 export type RelayProps<Props> = ContainerProps<Props>; // TODO: validate this
-export type Container<Props> = React.ComponentType<ContainerProps<Props> & { componentRef?: ((ref: any) => void) | undefined }>;
+export type Container<Props> = React.ComponentType<
+    ContainerProps<Props> & { componentRef?: ((ref: any) => void) | undefined }
+>;
 
 // TODO: validate the bellow three
 export type RelayFragmentContainer<TComponent extends React.ElementType> = React.ComponentType<
@@ -94,10 +91,12 @@ export type RelayRefetchContainer<TComponent extends React.ElementType> = React.
     ContainerProps<React.ComponentPropsWithoutRef<TComponent>>
 >;
 
-export function createFragmentContainer<Props>(
-    Component: React.ComponentType<Props & { relay?: RelayProp | undefined }>,
-    fragmentSpec: Record<string, GraphQLTaggedNode>,
-): Container<Props>;
+type PropsWithoutRelay<C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>> =
+    JSX.LibraryManagedAttributes<C, Omit<React.ComponentProps<C>, 'relay'>>;
+
+export function createFragmentContainer<
+    C extends React.ComponentType<React.ComponentProps<C> & { relay?: RelayProp | undefined }>,
+>(Component: C, fragmentSpec: Record<string, GraphQLTaggedNode>): Container<PropsWithoutRelay<C>>;
 
 export { fetchQuery_DEPRECATED } from 'relay-runtime';
 
@@ -105,25 +104,21 @@ export { graphql } from 'relay-runtime';
 export { readInlineData } from 'relay-runtime';
 export { requestSubscription } from 'relay-runtime';
 
-export function createPaginationContainer<Props>(
-    Component: React.ComponentType<
-        Props & {
-            relay: RelayPaginationProp;
-        }
-    >,
+export function createPaginationContainer<
+    C extends React.ComponentType<React.ComponentProps<C> & { relay: RelayPaginationProp }>,
+>(
+    Component: C,
     fragmentSpec: Record<string, GraphQLTaggedNode>,
-    connectionConfig: ConnectionConfig<Props>,
-): Container<Props>;
+    connectionConfig: ConnectionConfig<PropsWithoutRelay<C>>,
+): Container<PropsWithoutRelay<C>>;
 
-export function createRefetchContainer<Props>(
-    Component: React.ComponentType<
-        Props & {
-            relay: RelayRefetchProp;
-        }
-    >,
+export function createRefetchContainer<
+    C extends React.ComponentType<React.ComponentProps<C> & { relay: RelayRefetchProp }>,
+>(
+    Component: C,
     fragmentSpec: Record<string, GraphQLTaggedNode>,
     refetchQuery: GraphQLTaggedNode,
-): Container<Props>;
+): Container<PropsWithoutRelay<C>>;
 
 export interface ConnectionConfig<Props = object> {
     direction?: 'backward' | 'forward' | undefined;

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -172,6 +172,7 @@ const Story = (() => {
         story: Story_story;
         onLike: StoryLike;
         ignoreMe?: {} | undefined;
+        defaultProp: string;
     }
 
     interface State {
@@ -179,6 +180,10 @@ const Story = (() => {
     }
 
     class Story extends React.Component<Props> {
+        static defaultProps = {
+            defaultProp: 'default',
+        };
+
         state = {
             isLoading: false,
         };
@@ -424,9 +429,14 @@ type UserFeed_user = {
         loadMoreTitle: string;
         user: UserFeed_user;
         ignoreMe?: {} | undefined;
+        defaultProp: string;
     }
 
     class UserFeed extends React.Component<Props> {
+        static defaultProps = {
+            defaultProp: 'default',
+        };
+
         render() {
             const onStoryLike = (id: string) => console.log(`Liked story #${id}`);
             return (


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

This PR fixes an issue with the definition of `createFragmentContainer`, `createPaginationContainer` and `createRefetchContainer` where they would not preserve the optionality of `defaultProps` of wraped components.