### PR TITLE
[relay-runtime] null fields are removed

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -97,7 +97,6 @@ export { GraphQLSubscriptionConfig } from './lib/subscription/requestSubscriptio
 export {
     NormalizationArgument,
     NormalizationDefer,
-    NormalizationConnection,
     NormalizationField,
     NormalizationFlightField,
     NormalizationLinkedField,
@@ -108,8 +107,9 @@ export {
     NormalizationSelection,
     NormalizationSplitOperation,
     NormalizationStream,
+    NormalizationTypeDiscriminator,
+    NormalizationOperation,
 } from './lib/util/NormalizationNode';
-export { NormalizationOperation } from './lib/util/NormalizationNode';
 export {
     ReaderArgument,
     ReaderArgumentDefinition,

--- a/types/relay-runtime/lib/util/NormalizationNode.d.ts
+++ b/types/relay-runtime/lib/util/NormalizationNode.d.ts
@@ -1,73 +1,180 @@
-export type NormalizationArgument = NormalizationLiteral | NormalizationVariable;
+import type { ConcreteRequest } from "./RelayConcreteNode";
 
-export interface NormalizationDefer {
-    readonly if: string | null;
-    readonly kind: 'Defer';
-    readonly label: string;
-    readonly metadata: { readonly [key: string]: unknown } | null | undefined;
-    readonly selections: ReadonlyArray<NormalizationSelection>;
-}
-
-export interface NormalizationClientExtension {
-    readonly kind: string; // 'ClientExtension';
-    readonly selections: ReadonlyArray<NormalizationSelection>;
-}
-
-export type NormalizationField = NormalizationFlightField | NormalizationScalarField | NormalizationLinkedField;
-
-export interface NormalizationLinkedField {
-    readonly kind: string; // 'LinkedField';
-    readonly alias: string | null | undefined;
-    readonly name: string;
-    readonly storageKey?: string | null | undefined;
-    readonly args: ReadonlyArray<NormalizationArgument>;
-    readonly concreteType: string | null | undefined;
-    readonly plural: boolean;
-    readonly selections: ReadonlyArray<NormalizationSelection>;
-}
-
+/**
+ * Represents a single operation used to processing and normalize runtime
+ * request results.
+ */
 export interface NormalizationOperation {
-    readonly kind: string; // 'Operation';
+    readonly kind: string; // "Operation";
     readonly name: string;
     readonly argumentDefinitions: ReadonlyArray<NormalizationLocalArgumentDefinition>;
     readonly selections: ReadonlyArray<NormalizationSelection>;
 }
 
-export interface NormalizationScalarField {
-    readonly kind: string; // 'ScalarField';
-    readonly alias: string | null | undefined;
+export type NormalizationHandle =
+    | NormalizationScalarHandle
+    | NormalizationLinkedHandle;
+
+export interface NormalizationLinkedHandle {
+    readonly kind: string; // "LinkedHandle";
+    readonly alias?: string | null | undefined;
     readonly name: string;
-    readonly args: ReadonlyArray<NormalizationArgument> | null | undefined;
-    readonly storageKey: string | null | undefined;
+    readonly args?: ReadonlyArray<NormalizationArgument> | null | undefined;
+    readonly handle: string;
+    readonly key: string;
+    // NOTE: this property is optional because it's expected to be rarely used
+    readonly dynamicKey?: NormalizationArgument | null | undefined;
+    readonly filters?: ReadonlyArray<string> | null | undefined;
+    readonly handleArgs?: ReadonlyArray<NormalizationArgument>;
+}
+
+export interface NormalizationScalarHandle {
+    readonly kind: string; // "ScalarHandle";
+    readonly alias?: string | null | undefined;
+    readonly name: string;
+    readonly args?: ReadonlyArray<NormalizationArgument> | null | undefined;
+    readonly handle: string;
+    readonly key: string;
+    // NOTE: this property is optional because it's expected to be rarely used
+    readonly dynamicKey?: NormalizationArgument | null | undefined;
+    readonly filters?: ReadonlyArray<string> | null | undefined;
+    readonly handleArgs?: ReadonlyArray<NormalizationArgument>;
+}
+
+export type NormalizationArgument =
+    | NormalizationListValueArgument
+    | NormalizationLiteralArgument
+    | NormalizationObjectValueArgument
+    | NormalizationVariableArgument;
+
+export interface NormalizationCondition {
+    readonly kind: string; // "Condition";
+    readonly passingValue: boolean;
+    readonly condition: string;
+    readonly selections: ReadonlyArray<NormalizationSelection>;
+}
+
+export interface NormalizationClientExtension {
+    readonly kind: string; // "ClientExtension";
+    readonly selections: ReadonlyArray<NormalizationSelection>;
+}
+
+export type NormalizationField =
+    | NormalizationFlightField
+    | NormalizationScalarField
+    | NormalizationLinkedField;
+
+export interface NormalizationInlineFragment {
+    readonly kind: string; // "InlineFragment";
+    readonly selections: ReadonlyArray<NormalizationSelection>;
+    readonly type: string;
+    readonly abstractKey?: string | null | undefined;
+}
+
+export interface NormalizationFragmentSpread {
+    readonly kind: string; // "FragmentSpread";
+    readonly fragment: NormalizationSplitOperation;
+    readonly args?: ReadonlyArray<NormalizationArgument> | null | undefined;
+}
+
+export interface NormalizationLinkedField {
+    readonly kind: string; // "LinkedField";
+    readonly alias?: string | null | undefined;
+    readonly name: string;
+    readonly storageKey?: string | null | undefined;
+    readonly args?: ReadonlyArray<NormalizationArgument> | null | undefined;
+    readonly concreteType?: string | null | undefined;
+    readonly plural: boolean;
+    readonly selections: ReadonlyArray<NormalizationSelection>;
+}
+
+export interface NormalizationActorChange {
+    readonly kind: string; // "ActorChange";
+    readonly linkedField: NormalizationLinkedField;
+}
+
+export interface NormalizationModuleImport {
+    readonly args?: ReadonlyArray<NormalizationArgument> | null | undefined;
+    readonly kind: string; // "ModuleImport";
+    readonly documentName: string;
+    readonly fragmentPropName: string;
+    readonly fragmentName: string;
+}
+
+export interface NormalizationListValueArgument {
+    readonly kind: string; // "ListValue";
+    readonly name: string;
+    readonly items: ReadonlyArray<NormalizationArgument | null>;
+}
+
+export interface NormalizationLiteralArgument {
+    readonly kind: string; // "Literal";
+    readonly name: string;
+    readonly type?: string | null | undefined;
+    readonly value: any;
+}
+
+export interface NormalizationLocalArgumentDefinition {
+    readonly kind: string; // "LocalArgument";
+    readonly name: string;
+    readonly defaultValue: any;
+}
+
+export type NormalizationNode =
+    | NormalizationClientExtension
+    | NormalizationCondition
+    | NormalizationDefer
+    | NormalizationInlineFragment
+    | NormalizationLinkedField
+    | NormalizationOperation
+    | NormalizationSplitOperation
+    | NormalizationStream;
+
+export interface NormalizationScalarField {
+    readonly kind: string; // "ScalarField";
+    readonly alias?: string | null | undefined;
+    readonly name: string;
+    readonly args?: ReadonlyArray<NormalizationArgument> | null | undefined;
+    readonly storageKey?: string | null | undefined;
 }
 
 export interface NormalizationFlightField {
-    readonly kind: string; // 'FlightField';
-    readonly alias: string | null | undefined;
+    readonly kind: string; // "FlightField";
+    readonly alias?: string | null | undefined;
     readonly name: string;
-    readonly args: ReadonlyArray<NormalizationArgument> | null | undefined;
+    readonly args?: ReadonlyArray<NormalizationArgument> | null | undefined;
     readonly storageKey: string | null | undefined;
 }
 
+export interface NormalizationClientComponent {
+    readonly args?: ReadonlyArray<NormalizationArgument> | null | undefined;
+    readonly kind: string; // "ClientComponent";
+    readonly fragment: NormalizationNode;
+}
+
 export interface NormalizationTypeDiscriminator {
-    readonly kind: string; // 'TypeDiscriminator';
+    readonly kind: string; // "TypeDiscriminator";
     readonly abstractKey: string;
 }
 
 export type NormalizationSelection =
     | NormalizationCondition
+    | NormalizationClientComponent
     | NormalizationClientExtension
     | NormalizationDefer
     | NormalizationField
     | NormalizationFlightField
+    | NormalizationFragmentSpread
     | NormalizationHandle
     | NormalizationInlineFragment
     | NormalizationModuleImport
     | NormalizationStream
+    | NormalizationActorChange
     | NormalizationTypeDiscriminator;
 
 export interface NormalizationSplitOperation {
-    readonly kind: string; // 'SplitOperation';
+    readonly argumentDefinitions?: ReadonlyArray<NormalizationLocalArgumentDefinition>;
+    readonly kind: string; // "SplitOperation";
     readonly name: string;
     readonly metadata: { readonly [key: string]: unknown } | null | undefined;
     readonly selections: ReadonlyArray<NormalizationSelection>;
@@ -75,81 +182,29 @@ export interface NormalizationSplitOperation {
 
 export interface NormalizationStream {
     readonly if: string | null;
-    readonly kind: string; // 'Stream';
+    readonly kind: string; // "Stream";
     readonly label: string;
-    readonly metadata: { readonly [key: string]: unknown } | null | undefined;
     readonly selections: ReadonlyArray<NormalizationSelection>;
 }
 
-export interface NormalizationLiteral {
-    readonly kind: string; // 'Literal';
-    readonly name: string;
-    readonly type?: string | null | undefined;
-    readonly value?: unknown | undefined;
+export interface NormalizationDefer {
+    readonly if: string | null;
+    readonly kind: string; // "Defer";
+    readonly label: string;
+    readonly selections: ReadonlyArray<NormalizationSelection>;
 }
 
-export interface NormalizationVariable {
-    readonly kind: string; // 'Variable';
+export interface NormalizationVariableArgument {
+    readonly kind: string; // "Variable";
     readonly name: string;
     readonly type?: string | null | undefined;
     readonly variableName: string;
 }
 
-export interface NormalizationConnection {
-    readonly kind: string;
-    readonly label: string;
+export interface NormalizationObjectValueArgument {
+    readonly kind: string; // "ObjectValue";
     readonly name: string;
-    readonly args: ReadonlyArray<NormalizationArgument>;
-    readonly edges: NormalizationLinkedField;
-    readonly pageInfo: NormalizationLinkedField;
-}
-
-export interface NormalizationLocalArgumentDefinition {
-    readonly kind: string;
-    readonly name: string;
-    readonly defaultValue: any;
-}
-
-export interface NormalizationModuleImport {
-    readonly kind: string;
-    readonly documentName: string;
-    readonly fragmentPropName: string;
-    readonly fragmentName: string;
-}
-
-export interface NormalizationCondition {
-    readonly kind: string; // 'Condition';
-    readonly passingValue: boolean;
-    readonly condition: string;
-    readonly selections: ReadonlyArray<NormalizationSelection>;
-}
-
-export type NormalizationHandle = NormalizationScalarHandle | NormalizationLinkedHandle;
-
-export interface NormalizationLinkedHandle {
-    readonly kind: string; // 'LinkedHandle';
-    readonly alias: string | null | undefined;
-    readonly name: string;
-    readonly args: ReadonlyArray<NormalizationArgument> | null | undefined;
-    readonly handle: string;
-    readonly key: string;
-    readonly filters: ReadonlyArray<string> | null | undefined;
-}
-
-export interface NormalizationScalarHandle {
-    readonly kind: string; // 'ScalarHandle';
-    readonly alias: string | null | undefined;
-    readonly name: string;
-    readonly args: ReadonlyArray<NormalizationArgument> | null | undefined;
-    readonly handle: string;
-    readonly key: string;
-    readonly filters: ReadonlyArray<string> | null | undefined;
-}
-
-export interface NormalizationInlineFragment {
-    readonly kind: string; // 'InlineFragment';
-    readonly selections: ReadonlyArray<NormalizationSelection>;
-    readonly type: string;
+    readonly fields: ReadonlyArray<NormalizationArgument>;
 }
 
 export type NormalizationSelectableNode =
@@ -158,3 +213,7 @@ export type NormalizationSelectableNode =
     | NormalizationOperation
     | NormalizationSplitOperation
     | NormalizationStream;
+
+export type NormalizationRootNode =
+    | ConcreteRequest
+    | NormalizationSplitOperation;

--- a/types/relay-runtime/lib/util/ReaderNode.d.ts
+++ b/types/relay-runtime/lib/util/ReaderNode.d.ts
@@ -1,46 +1,59 @@
-import { ConnectionMetadata } from '../handlers/connection/ConnectionHandler';
-import { ConcreteRequest } from './RelayConcreteNode';
+import type { ConnectionMetadata } from "../handlers/connection/ConnectionHandler";
+import type { ConcreteRequest } from "./RelayConcreteNode";
 
-export type ReaderArgument = ReaderLiteral | ReaderVariable | ReaderObjectValue | ReaderListValue;
+export interface ReaderFragmentSpread {
+    readonly kind: string; // 'FragmentSpread';
+    readonly name: string;
+    readonly args?: ReadonlyArray<ReaderArgument> | null | undefined;
+}
 
-export type ReaderArgumentDefinition = ReaderLocalArgument | ReaderRootArgument;
-
-export type ReaderField = ReaderScalarField | ReaderLinkedField;
+export interface ReaderInlineDataFragmentSpread {
+    readonly kind: string; // 'InlineDataFragmentSpread';
+    readonly name: string;
+    readonly selections: ReadonlyArray<ReaderSelection>;
+}
 
 export interface ReaderFragment {
     readonly kind: string; // 'Fragment';
     readonly name: string;
     readonly type: string;
     readonly abstractKey?: string | null | undefined;
-    readonly metadata:
-        | {
-              readonly connection?: ReadonlyArray<ConnectionMetadata> | undefined;
-              readonly mask?: boolean | undefined;
-              readonly plural?: boolean | undefined;
-              readonly refetch?: ReaderRefetchMetadata | undefined;
-          }
-        | null
-        | undefined;
+    readonly metadata?: {
+        readonly connection?: ReadonlyArray<ConnectionMetadata>;
+        readonly mask?: boolean;
+        readonly plural?: boolean;
+        readonly refetch?: ReaderRefetchMetadata;
+    } | null | undefined;
     readonly argumentDefinitions: ReadonlyArray<ReaderArgumentDefinition>;
     readonly selections: ReadonlyArray<ReaderSelection>;
 }
 
-export interface ReaderInlineDataFragment {
-    readonly kind: 'InlineDataFragment';
-    readonly name: string;
+// Marker type for a @refetchable fragment
+export interface ReaderRefetchableFragment extends ReaderFragment {
+    readonly metadata: {
+        readonly connection?: [ConnectionMetadata];
+        readonly refetch: ReaderRefetchMetadata;
+    };
 }
 
-export interface ReaderLinkedField {
-    readonly kind: string; // 'LinkedField';
-    readonly alias: string | null | undefined;
-    readonly name: string;
-    readonly storageKey: string | null | undefined;
-    readonly args: ReadonlyArray<ReaderArgument>;
-    readonly concreteType: string | null | undefined;
-    readonly plural: boolean;
-    readonly selections: ReadonlyArray<ReaderSelection>;
+// Marker Type for a @refetchable fragment with a single use of @connection
+export interface ReaderPaginationFragment extends ReaderFragment {
+    readonly metadata: {
+        readonly connection: [ConnectionMetadata];
+        readonly refetch: ReaderRefetchMetadata & {
+            connection: ReaderPaginationMetadata;
+        }
+    };
 }
 
+export interface ReaderRefetchMetadata {
+    readonly connection?: ReaderPaginationMetadata | null | undefined;
+    readonly operation: string | ConcreteRequest;
+    readonly fragmentPathInResult: string[];
+    readonly identifierField?: string | null | undefined;
+}
+
+// Stricter form of ConnectionMetadata
 export interface ReaderPaginationMetadata {
     readonly backward: {
         readonly count: string;
@@ -53,110 +66,20 @@ export interface ReaderPaginationMetadata {
     readonly path: ReadonlyArray<string>;
 }
 
-export interface ReaderRefetchableFragment extends ReaderFragment {
-    readonly metadata: {
-        readonly connection?: [ConnectionMetadata] | undefined;
-        readonly refetch: ReaderRefetchMetadata;
-    };
-}
-
-export interface ReaderScalarField {
-    readonly kind: string; // 'ScalarField';
-    readonly alias: string | null | undefined;
-    readonly name: string;
-    readonly args: ReadonlyArray<ReaderArgument> | null | undefined;
-    readonly storageKey: string | null | undefined;
-}
-
-export interface ReaderFlightField {
-    readonly kind: string; // 'FlightField',
-    readonly alias: string | null | undefined;
-    readonly name: string;
-    readonly args: ReadonlyArray<ReaderArgument> | null | undefined;
-    readonly storageKey: string | null | undefined;
-}
-
-export interface ReaderDefer {
-    readonly kind: string; // 'Defer',
-    readonly selections: ReadonlyArray<ReaderSelection>;
-}
-
-export interface ReaderStream {
-    readonly kind: string; // 'Stream',
-    readonly selections: ReadonlyArray<ReaderSelection>;
-}
-
-export type RequiredFieldAction = 'NONE' | 'LOG' | 'THROW';
-
-export interface ReaderRequiredField {
-    readonly kind: string; // 'RequiredField'
-    readonly field: ReaderField;
-    readonly action: RequiredFieldAction;
-    readonly path: string;
-}
-
-export type ReaderSelection =
-    | ReaderCondition
-    | ReaderClientExtension
-    | ReaderDefer
-    | ReaderField
-    | ReaderFlightField
-    | ReaderFragmentSpread
-    | ReaderInlineDataFragmentSpread
-    | ReaderInlineFragment
-    | ReaderModuleImport
-    | ReaderStream
-    | ReaderRequiredField;
-
-export interface ReaderSplitOperation {
-    readonly kind: string; // 'SplitOperation';
-    readonly name: string;
-    readonly metadata: { readonly [key: string]: unknown } | null | undefined;
-    readonly selections: ReadonlyArray<ReaderSelection>;
-}
-
-export interface ReaderLiteral {
-    readonly kind: string; // 'Literal';
-    readonly name: string;
-    readonly value: unknown;
-}
-
-export interface ReaderVariable {
-    readonly kind: string; // 'Variable';
-    readonly name: string;
-    readonly type?: string | null | undefined;
-    readonly variableName: string;
-}
-
-export interface ReaderObjectValue {
-    readonly kind: string; // 'ObjectValue';
-    readonly name: string;
-    readonly fields: ReadonlyArray<ReaderArgument>;
-}
-
-export interface ReaderListValue {
-    readonly kind: string; // 'ListValue';
-    readonly name: string;
-    readonly items: ReadonlyArray<ReaderArgument | null>;
-}
-
-export interface ReaderLocalArgument {
-    readonly kind: string; // 'LocalArgument';
-    readonly name: string;
-    readonly defaultValue: unknown;
-}
-
-export interface ReaderRootArgument {
-    readonly kind: string; // 'RootArgument';
+export interface ReaderInlineDataFragment {
+    readonly kind: string; // 'InlineDataFragment';
     readonly name: string;
 }
 
-export interface ReaderRefetchMetadata {
-    readonly connection?: ReaderPaginationMetadata | null | undefined;
-    readonly operation: string | ConcreteRequest;
-    readonly fragmentPathInResult: ReadonlyArray<string>;
-    readonly identifierField?: string | null | undefined;
-}
+export type ReaderArgument =
+    | ReaderListValueArgument
+    | ReaderLiteralArgument
+    | ReaderObjectValueArgument
+    | ReaderVariableArgument;
+
+export type ReaderArgumentDefinition =
+    | ReaderLocalArgument
+    | ReaderRootArgument;
 
 export interface ReaderCondition {
     readonly kind: string; // 'Condition';
@@ -170,10 +93,14 @@ export interface ReaderClientExtension {
     readonly selections: ReadonlyArray<ReaderSelection>;
 }
 
-export interface ReaderFragmentSpread {
-    readonly kind: string; // 'FragmentSpread';
+export type ReaderField =
+    | ReaderScalarField
+    | ReaderLinkedField
+    | ReaderRelayResolver;
+
+export interface ReaderRootArgument {
+    readonly kind: string; // 'RootArgument';
     readonly name: string;
-    readonly args: ReadonlyArray<ReaderArgument> | null | undefined;
 }
 
 export interface ReaderInlineFragment {
@@ -183,35 +110,138 @@ export interface ReaderInlineFragment {
     readonly abstractKey?: string | null | undefined;
 }
 
-export type ReaderSelectableNode = ReaderFragment | ReaderSplitOperation;
-
-export interface ReaderPaginationFragment extends ReaderFragment {
-    readonly metadata: {
-        readonly connection: [ConnectionMetadata];
-        readonly refetch: ReaderRefetchMetadata & {
-            connection: ReaderPaginationMetadata;
-        };
-    };
-}
-
-export interface ReaderConnection {
-    readonly kind: string;
-    readonly label: string;
+export interface ReaderLinkedField {
+    readonly kind: string; // 'LinkedField';
+    readonly alias?: string | null | undefined;
     readonly name: string;
-    readonly args: ReadonlyArray<ReaderArgument>;
-    readonly edges: ReaderLinkedField;
-    readonly pageInfo: ReaderLinkedField;
-}
-
-export interface ReaderInlineDataFragmentSpread {
-    readonly kind: string;
-    readonly name: string;
+    readonly storageKey?: string | null | undefined;
+    readonly args?: ReadonlyArray<ReaderArgument> | null | undefined;
+    readonly concreteType?: string | null | undefined;
+    readonly plural: boolean;
     readonly selections: ReadonlyArray<ReaderSelection>;
 }
 
+export interface ReaderActorChange {
+    readonly kind: string; // 'ActorChange';
+    readonly alias?: string | null | undefined;
+    readonly name: string;
+    readonly storageKey?: string | null | undefined;
+    readonly args?: ReadonlyArray<ReaderArgument> | null | undefined;
+    readonly fragmentSpread: ReaderFragmentSpread;
+}
+
 export interface ReaderModuleImport {
-    readonly kind: string;
+    readonly args?: ReadonlyArray<ReaderArgument> | null | undefined;
+    readonly kind: string; // 'ModuleImport';
     readonly documentName: string;
     readonly fragmentPropName: string;
     readonly fragmentName: string;
+}
+
+export interface ReaderListValueArgument {
+    readonly kind: string; // 'ListValue';
+    readonly name: string;
+    readonly items: ReadonlyArray<ReaderArgument | null>;
+}
+
+export interface ReaderLiteralArgument {
+    readonly kind: string; // 'Literal';
+    readonly name: string;
+    readonly type?: string | null | undefined;
+    readonly value: any;
+}
+
+export interface ReaderLocalArgument {
+    readonly kind: string; // 'LocalArgument';
+    readonly name: string;
+    readonly defaultValue: any;
+}
+
+export interface ReaderObjectValueArgument {
+    readonly kind: string; // 'ObjectValue';
+    readonly name: string;
+    readonly fields: ReadonlyArray<ReaderArgument>;
+}
+
+export type ReaderNode =
+    | ReaderCondition
+    | ReaderLinkedField
+    | ReaderFragment
+    | ReaderInlineFragment;
+
+export interface ReaderScalarField {
+    readonly kind: string; // 'ScalarField';
+    readonly alias?: string | null | undefined;
+    readonly name: string;
+    readonly args?: ReadonlyArray<ReaderArgument> | null | undefined;
+    readonly storageKey?: string | null | undefined;
+}
+
+export interface ReaderFlightField {
+    readonly kind: string; // 'FlightField';
+    readonly alias?: string | null | undefined;
+    readonly name: string;
+    readonly args?: ReadonlyArray<ReaderArgument> | null | undefined;
+    readonly storageKey: string | null | undefined;
+}
+
+export interface ReaderDefer {
+    readonly kind: string; // 'Defer';
+    readonly selections: ReadonlyArray<ReaderSelection>;
+}
+
+export interface ReaderStream {
+    readonly kind: string; // 'Stream';
+    readonly selections: ReadonlyArray<ReaderSelection>;
+}
+
+export type RequiredFieldAction = "NONE" | "LOG" | "THROW";
+
+export interface ReaderRequiredField {
+    readonly kind: string; // 'RequiredField';
+    readonly field: ReaderField;
+    readonly action: RequiredFieldAction;
+    readonly path: string;
+}
+
+export interface ReaderRelayResolver {
+    readonly kind: string; // 'RelayResolver';
+    readonly alias?: string | null | undefined;
+    readonly name: string;
+    readonly fragment: ReaderFragmentSpread;
+    readonly resolverModule: (rootKey: {
+        readonly $data?: any;
+        readonly $fragmentSpreads: any;
+        readonly $fragmentRefs: any;
+    }) => any;
+}
+
+export interface ReaderClientEdge {
+    readonly kind: string; // 'ClientEdge';
+    readonly linkedField: ReaderLinkedField;
+    readonly operation: ConcreteRequest;
+    readonly backingField: ReaderRelayResolver | ReaderClientExtension;
+}
+
+export type ReaderSelection =
+    | ReaderCondition
+    | ReaderClientEdge
+    | ReaderClientExtension
+    | ReaderDefer
+    | ReaderField
+    | ReaderActorChange
+    | ReaderFlightField
+    | ReaderFragmentSpread
+    | ReaderInlineDataFragmentSpread
+    | ReaderInlineFragment
+    | ReaderModuleImport
+    | ReaderStream
+    | ReaderRequiredField
+    | ReaderRelayResolver;
+
+export interface ReaderVariableArgument {
+    readonly kind: string; // 'Variable';
+    readonly name: string;
+    readonly type?: string | null | undefined;
+    readonly variableName: string;
 }


### PR DESCRIPTION
In order to support https://github.com/facebook/relay/commit/3c701233f3794607f5cd168a258970880ee8ffa3

(also synced with all other missed types)