### PR TITLE
Add Vimeo player event types

### DIFF
--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -10,36 +10,95 @@
 
 export type CallbackFunction = (...args: any[]) => any;
 
-export interface Error {name: string; message: string; method: string; }
+export interface Error {
+    name: string;
+    message: string;
+    method: string;
+}
 
-export interface PasswordError extends Error {name: "PasswordError"; message: string; method: string; }
-export interface PrivacyError extends Error {name: "PrivacyError"; message: string; method: string; }
-export interface InvalidTrackLanguageError extends Error {name: "InvalidTrackLanguageError"; message: string; method: string; }
-export interface InvalidTrackError extends Error {name: "InvalidTrackError"; message: string; method: string; }
-export interface UnsupportedError extends Error {name: "UnsupportedError"; message: string; method: string; }
-export interface ContrastError extends Error {name: "ContrastError"; message: string; method: string; }
-export interface InvalidCuePoint extends Error {name: "InvalidCuePoint"; message: string; method: string; }
-export interface RangeError extends Error {name: "RangeError"; message: string; method: string; }
-export interface TypeError extends Error {name: "TypeError"; message: string; method: string; }
+export interface PasswordError extends Error {
+    name: 'PasswordError';
+    message: string;
+    method: string;
+}
+export interface PrivacyError extends Error {
+    name: 'PrivacyError';
+    message: string;
+    method: string;
+}
+export interface InvalidTrackLanguageError extends Error {
+    name: 'InvalidTrackLanguageError';
+    message: string;
+    method: string;
+}
+export interface InvalidTrackError extends Error {
+    name: 'InvalidTrackError';
+    message: string;
+    method: string;
+}
+export interface UnsupportedError extends Error {
+    name: 'UnsupportedError';
+    message: string;
+    method: string;
+}
+export interface ContrastError extends Error {
+    name: 'ContrastError';
+    message: string;
+    method: string;
+}
+export interface InvalidCuePoint extends Error {
+    name: 'InvalidCuePoint';
+    message: string;
+    method: string;
+}
+export interface RangeError extends Error {
+    name: 'RangeError';
+    message: string;
+    method: string;
+}
+export interface TypeError extends Error {
+    name: 'TypeError';
+    message: string;
+    method: string;
+}
 
-export type EventName = "play" | "pause" | "ended" | "timeupdate" | "progress" | "seeked" | "seeking" | "texttrackchange" |
-                        "cuechange" | "cuepoint" | "volumechange" | "playbackratechange" | "bufferstart" | "bufferend" | "error" | "loaded" |  string;
+export type EventName =
+    | 'play'
+    | 'pause'
+    | 'ended'
+    | 'timeupdate'
+    | 'progress'
+    | 'seeked'
+    | 'seeking'
+    | 'texttrackchange'
+    | 'cuechange'
+    | 'cuepoint'
+    | 'volumechange'
+    | 'playbackratechange'
+    | 'bufferstart'
+    | 'bufferend'
+    | 'error'
+    | 'loaded'
+    | string;
 export type EventCallback = (data: any) => any;
 
 export type VimeoTimeRange = [number, number];
