### PR TITLE
[sinon] allow readonly array types to be used as TArgs parameter

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -27,7 +27,7 @@ declare namespace Sinon {
         [K in keyof T]: SinonMatcher | (T[K] extends object ? MatchArguments<T[K]> : never) | T[K];
     };
 
-    interface SinonSpyCallApi<TArgs extends any[] = any[], TReturnValue = any> {
+    interface SinonSpyCallApi<TArgs extends readonly any[] = any[], TReturnValue = any> {
         // Properties
         /**
          * Array of received arguments.
@@ -127,7 +127,7 @@ declare namespace Sinon {
         yieldToOn(property: string, obj: any, ...args: any[]): unknown[];
     }
 
-    interface SinonSpyCall<TArgs extends any[] = any[], TReturnValue = any>
+    interface SinonSpyCall<TArgs extends readonly any[] = any[], TReturnValue = any>
         extends SinonSpyCallApi<TArgs, TReturnValue> {
         /**
          * The call’s this value.
@@ -170,7 +170,7 @@ declare namespace Sinon {
         calledAfter(call: SinonSpyCall<any>): boolean;
     }
 
-    interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
+    interface SinonSpy<TArgs extends readonly any[] = any[], TReturnValue = any>
         extends Pick<
             SinonSpyCallApi<TArgs, TReturnValue>,
             Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, "args">
@@ -400,7 +400,7 @@ declare namespace Sinon {
         ? SinonSpy<TArgs, TReturnValue>
         : T;
 
-    interface SinonStub<TArgs extends any[] = any[], TReturnValue = any> extends SinonSpy<TArgs, TReturnValue> {
+    interface SinonStub<TArgs extends readonly any[] = any[], TReturnValue = any> extends SinonSpy<TArgs, TReturnValue> {
         /**
          * Resets the stub’s behaviour to the default behaviour
          * You can reset behaviour of all stubs using sinon.resetBehavior()
@@ -663,7 +663,7 @@ declare namespace Sinon {
         /**
          * Creates an anonymous stub function
          */
-        <TArgs extends any[] = any[], R = any>(): SinonStub<TArgs, R>;
+        <TArgs extends readonly any[] = any[], R = any>(): SinonStub<TArgs, R>;
 
         /* tslint:enable:no-unnecessary-generics */
 
@@ -1486,12 +1486,12 @@ declare namespace Sinon {
         /**
          * Creates a basic fake, with no behavior
          */
-        <TArgs extends any[] = any[], TReturnValue = any>(): SinonSpy<TArgs, TReturnValue>;
+        <TArgs extends readonly any[] = any[], TReturnValue = any>(): SinonSpy<TArgs, TReturnValue>;
         /**
          * Wraps an existing Function to record all interactions, while leaving it up to the func to provide the behavior.
          * This is useful when complex behavior not covered by the sinon.fake.* methods is required or when wrapping an existing function or method.
          */
-        <TArgs extends any[] = any[], TReturnValue = any>(fn: (...args: TArgs) => TReturnValue): SinonSpy<
+        <TArgs extends readonly any[] = any[], TReturnValue = any>(fn: (...args: TArgs) => TReturnValue): SinonSpy<
             TArgs,
             TReturnValue
         >;
@@ -1499,18 +1499,18 @@ declare namespace Sinon {
          * Creates a fake that returns the val argument
          * @param val Returned value
          */
-        returns<TArgs extends any[] = any[], TReturnValue = any>(val: TReturnValue): SinonSpy<TArgs, TReturnValue>;
+        returns<TArgs extends readonly any[] = any[], TReturnValue = any>(val: TReturnValue): SinonSpy<TArgs, TReturnValue>;
         /**
          * Creates a fake that throws an Error with the provided value as the message property.
          * If an Error is passed as the val argument, then that will be the thrown value. If any other value is passed, then that will be used for the message property of the thrown Error.
          * @param val Returned value or throw value if an Error
          */
-        throws<TArgs extends any[] = any[], TReturnValue = any>(val: Error | string): SinonSpy<TArgs, TReturnValue>;
+        throws<TArgs extends readonly any[] = any[], TReturnValue = any>(val: Error | string): SinonSpy<TArgs, TReturnValue>;
         /**
          * Creates a fake that returns a resolved Promise for the passed value.
          * @param val Resolved promise
          */
-        resolves<TArgs extends any[] = any[], TReturnValue = any>(
+        resolves<TArgs extends readonly any[] = any[], TReturnValue = any>(
             val: TReturnValue extends PromiseLike<infer TResolveValue> ? TResolveValue : any,
         ): SinonSpy<TArgs, TReturnValue>;
         /**
@@ -1519,15 +1519,15 @@ declare namespace Sinon {
          * If any other value is passed, then that will be used for the message property of the Error returned by the promise.
          * @param val Rejected promise
          */
-        rejects<TArgs extends any[] = any[], TReturnValue = any>(val: any): SinonSpy<TArgs, TReturnValue>;
+        rejects<TArgs extends readonly any[] = any[], TReturnValue = any>(val: any): SinonSpy<TArgs, TReturnValue>;
         /**
          * fake expects the last argument to be a callback and will invoke it with the given arguments.
          */
-        yields<TArgs extends any[] = any[], TReturnValue = any>(...args: any[]): SinonSpy<TArgs, TReturnValue>;
+        yields<TArgs extends readonly any[] = any[], TReturnValue = any>(...args: any[]): SinonSpy<TArgs, TReturnValue>;
         /**
          * fake expects the last argument to be a callback and will invoke it asynchronously with the given arguments.
          */
-        yieldsAsync<TArgs extends any[] = any[], TReturnValue = any>(...args: any[]): SinonSpy<TArgs, TReturnValue>;
+        yieldsAsync<TArgs extends readonly any[] = any[], TReturnValue = any>(...args: any[]): SinonSpy<TArgs, TReturnValue>;
     }
 
     interface SinonSandbox {

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -830,6 +830,9 @@ function testTypedStub() {
     const fooStub: sinon.SinonStubbedInstance<Foo> = {
         bar: sinon.stub(),
     };
+
+    const stub3 = sinon.stub<readonly [number, string], boolean>();
+    stub3.firstCall.args; // $ExpectType readonly [number, string]
 }
 
 function testMock() {
@@ -939,4 +942,8 @@ async function testTypedFake() {
     fake11.firstCall.returnValue; // $ExpectType boolean
 
     sinon.fake<[boolean, string], number>(typedFn); // $ExpectError
+
+    const fake12 = sinon.fake<readonly [boolean, string], number>();
+
+    fake12.firstCall.args; // $ExpectType readonly [boolean, string]
 }


### PR DESCRIPTION
In my codebase I’m using the [`prefer-readonly-type`](https://github.com/jonaskello/eslint-plugin-functional/blob/974eae08edc5880d03dd97b8ccab85dd6b8f812e/docs/rules/prefer-readonly-type.md) ESLint rule, which means I specify all array types like this `readonly string[]` or  tuples like `readonly [string, number]`.
So when ever I need to define the `TArgs` parameter explicitly for a sinon spy or fake in one of my unit tests I get a linting error because the current `TArgs` constraint doesn’t allow readonly arrays. E.g.

```
const fake = sinon.fake<readonly [number, string], boolan>()
```


gives a type error because `readonly [number, string]` doesn’t match with the constraint `any[]`.

I think there is no need for sinon the require mutable arrays for `TArgs` and since mutable arrays are compatible to readonly arrays there should be no conflict with allow readonly.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jonaskello/eslint-plugin-functional/blob/974eae08edc5880d03dd97b8ccab85dd6b8f812e/docs/rules/prefer-readonly-type.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

