### PR TITLE
@types/ember v4: make route model type generic object

### DIFF
--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -12,7 +12,8 @@ type RouteModel = object | string | number;
  * The `Ember.Route` class is used to define individual routes. Refer to
  * the [routing guide](http://emberjs.com/guides/routing/) for documentation.
  */
-export default class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) {
+export default class Route<Model = unknown, Params extends object = object>
+    extends EmberObject.extend(ActionHandler, Evented) {
     // methods
     /**
      * This hook is called after this route's model has resolved. It follows
@@ -68,7 +69,7 @@ export default class Route<Model = unknown> extends EmberObject.extend(ActionHan
      * A hook you can implement to convert the URL into the model for
      * this route.
      */
-    model(params: Record<string, unknown>, transition: Transition): Model | PromiseLike<Model>;
+    model(params: Params, transition: Transition): Model | PromiseLike<Model>;
 
     /**
      * Returns the model of a parent (or any ancestor) route

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -164,3 +164,16 @@ class WithBadReturningBeforeAndModelHooks extends Route {
         return "returning anything else is nonsensical (if 'legal')"; // $ExpectError
     }
 }
+
+interface RouteParams {
+    cool: string;
+}
+
+class WithParamsInModel extends Route<boolean, RouteParams> {
+    model(params: RouteParams, transition: Transition) {
+        return true;
+    }
+}
+
+// @ts-expect-error
+class WithNonsenseParams extends Route<boolean, number> {}

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -177,3 +177,12 @@ class WithParamsInModel extends Route<boolean, RouteParams> {
 
 // @ts-expect-error
 class WithNonsenseParams extends Route<boolean, number> {}
+
+class WithImplicitParams extends Route {
+    model(params: RouteParams) {
+        return { whatUp: 'dog' };
+    }
+}
+
+// $ExpectType RouteParams
+type ImplicitParams = WithImplicitParams extends Route<any, infer T> ? T : never;


### PR DESCRIPTION
This allows the model hook to be defined using an extracted interface naming the parameters. While `object` isn't *usually* preferable, it is the correct type here because it does not require an index signature.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **N/A:** this is types-only behavior
