### PR TITLE
meteor: Make ObserveChangesCallbacks.added more specific

### DIFF
--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -334,8 +334,8 @@ declare namespace Mongo {
         movedTo?(document: T, fromIndex: number, toIndex: number, before: T | null): void;
     }
     interface ObserveChangesCallbacks<T> {
-        added?(id: string, fields: Partial<T>): void;
-        addedBefore?(id: string, fields: Partial<T>, before: T | null): void;
+        added?(id: string, fields: Omit<T, '_id'>): void;
+        addedBefore?(id: string, fields: Omit<T, '_id'>, before: T | null): void;
         changed?(id: string, fields: Partial<T>): void;
         movedBefore?(id: string, before: T | null): void;
         removed?(id: string): void;

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -340,8 +340,8 @@ declare module 'meteor/mongo' {
             movedTo?(document: T, fromIndex: number, toIndex: number, before: T | null): void;
         }
         interface ObserveChangesCallbacks<T> {
-            added?(id: string, fields: Partial<T>): void;
-            addedBefore?(id: string, fields: Partial<T>, before: T | null): void;
+            added?(id: string, fields: Omit<T, '_id'>): void;
+            addedBefore?(id: string, fields: Omit<T, '_id'>, before: T | null): void;
             changed?(id: string, fields: Partial<T>): void;
             movedBefore?(id: string, before: T | null): void;
             removed?(id: string): void;

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -422,12 +422,13 @@ namespace MeteorTests {
      * From Collections, cursor.observeChanges section
      */
     // DA: I added this line to make it work
-    var Users = new Mongo.Collection('users');
+    var Users = new Mongo.Collection<{ _id: string, name: string }>('users');
 
     var count1 = 0;
     var query = Users.find({ admin: true, onlineNow: true });
     var handle = query.observeChanges({
-        added: function (id: string, user: { name: string }) {
+        added: function (id: string, user) {
+            user._id; // $ExpectError
             count1++;
             console.log(user.name + ' brings the total to ' + count1 + ' admins.');
         },

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -443,12 +443,13 @@ namespace MeteorTests {
      * From Collections, cursor.observeChanges section
      */
     // DA: I added this line to make it work
-    var Users = new Mongo.Collection('users');
+    var Users = new Mongo.Collection<{ _id: string, name: string }>('users');
 
     var count1 = 0;
     var query = Users.find({ admin: true, onlineNow: true });
     var handle = query.observeChanges({
-        added: function (id: string, user: { name: string }) {
+        added: function (id: string, user) {
+            user._id; // $ExpectError
             count1++;
             console.log(user.name + ' brings the total to ' + count1 + ' admins.');
         },


### PR DESCRIPTION
The docs specifically say that the `fields` parameter of both `added`
and `addedBefore` "contains all fields of the document excluding the
`_id` field," meaning that we can use a stronger type than just
`Partial`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/api/collections.html#:~:text=added(id%2C%20fields,before%60%20is%20%60null%60.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
