### PR TITLE
fix jsqubits toffoli arguments type

### DIFF
--- a/types/jsqubits/index.d.ts
+++ b/types/jsqubits/index.d.ts
@@ -74,12 +74,6 @@ declare namespace jsqubits {
             controlledSwap(controlBits: undefined | SingleQubitOperatorTargetQubits, targetBit1: number, targetBit2: number): QState;
             swap(targetBit1: number, targetBit2: number): QState;
 
-            /**
-             * toffoli args is
-             * (...controlBit: SingleQubitOperatorTargetQubits[], targetBit: SingleQubitOperatorTargetQubits)
-             * but TypeScript3.4 cannot define this args.
-             * welcome Pull Request.
-             */
             toffoli(...args: ToffoliArgs): QState;
 
             controlledApplicationOfqBitOperator(

--- a/types/jsqubits/index.d.ts
+++ b/types/jsqubits/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/davidbkemp/jsqubits
 // Definitions by: kamakiri01 <https://github.com/kamakiri01>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 4.0
 
 export = jsqubits;
 
@@ -80,7 +80,7 @@ declare namespace jsqubits {
              * but TypeScript3.4 cannot define this args.
              * welcome Pull Request.
              */
-            toffoli(...args: SingleQubitOperatorTargetQubits[]): QState;
+            toffoli(...args: ToffoliArgs): QState;
 
             controlledApplicationOfqBitOperator(
                 controlBits: undefined | SingleQubitOperatorTargetQubits,
@@ -110,7 +110,7 @@ declare namespace jsqubits {
             conjugate(): Complex;
             toString(): string;
             inspect(): string;
-            format(options?: { decimalPlaces?: number | undefined }): string;
+            format(options?: { decimalPlaces?: number }): string;
             negate(): Complex;
             magnitude(): number;
             phase(): number;
@@ -136,6 +136,11 @@ declare namespace jsqubits {
         }
     }
 }
+
+// At least one control bit must be supplied to toffoli()
+type ToffoliControlQubits = [SingleQubitOperatorTargetQubits, ...SingleQubitOperatorTargetQubits[]];
+
+type ToffoliArgs = [...controlBits: ToffoliControlQubits, targetBit: SingleQubitOperatorTargetQubits];
 
 interface ExternalJSQubitsStatic {
     jsqubits: JSQubitsStatic;


### PR DESCRIPTION
This PR makes the type accurate.
TypeScript4 allows to specify that the last type of a library argument is the target bit.

```
toffoli(controlBit, controlBit, ..., targetBit ) {
```
https://github.com/davidbkemp/jsqubits/blob/master/lib/QState.js#L429
This can be expressed by Variadic Tuple Types of TypeScript4.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
