### PR TITLE
[meteor] Change user profile type to empty interface

### DIFF
--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -36,12 +36,19 @@ declare namespace Meteor {
         address: string;
         verified: boolean;
     }
+    /**
+     * UserProfile is left intentionally underspecified here, to allow you
+     * to override it in your application (but keep in mind that the default
+     * Meteor configuration allows users to write directly to their user
+     * record's profile field)
+     */
+    interface UserProfile {}
     interface User {
         _id: string;
         username?: string | undefined;
         emails?: UserEmail[] | undefined;
         createdAt?: Date | undefined;
-        profile?: any;
+        profile?: UserProfile;
         services?: any;
     }
 

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -41,12 +41,19 @@ declare module 'meteor/meteor' {
             address: string;
             verified: boolean;
         }
+        /**
+         * UserProfile is left intentionally underspecified here, to allow you
+         * to override it in your application (but keep in mind that the default
+         * Meteor configuration allows users to write directly to their user
+         * record's profile field)
+         */
+        interface UserProfile {}
         interface User {
             _id: string;
             username?: string | undefined;
             emails?: UserEmail[] | undefined;
             createdAt?: Date | undefined;
-            profile?: any;
+            profile?: UserProfile;
             services?: any;
         }
 

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -3,6 +3,12 @@
 // that don't have corresponding globals belong in
 // `meteor-tests-module-only.ts`.
 
+declare namespace Meteor {
+    interface UserProfile {
+        name?: string | undefined;
+    }
+}
+
 /**
  * All code below was copied from the examples at http://docs.meteor.com/.
  * When necessary, code was added to make the examples work (e.g. declaring a variable
@@ -669,7 +675,7 @@ namespace MeteorTests {
     Accounts.emailTemplates.siteName = 'AwesomeSite';
     Accounts.emailTemplates.from = 'AwesomeSite Admin <accounts@example.com>';
     Accounts.emailTemplates.enrollAccount.subject = function (user) {
-        return 'Welcome to Awesome Town, ' + user.profile.name;
+        return 'Welcome to Awesome Town, ' + user.profile?.name;
     };
     Accounts.emailTemplates.enrollAccount.text = function (user: any, url: string) {
         return (
@@ -1026,7 +1032,7 @@ namespace MeteorTests {
     Accounts.emailTemplates.headers = { asdf: 'asdf', qwer: 'qwer' };
 
     Accounts.emailTemplates.enrollAccount.subject = function (user: Meteor.User) {
-        return 'Welcome to Awesome Town, ' + user.profile.name;
+        return 'Welcome to Awesome Town, ' + user.profile?.name;
     };
     Accounts.emailTemplates.enrollAccount.html = function (user: Meteor.User, url: string) {
         return '<h1>Some html here</h1>';

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -32,6 +32,9 @@ declare module 'meteor/meteor' {
             // One of the tests assigns a new property to the user so it has to be typed
             dexterity?: number | undefined;
         }
+        interface UserProfile {
+            name?: string | undefined;
+        }
     }
 }
 
@@ -693,7 +696,7 @@ namespace MeteorTests {
     Accounts.emailTemplates.siteName = 'AwesomeSite';
     Accounts.emailTemplates.from = 'AwesomeSite Admin <accounts@example.com>';
     Accounts.emailTemplates.enrollAccount.subject = function (user) {
-        return 'Welcome to Awesome Town, ' + user.profile.name;
+        return 'Welcome to Awesome Town, ' + user.profile?.name;
     };
     Accounts.emailTemplates.enrollAccount.text = function (user: any, url: string) {
         return (
@@ -1050,7 +1053,7 @@ namespace MeteorTests {
     Accounts.emailTemplates.headers = { asdf: 'asdf', qwer: 'qwer' };
 
     Accounts.emailTemplates.enrollAccount.subject = function (user: Meteor.User) {
-        return 'Welcome to Awesome Town, ' + user.profile.name;
+        return 'Welcome to Awesome Town, ' + user.profile?.name;
     };
     Accounts.emailTemplates.enrollAccount.html = function (user: Meteor.User, url: string) {
         return '<h1>Some html here</h1>';


### PR DESCRIPTION
Previously, the `profile` field on `Meteor.User` was declared as `any`.
This makes it impossible to declare a more specific type for the profile
object in your own app (it throws an error - `Subsequent property
declarations must have the same type. Property 'profile' must be of type
'any' ...`).

Instead, create a new empty `UserProfile` interface and use that as the
type of `profile`. This makes it easy for app developers to re-open the
type of `UserProfile` and add their own fields to it.

Note that this is a breaking change, as it will cause accesses to fields
under `profile` to fail, where previously they would succeed.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.