### PR TITLE
[amplitude-js] Add new or missing methods, configuration options and parameters

### DIFF
--- a/types/amplitude-js/amplitude-js-tests.ts
+++ b/types/amplitude-js/amplitude-js-tests.ts
@@ -90,6 +90,9 @@ import amplitude = require('amplitude-js');
     client.groupIdentify('type', 'name', identify, (httpCode, response, details) => {});
     client.logRevenue(3.99, 1, 'product_1234');
     client.logRevenueV2(revenue);
+    client.setLibrary();
+    client.setLibrary('library');
+    client.setLibrary('library', '1.12.3');
     identify = new amplitude.Identify()
         .set('colors', ['rose', 'gold'])
         .add('karma', 1)

--- a/types/amplitude-js/amplitude-js-tests.ts
+++ b/types/amplitude-js/amplitude-js-tests.ts
@@ -65,6 +65,8 @@ import amplitude = require('amplitude-js');
     client.logEvent('Clicked Homepage Button', { finished_flow: false, clicks: 15 });
     client.logEvent('EVENT_IDENTIFIER_HERE', { color: 'blue', age: 20, key: 'value' });
     client.logEvent('EVENT_IDENTIFIER_HERE', null, (httpCode, response) => {});
+    client.logEvent('EVENT_IDENTIFIER_HERE', null, undefined, (httpCode, response) => {});
+    client.logEvent('EVENT_IDENTIFIER_HERE', null, undefined, undefined, true);
     client.logEventWithGroups('initialize_game', { key: 'value' }, { sport: 'soccer' });
     client.logEventWithTimestamp('EVENT_IDENTIFIER_HERE', { key: 'value' }, 1505430378000, (httpCode, response) => {});
     client.setDeviceId('45f0954f-eb79-4463-ac8a-233a6f45a8f0');
@@ -94,6 +96,17 @@ import amplitude = require('amplitude-js');
     client.setLibrary();
     client.setLibrary('library');
     client.setLibrary('library', '1.12.3');
+    client.setMinTimeBetweenSessionsMillis(200);
+    client.onInit((_: amplitude.AmplitudeClient) => {});
+    client.setLibrary('library', '1.12.3');
+    client.getUserId() === '123';
+    client.getDeviceId() === '45f0954f-eb79-4463-ac8a-233a6f45a8f0';
+    client.setUseDynamicConfig(true);
+    client.setServerUrl('example.com');
+    client.setServerZone('EU');
+    client.setServerZone('US', false);
+    client.setEventUploadThreshold(10);
+
     identify = new amplitude.Identify()
         .set('colors', ['rose', 'gold'])
         .add('karma', 1)

--- a/types/amplitude-js/amplitude-js-tests.ts
+++ b/types/amplitude-js/amplitude-js-tests.ts
@@ -108,6 +108,7 @@ import amplitude = require('amplitude-js');
     client.setEventUploadThreshold(10);
     client.onNewSessionStart((_: amplitude.AmplitudeClient) => {});
     client.onInit((_: amplitude.AmplitudeClient) => {});
+    client.enableTracking();
 
     identify = new amplitude.Identify()
         .set('colors', ['rose', 'gold'])

