### PR TITLE
Add types for react-dual-listbox

### DIFF
--- a/types/react-dual-listbox/index.d.ts
+++ b/types/react-dual-listbox/index.d.ts
@@ -6,7 +6,9 @@
 
 import * as React from 'react';
 
-/** A value-based option. */
+/**
+ * A value-based option.
+ */
 export interface ValueOption<T> {
     /**
      * Whether the option is disabled or not.
@@ -14,15 +16,23 @@ export interface ValueOption<T> {
      * @default false
      */
     disabled?: boolean;
-    /** Adds the HTML `title` attribute to the option. */
+    /**
+     * Adds the HTML `title` attribute to the option.
+     */
     title?: string;
-    /** The option label. */
+    /**
+     * The option label.
+     */
     label: string;
-    /** The option value. */
+    /**
+     * The option value.
+     */
     value: T;
 }
 
-/** A category with other categories and values. */
+/**
+ * A category with other categories and values.
+ */
 export interface CategoryOption<T> {
     /**
      * Whether the category is disabled or not.
@@ -30,43 +40,49 @@ export interface CategoryOption<T> {
      * @default false
      */
     disabled?: boolean;
-    /** Adds the HTML `title` attribute to the option. */
+    /**
+     * Adds the HTML `title` attribute to the option.
+     */
     title?: string;
-    /** The category label. */
+    /**
+     * The category label.
+     */
     label: string;
-    /** The category child options. */
+    /**
+     * The category child options.
+     */
     options: Array<Option<T>>;
 }
 
-/** Valid options include values and categories. */
+/**
+ * Valid options include values and categories.
+ */
 export type Option<T> = ValueOption<T> | CategoryOption<T>;
 
-/** A filter. */
+/**
+ * A filter.
+ */
 export interface Filter<T> {
-    /** Available options. */
+    /**
+     * Available options.
+     */
     available: T[];
-    /** Selected options. */
+    /**
+     * Selected options.
+     */
     selected: T[];
 }
 
