### PR TITLE
[jsforce] add missing limitInfo property to Connection class

### DIFF
--- a/types/jsforce/api/analytics.d.ts
+++ b/types/jsforce/api/analytics.d.ts
@@ -22,7 +22,7 @@ export class Dashboard {
 export class ReportInstance {
     constructor(report: Report, id: string);
 
-    retrieve(callback: Callback<ReportResult>): Promise<ReportResult>
+    retrieve(callback: Callback<ReportResult>): Promise<ReportResult>;
 }
 
 export class Report {
@@ -51,20 +51,15 @@ export class Report {
     instances(callback?: Callback<ReportInstance[]>): Promise<ReportInstance[]>;
 }
 
-export interface ReportInstanceAttrs {
-}
+export interface ReportInstanceAttrs {}
 
-export interface ReportMetadata {
-}
+export interface ReportMetadata {}
 
-export interface ReportResult {
-}
+export interface ReportResult {}
 
-export interface ReportInfo {
-}
+export interface ReportInfo {}
 
-export interface DashboardInfo {
-}
+export interface DashboardInfo {}
 
 export class Analytics {
     report(id: string): Promise<Report>;

--- a/types/jsforce/api/chatter.d.ts
+++ b/types/jsforce/api/chatter.d.ts
@@ -24,8 +24,7 @@ interface RequestParams {
     body?: string | undefined;
 }
 
-export class RequestResult {
-}
+export class RequestResult {}
 
 export class Request<T> implements PromiseLike<T> {
     constructor(chatter: Chatter, params: RequestParams);
@@ -36,8 +35,10 @@ export class Request<T> implements PromiseLike<T> {
 
     stream(): Stream;
 
-    then<TResult1, TResult2>(onfulfilled?: ((value: T) => (PromiseLike<TResult1> | TResult1)) | null,
-                             onrejected?: ((reason: any) => (PromiseLike<TResult2> | TResult2)) | null): Promise<TResult1 | TResult2>;
+    then<TResult1, TResult2>(
+        onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null,
+        onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null,
+    ): Promise<TResult1 | TResult2>;
 
     finally(onfinally?: () => void): Promise<T>;
 
@@ -65,5 +66,5 @@ export class Chatter {
 
     request(params: RequestParams, callback?: Callback<Request<RequestResult>>): Request<RequestResult>;
 
-    resource(url: string, queryParams?: object): Resource<RequestResult>
+    resource(url: string, queryParams?: object): Resource<RequestResult>;
 }

--- a/types/jsforce/api/metadata.d.ts
+++ b/types/jsforce/api/metadata.d.ts
@@ -66,7 +66,7 @@ interface MetadataInfo {
 }
 
 interface Package {
-    apiAccessLevel?: "Unrestricted" | "Restricted" | undefined;
+    apiAccessLevel?: 'Unrestricted' | 'Restricted' | undefined;
     description?: string | undefined;
     fullName?: string | undefined;
     namespacePrefix?: string | undefined;
@@ -110,17 +110,17 @@ interface RetrieveResult {
     fileProperties: FileProperties[];
     id: string;
     messages: RetrieveMessage[];
-    zipFile: string
+    zipFile: string;
 }
 
 interface SaveResult {
     success: boolean;
     fullName: string;
-    errors?: SaveError | Array<SaveError> | undefined
+    errors?: SaveError | Array<SaveError> | undefined;
 }
 
 interface SaveError {
-    fields: string|string[];
+    fields: string | string[];
     message: string;
     statusCode: string;
 }
@@ -145,27 +145,29 @@ interface AsyncResult {
 }
 
 interface DeployOptions {
-    allowMissingFiles?:    boolean | undefined;
+    allowMissingFiles?: boolean | undefined;
     autoUpdatePackage?: boolean | undefined;
-    checkOnly?:    boolean | undefined;
+    checkOnly?: boolean | undefined;
     ignoreWarnings?: boolean | undefined;
     performRetrieve?: boolean | undefined;
     purgeOnDelete?: boolean | undefined;
     rollbackOnError?: boolean | undefined;
     runAllTests?: boolean | undefined;
     runTests?: string[] | undefined;
-    singlePackage?:    boolean | undefined;
+    singlePackage?: boolean | undefined;
 }
 
 export class AsyncResultLocator<T> extends EventEmitter implements PromiseLike<T> {
-    check(callback?: Callback<T>): Promise<T>
+    check(callback?: Callback<T>): Promise<T>;
 
-    complete(callback?: Callback<T>): Promise<T>
+    complete(callback?: Callback<T>): Promise<T>;
 
     poll(interval: number, timeout: number): void;
 
-    then<TResult1, TResult2>(onfulfilled?: ((value: T) => (PromiseLike<TResult1> | TResult1)) | null,
-                             onrejected?: ((reason: any) => (PromiseLike<TResult2> | TResult2)) | null): Promise<TResult1 | TResult2>;
+    then<TResult1, TResult2>(
+        onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null,
+        onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null,
+    ): Promise<TResult1 | TResult2>;
 
     finally(onfinally?: () => void): Promise<T>;
 }
@@ -179,59 +181,55 @@ export class Metadata {
 
     constructor(conn: Connection);
 
-    checkDeployStatus(
-        id: string,
-        includeDetails?: boolean,
-        callback?: Callback<DeployResult>
-    ): Promise<DeployResult>;
+    checkDeployStatus(id: string, includeDetails?: boolean, callback?: Callback<DeployResult>): Promise<DeployResult>;
 
     checkRetrieveStatus(id: string, callback?: Callback<RetrieveResult>): Promise<RetrieveResult>;
 
     checkStatus(
         ids: string | string[],
-        callback?: Callback<AsyncResult | Array<AsyncResult>>
+        callback?: Callback<AsyncResult | Array<AsyncResult>>,
     ): AsyncResultLocator<AsyncResult | Array<AsyncResult>>;
 
     create(
         type: string,
         metadata: MetadataInfo | Array<MetadataInfo>,
-        callback?: Callback<SaveResult | Array<SaveResult>>
+        callback?: Callback<SaveResult | Array<SaveResult>>,
     ): Promise<SaveResult | Array<SaveResult>>;
 
     createAsync(
         type: string,
         metadata: MetadataInfo | Array<MetadataInfo>,
-        callback?: Callback<SaveResult | Array<SaveResult>>
+        callback?: Callback<SaveResult | Array<SaveResult>>,
     ): Promise<SaveResult | Array<SaveResult>>;
 
     createSync(
         type: string,
         metadata: MetadataInfo | Array<MetadataInfo>,
-        callback?: Callback<SaveResult | Array<SaveResult>>
+        callback?: Callback<SaveResult | Array<SaveResult>>,
     ): Promise<SaveResult | Array<SaveResult>>;
 
     delete(
         type: string,
         fullNames: string | string[],
-        callback?: Callback<SaveResult | Array<SaveResult>>
+        callback?: Callback<SaveResult | Array<SaveResult>>,
     ): Promise<SaveResult | Array<SaveResult>>;
 
     deleteAsync(
         type: string,
         metadata: string | string[] | MetadataInfo | Array<MetadataInfo>,
-        callback?: Callback<AsyncResult | Array<AsyncResult>>
+        callback?: Callback<AsyncResult | Array<AsyncResult>>,
     ): AsyncResultLocator<AsyncResult | Array<AsyncResult>>;
 
     deleteSync(
         type: string,
         fullNames: string | string[],
-        callback?: Callback<SaveResult | Array<SaveResult>>
+        callback?: Callback<SaveResult | Array<SaveResult>>,
     ): Promise<SaveResult | Array<SaveResult>>;
 
     deploy(
         zipInput: Stream | Buffer | string,
         options: DeployOptions,
-        callback?: Callback<AsyncResult>
+        callback?: Callback<AsyncResult>,
     ): DeployResultLocator<AsyncResult>;
 
     describe(version?: string, callback?: Callback<DescribeMetadataResult>): Promise<DescribeMetadataResult>;
@@ -239,26 +237,26 @@ export class Metadata {
     list(
         queries: ListMetadataQuery | Array<ListMetadataQuery>,
         version?: string,
-        callback?: Callback<Array<FileProperties>>
+        callback?: Callback<Array<FileProperties>>,
     ): Promise<Array<FileProperties>>;
 
     read(
         type: string,
         fullNames: string | string[],
-        callback?: Callback<MetadataInfo | Array<MetadataInfo>>
+        callback?: Callback<MetadataInfo | Array<MetadataInfo>>,
     ): Promise<MetadataInfo | Array<MetadataInfo>>;
 
     readSync(
         type: string,
         fullNames: string | string[],
-        callback?: Callback<MetadataInfo | Array<MetadataInfo>>
+        callback?: Callback<MetadataInfo | Array<MetadataInfo>>,
     ): Promise<MetadataInfo | Array<MetadataInfo>>;
 
     rename(
         type: string,
         oldFullName: string,
         newFullName: string,
-        callback?: Callback<SaveResult>
+        callback?: Callback<SaveResult>,
     ): Promise<SaveResult>;
 
     retrieve(request: RetrieveRequest, callback?: Callback<AsyncResult>): RetrieveResultLocator<AsyncResult>;
@@ -266,24 +264,24 @@ export class Metadata {
     update(
         type: string,
         updateMetadata: MetadataInfo | Array<MetadataInfo>,
-        callback?: Callback<SaveResult | Array<SaveResult>>
+        callback?: Callback<SaveResult | Array<SaveResult>>,
     ): Promise<SaveResult | Array<SaveResult>>;
 
     updateAsync(
         type: string,
         updateMetadata: MetadataInfo,
-        callback?: Callback<AsyncResult | Array<AsyncResult>>
+        callback?: Callback<AsyncResult | Array<AsyncResult>>,
     ): AsyncResultLocator<AsyncResult | Array<AsyncResult>>;
 
     updateSync(
         type: string,
         updateMetadata: MetadataInfo | Array<MetadataInfo>,
-        callback?: Callback<SaveResult | Array<SaveResult>>
+        callback?: Callback<SaveResult | Array<SaveResult>>,
     ): Promise<SaveResult | Array<SaveResult>>;
 
     upsert(
         type: string,
         metadata: MetadataInfo | Array<MetadataInfo>,
-        callback?: Callback<UpsertResult | Array<UpsertResult>>
+        callback?: Callback<UpsertResult | Array<UpsertResult>>,
     ): Promise<UpsertResult | Array<UpsertResult>>;
 }

--- a/types/jsforce/api/soap.d.ts
+++ b/types/jsforce/api/soap.d.ts
@@ -1,4 +1,4 @@
-import { Connection, Callback } from "../connection";
+import { Connection, Callback } from '../connection';
 
 export class SoapApi {
     constructor(conn: Connection);

--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -18,7 +18,7 @@ import { Bulk } from './bulk';
 import { Cache } from './cache';
 import { OAuth2, Streaming } from '.';
 import { HttpApiOptions } from './http-api';
-import { LimitsInfo } from './limits-info';
+import { LimitInfo, LimitsInfo } from './limits-info';
 
 export type Callback<T> = (err: Error | null, result: T) => void;
 // The type for these options was determined by looking at the usage
@@ -311,6 +311,7 @@ export class Connection extends BaseConnection {
     oauth2: OAuth2;
     streaming: Streaming;
     cache: Cache;
+    limitInfo?: LimitInfo;
 
     // Specific to Connection
     instanceUrl: string;

--- a/types/jsforce/limits-info.d.ts
+++ b/types/jsforce/limits-info.d.ts
@@ -17,6 +17,13 @@ export interface DailyApiRequests extends Limit {
     'SalesforceA': Limit;
 }
 
+export interface LimitInfo {
+    apiUsage: {
+        used: number;
+        limit: number;
+    }
+}
+
 export interface LimitsInfo {
     ConcurrentAsyncGetReportInstances: Limit;
     ConcurrentSyncReportRuns: Limit;


### PR DESCRIPTION
Adding optional limitInfo property to Connection, which becomes available after a request and field out from response header. It was already present in jsforce version 1.9, but is missing here.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[Documentation reference](https://jsforce.github.io/document/#api-limit-and-usage)
[Code reference](https://github.com/jsforce/jsforce/blob/master/lib/connection.js#L342)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.