### PR TITLE
node-fetch: restore types (for v2), update version, allow `agent: false`

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -3069,10 +3069,6 @@
             "libraryName": "node-downloader-helper",
             "asOfVersion": "1.0.16"
         },
-        "node-fetch": {
-            "libraryName": "node-fetch",
-            "asOfVersion": "3.0.0"
-        },
         "node-json-db": {
             "libraryName": "node-json-db",
             "asOfVersion": "0.9.2"

--- a/types/file-fetch/package.json
+++ b/types/file-fetch/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/node-fetch": "^2.5.12"
-    }
-}

--- a/types/frisby/package.json
+++ b/types/frisby/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/node-fetch": "^2.5.12",
         "joi": "^17.3.0"
     }
 }

--- a/types/libnpmpublish/package.json
+++ b/types/libnpmpublish/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/node-fetch": "^2.5.12"
-    }
-}

--- a/types/make-fetch-happen/package.json
+++ b/types/make-fetch-happen/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/node-fetch": "^2.5.12"
-    }
-}

--- a/types/node-fetch/externals.d.ts
+++ b/types/node-fetch/externals.d.ts
@@ -1,0 +1,21 @@
+// `AbortSignal` is defined here to prevent a dependency on a particular
+// implementation like the `abort-controller` package, and to avoid requiring
+// the `dom` library in `tsconfig.json`.
+
+export interface AbortSignal {
+    aborted: boolean;
+
+    addEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
+        capture?: boolean | undefined,
+        once?: boolean | undefined,
+        passive?: boolean | undefined
+    }) => void;
+
+    removeEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
+        capture?: boolean | undefined
+    }) => void;
+
+    dispatchEvent: (event: any) => boolean;
+
+    onabort: null | ((this: AbortSignal, event: any) => void);
+}

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -1,0 +1,223 @@
+// Type definitions for node-fetch 2.5
+// Project: https://github.com/bitinn/node-fetch
+// Definitions by: Torsten Werner <https://github.com/torstenwerner>
+//                 Niklas Lindgren <https://github.com/nikcorg>
+//                 Vinay Bedre <https://github.com/vinaybedre>
+//                 Antonio Román <https://github.com/kyranet>
+//                 Andrew Leedham <https://github.com/AndrewLeedham>
+//                 Jason Li <https://github.com/JasonLi914>
+//                 Steve Faulkner <https://github.com/southpolesteve>
+//                 ExE Boss <https://github.com/ExE-Boss>
+//                 Alex Savin <https://github.com/alexandrusavin>
+//                 Alexis Tyler <https://github.com/OmgImAlexis>
+//                 Jakub Kisielewski <https://github.com/kbkk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import FormData = require('form-data');
+import { Agent } from "http";
+import { URLSearchParams, URL } from "url";
+import { AbortSignal } from "./externals";
+
+export class Request extends Body {
+    constructor(input: RequestInfo, init?: RequestInit);
+    clone(): Request;
+    context: RequestContext;
+    headers: Headers;
+    method: string;
+    redirect: RequestRedirect;
+    referrer: string;
+    url: string;
+
+    // node-fetch extensions to the whatwg/fetch spec
+    agent?: Agent | ((parsedUrl: URL) => Agent) | undefined;
+    compress: boolean;
+    counter: number;
+    follow: number;
+    hostname: string;
+    port?: number | undefined;
+    protocol: string;
+    size: number;
+    timeout: number;
+}
+
+export interface RequestInit {
+    // whatwg/fetch standard options
+    body?: BodyInit | undefined;
+    headers?: HeadersInit | undefined;
+    method?: string | undefined;
+    redirect?: RequestRedirect | undefined;
+    signal?: AbortSignal | null | undefined;
+
+    // node-fetch extensions
+    agent?: Agent | ((parsedUrl: URL) => Agent) | undefined; // =null http.Agent instance, allows custom proxy, certificate etc.
+    compress?: boolean | undefined; // =true support gzip/deflate content encoding. false to disable
+    follow?: number | undefined; // =20 maximum redirect count. 0 to not follow redirect
+    size?: number | undefined; // =0 maximum response body size in bytes. 0 to disable
+    timeout?: number | undefined; // =0 req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
+
+    // node-fetch does not support mode, cache or credentials options
+}
+
+export type RequestContext =
+    "audio"
+    | "beacon"
+    | "cspreport"
+    | "download"
+    | "embed"
+    | "eventsource"
+    | "favicon"
+    | "fetch"
+    | "font"
+    | "form"
+    | "frame"
+    | "hyperlink"
+    | "iframe"
+    | "image"
+    | "imageset"
+    | "import"
+    | "internal"
+    | "location"
+    | "manifest"
+    | "object"
+    | "ping"
+    | "plugin"
+    | "prefetch"
+    | "script"
+    | "serviceworker"
+    | "sharedworker"
+    | "style"
+    | "subresource"
+    | "track"
+    | "video"
+    | "worker"
+    | "xmlhttprequest"
+    | "xslt";
+export type RequestMode = "cors" | "no-cors" | "same-origin";
+export type RequestRedirect = "error" | "follow" | "manual";
+export type RequestCredentials = "omit" | "include" | "same-origin";
+
+export type RequestCache =
+    "default"
+    | "force-cache"
+    | "no-cache"
+    | "no-store"
+    | "only-if-cached"
+    | "reload";
+
+export class Headers implements Iterable<[string, string]> {
+    constructor(init?: HeadersInit);
+    forEach(callback: (value: string, name: string) => void): void;
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    raw(): { [k: string]: string[] };
+    set(name: string, value: string): void;
+
+    // Iterable methods
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+    [Symbol.iterator](): Iterator<[string, string]>;
+}
+
+type BlobPart = ArrayBuffer | ArrayBufferView | Blob | string;
+
+interface BlobOptions {
+    type?: string | undefined;
+    endings?: "transparent" | "native" | undefined;
+}
+
+export class Blob {
+    constructor(blobParts?: BlobPart[], options?: BlobOptions);
+    readonly type: string;
+    readonly size: number;
+    slice(start?: number, end?: number): Blob;
+    text(): Promise<string>;
+}
+
+export class Body {
+    constructor(body?: any, opts?: { size?: number | undefined; timeout?: number | undefined });
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    body: NodeJS.ReadableStream;
+    bodyUsed: boolean;
+    buffer(): Promise<Buffer>;
+    json(): Promise<any>;
+    size: number;
+    text(): Promise<string>;
+    textConverted(): Promise<string>;
+    timeout: number;
+}
+
+interface SystemError extends Error {
+    code?: string | undefined;
+}
+
+export class FetchError extends Error {
+    name: "FetchError";
+    constructor(message: string, type: string, systemError?: SystemError);
+    type: string;
+    code?: string | undefined;
+    errno?: string | undefined;
+}
+
+export class Response extends Body {
+    constructor(body?: BodyInit, init?: ResponseInit);
+    static error(): Response;
+    static redirect(url: string, status: number): Response;
+    clone(): Response;
+    headers: Headers;
+    ok: boolean;
+    redirected: boolean;
+    status: number;
+    statusText: string;
+    type: ResponseType;
+    url: string;
+}
+
+export type ResponseType =
+    "basic"
+    | "cors"
+    | "default"
+    | "error"
+    | "opaque"
+    | "opaqueredirect";
+
+export interface ResponseInit {
+    headers?: HeadersInit | undefined;
+    size?: number | undefined;
+    status?: number | undefined;
+    statusText?: string | undefined;
+    timeout?: number | undefined;
+    url?: string | undefined;
+}
+
+interface URLLike {
+    href: string;
+}
+
+export type HeadersInit = Headers | string[][] | { [key: string]: string };
+// HeaderInit is exported to support backwards compatibility. See PR #34382
+export type HeaderInit = HeadersInit;
+export type BodyInit =
+    ArrayBuffer
+    | ArrayBufferView
+    | NodeJS.ReadableStream
+    | string
+    | URLSearchParams
+    | FormData;
+export type RequestInfo = string | URLLike | Request;
+
+declare function fetch(
+    url: RequestInfo,
+    init?: RequestInit
+): Promise<Response>;
+
+declare namespace fetch {
+    function isRedirect(code: number): boolean;
+}
+
+export default fetch;

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -16,7 +16,7 @@
 /// <reference types="node" />
 
 import FormData = require('form-data');
