### PR TITLE
Hack around remark-validate-link warnings

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -338,7 +338,7 @@ Si planeas continuar actualizando la versión anterior del paquete, puedes crear
 1. Actualiza las rutas relativas en `tsconfig.json` al igual que `tslint.json`.
 2. Añadir reglas de mapeo de rutas para asegurarte de que la prueba se está ejecutando contra la versión prevista.
 
-Por ejemplo [history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/history/v2/tsconfig.json) se ve así:
+Por ejemplo [history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) se ve así:
 
 ```json
 {

--- a/README.it.md
+++ b/README.it.md
@@ -25,7 +25,7 @@ Leggi il [manuale di TypeScript](https://www.typescriptlang.org/docs/handbook/de
 
 ### npm
 
-Il metodo preferito per installarli è usando npm. 
+Il metodo preferito per installarli è usando npm.
 
 Ad esempio:
 
@@ -107,7 +107,7 @@ Crea un `types/foo/index.d.ts` contenente le dichiarazioni per il tuo modulo "pi
 Ora dovresti essere in grado di importare `"pippo"` nel tuo codice, con i tipi riferiti alle dichiarazioni che hai appena creato.
 Poi fai una build **ed** esegui il codice per essere sicuro che le definizioni dei tipi corrispondano effettivamente a ciò che capita a runtime.
 
-Una volta che hai testato le definizioni su del codice reale, fai una [pull request](#fai-una-pull-request), 
+Una volta che hai testato le definizioni su del codice reale, fai una [pull request](#fai-una-pull-request),
 poi segui le istruzioni per [modificare un package preesistente](#modificare-un-package-preesistente] o [creare un nuovo package](#creare-un-nuovo-package).
 
 ### Fai una pull request
@@ -116,7 +116,7 @@ Una volta che hai testato il tuo package, puoi condividerlo su Definitely Typed.
 
 Inanzitutto, [sdoppia](https://guides.github.com/activities/forking/) questa repo, [clonala](#clone-parziale), installa [node](https://nodejs.org/) ed esegui `npm install`. Se stai usando `npm` v7 devi aggiungere `--legacy-peer-deps` al comando.
 
-Utilizziamo un bot per far sì che un gran numero di pull request su Definitely Typed possano essere gestite interamente in modo autonomo. Puoi scoprire di più a riguardo di come e perchè [qui](https://devblogs.microsoft.com/typescript/changes-to-how-we-manage-definitelytyped/). 
+Utilizziamo un bot per far sì che un gran numero di pull request su Definitely Typed possano essere gestite interamente in modo autonomo. Puoi scoprire di più a riguardo di come e perchè [qui](https://devblogs.microsoft.com/typescript/changes-to-how-we-manage-definitelytyped/).
 
 Ecco qui un'immagine che mostra il ciclo vitale di una pull request su Definitely Typed.
 
@@ -261,7 +261,7 @@ Per maggiori dettagli, leggi il readme di [dtslint](https://github.com/Microsoft
 
 Il file di configurazione del linter, `tslint.json`, dovrebbe contenere `{ "extends": "@definitelytyped/dtslint/dt.json" }` e nessun'altra regola.
 
-Se per qualche ragione qualche regola necessita di essere disabilitata, [disabilitala solo per la riga di codice in cui dovrebbe esserlo](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line) usando `// tslint:disable-next-line:[ruleName]` e non disabilitandola per tutto il package. 
+Se per qualche ragione qualche regola necessita di essere disabilitata, [disabilitala solo per la riga di codice in cui dovrebbe esserlo](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line) usando `// tslint:disable-next-line:[ruleName]` e non disabilitandola per tutto il package.
 
 #### `tsconfig.json`
 
@@ -307,7 +307,7 @@ Se un file non è nè testato nè riferito nell'`index.d.ts`, aggiungilo in un f
 * `var foo: string | any`:
   Quando `any` è usato in un tipo disgiuntipo, il tipo risultanto rimane `any`. Quindi mentre la porzione `string` di questo tipo potrebbe _sembrare_ utile, in realtà non offre nessuna precisazione rispetto ad un banalissimo `any`.
     In funzione delle tue intenzioni, delle alternative accettabili sono `any`, `string` o `string | object`.
