### PR TITLE
fix inquirer types

### DIFF
--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -136,7 +136,7 @@ declare namespace inquirer {
         /**
          * Prompts the questions to the user.
          */
-        <T>(questions: QuestionCollection<T>, initialAnswers?: Partial<T>): Promise<T> & { ui: PromptUI };
+        <T extends Answers = Answers>(questions: QuestionCollection<T>, initialAnswers?: Partial<T>): Promise<T> & { ui: PromptUI<T> };
 
         /**
          * Registers a new prompt-type.
@@ -318,7 +318,22 @@ declare namespace inquirer {
          * Either a value indicating whether the answer is valid or a `string` which describes the error.
          */
         validate?(input: any, answers?: T): boolean | string | Promise<boolean | string>;
+
+        /**
+         * Force to prompt the question if the answer already exists.
+         */
+        askAnswered?: boolean;
     }
+
+    /**
+     * Represents the possible answers of each question in the prompt
+     */
+    type QuestionAnswer<T extends Answers = Answers> = {
+        [K in keyof T]: {
+            name: K;
+            answer: T[K]
+        }
+    }[keyof T];
 
     /**
      * Represents a choice-item.

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inquirer 8.1
+// Type definitions for inquirer 8.2
 // Project: https://github.com/SBoudrias/Inquirer.js
 // Definitions by: Qubo <https://github.com/tkQubo>
 //                 Parvez <https://github.com/ppathan>

--- a/types/inquirer/inquirer-tests.ts
+++ b/types/inquirer/inquirer-tests.ts
@@ -1,5 +1,5 @@
 import { createInterface } from 'readline';
-import { Separator } from 'inquirer';
+import { DistinctQuestion, Separator } from 'inquirer';
 import inquirer = require('inquirer');
 import InputPrompt = require('inquirer/lib/prompts/input');
 import { fetchAsyncQuestionProperty } from 'inquirer/lib/utils/utils';
@@ -7,6 +7,7 @@ import incrementListIndex = require('inquirer/lib/utils/incrementListIndex');
 import Choices = require('inquirer/lib/objects/choices');
 import Paginator = require('inquirer/lib/utils/paginator');
 import ScreenManager = require('inquirer/lib/utils/screen-manager');
+import { Subject } from 'rxjs';
 
 {
     new inquirer.Separator('');
@@ -30,18 +31,22 @@ import ScreenManager = require('inquirer/lib/utils/screen-manager');
 {
     const checkBoxQuestion: inquirer.CheckboxQuestion = {
         type: 'checkbox',
+        askAnswered: true,
     };
 
     const listQuestion: inquirer.ListQuestion = {
         type: 'list',
+        askAnswered: true,
     };
 
     const rawListQuestion: inquirer.RawListQuestion = {
         type: 'rawlist',
+        askAnswered: true,
     };
 
     const expandQuestion: inquirer.ExpandQuestion = {
         type: 'expand',
+        askAnswered: true,
     };
 
     // $ExpectError
@@ -171,4 +176,38 @@ fetchAsyncQuestionProperty(
     const paginator = new Paginator(screen);
     paginator.paginate('test', 0);
     paginator.paginate('test', 0, 0);
+}
+
+{
+    const prompts = new Subject<DistinctQuestion>();
+    const promptResult = inquirer.prompt(prompts);
+    promptResult.ui.process.subscribe({
+        next: (value: {name: string, answer: any}) => {
+            // DO NOTHING
+        },
+    });
+    // $ExpectError
+    promptResult.ui.process.subscribe({
+        next: (value: {name_: string, answer: number}) => {
+            // DO NOTHING
+        },
+    });
+    prompts.complete();
+}
+
+{
+    const prompts = new Subject<DistinctQuestion<{str: string; num: number}>>();
+    const promptResult = inquirer.prompt(prompts);
+    promptResult.ui.process.subscribe({
+        next: (value: {name: 'str', answer: string} | {name: 'num', answer: number}) => {
+            // DO NOTHING
+        },
+    });
+    // $ExpectError
+    promptResult.ui.process.subscribe({
+        next: (value: {name: string, answer: number}) => {
+            // DO NOTHING
+        },
+    });
+    prompts.complete();
 }

--- a/types/inquirer/inquirer-tests.ts
+++ b/types/inquirer/inquirer-tests.ts
@@ -203,6 +203,17 @@ fetchAsyncQuestionProperty(
             // DO NOTHING
         },
     });
+    promptResult.ui.process.subscribe({
+        next: (value) => {
+            if (value.name === "str") {
+                // $ExpectType string
+                value.answer;
+            } else {
+                // $ExpectType number
+                value.answer;
+            }
+        },
+    });
     // $ExpectError
     promptResult.ui.process.subscribe({
         next: (value: {name: string, answer: number}) => {

--- a/types/inquirer/lib/ui/prompt.d.ts
+++ b/types/inquirer/lib/ui/prompt.d.ts
@@ -1,11 +1,11 @@
-import { defer, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import inquirer = require('../..');
 import UI = require('./baseUI');
 
 /**
  * Represents the prompt ui.
  */
