### PR TITLE
[chrome] Update saveAsMHTML callback to indicate that it receives a Blob

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5820,7 +5820,7 @@ declare namespace chrome.pageCapture {
      * function(binary mhtmlData) {...};
      * Parameter mhtmlData: The MHTML data as a Blob.
      */
-    export function saveAsMHTML(details: SaveDetails, callback: (mhtmlData?: ArrayBuffer) => void): void;
+    export function saveAsMHTML(details: SaveDetails, callback: (mhtmlData?: Blob) => void): void;
 }
 
 ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1250,3 +1250,7 @@ function testBrowsingData() {
     chrome.browsingData.removeServiceWorkers({});
     chrome.browsingData.removeServiceWorkers({}, () => {});
 }
+
+function testPageCapture() {
+  chrome.pageCapture.saveAsMHTML({ tabId: 0 }, (data: Blob | undefined) => {});
+}


### PR DESCRIPTION
In modern versions of chrome this callback receives a `Blob` not an
`ArrayBuffer`. I'm not sure if this is manifest / version dependent, but
even the documentation indicates that it should be a blob.

I'm not sure if this counts as breaking, and I don't know this history of chrome's return for this function, but I can update the version if that's desired.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/pageCapture/#method-saveAsMHTML
  *note* - this documentation also says array buffer, but it is in fact a Blob, at least in chrome 97 64-bit on windows, but I don't expect it to be platform dependent. Example from an extension:
  ```
  chrome.pageCapture.saveAsMHTML({ tabId }, blob => console.log(blob));
  // Blob {size: 8598161, type: ''}
  ```
