### PR TITLE
[react] Remove note from useMemo documentation

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1113,18 +1113,6 @@ declare namespace React {
     /**
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
      *
-     * Usage note: if calling `useMemo` with a referentially stable function, also give it as the input in
-     * the second argument.
-     *
-     * ```ts
-     * function expensive () { ... }
-     *
-     * function Component () {
-     *   const expensiveResult = useMemo(expensive, [expensive])
-     *   return ...
-     * }
-     * ```
-     *
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usememo
      */

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1107,18 +1107,6 @@ declare namespace React {
     /**
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
      *
-     * Usage note: if calling `useMemo` with a referentially stable function, also give it as the input in
-     * the second argument.
-     *
-     * ```ts
-     * function expensive () { ... }
-     *
-     * function Component () {
-     *   const expensiveResult = useMemo(expensive, [expensive])
-     *   return ...
-     * }
-     * ```
-     *
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usememo
      */


### PR DESCRIPTION
The documentation for `useMemo` in the declaration file currently contains this text:
> Usage note: if calling `useMemo` with a referentially stable function, also give it as the input in
> the second argument.
> 
> ```ts
> function expensive () { ... }
> 
> function Component () {
>   const expensiveResult = useMemo(expensive, [expensive])
>   return ...
> }
> ```

However, I believe that this is not accurate. I fail to understand why this:
```ts
useMemo(expensive, [expensive])
```
would cause different behaviour than this:
```ts
useMemo(expensive, [])
```
In my understanding, "`expensive`" being referentially stable means its presence in the dependency list has no effect ‒ as it is equal to itself across calls to the hook. If I am right, then the usage note can be taken out.

cc: @Jessidhia

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [reactjs.org/docs/hooks-reference.html#usememo](https://reactjs.org/docs/hooks-reference.html#usememo)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
