### PR TITLE
[minio] Fixed return type in listenBucketNotification

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -368,7 +368,7 @@ export class Client {
     setBucketPolicy(bucketName: string, bucketPolicy: string, callback: NoResultCallback): void;
     setBucketPolicy(bucketName: string, bucketPolicy: string): Promise<void>;
 
-    listenBucketNotification(bucketName: string, prefix: string, suffix: string, events: NotificationEvent[]): EventEmitter;
+    listenBucketNotification(bucketName: string, prefix: string, suffix: string, events: NotificationEvent[]): NotificationPoller;
 
     // Custom Settings
     setS3TransferAccelerate(endpoint: string): void;

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -306,7 +306,9 @@ minio.setBucketNotification('testBucket', notificationConfig);
 minio.removeAllBucketNotification('testBucket', (error: Error|null) => { console.log(error); });
 minio.removeAllBucketNotification('testBucket');
 
-minio.listenBucketNotification('testBucket', 'pref_', '_suf', [ Minio.ObjectCreatedAll ]);
+const poller = minio.listenBucketNotification('testBucket', 'pref_', '_suf', [Minio.ObjectCreatedAll]);
+poller.start();
+poller.stop();
 
 minio.getBucketPolicy('testBucket', (error: Error|null, policy: string) => { console.log(error, policy); });
 minio.getBucketPolicy('testBucket');


### PR DESCRIPTION
Changed the return type of listenBucketNotification function from node's EventEmitter to already defined NotificationPoller that was not used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Minio docs here](https://docs.min.io/docs/javascript-client-api-reference.html#listenBucketNotification)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
