### PR TITLE
[sinon] accept partial objects and sinon matchers in *calledWithMatch methods

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -19,6 +19,10 @@ interface Event {} // tslint:disable-line no-empty-interface
 interface Document {} // tslint:disable-line no-empty-interface
 
 declare namespace Sinon {
+    type DeepPartialOrMatcher<T> = {
+        [K in keyof T]?: SinonMatcher | (T[K] extends object ? DeepPartialOrMatcher<T[K]> : T[K]);
+    };
+
     type MatchArguments<T> = {
         [K in keyof T]: SinonMatcher | (T[K] extends object ? MatchArguments<T[K]> : never) | T[K];
     };
@@ -65,7 +69,7 @@ declare namespace Sinon {
          * This behaves the same as spy.calledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        calledWithMatch(...args: TArgs): boolean;
+        calledWithMatch(...args: DeepPartialOrMatcher<TArgs>): boolean;
         /**
          * Returns true if call did not receive provided arguments.
          * @param args
@@ -76,7 +80,7 @@ declare namespace Sinon {
          * This behaves the same as spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...).
          * @param args
          */
-        notCalledWithMatch(...args: TArgs): boolean;
+        notCalledWithMatch(...args: DeepPartialOrMatcher<TArgs>): boolean;
         /**
          * Returns true if spy returned the provided value at least once.
          * Uses deep comparison for objects and arrays. Use spy.returned(sinon.match.same(obj)) for strict comparison (see matchers).
@@ -1158,7 +1162,10 @@ declare namespace Sinon {
          * This behaves the same way as sinon.assert.calledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          * It's possible to assert on a dedicated spy call: sinon.assert.calledWithMatch(spy.secondCall, arg1, arg2, ...);.
          */
-        calledWithMatch<TArgs extends any[]>(spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>, ...args: TArgs): void;
+        calledWithMatch<TArgs extends any[]>(
+            spyOrSpyCall: SinonSpy<TArgs> | SinonSpyCall<TArgs>,
+            ...args: DeepPartialOrMatcher<TArgs>
+        ): void;
         /**
          * Passes if spy was called once with matching arguments.
          * This behaves the same way as calling both sinon.assert.calledOnce(spy) and
@@ -1172,14 +1179,14 @@ declare namespace Sinon {
          * Passes if spy was always called with matching arguments.
          * This behaves the same way as sinon.assert.alwaysCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          */
-        alwaysCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: TArgs): void;
+        alwaysCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: DeepPartialOrMatcher<TArgs>): void;
         /**
          * Passes if spy was never called with matching arguments.
          * This behaves the same way as sinon.assert.neverCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...).
          * @param spy
          * @param args
          */
