### PR TITLE
[ember] Add declarations for strict-mode template entities

### DIFF
--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -8,10 +8,11 @@
 
 /// <reference types="jquery" />
 
-import CoreView from "@ember/component/-private/core-view";
-import ClassNamesSupport from "@ember/component/-private/class-names-support";
-import ViewMixin from "@ember/component/-private/view-mixin";
+import CoreView from '@ember/component/-private/core-view';
+import ClassNamesSupport from '@ember/component/-private/class-names-support';
+import ViewMixin from '@ember/component/-private/view-mixin';
 import { ComponentManager, Capabilities } from './-private/glimmer-interfaces';
+import { Opaque } from 'ember/-private/type-utils';
 
 // Re-export these types so people can use them!
 export { ComponentManager, Capabilities };
@@ -20,10 +21,7 @@ interface TemplateFactory {
     __htmlbars_inline_precompile_template_factory: any;
 }
 
-export default class Component extends CoreView.extend(
-    ViewMixin,
-    ClassNamesSupport
-) {
+export default class Component extends CoreView.extend(ViewMixin, ClassNamesSupport) {
     // methods
     readDOMAttr(name: string): string;
     // properties
@@ -106,10 +104,28 @@ export default class Component extends CoreView.extend(
  * @param object the object to associate with the componetn manager
  * @return the same object passed in, now associated with the manager
  */
-export function setComponentManager<T>(
-    managerFactory: (owner: unknown) => ComponentManager<unknown>,
-    object: T
-): T;
+export function setComponentManager<T>(managerFactory: (owner: unknown) => ComponentManager<unknown>, object: T): T;
+
+// In normal TypeScript, these built-in components are essentially opaque tokens
+// that just need to be importable. Declaring them with unique interfaces
+// like this, however, gives tools like Glint (that DO have a richer
+// notion of what they are) a place to install more detailed type information.
+export interface Input extends Opaque<'component:input'> {}
+export interface Textarea extends Opaque<'component:textarea'> {}
+
+/**
+ * The `Input` component lets you create an HTML `<input>` element.
+ *
+ * @see https://api.emberjs.com/ember/4.1/classes/Ember.Templates.components/methods/Input?anchor=Input
+ */
+export const Input: Input;
+
+/**
+ * The `Textarea` component inserts a new instance of `<textarea>` tag into the template.
+ *
+ * @see https://api.emberjs.com/ember/4.1/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea
+ */
+export const Textarea: Textarea;
 
 // Do not export anything but what we *explicitly* say to export.
 export {};

--- a/types/ember__component/test/built-ins.ts
+++ b/types/ember__component/test/built-ins.ts
@@ -1,0 +1,4 @@
+import { Input, Textarea } from '@ember/component';
+
+Input; // $ExpectType Input
+Textarea; // $ExpectType Textarea

--- a/types/ember__component/tsconfig.json
+++ b/types/ember__component/tsconfig.json
@@ -25,6 +25,7 @@
         "index.d.ts",
         "test/lib/assert.ts",
         "test/component.ts",
+        "test/built-ins.ts",
         "test/helper.ts",
         "test/template-only.ts"
     ]

--- a/types/ember__helper/ember__helper-tests.ts
+++ b/types/ember__helper/ember__helper-tests.ts
@@ -1,0 +1,7 @@
+import { array, concat, fn, get, hash } from '@ember/helper';
+
+array; // $ExpectType ArrayHelper
+concat; // $ExpectType ConcatHelper
+fn; // $ExpectType FnHelper
+get; // $ExpectType GetHelper
+hash; // $ExpectType HashHelper

--- a/types/ember__helper/index.d.ts
+++ b/types/ember__helper/index.d.ts
@@ -1,0 +1,55 @@
+// Type definitions for non-npm package @ember/helper 4.0
+// Project: https://github.com/emberjs/ember.js
+// Definitions by: Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.4
+
+import { Opaque } from 'ember/-private/type-utils';
+
+// In normal TypeScript, these helpers are essentially opaque tokens
+// that just need to be importable. Declaring them with unique interfaces
+// like this, however, gives tools like Glint (that DO have a richer
+// notion of what they are) a place to install more detailed type information.
+export interface ArrayHelper extends Opaque<'helper:array'> {}
+export interface ConcatHelper extends Opaque<'helper:concat'> {}
+export interface FnHelper extends Opaque<'helper:fn'> {}
+export interface GetHelper extends Opaque<'helper:get'> {}
+export interface HashHelper extends Opaque<'helper:hash'> {}
+
+/**
+ * Use the `{{array}}` helper to create an array to pass as an option to your components.
+ *
+ * @see https://api.emberjs.com/ember/4.1/classes/Ember.Templates.helpers/methods/array?anchor=array
+ */
+export const array: ArrayHelper;
+
+/**
+ * Concatenates the given arguments into a string.
+ *
+ * @see https://api.emberjs.com/ember/4.1/classes/Ember.Templates.helpers/methods/concat?anchor=concat
+ */
+export const concat: ConcatHelper;
+
+/**
+ * The `fn` helper allows you to ensure a function that you are passing off to another component, helper, or modifier
+ * has access to arguments that are available in the template.
+ *
+ * @see https://api.emberjs.com/ember/4.1/classes/Ember.Templates.helpers/methods/fn?anchor=fn
+ */
+export const fn: FnHelper;
+
+/**
+ * Dynamically look up a property on an object.
+ *
+ * @see https://api.emberjs.com/ember/4.1/classes/Ember.Templates.helpers/methods/get?anchor=get
+ */
+export const get: GetHelper;
+
+/**
+ * Use the `{{hash}}` helper to create a hash to pass as an option to your components.
+ *
+ * @see https://api.emberjs.com/ember/4.1/classes/Ember.Templates.helpers/methods/hash?anchor=hash
+ */
+export const hash: HashHelper;

--- a/types/ember__helper/tsconfig.json
+++ b/types/ember__helper/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "strict": true,
+        "exactOptionalPropertyTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ember/*": [
+                "ember__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ember__helper-tests.ts"
+    ]
+}

--- a/types/ember__helper/tslint.json
+++ b/types/ember__helper/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/ember__modifier/ember__modifier-tests.ts
+++ b/types/ember__modifier/ember__modifier-tests.ts
@@ -1,0 +1,3 @@
+import { on } from '@ember/modifier';
+
+on; // $ExpectType OnModifier

--- a/types/ember__modifier/index.d.ts
+++ b/types/ember__modifier/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for non-npm package @ember/modifier 4.0
+// Project: https://github.com/emberjs/ember.js
+// Definitions by: Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.4
+
+import { Opaque } from 'ember/-private/type-utils';
+
+// In normal TypeScript, this modifier is essentially an opaque token
+// that just needs to be importable. Declaring it with a unique interface
+// like this, however, gives tools like Glint (that DO have a richer
+// notion of what it is) a place to install more detailed type information.
+export interface OnModifier extends Opaque<'modifier:on'> {}
+
+/**
+ * The `{{on}}` modifier lets you easily add event listeners.
+ *
+ * @see https://api.emberjs.com/ember/4.1/classes/Ember.Templates.helpers/methods/on?anchor=on
+ */
+export const on: OnModifier;

--- a/types/ember__modifier/tsconfig.json
+++ b/types/ember__modifier/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "strict": true,
+        "exactOptionalPropertyTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ember/*": [
+                "ember__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ember__modifier-tests.ts"
+    ]
+}

