### PR TITLE
[@mailchimp/mailchimp_marketing] Replace Status enum with union type

### DIFF
--- a/types/mailchimp__mailchimp_marketing/index.d.ts
+++ b/types/mailchimp__mailchimp_marketing/index.d.ts
@@ -16,13 +16,7 @@ export interface Options {
     skipMergeValidation: boolean;
 }
 
-export enum Status {
-    'subscribed' = 'subscribed',
-    'unsubscribed' = 'unsubscribed',
-    'cleaned' = 'cleaned',
-    'pending' = 'pending',
-    'transactional' = 'transactional',
-}
+export type Status = 'subscribed' | 'unsubscribed' | 'cleaned' | 'pending' | 'transactional';
 
 export interface Body {
     status?: Status | undefined;

--- a/types/mailchimp__mailchimp_marketing/mailchimp__mailchimp_marketing-tests.ts
+++ b/types/mailchimp__mailchimp_marketing/mailchimp__mailchimp_marketing-tests.ts
@@ -1,5 +1,4 @@
 import mailchimp = require('@mailchimp/mailchimp_marketing');
-import { Status } from 'mailchimp__mailchimp_marketing';
 
 // void;
 mailchimp.setConfig({
@@ -10,7 +9,7 @@ mailchimp.setConfig({
 
 const setListMemberBody = {
     email_address: 'test',
-    status_if_new: Status.subscribed,
+    status_if_new: 'subscribed' as const,
 };
 
 const addListMemberBody = {


### PR DESCRIPTION
Related discussion: #58422

An enum in a type definition is saying that there exists an object with the properties listed, but there is no `Status` object in the original code. This PR replaces the enum with a union type, solving the problem.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test mailchimp__mailchimp_marketing`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
