### PR TITLE
@types/dom-speech-recognition: add prefixed global variables for Chrome

### DIFF
--- a/types/dom-speech-recognition/dom-speech-recognition-tests.ts
+++ b/types/dom-speech-recognition/dom-speech-recognition-tests.ts
@@ -27,6 +27,7 @@ const speechGrammarList2: SpeechGrammarList = {
     addFromURI: (src: string, weight?: number) => undefined,
     item: (index: number) => speechGrammar2,
 };
+const speechGrammarList3 = new webkitSpeechGrammarList();
 
 const speechRecognition = new SpeechRecognition();
 const speechRecognition2: SpeechRecognition = {
@@ -61,6 +62,7 @@ const speechRecognition2: SpeechRecognition = {
         options?: boolean | EventListenerOptions,
     ) => undefined,
 };
+const speechRecognition3 = new webkitSpeechRecognition();
 
 const speechRecognitionResultList = new SpeechRecognitionResultList();
 
@@ -70,6 +72,7 @@ const speechRecognitionEventInit: SpeechRecognitionEventInit = {
 };
 
 const speechRecognitionEvent = new SpeechRecognitionEvent('type', speechRecognitionEventInit);
+const speechRecognitionEvent2 = new webkitSpeechRecognitionEvent('type', speechRecognitionEventInit);
 
 const speechRecognitionErrorEventInit: SpeechRecognitionErrorEventInit = {
     error: 'aborted',

--- a/types/dom-speech-recognition/index.d.ts
+++ b/types/dom-speech-recognition/index.d.ts
@@ -132,3 +132,12 @@ interface SpeechGrammarList {
 }
 
 declare var SpeechGrammarList: { prototype: SpeechGrammarList; new (): SpeechGrammarList };
+
+// prefixed global variables in Chrome; should match the equivalents above
+// https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API#chrome_support
+declare var webkitSpeechRecognition: { prototype: SpeechRecognition; new (): SpeechRecognition; };
+declare var webkitSpeechGrammarList: { prototype: SpeechGrammarList; new (): SpeechGrammarList; };
+declare var webkitSpeechRecognitionEvent: {
+    prototype: SpeechRecognitionEvent;
+    new (type: string, eventInitDict: SpeechRecognitionEventInit): SpeechRecognitionEvent;
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Chrome support for the Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API#chrome_support)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (not applicable)
