### PR TITLE
[prettier] add isBlockComment to printer type definitions

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -242,6 +242,7 @@ export interface Printer<T = any> {
     massageAstNode?: ((node: any, newNode: any, parent: any) => any) | undefined;
     hasPrettierIgnore?: ((path: AstPath<T>) => boolean) | undefined;
     canAttachComment?: ((node: T) => boolean) | undefined;
+    isBlockComment?: ((node: T) => boolean) | undefined;
     willPrintOwnComments?: ((path: AstPath<T>) => boolean) | undefined;
     printComment?: ((commentPath: AstPath<T>, options: ParserOptions<T>) => Doc) | undefined;
     handleComments?:


### PR DESCRIPTION
Add the optional `isBlockComment` type definition of the printer that is officially documented here: https://prettier.io/docs/en/plugins.html#optional-isblockcomment

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://prettier.io/docs/en/plugins.html#optional-isblockcomment
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **I am using prettier 2.5.1, but isBlockComment was already there in previous versions.**

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
