### PR TITLE
fix(sinon): re-use DT's fake-timers

### DIFF
--- a/types/karma-sinon-chai/tsconfig.json
+++ b/types/karma-sinon-chai/tsconfig.json
@@ -13,6 +13,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/*": [
+                "sinonjs__*"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon-sandbox/tsconfig.json
+++ b/types/sinon-sandbox/tsconfig.json
@@ -14,6 +14,11 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@sinonjs/*": [
+                "sinonjs__*"
+            ]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/sinon/package.json
+++ b/types/sinon/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@sinonjs/fake-timers": "^7.1.0"
-    }
-}

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -1,11 +1,12 @@
-import sinon = require("sinon");
+import sinon = require('sinon');
+import fakeTimers = require('@sinonjs/fake-timers');
 
 function testSandbox() {
     const obj = {};
 
     sinon.createSandbox({
         injectInto: obj,
-        properties: ["spy", "stub"],
+        properties: ['spy', 'stub'],
         useFakeTimers: true,
         useFakeServer: true,
     });
@@ -24,9 +25,9 @@ function testSandbox() {
     const sb = sinon.createSandbox();
 
     sb.fake.returns(42);
-    sb.match(/foo/).test("foo");
+    sb.match(/foo/).test('foo');
 
-    sb.assert.pass("foo");
+    sb.assert.pass('foo');
     sb.clock.tick(1000);
     sb.spy();
     sb.stub();
@@ -44,7 +45,7 @@ function testSandbox() {
     xhr.restore();
 
     const server = sb.useFakeServer();
-    server.respondWith("foo");
+    server.respondWith('foo');
 
     sb.restore();
     sb.reset();
@@ -68,10 +69,10 @@ function testSandbox() {
         set setter(val) {},
     };
 
-    sb.replace(replaceMe, "prop", 10);
-    sb.replace(replaceMe, "method", sb.spy());
-    sb.replaceGetter(replaceMe, "getter", () => 14);
-    sb.replaceSetter(replaceMe, "setter", v => {});
+    sb.replace(replaceMe, 'prop', 10);
+    sb.replace(replaceMe, 'method', sb.spy());
+    sb.replaceGetter(replaceMe, 'getter', () => 14);
+    sb.replaceSetter(replaceMe, 'setter', v => {});
 
     const cls = class {
         foo(arg1: string, arg2: number): number {
@@ -90,8 +91,8 @@ function testSandbox() {
 
     const stubInstance = sb.createStubInstance(cls);
     const privateFooStubbedInstance = sb.createStubInstance(PrivateFoo);
-    stubInstance.foo.calledWith("foo", 1);
-    stubInstance.foo.calledWith("foo");
+    stubInstance.foo.calledWith('foo', 1);
+    stubInstance.foo.calledWith('foo');
     privateFooStubbedInstance.foo.calledWith();
     const clsFoo: sinon.SinonStub<[string, number], number> = stubInstance.foo;
     const privateFooFoo: sinon.SinonStub<[], void> = privateFooStubbedInstance.foo;
@@ -153,11 +154,11 @@ function testFakeServer() {
 function testXHR() {
     const xhr = new sinon.FakeXMLHttpRequest();
     const headers = xhr.getAllResponseHeaders();
-    const header = xhr.getResponseHeader("foo");
+    const header = xhr.getResponseHeader('foo');
 
-    xhr.setResponseHeaders({ "Content-Type": "text/html" });
-    xhr.setResponseBody("foo");
-    xhr.respond(200, { "Content-Type": "foo" }, "bar");
+    xhr.setResponseHeaders({ 'Content-Type': 'text/html' });
+    xhr.setResponseBody('foo');
+    xhr.respond(200, { 'Content-Type': 'foo' }, 'bar');
     xhr.error();
 
     sinon.FakeXMLHttpRequest.useFilters = true;
@@ -167,8 +168,8 @@ function testXHR() {
 }
 
 function testClock() {
-    let clock = sinon.clock.create(1000);
-    clock = sinon.clock.create(new Date());
+    let clock = sinon.clock.create(1000) as fakeTimers.BrowserClock;
+    clock = sinon.clock.create(new Date()) as fakeTimers.BrowserClock;
 
     let now = 0;
     now = clock.now;
@@ -181,10 +182,10 @@ function testClock() {
     clock.setImmediate(fn);
     clock.requestAnimationFrame(fn);
 
-    now = clock.setTimeout(fnWithArgs, 0, 1234, "abc");
-    now = clock.setInterval(fnWithArgs, 0, 1234, "abc");
+    now = clock.setTimeout(fnWithArgs, 0, 1234, 'abc');
+    now = clock.setInterval(fnWithArgs, 0, 1234, 'abc');
 
-    clock.setImmediate(fnWithArgs, 1234, "abc"); // $ExpectType NodeTimer
+    clock.setImmediate(fnWithArgs, 1234, 'abc'); // $ExpectType number
 
     let timer = clock.setTimeout(fn, 0);
     clock.clearTimeout(timer);
@@ -196,12 +197,13 @@ function testClock() {
     const animTimer = clock.requestAnimationFrame(fn);
     clock.cancelAnimationFrame(animTimer);
 
-    clock.nextTick(fn);
+    const nodeClock = sinon.clock.create(1) as fakeTimers.NodeClock & fakeTimers.InstalledClock;
+    nodeClock.nextTick(fn);
 
     clock.tick(1);
-    clock.tick("00:10");
+    clock.tick('00:10');
     clock.tickAsync(500).then(val => val.toExponential());
-    clock.tickAsync("500").then(val => val.toExponential());
+    clock.tickAsync('500').then(val => val.toExponential());
 
     clock.next();
     clock.nextAsync().then(val => val.toExponential());
@@ -213,9 +215,9 @@ function testClock() {
     clock.runToLastAsync().then(val => val.toExponential());
 
     clock.reset();
-    clock.runMicrotasks();
+    nodeClock.runMicrotasks();
     clock.runToFrame();
-    clock.uninstall();
+    nodeClock.uninstall();
     clock.setSystemTime(1000);
     clock.setSystemTime(new Date());
 }
@@ -224,7 +226,7 @@ function testExpectation() {
     const obj = {};
 
     let ex = sinon.expectation.create();
-    ex = sinon.expectation.create("some name");
+    ex = sinon.expectation.create('some name');
 
     ex.atLeast(5).atMost(10);
     ex.never();
@@ -232,8 +234,8 @@ function testExpectation() {
     ex.twice();
     ex.thrice();
     ex.exactly(5);
-    ex.withArgs("a", "b");
-    ex.withExactArgs("a", "b");
+    ex.withArgs('a', 'b');
+    ex.withExactArgs('a', 'b');
     ex.on(obj);
     ex.verify();
     ex.restore();
@@ -244,56 +246,56 @@ function testMatch() {
     const fn = () => {};
 
     sinon.match(5).test(5);
-    sinon.match("str").test("foo");
-    sinon.match(/foo/).test("foo");
+    sinon.match('str').test('foo');
+    sinon.match(/foo/).test('foo');
     sinon.match({ a: 5, b: 6 }).test({});
-    sinon.match(v => true).test("foo");
-    sinon.match(v => true, "some message").test("foo");
-    sinon.match.any.test("foo");
-    sinon.match.defined.test("foo");
-    sinon.match.truthy.test("foo");
-    sinon.match.falsy.test("foo");
-    sinon.match.bool.test("foo");
-    sinon.match.number.test("foo");
-    sinon.match.string.test("foo");
-    sinon.match.object.test("foo");
+    sinon.match(v => true).test('foo');
+    sinon.match(v => true, 'some message').test('foo');
+    sinon.match.any.test('foo');
+    sinon.match.defined.test('foo');
+    sinon.match.truthy.test('foo');
+    sinon.match.falsy.test('foo');
+    sinon.match.bool.test('foo');
+    sinon.match.number.test('foo');
+    sinon.match.string.test('foo');
+    sinon.match.object.test('foo');
     sinon.match.func.test(fn);
     sinon.match.map.test(
         new Map([
-            ["a", 1],
-            ["b", 2],
+            ['a', 1],
+            ['b', 2],
         ]),
     );
     sinon.match.set.test(new Set([1, 2, 3]));
     sinon.match.array.test([1, 2, 3]);
-    sinon.match.regexp.test("foo");
-    sinon.match.date.test("foo");
-    sinon.match.symbol.test("foo");
+    sinon.match.regexp.test('foo');
+    sinon.match.date.test('foo');
+    sinon.match.symbol.test('foo');
     sinon.match.in([1, 2, 3]).test(1);
     sinon.match.same(obj);
-    sinon.match.typeOf("string").test("foo");
-    sinon.match.instanceOf(fn).test("foo");
-    sinon.match.has("prop").test(obj);
-    sinon.match.has("prop", 123).test(obj);
-    sinon.match.hasOwn("prop").test(obj);
-    sinon.match.hasOwn("prop", 123).test(obj);
-    sinon.match.hasNested("prop.foo.bar").test(obj);
-    sinon.match.hasNested("prop.foo.bar", 123).test(obj);
-    sinon.match.every(sinon.match.number).test([1, 2, "three"]);
-    sinon.match.some(sinon.match.number).test([1, 2, "three"]);
-    sinon.match.array.deepEquals([{ a: "b" }]).test([]);
-    sinon.match.array.startsWith([{ a: "b" }]).test([]);
-    sinon.match.array.deepEquals([{ a: "b" }]).test([]);
-    sinon.match.array.contains([{ a: "b" }]).test([]);
+    sinon.match.typeOf('string').test('foo');
+    sinon.match.instanceOf(fn).test('foo');
+    sinon.match.has('prop').test(obj);
+    sinon.match.has('prop', 123).test(obj);
+    sinon.match.hasOwn('prop').test(obj);
+    sinon.match.hasOwn('prop', 123).test(obj);
+    sinon.match.hasNested('prop.foo.bar').test(obj);
+    sinon.match.hasNested('prop.foo.bar', 123).test(obj);
+    sinon.match.every(sinon.match.number).test([1, 2, 'three']);
+    sinon.match.some(sinon.match.number).test([1, 2, 'three']);
+    sinon.match.array.deepEquals([{ a: 'b' }]).test([]);
+    sinon.match.array.startsWith([{ a: 'b' }]).test([]);
+    sinon.match.array.deepEquals([{ a: 'b' }]).test([]);
+    sinon.match.array.contains([{ a: 'b' }]).test([]);
     sinon.match.map
         .deepEquals(
             new Map([
-                ["a", true],
-                ["b", false],
+                ['a', true],
+                ['b', false],
             ]),
         )
         .test(new Map());
-    sinon.match.map.contains(new Map([["a", true]])).test(new Map());
+    sinon.match.map.contains(new Map([['a', true]])).test(new Map());
 }
 
 function testFake() {
@@ -352,8 +354,8 @@ function testAssert() {
     const obj = {};
 
     sinon.assert.fail();
-    sinon.assert.fail("foo");
-    sinon.assert.pass("foo");
+    sinon.assert.fail('foo');
+    sinon.assert.pass('foo');
     sinon.assert.notCalled(spy);
     sinon.assert.called(spy);
     sinon.assert.calledOnce(spy);
@@ -363,35 +365,35 @@ function testAssert() {
     sinon.assert.callOrder(spy, spyTwo);
     sinon.assert.calledOn(spy, obj);
     sinon.assert.calledOn(spy.firstCall, obj);
-    sinon.assert.calledWith(spy, "a", "b", "c");
+    sinon.assert.calledWith(spy, 'a', 'b', 'c');
     sinon.assert.alwaysCalledOn(spy, obj);
-    sinon.assert.alwaysCalledWith(spy, "a", "b", "c");
-    sinon.assert.neverCalledWith(spy, "a", "b", "c");
-    sinon.assert.calledWithExactly(spy, "a", "b", "c");
-    sinon.assert.calledOnceWithExactly(spy, "a", "b", "c");
-    sinon.assert.alwaysCalledWithExactly(spy, "a", "b", "c");
-    sinon.assert.calledWithMatch(spy, "a", "b", "c");
-    sinon.assert.calledWithMatch(spy.firstCall, "a", "b", "c");
-    sinon.assert.calledOnceWithMatch(spy, "a", "b", "c");
-    sinon.assert.calledOnceWithMatch(spy.firstCall, "a", "b", "c");
-    sinon.assert.alwaysCalledWithMatch(spy, "a", "b", "c");
-    sinon.assert.neverCalledWithMatch(spy, "a", "b", "c");
+    sinon.assert.alwaysCalledWith(spy, 'a', 'b', 'c');
+    sinon.assert.neverCalledWith(spy, 'a', 'b', 'c');
+    sinon.assert.calledWithExactly(spy, 'a', 'b', 'c');
+    sinon.assert.calledOnceWithExactly(spy, 'a', 'b', 'c');
+    sinon.assert.alwaysCalledWithExactly(spy, 'a', 'b', 'c');
+    sinon.assert.calledWithMatch(spy, 'a', 'b', 'c');
+    sinon.assert.calledWithMatch(spy.firstCall, 'a', 'b', 'c');
+    sinon.assert.calledOnceWithMatch(spy, 'a', 'b', 'c');
+    sinon.assert.calledOnceWithMatch(spy.firstCall, 'a', 'b', 'c');
+    sinon.assert.alwaysCalledWithMatch(spy, 'a', 'b', 'c');
+    sinon.assert.neverCalledWithMatch(spy, 'a', 'b', 'c');
     sinon.assert.calledWithNew(spy);
     sinon.assert.calledWithNew(spy.firstCall);
     sinon.assert.threw(spy);
     sinon.assert.threw(spy.firstCall);
-    sinon.assert.threw(spy, "foo error");
-    sinon.assert.threw(spy.firstCall, "foo error");
-    sinon.assert.threw(spy, new Error("foo"));
-    sinon.assert.threw(spy.firstCall, new Error("foo"));
+    sinon.assert.threw(spy, 'foo error');
+    sinon.assert.threw(spy.firstCall, 'foo error');
+    sinon.assert.threw(spy, new Error('foo'));
+    sinon.assert.threw(spy.firstCall, new Error('foo'));
     sinon.assert.alwaysThrew(spy);
-    sinon.assert.alwaysThrew(spy, "foo error");
-    sinon.assert.alwaysThrew(spy, new Error("foo"));
-    sinon.assert.match("a", "b");
+    sinon.assert.alwaysThrew(spy, 'foo error');
+    sinon.assert.alwaysThrew(spy, new Error('foo'));
+    sinon.assert.match('a', 'b');
     sinon.assert.match(1, 1 + 1);
-    sinon.assert.match({ a: 1 }, { b: 2, c: "abc" });
+    sinon.assert.match({ a: 1 }, { b: 2, c: 'abc' });
     sinon.assert.expose(obj);
-    sinon.assert.expose(obj, { prefix: "blah" });
+    sinon.assert.expose(obj, { prefix: 'blah' });
     sinon.assert.expose(obj, { includeFail: true });
 
     const typedSpy = sinon.spy((arg1: string, arg2: boolean) => 123);
@@ -404,9 +406,9 @@ function testAssert() {
     sinon.assert.callOrder(typedSpy, spyTwo);
     sinon.assert.calledOn(typedSpy, obj);
     sinon.assert.calledOn(typedSpy.firstCall, obj);
-    sinon.assert.calledWith(typedSpy, "a", true);
-    sinon.assert.calledWith(typedSpy, "a");
-    sinon.assert.calledWith(typedSpy, "a", "b"); // $ExpectError
+    sinon.assert.calledWith(typedSpy, 'a', true);
+    sinon.assert.calledWith(typedSpy, 'a');
+    sinon.assert.calledWith(typedSpy, 'a', 'b'); // $ExpectError
     sinon.assert.alwaysCalledOn(typedSpy, obj);
     sinon.assert.alwaysCalledWith(typedSpy, 'a', 'b', 'c'); // $ExpectError
     sinon.assert.alwaysCalledWith(typedSpy, 'a', true);
@@ -431,18 +433,18 @@ function testAssert() {
     sinon.assert.calledWithNew(typedSpy.firstCall);
     sinon.assert.threw(typedSpy);
     sinon.assert.threw(typedSpy.firstCall);
-    sinon.assert.threw(typedSpy, "foo error");
-    sinon.assert.threw(typedSpy.firstCall, "foo error");
-    sinon.assert.threw(typedSpy, new Error("foo"));
-    sinon.assert.threw(typedSpy.firstCall, new Error("foo"));
+    sinon.assert.threw(typedSpy, 'foo error');
+    sinon.assert.threw(typedSpy.firstCall, 'foo error');
+    sinon.assert.threw(typedSpy, new Error('foo'));
+    sinon.assert.threw(typedSpy.firstCall, new Error('foo'));
     sinon.assert.alwaysThrew(typedSpy);
-    sinon.assert.alwaysThrew(typedSpy, "foo error");
-    sinon.assert.alwaysThrew(typedSpy, new Error("foo"));
-    sinon.assert.match("a", "b");
+    sinon.assert.alwaysThrew(typedSpy, 'foo error');
+    sinon.assert.alwaysThrew(typedSpy, new Error('foo'));
+    sinon.assert.match('a', 'b');
     sinon.assert.match(1, 1 + 1);
-    sinon.assert.match({ a: 1 }, { b: 2, c: "abc" });
+    sinon.assert.match({ a: 1 }, { b: 2, c: 'abc' });
     sinon.assert.expose(obj);
-    sinon.assert.expose(obj, { prefix: "blah" });
+    sinon.assert.expose(obj, { prefix: 'blah' });
     sinon.assert.expose(obj, { includeFail: true });
 
     const spyDeepObject = sinon.spy((_arg1: { foo: { first: string; second: number } }, _arg2: string): boolean => {
@@ -507,16 +509,16 @@ function testTypedSpy() {
     };
 
     const instance = new cls();
-    const spy = sinon.spy(instance, "foo");
+    const spy = sinon.spy(instance, 'foo');
 
-    spy.calledWith(5, "x");
-    spy.calledWith(sinon.match(5), "x");
-    spy.calledWithExactly(5, "x");
-    spy.calledWithExactly(5, sinon.match("x"));
-    spy.calledOnceWith(5, "x");
-    spy.calledOnceWith(sinon.match(5), "x");
-    spy.notCalledWith(5, "x");
-    spy.notCalledWith(sinon.match(5), "x");
+    spy.calledWith(5, 'x');
+    spy.calledWith(sinon.match(5), 'x');
+    spy.calledWithExactly(5, 'x');
+    spy.calledWithExactly(5, sinon.match('x'));
+    spy.calledOnceWith(5, 'x');
+    spy.calledOnceWith(sinon.match(5), 'x');
+    spy.notCalledWith(5, 'x');
+    spy.notCalledWith(sinon.match(5), 'x');
     spy.returned(5);
     spy.returned(sinon.match(5));
     spy.calledWithMatch(5, 'x', true); // $ExpectError
@@ -571,24 +573,24 @@ function testTypedSpy() {
     accessorSpy.get.returned(5);
     accessorSpy.set.calledWith(55);
 
-    const getterSpy = sinon.spy(instance, "getterTest", ["get"]);
+    const getterSpy = sinon.spy(instance, 'getterTest', ['get']);
     getterSpy.get.returned(5);
 
-    const setterSpy = sinon.spy(instance, "setterTest", ["set"]);
+    const setterSpy = sinon.spy(instance, 'setterTest', ['set']);
     setterSpy.set.calledWith(100);
 }
 
 function testInstanceSpy() {
     const obj = {
         foo(arg: number): string {
-            return "xyz";
+            return 'xyz';
         },
     };
 
     const spy = sinon.spy(obj); // $ExpectType SinonSpiedInstance<{ foo(arg: number): string; }>
 
     spy.foo.calledWith(5);
-    spy.foo.returns("bar"); // $ExpectError
+    spy.foo.returns('bar'); // $ExpectError
 }
 
 function testSpy() {
@@ -606,12 +608,12 @@ function testSpy() {
     const instance = new obj();
 
     const spy = sinon.spy(); // $ExpectType SinonSpy<any[], any>
-    const spyTwo = sinon.spy().named("spyTwo");
+    const spyTwo = sinon.spy().named('spyTwo');
 
-    const methodSpy = sinon.spy(instance, "foo"); // $ExpectType SinonSpy<[], void>
+    const methodSpy = sinon.spy(instance, 'foo'); // $ExpectType SinonSpy<[], void>
     methodSpy.wrappedMethod; // $ExpectType () => void
 
-    const methodSpy2 = sinon.spy(instance, "foobar"); // $ExpectType SinonSpy<[(string | undefined)?], string | undefined> || SinonSpy<[p1?: string | undefined], string | undefined>
+    const methodSpy2 = sinon.spy(instance, 'foobar'); // $ExpectType SinonSpy<[(string | undefined)?], string | undefined> || SinonSpy<[p1?: string | undefined], string | undefined>
     methodSpy2.wrappedMethod; // $ExpectType (p1?: string | undefined) => string | undefined
 
     methodSpy.calledBefore(methodSpy2);
@@ -637,7 +639,7 @@ function testSpy() {
 
     const fnSpy = sinon.spy(fn); // $ExpectType SinonSpy<[string, number], boolean> || SinonSpy<[arg: string, arg2: number], boolean>
     fn = fnSpy; // Should be assignable to original function
-    fnSpy("a", 1); // $ExpectType boolean
+    fnSpy('a', 1); // $ExpectType boolean
     fnSpy.args; // $ExpectType [string, number][] || [arg: string, arg2: number][]
     fnSpy.returnValues; // $ExpectType boolean[]
 
@@ -649,43 +651,43 @@ function testSpy() {
     spy.calledImmediatelyBefore(spyTwo);
     spy.calledImmediatelyAfter(spyTwo);
     spy.calledWithNew();
-    spy.withArgs("a", 1).calledBefore(spyTwo);
+    spy.withArgs('a', 1).calledBefore(spyTwo);
     spy.alwaysCalledOn(instance);
-    spy.alwaysCalledWith("a", 1);
-    spy.alwaysCalledWith("a");
-    spy.alwaysCalledWithExactly("a", 1);
-    spy.alwaysCalledWithMatch("foo");
-    spy.neverCalledWith("b", 2);
-    spy.neverCalledWith("b");
-    spy.neverCalledWithMatch("foo", "bar");
+    spy.alwaysCalledWith('a', 1);
+    spy.alwaysCalledWith('a');
+    spy.alwaysCalledWithExactly('a', 1);
+    spy.alwaysCalledWithMatch('foo');
+    spy.neverCalledWith('b', 2);
+    spy.neverCalledWith('b');
+    spy.neverCalledWithMatch('foo', 'bar');
     spy.alwaysThrew();
-    spy.alwaysThrew("foo");
-    spy.alwaysThrew(new Error("foo"));
-    spy.alwaysReturned("foo");
-    spy.invokeCallback("a", "b");
+    spy.alwaysThrew('foo');
+    spy.alwaysThrew(new Error('foo'));
+    spy.alwaysReturned('foo');
+    spy.invokeCallback('a', 'b');
     spy.calledOn(instance);
-    spy.calledWith("a", 2);
-    spy.calledWithExactly("a", 2);
-    spy.calledOnceWith("a", 2);
-    spy.calledOnceWithExactly("a", 2);
-    spy.calledWithMatch("bar", 2);
-    spy.notCalledWith("a", 2);
-    spy.notCalledWithMatch("a", 2);
+    spy.calledWith('a', 2);
+    spy.calledWithExactly('a', 2);
+    spy.calledOnceWith('a', 2);
+    spy.calledOnceWithExactly('a', 2);
+    spy.calledWithMatch('bar', 2);
+    spy.notCalledWith('a', 2);
+    spy.notCalledWithMatch('a', 2);
     spy.returned(true);
-    spy.returned("foo");
+    spy.returned('foo');
     spy.returned(2);
     spy.threw();
-    spy.threw("foo");
-    spy.threw(new Error("foo"));
+    spy.threw('foo');
+    spy.threw(new Error('foo'));
     spy.callArg(1); // $ExpectType unknown[]
     spy.callArgOn(1, instance); // $ExpectType unknown[]
-    spy.callArgOn(1, instance, "a", 2); // $ExpectType unknown[]
-    spy.callArgWith(1, "a", 2); // $ExpectType unknown[]
-    spy.callArgOnWith(1, instance, "a", 2); // $ExpectType unknown[]
-    spy.yield("a", 2); // $ExpectType unknown[]
-    spy.yieldOn(instance, "a", 2); // $ExpectType unknown[]
-    spy.yieldTo("prop", "a", 2); // $ExpectType unknown[]
-    spy.yieldToOn("prop", instance, "a", 2); // $ExpectType unknown[]
+    spy.callArgOn(1, instance, 'a', 2); // $ExpectType unknown[]
+    spy.callArgWith(1, 'a', 2); // $ExpectType unknown[]
+    spy.callArgOnWith(1, instance, 'a', 2); // $ExpectType unknown[]
+    spy.yield('a', 2); // $ExpectType unknown[]
+    spy.yieldOn(instance, 'a', 2); // $ExpectType unknown[]
+    spy.yieldTo('prop', 'a', 2); // $ExpectType unknown[]
+    spy.yieldToOn('prop', instance, 'a', 2); // $ExpectType unknown[]
 
     let call = spy.firstCall;
     call = spy.secondCall;
@@ -712,10 +714,10 @@ function testStub() {
             return 1;
         }
         promiseFunc() {
-            return Promise.resolve("foo");
+            return Promise.resolve('foo');
         }
         promiseLikeFunc() {
-            return Promise.resolve("foo") as PromiseLike<string>;
+            return Promise.resolve('foo') as PromiseLike<string>;
         }
         unresolvableReturnFunc(): any {
             return Promise.resolve();
@@ -730,15 +732,15 @@ function testStub() {
 
     const spy: sinon.SinonSpy = stub;
 
-    const promiseStub = sinon.stub(instance, "promiseFunc");
-    promiseStub.resolves("test");
+    const promiseStub = sinon.stub(instance, 'promiseFunc');
+    promiseStub.resolves('test');
     promiseStub.resolves(123); // $ExpectError
 
-    const promiseUnresolvableReturn = sinon.stub(instance, "unresolvableReturnFunc");
-    promiseUnresolvableReturn.resolves(["anything", 123, true]);
+    const promiseUnresolvableReturn = sinon.stub(instance, 'unresolvableReturnFunc');
+    promiseUnresolvableReturn.resolves(['anything', 123, true]);
 
-    const promiseLikeStub = sinon.stub(instance, "promiseLikeFunc");
-    promiseLikeStub.resolves("test");
+    const promiseLikeStub = sinon.stub(instance, 'promiseLikeFunc');
+    promiseLikeStub.resolves('test');
 
     sinon.stub(instance);
 
@@ -748,70 +750,70 @@ function testStub() {
 
     stub.returns(true);
     stub.returns(5);
-    stub.returns("foo");
+    stub.returns('foo');
     stub.returnsArg(1);
     stub.returnsThis();
     stub.resolves();
-    stub.resolves("foo");
+    stub.resolves('foo');
     stub.resolvesArg(1);
     stub.resolvesThis();
     stub.throws();
-    stub.throws("err");
-    stub.throws(new Error("err"));
+    stub.throws('err');
+    stub.throws(new Error('err'));
     stub.throwsArg(1);
-    stub.throwsException("err");
-    stub.throwsException(new Error("err"));
+    stub.throwsException('err');
+    stub.throwsException(new Error('err'));
     stub.rejects();
-    stub.rejects("TypeError");
+    stub.rejects('TypeError');
     stub.rejects(1234);
     stub.callsArg(1);
     stub.callThrough();
     stub.callsArgOn(1, instance);
-    stub.callsArgWith(1, "a", 2);
+    stub.callsArgWith(1, 'a', 2);
     stub.callsArgAsync(1);
     stub.callsArgOnAsync(1, instance);
-    stub.callsArgWithAsync(1, "a", 2);
-    stub.callsArgOnWithAsync(1, instance, "a", 2);
+    stub.callsArgWithAsync(1, 'a', 2);
+    stub.callsArgOnWithAsync(1, instance, 'a', 2);
     stub.callsFake((s1, s2, s3) => {});
     stub.callsFake(() => {});
     stub.get(() => true);
     stub.set(v => {});
     stub.onCall(1).returns(true);
-    stub.onFirstCall().resolves("foo");
-    stub.onSecondCall().resolves("foo");
-    stub.onThirdCall().resolves("foo");
-    stub.value("foo");
-    stub.yields("a", 2);
-    stub.yieldsOn(instance, "a", 2);
-    stub.yieldsRight("a", 2);
-    stub.yieldsTo("foo", "a", 2);
-    stub.yieldsToOn("foo", instance, "a", 2);
-    stub.yieldsAsync("a", 2);
-    stub.yieldsOnAsync(instance, "a", 2);
-    stub.yieldsToAsync("foo", "a", 2);
-    stub.yieldsToOnAsync("foo", instance, "a", 2);
-    stub.withArgs("a", 2).returns(true);
+    stub.onFirstCall().resolves('foo');
+    stub.onSecondCall().resolves('foo');
+    stub.onThirdCall().resolves('foo');
+    stub.value('foo');
+    stub.yields('a', 2);
+    stub.yieldsOn(instance, 'a', 2);
+    stub.yieldsRight('a', 2);
+    stub.yieldsTo('foo', 'a', 2);
+    stub.yieldsToOn('foo', instance, 'a', 2);
+    stub.yieldsAsync('a', 2);
+    stub.yieldsOnAsync(instance, 'a', 2);
+    stub.yieldsToAsync('foo', 'a', 2);
+    stub.yieldsToOnAsync('foo', instance, 'a', 2);
+    stub.withArgs('a', 2).returns(true);
 
     // Type-safe stubs
-    const stub2 = sinon.stub(instance, "foo").named("namedStub");
+    const stub2 = sinon.stub(instance, 'foo').named('namedStub');
     instance.foo = stub2; // Should be assignable to original
     stub2.returns(true); // $ExpectError
     stub2.returns(5);
-    stub2.returns("foo"); // $ExpectError
+    stub2.returns('foo'); // $ExpectError
     stub2.callsFake((arg: string) => 1);
     stub2.callsFake((arg: number) => 1); // $ExpectError
-    stub2.callsFake((arg: string) => "a"); // $ExpectError
+    stub2.callsFake((arg: string) => 'a'); // $ExpectError
     stub2.onCall(1).returns(2);
-    stub2.withArgs("a", 2).returns("true"); // $ExpectError
-    stub2.withArgs("a").returns(1);
-    stub2.withArgs("a").returns("a"); // $ExpectError
+    stub2.withArgs('a', 2).returns('true'); // $ExpectError
+    stub2.withArgs('a').returns(1);
+    stub2.withArgs('a').returns('a'); // $ExpectError
 
-    const stub3 = sinon.stub(instance, "fooDeep").named("namedStubDeep");
+    const stub3 = sinon.stub(instance, 'fooDeep').named('namedStubDeep');
     stub3.calledWith({ s: sinon.match.string });
 
-    const pStub = sinon.stub(instance, "promiseFunc");
+    const pStub = sinon.stub(instance, 'promiseFunc');
     pStub.resolves();
-    pStub.resolves("foo");
+    pStub.resolves('foo');
     pStub.resolves(1); // $ExpectError
 }
 
@@ -824,9 +826,9 @@ function testTypedStub() {
     let stub: sinon.SinonStub<[number, string], boolean> = sinon.stub();
     let stub2 = sinon.stub<[number, string], boolean>();
     const foo = new Foo();
-    stub = sinon.stub(foo, "bar");
-    stub2 = sinon.stub(foo, "bar");
-    const result: boolean = stub(42, "qux");
+    stub = sinon.stub(foo, 'bar');
+    stub2 = sinon.stub(foo, 'bar');
+    const result: boolean = stub(42, 'qux');
     const fooStub: sinon.SinonStubbedInstance<Foo> = {
         bar: sinon.stub(),
     };
@@ -836,13 +838,13 @@ function testMock() {
     const obj = {};
     const mock = sinon.mock(obj);
 
-    mock.expects("method").atLeast(2).atMost(5);
+    mock.expects('method').atLeast(2).atMost(5);
     mock.restore();
     mock.verify();
 }
 
 function testAddBehavior() {
-    sinon.addBehavior("returnsNum", (fake, n) => {
+    sinon.addBehavior('returnsNum', (fake, n) => {
         fake.returns(n);
     });
 }
@@ -862,7 +864,7 @@ async function testPromises() {
     typedPromise.resolvedValue; // $ExpectType number | undefined
     typedPromise.rejectedValue; // $ExpectType unknown
 
-    const executor = sinon.promise<string>((resolve) => {
+    const executor = sinon.promise<string>(resolve => {
         resolve('abc');
     });
     const executor2 = sinon.promise<string>((resolve, reject) => {

--- a/types/sinon/tsconfig.json
+++ b/types/sinon/tsconfig.json
@@ -16,6 +16,9 @@
         ],
         "types": [],
         "paths": {
+            "@sinonjs/*": [
+                "sinonjs__*"
+            ]
         },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
it appears @sinonjs/fake-timers stopped shipping a type.  this caused the sinon types to be stuck on the types in v7, installing that old version in node_modules.

meanwhile, @types/sinonjs_fake-timers adapted to v8 and newest sinon already uses v9.

this PR changes @types/sinon to depend on @types/sinonjs__fake-timers again, as they seem most up-to-date.

the test changes are similar to what's found in the tests for @types/sinonjs__fake-times (the casting to BrowserClock or NodeClock)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: #52297 moved to official types; this moves it back
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