-import { Agent } from "http";
+import { RequestOptions } from "http";
 import { URLSearchParams, URL } from "url";
 import { AbortSignal } from "./externals";
 
@@ -31,7 +31,7 @@ export class Request extends Body {
     url: string;
 
     // node-fetch extensions to the whatwg/fetch spec
-    agent?: Agent | ((parsedUrl: URL) => Agent) | undefined;
+    agent?: RequestOptions['agent'] | ((parsedUrl: URL) => RequestOptions['agent']);
     compress: boolean;
     counter: number;
     follow: number;
@@ -51,7 +51,7 @@ export interface RequestInit {
     signal?: AbortSignal | null | undefined;
 
     // node-fetch extensions
-    agent?: Agent | ((parsedUrl: URL) => Agent) | undefined; // =null http.Agent instance, allows custom proxy, certificate etc.
+    agent?: RequestOptions['agent'] | ((parsedUrl: URL) => RequestOptions['agent']); // =null http.Agent instance, allows custom proxy, certificate etc.
     compress?: boolean | undefined; // =true support gzip/deflate content encoding. false to disable
     follow?: number | undefined; // =20 maximum redirect count. 0 to not follow redirect
     size?: number | undefined; // =0 maximum response body size in bytes. 0 to disable

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-fetch 2.5
+// Type definitions for node-fetch 2.6
 // Project: https://github.com/bitinn/node-fetch
 // Definitions by: Torsten Werner <https://github.com/torstenwerner>
 //                 Niklas Lindgren <https://github.com/nikcorg>

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -11,6 +11,7 @@
 //                 Alex Savin <https://github.com/alexandrusavin>
 //                 Alexis Tyler <https://github.com/OmgImAlexis>
 //                 Jakub Kisielewski <https://github.com/kbkk>
+//                 David Glasser <https://github.com/glasser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -1,0 +1,216 @@
+import fetch, {
+    Blob,
+    Headers,
+    Request,
+    RequestInit,
+    Response,
+    FetchError
+} from "node-fetch";
+import { URL } from "url";
+import { Agent } from "http";
+
+function test_fetchUrlWithOptions() {
+    const headers = new Headers();
+    headers.append("Content-Type", "application/json");
+    const requestOptions: RequestInit = {
+        compress: true,
+        follow: 10,
+        headers,
+        method: "POST",
+        redirect: "manual",
+        size: 100,
+        timeout: 5000
+    };
+    handlePromise(
+        fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions)
+    );
+}
+
+function test_fetchUrlWithHeadersObject() {
+    const requestOptions: RequestInit = {
+        headers: {
+            "Content-Type": "application/json"
+        },
+        method: "POST"
+    };
+    handlePromise(
+        fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions)
+    );
+}
+
+function test_fetchUrl() {
+    handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php"));
+}
+
+function test_fetchUrlArrayBuffer() {
+    handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php"), true);
+}
+
+function test_fetchUrlWithRequestObject() {
+    const requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        signal: {
+            aborted: false,
+
+            addEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+                capture?: boolean | undefined,
+                once?: boolean | undefined,
+                passive?: boolean | undefined
+            }) => undefined,
+
+            removeEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+                capture?: boolean | undefined
+            }) => undefined,
+
+            dispatchEvent: (event: any) => false,
+            onabort: null,
+        }
+    };
+    const request: Request = new Request(
+        "http://www.andlabs.net/html5/uCOR.php",
+        requestOptions
+    );
+    const timeout: number = request.timeout;
+    const size: number = request.size;
+    const agent: Agent | ((parsedUrl: URL) => Agent) | undefined = request.agent;
+    const protocol: string = request.protocol;
+
+    handlePromise(fetch(request));
+}
+
+function test_fetchUrlObject() {
+    handlePromise(fetch(new URL("https://example.org")));
+}
+
+async function test_responseReturnTypes() {
+    const response = await fetch(new URL("https://example.org"));
+
+    // $ExpectType Blob
+    const blob = await response.clone().blob();
+
+    // $ExpectType string
+    const text = await response.clone().text();
+
+    // $ExpectType Buffer
+    const buffer = await response.clone().buffer();
+}
+
+function test_fetchUrlObjectWithRequestObject() {
+    const requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        signal: {
+            aborted: false,
+
+            addEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+                capture?: boolean | undefined,
+                once?: boolean | undefined,
+                passive?: boolean | undefined
+            }) => undefined,
+
+            removeEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+                capture?: boolean | undefined
+            }) => undefined,
+
+            dispatchEvent: (event: any) => false,
+            onabort: null,
+        }
+    };
+    const request: Request = new Request(
+        new URL("https://example.org"),
+        requestOptions
+    );
+    const timeout: number = request.timeout;
+    const size: number = request.size;
+    const agent: Agent | ((parsedUrl: URL) => Agent) | undefined = request.agent;
+    const protocol: string = request.protocol;
+
+    handlePromise(fetch(request));
+}
+
+function test_globalFetchVar() {
+    fetch("http://test.com", {}).then(response => {
+        // for test only
+    });
+}
+
+function handlePromise(
+    promise: Promise<Response>,
+    isArrayBuffer: boolean = false
+) {
+    promise
+        .then(
+            (response): Promise<string | ArrayBuffer> => {
+                if (response.type === "basic") {
+                    // for test only
+                }
+                if (isArrayBuffer) {
+                    return response.arrayBuffer();
+                } else {
+                    return response.text();
+                }
+            }
+        )
+        .then((text: string | ArrayBuffer) => {
+            console.log(text);
+        });
+}
+
+function test_headers() {
+    const headers = new Headers();
+    const myHeader = "foo";
+    headers.raw()[myHeader]; // $ExpectType string[]
+
+    [...headers]; // $ExpectType [string, string][]
+    [...headers.entries()]; // $ExpectType [string, string][]
+    [...headers.keys()]; // $ExpectType string[]
+    [...headers.values()]; // $ExpectType string[]
+}
+
+function test_isRedirect() {
+    fetch.isRedirect(301);
+    fetch.isRedirect(201);
+}
+
+function test_FetchError() {
+    new FetchError("message", "type", {
+        name: 'Error',
+        message: 'Error message',
+        code: "systemError",
+    });
+    new FetchError("message", "type", {
+        name: 'Error',
+        message: "Error without code",
+    });
+    new FetchError("message", "type");
+}
+
+function test_Blob() {
+    new Blob();
+    new Blob(["beep", "boop"]);
+    new Blob(["beep", "boop"], { endings: "native" });
+    new Blob(["beep", "boop"], { type: "text/plain" });
+}
+
+function test_ResponseInit() {
+    fetch("http://test.com", {}).then(response => {
+        new Response(response.body);
+        new Response(response.body, {
+            url: response.url,
+            size: response.size,
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+            timeout: response.timeout
+        });
+    });
+}
+
+async function test_BlobText() {
+    const someString = await new Blob(["Hello world"]).text(); // $ExpectType string
+}

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -19,7 +19,8 @@ function test_fetchUrlWithOptions() {
         method: "POST",
         redirect: "manual",
         size: 100,
-        timeout: 5000
+        timeout: 5000,
+        agent: false,
     };
     handlePromise(
         fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions)
