### PR TITLE
[README] Don't check links to other branches

### DIFF
--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -2,11 +2,27 @@ name: Check Markdown links
 on:
   pull_request:
     paths:
-      - '**.md'
+      - "**.md"
+      - .github/workflows/lint-md.yml
+      - package.json
+  push:
+    paths:
+      - "**.md"
+      - .github/workflows/lint-md.yml
+      - package.json
 jobs:
   lint-md:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        #with:
+        #  cache: npm
       - run: npm install
-      - run: npx remark --use validate-links --frail . .github
+      - name: Cherry pick https://github.com/remarkjs/remark-validate-links/pull/65
+        run: |
+          curl https://patch-diff.githubusercontent.com/raw/remarkjs/remark-validate-links/pull/65.patch |
+          git apply \
+            --directory node_modules/remark-validate-links \
+            --exclude 'node_modules/remark-validate-links/test/*' \
+      - run: npm exec -- remark --use 'validate-links=repository:"https://github.com/DefinitelyTyped/DefinitelyTyped.git#master"' --frail . .github

--- a/README.es.md
+++ b/README.es.md
@@ -338,7 +338,7 @@ Si planeas continuar actualizando la versión anterior del paquete, puedes crear
 1. Actualiza las rutas relativas en `tsconfig.json` al igual que `tslint.json`.
 2. Añadir reglas de mapeo de rutas para asegurarte de que la prueba se está ejecutando contra la versión prevista.
 
-Por ejemplo [history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) se ve así:
+Por ejemplo [history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) se ve así:
 
 ```json
 {

--- a/README.it.md
+++ b/README.it.md
@@ -497,7 +497,7 @@ Siccome la cartella principale deve sempre contenere le dichiarazioni dei tipi p
 
 Ad esempio, la libreria [`history`](https://github.com/ReactTraining/history/) ha avuto delle modifiche sostanziali passando dalla versione `2.x` alla `3.x`.
 Siccome molti utenti sono rimasti alla `2.x`, un mantenitore che voleva fare ulteriori aggiornamenti alle dichiarazioni dei tipi di questa vecchia versione ha aggiunto una sottocartella `v2` nella repo delle dichiarazioni dei tipi di questa libreria.
-Nel momento in cui questo README è stato scritto, il [`tsconfig.json` della history v2](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) è così:
+Nel momento in cui questo README è stato scritto, il [`tsconfig.json` della history v2](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) è così:
 
 ```json
 {

--- a/README.ja.md
+++ b/README.ja.md
@@ -478,7 +478,7 @@ Definitely Typed の各パッケージは npm に公開される際にバージ�
 
 たとえば、 [`history`](https://github.com/ReactTraining/history/) ライブラリはバージョン `2.x` から `3.x` の間で破壊的な変更を行いました。
 多くのユーザーがなお古いバージョン `2.x` 系を使用していたので、バージョン `3.x` 系の型定義に更新したかったメンテナーは `v2` フォルダーを作成し、そこに古いバージョン用の型定義を含めるようにしました。
-下記は、執筆時点<small>（訳注: 英語版執筆当時）</small>の [history モジュールの v2 の `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) の大まかな内容です:
+下記は、執筆時点<small>（訳注: 英語版執筆当時）</small>の [history モジュールの v2 の `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) の大まかな内容です:
 
 ```json
 {

--- a/README.ko.md
+++ b/README.ko.md
@@ -365,7 +365,7 @@ npm 패키지의 경우, `node -p 'require("foo")'` 가 원하는 값이라면 `
 1. `tsconfig.json` 와 `tslint.json` 에 포함된 상대경로들을 수정해주어야 합니다.
 2. 경로 대응 규칙(Path mapping rule)을 추가하여 테스트가 올바른 버전을 검사하도록 해야합니다.
 
-예를 들어, [history 패키지의 2 버전의 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) 파일은 다음과 같이 생겼습니다.
+예를 들어, [history 패키지의 2 버전의 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) 파일은 다음과 같이 생겼습니다.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ Because the root folder should always contain the type declarations for the late
 
 For example, the [`history`](https://github.com/ReactTraining/history/) library introduced breaking changes between version `2.x` and `3.x`.
 Because many users still consumed the older `2.x` version, a maintainer who wanted to update the type declarations for this library to `3.x` added a `v2` folder inside the history repository that contains type declarations for the older version.
-At the time of writing, the [history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) looks roughly like:
+At the time of writing, the [history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) looks roughly like:
 
 ```json
 {

--- a/README.pt.md
+++ b/README.pt.md
@@ -475,7 +475,7 @@ Porque o diretório-raíz deve sempre conter as declarações de tipo para as ú
 
 Por exemplo, a biblioteca [`history`](https://github.com/ReactTraining/history/) introduziu mudanças drásticas entre a versão `2.x` e `3.x`.
 Mas porque muitos usuários ainda consumiam a antiga versão `2.x`, o mantenedor que queria atualizar as declarações de tipo dessa biblioteca para a versão `3.x` adidionou uma pasta `v2` dentro do repositório "history" que contém declarações de tipo para a versão anterior.
-No tempo de escrita, a [history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) está assim:
+No tempo de escrita, a [history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) está assim:
 
 ```json
 {

--- a/README.ru.md
+++ b/README.ru.md
@@ -360,7 +360,7 @@ Once a week the Definition Owners are synced to the file [.github/CODEOWNERS](ht
 1. Обновите относительные пути в `tsconfig.json` а также в `tslint.json`.
 2. Добавьте правила сопоставления путей, чтобы убедиться, что тесты выполняются для предполагаемой версии.
 
-Например [history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) looks like:
+Например [history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) looks like:
 
 ```json
 {

--- a/README.zh.md
+++ b/README.zh.md
@@ -489,7 +489,7 @@ _注意：本节中的讨论假定你熟悉 [语义版本控制](https://semver.
 
 例如，[`history`](https://github.com/ReactTraining/history/) 库在 `2.x` 到 `3.x` 版本间引入了重大的修改。
 因为许多用户仍然使用较老的 `2.x` 版本，维护人员想要将此库的类型声明更新到 `3.x`, 需要在仓库里添加 `v2` 文件夹，里面包含了旧版本的类型声明。
-在编写时，[history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) 大致如下：
+在编写时，[history v2 `tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/history/v2/tsconfig.json) 大致如下：
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "jsdom": "^17.0.0",
         "prettier": "^2.1.1",
         "remark-cli": "^9.0.0",
-        "remark-validate-links": "^10.0.2",
+        "remark-validate-links": "^11.0.2",
         "typescript": "next",
         "w3c-xmlserializer": "^2.0.0",
         "yargs": "^17.1.1"


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/58598

@amcasey Thanks for opening https://github.com/DefinitelyTyped/DefinitelyTyped/issues/58598, what do you think of this fix? It cherry picks https://github.com/remarkjs/remark-validate-links/pull/65 and undoes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58599.

Leaving the escapes until https://github.com/remarkjs/remark-validate-links/pull/65 is :crossed_fingers: merged seems fine too!