### PR TITLE
feat(gh-pages): add `beforeAdd` publish option

### DIFF
--- a/types/gh-pages/gh-pages-tests.ts
+++ b/types/gh-pages/gh-pages-tests.ts
@@ -20,6 +20,11 @@ ghpages.publish(
             email: 'daniel@example.com',
         },
         history: true,
+        async beforeAdd(git) {
+          return Promise.resolve().then(() => {
+            return git.rm('hello-outdated-world.txt');
+          });
+        }
     },
     callback,
 );

--- a/types/gh-pages/gh-pages-tests.ts
+++ b/types/gh-pages/gh-pages-tests.ts
@@ -21,10 +21,10 @@ ghpages.publish(
         },
         history: true,
         async beforeAdd(git) {
-          return Promise.resolve().then(() => {
-            return git.rm('hello-outdated-world.txt');
-          });
-        }
+            return Promise.resolve().then(() => {
+                return git.rm('hello-outdated-world.txt');
+            });
+        },
     },
     callback,
 );

--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -20,7 +20,7 @@ export interface Git {
     clone: (repo: string, dir: string, branch: string, options: PublishOptions) => Promise<this>;
 }
 export interface PublishOptions {
-    beforeAdd?: ((git: Git) => Promise<Git | void>) | null | undefined;
+    beforeAdd?: ((git: Git) => Promise<Git | undefined>) | null | undefined;
     add?: boolean | undefined;
     branch?: string | undefined;
     dest?: string | undefined;

--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -7,7 +7,7 @@ export interface Git {
     cwd: string;
     cmd: string;
     output: string;
-    exec: (command: string) => Promise<this | Error>;
+    exec: (command: string) => Promise<this>;
     init: () => Promise<this | Error>;
     clean: () => Promise<this | Error>;
     reset: (remote: string, branch: string) => Promise<this | Error>;

--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -3,24 +3,24 @@
 // Definitions by: Daniel Rosenwasser <https://github.com/DanielRosenwasser>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-interface Git {
-  cwd: string;
-  cmd: string;
-  output: string;
-  exec: (command: string) => Promise<this | Error>;
-  init: () => Promise<this | Error>;
-  clean: () => Promise<this | Error>;
-  reset: (remote: string, branch: string) => Promise<this | Error>;
-  fetch: (remote: string) => Promise<this | Error>;
-  checkout: (remote: string, branch: string) => Promise<this | Error>;
-  rm: (files: string | string[]) => Promise<this | Error>;
-  add: (files: string | string[]) => Promise<this | Error>;
-  commit: (message: string)  => Promise<this | Error>;
-  tag: (name: string)  => Promise<this | Error>;
-  push: (remote: string, branch: string, force?: boolean) => Promise<this | Error>;
-  getRemoteUrl: (remote: string) => Promise<this | Error>;
-  deleteRef: (branch: string)=> Promise<this | Error>;
-  clone: (repo: string, dir: string, branch: string, options: PublishOptions) => Promise<this | Error>;
+export interface Git {
+    cwd: string;
+    cmd: string;
+    output: string;
+    exec: (command: string) => Promise<this | Error>;
+    init: () => Promise<this | Error>;
+    clean: () => Promise<this | Error>;
+    reset: (remote: string, branch: string) => Promise<this | Error>;
+    fetch: (remote: string) => Promise<this | Error>;
+    checkout: (remote: string, branch: string) => Promise<this | Error>;
+    rm: (files: string | string[]) => Promise<this | Error>;
+    add: (files: string | string[]) => Promise<this | Error>;
+    commit: (message: string) => Promise<this | Error>;
+    tag: (name: string) => Promise<this | Error>;
+    push: (remote: string, branch: string, force?: boolean) => Promise<this | Error>;
+    getRemoteUrl: (remote: string) => Promise<this | Error>;
+    deleteRef: (branch: string) => Promise<this | Error>;
+    clone: (repo: string, dir: string, branch: string, options: PublishOptions) => Promise<this | Error>;
 }
 export interface PublishOptions {
     beforeAdd?: null | ((git: Git) => Promise<Git | Error>);
@@ -48,10 +48,13 @@ export interface PublishOptions {
     silent?: boolean | undefined;
     src?: string | string[] | undefined;
     tag?: string | undefined;
-    user?: null | {
-        name: string;
-        email: string;
-    } | undefined;
+    user?:
+        | null
+        | {
+              name: string;
+              email: string;
+          }
+        | undefined;
 }
 
 /**

--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -4,9 +4,6 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 export interface Git {
-    cwd: string;
-    cmd: string;
-    output: string;
     exec: (command: string) => Promise<this>;
     init: () => Promise<this>;
     clean: () => Promise<this>;

--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -3,8 +3,27 @@
 // Definitions by: Daniel Rosenwasser <https://github.com/DanielRosenwasser>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+interface Git {
+  cwd: string;
+  cmd: string;
+  output: string;
+  exec: (command: string) => Promise<this | Error>;
+  init: () => Promise<this | Error>;
+  clean: () => Promise<this | Error>;
+  reset: (remote: string, branch: string) => Promise<this | Error>;
+  fetch: (remote: string) => Promise<this | Error>;
+  checkout: (remote: string, branch: string) => Promise<this | Error>;
+  rm: (files: string | string[]) => Promise<this | Error>;
+  add: (files: string | string[]) => Promise<this | Error>;
+  commit: (message: string)  => Promise<this | Error>;
+  tag: (name: string)  => Promise<this | Error>;
+  push: (remote: string, branch: string, force?: boolean) => Promise<this | Error>;
+  getRemoteUrl: (remote: string) => Promise<this | Error>;
+  deleteRef: (branch: string)=> Promise<this | Error>;
+  clone: (repo: string, dir: string, branch: string, options: PublishOptions) => Promise<this | Error>;
+}
 export interface PublishOptions {
+    beforeAdd?: null | ((git: Git) => Promise<Git | Error>);
     add?: boolean | undefined;
     branch?: string | undefined;
     dest?: string | undefined;
@@ -45,6 +64,7 @@ export function publish(basePath: string, config: PublishOptions, callback?: (er
 export function clean(): void;
 
 export interface Defaults {
+    beforeAdd: null;
     dest: '.';
     add: false;
     git: 'git';

--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -8,22 +8,22 @@ export interface Git {
     cmd: string;
     output: string;
     exec: (command: string) => Promise<this>;
-    init: () => Promise<this | Error>;
-    clean: () => Promise<this | Error>;
-    reset: (remote: string, branch: string) => Promise<this | Error>;
-    fetch: (remote: string) => Promise<this | Error>;
-    checkout: (remote: string, branch: string) => Promise<this | Error>;
-    rm: (files: string | string[]) => Promise<this | Error>;
-    add: (files: string | string[]) => Promise<this | Error>;
-    commit: (message: string) => Promise<this | Error>;
-    tag: (name: string) => Promise<this | Error>;
-    push: (remote: string, branch: string, force?: boolean) => Promise<this | Error>;
-    getRemoteUrl: (remote: string) => Promise<this | Error>;
-    deleteRef: (branch: string) => Promise<this | Error>;
-    clone: (repo: string, dir: string, branch: string, options: PublishOptions) => Promise<this | Error>;
+    init: () => Promise<this>;
+    clean: () => Promise<this>;
+    reset: (remote: string, branch: string) => Promise<this>;
+    fetch: (remote: string) => Promise<this>;
+    checkout: (remote: string, branch: string) => Promise<this>;
+    rm: (files: string | string[]) => Promise<this>;
+    add: (files: string | string[]) => Promise<this>;
+    commit: (message: string) => Promise<this>;
+    tag: (name: string) => Promise<this>;
+    push: (remote: string, branch: string, force?: boolean) => Promise<this>;
+    getRemoteUrl: (remote: string) => Promise<this>;
+    deleteRef: (branch: string) => Promise<this>;
+    clone: (repo: string, dir: string, branch: string, options: PublishOptions) => Promise<this>;
 }
 export interface PublishOptions {
-    beforeAdd?: ((git: Git) => Promise<Git | void>) | null | undefined; 
+    beforeAdd?: ((git: Git) => Promise<Git | void>) | null | undefined;
     add?: boolean | undefined;
     branch?: string | undefined;
     dest?: string | undefined;

--- a/types/gh-pages/index.d.ts
+++ b/types/gh-pages/index.d.ts
@@ -23,7 +23,7 @@ export interface Git {
     clone: (repo: string, dir: string, branch: string, options: PublishOptions) => Promise<this | Error>;
 }
 export interface PublishOptions {
-    beforeAdd?: null | ((git: Git) => Promise<Git | Error>);
+    beforeAdd?: ((git: Git) => Promise<Git | void>) | null | undefined; 
     add?: boolean | undefined;
     branch?: string | undefined;
     dest?: string | undefined;


### PR DESCRIPTION
This PR adds a missing publish option to the types for `gh-pages`.

[`beforeAdd` is an optional callback](https://github.com/tschaub/gh-pages#optionsbeforeadd) that is run before `git add`. This option has been available since version [3.0.0](https://github.com/tschaub/gh-pages/blob/8d9f3b2b0922d127d0bef67599ccfe5e2ae80bc4/changelog.md#v300).

The `Git` interface is modelled using [`gh-pages/lib/git.js`](https://github.com/tschaub/gh-pages/blob/8d9f3b2b0922d127d0bef67599ccfe5e2ae80bc4/lib/git.js).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tschaub/gh-pages/blob/8d9f3b2b0922d127d0bef67599ccfe5e2ae80bc4/changelog.md#v300
