### PR TITLE
remove Triple Slash Directives from @types/bn.js

### DIFF
--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -5,8 +5,6 @@
 //                 Gaylor Bosson <https://github.com/Gilthoniel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="node"/>
-
 declare namespace BN {
     type Endianness = 'le' | 'be';
     type IPrimeName = 'k256' | 'p224' | 'p192' | 'p25519';

--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for bn.js 5.1
+// Type definitions for bn.js 5.2
 // Project: https://github.com/indutny/bn.js
 // Definitions by: Leonid Logvinov <https://github.com/LogvinovLeon>
 //                 Henry Nguyen <https://github.com/HenryNguyen5>

--- a/types/bn.js/tsconfig.json
+++ b/types/bn.js/tsconfig.json
@@ -8,7 +8,7 @@
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
-        "types": [],
+        "types": ["node"],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/bn.js/tsconfig.json
+++ b/types/bn.js/tsconfig.json
@@ -8,7 +8,6 @@
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
-        "types": ["node"],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
The `/// <reference types="node" />` is not needed - it causes static linking to an old version of `@types/node` and not being able to use new one with _yarn PnP_

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