--- a/types/ember__modifier/tslint.json
+++ b/types/ember__modifier/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/ember__routing/index.d.ts
+++ b/types/ember__routing/index.d.ts
@@ -11,6 +11,21 @@ export { default as Router } from '@ember/routing/router';
 import RouterService from '@ember/routing/router-service';
 import '@ember/routing/-private/router-dsl';
 import '@ember/routing/-private/transition';
+import { Opaque } from 'ember/-private/type-utils';
 interface Registry {
     'router': RouterService;
 }
+
+// In normal TypeScript, this component is essentially an opaque token
+// that just needs to be importable. Declaring it with a unique interface
+// like this, however, gives tools like Glint (that DO have a richer
+// notion of what it is) a place to install more detailed type information.
+export interface LinkTo extends Opaque<'component:link-to'> {}
+
+/**
+ * The `LinkTo` component renders a link to the supplied `route` passing
+ * an optionally supplied model to the route as its `model` context of the route.
+ *
+ * @see https://api.emberjs.com/ember/4.1/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo
+ */
+export const LinkTo: LinkTo;

--- a/types/ember__routing/test/built-ins.ts
+++ b/types/ember__routing/test/built-ins.ts
@@ -1,0 +1,3 @@
+import { LinkTo } from '@ember/routing';
+
+LinkTo; // $ExpectType LinkTo

--- a/types/ember__routing/tsconfig.json
+++ b/types/ember__routing/tsconfig.json
@@ -24,6 +24,7 @@
     "files": [
         "index.d.ts",
         "test/lib/assert.ts",
+        "test/built-ins.ts",
         "test/route.ts",
         "test/router.ts",
         "test/router-service.ts"


### PR DESCRIPTION
<details>
<summary>Checklists</summary>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (details below)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

</details>

This change introduces declarations for importable entities for use in Ember's templating system as defined in [the Handlebars Strict Mode RFC](https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md#handlebars-strict-mode).

That RFC introduces two packages that previously didn't exist specifically for hosting these entities (`@ember/helper` and `@ember/modifier`) as well as adding exports to `@ember/routing` and `@ember/component`.

@chriskrycho per our recent Discord conversation I went with augmentable interfaces extending from `Opaque` for the types of these items so that we can merge template-specific type info from e.g. Glint. If you've had any ideas in the meantime for other ways to approach this, though, I'm happy to update.