### PR TITLE
Update to new mongodb types to match new driver version in meteor 2.6

### DIFF
--- a/types/meteor/README.md
+++ b/types/meteor/README.md
@@ -2,8 +2,7 @@
 
 ## Description
 
-These are the definitions for version 2.0 of Meteor.  These definitions were generated from the same [Meteor data.js file](https://github.com/meteor/meteor/blob/devel/docs/client/data.js) that is used to generate the official [Meteor docs](http://docs.meteor.com/).  The code that generates these definitions can be found [here](https://github.com/meteor-typescript/meteor-typescript-libs/).
-
+These are the definitions for version 2.6 of Meteor.  These definitions were long ago (Meteor 1.x days) generated from the same [Meteor data.js file](https://github.com/meteor/meteor/blob/devel/docs/client/data.js) that is used to generate the official [Meteor docs](http://docs.meteor.com/) but are now updated manually.
 
 ## Meteor `typescript` package
 

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -1,6 +1,6 @@
 import * as MongoNpmModule from 'mongodb';
 // tslint:disable-next-line:no-duplicate-imports
-import { Collection as MongoCollection, Db as MongoDb, IndexOptions, MongoClient } from 'mongodb';
+import { Collection as MongoCollection, Db as MongoDb, CreateIndexesOptions as IndexOptions, MongoClient } from 'mongodb';
 import { Meteor } from 'meteor/meteor';
 
 declare module 'meteor/mongo' {

--- a/types/meteor/package.json
+++ b/types/meteor/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^3.6.20"
+        "mongodb": "^4.3.1"
     }
 }

--- a/types/meteor/test/meteor-mongo-tests.ts
+++ b/types/meteor/test/meteor-mongo-tests.ts
@@ -523,7 +523,7 @@ Attachment.find({}, { transform: null }).observe({
 
 // Test MongoInternals
 
-MongoInternals.NpmModules.mongodb.module.connect('...');
+MongoInternals.NpmModules.mongodb.module.MongoClient.connect('...');
 
 // Check Errors
 // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/meteor/meteor/discussions/11749
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
