### PR TITLE
auth0-lock: Document event listener removal methods inherited from EventEmitter class

### DIFF
--- a/types/auth0-lock/auth0-lock-tests.ts
+++ b/types/auth0-lock/auth0-lock-tests.ts
@@ -97,6 +97,11 @@ lock.on("authenticated", function(authResult: AuthResult) {
   });
 });
 
+// "off" listener removal. Auth0 lock inherits this method from EventEmitter
+// https://github.com/browserify/events/blob/48e3d18659caf72d94d319871106f089bb40002d/events.js#L321
+
+lock.off('authenticated', (authResult) => {});
+
 // test theme
 
 const themeOptions : Auth0LockConstructorOptions = {

--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -229,6 +229,13 @@ interface Auth0LockCore {
     on(event: "unrecoverable_error" | "authorization_error", callback: (error: auth0.Auth0Error) => void): void;
     on(event: "authenticated", callback: (authResult: AuthResult) => void): void;
     on(event: string, callback: (...args: any[]) => void): void;
+
+    // though not documented, these methods are inherited from EventEmitter
+    // https://github.com/browserify/events/blob/48e3d18659caf72d94d319871106f089bb40002d/events.js#L321
+    off(event: "show" | "hide", callback: () => void): void;
+    off(event: "unrecoverable_error" | "authorization_error", callback: (error: auth0.Auth0Error) => void): void;
+    off(event: "authenticated", callback: (authResult: AuthResult) => void): void;
+    off(event: string, callback: (...args: any[]) => void): void;
 }
 
 interface Auth0LockStatic extends Auth0LockCore {


### PR DESCRIPTION
# auth0-lock: Document event listener removal methods inherited from EventEmitter class

Though not documented by auth0, the implementation of auth0 lock inherits its `on` method from the `EventEmitter` class in the `events` package.[0]

As a consequence of this, it also inherits the `off` method, to remove event listeners.[1][2]

[0] https://github.com/auth0/lock/blob/master/src/core.js#L25
[1] https://github.com/browserify/events/blob/main/events.js#L321
[2] https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/events/index.d.ts#L23

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