@@ -75,7 +76,7 @@ function test_fetchUrlWithRequestObject() {
     );
     const timeout: number = request.timeout;
     const size: number = request.size;
-    const agent: Agent | ((parsedUrl: URL) => Agent) | undefined = request.agent;
+    const agent: Agent | ((parsedUrl: URL) => boolean | Agent | undefined) | boolean | undefined = request.agent;
     const protocol: string = request.protocol;
 
     handlePromise(fetch(request));
@@ -127,7 +128,7 @@ function test_fetchUrlObjectWithRequestObject() {
     );
     const timeout: number = request.timeout;
     const size: number = request.size;
-    const agent: Agent | ((parsedUrl: URL) => Agent) | undefined = request.agent;
+    const agent: Agent | ((parsedUrl: URL) => boolean | Agent | undefined) | boolean | undefined = request.agent;
     const protocol: string = request.protocol;
 
     handlePromise(fetch(request));

--- a/types/node-fetch/package.json
+++ b/types/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "form-data": "^3.0.0"
+        "form-data": "^2.3.3"
     }
 }

--- a/types/node-fetch/package.json
+++ b/types/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/node-fetch": "^2.5.12"
+        "form-data": "^3.0.0"
     }
 }

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -1,11 +1,14 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "ES6",
+        "target": "es6",
         "lib": [
             "es6"
         ],
-        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "ES6",
+        "lib": [
+            "es6"
+        ],
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-fetch-tests.ts"
+    ]
+}

--- a/types/node-fetch/tslint.json
+++ b/types/node-fetch/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json"
 }

--- a/types/node-fetch/tslint.json
+++ b/types/node-fetch/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/npm-registry-fetch/package.json
+++ b/types/npm-registry-fetch/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/node-fetch": "^2.5.12"
-    }
-}

--- a/types/proto-fetch/package.json
+++ b/types/proto-fetch/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/node-fetch": "^2.5.12"
-    }
-}

--- a/types/react-native-version-check/package.json
+++ b/types/react-native-version-check/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/node-fetch": "^2.5.12"
-    }
-}

--- a/types/zipkin-instrumentation-fetch/package.json
+++ b/types/zipkin-instrumentation-fetch/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "@types/node-fetch": "^2.5.12",
     "zipkin": ">=0.11.0",
     "zipkin-transport-http": "^0.12.0"
   }


### PR DESCRIPTION
As discussed with @sandersn on #55533, this PR restores previously-deleted types for `node-fetch@2`.  It updates the version from v2.5 to v2.6 and fixes an error in the types where `agent: false` was not allowed.

The individual commits in the PR have more detailed commit messages.