### PR TITLE
Revert "fix: `lodash.groupBy` result never contains empty arrays"

### DIFF
--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -946,53 +946,53 @@ declare module "../index" {
          * @param iteratee The function invoked per iteration.
          * @return Returns the composed aggregate object.
          */
-        groupBy<T>(collection: List<T> | null | undefined, iteratee?: ValueIteratee<T>): Dictionary<[T, ...T[]]>;
+        groupBy<T>(collection: List<T> | null | undefined, iteratee?: ValueIteratee<T>): Dictionary<T[]>;
         /**
          * @see _.groupBy
          */
-        groupBy<T extends object>(collection: T | null | undefined, iteratee?: ValueIteratee<T[keyof T]>): Dictionary<[T[keyof T], ...Array<T[keyof T]>]>;
+        groupBy<T extends object>(collection: T | null | undefined, iteratee?: ValueIteratee<T[keyof T]>): Dictionary<Array<T[keyof T]>>;
     }
     interface String {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<string>): Object<Dictionary<[string, ...string[]]>>;
+        groupBy(iteratee?: ValueIteratee<string>): Object<Dictionary<string[]>>;
     }
     interface Collection<T> {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<T>): Object<Dictionary<[T, ...T[]]>>;
+        groupBy(iteratee?: ValueIteratee<T>): Object<Dictionary<T[]>>;
     }
     interface Object<T> {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<T[keyof T]>): Object<Dictionary<[T[keyof T], ...Array<T[keyof T]>]>>;
+        groupBy(iteratee?: ValueIteratee<T[keyof T]>): Object<Dictionary<Array<T[keyof T]>>>;
     }
     interface StringChain {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<string>): ObjectChain<Dictionary<[string, ...string[]]>>;
+        groupBy(iteratee?: ValueIteratee<string>): ObjectChain<Dictionary<string[]>>;
     }
     interface StringNullableChain {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<string>): ObjectChain<Dictionary<[string, ...string[]]>>;
+        groupBy(iteratee?: ValueIteratee<string>): ObjectChain<Dictionary<string[]>>;
     }
     interface CollectionChain<T> {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<T>): ObjectChain<Dictionary<[T, ...T[]]>>;
