### PR TITLE
[scriptable-ios] make alpha parameter in `Color` constructor optional

### DIFF
--- a/types/scriptable-ios/index.d.ts
+++ b/types/scriptable-ios/index.d.ts
@@ -657,7 +657,7 @@ declare class Color {
      * @param alpha - Alpha value.
      * @see https://docs.scriptable.app/color/#-new-color
      */
-    constructor(hex: string, alpha: number);
+    constructor(hex: string, alpha?: number);
 
     /**
      * _Constructs a black color._

--- a/types/scriptable-ios/scriptable-ios-tests.ts
+++ b/types/scriptable-ios/scriptable-ios-tests.ts
@@ -57,6 +57,9 @@
 
     // $ExpectType Color
     Color.dynamic(c, Color.black());
+
+    // Optional alpha paramneter
+    new Color('ffffff');
 }
 
 {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.scriptable.app/color/#-new-color
  > Constructs a new color with a hex value and optionally an alpha value.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.