### PR TITLE
[memory-cache] Add missing importJson and exportJson functions

### DIFF
--- a/types/memory-cache/index.d.ts
+++ b/types/memory-cache/index.d.ts
@@ -35,3 +35,13 @@ export function debug(bool: boolean): void;
 export function hits(): number;
 export function misses(): number;
 export function keys(): any[];
+
+/**
+ * @returns The new size of the cache
+ * @see {@link https://github.com/ptarjan/node-cache#importjson--functionjson-string-options--skipduplicates-boolean-}
+ */
+export function importJson(json: string, options?: { skipDuplicates?: boolean | undefined }): number;
+/**
+ * @returns A JSON string representing all the cache data
+ */
+export function exportJson(): string;

--- a/types/memory-cache/index.d.ts
+++ b/types/memory-cache/index.d.ts
@@ -19,6 +19,16 @@ export class CacheClass<K, V> {
     hits(): number;
     misses(): number;
     keys(): K[];
+
+    /**
+     * @returns The new size of the cache
+     * @see {@link https://github.com/ptarjan/node-cache#importjson--functionjson-string-options--skipduplicates-boolean-}
+     */
+    importJson(json: string, options?: { skipDuplicates?: boolean | undefined }): number;
+    /**
+     * @returns A JSON string representing all the cache data
+     */
+    exportJson(): string;
 }
 
 export const Cache: typeof CacheClass;

--- a/types/memory-cache/memory-cache-tests.ts
+++ b/types/memory-cache/memory-cache-tests.ts
@@ -36,3 +36,7 @@ customKeys = customCache.keys();
 memoryCache.importJson('{}');
 memoryCache.importJson('{}', { skipDuplicates: true });
 memoryCache.exportJson(); // $ExpectType string
+
+customCache.importJson('{}');
+customCache.importJson('{}', { skipDuplicates: true });
+customCache.exportJson(); // $ExpectType string

--- a/types/memory-cache/memory-cache-tests.ts
+++ b/types/memory-cache/memory-cache-tests.ts
@@ -8,8 +8,8 @@ let returnedValue: string;
 
 returnedValue = memoryCache.put(key, value);
 returnedValue = memoryCache.put(key, value, num);
-returnedValue = memoryCache.put(key, value, num, (key) => { });
-returnedValue = memoryCache.put(key, value, num, (key, value) => { });
+returnedValue = memoryCache.put(key, value, num, key => {});
+returnedValue = memoryCache.put(key, value, num, (key, value) => {});
 
 value = memoryCache.get(key);
 memoryCache.del(key);
@@ -32,3 +32,7 @@ customValue = customCache.put(customKey, customValue);
 customCache.get(customKey);
 customCache.del(customKey);
 customKeys = customCache.keys();
+
+memoryCache.importJson('{}');
+memoryCache.importJson('{}', { skipDuplicates: true });
+memoryCache.exportJson(); // $ExpectType string


### PR DESCRIPTION
Related discussion: #58547

Adds missing importJson and exportJson functions.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test memory-cache`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - importJson: https://github.com/ptarjan/node-cache#importjson--functionjson-string-options--skipduplicates-boolean-
  - exportJson: https://github.com/ptarjan/node-cache#exportjson--function
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
