### PR TITLE
[@types/rc] : rc(...).configs and rc(...).config wrong types

### DIFF
--- a/types/rc/index.d.ts
+++ b/types/rc/index.d.ts
@@ -3,39 +3,190 @@
 // Definitions by: Daniel Rosenwasser <https://github.com/DanielRosenwasser>
 //                 BendingBender <https://github.com/BendingBender>
 //                 kusyka911 <https://github.com/kusyka911>
+//                 David Gabison <https://github.com/pulsovi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
-interface RcResultType<T> {
+import minimist = require('minimist');
+
+interface RcResultType extends Record<number | string | symbol, unknown> {
     /**
-     * Contains all parsed configurations from different sources
+     * Contains file path of all parsed configurations from different sources
      * like '/etc/${appname}rc', '/etc/${appname}/config', and other.
      */
-    configs: T[];
+    configs?: string[];
     /**
      * same as RcResultType.configs[RcResultType.configs.length - 1]
      */
-    config: T;
-    /**
-     * For compatibility with previous versions of '@types/rc'
-     */
-    [key: string]: any;
+    config?: string;
 }
 
-declare function rc<T extends object = { [key: string]: any }>(
-    name: string,
-    defaults?: T,
+declare function rc(
     /**
-     * Parsed argv object. For example, if args is `--foo bar`, then this value should be `{foo: 'bar'}`
+     * The name of the app to configure, rc will search for this files :
+     * `/etc/${name}/config`,
+     * `/etc/${name}rc`,
+     * `~/.config/${name}/config`,
+     * `~/.config/${name}`,
+     * `~/.${name}/config`,
+     * `~/.${name}rc` and
+     * `.${name}rc` in CWD and its ancestors
+     */
+    name: string,
+    /**
+     * Default config values.
+     * Can be an Object that contains the default values for the config,
+     * the path of a JSON or INI file to use as default config or
+     * can be `null` or `undefined` for no default values
+     */
+    defaults?: string | null,
+    /**
+     * Parsed argv object.
+     * For example, if args is `--foo bar`, then this value should be `{foo: 'bar'}`
      * If `argv` is `null` or `undefined`, then `rc`'s default parser will parse `process.argv`.
      */
-    argv?: T | null,
+    argv?: null,
     /**
      * Custom config file parser.
      * This function will be passed the string contents of each
-     * discovered configuration file should return a parsed object dictionary.
+     * discovered configuration file, should return a parsed object dictionary.
      */
-    parse?: ((content: string) => { [key: string]: any }) | null
-): T & RcResultType<T>;
+    parse?: (content: string) => object
+): RcResultType & minimist.ParsedArgs;
+declare function rc<T extends object>(
+    /**
+     * The name of the app to configure, rc will search for this files :
+     * `/etc/${name}/config`,
+     * `/etc/${name}rc`,
+     * `~/.config/${name}/config`,
+     * `~/.config/${name}`,
+     * `~/.${name}/config`,
+     * `~/.${name}rc` and
+     * `.${name}rc` in CWD and its ancestors
+     */
+    name: string,
+    /**
+     * Default config values.
+     * Can be an Object that contains the default values for the config,
+     * the path of a JSON or INI file to use as default config or
+     * can be `null` or `undefined` for no default values
+     */
+    defaults: T,
+    /**
+     * Parsed argv object.
+     * For example, if args is `--foo bar`, then this value should be `{foo: 'bar'}`
+     * If `argv` is `null` or `undefined`, then `rc`'s default parser will parse `process.argv`.
+     */
+    argv?: null,
+    /**
+     * Custom config file parser.
+     * This function will be passed the string contents of each
+     * discovered configuration file, should return a parsed object dictionary.
+     */
+    parse?: (content: string) => object
+): T & RcResultType & minimist.ParsedArgs;
+declare function rc<U extends object>(
+    /**
+     * The name of the app to configure, rc will search for this files :
+     * `/etc/${name}/config`,
+     * `/etc/${name}rc`,
+     * `~/.config/${name}/config`,
+     * `~/.config/${name}`,
+     * `~/.${name}/config`,
+     * `~/.${name}rc` and
+     * `.${name}rc` in CWD and its ancestors
+     */
+    name: string,
+    /**
+     * Default config values.
+     * Can be an Object that contains the default values for the config,
+     * the path of a JSON or INI file to use as default config or
+     * can be `null` or `undefined` for no default values
+     */
+    defaults: string | null | undefined,
+    /**
+     * Parsed argv object.
+     * For example, if args is `--foo bar`, then this value should be `{foo: 'bar'}`
+     * If `argv` is `null` or `undefined`, then `rc`'s default parser will parse `process.argv`.
+     */
+    argv: U,
+    /**
+     * Custom config file parser.
+     * This function will be passed the string contents of each
+     * discovered configuration file, should return a parsed object dictionary.
+     */
+    parse?: (content: string) => object
+): U & RcResultType;
+declare function rc<
+    T extends object,
+    U extends object
+>(
+    /**
+     * The name of the app to configure, rc will search for this files :
+     * `/etc/${name}/config`,
+     * `/etc/${name}rc`,
+     * `~/.config/${name}/config`,
+     * `~/.config/${name}`,
+     * `~/.${name}/config`,
+     * `~/.${name}rc` and
+     * `.${name}rc` in CWD and its ancestors
+     */
+    name: string,
+    /**
+     * Default config values.
+     * Can be an Object that contains the default values for the config,
+     * the path of a JSON or INI file to use as default config or
+     * can be `null` or `undefined` for no default values
+     */
+    defaults: T,
+    /**
+     * Parsed argv object.
+     * For example, if args is `--foo bar`, then this value should be `{foo: 'bar'}`
+     * If `argv` is `null` or `undefined`, then `rc`'s default parser will parse `process.argv`.
+     */
+    argv: U,
+    /**
+     * Custom config file parser.
+     * This function will be passed the string contents of each
+     * discovered configuration file, should return a parsed object dictionary.
+     */
+    parse?: (content: string) => object
+): T & U & RcResultType;
+declare function rc<
+    T extends object | string | null | undefined,
+    U extends object | null | undefined
+>(
+    /**
+     * The name of the app to configure, rc will search for this files :
+     * `/etc/${name}/config`,
+     * `/etc/${name}rc`,
+     * `~/.config/${name}/config`,
+     * `~/.config/${name}`,
+     * `~/.${name}/config`,
+     * `~/.${name}rc` and
+     * `.${name}rc` in CWD and its ancestors
+     */
+    name: string,
+    /**
+     * Default config values.
+     * Can be an Object that contains the default values for the config,
+     * the path of a JSON or INI file to use as default config or
+     * can be `null` or `undefined` for no default values
+     */
+    defaults: T,
+    /**
+     * Parsed argv object.
+     * For example, if args is `--foo bar`, then this value should be `{foo: 'bar'}`
+     * If `argv` is `null` or `undefined`, then `rc`'s default parser will parse `process.argv`.
+     */
+    argv: U,
+    /**
+     * Custom config file parser.
+     * This function will be passed the string contents of each
+     * discovered configuration file, should return a parsed object dictionary.
+     */
+    parse?: (content: string) => object
+): (T extends string | null | undefined ?
+  (U extends null | undefined ? minimist.ParsedArgs : U) & RcResultType :
+  T & (U extends null | undefined ? minimist.ParsedArgs : U) & RcResultType);
 
 export = rc;

--- a/types/rc/rc-tests.ts
+++ b/types/rc/rc-tests.ts
@@ -1,26 +1,36 @@
 import rc = require('rc');
 
-const confA = rc('appname1', {
+// without any arg
+rc(); // $ExpectError
+
+// with appname arg only
+rc('appname');
+
+// with default values object
+const confA = rc('appname', {
     port: 2468,
     views: {
         engine: 'jade',
     },
 });
 
-////////////////////
+// with default config file
+rc('appname', './default-config.json');
 
-const appCfg = rc('appname2', {}, null, function parse(s) {
-    return JSON.parse(s.toLowerCase());
+// with parsed argv
+rc('appname', null, {
+    option: false,
+    envOption: 24,
+    argv: {
+        remain: [],
+        cooked: ['--no-option', '--envOption', '24'],
+        original: ['--no-option', '--envOption=24'],
+    },
 });
 
-appCfg.configs[0];
-appCfg.configs[1];
-appCfg.config;
-
-////////////////////
-
-const customArgv = rc(
-    'appname3',
+// with both default values AND parsed argv
+rc(
+    'appname',
     {
         option: true,
     },
@@ -35,18 +45,46 @@ const customArgv = rc(
     }
 );
 
-////////////////////
+// with parse function
+rc('appname', null, null, content => JSON.parse(content.toLowerCase()));
 
+// with defaults and parse but not argv
+rc('appname', { option: true }, null, content => JSON.parse(content.toLowerCase()));
+
+// call with interface
 interface AppConfig {
     port: number;
     views: {
         engine: string,
     };
 }
-
-const genericConf = rc<AppConfig>('appname4', {
+rc<AppConfig>('appname', {
     port: 1234,
     views: {
         engine: 'jade'
     }
 });
+
+// calling with type definition
+rc<{
+    port: number;
+    views: {
+        engine: string,
+    };
+}>('appname', {
+    port: 1234,
+    views: {
+        engine: 'jade'
+    }
+});
+
+// return type
+const appCfg = rc('appname');
+appCfg.configs; // $ExpectType string[] | undefined
+if (appCfg.configs) {
+    appCfg.configs[0]; // $ExpectType string
+    appCfg.configs[1]; // $ExpectType string
+///   actually, when configs is defined as string[], config have to be string
+///       but I don't known how to write this in `index.d.ts`, sorry...
+//    appCfg.config; // $ExpectType string
+}


### PR DESCRIPTION
fix: rc(...).config and rc(...).configs types :
- they can be undefined,
- when they are defined, them are not T and T[] but string and string[]

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [rc github page](https://github.com/dominictarr/rc)
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~