### PR TITLE
types/convict: Improved PathImpl to stop at SchemaObj key

### DIFF
--- a/types/convict-format-with-validator/index.d.ts
+++ b/types/convict-format-with-validator/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mozilla/node-convict/tree/master/packages/convict-format-with-validator
 // Definitions by: Louis Tung <https://github.com/louis79719>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.1
+// TypeScript Version: 4.2
 
 import * as convict from 'convict';
 

--- a/types/convict/convict-tests.ts
+++ b/types/convict/convict-tests.ts
@@ -61,7 +61,7 @@ interface Foo {
 // $ExpectType Config<{ foo: Foo; }>
 convict({
     foo: {
-        format(val): asserts val is Foo {},
+        format(val): asserts val is Foo { },
         default: { a: "a" },
     },
 });
@@ -196,8 +196,6 @@ const schema = conf.getSchema();
 
 const schemaVal = conf.getSchema().properties.db.properties.port.default;
 
-conf.get();
-
 // @ts-expect-error Trying to access no existing property
 conf.get("unknownkey");
 
@@ -209,6 +207,9 @@ conf.getSchema();
 conf.getProperties();
 conf.getSchemaString();
 conf.toString();
+
+// @ts-expect-error Trying to access schemaObj keys
+conf.get('db.password.default');
 
 const conf2 = convict(
     {

--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -112,7 +112,9 @@ declare namespace convict {
         ? T[K] extends Record<string, any>
             ? T[K] extends ArrayLike<any>
                 ? K | `${K}.${PathImpl<T[K], Exclude<keyof T[K], keyof any[]>>}`
-                : K | `${K}.${PathImpl<T[K], keyof T[K]>}`
+                : T[K] extends SchemaObj
+                    ? K
+                    : K | `${K}.${PathImpl<T[K], keyof T[K]>}`
             : K
         : never;
 

--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -7,7 +7,7 @@
 //                 Igor Strebezhev <https://github.com/xamgore>
 //                 Peter Somogyvari <https://github.com/petermetz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.1
+// TypeScript Version: 4.2
 
 /// <reference types="node" />
 

--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -112,9 +112,7 @@ declare namespace convict {
         ? T[K] extends Record<string, any>
             ? T[K] extends ArrayLike<any>
                 ? K | `${K}.${PathImpl<T[K], Exclude<keyof T[K], keyof any[]>>}`
-                : T[K] extends SchemaObj
-                    ? K
-                    : K | `${K}.${PathImpl<T[K], keyof T[K]>}`
+                : K | `${K}.${PathImpl<T[K], keyof T[K]>}`
             : K
         : never;
 
@@ -127,8 +125,8 @@ declare namespace convict {
                 : never
             : never
         : P extends keyof T
-        ? T[P]
-        : never;
+            ? T[P]
+            : never;
 
     interface Config<T> {
         /**


### PR DESCRIPTION
Following improves the utility type of convict in order to stop the keys before SchemaObj. I would like to improve the types to only show me dotted keys that stop before the prototype function names for strings and arrays. Hopefully there is someone in the community that can help with that

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
