### PR TITLE
[react-google-recaptcha] restore ref functionality

### DIFF
--- a/types/react-google-recaptcha/index.d.ts
+++ b/types/react-google-recaptcha/index.d.ts
@@ -52,7 +52,7 @@ type Type = "image" | "audio";
 type Size = "compact" | "normal" | "invisible";
 type Badge = "bottomright" | "bottomleft" | "inline";
 
-export interface ReCAPTCHAProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange'> {
+export interface ReCAPTCHAProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'ref'> {
     /**
      * The API client key
      */

--- a/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
+++ b/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 import ReCAPTCHA, { ReCAPTCHA as ReCAPTCHA2 } from 'react-google-recaptcha';
 
-const basicRecapchta = <ReCAPTCHA sitekey="xxx" onChange={a => a} className="mockclass" />;
+const handleRef = (ref: ReCAPTCHA): void => { return; };
+
+const basicRecapchta = <ReCAPTCHA ref={handleRef} sitekey="xxx" onChange={a => a} className="mockclass" />;
 const invisibleRecaptcha: React.FC = () => {
     const recaptchaRef = React.createRef<ReCAPTCHA>();
 
     return <ReCAPTCHA ref={recaptchaRef} sitekey="xxx" size="invisible" asyncScriptOnLoad={() => { }} className="mockclass" />;
 };
 
-const basicRecapchta2 = <ReCAPTCHA2 sitekey="xxx" onChange={a => a} className="mockclass" />;
+const basicRecapchta2 = <ReCAPTCHA2 ref={handleRef} sitekey="xxx" onChange={a => a} className="mockclass" />;
 const invisibleRecaptcha2: React.FC = () => {
     const recaptchaRef = React.createRef<ReCAPTCHA2>();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Props are passed to a div but ref is ignored and is resolved as the class instead](https://github.com/dozoisch/react-google-recaptcha/blob/master/src/recaptcha.js#L144)

Addresses: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58375#issuecomment-1027214334

It looks like tests were already trying to address the ref type but they didn't fail as they should have in my last PR #58375 . Please forgive me @ChrisCrossCrash <3