### PR TITLE
fix(graphql-upload): allow `graphql@0.13.1 - 16` to match package

### DIFF
--- a/types/graphql-upload/package.json
+++ b/types/graphql-upload/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "^15.3.0 || ^16.2.0"
+    "graphql": "0.13.1 - 16"
   }
 }

--- a/types/graphql-upload/package.json
+++ b/types/graphql-upload/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "^16.2.0"
+    "graphql": "^15.3.0 || ^16.2.0"
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:[ <<url here>>](https://github.com/jaydenseric/graphql-upload/blob/0cbc9d90a181ace59be279fee4c3b269c47d1cbe/package.json#L46-L48)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The range should as the link above suggest probably be even wider. But at least this reverts the breaking change introduced by #58039. My project is stuck at v15 for now, and these types installing v16 results in a type error.