### PR TITLE
[ember] Fix Ember types when using `exactOptionalPropertyTypes`

### DIFF
--- a/types/ember-resolver/tsconfig.json
+++ b/types/ember-resolver/tsconfig.json
@@ -15,6 +15,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember/test/object.ts
+++ b/types/ember/test/object.ts
@@ -9,7 +9,7 @@ const LifetimeHooks = Ember.Object.extend({
     },
 
     willDestroy() {
-        delete this.resource;
+        this.resource = undefined;
         this._super();
     },
 });

--- a/types/ember/tsconfig.json
+++ b/types/ember/tsconfig.json
@@ -16,6 +16,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__application/tsconfig.json
+++ b/types/ember__application/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__array/tsconfig.json
+++ b/types/ember__array/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -18,9 +18,9 @@ export default class Helper<S extends HelperSignature = HelperSignature> extends
      * example:
      */
     static helper<
-        P extends HelperSignature['PositionalArgs'],
-        N extends HelperSignature['NamedArgs'],
-        R extends HelperSignature['Return']
+        P extends NonNullable<HelperSignature['PositionalArgs']>,
+        N extends NonNullable<HelperSignature['NamedArgs']>,
+        R extends NonNullable<HelperSignature['Return']>,
     >(
         helper: (positional: P, named: N) => R
     ): Helper<{ PositionalArgs: P, NamedArgs: N, Return: R }>;
@@ -52,9 +52,9 @@ interface FunctionBasedHelper<S extends HelperSignature>
  * ```
  */
 export function helper<
-    P extends HelperSignature['PositionalArgs'],
-    N extends HelperSignature['NamedArgs'],
-    R extends HelperSignature['Return'],
+    P extends NonNullable<HelperSignature['PositionalArgs']>,
+    N extends NonNullable<HelperSignature['NamedArgs']>,
+    R extends NonNullable<HelperSignature['Return']>,
 >(
     helperFn: (positional: P, named: N) => R
 ): FunctionBasedHelper<{

--- a/types/ember__component/tsconfig.json
+++ b/types/ember__component/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__controller/tsconfig.json
+++ b/types/ember__controller/tsconfig.json
@@ -16,6 +16,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true,
         "experimentalDecorators": true
     },

--- a/types/ember__debug/tsconfig.json
+++ b/types/ember__debug/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__engine/tsconfig.json
+++ b/types/ember__engine/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__error/tsconfig.json
+++ b/types/ember__error/tsconfig.json
@@ -16,6 +16,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__object/test/object.ts
+++ b/types/ember__object/test/object.ts
@@ -9,7 +9,7 @@ const LifetimeHooks = EmberObject.extend({
     },
 
     willDestroy() {
-        delete this.resource;
+        this.resource = undefined;
         this._super();
     },
 });

--- a/types/ember__object/tsconfig.json
+++ b/types/ember__object/tsconfig.json
@@ -19,6 +19,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__polyfills/tsconfig.json
+++ b/types/ember__polyfills/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__routing/tsconfig.json
+++ b/types/ember__routing/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__runloop/tsconfig.json
+++ b/types/ember__runloop/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__service/tsconfig.json
+++ b/types/ember__service/tsconfig.json
@@ -17,6 +17,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__string/tsconfig.json
+++ b/types/ember__string/tsconfig.json
@@ -16,6 +16,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__template/tsconfig.json
+++ b/types/ember__template/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__test/tsconfig.json
+++ b/types/ember__test/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/ember__utils/tsconfig.json
+++ b/types/ember__utils/tsconfig.json
@@ -18,6 +18,7 @@
         },
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/htmlbars-inline-precompile/tsconfig.json
+++ b/types/htmlbars-inline-precompile/tsconfig.json
@@ -14,6 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/rsvp/tsconfig.json
+++ b/types/rsvp/tsconfig.json
@@ -16,6 +16,7 @@
         ],
         "types": [],
         "noEmit": true,
+        "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-------

A few notes:

1) I'm not sure this is the right fix for the problem.
2) I'm not sure whether it's "correct" to add `exactOptionalPropertyTypes` to `ember/tsconfig.json`. This will make sure further regressions are not allowed. But should it also be added in all sub-packages? Or it shouldn't be added at all - but in that case how do we test it?