### PR TITLE
Update ResizeObserver to match TS 4.6 DOM

### DIFF
--- a/types/resize-observer-browser/index.d.ts
+++ b/types/resize-observer-browser/index.d.ts
@@ -44,5 +44,5 @@ interface ResizeObserverEntry {
     readonly contentRect: DOMRectReadOnly;
     readonly borderBoxSize: ReadonlyArray<ResizeObserverSize>;
     readonly contentBoxSize: ReadonlyArray<ResizeObserverSize>;
-    readonly devicePixelContentBoxSize?: ReadonlyArray<ResizeObserverSize> | undefined;
+    readonly devicePixelContentBoxSize: ReadonlyArray<ResizeObserverSize>;
 }


### PR DESCRIPTION
ResizeObserverEntry.devicePixelContentBoxSize cannot be `undefined`. Now that devicePixelContentBoxSize is in TS 4.6, the type in resize-observer-browser must match exactly. This PR removes `undefined` from devicePixelContentBoxSize's type.
