### PR TITLE
[@types/paypal-checkout-components] add type definitions for PayPal SDK Buttons renderer

### DIFF
--- a/types/paypal-checkout-components/index.d.ts
+++ b/types/paypal-checkout-components/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 3.1
 
 import {
-  ButtonRenderer, FundingOption
+  ButtonRenderer, ButtonsRenderer, FundingOption
 } from './modules/button';
 
 import {
@@ -34,6 +34,8 @@ import {
 
 export const Button: ButtonRenderer;
 
+export const Buttons: ButtonsRenderer;
+
 export {
   Address,
   AuthorizationData,
@@ -43,6 +45,7 @@ export {
   AuthorizationResponseDetails,
   AuthorizationResponseDetails as TokenizePayloadDetails, // maintain backwards compatibility
   ButtonRenderer,
+  ButtonsRenderer,
   ButtonColorOption,
   ButtonLabelOption,
   ButtonShapeOption,

--- a/types/paypal-checkout-components/modules/button.d.ts
+++ b/types/paypal-checkout-components/modules/button.d.ts
@@ -6,7 +6,8 @@ export enum FundingOption {
     CREDIT,
     CARD,
     VENMO,
-    ELV
+    ELV,
+    PAYPAL,
 }
 
 export interface ButtonRenderer {
@@ -48,4 +49,18 @@ export interface ButtonRenderer {
         },
         selector: string,
     ): void;
+}
+
+export interface ButtonsRenderer {
+    (
+        options: {
+            fundingSource?: string | undefined;
+            createOrder?: (() => Promise<string>) | undefined;
+            createBillingAgreement?: (() => Promise<string>) | undefined;
+            onApprove: (data: AuthorizationData, actions: object) => Promise<AuthorizationResponse>;
+            onCancel?: ((data: CancellationData, actions: object) => void) | undefined;
+            onError?: ((error: string) => void) | undefined;
+        }
+    ): ButtonsRenderer;
+    render(selector: string): void;
 }

--- a/types/paypal-checkout-components/test/button.ts
+++ b/types/paypal-checkout-components/test/button.ts
@@ -1,4 +1,5 @@
 const buttonRenderer: paypal.ButtonRenderer = paypal.Button;
+const buttonsRenderer: paypal.ButtonsRenderer = paypal.Buttons;
 
 buttonRenderer.render(
     {
@@ -41,3 +42,37 @@ buttonRenderer.render(
     },
     '#paypal-button',
 );
+
+buttonsRenderer({
+    fundingSource: 'paypal',
+
+    createOrder: async (): Promise<string> => {
+        return 'payment__id_123';
+    },
+
+    onApprove: async (
+        data: paypal.AuthorizationData,
+        actions: object,
+    ): Promise<paypal.AuthorizationResponse> => {
+        console.log('onAuthorize', data, actions);
+
+        return {
+            nonce: 'foo',
+            type: paypal.FlowType.Checkout,
+            details: {
+                email: 'foo@bar.com',
+                payerId: '123',
+                firstName: 'Buyer',
+                lastName: 'McGee',
+            },
+        };
+    },
+
+    onCancel: (data: paypal.CancellationData) => {
+        console.log('PayPal JS SDK payment cancelled', data);
+    },
+
+    onError: (error: string) => {
+        console.error('PayPal JS SDK error', error);
+    },
+}).render('#paypal-button');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

https://github.com/braintree/braintree-web/blob/main/src/paypal-checkout/paypal-checkout.js
https://braintree.github.io/braintree-web/current/PayPalCheckout.html

`paypal.Button.render` from checkout.js is deprecated and it is recommended to use `paypal.Buttons(...).render` from `paypal-checkout-components` now


