### PR TITLE
[react-redux] Allow connect function to take JSXElementConstructor

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -25,16 +25,14 @@ import {
     ClassAttributes,
     Component,
     ComponentClass,
-    ComponentType,
-    FunctionComponent,
     Context,
+    JSXElementConstructor,
     NamedExoticComponent,
     ReactNode
 } from 'react';
 
 import {
     Action,
-    ActionCreator,
     AnyAction,
     Dispatch,
     Store
@@ -64,7 +62,7 @@ export interface DispatchProp<A extends Action = AnyAction> {
 }
 
 export type AdvancedComponentDecorator<TProps, TOwnProps> =
-    (component: ComponentType<TProps>) => NamedExoticComponent<TOwnProps>;
+    (component: JSXElementConstructor<TProps>) => NamedExoticComponent<TOwnProps>;
 
 /**
  * A property P will be present if:
@@ -104,7 +102,7 @@ export type Shared<
     };
 
 // Infers prop type from component C
-export type GetProps<C> = C extends ComponentType<infer P>
+export type GetProps<C> = C extends JSXElementConstructor<infer P>
     ? C extends ComponentClass<P> ? ClassAttributes<InstanceType<C>> & P : P
     : never;
 
@@ -114,7 +112,7 @@ export type GetLibraryManagedProps<C> = JSX.LibraryManagedAttributes<C, GetProps
 
 // Defines WrappedComponent and derives non-react statics.
 export type ConnectedComponent<
-    C extends ComponentType<any>,
+    C extends JSXElementConstructor<any>,
     P
 > = NamedExoticComponent<P> & hoistNonReactStatics.NonReactStatics<C> & {
     WrappedComponent: C;
@@ -125,7 +123,7 @@ export type ConnectedComponent<
 // render. Also adds new prop requirements from TNeedsProps.
 // Uses distributive omit to preserve discriminated unions part of original prop type
 export type InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> =
-    <C extends ComponentType<Matching<TInjectedProps, GetProps<C>>>>(
+    <C extends JSXElementConstructor<Matching<TInjectedProps, GetProps<C>>>>(
         component: C
     ) => ConnectedComponent<C, DistributiveOmit<GetLibraryManagedProps<C>, keyof Shared<TInjectedProps, GetLibraryManagedProps<C>>> & TNeedsProps>;
 

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1603,14 +1603,13 @@ function testPreserveDiscriminatedUnions() {
  * The `withStyles` HOC in MUI returns a `JSXElementConstructor` instead of a `ComponentType` as of
  * https://github.com/mui/material-ui/pull/24746.
  */
+interface Props {
+    foo: number;
+    bar: boolean;
+}
+declare const TestComponentJSXElementConstructorIsAllowed: React.JSXElementConstructor<Props>;
+
 function testJSXElementConstructorIsAllowed() {
-    interface Props {
-        foo: number;
-        bar: boolean;
-    }
-
-    const TestComponent: React.JSXElementConstructor<Props> = () => null;
-
     interface StoreState {
         stateThings: number;
     }
@@ -1618,6 +1617,6 @@ function testJSXElementConstructorIsAllowed() {
         foo: state.stateThings,
     });
 
-    const ConnectedComponent = connect(mapStateToProps)(TestComponent);
+    const ConnectedComponent = connect(mapStateToProps)(TestComponentJSXElementConstructorIsAllowed);
     <ConnectedComponent bar />;
 }

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -4,11 +4,9 @@ import * as ReactDOM from 'react-dom';
 import {
     Store,
     Dispatch,
-    AnyAction,
     ActionCreator,
     createStore,
     bindActionCreators,
-    ActionCreatorsMapObject,
     Reducer,
 } from 'redux';
 import {
@@ -18,7 +16,6 @@ import {
     Provider,
     DispatchProp,
     MapStateToProps,
-    Options,
     ReactReduxContext,
     ReactReduxContextValue,
     Selector,
@@ -1600,4 +1597,27 @@ function testPreserveDiscriminatedUnions() {
     <ConnectedMyText type="plain" color="red" params={someParams} />; // $ExpectError
     <ConnectedMyText type="localized" color="red" />; // $ExpectError
     <ConnectedMyText type="localized" color="red" params={someParams} />;
+}
+
+/**
+ * The `withStyles` HOC in MUI returns a `JSXElementConstructor` instead of a `ComponentType` as of
+ * https://github.com/mui/material-ui/pull/24746.
+ */
+function testJSXElementConstructorIsAllowed() {
+    interface Props {
+        foo: number;
+        bar: boolean;
+    }
+
+    const TestComponent: React.JSXElementConstructor<Props> = () => null;
+
+    interface StoreState {
+        stateThings: number;
+    }
+    const mapStateToProps = (state: StoreState) => ({
+        foo: state.stateThings,
+    });
+
+    const ConnectedComponent = connect(mapStateToProps)(TestComponent);
+    <ConnectedComponent bar />;
 }


### PR DESCRIPTION
MUI [updated](https://github.com/mui/material-ui/pull/24746) their `withStyles` HOC to return a `JSXElementConstructor`. This PR updates the `connect` function types to accept a `JSXElementConstructor` so that `connect` can be used in conjunction with `withStyles`.
```tsx
import * as React from "react";
import { createStyles, withStyles, WithStyles } from "@mui/styles";
import { connect } from "react-redux";

const styles = createStyles({
  root: {
    /* ... */
  },
});

interface Props extends WithStyles<typeof styles> {
  foo: number;
  bar: boolean;
}

const Test = (props: Props) => null;

interface StoreState {
  stateThings: number;
}
const mapStateToProps = (state: StoreState) => ({
  foo: state.stateThings,
});

const ConnectedTest = connect(mapStateToProps)(withStyles(styles)(Test));

<ConnectedTest foo={5} bar />;
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mui/material-ui/pull/24746
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
