### PR TITLE
[chrome] saveAsMHTML callback type is Blob

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5820,7 +5820,7 @@ declare namespace chrome.pageCapture {
      * function(binary mhtmlData) {...};
      * Parameter mhtmlData: The MHTML data as a Blob.
      */
-    export function saveAsMHTML(details: SaveDetails, callback: (mhtmlData?: ArrayBuffer) => void): void;
+    export function saveAsMHTML(details: SaveDetails, callback: (mhtmlData?: Blob) => void): void;
 }
 
 ////////////////////


### PR DESCRIPTION
The `chrome.pageCapture.saveAsMHTML` callback type is actually Blob; the documentation is ambiguous.
See discussion at https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58561

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://developer.chrome.com/docs/extensions/reference/pageCapture/#method-saveAsMHTML)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
