### PR TITLE
Update MongoDB type definitions inside @types/meteor

### DIFF
--- a/types/angular-meteor/index.d.ts
+++ b/types/angular-meteor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Urigo/angular-meteor
 // Definitions by: Peter Grman <https://github.com/pgrm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="meteor" />
 

--- a/types/meteor-jboulhous-dev/index.d.ts
+++ b/types/meteor-jboulhous-dev/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jboulhous/dev
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="meteor" />
 

--- a/types/meteor-mdg-validated-method/index.d.ts
+++ b/types/meteor-mdg-validated-method/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Artemis Kearney <https://github.com/artemiswkearney>
 //                 Nicusor Chiciuc <https://github.com/nicu-chiciuc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 // Inspiration taken from https://github.com/nicu-chiciuc/typed-meteor-methods,
 // which was based on https://github.com/meteor-typings/validated-method/blob/master/main.d.ts by Dave Allen

--- a/types/meteor-persistent-session/index.d.ts
+++ b/types/meteor-persistent-session/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/okgrow/meteor-persistent-session
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="meteor" />
 

--- a/types/meteor-prime8consulting-oauth2/index.d.ts
+++ b/types/meteor-prime8consulting-oauth2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/prime-8-consulting/meteor-oauth2/
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="meteor" />
 

--- a/types/meteor/README.md
+++ b/types/meteor/README.md
@@ -2,8 +2,7 @@
 
 ## Description
 
-These are the definitions for version 2.0 of Meteor.  These definitions were generated from the same [Meteor data.js file](https://github.com/meteor/meteor/blob/devel/docs/client/data.js) that is used to generate the official [Meteor docs](http://docs.meteor.com/).  The code that generates these definitions can be found [here](https://github.com/meteor-typescript/meteor-typescript-libs/).
-
+These are the definitions for version 2.6 of Meteor.  These definitions were long ago (Meteor 1.x days) generated from the same [Meteor data.js file](https://github.com/meteor/meteor/blob/devel/docs/client/data.js) that is used to generate the official [Meteor docs](http://docs.meteor.com/) but are now updated manually.
 
 ## Meteor `typescript` package
 

--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Meteor 2.0
+// Type definitions for Meteor 2.6
 // Project: http://www.meteor.com/
 // Definitions by: Alex Borodach <https://github.com/barbatus>
 //                 Dave Allen <https://github.com/fullflavedave>
@@ -19,7 +19,7 @@
 //                 Markus Peloso <https://github.com/ToastHawaii>
 //                 Erik Demaine <https://github.com/edemaine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference path="./accounts-base.d.ts" />
 /// <reference path="./globals/accounts-base.d.ts" />

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -1,6 +1,6 @@
 import * as MongoNpmModule from 'mongodb';
 // tslint:disable-next-line:no-duplicate-imports
-import { Collection as MongoCollection, Db as MongoDb, IndexOptions, MongoClient } from 'mongodb';
+import { Collection as MongoCollection, Db as MongoDb, CreateIndexesOptions as IndexOptions, MongoClient } from 'mongodb';
 import { Meteor } from 'meteor/meteor';
 
 declare module 'meteor/mongo' {

--- a/types/meteor/package.json
+++ b/types/meteor/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^3.6.20"
+        "mongodb": "^4.3.1"
     }
 }

--- a/types/meteor/test/meteor-mongo-tests.ts
+++ b/types/meteor/test/meteor-mongo-tests.ts
@@ -523,7 +523,7 @@ Attachment.find({}, { transform: null }).observe({
 
 // Test MongoInternals
 
-MongoInternals.NpmModules.mongodb.module.connect('...');
+MongoInternals.NpmModules.mongodb.module.MongoClient.connect('...');
 
 // Check Errors
 // $ExpectError

--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -7,7 +7,7 @@
 //                 Rafa Horo <https://github.com/rafahoro>
 //                 Stepan Yurtsiv <https://github.com/yurtsiv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 import { check } from 'meteor/check';
 


### PR DESCRIPTION
Update MongoDB type definitions inside Meteor types so we can read directly from MongoDB typedefs now that they are published from the npm package.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url](https://github.com/mongodb/node-mongodb-native/blob/HEAD/docs/CHANGES_4.0.0.md)

Pending tests:
- [x] When running `npm test meteor` I'm getting errors due to Typescript 3.8, the errors are coming from `node_modules/mongodb`. Many errors like:
  ```txt
  Error: Errors in typescript@3.8 for external dependencies:
  node_modules/mongodb/mongodb.ts34.d.ts(36,135): error TS2304: Cannot find name 'TypedEventEmitter'.
  ```