### PR TITLE
Fix Missing Property in 3.js Raycaster

### DIFF
--- a/types/three/src/core/Raycaster.d.ts
+++ b/types/three/src/core/Raycaster.d.ts
@@ -22,6 +22,7 @@ export interface Intersection<TIntersected extends Object3D = Object3D> {
     faceIndex?: number | undefined;
     object: TIntersected;
     uv?: Vector2 | undefined;
+    uv2?: Vector2 | undefined;
     instanceId?: number | undefined;
 }
 


### PR DESCRIPTION
Adds uv2 to Intersection interface to more accurately reflect the original documentation. 

(This change allowed me to access the UV2 values as intended when tested on my local machine, I could not find the relevant tests to put it into the formal testing process)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://threejs.org/docs/#api/en/core/Raycaster.intersectObject)>>