-  
+
 ### Proprietari delle definizioni
 
 DT ha il concetto di "Proprietari delle definizioni", che sono coloro i quali vogliono mantenere la qualità delle definizioni dei tipi di un certo modulo.
@@ -326,7 +326,7 @@ Per aggiungerti come pprietario delle definizioni:
     //                 Steve <https://github.com/steve>
     //                 John <https://github.com/john>
     ```
-  
+
 Una volta alla settimana i proprietari delle definizioni saranno sincronizzati nel file [.github/CODEOWNERS](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/CODEOWNERS) che è la nostra fonte di verità.
 
 ## Domande frequenti
@@ -381,9 +381,9 @@ Questa [risposta su Stack Overflow](https://stackoverflow.com/questions/39415661
 
 Risulta preferibile importare un modulo usando la sintassi `import foo = require("foo");`.
 In ogni caso, se vuoi usare un import default come `import foo from "foo";`, hai due possibilità:
-- puoi usare l'opzione del traspilatore TypeScript [`--allowSyntheticDefaultImports`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#support-for-default-import-interop-with-systemjs) se il tuo modulo supporta a ntime 
+- puoi usare l'opzione del traspilatore TypeScript [`--allowSyntheticDefaultImports`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#support-for-default-import-interop-with-systemjs) se il tuo modulo supporta a ntime
 
-Importare il modulo usando la sintassi `import foo = require("foo");` è più appropriato. 
+Importare il modulo usando la sintassi `import foo = require("foo");` è più appropriato.
 Comunque, se vuoi usare un default import come `import foo from "foo";` hai due possibilità:
 - puoi usare [l'opzione di compilazione `--allowSyntheticDefaultImports`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#support-for-default-import-interop-with-systemjs) se il tuo ambiente di runtime supporta uno schema interop per moduli non ECMAScript, come nel caso in cui gli import di default sono supportati (Webpack, SystemJS, esm, ...)
 - puoi usare [l'opzione di compilazione `--esModuleInterop`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-form-commonjs-modules-with---esmoduleinterop) se sia Typescript ad occuparsi dell'interop di moduli non ECMAScript (da TypeScript 2.7 in su).
@@ -416,12 +416,12 @@ Ecco qui un breve esempio per iniziare:
         }
       }
    ```
-   
+
 2. Crea la sottocartella menzionata dal campo `typesVersions` dentro la tua cartella dei tipi (che nel nostro esempio è `ts3.6/`).
    `ts3.6/` suppporterà le versioni uguali od inferiori alla 3.6, quindi copia i tipi esistenti con i test lì.
 
    Dovrai eliminare l'header delle definizioni da `ts3.6/index.d.ts` dal momento che solo la root `index.d.ts` può averlo.
-   
+
 3. Cambia le opzioni `baseUrl` e `typeRoots` in `ts3.6/tsconfig.json` per correggere i path, dovrebbe essere simile a:
    ```json
     {
@@ -431,12 +431,12 @@ Ecco qui un breve esempio per iniziare:
         }
     }
     ```
-   
+
 4. Nel root del package, aggiungi le funzionalità di Typescript 3.7 che vuoi usare.
    Quando il package viene installato, Typescript 3.6 o inferiore partirà da `ts3.6/index.d.ts`, mentre Typescript 3.7 o superiore partirà da `index.d.ts`.
 
    Dai un'occhiata a [bluebird](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f2512c2cf7cdcf9a487d989e288174e49b7839ab/types/bluebird) per averne un esempio.
