### PR TITLE
[node] Allow `undefined` as a second parameter of `util.inspect`

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -43,6 +43,9 @@ util.inspect({
     [util.inspect.custom]: <util.CustomInspectFunction> ((depth, opts) => opts.stylize('woop', 'module')),
 });
 
+(options?: util.InspectOptions) => util.inspect({ }, options);
+(showHidden?: boolean) => util.inspect({ }, showHidden);
+
 util.format('%s:%s', 'foo');
 util.format('%s:%s', 'foo', 'bar', 'baz');
 util.format(1, 2, 3);

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -317,7 +317,7 @@ declare module 'util' {
      * @return The representation of `object`.
      */
     export function inspect(object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
-    export function inspect(object: any, options: InspectOptions): string;
+    export function inspect(object: any, options?: InspectOptions): string;
     export namespace inspect {
         let colors: NodeJS.Dict<[number, number]>;
         let styles: {


### PR DESCRIPTION
Allow `undefined` as a second parameter for both signatures of `util.inspect`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://nodejs.org/api/util.html#utilinspectobject-options
  - https://github.com/nodejs/node/blob/v17.4.0/lib/internal/util/inspect.js#L287
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.