### PR TITLE
ioredis: added getex

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -220,6 +220,10 @@ declare namespace IORedis {
         getBuffer(key: KeyType, callback: Callback<Buffer>): void;
         getBuffer(key: KeyType): Promise<Buffer>;
 
+        getex(key: KeyType, expiryMode?: string, time?: number | string): Promise<string | null>;
+        getex(key: KeyType, callback: Callback<string | null>): void;
+        getex(key: KeyType, expiryMode: string, time: number | string, callback: Callback<string | null>): void;
+
         set(
             key: KeyType,
             value: ValueType,
@@ -1333,6 +1337,7 @@ declare namespace IORedis {
 
         get(key: KeyType, callback?: Callback<string>): Pipeline;
         getBuffer(key: KeyType, callback?: Callback<Buffer>): Pipeline;
+        getex(key: KeyType, expiryMode: string, time: number, callback?: Callback<string>): Pipeline;
 
         set(key: KeyType, value: ValueType, callback?: Callback<string>): Pipeline;
         set(key: KeyType, value: ValueType, setMode: string, callback?: Callback<string>): Pipeline;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -20,6 +20,7 @@
 //                 T.J. Tarazevits <https://github.com/venku122>
 //                 Michiel De Mey <https://github.com/michieldemey>
 //                 Dae Heon Han <https://github.com/honeyirene>
+//                 Yongkyun Choi <https://github.com/DracoVirus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -19,8 +19,15 @@ redis.get('foo', cb);
 redis.getdel('foo', cb);
 
 redis.set('foo', 'bar');
-redis.getrangeBuffer("foo", 0, 1, cb);
-redis.getrangeBuffer("foo", 0, 1).then(b => cb(null, b));
+redis.getex('foo', cb);
+redis.getex('key', 'PX', 10);
+redis.getex('key', (err, data) => {});
+redis.getex('key', 'PX', 10, (err, data) => {});
+redis.getdel('foo', cb);
+
+redis.set('foo', 'bar');
+redis.getrangeBuffer('foo', 0, 1, cb);
+redis.getrangeBuffer('foo', 0, 1).then(b => cb(null, b));
 
 // Static check that returned value is always a number
 redis.del('foo', 'bar').then(result => result * 1);


### PR DESCRIPTION
ioredis: was missing getex method definition.
added:
- zrangeBuffer

> 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://redis.io/commands/getex>>
