### PR TITLE
Update timepicker to allow timeFormat functions

### DIFF
--- a/types/timepicker/index.d.ts
+++ b/types/timepicker/index.d.ts
@@ -124,7 +124,7 @@ interface JQueryTimepickerOptions {
     // Characters can be escaped with a preceeding double slash (e.g. H\\hi).
     // Alternatively, you can specify a function instead of a string, to use completely custom time formatting.
     // In this case, the format function receives a Date object and is expected to return a formatted time as a string. default: 'g:ia'
-    timeFormat?: string | undefined;
+    timeFormat?: string | ((date: Date) => string) | undefined;
 
     // Highlight the nearest corresponding time option as a value is typed into the form input.
     // default: true

--- a/types/timepicker/timepicker-tests.ts
+++ b/types/timepicker/timepicker-tests.ts
@@ -14,5 +14,5 @@ $('#timepicker').timepicker({
 // with timeFormat function
 $('#timepicker').timepicker({
     timeFormat: (date: Date) =>
-        date.getHours().toString() + ":" + date.getMinutes().toString(),
+        `${date.getHours()}:${date.getMinutes()}`,
 });

--- a/types/timepicker/timepicker-tests.ts
+++ b/types/timepicker/timepicker-tests.ts
@@ -5,3 +5,14 @@ $('#timepicker').timepicker({});
 $('#timepicker').timepicker({
     step: 60,
 });
+
+// with timeFormat string
+$('#timepicker').timepicker({
+    timeFormat: "H:i",
+});
+
+// with timeFormat function
+$('#timepicker').timepicker({
+    timeFormat: (date: Date) =>
+        date.getHours().toString() + ":" + date.getMinutes().toString(),
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- `N/A` The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- `N/A` If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- `N/A` Create it with `dts-gen --dt`, not by basing it on an existing project.
- `N/A` Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- `N/A` `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- `N/A` `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/dfbcac108f4c160c7113c0d5a47f80bca56aa2b1/types/timepicker/index.d.ts#L125-L126> and <https://github.com/jonthornton/jquery-timepicker/blob/master/README.md#options>
- `N/A` If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- `N/A` If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- `N/A` Delete the package's directory.
- `N/A` Add it to `notNeededPackages.json`.
