### PR TITLE
wrap data-api-client in a namespace to improve type visibility

### DIFF
--- a/types/data-api-client/data-api-client-tests.ts
+++ b/types/data-api-client/data-api-client-tests.ts
@@ -1,6 +1,6 @@
 import Client = require('data-api-client');
 
-const client = Client({
+const client: Client.iDataAPIClient = Client({
     resourceArn: '',
     secretArn: '',
     database: '',
@@ -24,15 +24,13 @@ client.query({ sql: 'SELECT * FROM Users;', parameters: {}, transactionId: '' })
     }
 });
 
-client
-    .query<{ id: string; name: string }>('SELECT * FROM Users WHERE id = :id;', { id: 'id' })
-    .then(res => {
-        if (res.records?.length) {
-            const user = res.records[0];
-            user.id;
-            user.name;
-        }
-    });
+client.query<{ id: string; name: string }>('SELECT * FROM Users WHERE id = :id;', { id: 'id' }).then(res => {
+    if (res.records?.length) {
+        const user = res.records[0];
+        user.id;
+        user.name;
+    }
+});
 
 client
     .transaction()

--- a/types/data-api-client/index.d.ts
+++ b/types/data-api-client/index.d.ts
@@ -8,70 +8,68 @@
 // This is added because aws-sdk depends on @types/node
 /// <reference types="node" />
 
-declare module 'data-api-client' {
-    import type { ClientConfiguration, Types } from 'aws-sdk/clients/rdsdataservice';
-    namespace Client {
-        type OmittedValues = 'database' | 'resourceArn' | 'secretArn' | 'schema';
+import type { ClientConfiguration, Types } from 'aws-sdk/clients/rdsdataservice';
+declare namespace Client {
+    type OmittedValues = 'database' | 'resourceArn' | 'secretArn' | 'schema';
 
-        interface iParams {
-            secretArn: string;
-            resourceArn: string;
-            database?: string | undefined;
-            keepAlive?: boolean | undefined;
-            hydrateColumnNames?: boolean | undefined;
-            sslEnabled?: boolean | undefined;
-            options?: ClientConfiguration | undefined;
-            region?: string | undefined;
-            engine?: 'mysql' | 'pg' | undefined;
-            formatOptions?:
-                | {
-                      deserializeDate?: boolean | undefined;
-                      treatAsLocalDate?: boolean | undefined;
-                  }
-                | undefined;
-        }
-
-        interface Transaction {
-            query(sql: string, params?: [] | unknown): Transaction; // params can be [] or {};
-            query(
-                obj:
-                    | {
-                          sql: string;
-                          parameters: [] | unknown;
-                          database?: string | undefined;
-                          hydrateColumnNames?: boolean | undefined;
-                      }
-                    | ((prevResult: { insertId?: any }) => any),
-            ): Transaction;
-
-            rollback: (error: Error, status: any) => void;
-            commit: () => Promise<void>;
-        }
-
-        interface iDataAPIClient {
-            /* tslint:disable:no-unnecessary-generics */
-            query<T = any>(sql: string, params?: [] | unknown): Promise<iDataAPIQueryResult<T>>; // params can be [] or {};
-            query<T = any>(obj: {
-                sql: string;
-                parameters?: [] | unknown | undefined;
-                transactionId?: string | undefined;
-                database?: string | undefined;
-                hydrateColumnNames?: boolean | undefined;
-            }): Promise<iDataAPIQueryResult<T>>;
-            transaction(): Transaction; // needs to return an interface with
-
-            // promisified versions of the RDSDataService methods
-            batchExecuteStatement: (params: Omit<Types.BatchExecuteStatementRequest, OmittedValues>) => Promise<any>;
-            beginTransaction: () => Promise<Types.BeginTransactionResponse>;
-            commitTransaction: (params: Omit<Types.CommitTransactionRequest, OmittedValues>) => Promise<any>;
-            executeStatement: (params: Omit<Types.ExecuteStatementRequest, OmittedValues>) => Promise<any>;
-            rollbackTransaction: (params: Omit<Types.RollbackTransactionRequest, OmittedValues>) => Promise<any>;
-        }
-
-        interface iDataAPIQueryResult<T = any> {
-            records: T[];
-        }
+    interface iParams {
+        secretArn: string;
+        resourceArn: string;
+        database?: string | undefined;
+        keepAlive?: boolean | undefined;
+        hydrateColumnNames?: boolean | undefined;
+        sslEnabled?: boolean | undefined;
+        options?: ClientConfiguration | undefined;
+        region?: string | undefined;
+        engine?: 'mysql' | 'pg' | undefined;
+        formatOptions?:
+            | {
+                  deserializeDate?: boolean | undefined;
+                  treatAsLocalDate?: boolean | undefined;
+              }
+            | undefined;
     }
-    function Client(params: Client.iParams): Client.iDataAPIClient;
-    export = Client;
+
+    interface Transaction {
+        query(sql: string, params?: [] | unknown): Transaction; // params can be [] or {};
+        query(
+            obj:
+                | {
+                      sql: string;
+                      parameters: [] | unknown;
+                      database?: string | undefined;
+                      hydrateColumnNames?: boolean | undefined;
+                  }
+                | ((prevResult: { insertId?: any }) => any),
+        ): Transaction;
+
+        rollback: (error: Error, status: any) => void;
+        commit: () => Promise<void>;
+    }
+
+    interface iDataAPIClient {
+        /* tslint:disable:no-unnecessary-generics */
+        query<T = any>(sql: string, params?: [] | unknown): Promise<iDataAPIQueryResult<T>>; // params can be [] or {};
+        query<T = any>(obj: {
+            sql: string;
+            parameters?: [] | unknown | undefined;
+            transactionId?: string | undefined;
+            database?: string | undefined;
+            hydrateColumnNames?: boolean | undefined;
+        }): Promise<iDataAPIQueryResult<T>>;
+        transaction(): Transaction; // needs to return an interface with
+
+        // promisified versions of the RDSDataService methods
+        batchExecuteStatement: (params: Omit<Types.BatchExecuteStatementRequest, OmittedValues>) => Promise<any>;
+        beginTransaction: () => Promise<Types.BeginTransactionResponse>;
+        commitTransaction: (params: Omit<Types.CommitTransactionRequest, OmittedValues>) => Promise<any>;
+        executeStatement: (params: Omit<Types.ExecuteStatementRequest, OmittedValues>) => Promise<any>;
+        rollbackTransaction: (params: Omit<Types.RollbackTransactionRequest, OmittedValues>) => Promise<any>;
+    }
+
+    interface iDataAPIQueryResult<T = any> {
+        records: T[];
+    }
 }
+function Client(params: Client.iParams): Client.iDataAPIClient;
+export = Client;

--- a/types/data-api-client/index.d.ts
+++ b/types/data-api-client/index.d.ts
@@ -71,5 +71,5 @@ declare namespace Client {
         records: T[];
     }
 }
-function Client(params: Client.iParams): Client.iDataAPIClient;
+declare function Client(params: Client.iParams): Client.iDataAPIClient;
 export = Client;

--- a/types/data-api-client/index.d.ts
+++ b/types/data-api-client/index.d.ts
@@ -8,67 +8,70 @@
 // This is added because aws-sdk depends on @types/node
 /// <reference types="node" />
 
-import type { ClientConfiguration, Types } from 'aws-sdk/clients/rdsdataservice';
+declare module 'data-api-client' {
+    import type { ClientConfiguration, Types } from 'aws-sdk/clients/rdsdataservice';
+    namespace Client {
+        type OmittedValues = 'database' | 'resourceArn' | 'secretArn' | 'schema';
 
-type OmittedValues = 'database' | 'resourceArn' | 'secretArn' | 'schema';
+        interface iParams {
+            secretArn: string;
+            resourceArn: string;
+            database?: string | undefined;
+            keepAlive?: boolean | undefined;
+            hydrateColumnNames?: boolean | undefined;
+            sslEnabled?: boolean | undefined;
+            options?: ClientConfiguration | undefined;
+            region?: string | undefined;
+            engine?: 'mysql' | 'pg' | undefined;
+            formatOptions?:
+                | {
+                      deserializeDate?: boolean | undefined;
+                      treatAsLocalDate?: boolean | undefined;
+                  }
+                | undefined;
+        }
 
-interface iParams {
-    secretArn: string;
-    resourceArn: string;
-    database?: string | undefined;
-    keepAlive?: boolean | undefined;
-    hydrateColumnNames?: boolean | undefined;
-    sslEnabled?: boolean | undefined;
-    options?: ClientConfiguration | undefined;
-    region?: string | undefined;
-    engine?: 'mysql' | 'pg' | undefined;
-    formatOptions?: {
-        deserializeDate?: boolean | undefined;
-        treatAsLocalDate?: boolean | undefined;
-    } | undefined;
+        interface Transaction {
+            query(sql: string, params?: [] | unknown): Transaction; // params can be [] or {};
+            query(
+                obj:
+                    | {
+                          sql: string;
+                          parameters: [] | unknown;
+                          database?: string | undefined;
+                          hydrateColumnNames?: boolean | undefined;
+                      }
+                    | ((prevResult: { insertId?: any }) => any),
+            ): Transaction;
+
+            rollback: (error: Error, status: any) => void;
+            commit: () => Promise<void>;
+        }
+
+        interface iDataAPIClient {
+            /* tslint:disable:no-unnecessary-generics */
+            query<T = any>(sql: string, params?: [] | unknown): Promise<iDataAPIQueryResult<T>>; // params can be [] or {};
+            query<T = any>(obj: {
+                sql: string;
+                parameters?: [] | unknown | undefined;
+                transactionId?: string | undefined;
+                database?: string | undefined;
+                hydrateColumnNames?: boolean | undefined;
+            }): Promise<iDataAPIQueryResult<T>>;
+            transaction(): Transaction; // needs to return an interface with
+
+            // promisified versions of the RDSDataService methods
+            batchExecuteStatement: (params: Omit<Types.BatchExecuteStatementRequest, OmittedValues>) => Promise<any>;
+            beginTransaction: () => Promise<Types.BeginTransactionResponse>;
+            commitTransaction: (params: Omit<Types.CommitTransactionRequest, OmittedValues>) => Promise<any>;
+            executeStatement: (params: Omit<Types.ExecuteStatementRequest, OmittedValues>) => Promise<any>;
+            rollbackTransaction: (params: Omit<Types.RollbackTransactionRequest, OmittedValues>) => Promise<any>;
+        }
+
+        interface iDataAPIQueryResult<T = any> {
+            records: T[];
+        }
+    }
+    function Client(params: Client.iParams): Client.iDataAPIClient;
+    export = Client;
 }
-
-interface Transaction {
-    query(sql: string, params?: [] | unknown): Transaction; // params can be [] or {};
-    query(
-        obj:
-            | {
-                  sql: string;
-                  parameters: [] | unknown;
-                  database?: string | undefined;
-                  hydrateColumnNames?: boolean | undefined;
-              }
-            | ((prevResult: { insertId?: any }) => any),
-    ): Transaction;
-
-    rollback: (error: Error, status: any) => void;
-    commit: () => Promise<void>;
-}
-
-interface iDataAPIClient {
-    /* tslint:disable:no-unnecessary-generics */
-    query<T = any>(sql: string, params?: [] | unknown): Promise<iDataAPIQueryResult<T>>; // params can be [] or {};
-    query<T = any>(obj: {
-        sql: string;
-        parameters?: [] | unknown | undefined;
-        transactionId?: string | undefined;
-        database?: string | undefined;
-        hydrateColumnNames?: boolean | undefined;
-    }): Promise<iDataAPIQueryResult<T>>;
-    transaction(): Transaction; // needs to return an interface with
-
-    // promisified versions of the RDSDataService methods
-    batchExecuteStatement: (params: Omit<Types.BatchExecuteStatementRequest, OmittedValues>) => Promise<any>;
-    beginTransaction: () => Promise<Types.BeginTransactionResponse>;
-    commitTransaction: (params: Omit<Types.CommitTransactionRequest, OmittedValues>) => Promise<any>;
-    executeStatement: (params: Omit<Types.ExecuteStatementRequest, OmittedValues>) => Promise<any>;
-    rollbackTransaction: (params: Omit<Types.RollbackTransactionRequest, OmittedValues>) => Promise<any>;
-}
-
-interface iDataAPIQueryResult<T = any> {
-    records: T[];
-}
-
-declare function Client(params: iParams): iDataAPIClient;
-
-export = Client;

--- a/types/data-api-client/tsconfig.json
+++ b/types/data-api-client/tsconfig.json
@@ -6,7 +6,6 @@
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
-        "esModuleInterop": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],

--- a/types/data-api-client/tsconfig.json
+++ b/types/data-api-client/tsconfig.json
@@ -6,6 +6,7 @@
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
+        "esModuleInterop": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],


### PR DESCRIPTION
I had the necessity to use the type iDataAPIClient in my own interface, but with the current declaration I couldn't import that type in any way. So I edited the declaration in this way, putting everything inside a namespace which allow me to do stuff like this:
```
import Client from 'data-api-client';

export async function inTransaction(
    f: (dbClient: Client.iDataAPIClient, transactionId: string) => Promise<void>
) {
    const secretArn = process.env.AURORA_SECRET_ARN;
    const resourceArn = process.env.AURORA_CLUSTER_ARN;
    const database = process.env.DB_NAME;
    const dbClient = Client({
        secretArn,
        resourceArn,
        database,
    });

    const { transactionId } = await dbClient.beginTransaction();
    if (!transactionId) throw new Error('unable to begin transaction');
    try {
        await f(dbClient, transactionId);
    } catch (e) {
        await dbClient.rollbackTransaction({ transactionId });
        throw e;
    }
    await dbClient.commitTransaction({ transactionId });
}
```

Specifically, in this example, it allows to have a type safe signature for the passed function.