-   
+
 #### Voglio aggiungere una API DOM che non è presente di default su Typescript.
 
 Questo potrebbe riguardare [TSJS-Lib-Generator](https://github.com/Microsoft/TSJS-lib-generator#readme). Dai un'occhiata a quelle guide.
@@ -476,7 +476,7 @@ Solitamente, solo l'ultima causa da problemi.
 * Molto spesso capita che le versioni delle dichiaraizoni dei tipi rimangano indietro rispetto a quelle del pacchetto JavaScript, questo perchè molte volte non sono gli stessi autori dei pacchetti JavaScript
   a farne anche le dichiarazioni dei tipi ma utenti terzi. Per questo motivo potrebbero esserci dei ritardi di giorni, settimane o perfino mesi prima che arrivi una pull request da qualche benefattore che riallinea il pacchetto `@type` con l'ultima versione JavaScript.
   Se ti ritrovi in questa situazione, puoi essere tu stesso a fare la differenza ed a risolvere il problema diventando un membro a tutti gli effetti della Community.
-  
+
 :exclamation: Se stai aggiornando le dichiarazioni dei tipi per una libreria, ricordati di cambiare sempre la `major.minor` nella prima riga del `index.d.ts` in modo che con quella della libreria dei cui tipi stai dichiarando! :exclamation:
 
 #### Se l'aggiornamento di una libreria comprende modifiche sostanziali (aggiornamento major), come faccio ad aggiornare il suo pacchetto '@types`?
@@ -497,7 +497,7 @@ Siccome la cartella principale deve sempre contenere le dichiarazioni dei tipi p
 
 Ad esempio, la libreria [`history`](https://github.com/ReactTraining/history/) ha avuto delle modifiche sostanziali passando dalla versione `2.x` alla `3.x`.
 Siccome molti utenti sono rimasti alla `2.x`, un mantenitore che voleva fare ulteriori aggiornamenti alle dichiarazioni dei tipi di questa vecchia versione ha aggiunto una sottocartella `v2` nella repo delle dichiarazioni dei tipi di questa libreria.
-Nel momento in cui questo README è stato scritto, il [`tsconfig.json` della history v2](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) è così:
+Nel momento in cui questo README è stato scritto, il [`tsconfig.json` della history v2](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) è così:
 
 ```json
 {
@@ -526,9 +526,9 @@ Nota che `/// <reference types=".." />` non funziona con il mapping degli indiri
 
 La guida di Typescript spiega benissimo [come scrivere le definizioni dei tipi](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) ed ha anche [un file di esempio](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) che è esattamente una libreria che può essere usata sia come modulo su nodejs che come libreria globale in una pagina web.
 
-Per accertarti che le tue definizioni possono essere usate sia globalmente che che modulo importato, crea una cartella `test` e creaci dentro due file di test. 
-Chiamane uno `NomeLibreria-global.test.ts` e l'altro `YourLibraryName-module.test.ts`. 
-Il file di test *global* dovrebbe controllare che le definizioni funzionano bene quando la libreria è usata globalmente in una pagina web (in questo caso non bisogna specificare un `import`). 
+Per accertarti che le tue definizioni possono essere usate sia globalmente che che modulo importato, crea una cartella `test` e creaci dentro due file di test.
+Chiamane uno `NomeLibreria-global.test.ts` e l'altro `YourLibraryName-module.test.ts`.
+Il file di test *global* dovrebbe controllare che le definizioni funzionano bene quando la libreria è usata globalmente in una pagina web (in questo caso non bisogna specificare un `import`).
 Il file di test *module*, invece, controlla se le definzioni funzionano quando la libreria viene importata come un modulo.
 Se aggiungi la proprietà `files` nel tuo `tsconfig.json`, assicurati di includere entrambi questi file di test. Un [esempio pratico](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) è disponibile nelle dichiarazioni dei tipi di `big.js`.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -478,7 +478,7 @@ Definitely Typed の各パッケージは npm に公開される際にバージ�
 
 たとえば、 [`history`](https://github.com/ReactTraining/history/) ライブラリはバージョン `2.x` から `3.x` の間で破壊的な変更を行いました。
 多くのユーザーがなお古いバージョン `2.x` 系を使用していたので、バージョン `3.x` 系の型定義に更新したかったメンテナーは `v2` フォルダーを作成し、そこに古いバージョン用の型定義を含めるようにしました。
-下記は、執筆時点<small>（訳注: 英語版執筆当時）</small>の [history モジュールの v2 の `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) の大まかな内容です:
+下記は、執筆時点<small>（訳注: 英語版執筆当時）</small>の [history モジュールの v2 の `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) の大まかな内容です:
 
 ```json
 {

--- a/README.ko.md
+++ b/README.ko.md
@@ -365,7 +365,7 @@ npm 패키지의 경우, `node -p 'require("foo")'` 가 원하는 값이라면 `
 1. `tsconfig.json` 와 `tslint.json` 에 포함된 상대경로들을 수정해주어야 합니다.
 2. 경로 대응 규칙(Path mapping rule)을 추가하여 테스트가 올바른 버전을 검사하도록 해야합니다.
 
-예를 들어, [history 패키지의 2 버전의 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/history/v2/tsconfig.json) 파일은 다음과 같이 생겼습니다.
+예를 들어, [history 패키지의 2 버전의 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) 파일은 다음과 같이 생겼습니다.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ You may need to add manual [references](https://www.typescriptlang.org/docs/hand
 
 ## How can I contribute?
 
-Definitely Typed only works because of contributions by users like you! 
+Definitely Typed only works because of contributions by users like you!
 
 ### Testing
 
 Before you share your improvement with the world, use the types yourself by creating a `typename.d.ts` file in your project and filling out its exports:
 
 ```ts
-declare module "libname" { 
+declare module "libname" {
   // Types inside here
   export function helloWorldMessage(): string
 }
@@ -399,7 +399,7 @@ PRs that have been approved by an author listed in the definition's header are u
 
 #### I'd like to submit a change to a very popular project, why are they treated differently?
 
-For changes to very popular modules, e.g. Node/Express/Jest which have many millions of downloads each per week on npm, the requirements for contributions are a bit higher. 
+For changes to very popular modules, e.g. Node/Express/Jest which have many millions of downloads each per week on npm, the requirements for contributions are a bit higher.
 Changes to these projects can have massive ecosystem effects, and so we treat changes to them with a lot of care.
 These modules require both a sign-off from a DT maintainer, and enthusiastic support from the module owners. The bar for passing this can be quite high, and often PRs can go stale because it doesn't have a champion.
 If you're finding that no-one is committing, try to make your PR have a smaller focus.
@@ -555,7 +555,7 @@ Because the root folder should always contain the type declarations for the late
 
 For example, the [`history`](https://github.com/ReactTraining/history/) library introduced breaking changes between version `2.x` and `3.x`.
 Because many users still consumed the older `2.x` version, a maintainer who wanted to update the type declarations for this library to `3.x` added a `v2` folder inside the history repository that contains type declarations for the older version.
-At the time of writing, the [history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) looks roughly like:
+At the time of writing, the [history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) looks roughly like:
 
 ```json
 {

--- a/README.pt.md
+++ b/README.pt.md
@@ -475,7 +475,7 @@ Porque o diretório-raíz deve sempre conter as declarações de tipo para as ú
 
 Por exemplo, a biblioteca [`history`](https://github.com/ReactTraining/history/) introduziu mudanças drásticas entre a versão `2.x` e `3.x`.
 Mas porque muitos usuários ainda consumiam a antiga versão `2.x`, o mantenedor que queria atualizar as declarações de tipo dessa biblioteca para a versão `3.x` adidionou uma pasta `v2` dentro do repositório "history" que contém declarações de tipo para a versão anterior.
-No tempo de escrita, a [history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) está assim:
+No tempo de escrita, a [history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) está assim:
 
 ```json
 {

--- a/README.ru.md
+++ b/README.ru.md
@@ -360,7 +360,7 @@ Once a week the Definition Owners are synced to the file [.github/CODEOWNERS](ht
 1. Обновите относительные пути в `tsconfig.json` а также в `tslint.json`.
 2. Добавьте правила сопоставления путей, чтобы убедиться, что тесты выполняются для предполагаемой версии.
 
-Например [history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/history/v2/tsconfig.json) looks like:
+Например [history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) looks like:
 
 ```json
 {

--- a/README.zh.md
+++ b/README.zh.md
@@ -489,7 +489,7 @@ _注意：本节中的讨论假定你熟悉 [语义版本控制](https://semver.
 
 例如，[`history`](https://github.com/ReactTraining/history/) 库在 `2.x` 到 `3.x` 版本间引入了重大的修改。
 因为许多用户仍然使用较老的 `2.x` 版本，维护人员想要将此库的类型声明更新到 `3.x`, 需要在仓库里添加 `v2` 文件夹，里面包含了旧版本的类型声明。
-在编写时，[history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) 大致如下：
+在编写时，[history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) 大致如下：
 
 ```json
 {


### PR DESCRIPTION
It appears that `remark-validate-link` uses `hosted-git-info` to convert our GH permalink into a relative link (since it shares a prefix with our GH repo) and then warns that the relative link is dangling.  This change uses URL encoding to defeat the tool's simple prefix matching.

Filed #58598 to investigate a real solution.