-/** Properties common to every `DualListBox`. */
+/**
+ * Properties common to every `DualListBox`.
+ */
 export interface CommonProperties<T> {
     /**
      * Available options.
-     *
-     * @example
-     * const options = [
-     *   { value: 'one', label: 'One'},
-     *   { value: 'two', label: 'Two'},
-     * ];
-     * <DualListBox options={options} />
      */
     options: Array<Option<T>>;
     /**
      * Selected options.
-     *
-     * @example
-     * <DualListBox options={options} selected={['one']} />
      */
     selected?: T[];
     /**
@@ -77,26 +93,17 @@ export interface CommonProperties<T> {
      * Override the default alignment of action buttons.
      *
      * @default "middle"
-     *
-     * @example
-     * <DualListBox options={options} alignActions="top" />
      */
     alignActions?: 'top' | 'middle';
     /**
      * If true, duplicate options will be allowed in the selected list box.
      *
      * @default false
-     *
-     * @example
-     * <DualListBox options={options} allowDuplicates />
      */
     allowDuplicates?: boolean;
     /**
-     * A subset of the `options` array to optionally filter the available list box.
-     *
-     * @example
-     * const available = ['io', 'europa', 'ganymede', 'callisto'];
-     * <DualListBox options={options} available={available} />;
+     * A subset of the `options` array to optionally filter the available list
+     * box.
      */
     available?: T[];
     /**
@@ -161,9 +168,6 @@ export interface CommonProperties<T> {
      * A list of key codes that will trigger a toggle of the selected options.
      *
      * @default [13, 32]
-     *
-     * @example
-     * <DualListBox options={options} moveKeyCodes={[13, 32]} />
      */
     moveKeyCodes?: number[];
     /**
@@ -178,9 +182,6 @@ export interface CommonProperties<T> {
      * selected items according to the order of the `options` property.
      *
      * @default false
-     *
-     * @example
-     * <DualListBox options={options} preserveSelectOrder />
      */
     preserveSelectOrder?: boolean;
     /**
@@ -206,71 +207,40 @@ export interface CommonProperties<T> {
     showOrderButtons?: boolean;
 }
 
-/** Additional `DualListBox` properties with filter. */
+/**
+ * Additional `DualListBox` properties with filter.
+ */
 export interface FilterProperties<T, F extends boolean> {
     /**
      * Flag that determines whether filtering is enabled.
      *
      * @default false
-     *
-     * @example
-     * <DualListBox options={options} canFilter />
      */
     canFilter?: F;
     /**
      * Override the default filtering function.
-     *
-     * @example
-     * <DualListBox
-     *   options={options}
-     *   filterCallback={(option, filterInput) => !!(...)}
-     *   canFilter
-     * />
      */
     filterCallback?: F extends true ? (option: Option<T>, filterInput: string) => boolean : undefined;
     /**
      * Override the default filter placeholder.
-     *
-     * @example
-     * <DualListBox
-     *   options={options}
-     *   filterPlaceholder="..."
-     *   canFilter
-     * />
      */
     filterPlaceholder?: F extends true ? string : undefined;
     /**
      * Control the filter search text.
-     *
-     * @example
-     * const filter = { available: 'europa', selected: '' };
-     * <DualListBox
-     *   options={options}
-     *   filter={filter}
-     *   canFilter
-     * />
      */
     filter?: Filter<T>;
     /**
      * Handle filter change.
-     *
-     * @example
-     * <DualListBox
-     *   options={options}
-     *   onFilterChange={filter => {...}}
-     *   canFilter
-     * />
      */
     onFilterChange?: F extends true ? (filter: string) => void : undefined;
 }
 
-/** Additional `DualListBox` properties with complex selected values. */
+/**
+ * Additional `DualListBox` properties with complex selected values.
+ */
 export interface ValueProperties<T, V extends boolean> {
     /**
      * The handler called when options are moved to either side.
-     *
-     * @example
-     * <DualListBox options={options} onChange={selected => {...}} />
      */
     // onChange?: (selected: (T | Option<T>)[]) => void;
     onChange?: (selected: V extends true ? T[] : Array<Option<T>>) => void;
@@ -279,22 +249,13 @@ export interface ValueProperties<T, V extends boolean> {
      * Otherwise, it is an array of options.
      *
      * @default true
-     *
-     * @example
-     * <DualListBox
-     *   options={options}
-     *   onChange={selectedValues => {...}}
-     * />
-     * <DualListBox
-     *   options={options}
-     *   simpleValue={false}
-     *   onChange={selectedOptions => {...}}
-     * />
      */
     simpleValue?: V;
 }
 
-/** `DualListBox` component properties. */
+/**
+ * `DualListBox` component properties.
+ */
 // export type DualListBoxProperties<P> = CommonProperties<P> & FilterProperties<P> & ValueProperties<P>;
 export interface DualListBoxProperties<P, F extends boolean, V extends boolean>
     extends CommonProperties<P>,
@@ -306,28 +267,6 @@ export interface DualListBoxProperties<P, F extends boolean, V extends boolean>
  *
  * The `DualListBox` is a controlled component, so you have to update the `selected` property in
  * conjunction with the `onChange` handler if you want the selected values to change.
- *
- * @example
- * // Example options (Option<string>[]).
- * const options: Option<string>[] = [
- *   { label: 'One', value: 'one' },
- *   { label: 'Two', value: 'two' },
- * ];
- *
- * const [selectedValues, setSelectedValues] = React.useState<string[]>([]);
- *
- * // Component handler
- * const handleChange = (selectedValues: string[]) => {
- *   setSelectedValues(selectedValues);
- * };
- *
- * // Usage example (`DualListBox` with options of
- * // `Options<string>[]` is a `DualListBox<string>`):
- * <DualListBox
- *   options={options}
- *   selected={selectedValues}
- *   onChange={handleChange}
- * />
  */
 export default class DualListBox<P, F extends boolean = false, V extends boolean = true> extends React.Component<
     DualListBoxProperties<P, F, V>

--- a/types/react-dual-listbox/index.d.ts
+++ b/types/react-dual-listbox/index.d.ts
@@ -1,0 +1,334 @@
+// Type definitions for react-dual-listbox 2.2
+// Project: https://github.com/jakezatecky/react-dual-listbox
+// Definitions by: Justin Hall <https://github.com/wKovacs64>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.9
+
+import * as React from 'react';
+
+/** A value-based option. */
+export interface ValueOption<T> {
+    /**
+     * Whether the option is disabled or not.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+    /** Adds the HTML `title` attribute to the option. */
+    title?: string;
+    /** The option label. */
+    label: string;
+    /** The option value. */
+    value: T;
+}
+
+/** A category with other categories and values. */
+export interface CategoryOption<T> {
+    /**
+     * Whether the category is disabled or not.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+    /** Adds the HTML `title` attribute to the option. */
+    title?: string;
+    /** The category label. */
+    label: string;
+    /** The category child options. */
+    options: Array<Option<T>>;
+}
+
+/** Valid options include values and categories. */
+export type Option<T> = ValueOption<T> | CategoryOption<T>;
+
+/** A filter. */
+export interface Filter<T> {
+    /** Available options. */
+    available: T[];
+    /** Selected options. */
+    selected: T[];
+}
+
+/** Properties common to every `DualListBox`. */
+export interface CommonProperties<T> {
+    /**
+     * Available options.
+     *
+     * @example
+     * const options = [
+     *   { value: 'one', label: 'One'},
+     *   { value: 'two', label: 'Two'},
+     * ];
+     * <DualListBox options={options} />
+     */
+    options: Array<Option<T>>;
+    /**
+     * Selected options.
+     *
+     * @example
+     * <DualListBox options={options} selected={['one']} />
+     */
+    selected?: T[];
+    /**
+     * A React function `ref` to the "selected" list box.
+     */
+    selectedRef?: ((availableInput: HTMLSelectElement) => void) | null;
+    /**
+     * Override the default alignment of action buttons.
+     *
+     * @default "middle"
+     *
+     * @example
+     * <DualListBox options={options} alignActions="top" />
+     */
+    alignActions?: 'top' | 'middle';
+    /**
+     * If true, duplicate options will be allowed in the selected list box.
+     *
+     * @default false
+     *
+     * @example
+     * <DualListBox options={options} allowDuplicates />
+     */
+    allowDuplicates?: boolean;
+    /**
+     * A subset of the `options` array to optionally filter the available list box.
+     *
+     * @example
+     * const available = ['io', 'europa', 'ganymede', 'callisto'];
+     * <DualListBox options={options} available={available} />;
+     */
+    available?: T[];
+    /**
+     * A React function `ref` to the "available" list box.
+     *
+     * @default null
+     */
+    availableRef?: ((availableInput: HTMLSelectElement) => void) | null;
+    /**
+     * An optional `className` to apply to the root node.
+     *
+     * @default null
+     */
+    className?: string | null;
+    /**
+     * If true, both "available" and "selected" list boxes will be disabled.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * A key-value pairing of action icons and their React nodes.
+     */
+    icons?: {
+        [k in
+            | 'moveLeft'
+            | 'moveAllLeft'
+            | 'moveRight'
+            | 'moveAllRight'
+            | 'moveDown'
+            | 'moveUp'
+            | 'moveTop'
+            | 'moveBottom']?: React.ReactNode;
+    };
+    /**
+     * An HTML ID prefix for the various sub elements.
+     *
+     * @default null
+     */
+    id?: string | null;
+    /**
+     * A key-value pairing of localized text.
+     */
+    lang?: {
+        [k in
+            | 'availableFilterHeader'
+            | 'availableHeader'
+            | 'moveAllLeft'
+            | 'moveAllRight'
+            | 'moveLeft'
+            | 'moveRight'
+            | 'moveBottom'
+            | 'moveDown'
+            | 'moveUp'
+            | 'moveTop'
+            | 'noAvailableOptions'
+            | 'noSelectedOptions'
+            | 'selectedFilterHeader'
+            | 'selectedHeader']?: string;
+    };
+    /**
+     * A list of key codes that will trigger a toggle of the selected options.
+     *
+     * @default [13, 32]
+     *
+     * @example
+     * <DualListBox options={options} moveKeyCodes={[13, 32]} />
+     */
+    moveKeyCodes?: number[];
+    /**
+     * A value for the `name` attribute on the hidden `<input />` element. This is potentially
+     * useful for form submissions.
+     *
+     * @default null
+     */
+    name?: string | null;
+    /**
+     * This flag will preserve the selection order.  By default, `react-dual-listbox` orders
+     * selected items according to the order of the `options` property.
+     *
+     * @default false
+     *
+     * @example
+     * <DualListBox options={options} preserveSelectOrder />
+     */
+    preserveSelectOrder?: boolean;
+    /**
+     * If true, labels above both the available and selected list boxes will appear. These labels
+     * derive from `lang`.
+     *
+     * @default false
+     */
+    showHeaderLabels?: boolean;
+    /**
+     * If true, text will appear in place of the available/selected list boxes when no options are
+     * present.
+     *
+     * @default false;
+     */
+    showNoOptionsText?: boolean;
+    /**
+     * If true, a set of up/down buttons will appear near the selected list box to allow the user
+     * to re-arrange the items.
+     *
+     * @default false
+     */
+    showOrderButtons?: boolean;
+}
+
+/** Additional `DualListBox` properties with filter. */
+export interface FilterProperties<T, F extends boolean> {
+    /**
+     * Flag that determines whether filtering is enabled.
+     *
+     * @default false
+     *
+     * @example
+     * <DualListBox options={options} canFilter />
+     */
+    canFilter?: F;
+    /**
+     * Override the default filtering function.
+     *
+     * @example
+     * <DualListBox
+     *   options={options}
+     *   filterCallback={(option, filterInput) => !!(...)}
+     *   canFilter
+     * />
+     */
+    filterCallback?: F extends true ? (option: Option<T>, filterInput: string) => boolean : undefined;
+    /**
+     * Override the default filter placeholder.
+     *
+     * @example
+     * <DualListBox
+     *   options={options}
+     *   filterPlaceholder="..."
+     *   canFilter
+     * />
+     */
+    filterPlaceholder?: F extends true ? string : undefined;
+    /**
+     * Control the filter search text.
+     *
+     * @example
+     * const filter = { available: 'europa', selected: '' };
+     * <DualListBox
+     *   options={options}
+     *   filter={filter}
+     *   canFilter
+     * />
+     */
+    filter?: Filter<T>;
+    /**
+     * Handle filter change.
+     *
+     * @example
+     * <DualListBox
+     *   options={options}
+     *   onFilterChange={filter => {...}}
+     *   canFilter
+     * />
+     */
+    onFilterChange?: F extends true ? (filter: string) => void : undefined;
+}
+
+/** Additional `DualListBox` properties with complex selected values. */
+export interface ValueProperties<T, V extends boolean> {
+    /**
+     * The handler called when options are moved to either side.
+     *
+     * @example
+     * <DualListBox options={options} onChange={selected => {...}} />
+     */
+    // onChange?: (selected: (T | Option<T>)[]) => void;
+    onChange?: (selected: V extends true ? T[] : Array<Option<T>>) => void;
+    /**
+     * If true, the selected value passed in onChange is an array of string values.
+     * Otherwise, it is an array of options.
+     *
+     * @default true
+     *
+     * @example
+     * <DualListBox
+     *   options={options}
+     *   onChange={selectedValues => {...}}
+     * />
+     * <DualListBox
+     *   options={options}
+     *   simpleValue={false}
+     *   onChange={selectedOptions => {...}}
+     * />
+     */
+    simpleValue?: V;
+}
+
+/** `DualListBox` component properties. */
+// export type DualListBoxProperties<P> = CommonProperties<P> & FilterProperties<P> & ValueProperties<P>;
+export interface DualListBoxProperties<P, F extends boolean, V extends boolean>
+    extends CommonProperties<P>,
+        FilterProperties<P, F>,
+        ValueProperties<P, V> {}
+
+/**
+ * A feature-rich dual list box for React.
+ *
+ * The `DualListBox` is a controlled component, so you have to update the `selected` property in
+ * conjunction with the `onChange` handler if you want the selected values to change.
+ *
+ * @example
+ * // Example options (Option<string>[]).
+ * const options: Option<string>[] = [
+ *   { label: 'One', value: 'one' },
+ *   { label: 'Two', value: 'two' },
+ * ];
+ *
+ * const [selectedValues, setSelectedValues] = React.useState<string[]>([]);
+ *
+ * // Component handler
+ * const handleChange = (selectedValues: string[]) => {
+ *   setSelectedValues(selectedValues);
+ * };
+ *
+ * // Usage example (`DualListBox` with options of
+ * // `Options<string>[]` is a `DualListBox<string>`):
+ * <DualListBox
+ *   options={options}
+ *   selected={selectedValues}
+ *   onChange={handleChange}
+ * />
+ */
+export default class DualListBox<P, F extends boolean = false, V extends boolean = true> extends React.Component<
+    DualListBoxProperties<P, F, V>
+> {}

--- a/types/react-dual-listbox/react-dual-listbox-tests.tsx
+++ b/types/react-dual-listbox/react-dual-listbox-tests.tsx
@@ -1,0 +1,178 @@
+import * as React from 'react';
+import DualListBox, { Option, ValueOption } from 'react-dual-listbox';
+
+/** Example options */
+// Flat options
+const flatOptions: Array<ValueOption<string>> = [
+    { label: 'One', value: 'one' }, // ValueOption<string>
+    { label: 'Two', value: 'two' }, // ValueOption<string>
+];
+
+// Nested options
+const nestedOptions: Array<Option<string>> = [
+    { label: 'Option 1', value: '1' }, // ValueOption<string>
+    {
+        label: 'Category',
+        options: [
+            { label: 'Option 2', value: '2' }, // ValueOption<string>
+            {
+                label: 'Nested Category',
+                options: [
+                    { label: 'Option 3', value: '4' }, // ValueOption<string>
+                ],
+            }, // CategoryOption<string>
+        ],
+    }, // CategoryOption<string>
+]; // Option<string>[]
+
+/** Example change handlers */
+// Simple value change handler.
+const valuesChange = (selectedValues: string[]) => {};
+// Complex value change handler.
+const optionsChange = (selectedValues: Array<Option<string>>) => {};
+
+/** Using flat and nested option structures. */
+<DualListBox options={flatOptions} className="foo" />;
+<DualListBox options={nestedOptions} />;
+
+/** Selection examples. */
+<DualListBox options={flatOptions} onChange={valuesChange} />;
+<DualListBox options={flatOptions} simpleValue onChange={valuesChange} />;
+<DualListBox options={flatOptions} simpleValue={false} onChange={optionsChange} />;
+
+/** Selection error examples. */
+<DualListBox
+    options={flatOptions}
+    // @ts-expect-error You can't use an options change handler when `simpleValues` is `true`.
+    onChange={optionsChange}
+/>;
+<DualListBox
+    options={flatOptions}
+    // @ts-expect-error You can't use an options change handler when `simpleValues` is `true`.
+    onChange={optionsChange}
+    simpleValue
+/>;
+<DualListBox
+    options={flatOptions}
+    // @ts-expect-error You can't use a values change handler when `simpleValues` is `false`.
+    onChange={valuesChange}
+    simpleValue={false}
+/>;
+
+/** Filtering examples. */
+<DualListBox options={flatOptions} canFilter={false} />;
+<DualListBox
+    options={flatOptions}
+    canFilter
+    filter={{
+        available: flatOptions.map(o => o.value),
+        selected: [],
+    }}
+    onFilterChange={() => {}}
+    filterPlaceholder={''}
+    filterCallback={(option: Option<string>) => true}
+/>;
+
+/** Filtering error examples. */
+// @ts-expect-error You can not use filter properties when `canFilter` is not `true`.
+<DualListBox
+    options={flatOptions}
+    filter={{
+        available: flatOptions.map(o => o.value),
+        selected: [],
+    }}
+    onFilterChange={() => {}}
+    filterPlaceholder={''}
+    filterCallback={(option: Option<string>) => true}
+/>;
+// @ts-expect-error You can not use filter properties when `canFilter` is not `true`.
+<DualListBox
+    options={flatOptions}
+    canFilter={false}
+    filter={{
+        available: flatOptions.map(o => o.value),
+        selected: [],
+    }}
+    onFilterChange={() => {}}
+    filterPlaceholder={''}
+    filterCallback={(option: Option<string>) => true}
+/>;
+
+/** Section labels. */
+<DualListBox
+    options={flatOptions}
+    available={flatOptions.map(o => o.value)}
+    lang={{ availableHeader: 'Available', selectedHeader: 'Selected' }}
+/>;
+
+/** Action alignment. */
+<DualListBox options={flatOptions} alignActions={'top'} />;
+
+/** Disabled. */
+<DualListBox options={flatOptions} disabled />;
+
+/** Preserving select order. */
+<DualListBox options={flatOptions} preserveSelectOrder />;
+
+/** `moveKeyCodes` example. */
+<DualListBox options={flatOptions} moveKeyCodes={[13, 32]} />;
+
+/** `icons` example. */
+<DualListBox
+    options={flatOptions}
+    icons={{
+        moveLeft: <span className="fa fa-chevron-left" />,
+        moveAllLeft: [<span key={0} className="fa fa-chevron-left" />, <span key={1} className="fa fa-chevron-left" />],
+        moveRight: <span className="fa fa-chevron-right" />,
+        moveAllRight: [
+            <span key={0} className="fa fa-chevron-right" />,
+            <span key={1} className="fa fa-chevron-right" />,
+        ],
+        moveDown: <span className="fa fa-chevron-down" />,
+        moveUp: <span className="fa fa-chevron-up" />,
+        moveTop: <span className="fa fa-double-angle-up" />,
+        moveBottom: <span className="fa fa-double-angle-down" />,
+    }}
+/>;
+
+/** Kitchen sink. */
+<DualListBox
+    id="my-dual-listbox-id-prefix"
+    name="my-hidden-input-name"
+    className="my-special-class"
+    options={flatOptions}
+    selected={[]}
+    alignActions={'top'}
+    allowDuplicates
+    available={flatOptions.map(o => o.value)}
+    icons={{
+        moveLeft: <span className="fa fa-chevron-left" />,
+        moveAllLeft: [<span key={0} className="fa fa-chevron-left" />, <span key={1} className="fa fa-chevron-left" />],
+        moveRight: <span className="fa fa-chevron-right" />,
+        moveAllRight: [
+            <span key={0} className="fa fa-chevron-right" />,
+            <span key={1} className="fa fa-chevron-right" />,
+        ],
+        moveDown: <span className="fa fa-chevron-down" />,
+        moveUp: <span className="fa fa-chevron-up" />,
+        moveTop: <span className="fa fa-double-angle-up" />,
+        moveBottom: <span className="fa fa-double-angle-down" />,
+    }}
+    lang={{ availableHeader: 'Available', selectedHeader: 'Selected' }}
+    moveKeyCodes={[13, 32]}
+    simpleValue={false}
+    onChange={optionsChange}
+    canFilter
+    filter={{
+        available: flatOptions.map(o => o.value),
+        selected: [],
+    }}
+    onFilterChange={() => {}}
+    filterPlaceholder={''}
+    filterCallback={(option: Option<string>) => true}
+    disabled
+    preserveSelectOrder
+    showHeaderLabels
+    showNoOptionsText
+    showOrderButtons
+/>;

--- a/types/react-dual-listbox/tsconfig.json
+++ b/types/react-dual-listbox/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "jsx": "react",
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-dual-listbox-tests.tsx"
+    ]
+}

--- a/types/react-dual-listbox/tslint.json
+++ b/types/react-dual-listbox/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

Most of the credit goes to @jmfirth for the initial work done in https://github.com/jakezatecky/react-dual-listbox/pull/37 a few years ago.