### PR TITLE
[gulp-javascript-obfuscator] Add type definitions

### DIFF
--- a/types/gulp-javascript-obfuscator/gulp-javascript-obfuscator-tests.ts
+++ b/types/gulp-javascript-obfuscator/gulp-javascript-obfuscator-tests.ts
@@ -1,0 +1,4 @@
+import gulp = require('gulp');
+import javascriptObfuscator = require('gulp-javascript-obfuscator');
+
+gulp.src('test.js').pipe(javascriptObfuscator()).pipe(gulp.dest('dist'));

--- a/types/gulp-javascript-obfuscator/gulp-javascript-obfuscator-tests.ts
+++ b/types/gulp-javascript-obfuscator/gulp-javascript-obfuscator-tests.ts
@@ -1,4 +1,10 @@
 import gulp = require('gulp');
 import javascriptObfuscator = require('gulp-javascript-obfuscator');
 
+// No args
 gulp.src('test.js').pipe(javascriptObfuscator()).pipe(gulp.dest('dist'));
+
+// Some javascript-obfuscator args
+gulp.src('test.js')
+    .pipe(javascriptObfuscator({ compact: true }))
+    .pipe(gulp.dest('dist'));

--- a/types/gulp-javascript-obfuscator/index.d.ts
+++ b/types/gulp-javascript-obfuscator/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for gulp-javascript-obfuscator 1.1
+// Project: https://github.com/javascript-obfuscator/gulp-javascript-obfuscator
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import { Transform } from 'readable-stream';
+import { ObfuscatorOptions } from 'javascript-obfuscator';
+
+declare function gulpJavaScriptObfuscator(options?: ObfuscatorOptions): Transform;
+
+export = gulpJavaScriptObfuscator;

--- a/types/gulp-javascript-obfuscator/package.json
+++ b/types/gulp-javascript-obfuscator/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "javascript-obfuscator": ">=1"
+        "javascript-obfuscator": "^3.0.0"
     }
 }

--- a/types/gulp-javascript-obfuscator/package.json
+++ b/types/gulp-javascript-obfuscator/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "javascript-obfuscator": ">=1"
+    }
+}

--- a/types/gulp-javascript-obfuscator/tsconfig.json
+++ b/types/gulp-javascript-obfuscator/tsconfig.json
@@ -1,23 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "gulp-javascript-obfuscator-tests.ts"
-    ]
+    "files": ["index.d.ts", "gulp-javascript-obfuscator-tests.ts"]
 }

--- a/types/gulp-javascript-obfuscator/tsconfig.json
+++ b/types/gulp-javascript-obfuscator/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "gulp-javascript-obfuscator-tests.ts"
+    ]
+}

--- a/types/gulp-javascript-obfuscator/tslint.json
+++ b/types/gulp-javascript-obfuscator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
As requested in #58443, adds type definitions for [gulp-javascript-obfuscator](https://www.npmjs.com/package/gulp-javascript-obfuscator).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test gulp-javascript-obfuscator`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
