### PR TITLE
Fix incorrect property being allowed to be undefined in resize-observer-browser

### DIFF
--- a/types/resize-observer-browser/index.d.ts
+++ b/types/resize-observer-browser/index.d.ts
@@ -44,5 +44,5 @@ interface ResizeObserverEntry {
     readonly contentRect: DOMRectReadOnly;
     readonly borderBoxSize: ReadonlyArray<ResizeObserverSize>;
     readonly contentBoxSize: ReadonlyArray<ResizeObserverSize>;
-    readonly devicePixelContentBoxSize?: ReadonlyArray<ResizeObserverSize> | undefined;
+    readonly devicePixelContentBoxSize: ReadonlyArray<ResizeObserverSize>;
 }

--- a/types/resize-observer-browser/resize-observer-browser-tests.ts
+++ b/types/resize-observer-browser/resize-observer-browser-tests.ts
@@ -23,7 +23,7 @@ function resizeObserverCallback(entries: ReadonlyArray<ResizeObserverEntry>): vo
             const boxSize = entry.contentBoxSize[0];
             console.log(`Content Box Size is ${boxSize.blockSize}, ${boxSize.inlineSize}`);
         }
-        if (entry.devicePixelContentBoxSize && entry.devicePixelContentBoxSize.length > 0) {
+        if (entry.devicePixelContentBoxSize.length > 0) {
             const boxSize = entry.devicePixelContentBoxSize[0];
             console.log(`Device Pixel Content Box Size is ${boxSize.blockSize}, ${boxSize.inlineSize}`);
         }


### PR DESCRIPTION
Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [URL](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/devicePixelContentBoxSize)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
