### PR TITLE
[yeoman-generator] Add missing signature for custom parsing function to OptionConfig.type

### DIFF
--- a/types/yeoman-generator/index.d.ts
+++ b/types/yeoman-generator/index.d.ts
@@ -180,7 +180,7 @@ declare namespace Generator {
         /**
          * The type of the option.
          */
-        type: typeof Boolean | typeof String | typeof Number;
+        type: typeof Boolean | typeof String | typeof Number | ((opt: string) => any);
 
         /**
          * The option name alias (example `-h` and --help`).

--- a/types/yeoman-generator/yeoman-generator-tests.ts
+++ b/types/yeoman-generator/yeoman-generator-tests.ts
@@ -200,6 +200,11 @@ generator.option('opt4', {
   default: 3.2,
 });
 generator.option('opt5');
+generator.option('opt6', {
+  type(opt: string): any {
+    return opt;
+  }
+});
 
 const optionValue1 = generator.options.opt1;
 


### PR DESCRIPTION
The 'type' option passed to the second argument of Generator.option accepts a custom function for parsing the option. (see [https://yeoman.io/authoring/user-interactions.html](https://yeoman.io/authoring/user-interactions.html))

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://yeoman.io/authoring/user-interactions.html](https://yeoman.io/authoring/user-interactions.html)