### PR TITLE
[braintree-web]: Add type defs for ThreeDSecure.off(...) method

### DIFF
--- a/types/braintree-web/modules/three-d-secure.d.ts
+++ b/types/braintree-web/modules/three-d-secure.d.ts
@@ -251,4 +251,10 @@ export interface ThreeDSecure {
      * Documentation link: https://braintree.github.io/braintree-web/current/ThreeDSecure.html#on
      */
     on(event: string, handler: (data?: any, next?: () => void) => void): void;
+
+    /**
+     * Unsubscribes the handler function to a named event
+     * Documentation link: https://braintree.github.io/braintree-web/current/ThreeDSecure.html#off
+     */
+     off(event: string, handler: (data?: any, next?: () => void) => void): void;
 }


### PR DESCRIPTION
Add the missing type def for ThreeDSecure.off(...) method.