### PR TITLE
fix(node): fix global URLSearchParams var type for TS 3.7.x compatibility

### DIFF
--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -168,8 +168,8 @@ import * as url from 'node:url';
     const dataUrl: string = url.URL.createObjectURL(new Blob(['']));
 }
 {
-    const dataUrl1: URL = new url.URL('file://test');
-    const dataUrl2: url.URL = new URL('file://test');
-    const urlSearchParams1: URLSearchParams = new url.URLSearchParams();
-    const urlSearchParams2: url.URLSearchParams = new URLSearchParams();
+    let dataUrl: url.URL = new url.URL('file://test');
+    dataUrl = new URL('file://test');
+    let urlSearchParams: url.URLSearchParams = new url.URLSearchParams('abc=123');
+    urlSearchParams = new URLSearchParams('abc=123');
 }

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -875,11 +875,16 @@ declare module 'url' {
          * https://nodejs.org/api/url.html#class-urlsearchparams
          * @since v10.0.0
          */
-        var URLSearchParams: {
-            prototype: URLSearchParams;
-            new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
-            toString(): string;
-        };
+        var URLSearchParams: typeof globalThis extends { SpeechRecognitionError: infer SpeechRecognitionError } ?
+            // For TS <= 3.8.2 compatibility
+            {
+                prototype: URLSearchParams;
+                new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+            }: {
+                prototype: URLSearchParams;
+                new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+                toString(): string;
+            };
     }
 }
 declare module 'node:url' {

--- a/types/node/v12/url.d.ts
+++ b/types/node/v12/url.d.ts
@@ -134,10 +134,15 @@ declare module 'url' {
          * https://nodejs.org/api/url.html#class-urlsearchparams
          * @since v10.0.0
          */
-        var URLSearchParams: {
-            prototype: URLSearchParams;
-            new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
-            toString(): string;
-        };
+        var URLSearchParams: typeof globalThis extends { SpeechRecognitionError: infer SpeechRecognitionError } ?
+            // For TS <= 3.8.2 compatibility
+            {
+                prototype: URLSearchParams;
+                new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+            }: {
+                prototype: URLSearchParams;
+                new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+                toString(): string;
+            };
     }
 }

--- a/types/node/v14/test/url.ts
+++ b/types/node/v14/test/url.ts
@@ -156,8 +156,8 @@ import * as url from 'node:url';
 }
 
 {
-    const dataUrl1: URL = new url.URL('file://test');
-    const dataUrl2: url.URL = new URL('file://test');
-    const urlSearchParams1: URLSearchParams = new url.URLSearchParams();
-    const urlSearchParams2: url.URLSearchParams = new URLSearchParams();
+    let dataUrl: url.URL = new url.URL('file://test');
+    dataUrl = new URL('file://test');
+    let urlSearchParams: url.URLSearchParams = new url.URLSearchParams('abc=123');
+    urlSearchParams = new URLSearchParams('abc=123');
 }

--- a/types/node/v14/url.d.ts
+++ b/types/node/v14/url.d.ts
@@ -133,11 +133,16 @@ declare module 'url' {
          * https://nodejs.org/api/url.html#class-urlsearchparams
          * @since v10.0.0
          */
-        var URLSearchParams: {
-            prototype: URLSearchParams;
-            new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
-            toString(): string;
-        };
+        var URLSearchParams: typeof globalThis extends { SpeechRecognitionError: infer SpeechRecognitionError } ?
+            // For TS <= 3.8.2 compatibility
+            {
+                prototype: URLSearchParams;
+                new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+            }: {
+                prototype: URLSearchParams;
+                new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+                toString(): string;
+            };
     }
 }
 declare module 'node:url' {

--- a/types/node/v16/test/url.ts
+++ b/types/node/v16/test/url.ts
@@ -168,8 +168,8 @@ import * as url from 'node:url';
     const dataUrl: string = url.URL.createObjectURL(new Blob(['']));
 }
 {
-    const dataUrl1: URL = new url.URL('file://test');
-    const dataUrl2: url.URL = new URL('file://test');
-    const urlSearchParams1: URLSearchParams = new url.URLSearchParams();
-    const urlSearchParams2: url.URLSearchParams = new URLSearchParams();
+    let dataUrl: url.URL = new url.URL('file://test');
+    dataUrl = new URL('file://test');
+    let urlSearchParams: url.URLSearchParams = new url.URLSearchParams('abc=123');
+    urlSearchParams = new URLSearchParams('abc=123');
 }

--- a/types/node/v16/url.d.ts
+++ b/types/node/v16/url.d.ts
@@ -835,11 +835,16 @@ declare module 'url' {
          * https://nodejs.org/api/url.html#class-urlsearchparams
          * @since v10.0.0
          */
-        var URLSearchParams: {
-            prototype: URLSearchParams;
-            new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
-            toString(): string;
-        };
+        var URLSearchParams: typeof globalThis extends { SpeechRecognitionError: infer SpeechRecognitionError } ?
+            // For TS <= 3.8.2 compatibility
+            {
+                prototype: URLSearchParams;
+                new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+            }: {
+                prototype: URLSearchParams;
+                new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
+                toString(): string;
+            };
     }
 }
 declare module 'node:url' {


### PR DESCRIPTION
closes #58562

relates #34960 #58277

The fix uses janky `lib.dom.d.ts` version detection for conditional type declaration.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
