### PR TITLE
jsonwebtoken: Fix bug that takes wrong type of callback on asynchronous call in verify()

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -192,17 +192,6 @@ export function sign(
 ): void;
 
 /**
- * Synchronously verify given token using a secret or a public key to get a decoded token
- * token - JWT string to verify
- * secretOrPublicKey - Either the secret for HMAC algorithms, or the PEM encoded public key for RSA and ECDSA.
- * [options] - Options for the verification
- * returns - The decoded token.
- */
-export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
-export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions & { complete?: false }): JwtPayload | string;
-export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): Jwt | JwtPayload | string;
-
-/**
  * Asynchronously verify given token using a secret or a public key to get a decoded token
  * token - JWT string to verify
  * secretOrPublicKey - A string or buffer containing either the secret for HMAC algorithms,
@@ -234,6 +223,17 @@ export function verify(
     options?: VerifyOptions,
     callback?: VerifyCallback,
 ): void;
+
+/**
+ * Synchronously verify given token using a secret or a public key to get a decoded token
+ * token - JWT string to verify
+ * secretOrPublicKey - Either the secret for HMAC algorithms, or the PEM encoded public key for RSA and ECDSA.
+ * [options] - Options for the verification
+ * returns - The decoded token.
+ */
+export function verify(token: string, secretOrPublicKey: Secret, options: VerifyOptions & { complete: true }): Jwt;
+export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions & { complete?: false }): JwtPayload | string;
+export function verify(token: string, secretOrPublicKey: Secret, options?: VerifyOptions): Jwt | JwtPayload | string;
 
 /**
  * Returns the decoded payload without verifying if the signature is valid.


### PR DESCRIPTION
VerifyCallback was being interpreted as VerifyOptions, fliping the code and putting the asynchronous part at the top makes a workaround. I think the problem is that all properties are optional, and, in fact it can match anything I guess.

```
export interface VerifyOptions {
    algorithms?: Algorithm[] | undefined;
    audience?: string | RegExp | Array<string | RegExp> | undefined;
    clockTimestamp?: number | undefined;
    clockTolerance?: number | undefined;
    /** return an object with the decoded `{ payload, header, signature }` instead of only the usual content of the payload. */
    complete?: boolean | undefined;
    issuer?: string | string[] | undefined;
    ignoreExpiration?: boolean | undefined;
    ignoreNotBefore?: boolean | undefined;
    jwtid?: string | undefined;
    /**
     * If you want to check `nonce` claim, provide a string value here.
     * It is used on Open ID for the ID Tokens. ([Open ID implementation notes](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes))
     */
    nonce?: string | undefined;
    subject?: string | undefined;
    maxAge?: string | number | undefined;
}
```

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I was using [this code](https://github.com/rodjosh/games-catalogue/blob/main/server/src/jwt.ts) when found the error:
```
jwt.verify(req.cookies.user_token, JWT_SECRET, (err, decoded)=>{
	if (err) throw new Error("Invalid token");

	const payload = decoded as Payload;
	res.locals.username = payload.user;
	next();
})
```

Before changes: 

![image](https://user-images.githubusercontent.com/96924932/153312856-9797e3d4-b73b-4a3a-ae0c-fcaca006b71b.png)