### PR TITLE
[tailwindcss] Make darkMode config option optional

### DIFF
--- a/types/tailwindcss/tailwind-config.d.ts
+++ b/types/tailwindcss/tailwind-config.d.ts
@@ -510,7 +510,7 @@ export interface TailwindConfig {
     // Not documented yet.
     content?: string[] | { files: string[]; extract: any; transform: any };
     presets?: any[];
-    darkMode: false | 'media' | 'class';
+    darkMode?: false | 'media' | 'class';
     variantOrder?: TailwindVariant[];
     prefix?: string;
     important?: boolean | string;

--- a/types/tailwindcss/test/tailwindcss-optional-config-tests.ts
+++ b/types/tailwindcss/test/tailwindcss-optional-config-tests.ts
@@ -1,0 +1,5 @@
+import type { TailwindConfig } from 'tailwindcss/tailwind-config';
+
+const tailwindConfig: TailwindConfig = {
+    theme: {},
+};

--- a/types/tailwindcss/test/tailwindcss-tests.ts
+++ b/types/tailwindcss/test/tailwindcss-tests.ts
@@ -2582,7 +2582,7 @@ tailwindConfig.plugins;
 // $ExpectType any[] | undefined
 tailwindConfig.presets;
 
-// $ExpectType false | "media" | "class"
+// $ExpectType false | "media" | "class" | undefined
 tailwindConfig.darkMode;
 
 tailwindConfig.darkMode = false;

--- a/types/tailwindcss/tsconfig.json
+++ b/types/tailwindcss/tsconfig.json
@@ -16,6 +16,7 @@
     "files": [
         "index.d.ts",
         "test/tailwindcss-tests.ts",
+        "test/tailwindcss-optional-config-tests.ts",
         "test/tailwindcss-plugin-tests.ts",
         "test/tailwindcss-default-config-code-tests.ts",
         "test/tailwindcss-default-config-value-tests.ts"


### PR DESCRIPTION
`darkMode` becomes optional in v3 ([upgrade guide](https://tailwindcss.com/docs/upgrade-guide#remove-dark-mode-configuration)).