### PR TITLE
[rtree] Fix rtree definitions

### DIFF
--- a/types/rtree/index.d.ts
+++ b/types/rtree/index.d.ts
@@ -16,8 +16,12 @@ declare class RTree {
     geoJSON(geoJSON: any): void;
     bbox(arg1: any, arg2?: any, arg3?: number, arg4?: number): any[];
     search(area: Rectangle, return_node?: boolean, return_array?: any[]): any[];
+    toJSON(printing?: string | number): string;
 }
 
-declare function rtreeFactory(max_node_width?: number): RTree;
+declare var rtreeLib: {
+    (max_node_width?: number): RTree;
+    fromJSON(json: string): RTree;
+};
 
-export = rtreeFactory;
+export = rtreeLib;

--- a/types/rtree/index.d.ts
+++ b/types/rtree/index.d.ts
@@ -19,7 +19,7 @@ declare class RTree {
     toJSON(printing?: string | number): string;
 }
 
-declare var rtreeLib: {
+declare const rtreeLib: {
     (max_node_width?: number): RTree;
     fromJSON(json: string): RTree;
 };

--- a/types/rtree/index.d.ts
+++ b/types/rtree/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for rtree 1.4.0
-// Project: https://github.com/leaflet-extras/RTree 
+// Project: https://github.com/leaflet-extras/RTree
 // Definitions by: Omede Firouz <https://github.com/oefirouz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -10,7 +10,7 @@ interface Rectangle {
     h: number;
 }
 
-interface RTreeStatic {
+declare class RTree {
     insert(bounds: Rectangle, element: Object): boolean;
     remove(area: Rectangle, element?: Object): any[];
     geoJSON(geoJSON: any): void;
@@ -18,8 +18,6 @@ interface RTreeStatic {
     search(area: Rectangle, return_node?: boolean, return_array?: any[]): any[];
 }
 
-interface RTreeFactory {
-    (max_node_width?: number): RTreeStatic;
-}
+declare function rtreeFactory(max_node_width?: number): RTree;
 
-declare var RTree: RTreeFactory;
+export = rtreeFactory;

--- a/types/rtree/rtree-tests.ts
+++ b/types/rtree/rtree-tests.ts
@@ -1,4 +1,4 @@
-import RTree from 'rtree';
+import RTree = require('rtree');
 
 const myRTree = RTree(5); // $ExpectType RTree
 const el = 'test';

--- a/types/rtree/rtree-tests.ts
+++ b/types/rtree/rtree-tests.ts
@@ -10,3 +10,6 @@ let intersections = myRTree.search({ x: 0.5, y: 0.5, w: 1, h: 1 });
 intersections = myRTree.remove({ x: 0.5, y: 0.5, w: 1, h: 1 }, 'notTest!');
 
 intersections = myRTree.remove({ x: 0.5, y: 0.5, w: 1, h: 1 });
+
+const json = myRTree.toJSON(); // $ExpectType string
+const myOtherRTree = RTree.fromJSON(json); // $ExpectType RTree

--- a/types/rtree/rtree-tests.ts
+++ b/types/rtree/rtree-tests.ts
@@ -1,11 +1,12 @@
-var myRTree = RTree(5);
-var el = "test";
+import RTree from 'rtree';
 
-myRTree.insert({x: 0, y: 0, w: 1, h: 1}, el);
+const myRTree = RTree(5); // $ExpectType RTree
+const el = 'test';
 
-var intersections = myRTree.search({x: 0.5, y: 0.5, w: 1, h: 1});
+myRTree.insert({ x: 0, y: 0, w: 1, h: 1 }, el);
 
-intersections = myRTree.remove({x: 0.5, y: 0.5, w: 1, h: 1}, "notTest!");
+let intersections = myRTree.search({ x: 0.5, y: 0.5, w: 1, h: 1 });
 
-intersections = myRTree.remove({x: 0.5, y: 0.5, w: 1, h: 1});
+intersections = myRTree.remove({ x: 0.5, y: 0.5, w: 1, h: 1 }, 'notTest!');
 
+intersections = myRTree.remove({ x: 0.5, y: 0.5, w: 1, h: 1 });

--- a/types/rtree/tsconfig.json
+++ b/types/rtree/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/rtree/tsconfig.json
+++ b/types/rtree/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
The current rtree type definitions give the following error due to no exports in the `index.d.ts`:

```
`...@types/rtree/index.d.ts' is not a module.
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.