### PR TITLE
[big.js] Deconstify enums

### DIFF
--- a/types/big.js/index.d.ts
+++ b/types/big.js/index.d.ts
@@ -6,13 +6,13 @@
 
 export type BigSource = number | string | Big;
 
-export const enum Comparison {
+export enum Comparison {
     GT = 1,
     EQ = 0,
     LT = -1,
 }
 
-export const enum RoundingMode {
+export enum RoundingMode {
     /**
      * Rounds towards zero.
      * I.e. truncate, no rounding.

--- a/types/big.js/index.d.ts
+++ b/types/big.js/index.d.ts
@@ -6,30 +6,59 @@
 
 export type BigSource = number | string | Big;
 
-export enum Comparison {
+// tslint:disable-next-line:no-const-enum
+export const enum Comparison {
+    /**
+     * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
+     * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
+     * Use > 0 instead.
+     */
     GT = 1,
+    /**
+     * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
+     * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
+     * Use 0 instead.
+     */
     EQ = 0,
+    /**
+     * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
+     * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
+     * Use < 0 instead.
+     */
     LT = -1,
 }
 
-export enum RoundingMode {
+// tslint:disable-next-line:no-const-enum
+export const enum RoundingMode {
     /**
      * Rounds towards zero.
      * I.e. truncate, no rounding.
+     * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
+     * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
+     * Use 0 instead.
      */
     RoundDown = 0,
     /**
      * Rounds towards nearest neighbour.
      * If equidistant, rounds away from zero.
+     * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
+     * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
+     * Use 1 instead.
      */
     RoundHalfUp = 1,
     /**
      * Rounds towards nearest neighbour.
      * If equidistant, rounds towards even neighbour.
+     * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
+     * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
+     * Use 2 instead.
      */
     RoundHalfEven = 2,
     /**
      * Rounds away from zero.
+     * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
+     * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
+     * Use 3 instead.
      */
     RoundUp = 3,
 }
@@ -104,21 +133,21 @@ export interface BigConstructor {
      * Rounds towards zero.
      * I.e. truncate, no rounding.
      */
-    readonly roundDown: RoundingMode.RoundDown;
+    readonly roundDown: 0;
     /**
      * Rounds towards nearest neighbour.
      * If equidistant, rounds away from zero.
      */
-    readonly roundHalfUp: RoundingMode.RoundHalfUp;
+    readonly roundHalfUp: 1;
     /**
      * Rounds towards nearest neighbour.
      * If equidistant, rounds towards even neighbour.
      */
-    readonly roundHalfEven: RoundingMode.RoundHalfEven;
+    readonly roundHalfEven: 2;
     /**
      * Rounds away from zero.
      */
-    readonly roundUp: RoundingMode.RoundUp;
+    readonly roundUp: 3;
 }
 
 export interface Big {

--- a/types/big.js/index.d.ts
+++ b/types/big.js/index.d.ts
@@ -35,7 +35,7 @@ export const enum RoundingMode {
      * I.e. truncate, no rounding.
      * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
      * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
-     * Use 0 instead.
+     * Use 0 or Big.roundDown instead.
      */
     RoundDown = 0,
     /**
@@ -43,7 +43,7 @@ export const enum RoundingMode {
      * If equidistant, rounds away from zero.
      * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
      * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
-     * Use 1 instead.
+     * Use 1 or Big.roundHalfUp instead.
      */
     RoundHalfUp = 1,
     /**
@@ -51,14 +51,14 @@ export const enum RoundingMode {
      * If equidistant, rounds towards even neighbour.
      * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
      * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
-     * Use 2 instead.
+     * Use 2 or Big.roundHalfEven instead.
      */
     RoundHalfEven = 2,
     /**
      * Rounds away from zero.
      * @deprecated Const enums cannot be used by JavaScript consumers or with single-file transpilation, i.e. isolatedModules
      * {@link https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-const-enum.md}.
-     * Use 3 instead.
+     * Use 3 or Big.roundUp instead.
      */
     RoundUp = 3,
 }
@@ -247,7 +247,7 @@ export interface Big {
      * significant digits using rounding mode rm, or Big.RM if rm is not specified.
      *
      * @param sd Significant digits: integer, 1 to MAX_DP inclusive.
-     * @param [rm] The rounding mode, one of the RoundingMode enumeration values
+     * @param rm Rounding mode: 0 (down), 1 (half-up), 2 (half-even) or 3 (up).
      * @throws `!prec!` if sd is invalid.
      * @throws `!Big.RM!` if rm is invalid.
      */
@@ -256,7 +256,7 @@ export interface Big {
      * Returns a Big number whose value is the value of this Big number rounded using rounding mode rm to a maximum of dp decimal places.
      *
      * @param dp Decimal places, 0 to 1e+6 inclusive
-     * @param rm The rounding mode, one of the RoundingMode enumeration values
+     * @param rm Rounding mode: 0 (down), 1 (half-up), 2 (half-even) or 3 (up).
      * @throws `!round!` if dp is invalid.
      * @throws `!Big.RM!` if rm is invalid.
      */

--- a/types/big.js/tslint.json
+++ b/types/big.js/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "@definitelytyped/dtslint/dt.json",
-    "rules": {
-        "no-const-enum": false
-    }
-}
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
These const enums [can't be used with `isolatedModules: true`](https://www.typescriptlang.org/tsconfig#references-to-const-enum-members):

```sh
error TS2748: Cannot access ambient const enums when the '--isolatedModules' flag is provided.
```

Can they be changed to plain enums?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29864