--- a/types/amplitude-js/amplitude-js-tests.ts
+++ b/types/amplitude-js/amplitude-js-tests.ts
@@ -211,6 +211,7 @@ const defaults: amplitude.Config = {
     language: 'en',
     logLevel: 'WARN',
     onError: () => {},
+    onExit: () => {},
     optOut: false,
     platform: 'iOS',
     sameSiteCookie: 'Lax', // cookie privacy policy
@@ -219,6 +220,7 @@ const defaults: amplitude.Config = {
     saveParamsReferrerOncePerSession: true,
     secureCookie: false,
     sessionTimeout: 30 * 60 * 1000,
+    sessionId: 'sessionid',
     storage: 'cookies',
     trackingOptions: {
         city: true,
@@ -239,6 +241,24 @@ const defaults: amplitude.Config = {
     unsentKey: 'amplitude_unsent',
     unsentIdentifyKey: 'amplitude_unsent_identify',
     uploadBatchSize: 100,
+    useNativeDeviceInfo: true,
+    transport: 'beacon',
+    serverZone: 'US',
+    serverZoneBasedApi: true,
+    useDynamicConfig: true,
+    logAttributionCapturedEvent: true,
+    plan: {
+        branch: 'branch',
+        source: 'source',
+        version: 'version',
+    },
+    headers: {
+        'X-Header': 'value',
+    },
+    library: {
+        name: 'name',
+        version: 'version',
+    },
 };
 
 // For versions starting from 8.9.0

--- a/types/amplitude-js/amplitude-js-tests.ts
+++ b/types/amplitude-js/amplitude-js-tests.ts
@@ -106,6 +106,8 @@ import amplitude = require('amplitude-js');
     client.setServerZone('EU');
     client.setServerZone('US', false);
     client.setEventUploadThreshold(10);
+    client.onNewSessionStart((_: amplitude.AmplitudeClient) => {});
+    client.onInit((_: amplitude.AmplitudeClient) => {});
 
     identify = new amplitude.Identify()
         .set('colors', ['rose', 'gold'])

--- a/types/amplitude-js/amplitude-js-tests.ts
+++ b/types/amplitude-js/amplitude-js-tests.ts
@@ -70,6 +70,7 @@ import amplitude = require('amplitude-js');
     client.setDeviceId('45f0954f-eb79-4463-ac8a-233a6f45a8f0');
     client.setDomain('.amplitude.com');
     client.setUserId('joe@gmail.com');
+    client.setUserId('joe@example.com', false);
     client.setUserId(null);
     client.setOptOut(true);
     client.setGroup('type', 'name');

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Amplitude SDK 8.9
+// Type definitions for Amplitude SDK 8.16
 // Project: https://github.com/amplitude/Amplitude-Javascript
 // Definitions by: Dan Manastireanu <https://github.com/danmana>
 //                 Kimmo Hintikka <https://github.com/HintikkaKimmo>

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -117,6 +117,8 @@ export class AmplitudeClient {
     setUserId(userId: string | null, startNewSession?: boolean): void;
     getUserId(): string;
 
+    enableTracking(): void;
+
     setDeviceId(id: string): void;
     getDeviceId(): string;
     regenerateDeviceId(): void;

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -142,6 +142,9 @@ export class AmplitudeClient {
     groupIdentify(groupType: string, groupName: string | string[], identify: Identify, callback?: Callback, errorCallback?: Callback, outOfSession?: boolean): void;
 
     setUserProperties(properties: any): void;
+    /**
+     * @deprecated Use `setUserProperties` instead
+     */
     setGlobalUserProperties(properties: any): void;
     clearUserProperties(): void;
 
@@ -161,7 +164,11 @@ export class AmplitudeClient {
     logEvent(event: string, data?: any, callback?: Callback, errorCallback?: Callback, outOfSession?: boolean): LogReturn;
     logEventWithGroups(event: string, data?: any, groups?: any, callback?: Callback, errorCallback?: Callback, outOfSession?: boolean): LogReturn;
     logRevenueV2(revenue_obj: Revenue): LogReturn;
-    logRevenue(pric: number, quantity: number, product: string): LogReturn;
+
+    /**
+     * @deprecated Use `logRevenueV2` instead
+     */
+    logRevenue(price: number, quantity: number, product: string): LogReturn;
     logEventWithTimestamp(event: string, data?: any, timestamp?: number, callback?: Callback, errorCallback?: Callback, outOfSession?: boolean): LogReturn;
 
     Identify: typeof Identify;

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -101,10 +101,12 @@ export class AmplitudeClient {
     cookieStorage: CookieStorage;
 
     init(apiKey: string, userId?: string, config?: Config, callback?: (client: AmplitudeClient) => void): void;
+    onInit(callback: (client: AmplitudeClient) => void): void;
 
     setLibrary(name?: string, version?: string): void;
     setVersionName(versionName: string): void;
 
+    onNewSessionStart(callback: (client: AmplitudeClient) => void): void;
     isNewSession(): boolean;
     setSessionId(sessionId: number): void;
     getSessionId(): number;

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -102,6 +102,7 @@ export class AmplitudeClient {
 
     init(apiKey: string, userId?: string, config?: Config, callback?: (client: AmplitudeClient) => void): void;
 
+    setLibrary(name?: string, version?: string): void;
     setVersionName(versionName: string): void;
 
     isNewSession(): boolean;

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -109,15 +109,18 @@ export class AmplitudeClient {
     setSessionId(sessionId: number): void;
     getSessionId(): number;
     resetSessionId(): void;
+    setMinTimeBetweenSessionsMillis(timeInMillis: number): void;
 
     setDomain(domain: string): void;
     setUserId(userId: string | null, startNewSession?: boolean): void;
+    getUserId(): string;
 
     setDeviceId(id: string): void;
+    getDeviceId(): string;
     regenerateDeviceId(): void;
 
-    identify(identify: Identify, callback?: Callback): void;
-    groupIdentify(groupType: string, groupName: string | string[], identify: Identify, callback?: Callback): void;
+    identify(identify: Identify, callback?: Callback, errorCallback?: Callback, outOfSession?: boolean): void;
+    groupIdentify(groupType: string, groupName: string | string[], identify: Identify, callback?: Callback, errorCallback?: Callback, outOfSession?: boolean): void;
 
     setUserProperties(properties: any): void;
     setGlobalUserProperties(properties: any): void;
@@ -125,17 +128,22 @@ export class AmplitudeClient {
 
     clearStorage(): boolean;
 
+    setUseDynamicConfig(useDynamicConfig: boolean): void;
+
     setOptOut(enable: boolean): void;
 
     setGroup(groupType: string, groupName: string | string[]): void;
 
     setTransport(transport: Transport): void;
+    setServerUrl(serverUrl: string): void;
+    setServerZone(serverZone: ServerZone, serverZoneBasedApi?: boolean): void;
 
-    logEvent(event: string, data?: any, callback?: Callback): LogReturn;
-    logEventWithGroups(event: string, data?: any, groups?: any, callback?: Callback): LogReturn;
+    setEventUploadThreshold(eventUploadThreshold: number): void;
+    logEvent(event: string, data?: any, callback?: Callback, errorCallback?: Callback, outOfSession?: boolean): LogReturn;
+    logEventWithGroups(event: string, data?: any, groups?: any, callback?: Callback, errorCallback?: Callback, outOfSession?: boolean): LogReturn;
     logRevenueV2(revenue_obj: Revenue): LogReturn;
     logRevenue(pric: number, quantity: number, product: string): LogReturn;
-    logEventWithTimestamp(event: string, data?: any, timestamp?: number, callback?: Callback): LogReturn;
+    logEventWithTimestamp(event: string, data?: any, timestamp?: number, callback?: Callback, errorCallback?: Callback, outOfSession?: boolean): LogReturn;
 
     Identify: typeof Identify;
     Revenue: typeof Revenue;

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -111,7 +111,7 @@ export class AmplitudeClient {
     resetSessionId(): void;
 
     setDomain(domain: string): void;
-    setUserId(userId: string | null): void;
+    setUserId(userId: string | null, startNewSession?: boolean): void;
 
     setDeviceId(id: string): void;
     regenerateDeviceId(): void;

--- a/types/amplitude-js/index.d.ts
+++ b/types/amplitude-js/index.d.ts
@@ -12,6 +12,7 @@ export type Transport = 'http' | 'beacon';
 // https://github.com/amplitude/Amplitude-JavaScript/blob/v8.9.0/src/server-zone.js#L9
 export type ServerZone = 'EU' | 'US';
 
+// https://amplitude.github.io/Amplitude-JavaScript/Options
 export interface Config {
     apiEndpoint?: string | undefined;
     batchEvents?: boolean | undefined;
@@ -35,6 +36,7 @@ export interface Config {
     logLevel?: 'DISABLE' | 'ERROR' | 'WARN' | 'INFO' | undefined;
     optOut?: boolean | undefined;
     onError?: (() => void) | undefined;
+    onExit?: (() => void) | undefined;
     platform?: string | undefined;
     sameSiteCookie?: 'Lax' | 'Strict' | 'None' | undefined;
     saveEvents?: boolean | undefined;
@@ -42,6 +44,7 @@ export interface Config {
     saveParamsReferrerOncePerSession?: boolean | undefined;
     secureCookie?: boolean | undefined;
     sessionTimeout?: number | undefined;
+    sessionId?: string | null;
     storage?: '' | 'cookies' | 'localStorage' | 'sessionStorage' | 'none';
     trackingOptions?: {
         city?: boolean | undefined;
@@ -66,6 +69,18 @@ export interface Config {
     transport?: Transport | undefined;
     serverZone?: ServerZone | undefined;
     serverZoneBasedApi?: boolean | undefined;
+    useDynamicConfig?: boolean | undefined;
+    logAttributionCapturedEvent?: boolean | undefined;
+    plan?: {
+        branch?: string;
+        source?: string;
+        version?: string;
+    } | undefined;
+    headers?: Record<string, string>;
+    library?: {
+        name?: string;
+        version?: string;
+    } | undefined;
 }
 
 export class Identify {


### PR DESCRIPTION
This updates the type definitions to the latest version `8.16.0`. In addition to that, I also marked the two methods `logRevenue` and `setGlobalUserProperties` in the `AmplitudeClient` as deprecated (as can be seen in the [official js-sdk api reference](https://amplitude.github.io/Amplitude-JavaScript/#amplitudeclientlogrevenue))

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
