### PR TITLE
[react-virtualized] Loosen `deferredMeasurementCache` prop

### DIFF
--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -1,7 +1,7 @@
 import { Validator, Requireable, PureComponent, Component } from 'react';
 import { List } from './List';
 import { Table } from './Table';
-import { CellMeasurerCache, MeasuredCellParent } from './CellMeasurer';
+import { CellMeasurerCache, CellMeasurerCacheInterface, MeasuredCellParent } from './CellMeasurer';
 import { Index, Map, Alignment, OverscanIndexRange } from '../../index';
 
 export type RenderedSection = {
@@ -197,7 +197,7 @@ export type GridCoreProps = {
      * If CellMeasurer is used to measure this Grid's children, this should be a pointer to its CellMeasurerCache.
      * A shared CellMeasurerCache reference enables Grid and CellMeasurer to share measurement data.
      */
-    deferredMeasurementCache?: CellMeasurerCache | undefined;
+    deferredMeasurementCache?: CellMeasurerCacheInterface | undefined;
     /**
      * Used to estimate the total width of a Grid before all of its columns have actually been measured.
      * The estimated total width is adjusted as columns are rendered.


### PR DESCRIPTION
The `deferredMeasurementCache` prop claims to require a `CellMeasurerCache`, but it just requires things that comply with that interface. This PR updates that.

I verified that nobody uses properties/methods of `deferredMeasurementCache` that aren't on `CellMeasurerCacheInterface`.

---


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test react-virtualized`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
  - Usages of `deferredMeasurementCache` across the repo: https://github.com/bvaughn/react-virtualized/search?q=deferredMeasurementCache
  - Relevant Flow types (not super helpful) https://github.com/bvaughn/react-virtualized/blob/abe0530a512639c042e74009fbf647abdb52d661/source/Grid/Grid.js#L106-L110
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