-        neverCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: TArgs): void;
+        neverCalledWithMatch<TArgs extends any[]>(spy: SinonSpy<TArgs>, ...args: DeepPartialOrMatcher<TArgs>): void;
         /**
          * Passes if spy was called with the new operator.
          * It’s possible to assert on a dedicated spy call: sinon.assert.calledWithNew(spy.secondCall, arg1, arg2, ...);.

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -408,23 +408,25 @@ function testAssert() {
     sinon.assert.calledWith(typedSpy, "a");
     sinon.assert.calledWith(typedSpy, "a", "b"); // $ExpectError
     sinon.assert.alwaysCalledOn(typedSpy, obj);
-    sinon.assert.alwaysCalledWith(typedSpy, "a", "b", "c"); // $ExpectError
-    sinon.assert.alwaysCalledWith(typedSpy, "a", true);
-    sinon.assert.alwaysCalledWith(typedSpy, "a");
-    sinon.assert.neverCalledWith(typedSpy, "a", false);
-    sinon.assert.neverCalledWith(typedSpy, "a", "b"); // $ExpectError
-    sinon.assert.neverCalledWith(typedSpy, "a");
-    sinon.assert.calledWithExactly(typedSpy, "a", true);
-    sinon.assert.calledWithExactly(typedSpy, "a", "b"); // $ExpectError
-    sinon.assert.alwaysCalledWithExactly(typedSpy, "a", true);
-    sinon.assert.alwaysCalledWithExactly(typedSpy, "a", 1); // $ExpectError
-    sinon.assert.calledWithMatch(typedSpy, "a", true);
-    sinon.assert.calledWithMatch(typedSpy.firstCall, "a", true);
-    sinon.assert.calledWithMatch(typedSpy.firstCall, "a", 2); // $ExpectError
-    sinon.assert.alwaysCalledWithMatch(typedSpy, "a", true);
-    sinon.assert.alwaysCalledWithMatch(typedSpy, "a", 2); // $ExpectError
-    sinon.assert.neverCalledWithMatch(typedSpy, "a", true);
-    sinon.assert.neverCalledWithMatch(typedSpy, "a", 2); // $ExpectError
+    sinon.assert.alwaysCalledWith(typedSpy, 'a', 'b', 'c'); // $ExpectError
+    sinon.assert.alwaysCalledWith(typedSpy, 'a', true);
+    sinon.assert.alwaysCalledWith(typedSpy, 'a');
+    sinon.assert.neverCalledWith(typedSpy, 'a', false);
+    sinon.assert.neverCalledWith(typedSpy, 'a', 'b'); // $ExpectError
+    sinon.assert.neverCalledWith(typedSpy, 'a');
+    sinon.assert.calledWithExactly(typedSpy, 'a', true);
+    sinon.assert.calledWithExactly(typedSpy, 'a', 'b'); // $ExpectError
+    sinon.assert.alwaysCalledWithExactly(typedSpy, 'a', true);
+    sinon.assert.alwaysCalledWithExactly(typedSpy, 'a', 1); // $ExpectError
+    sinon.assert.calledWithMatch(typedSpy, 'a');
+    sinon.assert.calledWithMatch(typedSpy, 'a', true);
+    sinon.assert.calledWithMatch(typedSpy, 'a', true, 42); // $ExpectError
+    sinon.assert.calledWithMatch(typedSpy.firstCall, 'a', true);
+    sinon.assert.calledWithMatch(typedSpy.firstCall, 'a', 2); // $ExpectError
+    sinon.assert.alwaysCalledWithMatch(typedSpy, 'a', true);
+    sinon.assert.alwaysCalledWithMatch(typedSpy, 'a', 2); // $ExpectError
+    sinon.assert.neverCalledWithMatch(typedSpy, 'a', true);
+    sinon.assert.neverCalledWithMatch(typedSpy, 'a', 2); // $ExpectError
     sinon.assert.calledWithNew(typedSpy);
     sinon.assert.calledWithNew(typedSpy.firstCall);
     sinon.assert.threw(typedSpy);
@@ -442,6 +444,51 @@ function testAssert() {
     sinon.assert.expose(obj);
     sinon.assert.expose(obj, { prefix: "blah" });
     sinon.assert.expose(obj, { includeFail: true });
+
+    const spyDeepObject = sinon.spy((_arg1: { foo: { first: string; second: number } }, _arg2: string): boolean => {
+        return true;
+    });
+
+    sinon.assert.calledWithMatch(spyDeepObject, {});
+    sinon.assert.calledWithMatch(spyDeepObject, { foo: {} });
+    sinon.assert.calledWithMatch(spyDeepObject, { bar: {} }); // $ExpectError
+    sinon.assert.calledWithMatch(spyDeepObject, { foo: { second: 42 } });
+    sinon.assert.calledWithMatch(spyDeepObject, { foo: { second: sinon.match.string } });
+    sinon.assert.calledWithMatch(spyDeepObject, { foo: sinon.match.object });
+    sinon.assert.calledWithMatch(spyDeepObject, { foo: sinon.match.any });
+    sinon.assert.calledWithMatch(spyDeepObject, {
+        foo: sinon.match.array.startsWith([]).and(sinon.match.has('first')),
+    });
+    sinon.assert.calledWithMatch(spyDeepObject, sinon.match.any, sinon.match.string);
+    sinon.assert.calledWithMatch(spyDeepObject, sinon.match.any, sinon.match.string, sinon.match.number); // $ExpectError
+    sinon.assert.calledWithMatch(spyDeepObject, { foo: { first: 'a', second: 42 } }, 'c');
+
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, {});
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, { foo: {} });
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, { bar: {} }); // $ExpectError
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, { foo: { second: 42 } });
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, { foo: { second: sinon.match.string } });
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, { foo: sinon.match.object });
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, { foo: sinon.match.any });
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, {
+        foo: sinon.match.array.startsWith([]).and(sinon.match.has('first')),
+    });
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, sinon.match.any, sinon.match.string);
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, sinon.match.any, sinon.match.string, sinon.match.number); // $ExpectError
+    sinon.assert.alwaysCalledWithMatch(spyDeepObject, { foo: { first: 'a', second: 42 } }, 'c');
+    sinon.assert.neverCalledWithMatch(spyDeepObject, {});
+    sinon.assert.neverCalledWithMatch(spyDeepObject, { foo: {} });
+    sinon.assert.neverCalledWithMatch(spyDeepObject, { bar: {} }); // $ExpectError
+    sinon.assert.neverCalledWithMatch(spyDeepObject, { foo: { second: 42 } });
+    sinon.assert.neverCalledWithMatch(spyDeepObject, { foo: { second: sinon.match.string } });
+    sinon.assert.neverCalledWithMatch(spyDeepObject, { foo: sinon.match.object });
+    sinon.assert.neverCalledWithMatch(spyDeepObject, { foo: sinon.match.any });
+    sinon.assert.neverCalledWithMatch(spyDeepObject, {
+        foo: sinon.match.array.startsWith([]).and(sinon.match.has('first')),
+    });
+    sinon.assert.neverCalledWithMatch(spyDeepObject, sinon.match.any, sinon.match.string);
+    sinon.assert.neverCalledWithMatch(spyDeepObject, sinon.match.any, sinon.match.string, sinon.match.number); // $ExpectError
+    sinon.assert.neverCalledWithMatch(spyDeepObject, { foo: { first: 'a', second: 42 } }, 'c');
 }
 
 function testTypedSpy() {
@@ -472,21 +519,55 @@ function testTypedSpy() {
     spy.notCalledWith(sinon.match(5), "x");
     spy.returned(5);
     spy.returned(sinon.match(5));
+    spy.calledWithMatch(5, 'x', true); // $ExpectError
+    spy.calledWithMatch(5, 'x');
+    spy.calledWithMatch(5);
+    spy.notCalledWithMatch(5, 'x', true); // $ExpectError
+    spy.notCalledWithMatch(5, 'x');
+    spy.notCalledWithMatch(5);
 
-    spy.withArgs(sinon.match(5), "x").calledWith(5, "x");
-    spy.alwaysCalledWith(sinon.match(5), "x");
-    spy.alwaysCalledWith(5, "x");
-    spy.alwaysCalledWithExactly(sinon.match(5), "x");
-    spy.alwaysCalledWithExactly(5, "x");
-    spy.neverCalledWith(sinon.match(5), "x");
-    spy.neverCalledWith(5, "x");
+    spy.withArgs(sinon.match(5), 'x').calledWith(5, 'x');
+    spy.alwaysCalledWith(sinon.match(5), 'x');
+    spy.alwaysCalledWith(5, 'x');
+    spy.alwaysCalledWithExactly(sinon.match(5), 'x');
+    spy.alwaysCalledWithExactly(5, 'x');
+    spy.neverCalledWith(sinon.match(5), 'x');
+    spy.neverCalledWith(5, 'x');
 
-    const stub = sinon.stub(instance, "foo");
+    const spyDeepObject = sinon.spy((_arg1: { foo: { first: string; second: number } }, _arg2: string): boolean => {
+        return true;
+    });
 
-    stub.withArgs(5, "x").returns(3);
-    stub.withArgs(sinon.match(5), "x").returns(5);
+    spyDeepObject.calledWithMatch();
+    spyDeepObject.calledWithMatch({});
+    spyDeepObject.calledWithMatch({ foo: {} });
+    spyDeepObject.calledWithMatch({ foo: { second: 42 } });
+    spyDeepObject.calledWithMatch({ foo: { second: sinon.match.string } });
+    spyDeepObject.calledWithMatch({ foo: sinon.match.object });
+    spyDeepObject.calledWithMatch({ foo: sinon.match.any });
+    spyDeepObject.calledWithMatch({ foo: sinon.match.array.startsWith([]).and(sinon.match.has('first')) });
+    spyDeepObject.calledWithMatch(sinon.match.any, sinon.match.string);
+    spyDeepObject.calledWithMatch(sinon.match.any, sinon.match.string, sinon.match.number); // $ExpectError
+    spyDeepObject.calledWithMatch({ foo: { first: 'a', second: 42 } }, 'c');
 
-    const accessorSpy = sinon.spy(instance, "accessorTest", ["get", "set"]);
+    spyDeepObject.notCalledWithMatch();
+    spyDeepObject.notCalledWithMatch({});
+    spyDeepObject.notCalledWithMatch({ foo: {} });
+    spyDeepObject.notCalledWithMatch({ foo: { second: 42 } });
+    spyDeepObject.notCalledWithMatch({ foo: { second: sinon.match.string } });
+    spyDeepObject.notCalledWithMatch({ foo: sinon.match.object });
+    spyDeepObject.notCalledWithMatch({ foo: sinon.match.any });
+    spyDeepObject.notCalledWithMatch({ foo: sinon.match.array.startsWith([]).and(sinon.match.has('first')) });
+    spyDeepObject.notCalledWithMatch(sinon.match.any, sinon.match.string);
+    spyDeepObject.notCalledWithMatch(sinon.match.any, sinon.match.string, sinon.match.number); // $ExpectError
+    spyDeepObject.notCalledWithMatch({ foo: { first: 'a', second: 42 } }, 'c');
+
+    const stub = sinon.stub(instance, 'foo');
+
+    stub.withArgs(5, 'x').returns(3);
+    stub.withArgs(sinon.match(5), 'x').returns(5);
+
+    const accessorSpy = sinon.spy(instance, 'accessorTest', ['get', 'set']);
     accessorSpy.get.returned(5);
     accessorSpy.set.calledWith(55);
 


### PR DESCRIPTION
Follow-up from #53467

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/v12.0.1/assertions/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
