### PR TITLE
[react-grid-layout] Fix innerRef prop type

### DIFF
--- a/types/react-grid-layout/index.d.ts
+++ b/types/react-grid-layout/index.d.ts
@@ -307,7 +307,7 @@ declare namespace ReactGridLayout {
          * Ref for getting a reference for the grid's wrapping div.
          * You can use this instead of a regular ref and the deprecated `ReactDOM.findDOMNode()`` function.
          */
-        innerRef?: React.Ref<"div">;
+        innerRef?: React.Ref<HTMLDivElement>;
     }
 
     interface ReactGridLayoutProps extends CoreProps {

--- a/types/react-grid-layout/react-grid-layout-tests.tsx
+++ b/types/react-grid-layout/react-grid-layout-tests.tsx
@@ -94,3 +94,15 @@ class ResponsiveGridWidthProviderTest extends React.Component {
         );
     }
 }
+
+class InnerRefObjectTest extends React.Component {
+    render() {
+        return <ReactGridLayout innerRef={React.createRef<HTMLDivElement>()} />;
+    }
+}
+
+class InnerRefCallbackTest extends React.Component {
+    render() {
+        return <ReactGridLayout innerRef={(_: HTMLDivElement) => {}} />;
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [react-grid-layout issue](https://github.com/react-grid-layout/react-grid-layout/issues/1648#issuecomment-1018242279)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

The [`Ref<"div">` used in the `react-grid-layout` source](https://github.com/react-grid-layout/react-grid-layout/blob/1.3.1/lib/ReactGridLayoutPropTypes.js#L94) is actually [a Flow type](https://github.com/facebook/flow/blob/v0.158/lib/react.js#L213-L216), (roughly) equivalent to `React.Ref<HTMLDivElement>` rather than a ref to the literal string `"div"`.