### PR TITLE
@types/react: Add ForwardedRef type in React 16 too

### DIFF
--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -557,8 +557,10 @@ declare namespace React {
         displayName?: string | undefined;
     }
 
+    type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
+
     interface ForwardRefRenderFunction<T, P = {}> {
-        (props: PropsWithChildren<P>, ref: ((instance: T | null) => void) | MutableRefObject<T | null> | null): ReactElement | null;
+        (props: PropsWithChildren<P>, ref: ForwardedRef<T>): ReactElement | null;
         displayName?: string | undefined;
         // explicit rejected with `never` required due to
         // https://github.com/microsoft/TypeScript/issues/36826

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -408,6 +408,12 @@ const ForwardingRefComponent = React.forwardRef((props: ForwardingRefComponentPr
     return React.createElement(RefComponent, { ref });
 });
 
+// Declaring forwardRef render function separately (not inline).
+const ForwardRefRenderFunction = (props: ForwardingRefComponentProps, ref: React.ForwardedRef<RefComponent>)  => {
+    return React.createElement(RefComponent, { ref });
+};
+React.forwardRef(ForwardRefRenderFunction);
+
 const ForwardingRefComponentPropTypes: React.WeakValidationMap<ForwardingRefComponentProps> = {};
 ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- ~~[ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~ see explanation below
- ~~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

-----

The type called `type ForwardedRef` exist in the v17's `@types/react` and this is referenced by multiple documentation & tutorials (e.g. [React TypeScript Cheatsheet](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/forward_and_create_ref/)). 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e3c521a24da49da20e5e8be40d6e7a4551c3a814/types/react/index.d.ts#L567-L570

However this (`type ForwardedRef`) does not exist in v16's `@types/react` even though the type can be easily extracted from `interface ForwardRenderFunction`'s `ref` argument. This PR does that.