### PR TITLE
fix(mysql): error when exactOptionalPropertyTypes is enabled

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -595,11 +595,6 @@ export interface MysqlError extends Error {
     fieldCount?: number | undefined;
 
     /**
-     * The stack trace for the error
-     */
-    stack?: string | undefined;
-
-    /**
      * Boolean, indicating if this error is terminal to the connection object.
      */
     fatal: boolean;

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -405,6 +405,8 @@ connection.query('SELECT 1', err => {
 });
 
 connection.query('USE name_of_db_that_does_not_exist', (err: mysql.MysqlError, rows: any) => {
+    // $ExpectType string
+    err.stack;
     console.log(err.code); // 'ER_BAD_DB_ERROR'
 });
 


### PR DESCRIPTION
TypeScript 4.4 introduces the option `exactOptionalPropertyTypes`.
When enabled, this makes `foo?: footype` distinct of `foo?: footype | undefined`.

Same error, that was happening for `@types/node` is happening in `@types/mysql`. Both packages extend native `Error`, and the `stack` property was extended from `stack?: string` to `stack?: string | undefined`. That collides with parent property definition and produces an error.

Solution borrowed from same issue in node types:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55425

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55425