-declare class PromptUI extends UI {
+declare class PromptUI<T extends inquirer.Answers = inquirer.Answers> extends UI {
     /**
      * Gets or sets the prompts of the ui.
      */
@@ -14,12 +14,12 @@ declare class PromptUI extends UI {
     /**
      * Gets or sets the answers provided by the user.
      */
-    answers: inquirer.Answers;
+    answers: T;
 
     /**
      * Gets or sets the event-flow of the process.
      */
-    process: Observable<inquirer.Answers>;
+    process: Observable<inquirer.QuestionAnswer<T>>;
 
     /**
      * Initializes a new instance of the `PromptUI` class.
@@ -41,12 +41,12 @@ declare class PromptUI extends UI {
      * @returns
      * The answers provided by the user.
      */
-    run(questions: Array<inquirer.DistinctQuestion<inquirer.Answers>>): Promise<inquirer.Answers>;
+    run(questions: Array<inquirer.DistinctQuestion<T>>): Promise<T>;
 
     /**
      * Finishes the process.
      */
-    protected onCompletion(): inquirer.Answers;
+    protected onCompletion(): T;
 
     /**
      * Processes a question.
@@ -58,7 +58,7 @@ declare class PromptUI extends UI {
      * The answer to the question.
      */
     protected processQuestion(
-        question: inquirer.DistinctQuestion<inquirer.Answers>,
+        question: inquirer.DistinctQuestion<T>,
     ): Observable<inquirer.ui.FetchedAnswer>;
 
     /**
@@ -71,7 +71,7 @@ declare class PromptUI extends UI {
      * The answer to the question.
      */
     protected fetchAnswer(
-        question: inquirer.ui.FetchedQuestion<inquirer.Answers>,
+        question: inquirer.ui.FetchedQuestion<T>,
     ): Observable<inquirer.ui.FetchedAnswer>;
 
     /**
@@ -84,8 +84,8 @@ declare class PromptUI extends UI {
      * The processed question.
      */
     protected setDefaultType(
-        question: inquirer.DistinctQuestion<inquirer.Answers>,
-    ): Observable<inquirer.DistinctQuestion<inquirer.Answers>>;
+        question: inquirer.DistinctQuestion<T>,
+    ): Observable<inquirer.DistinctQuestion<T>>;
 
     /**
      * Filters the question if it is runnable.
@@ -97,8 +97,8 @@ declare class PromptUI extends UI {
      * Either the event-flow of the question if it is runnable or an empty event-flow.
      */
     protected filterIfRunnable(
-        question: inquirer.DistinctQuestion<inquirer.Answers>,
-    ): Observable<inquirer.DistinctQuestion<inquirer.Answers>>;
+        question: inquirer.DistinctQuestion<T>,
+    ): Observable<inquirer.DistinctQuestion<T>>;
 }
 
 export = PromptUI;


### PR DESCRIPTION
I added the missing `askAnswered` property on the question interface (https://github.com/SBoudrias/Inquirer.js#question )
I fixed the PromptUI `process` observable type to the real one (https://github.com/SBoudrias/Inquirer.js/blob/a1da6cfc97fe29cdeb1edc8b2aafc20eeaf85dca/packages/inquirer/lib/ui/prompt.js#L105)
I also changed the PromptUI class to be generic as to the `Answers` type

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test inquirer`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SBoudrias/Inquirer.js#question https://github.com/SBoudrias/Inquirer.js/blob/a1da6cfc97fe29cdeb1edc8b2aafc20eeaf85dca/packages/inquirer/lib/ui/prompt.js#L105
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
