### PR TITLE
Add expand to RangySelection Interface to avoid false typescript error while using it in angular.

### DIFF
--- a/types/rangy/index.d.ts
+++ b/types/rangy/index.d.ts
@@ -54,6 +54,7 @@ interface RangySelection extends Selection {
     detach():any;
     inspect(): string;
     move(units: string, count: number, opts?: any): number;
+    expand(unit: string, expandOptions?);
 }
 
 interface RangyStatic {


### PR DESCRIPTION
Due to error in angular while using expand('word'). needed to add the function here.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`

