### PR TITLE
Generic types for deep-equal

### DIFF
--- a/types/deep-equal/index.d.ts
+++ b/types/deep-equal/index.d.ts
@@ -7,9 +7,9 @@ interface DeepEqualOptions {
     strict: boolean;
 }
 
-declare function deepEqual(
-    actual: any,
-    expected: any,
+declare function deepEqual<T, K = T>(
+    actual: T,
+    expected: K,
     opts?: DeepEqualOptions): boolean;
 
 export = deepEqual;


### PR DESCRIPTION
This allows for deepEqual to be used within rxjs pipelines with strict typing.
