### PR TITLE
fix: Correct types of jsforce execute arguments.

### DIFF
--- a/types/jsforce/api/analytics.d.ts
+++ b/types/jsforce/api/analytics.d.ts
@@ -10,7 +10,7 @@ export class Dashboard {
 
     delete(callback?: Callback<object>): Promise<any>;
 
-    components(componentIds: () => any | string[] | string, callback?: Callback<object>): Promise<any>;
+    components(componentIds: string[] | string | Callback<object>, callback?: Callback<object>): Promise<any>;
 
     status(callback?: Callback<object>): Promise<any>;
 
@@ -38,13 +38,13 @@ export class Report {
 
     explain(callback?: Callback<ExplainInfo>): Promise<ExplainInfo>;
 
-    run(options: () => any | object, callback?: Callback<ReportResult>): Promise<ReportResult>;
+    run(options: object | Callback<ReportResult>, callback?: Callback<ReportResult>): Promise<ReportResult>;
 
-    exec(options: () => any | object, callback?: Callback<ReportResult>): Promise<ReportResult>;
+    exec(options: object | Callback<ReportResult>, callback?: Callback<ReportResult>): Promise<ReportResult>;
 
-    execute(options: () => any | object, callback?: Callback<ReportResult>): Promise<ReportResult>;
+    execute(options: object | Callback<ReportResult>, callback?: Callback<ReportResult>): Promise<ReportResult>;
 
-    executeAsync(options: () => any | object, callback?: Callback<ReportInstanceAttrs>): Promise<ReportInstanceAttrs>;
+    executeAsync(options: object | Callback<ReportInstanceAttrs>, callback?: Callback<ReportInstanceAttrs>): Promise<ReportInstanceAttrs>;
 
     instance(id: string): ReportInstance;
 

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -614,6 +614,14 @@ async function testAnalytics(conn: sf.Connection): Promise<void> {
         Object.keys(reports[0]).forEach((key: string) => console.log(`key: ${key} : ${_report[key]}`));
         console.log('report keys from callback');
     });
+
+    const jsfReport: sf.Report = await conn.analytics.report('reportId');
+    const reportCallback = (err: Error | null, result: sf.ReportResult) => {
+        return result;
+    };
+    const reportResult1 = await jsfReport.execute({ details: true });
+    const reportResult2 = await jsfReport.execute({ details: true }, reportCallback);
+    const reportResult3 = await jsfReport.execute(reportCallback);
 }
 
 async function testExecuteAnonymous(conn: sf.Connection): Promise<void> {


### PR DESCRIPTION
The `execute` method is intended to take an optional options argument followed by an optional callback argument.  The first argument was previously declared as `options: () => any | object`.  This says that `options` is a function that returns `any` or `object` because it is missing parens around `() => any`.

The `run` and `exec` methods are aliases for `execute`.  The `components` and `executeAsync` methods are similar.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)  
Tested the `Report.execute` method.
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.  
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsforce/jsforce/blob/master/lib/api/analytics.js#L134
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.  
Does not apply.

