### PR TITLE
Added overload for row event to allow for useColumnNames

### DIFF
--- a/types/tedious/index.d.ts
+++ b/types/tedious/index.d.ts
@@ -445,9 +445,14 @@ export interface Request {
     on(event: 'requestCompleted', listener: () => void):this;
 
     /**
-     * A row resulting from execution of the SQL statement
+     * A row resulting from execution of the SQL statement with `config.options.useColumnNames` set to `false` (default).
      */
     on(event: 'row', listener: (columns: ColumnValue[]) => void):this;
+
+    /**
+     * A row resulting from execution of the SQL statement with `config.options.useColumnNames` set to `true`.
+     */
+    on(event: 'row', listener: (columns: Record<string, ColumnValue>) => void):this;
 
     /**
      * All rows from a result set have been provided (through row events). This token is used to indicate the completion of a SQL statement. As multiple SQL statements can be sent to the server in a single SQL batch, multiple done events can be generated. An done event is emited for each SQL statement in the SQL batch except variable declarations. For execution of SQL statements within stored procedures, doneProc and doneInProc events are used in place of done events.

--- a/types/tedious/tedious-tests.ts
+++ b/types/tedious/tedious-tests.ts
@@ -7,7 +7,8 @@ var config: tedious.ConnectionConfig = {
         instanceName: "someinstance",
         cryptoCredentialsDetails: {
             minVersion: "TLSv1"
-        }
+        },
+        useColumnNames: true
     },
     authentication: {
         type: "default",
@@ -36,7 +37,7 @@ connection.transaction((error: Error, done: (error?: Error) => void): void => {}
 
 var request = new tedious.Request("SELECT * FROM foo", (error: Error, rowCount: number): void => {
 });
-request.on("row", (row: tedious.ColumnValue[]): void => {
+request.on("row", (row: Record<string, tedious.ColumnValue>): void => {
 });
 connection.execSql(request);
 


### PR DESCRIPTION
In the [tedious documentation](https://tediousjs.github.io/tedious/api-request.html#event_row) about the `row` event it says the following:

> An array or object (depends on `config.options.useColumnNames`), where the columns can be accessed by index/name.

In case `useColumnNames` is set to `true`, the `row` event handler is passed an object type `Record<string, ColumnValue>`.