+        groupBy(iteratee?: ValueIteratee<T>): ObjectChain<Dictionary<T[]>>;
     }
     interface ObjectChain<T> {
         /**
          * @see _.groupBy
          */
-        groupBy(iteratee?: ValueIteratee<T[keyof T]>): ObjectChain<Dictionary<[T[keyof T], ...Array<T[keyof T]>]>>;
+        groupBy(iteratee?: ValueIteratee<T[keyof T]>): ObjectChain<Dictionary<Array<T[keyof T]>>>;
     }
     interface LoDashStatic {
         /**

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -1593,13 +1593,13 @@ declare namespace _ {
     interface LodashGroupBy {
         <T>(iteratee: lodash.ValueIteratee<T>): LodashGroupBy1x1<T>;
         <T>(iteratee: lodash.__, collection: lodash.List<T> | null | undefined): LodashGroupBy1x2<T>;
-        <T>(iteratee: lodash.ValueIteratee<T>, collection: lodash.List<T> | null | undefined): lodash.Dictionary<[T, ...T[]]>;
+        <T>(iteratee: lodash.ValueIteratee<T>, collection: lodash.List<T> | null | undefined): lodash.Dictionary<T[]>;
         <T extends object>(iteratee: lodash.__, collection: T | null | undefined): LodashGroupBy2x2<T>;
-        <T extends object>(iteratee: lodash.ValueIteratee<T[keyof T]>, collection: T | null | undefined): lodash.Dictionary<[T[keyof T], ...Array<T[keyof T]>]>;
+        <T extends object>(iteratee: lodash.ValueIteratee<T[keyof T]>, collection: T | null | undefined): lodash.Dictionary<Array<T[keyof T]>>;
     }
-    type LodashGroupBy1x1<T> = (collection: lodash.List<T> | object | null | undefined) => lodash.Dictionary<[T, ...T[]]>;
-    type LodashGroupBy1x2<T> = (iteratee: lodash.ValueIteratee<T>) => lodash.Dictionary<[T, ...T[]]>;
-    type LodashGroupBy2x2<T> = (iteratee: lodash.ValueIteratee<T[keyof T]>) => lodash.Dictionary<[T[keyof T], ...Array<T[keyof T]>]>;
+    type LodashGroupBy1x1<T> = (collection: lodash.List<T> | object | null | undefined) => lodash.Dictionary<T[]>;
+    type LodashGroupBy1x2<T> = (iteratee: lodash.ValueIteratee<T>) => lodash.Dictionary<T[]>;
+    type LodashGroupBy2x2<T> = (iteratee: lodash.ValueIteratee<T[keyof T]>) => lodash.Dictionary<Array<T[keyof T]>>;
     interface LodashGt {
         (value: any): LodashGt1x1;
         (value: lodash.__, other: any): LodashGt1x2;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -2512,49 +2512,49 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
 
 // _.groupBy
 {
-    _.groupBy(""); // $ExpectType Dictionary<[string, ...string[]]>
-    _.groupBy("", stringIterator); // $ExpectType Dictionary<[string, ...string[]]>
-    _.groupBy(list); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    _.groupBy(list, valueIterator); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    _.groupBy(list, "a"); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    _.groupBy(list, { a: 42 }); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    _.groupBy(dictionary); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    _.groupBy(dictionary, valueIterator); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    _.groupBy(dictionary, ""); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    _.groupBy(dictionary, { a: 42 }); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
+    _.groupBy(""); // $ExpectType Dictionary<string[]>
+    _.groupBy("", stringIterator); // $ExpectType Dictionary<string[]>
+    _.groupBy(list); // $ExpectType Dictionary<AbcObject[]>
+    _.groupBy(list, valueIterator); // $ExpectType Dictionary<AbcObject[]>
+    _.groupBy(list, "a"); // $ExpectType Dictionary<AbcObject[]>
+    _.groupBy(list, { a: 42 }); // $ExpectType Dictionary<AbcObject[]>
+    _.groupBy(dictionary); // $ExpectType Dictionary<AbcObject[]>
+    _.groupBy(dictionary, valueIterator); // $ExpectType Dictionary<AbcObject[]>
+    _.groupBy(dictionary, ""); // $ExpectType Dictionary<AbcObject[]>
+    _.groupBy(dictionary, { a: 42 }); // $ExpectType Dictionary<AbcObject[]>
 
-    _("").groupBy(); // $ExpectType Object<Dictionary<[string, ...string[]]>>
-    _("").groupBy(stringIterator); // $ExpectType Object<Dictionary<[string, ...string[]]>>
-    _(list).groupBy(); // $ExpectType Object<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _(list).groupBy(valueIterator); // $ExpectType Object<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _(list).groupBy(""); // $ExpectType Object<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _(list).groupBy({ a: 42 }); // $ExpectType Object<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _(dictionary).groupBy(); // $ExpectType Object<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _(dictionary).groupBy(valueIterator); // $ExpectType Object<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _(dictionary).groupBy(""); // $ExpectType Object<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _(dictionary).groupBy({ a: 42 }); // $ExpectType Object<Dictionary<[AbcObject, ...AbcObject[]]>>
+    _("").groupBy(); // $ExpectType Object<Dictionary<string[]>>
+    _("").groupBy(stringIterator); // $ExpectType Object<Dictionary<string[]>>
+    _(list).groupBy(); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(list).groupBy(valueIterator); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(list).groupBy(""); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(list).groupBy({ a: 42 }); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(dictionary).groupBy(); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(dictionary).groupBy(valueIterator); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(dictionary).groupBy(""); // $ExpectType Object<Dictionary<AbcObject[]>>
+    _(dictionary).groupBy({ a: 42 }); // $ExpectType Object<Dictionary<AbcObject[]>>
 
-    _.chain("").groupBy(); // $ExpectType ObjectChain<Dictionary<[string, ...string[]]>>
-    _.chain("").groupBy(stringIterator); // $ExpectType ObjectChain<Dictionary<[string, ...string[]]>>
-    _.chain(list).groupBy(); // $ExpectType ObjectChain<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _.chain(list).groupBy(valueIterator); // $ExpectType ObjectChain<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _.chain(list).groupBy(""); // $ExpectType ObjectChain<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _.chain(list).groupBy({ a: 42 }); // $ExpectType ObjectChain<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _.chain(dictionary).groupBy(); // $ExpectType ObjectChain<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _.chain(dictionary).groupBy(valueIterator); // $ExpectType ObjectChain<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _.chain(dictionary).groupBy(""); // $ExpectType ObjectChain<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _.chain(dictionary).groupBy({ a: 42 }); // $ExpectType ObjectChain<Dictionary<[AbcObject, ...AbcObject[]]>>
-    _.chain(nullableString).groupBy(); // $ExpectType ObjectChain<Dictionary<[string, ...string[]]>>
+    _.chain("").groupBy(); // $ExpectType ObjectChain<Dictionary<string[]>>
+    _.chain("").groupBy(stringIterator); // $ExpectType ObjectChain<Dictionary<string[]>>
+    _.chain(list).groupBy(); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(list).groupBy(valueIterator); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(list).groupBy(""); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(list).groupBy({ a: 42 }); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(dictionary).groupBy(); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(dictionary).groupBy(valueIterator); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(dictionary).groupBy(""); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(dictionary).groupBy({ a: 42 }); // $ExpectType ObjectChain<Dictionary<AbcObject[]>>
+    _.chain(nullableString).groupBy(); // $ExpectType ObjectChain<Dictionary<string[]>>
 
-    fp.groupBy(valueIterator, list); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    fp.groupBy(valueIterator)(list); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    fp.groupBy("a", list); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    fp.groupBy({ a: 42 }, list); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    fp.groupBy(["a", 42], list); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    fp.groupBy(valueIterator, dictionary); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    fp.groupBy("a", dictionary); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    fp.groupBy({ a: 42 }, dictionary); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
-    fp.groupBy(["a", 42], dictionary); // $ExpectType Dictionary<[AbcObject, ...AbcObject[]]>
+    fp.groupBy(valueIterator, list); // $ExpectType Dictionary<AbcObject[]>
+    fp.groupBy(valueIterator)(list); // $ExpectType Dictionary<AbcObject[]>
+    fp.groupBy("a", list); // $ExpectType Dictionary<AbcObject[]>
+    fp.groupBy({ a: 42 }, list); // $ExpectType Dictionary<AbcObject[]>
+    fp.groupBy(["a", 42], list); // $ExpectType Dictionary<AbcObject[]>
+    fp.groupBy(valueIterator, dictionary); // $ExpectType Dictionary<AbcObject[]>
+    fp.groupBy("a", dictionary); // $ExpectType Dictionary<AbcObject[]>
+    fp.groupBy({ a: 42 }, dictionary); // $ExpectType Dictionary<AbcObject[]>
+    fp.groupBy(["a", 42], dictionary); // $ExpectType Dictionary<AbcObject[]>
 }
 
 // _.includes


### PR DESCRIPTION
Reverting https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55914 as [requested by @aj-r](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55914#issuecomment-1012595869).