### PR TITLE
[node/v12] Add missing `serialization` option for `fork` and `spawn` methods of `child_process` module

### DIFF
--- a/types/node/v12/child_process.d.ts
+++ b/types/node/v12/child_process.d.ts
@@ -120,6 +120,16 @@ declare module 'child_process' {
 
     type StdioOptions = "pipe" | "ignore" | "inherit" | Array<("pipe" | "ipc" | "ignore" | "inherit" | Stream | number | null | undefined)>;
 
+    type SerializationType = 'json' | 'advanced';
+
+    interface MessagingOptions {
+        /**
+         * Specify the kind of serialization used for sending messages between processes.
+         * @default 'json'
+         */
+        serialization?: SerializationType | undefined;
+    }
+
     interface ProcessEnvOptions {
         uid?: number | undefined;
         gid?: number | undefined;
@@ -138,7 +148,7 @@ declare module 'child_process' {
         timeout?: number | undefined;
     }
 
-    interface SpawnOptions extends CommonOptions {
+    interface SpawnOptions extends CommonOptions, MessagingOptions {
         argv0?: string | undefined;
         stdio?: StdioOptions | undefined;
         detached?: boolean | undefined;
@@ -408,7 +418,7 @@ declare module 'child_process' {
         ): PromiseWithChild<{ stdout: string | Buffer, stderr: string | Buffer }>;
     }
 
-    interface ForkOptions extends ProcessEnvOptions {
+    interface ForkOptions extends ProcessEnvOptions, MessagingOptions {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;

--- a/types/node/v12/test/child_process.ts
+++ b/types/node/v12/test/child_process.ts
@@ -9,6 +9,7 @@ import { Writable, Readable, Pipe } from 'stream';
     childProcess.exec("echo test");
     childProcess.exec("echo test", { windowsHide: true });
     childProcess.spawn("echo");
+    childProcess.spawn("echo", { serialization: 'json' });
     childProcess.spawn("echo", { windowsHide: true });
     childProcess.spawn("echo", ["test"], { windowsHide: true });
     childProcess.spawn("echo", ["test"], { windowsHide: true, argv0: "echo-test" });
@@ -43,6 +44,7 @@ import { Writable, Readable, Pipe } from 'stream';
 {
     const forked = childProcess.fork('./', ['asd'] as ReadonlyArray<string>, {
         windowsVerbatimArguments: true,
+        serialization: 'advanced',
         silent: false,
         stdio: "inherit",
         execPath: '',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options), [child_process.spawn](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options)

## Summary

Current Node v12 typings for `fork` and `spawn` methods of `child_process` module are missing `serialization` option. As you can see in the documentation (links above) the option was added since Node v12.16.0.

I have copied the type definitions from v14 directory. Added basic tests as well.