### PR TITLE
fix (qlik-engineapi): dimension qSortCriterias is an array

### DIFF
--- a/types/qlik-engineapi/index.d.ts
+++ b/types/qlik-engineapi/index.d.ts
@@ -7888,7 +7888,7 @@ declare namespace EngineAPI {
          * >>This parameter is optional.
          * Default is to sort by alphabetical order, ascending.
          */
-        qSortCriterias?: ISortCriteria | undefined;
+        qSortCriterias?: ISortCriteria[] | undefined;
 
         /**
          * Defines the format of the value.


### PR DESCRIPTION
URL to documentation or source code which provides context for the suggested changes:
https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxInlineDimensionDef_header
As docs say: `qSortCriterias Array<SortCriteria>`

