### PR TITLE
@types/googlepay - CardParameters -  Add `assuranceDetailsRequired` attribute

### DIFF
--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -836,6 +836,26 @@ declare namespace google.payments.api {
     }
 
     /**
+     * Assurance details about what validation has been performed on the returned payment credentials so that appropriate instrument risk checks can be applied.
+     *
+     *  Note: If both cardHolderAuthenticated and accountVerified are true, you don’t need to step up the returned credentials.
+     *  If both aren’t, we recommend you to run the same risk checks and , authentication including 3D Secure flow if applicable.
+     */
+    interface AssuranceDetails {
+        /**
+         * If true, indicates that Cardholder possession validation has been performed on returned payment credential.
+         */
+        accountVerified?: true | false | undefined;
+
+        /**
+         * If true, indicates that identification and verifications (ID&V) was performed on the returned payment credential.
+         *
+         * If false, the same risk-based authentication can be performed as you would for card transactions. This risk-based authentication can include, but not limited to, step-up with 3D Secure protocol if applicable.
+         */
+        cardHolderAuthenticated?: true | false | undefined;
+    }
+
+    /**
      * Parameters for card networks that can be used in this request.
      *
      * This should only be set for [[PaymentMethodType|`CARD`]].
@@ -1101,6 +1121,17 @@ declare namespace google.payments.api {
      * method.
      */
     interface CardInfo {
+        /*
+         *  AssuranceDetails
+         *
+         *  This object provides information about what validation
+         *  has been performed on the returned payment credentials
+         *  so that appropriate instrument risk checks can be applied.
+         *
+         *  To receive this object, set assuranceDetailsRequired: true inside CardParameters
+         */
+        assuranceDetails?: AssuranceDetails | undefined;
+
         /**
          * The card network.
          *

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -850,7 +850,8 @@ declare namespace google.payments.api {
         /**
          * If true, indicates that identification and verifications (ID&V) was performed on the returned payment credential.
          *
-         * If false, the same risk-based authentication can be performed as you would for card transactions. This risk-based authentication can include, but not limited to, step-up with 3D Secure protocol if applicable.
+         * If false, the same risk-based authentication can be performed as you would for card transactions.
+         * This risk-based authentication can include, but not limited to, step-up with 3D Secure protocol if applicable.
          */
         cardHolderAuthenticated?: true | false | undefined;
     }

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -793,6 +793,17 @@ declare namespace google.payments.api {
         allowCreditCards?: false | true | undefined;
 
         /**
+         * Set to `true` to request assuranceDetails.
+         *
+         * If omitted, defaults to `false`.
+         *
+         * You may set if you need object provides information about the validation performed on the returned payment data.
+         *
+         * @default false
+         */
+        assuranceDetailsRequired?: false | true | undefined;
+
+        /**
          * Whether a billing address is required from the buyer.
          *
          * If omitted, defaults to `false`.

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -801,7 +801,7 @@ declare namespace google.payments.api {
          *
          * @default false
          */
-        assuranceDetailsRequired?: false | true | undefined;
+        assuranceDetailsRequired?: boolean | undefined;
 
         /**
          * Whether a billing address is required from the buyer.
@@ -845,7 +845,7 @@ declare namespace google.payments.api {
         /**
          * If true, indicates that Cardholder possession validation has been performed on returned payment credential.
          */
-        accountVerified?: true | false | undefined;
+        accountVerified?: boolean | undefined;
 
         /**
          * If true, indicates that identification and verifications (ID&V) was performed on the returned payment credential.
@@ -853,7 +853,7 @@ declare namespace google.payments.api {
          * If false, the same risk-based authentication can be performed as you would for card transactions.
          * This risk-based authentication can include, but not limited to, step-up with 3D Secure protocol if applicable.
          */
-        cardHolderAuthenticated?: true | false | undefined;
+        cardHolderAuthenticated?: boolean | undefined;
     }
 
     /**


### PR DESCRIPTION
Interface CardParameters missing boolean assuranceDetailsRequired attribute.

The attribute should be present as you can see in [documentation](https://developers.google.com/pay/api/web/reference/request-objects#CardParameters)

If attribute is set to true, also CardInfo interface should contain [assuranceDetails](https://developers.google.com/pay/api/web/reference/response-objects#assurance-details-specifications)


https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58431
