### PR TITLE
[react-router] Make SwitchProps children type more specific

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -122,7 +122,7 @@ export interface StaticRouterProps {
 
 export class StaticRouter extends React.Component<StaticRouterProps, any> {}
 export interface SwitchProps {
-    children?: React.ReactNode | undefined;
+    children?: Route | Redirect | undefined;
     location?: H.Location | undefined;
 }
 export class Switch extends React.Component<SwitchProps, any> {}

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -122,7 +122,7 @@ export interface StaticRouterProps {
 
 export class StaticRouter extends React.Component<StaticRouterProps, any> {}
 export interface SwitchProps {
-    children?: Route | Redirect | undefined;
+    children?: (Route | Redirect)[] | undefined;
     location?: H.Location | undefined;
 }
 export class Switch extends React.Component<SwitchProps, any> {}

--- a/types/react-router/ts4.0/index.d.ts
+++ b/types/react-router/ts4.0/index.d.ts
@@ -91,7 +91,7 @@ export interface StaticRouterProps {
 
 export class StaticRouter extends React.Component<StaticRouterProps, any> {}
 export interface SwitchProps {
-    children?: Route | Redirect;
+    children?: (Route | Redirect)[];
     location?: H.Location;
 }
 export class Switch extends React.Component<SwitchProps, any> {}

--- a/types/react-router/ts4.0/index.d.ts
+++ b/types/react-router/ts4.0/index.d.ts
@@ -91,7 +91,7 @@ export interface StaticRouterProps {
 
 export class StaticRouter extends React.Component<StaticRouterProps, any> {}
 export interface SwitchProps {
-    children?: React.ReactNode;
+    children?: Route | Redirect;
     location?: H.Location;
 }
 export class Switch extends React.Component<SwitchProps, any> {}


### PR DESCRIPTION
Related discussion: #58596

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test react-router`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://v5.reactrouter.com/web/api/Switch/children-node>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
