### PR TITLE
[google-map-react] fix 'v' in BootstrapURLKey

### DIFF
--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 const center = { lat: 0, lng: 0 };
 
 const key: BootstrapURLKeys = { key: 'my-google-maps-key', libraries: "places" };
-const client: BootstrapURLKeys = { client: 'my-client-identifier', v: '3.28' , language: 'en', libraries: "places", region: "PR", id: 'custom-id' };
+const client: BootstrapURLKeys = { client: 'my-client-identifier', version: '3.28' , language: 'en', libraries: "places", region: "PR", id: 'custom-id' };
 const options: MapOptions = {
     zoomControl: false,
     gestureHandling: 'cooperative',

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -9,7 +9,8 @@ import * as React from 'react';
 declare class googleMapReact extends React.Component<googleMapReact.Props> {}
 
 declare namespace googleMapReact {
-    type BootstrapURLKeys = ({ key: string } | { client: string; v: string }) & {
+    type BootstrapURLKeys = ({ key: string } | { client: string }) & {
+        version?: string | undefined;
         language?: string | undefined;
         region?: string | undefined;
         libraries?: string[] | string | undefined;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:


https://github.com/google-map-react/google-map-react/blob/master/src/loaders/google_map_loader.js#L65

In `google-map-react`, call `new Loader` in `@googlemaps/js-api-loader` and pass `v`.

https://github.com/googlemaps/js-api-loader/blob/main/src/index.ts#L86

`@googlemaps/js-api-loader` requires `version` to be specified and does not work with `v`.