### PR TITLE
[node] Update stream .destroy and .end types for v16

### DIFF
--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -583,3 +583,17 @@ async function testTransferringStreamWithPostMessage() {
     // error TS2532: Cannot use 'stream' as a target of a postMessage call because it is not a Transferable.
     // port2.postMessage(stream, [stream]);
 }
+
+function testEndandDestroy() {
+    // $ExpectType Readable
+    new Readable().destroy();
+    // $ExpectType Writable
+    new Writable().destroy();
+
+    // $ExpectType Writable
+    new Writable().end();
+    // $ExpectType Writable
+    new Writable().end('');
+    // $ExpectType Writable
+    new Writable().end('', 'utf8');
+}

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -583,17 +583,3 @@ async function testTransferringStreamWithPostMessage() {
     // error TS2532: Cannot use 'stream' as a target of a postMessage call because it is not a Transferable.
     // port2.postMessage(stream, [stream]);
 }
-
-function testEndandDestroy() {
-    // $ExpectType Readable
-    new Readable().destroy();
-    // $ExpectType Writable
-    new Writable().destroy();
-
-    // $ExpectType Writable
-    new Writable().end();
-    // $ExpectType Writable
-    new Writable().end('');
-    // $ExpectType Writable
-    new Writable().end('', 'utf8');
-}

--- a/types/node/v16/http.d.ts
+++ b/types/node/v16/http.d.ts
@@ -959,7 +959,7 @@ declare module 'http' {
          * as an argument to any listeners on the event.
          * @since v0.3.0
          */
-        destroy(error?: Error): void;
+        destroy(error?: Error): this;
     }
     interface AgentOptions extends Partial<TcpSocketConnectOpts> {
         /**

--- a/types/node/v16/http2.d.ts
+++ b/types/node/v16/http2.d.ts
@@ -1516,9 +1516,9 @@ declare module 'http2' {
          * is finished.
          * @since v8.4.0
          */
-        end(callback?: () => void): void;
-        end(data: string | Uint8Array, callback?: () => void): void;
-        end(data: string | Uint8Array, encoding: BufferEncoding, callback?: () => void): void;
+        end(callback?: () => void): this;
+        end(data: string | Uint8Array, callback?: () => void): this;
+        end(data: string | Uint8Array, encoding: BufferEncoding, callback?: () => void): this;
         /**
          * Reads out a header that has already been queued but not sent to the client.
          * The name is case-insensitive.

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -288,9 +288,9 @@ declare module 'net' {
          * @param callback Optional callback for when the socket is finished.
          * @return The socket itself.
          */
-        end(callback?: () => void): void;
-        end(buffer: Uint8Array | string, callback?: () => void): void;
-        end(str: Uint8Array | string, encoding?: BufferEncoding, callback?: () => void): void;
+        end(callback?: () => void): this;
+        end(buffer: Uint8Array | string, callback?: () => void): this;
+        end(str: Uint8Array | string, encoding?: BufferEncoding, callback?: () => void): this;
         /**
          * events.EventEmitter
          *   1. close

--- a/types/node/v16/stream.d.ts
+++ b/types/node/v16/stream.d.ts
@@ -408,7 +408,7 @@ declare module 'stream' {
              * @since v8.0.0
              * @param error Error which will be passed as payload in `'error'` event
              */
-            destroy(error?: Error): void;
+            destroy(error?: Error): this;
             /**
              * Event emitter
              * The defined events on documents including:
@@ -639,9 +639,9 @@ declare module 'stream' {
              * @param encoding The encoding if `chunk` is a string
              * @param callback Callback for when the stream is finished.
              */
-            end(cb?: () => void): void;
-            end(chunk: any, cb?: () => void): void;
-            end(chunk: any, encoding: BufferEncoding, cb?: () => void): void;
+            end(cb?: () => void): this;
+            end(chunk: any, cb?: () => void): this;
+            end(chunk: any, encoding: BufferEncoding, cb?: () => void): this;
             /**
              * The `writable.cork()` method forces all written data to be buffered in memory.
              * The buffered data will be flushed when either the {@link uncork} or {@link end} methods are called.
@@ -707,7 +707,7 @@ declare module 'stream' {
              * @since v8.0.0
              * @param error Optional, an error to emit with `'error'` event.
              */
-            destroy(error?: Error): void;
+            destroy(error?: Error): this;
             /**
              * Event emitter
              * The defined events on documents including:
@@ -853,9 +853,9 @@ declare module 'stream' {
             write(chunk: any, encoding?: BufferEncoding, cb?: (error: Error | null | undefined) => void): boolean;
             write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
             setDefaultEncoding(encoding: BufferEncoding): this;
-            end(cb?: () => void): void;
-            end(chunk: any, cb?: () => void): void;
-            end(chunk: any, encoding?: BufferEncoding, cb?: () => void): void;
+            end(cb?: () => void): this;
+            end(chunk: any, cb?: () => void): this;
+            end(chunk: any, encoding?: BufferEncoding, cb?: () => void): this;
             cork(): void;
             uncork(): void;
         }

--- a/types/node/v16/test/stream.ts
+++ b/types/node/v16/test/stream.ts
@@ -583,3 +583,17 @@ async function testTransferringStreamWithPostMessage() {
     // error TS2532: Cannot use 'stream' as a target of a postMessage call because it is not a Transferable.
     // port2.postMessage(stream, [stream]);
 }
+
+function testEndandDestroy() {
+    // $ExpectType Readable
+    new Readable().destroy();
+    // $ExpectType Writable
+    new Writable().destroy();
+
+    // $ExpectType Writable
+    new Writable().end();
+    // $ExpectType Writable
+    new Writable().end('');
+    // $ExpectType Writable
+    new Writable().end('', 'utf8');
+}


### PR DESCRIPTION
I am not sure why https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57473 didn't include the changes for node 16 as well. Feel free to close this if it was intended

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v16.x/docs/api/stream.html