### PR TITLE
[netlify-identity-widget] user_metadata can be null

### DIFF
--- a/types/netlify-identity-widget/index.d.ts
+++ b/types/netlify-identity-widget/index.d.ts
@@ -58,9 +58,9 @@ export interface User {
     token?: Token | undefined;
     url: string;
     user_metadata: {
-        avatar_url: string;
-        full_name: string;
-    };
+        avatar_url?: string;
+        full_name?: string;
+    } | null;
 }
 
 /**

--- a/types/netlify-identity-widget/netlify-identity-widget-tests.ts
+++ b/types/netlify-identity-widget/netlify-identity-widget-tests.ts
@@ -81,6 +81,21 @@ NetlifyIdentityWidget.off('error', (err) => {});
 // Use the current logged in user
 const user = NetlifyIdentityWidget.currentUser();
 
+// User could be null
+// $ExpectError
+const userID = user.id;
+
+if (user != null) {
+  // user_metadata could be null
+  // $ExpectError
+  const name = user.user_metadata.full_name;
+
+  if (user.user_metadata != null) {
+    // $ExpectType string | undefined
+    const name = user.user_metadata.full_name;
+  }
+}
+
 // If a user is logged in, logout returns a Promise<void>
 const logoutPromise = NetlifyIdentityWidget.logout();
 if (logoutPromise) {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
This library wraps [gotrue-js](https://github.com/netlify/gotrue-js), which shows on their README examples that `user_metadata` can be null, *and* the fields are not guaranteed. I also confirmed this in testing in my own app (had a runtime error because assumed it would not be null as per the type definition).
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.