### PR TITLE
[follow-redirects] Fix uncallable expression errors when unioned

### DIFF
--- a/types/follow-redirects/follow-redirects-tests.ts
+++ b/types/follow-redirects/follow-redirects-tests.ts
@@ -25,6 +25,9 @@ http.request(
 const request = http.request({});
 request.end();
 
+http.get('http://bit.ly/900913');
+http.get({ headers: { Accept: 'application/json' } });
+http.get(new URL('http://bit.ly/900913'));
 http.get('http://bit.ly/900913', response => {
     response.on('data', chunk => {
         console.log(chunk);
@@ -36,6 +39,9 @@ http.get('http://bit.ly/900913', { headers: { Accept: 'application/json' } }, _r
 http.get(new URL('http://bit.ly/900913'), _res => {});
 http.get(new URL('http://bit.ly/900913'), { headers: { Accept: 'application/json' } }, _res => {});
 
+https.get('http://bit.ly/900913');
+https.get({ headers: { Accept: 'application/json' } });
+https.get(new URL('http://bit.ly/900913'));
 https
     .get('http://bit.ly/900913', response => {
         console.log(response.responseUrl, response.redirects);
@@ -49,3 +55,7 @@ https
 https.get('http://bit.ly/900913', { headers: { Accept: 'application/json' } }, _res => {});
 https.get(new URL('http://bit.ly/900913'), _res => {});
 https.get(new URL('http://bit.ly/900913'), { headers: { Accept: 'application/json' } }, _res => {});
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58510#issuecomment-1027810928
+declare const isHTTP: boolean;
+(isHTTP ? http : https).request({ headers: { Accept: 'application/json' } }, _res => {});

--- a/types/follow-redirects/index.d.ts
+++ b/types/follow-redirects/index.d.ts
@@ -71,23 +71,28 @@ export interface RedirectableRequest<Request extends WrappableRequest, Response>
 }
 
 export interface RedirectScheme<Options, Request extends WrappableRequest, Response> {
+    /**
+     * This function has two overloads:
+     * ```typescript
+     * request(options: string | URL | Options, callback)
+     * request(url: string | URL, options: Options, callback)
+     * ```
+     */
     request(
-        options: string | URL | (Options & FollowOptions<Options>),
+        url: string | URL | (Options & FollowOptions<Options>),
+        options?: (Options & FollowOptions<Options>) | ((res: Response & FollowResponse) => void),
         callback?: (res: Response & FollowResponse) => void,
     ): RedirectableRequest<Request, Response>;
-    request(
-        url: string | URL,
-        options: Options & FollowOptions<Options>,
-        callback?: (res: Response & FollowResponse) => void,
-    ): RedirectableRequest<Request, Response>;
-
+    /**
+     * This function has two overloads:
+     * ```typescript
+     * get(options: string | URL | Options, callback)
+     * get(url: string | URL, options: Options, callback)
+     * ```
+     */
     get(
-        options: string | URL | (Options & FollowOptions<Options>),
-        callback?: (res: Response & FollowResponse) => void,
-    ): RedirectableRequest<Request, Response>;
-    get(
-        url: string | URL,
-        options: Options & FollowOptions<Options>,
+        url: string | URL | (Options & FollowOptions<Options>),
+        options?: (Options & FollowOptions<Options>) | ((res: Response & FollowResponse) => void),
         callback?: (res: Response & FollowResponse) => void,
     ): RedirectableRequest<Request, Response>;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58510#issuecomment-1027810928
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

------

This commit fixes the breaking issue mentioned in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58510#issuecomment-1027810928.
The breakage seems to be caused by limitations of TypeScript dealing with function overloads and union types, so I replaced the overloads with something naïve and added some doc comments to hopefully make the usage of the functions clearer.

This change introduces some false negatives, but I don't think there's any way to work around it:

```typescript
// These shouldn't be legal, but they will be if this PR is merged.
http.request(options, options)
http.request(url, callback, callback)
```