### PR TITLE
[atna-audit] Updating TLS sendAuditEvent options type

### DIFF
--- a/types/atna-audit/atna-audit-tests.ts
+++ b/types/atna-audit/atna-audit-tests.ts
@@ -70,5 +70,7 @@ atna.send.sendAuditEvent(syslog, {
         key: 'key',
         cert: 'cert',
         ca: 'ca',
+        enableTrace: true,
+        checkServerIdentity: (servername, cert) => undefined,
     },
 });

--- a/types/atna-audit/index.d.ts
+++ b/types/atna-audit/index.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="node" />
 
-import type { SecureContextOptions } from 'tls';
+import type { ConnectionOptions } from 'tls';
 
 export interface Constants {
     OUTCOME_SUCCESS: 0;
@@ -155,11 +155,7 @@ export namespace send {
 
     interface TlsConnDetail extends CommonConnDetail {
         interface: 'tls';
-        options: {
-            key: SecureContextOptions['key'];
-            cert: SecureContextOptions['cert'];
-            ca: SecureContextOptions['ca'];
-        };
+        options?: ConnectionOptions;
     }
 
     type SendConnDetail = UdpConnDetail | TcpConnDetail | TlsConnDetail;


### PR DESCRIPTION
It used to only specify specific properties, and the `options` object was
required. Now all properties are allowed that `tls.connect` accepts.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jembi/atna-audit/blob/master/lib/sendAudit.js#L17
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