-export type VimeoVideoQuality = "4K" | "2K" | "1080p" | "720p" | "540p" | "360p" | "240p";
+export type VimeoVideoQuality = '4K' | '2K' | '1080p' | '720p' | '540p' | '360p' | '240p';
 
 export class Player {
-    constructor(element: HTMLIFrameElement|HTMLElement|string, options?: Options);
+    constructor(element: HTMLIFrameElement | HTMLElement | string, options?: Options);
 
     on(event: EventName, callback: EventCallback): void;
     off(event: EventName, callback?: EventCallback): void;
     loadVideo(id: number | string): VimeoPromise<number, TypeError | PasswordError | PrivacyError | Error>;
     ready(): VimeoPromise<void, Error>;
-    enableTextTrack(language: string, kind?: string): VimeoPromise<VimeoTextTrack, InvalidTrackLanguageError | InvalidTrackError | Error>;
+    enableTextTrack(
+        language: string,
+        kind?: string,
+    ): VimeoPromise<VimeoTextTrack, InvalidTrackLanguageError | InvalidTrackError | Error>;
     disableTextTrack(): VimeoPromise<void, Error>;
-    pause(): VimeoPromise<void, PasswordError | PrivacyError |Error>;
-    play(): VimeoPromise<void, PasswordError | PrivacyError |Error>;
+    pause(): VimeoPromise<void, PasswordError | PrivacyError | Error>;
+    play(): VimeoPromise<void, PasswordError | PrivacyError | Error>;
     unload(): VimeoPromise<void, Error>;
     getAutopause(): VimeoPromise<boolean, UnsupportedError | Error>;
     setAutopause(autopause: boolean): VimeoPromise<boolean, UnsupportedError | Error>;
@@ -119,10 +178,7 @@ export interface Options {
 }
 
 export interface VimeoPromise<Result, Reason> extends Promise<Result> {
-    (
-        successCallback?: (promiseValue: Result) => void,
-        rejectCallback?: (reasonValue: Reason) => void
-    ): Promise<Result>;
+    (successCallback?: (promiseValue: Result) => void, rejectCallback?: (reasonValue: Reason) => void): Promise<Result>;
 }
 
 /*~ You can declare properties of the module using const, let, or var */

--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -8,6 +8,8 @@
 //                 Kohei Watanabe <https://github.com/kou029w>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export type TrackKind = 'captions' | 'subtitles';
+
 export type CallbackFunction = (...args: any[]) => any;
 
 export interface Error {
@@ -62,25 +64,226 @@ export interface TypeError extends Error {
     method: string;
 }
 
-export type EventName =
-    | 'play'
-    | 'pause'
-    | 'ended'
-    | 'timeupdate'
-    | 'progress'
-    | 'seeked'
-    | 'seeking'
-    | 'texttrackchange'
-    | 'cuechange'
-    | 'cuepoint'
-    | 'volumechange'
-    | 'playbackratechange'
-    | 'bufferstart'
-    | 'bufferend'
-    | 'error'
-    | 'loaded'
-    | string;
-export type EventCallback = (data: any) => any;
+export interface TimeEvent {
+    duration: number;
+    percent: number;
+    seconds: number;
+}
+
+export interface TextTrackChangeEvent {
+    kind: TrackKind | null;
+    label: string | null;
+    language: string | null;
+}
+
+export interface ChapterChangeEvent {
+    startTime: number;
+    title: string;
+
+    /**
+     * The `index` property of each chapter is the place it holds in the order of all the chapters. It starts at 1.
+     */
+    index: number;
+}
+
+export interface Cue {
+    /**
+     * The `html` property contains the HTML that the Player renders for that cue.
+     */
+    html: string;
+
+    /**
+     * The `text` property of each cue is the raw value parsed from the caption or subtitle file.
+     */
+    text: string;
+}
+
+export interface CueChangeEvent {
+    cues: Cue[];
+    kind: TrackKind;
+    label: string;
+    language: string;
+}
+
+export interface CuePointEvent {
+    time: number;
+
+    /**
+     * The `data` property will be the custom data provided in the `addCuePoint()` call, or an empty object if none was provided.
+     */
+    data: VimeoCuePointData;
+    id: string;
+}
+
+export interface VolumeChangeEvent {
+    volume: number;
+}
+
+export interface PlaybackRateEvent {
+    playbackRate: number;
+}
+
+export interface LoadedEvent {
+    id: number;
+}
+
+export interface DurationChangeEvent {
+    duration: number;
+}
+
+export interface FullScreenChangeEvent {
+    fullscreen: boolean;
+}
+
+export interface QualityChangeEvent {
+    quality: VimeoVideoQuality;
+}
+
+export interface CameraChangeEvent {
+    yaw: number;
+    pitch: number;
+    roll: number;
+    fov: number;
+}
+
+export interface ResizeEvent {
+    videoWidth: number;
+    videoHeight: number;
+}
+
+export interface EventMap {
+    /**
+     * Triggered when video playback is initiated.
+     */
+    play: TimeEvent;
+
+    /**
+     * Triggered when the video starts playing.
+     */
+    playing: TimeEvent;
+
+    /**
+     * Triggered when the video pauses.
+     */
+    pause: TimeEvent;
+
+    /**
+     * Triggered any time the video playback reaches the end. _Note_: when loop is turned on, the ended `event` will not fire.
+     */
+    ended: TimeEvent;
+
+    /**
+     * Triggered as the `currentTime` of the video updates. It generally fires every 250ms, but it may vary depending on the browser.
+     */
+    timeupdate: TimeEvent;
+
+    /**
+     * Triggered as the video is loaded. Reports back the amount of the video that has been buffered.
+     */
+    progress: TimeEvent;
+
+    /**
+     * Triggered when the player starts seeking to a specific time. A `timeupdate` event will also be fired at the same time.
+     */
+    seeking: TimeEvent;
+
+    /**
+     * Triggered when the player seeks to a specific time. A `timeupdate` event will also be fired at the same time.
+     */
+    seeked: TimeEvent;
+
+    /**
+     * Triggered when the active text track (captions/subtitles) changes. The values will be null if text tracks are turned off.
+     */
+    texttrackchange: TextTrackChangeEvent;
+
+    /**
+     * Triggered when the current chapter changes.
+     */
+    chapterchange: ChapterChangeEvent;
+
+    /**
+     * Triggered when the active cue for the current text track changes. It also fires when the active text track changes. There may be multiple cues active.
+     */
+    cuechange: CueChangeEvent;
+
+    /**
+     * Triggered when the current time hits a registered cue point.
+     */
+    cuepoint: CuePointEvent;
+
+    /**
+     * Triggered when the volume in the player changes. Some devices do not support setting the volume of the video independently from the system volume, so this event will never fire on those
+     * devices.
+     */
+    volumechange: VolumeChangeEvent;
+
+    /**
+     * Triggered when the playback rate of the video in the player changes. The ability to change rate can be disabled by the creator and the event will not fire for those videos. The new playback
+     * rate is returned with the event.
+     */
+    playbackratechange: PlaybackRateEvent;
+
+    /**
+     * Triggered when buffering starts in the player. This is also triggered during preload and while seeking. There is no associated data with this event.
+     */
+    bufferstart: never;
+
+    /**
+     * Triggered when buffering ends in the player. This is also triggered at the end of preload and seeking. There is no associated data with this event.
+     */
+    bufferend: never;
+
+    /**
+     * Triggered when some kind of error is generated in the player. In general if you are using this API library, you should use `.catch()` on each method call instead of globally listening for
+     * error events.
+     *
+     * If the error was generated from a method call, the name of that method will be included.
+     */
+    error: Error;
+
+    /**
+     * Triggered when a new video is loaded in the player.
+     */
+    loaded: LoadedEvent;
+
+    /**
+     * Triggered when the duration attribute has been updated.
+     */
+    durationchange: DurationChangeEvent;
+
+    /**
+     * Triggered when the player enters or exits fullscreen.
+     */
+    fullscreenchange: FullScreenChangeEvent;
+
+    /**
+     * Triggered when the set quality changes.
+     */
+    qualitychange: QualityChangeEvent;
+
+    /**
+     * Triggered when any of the camera properties change for 360° videos.
+     */
+    camerachange: CameraChangeEvent;
+
+    /**
+     * Triggered when the intrinsic size of the media changes.
+     */
+    resize: ResizeEvent;
+
+    /**
+     * Triggered when the player enters picture-in-picture.
+     */
+    enterpictureinpicture: never;
+
+    /**
+     * Triggered when the player leaves picture-in-picture.
+     */
+    leavepictureinpicture: never;
+}
+
+export type EventCallback<Data = any> = (data: Data) => any;
 
 export type VimeoTimeRange = [number, number];
 export type VimeoVideoQuality = '4K' | '2K' | '1080p' | '720p' | '540p' | '360p' | '240p';
@@ -88,13 +291,15 @@ export type VimeoVideoQuality = '4K' | '2K' | '1080p' | '720p' | '540p' | '360p'
 export class Player {
     constructor(element: HTMLIFrameElement | HTMLElement | string, options?: Options);
 
-    on(event: EventName, callback: EventCallback): void;
-    off(event: EventName, callback?: EventCallback): void;
+    on<EventName extends keyof EventMap>(event: EventName, callback: EventCallback<EventMap[EventName]>): void;
+    on(event: string, callback?: EventCallback): void;
+    off<EventName extends keyof EventMap>(event: EventName, callback: EventCallback<EventMap[EventName]>): void;
+    off(event: string, callback?: EventCallback): void;
     loadVideo(id: number | string): VimeoPromise<number, TypeError | PasswordError | PrivacyError | Error>;
     ready(): VimeoPromise<void, Error>;
     enableTextTrack(
         language: string,
-        kind?: string,
+        kind?: TrackKind,
     ): VimeoPromise<VimeoTextTrack, InvalidTrackLanguageError | InvalidTrackError | Error>;
     disableTextTrack(): VimeoPromise<void, Error>;
     pause(): VimeoPromise<void, PasswordError | PrivacyError | Error>;
@@ -146,7 +351,7 @@ export interface VimeoCuePointData {
 
 export interface VimeoTextTrack {
     language: string;
-    kind: string;
+    kind: TrackKind;
     label: string;
     mode?: string | undefined;
 }

--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -292,7 +292,7 @@ export class Player {
     constructor(element: HTMLIFrameElement | HTMLElement | string, options?: Options);
 
     on<EventName extends keyof EventMap>(event: EventName, callback: EventCallback<EventMap[EventName]>): void;
-    on(event: string, callback?: EventCallback): void;
+    on(event: string, callback: EventCallback): void;
     off<EventName extends keyof EventMap>(event: EventName, callback: EventCallback<EventMap[EventName]>): void;
     off(event: string, callback?: EventCallback): void;
     loadVideo(id: number | string): VimeoPromise<number, TypeError | PasswordError | PrivacyError | Error>;

--- a/types/vimeo__player/vimeo__player-tests.ts
+++ b/types/vimeo__player/vimeo__player-tests.ts
@@ -2,7 +2,7 @@ import Player from '@vimeo/player';
 
 // based on README.md of @vimeo/player >> https://github.com/vimeo/player.js
 
-let player: Player ;
+let player: Player;
 
 player = new Player('handstick', {
     id: 19231868,
@@ -20,7 +20,7 @@ player = new Player('handstick', {
     portrait: true,
     speed: false,
     title: true,
-    transparent: true
+    transparent: true,
 });
 
 const onPlay = (data: any) => {
@@ -36,478 +36,592 @@ player.off('play', onPlay);
 // listeners.
 player.off('play');
 
-player.loadVideo(76979871).then((id) => {
-    // the video successfully loaded
-}).catch((error) => {
-    switch (error.name) {
-        case 'TypeError':
-            // the id was not a number
-            break;
+player
+    .loadVideo(76979871)
+    .then(id => {
+        // the video successfully loaded
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'TypeError':
+                // the id was not a number
+                break;
 
-        case 'PasswordError':
-            // the video is password-protected and the viewer needs to enter the
-            // password first
-            break;
+            case 'PasswordError':
+                // the video is password-protected and the viewer needs to enter the
+                // password first
+                break;
 
-        case 'PrivacyError':
-            // the video is password-protected or private
-            break;
+            case 'PrivacyError':
+                // the video is password-protected or private
+                break;
 
-        default:
-            // some other error occurred
-            break;
-    }
-});
+            default:
+                // some other error occurred
+                break;
+        }
+    });
 
-player.loadVideo('http://vimeo.com/video/76979871').then((id) => {
-    // the video successfully loaded
-}).catch((error) => {
-    switch (error.name) {
-        case 'TypeError':
-            // the id was not a number
-            break;
+player
+    .loadVideo('http://vimeo.com/video/76979871')
+    .then(id => {
+        // the video successfully loaded
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'TypeError':
+                // the id was not a number
+                break;
 
-        case 'PasswordError':
-            // the video is password-protected and the viewer needs to enter the
-            // password first
-            break;
+            case 'PasswordError':
+                // the video is password-protected and the viewer needs to enter the
+                // password first
+                break;
 
-        case 'PrivacyError':
-            // the video is password-protected or private
-            break;
+            case 'PrivacyError':
+                // the video is password-protected or private
+                break;
 
-        default:
-            // some other error occurred
-            break;
-    }
-});
+            default:
+                // some other error occurred
+                break;
+        }
+    });
 
 player.ready().then(() => {
     // the player is ready
 });
 
-player.enableTextTrack('en').then((track) => {
-    console.log(track.label);
-    console.log(track.kind);
-    console.log(track.language);
-    // track.language = the iso code for the language
-    // track.kind = 'captions' or 'subtitles'
-    // track.label = the human-readable label
-}).catch((error) => {
-    switch (error.name) {
-        case 'InvalidTrackLanguageError':
-            // no track was available with the specified language
-            break;
-
-        case 'InvalidTrackError':
-            // no track was available with the specified language and kind
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.disableTextTrack().then(() => {
-    // the track was disabled
-}).catch((error) => {
-    // an error occurred
-});
-
-player.pause().then(() => {
-    // the video was paused
-}).catch((error) => {
-    switch (error.name) {
-        case 'PasswordError':
-            // the video is password-protected and the viewer needs to enter the
-            // password first
-            break;
-
-        case 'PrivacyError':
-            // the video is private
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.play().then(() => {
-    // the video was played
-}).catch((error) => {
-    switch (error.name) {
-        case 'PasswordError':
-            // the video is password-protected and the viewer needs to enter the
-            // password first
-            break;
-
-        case 'PrivacyError':
-            // the video is private
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.unload().then(() => {
-    // the video was unloaded
-}).catch((error) => {
-    // an error occurred
-});
-
-player.getAutopause().then((autopause) => {
-    // autopause = whether autopause is turned on or off
-}).catch((error) => {
-    switch (error.name) {
-        case 'UnsupportedError':
-            // Autopause is not supported with the current player or browser
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.setAutopause(false).then((autopause) => {
-    // autopause was turned off
-}).catch((error) => {
-    switch (error.name) {
-        case 'UnsupportedError':
-            // Autopause is not supported with the current player or browser
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.getColor().then((color) => {
-    // color = the hex color of the player
-}).catch((error) => {
-    // an error occurred
-});
-
-player.setColor('#00adef').then((color) => {
-    // color was successfully set
-}).catch((error) => {
-    switch (error.name) {
-        case 'ContrastError':
-            // the color was set, but the contrast is outside of the acceptable
-            // range
-            break;
-
-        case 'TypeError':
-            // the string was not a valid hex or rgb color
-            break;
-
-        case 'EmbedSettingsError':
-            // the owner of the video has chosen to use a specific color
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.addCuePoint(15, {
-    customKey: 'customValue'
-}).then((id) => {
-    // cue point was added successfully
-}).catch((error) => {
-    switch (error.name) {
-        case 'UnsupportedError':
-            // cue points are not supported with the current player or browser
-            break;
-
-        case 'RangeError':
-            // the time was less than 0 or greater than the video’s duration
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.removeCuePoint('09ecf4e4-b587-42cf-ad9f-e666b679c9ab').then((id) => {
-    // cue point was removed successfully
-}).catch((error) => {
-    switch (error.name) {
-        case 'UnsupportedError':
-            // cue points are not supported with the current player or browser
-            break;
-
-        case 'InvalidCuePoint':
-            // a cue point with the id passed wasn’t found
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.getCuePoints().then((cuePoints) => {
-    // cuePoints = an array of cue point objects
-}).catch((error) => {
-    switch (error.name) {
-        case 'UnsupportedError':
-            // cue points are not supported with the current player or browser
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.getCurrentTime().then((seconds) => {
-    // seconds = the current playback position
-}).catch((error) => {
-    // an error occurred
-});
-
-player.setCurrentTime(30.456).then((seconds) => {
-    // seconds = the actual time that the player seeked to
-}).catch((error) => {
-    switch (error.name) {
-        case 'RangeError':
-            // the time was less than 0 or greater than the video’s duration
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.getDuration().then((duration) => {
-    // duration = the duration of the video in seconds
-}).catch((error) => {
-    // an error occurred
-});
-
-player.getEnded().then((ended) => {
-    // ended = whether or not the video has ended
-}).catch((error) => {
-    // an error occurred
-});
-
-player.getLoop().then((loop) => {
-    // loop = whether loop is turned on or not
-}).catch((error) => {
-    // an error occurred
-});
-
-player.setLoop(true).then((loop) => {
-    // loop was turned on
-}).catch((error) => {
-    // an error occurred
-});
-
-player.getMuted().then((muted) => {
-    // muted = whether muted is turned on or not
-}).catch((error) => {
-    // an error occurred
-});
-
-player.setMuted(true).then((muted) => {
-    // muted was turned on
-}).catch((error) => {
-    // an error occurred
-});
-
-player.getPaused().then((paused) => {
-    // paused = whether or not the player is paused
-}).catch((error) => {
-    // an error occurred
-});
-
-player.getPlaybackRate().then((playbackRate) => {
-   // playbackRate = a numeric value of the current playback rate
-}).catch((error) => {
-    // an error occurred
-});
-
-player.setPlaybackRate(0.5).then((playbackRate) => {
-    // playback rate was set
-}).catch((error) => {
-    switch (error.name) {
-        case 'RangeError':
-            // the playback rate was less than 0.5 or greater than 2
-            break;
-
-        default:
-            // some other error occurred
-            break;
-    }
-});
-
-player.getTextTracks().then((tracks) => {
-    // tracks = an array of track objects
-    tracks.forEach((track) => {
+player
+    .enableTextTrack('en')
+    .then(track => {
         console.log(track.label);
         console.log(track.kind);
         console.log(track.language);
-        console.log(track.mode);
+        // track.language = the iso code for the language
+        // track.kind = 'captions' or 'subtitles'
+        // track.label = the human-readable label
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'InvalidTrackLanguageError':
+                // no track was available with the specified language
+                break;
+
+            case 'InvalidTrackError':
+                // no track was available with the specified language and kind
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
     });
-}).catch((error) => {
-    // an error occurred
-    error.name;
-});
 
-player.getVideoEmbedCode().then((embedCode) => {
-    // embedCode = <iframe> embed code
-}).catch((error) => {
-    // an error occurred
-});
+player
+    .disableTextTrack()
+    .then(() => {
+        // the track was disabled
+    })
+    .catch(error => {
+        // an error occurred
+    });
 
-player.getVideoId().then((id) => {
-    // id = the video id
-}).catch((error) => {
-    // an error occurred
-});
+player
+    .pause()
+    .then(() => {
+        // the video was paused
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'PasswordError':
+                // the video is password-protected and the viewer needs to enter the
+                // password first
+                break;
 
-player.getVideoTitle().then((title) => {
-    // title = the title of the video
-}).catch((error) => {
-    // an error occurred
-});
+            case 'PrivacyError':
+                // the video is private
+                break;
 
-player.getVideoWidth().then((width) => {
-    // width = the width of the video that is currently playing
-}).catch((error) => {
-    // an error occurred
-});
+            default:
+                // some other error occurred
+                break;
+        }
+    });
 
-player.getVideoHeight().then((height) => {
-    // height = the height of the video that is currently playing
-}).catch((error) => {
-    // an error occurred
-});
+player
+    .play()
+    .then(() => {
+        // the video was played
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'PasswordError':
+                // the video is password-protected and the viewer needs to enter the
+                // password first
+                break;
 
-Promise.all([player.getVideoWidth(), player.getVideoHeight()]).then((dimensions) => {
+            case 'PrivacyError':
+                // the video is private
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
+    });
+
+player
+    .unload()
+    .then(() => {
+        // the video was unloaded
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getAutopause()
+    .then(autopause => {
+        // autopause = whether autopause is turned on or off
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'UnsupportedError':
+                // Autopause is not supported with the current player or browser
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
+    });
+
+player
+    .setAutopause(false)
+    .then(autopause => {
+        // autopause was turned off
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'UnsupportedError':
+                // Autopause is not supported with the current player or browser
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
+    });
+
+player
+    .getColor()
+    .then(color => {
+        // color = the hex color of the player
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .setColor('#00adef')
+    .then(color => {
+        // color was successfully set
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'ContrastError':
+                // the color was set, but the contrast is outside of the acceptable
+                // range
+                break;
+
+            case 'TypeError':
+                // the string was not a valid hex or rgb color
+                break;
+
+            case 'EmbedSettingsError':
+                // the owner of the video has chosen to use a specific color
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
+    });
+
+player
+    .addCuePoint(15, {
+        customKey: 'customValue',
+    })
+    .then(id => {
+        // cue point was added successfully
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'UnsupportedError':
+                // cue points are not supported with the current player or browser
+                break;
+
+            case 'RangeError':
+                // the time was less than 0 or greater than the video’s duration
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
+    });
+
+player
+    .removeCuePoint('09ecf4e4-b587-42cf-ad9f-e666b679c9ab')
+    .then(id => {
+        // cue point was removed successfully
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'UnsupportedError':
+                // cue points are not supported with the current player or browser
+                break;
+
+            case 'InvalidCuePoint':
+                // a cue point with the id passed wasn’t found
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
+    });
+
+player
+    .getCuePoints()
+    .then(cuePoints => {
+        // cuePoints = an array of cue point objects
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'UnsupportedError':
+                // cue points are not supported with the current player or browser
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
+    });
+
+player
+    .getCurrentTime()
+    .then(seconds => {
+        // seconds = the current playback position
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .setCurrentTime(30.456)
+    .then(seconds => {
+        // seconds = the actual time that the player seeked to
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'RangeError':
+                // the time was less than 0 or greater than the video’s duration
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
+    });
+
+player
+    .getDuration()
+    .then(duration => {
+        // duration = the duration of the video in seconds
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getEnded()
+    .then(ended => {
+        // ended = whether or not the video has ended
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getLoop()
+    .then(loop => {
+        // loop = whether loop is turned on or not
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .setLoop(true)
+    .then(loop => {
+        // loop was turned on
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getMuted()
+    .then(muted => {
+        // muted = whether muted is turned on or not
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .setMuted(true)
+    .then(muted => {
+        // muted was turned on
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getPaused()
+    .then(paused => {
+        // paused = whether or not the player is paused
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getPlaybackRate()
+    .then(playbackRate => {
+        // playbackRate = a numeric value of the current playback rate
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .setPlaybackRate(0.5)
+    .then(playbackRate => {
+        // playback rate was set
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'RangeError':
+                // the playback rate was less than 0.5 or greater than 2
+                break;
+
+            default:
+                // some other error occurred
+                break;
+        }
+    });
+
+player
+    .getTextTracks()
+    .then(tracks => {
+        // tracks = an array of track objects
+        tracks.forEach(track => {
+            console.log(track.label);
+            console.log(track.kind);
+            console.log(track.language);
+            console.log(track.mode);
+        });
+    })
+    .catch(error => {
+        // an error occurred
+        error.name;
+    });
+
+player
+    .getVideoEmbedCode()
+    .then(embedCode => {
+        // embedCode = <iframe> embed code
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getVideoId()
+    .then(id => {
+        // id = the video id
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getVideoTitle()
+    .then(title => {
+        // title = the title of the video
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getVideoWidth()
+    .then(width => {
+        // width = the width of the video that is currently playing
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+player
+    .getVideoHeight()
+    .then(height => {
+        // height = the height of the video that is currently playing
+    })
+    .catch(error => {
+        // an error occurred
+    });
+
+Promise.all([player.getVideoWidth(), player.getVideoHeight()]).then(dimensions => {
     const width = dimensions[0];
     const height = dimensions[1];
 });
 
-player.getVideoUrl().then((url) => {
-    // url = the vimeo.com url for the video
-}).catch((error) => {
-    switch (error.name) {
-        case 'PrivacyError':
-            // the url isn’t available because of the video’s privacy setting
-            break;
+player
+    .getVideoUrl()
+    .then(url => {
+        // url = the vimeo.com url for the video
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'PrivacyError':
+                // the url isn’t available because of the video’s privacy setting
+                break;
 
-        default:
-            // some other error occurred
-            break;
-    }
-});
+            default:
+                // some other error occurred
+                break;
+        }
+    });
 
-player.getVolume().then((volume) => {
-    // volume = the volume level of the player
-}).catch((error) => {
-    // an error occurred
-});
+player
+    .getVolume()
+    .then(volume => {
+        // volume = the volume level of the player
+    })
+    .catch(error => {
+        // an error occurred
+    });
 
-player.setVolume(0.5).then((volume) => {
-    // volume was set
-}).catch((error) => {
-    switch (error.name) {
-        case 'RangeError':
-            // the volume was less than 0 or greater than 1
-            break;
+player
+    .setVolume(0.5)
+    .then(volume => {
+        // volume was set
+    })
+    .catch(error => {
+        switch (error.name) {
+            case 'RangeError':
+                // the volume was less than 0 or greater than 1
+                break;
 
-        default:
-            // some other error occurred
-            break;
-    }
-});
+            default:
+                // some other error occurred
+                break;
+        }
+    });
 
-player.getSeeking().then((seeking) => {
-    // seeking = whether the player is seeking or not
-}).catch((error) => {
-    // an error occurred
-});
+player
+    .getSeeking()
+    .then(seeking => {
+        // seeking = whether the player is seeking or not
+    })
+    .catch(error => {
+        // an error occurred
+    });
 
-player.getBuffered().then((buffered) => {
-    // buffered = an array of the buffered video time ranges.
-}).catch((error) => {
-    // an error occurred
-});
+player
+    .getBuffered()
+    .then(buffered => {
+        // buffered = an array of the buffered video time ranges.
+    })
+    .catch(error => {
+        // an error occurred
+    });
 
-player.getPlayed().then((played) => {
-    // played = array values of the played video time ranges.
-}).catch((error) => {
-    // an error occurred
-});
+player
+    .getPlayed()
+    .then(played => {
+        // played = array values of the played video time ranges.
+    })
+    .catch(error => {
+        // an error occurred
+    });
 
-player.getSeekable().then((seekable) => {
-    // seekable = array values of the seekable video time ranges.
-}).catch((error) => {
-    // an error occurred
-});
+player
+    .getSeekable()
+    .then(seekable => {
+        // seekable = array values of the seekable video time ranges.
+    })
+    .catch(error => {
+        // an error occurred
+    });
 
 // EVENTS
 
-player.on('play', (data) => {
+player.on('play', data => {
     // data is an object containing properties specific to that event
     console.log(data.duration); // 61.857
-    console.log(data.percent);  // 0
-    console.log(data.seconds);  // 0
+    console.log(data.percent); // 0
+    console.log(data.seconds); // 0
 });
 
-player.on('pause', (data) => {
+player.on('pause', data => {
     // data is an object containing properties specific to that event
     console.log(data.duration); // 61.857
-    console.log(data.percent);  // 0
-    console.log(data.seconds);  // 0
+    console.log(data.percent); // 0
+    console.log(data.seconds); // 0
 });
 
-player.on('ended', (data) => {
+player.on('ended', data => {
     // data is an object containing properties specific to that event
     console.log(data.duration); // 61.857
-    console.log(data.percent);  // 1
-    console.log(data.seconds);  // 61.857
+    console.log(data.percent); // 1
+    console.log(data.seconds); // 61.857
 });
 
-player.on('timeupdate', (data) => {
+player.on('timeupdate', data => {
     // data is an object containing properties specific to that event
     console.log(data.duration); // 61.857
-    console.log(data.percent);  // 0.049
-    console.log(data.seconds);  // 3.034
+    console.log(data.percent); // 0.049
+    console.log(data.seconds); // 3.034
 });
 
-player.on('progress', (data) => {
+player.on('progress', data => {
     // data is an object containing properties specific to that event
     console.log(data.duration); // 61.857
-    console.log(data.percent);  // 0.502
-    console.log(data.seconds);  // 31.052
+    console.log(data.percent); // 0.502
+    console.log(data.seconds); // 31.052
 });
 
-player.on('seeked', (data) => {
+player.on('seeked', data => {
     // data is an object containing properties specific to that event
     console.log(data.duration); // 61.857
-    console.log(data.percent);  // 0.485
-    console.log(data.seconds);  // 30
+    console.log(data.percent); // 0.485
+    console.log(data.seconds); // 30
 });
 
-player.on('texttrackchange', (data) => {
+player.on('texttrackchange', data => {
     // data is an object containing properties specific to that event
     console.log(data.kind);
     console.log(data.label);
     console.log(data.language);
 });
 
-player.on('cuechange', (data) => {
+player.on('cuechange', data => {
     // data is an object containing properties specific to that event
     console.log(data.cues); // Array of Cues
     console.log(data.cues[0].html);
@@ -517,7 +631,7 @@ player.on('cuechange', (data) => {
     console.log(data.language);
 });
 
-player.on('cuepoint', (data) => {
+player.on('cuepoint', data => {
     // data is an object containing properties specific to that event
     console.log(data.time);
     console.log(data.data);
@@ -525,39 +639,39 @@ player.on('cuepoint', (data) => {
     console.log(data.id);
 });
 
-player.on('volumechange', (data) => {
+player.on('volumechange', data => {
     // data is an object containing properties specific to that event
     console.log(data.volume);
 });
 
-player.on('playbackratechange', (data) => {
-   // data is an object containing properties specific to that event
-   console.log(data.playbackRate);
+player.on('playbackratechange', data => {
+    // data is an object containing properties specific to that event
+    console.log(data.playbackRate);
 });
 
-player.on('bufferstart', (data) => {
-   // no associated data with this event
+player.on('bufferstart', data => {
+    // no associated data with this event
 });
 
-player.on('bufferend', (data) => {
-   // no associated data with this event
+player.on('bufferend', data => {
+    // no associated data with this event
 });
 
-player.on('seeking', (data) => {
+player.on('seeking', data => {
     // data is an object containing properties specific to that event
     console.log(data.duration); // 61.857
-    console.log(data.percent);  // 0.485
-    console.log(data.seconds);  // 30
- });
+    console.log(data.percent); // 0.485
+    console.log(data.seconds); // 30
+});
 
-player.on('error', (data) => {
+player.on('error', data => {
     // data is an object containing properties specific to that event
     console.log(data.message);
     console.log(data.method);
     console.log(data.name);
 });
 
-player.on('loaded', (data) => {
+player.on('loaded', data => {
     // data is an object containing properties specific to that event
     console.log(data.id);
 });

--- a/types/vimeo__player/vimeo__player-tests.ts
+++ b/types/vimeo__player/vimeo__player-tests.ts
@@ -574,74 +574,103 @@ player
 
 player.on('play', data => {
     // data is an object containing properties specific to that event
-    console.log(data.duration); // 61.857
-    console.log(data.percent); // 0
-    console.log(data.seconds); // 0
+    // $ExpectType number
+    data.duration;
+    // $ExpectType number
+    data.percent;
+    // $ExpectType number
+    data.seconds;
 });
 
 player.on('pause', data => {
     // data is an object containing properties specific to that event
-    console.log(data.duration); // 61.857
-    console.log(data.percent); // 0
-    console.log(data.seconds); // 0
+    // $ExpectType number
+    data.duration;
+    // $ExpectType number
+    data.percent;
+    // $ExpectType number
+    data.seconds;
 });
 
 player.on('ended', data => {
     // data is an object containing properties specific to that event
-    console.log(data.duration); // 61.857
-    console.log(data.percent); // 1
-    console.log(data.seconds); // 61.857
+    // $ExpectType number
+    data.duration;
+    // $ExpectType number
+    data.percent;
+    // $ExpectType number
+    data.seconds;
 });
 
 player.on('timeupdate', data => {
     // data is an object containing properties specific to that event
-    console.log(data.duration); // 61.857
-    console.log(data.percent); // 0.049
-    console.log(data.seconds); // 3.034
+    // $ExpectType number
+    data.duration;
+    // $ExpectType number
+    data.percent;
+    // $ExpectType number
+    data.seconds;
 });
 
 player.on('progress', data => {
     // data is an object containing properties specific to that event
-    console.log(data.duration); // 61.857
-    console.log(data.percent); // 0.502
-    console.log(data.seconds); // 31.052
+    // $ExpectType number
+    data.duration;
+    // $ExpectType number
+    data.percent;
+    // $ExpectType number
+    data.seconds;
 });
 
 player.on('seeked', data => {
     // data is an object containing properties specific to that event
-    console.log(data.duration); // 61.857
-    console.log(data.percent); // 0.485
-    console.log(data.seconds); // 30
+    // $ExpectType number
+    data.duration;
+    // $ExpectType number
+    data.percent;
+    // $ExpectType number
+    data.seconds;
 });
 
 player.on('texttrackchange', data => {
     // data is an object containing properties specific to that event
-    console.log(data.kind);
-    console.log(data.label);
-    console.log(data.language);
+    // This can’t be asserted consistently between TypeScript versions.
+    data.kind;
+    // $ExpectType string | null
+    data.label;
+    // $ExpectType string | null
+    data.language;
 });
 
 player.on('cuechange', data => {
     // data is an object containing properties specific to that event
     console.log(data.cues); // Array of Cues
-    console.log(data.cues[0].html);
-    console.log(data.cues[0].text);
-    console.log(data.label);
+    // $ExpectType string
+    data.cues[0].html;
+    // $ExpectType string
+    data.cues[0].text;
+    // $ExpectType string
+    data.label;
     console.log(data.kind);
-    console.log(data.language);
+    // $ExpectType string
+    data.language;
 });
 
 player.on('cuepoint', data => {
     // data is an object containing properties specific to that event
-    console.log(data.time);
+    // $ExpectType number
+    data.time;
     console.log(data.data);
-    console.log(data.data.customKey);
-    console.log(data.id);
+    // $ExpectType any
+    data.data.customKey;
+    // $ExpectType string
+    data.id;
 });
 
 player.on('volumechange', data => {
     // data is an object containing properties specific to that event
-    console.log(data.volume);
+    // $ExpectType number
+    data.volume;
 });
 
 player.on('playbackratechange', data => {
@@ -649,29 +678,32 @@ player.on('playbackratechange', data => {
     console.log(data.playbackRate);
 });
 
-player.on('bufferstart', data => {
+player.on('bufferstart', () => {
     // no associated data with this event
 });
 
-player.on('bufferend', data => {
+player.on('bufferend', () => {
     // no associated data with this event
 });
 
 player.on('seeking', data => {
     // data is an object containing properties specific to that event
-    console.log(data.duration); // 61.857
-    console.log(data.percent); // 0.485
-    console.log(data.seconds); // 30
+    // $ExpectType number
+    data.duration;
+    // $ExpectType number
+    data.percent;
+    // $ExpectType number
+    data.seconds;
 });
 
 player.on('error', data => {
     // data is an object containing properties specific to that event
-    console.log(data.message);
-    console.log(data.method);
-    console.log(data.name);
+    // $ExpectType Error
+    data;
 });
 
 player.on('loaded', data => {
     // data is an object containing properties specific to that event
-    console.log(data.id);
+    // $ExpectType number
+    data.id;
 });


### PR DESCRIPTION
The first commit simply formats the `@vimeo/player` types using Prettier. Have a look if you don’t trust it, but it can be ignored. :)

The second commit introduces an event map similar to `HTMLElementEventMap`. This maps each event name to an event type that has specific typed properties.

The docs have been taken from https://github.com/vimeo/player.js#events.

The `EventName` type has been removed, because it was equivalent to `string`.

Also the event related type tests have been updated to use dtslint type assertions.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vimeo/player.js#events
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
