### PR TITLE
Update web-locks-api for TS 4.6' DOM

### DIFF
--- a/types/web-locks-api/index.d.ts
+++ b/types/web-locks-api/index.d.ts
@@ -8,9 +8,15 @@ interface Lock {
   readonly name: string;
 }
 
+interface LockInfo {
+    clientId?: string;
+    mode?: 'exclusive' | 'shared';
+    name?: string;
+}
+
 interface LockManagerSnapshot {
-  held: Lock[];
-  pending: Lock[];
+  held?: LockInfo[] | undefined;
+  pending?: LockInfo[] | undefined;
 }
 
 interface LockManagerRequestOptions {


### PR DESCRIPTION
Now that more of the Web Locks API is in TS 4.6' DOM, `@types/web-locks-api` has to match exactly.

This PR introduces the `LockInfo` type and changes LockManagerSnapshot's types to use it.
