### PR TITLE
[react-dual-listbox]: allow readonly options

### DIFF
--- a/types/react-dual-listbox/index.d.ts
+++ b/types/react-dual-listbox/index.d.ts
@@ -51,7 +51,7 @@ export interface CategoryOption<T> {
     /**
      * The category child options.
      */
-    options: Array<Option<T>>;
+    options: ReadonlyArray<Option<T>> | Array<Option<T>>;
 }
 
 /**
@@ -66,11 +66,11 @@ export interface Filter<T> {
     /**
      * Available options.
      */
-    available: T[];
+    available: readonly T[] | T[];
     /**
      * Selected options.
      */
-    selected: T[];
+    selected: readonly T[] | T[];
 }
 
 /**
@@ -80,11 +80,11 @@ export interface CommonProperties<T> {
     /**
      * Available options.
      */
-    options: Array<Option<T>>;
+    options: ReadonlyArray<Option<T>> | Array<Option<T>>;
     /**
      * Selected options.
      */
-    selected?: T[];
+    selected?: readonly T[] | T[];
     /**
      * A React function `ref` to the "selected" list box.
      */
@@ -105,7 +105,7 @@ export interface CommonProperties<T> {
      * A subset of the `options` array to optionally filter the available list
      * box.
      */
-    available?: T[];
+    available?: readonly T[] | T[];
     /**
      * A React function `ref` to the "available" list box.
      *

--- a/types/react-dual-listbox/react-dual-listbox-tests.tsx
+++ b/types/react-dual-listbox/react-dual-listbox-tests.tsx
@@ -7,6 +7,7 @@ const flatOptions: Array<ValueOption<string>> = [
     { label: 'One', value: 'one' }, // ValueOption<string>
     { label: 'Two', value: 'two' }, // ValueOption<string>
 ];
+const readonlyFlatOptions = flatOptions as ReadonlyArray<ValueOption<string>>;
 
 // Nested options
 const nestedOptions: Array<Option<string>> = [
@@ -24,6 +25,7 @@ const nestedOptions: Array<Option<string>> = [
         ],
     }, // CategoryOption<string>
 ]; // Option<string>[]
+const readonlyNestedOptions = nestedOptions as ReadonlyArray<Option<string>>;
 
 /** Example change handlers */
 // Simple value change handler.
@@ -33,12 +35,17 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
 
 /** Using flat and nested option structures. */
 <DualListBox options={flatOptions} className="foo" />;
+<DualListBox options={readonlyFlatOptions} className="foo" />;
 <DualListBox options={nestedOptions} />;
+<DualListBox options={readonlyNestedOptions} />;
 
 /** Selection examples. */
 <DualListBox options={flatOptions} onChange={valuesChange} />;
+<DualListBox options={readonlyFlatOptions} onChange={valuesChange} />;
 <DualListBox options={flatOptions} simpleValue onChange={valuesChange} />;
+<DualListBox options={readonlyFlatOptions} simpleValue onChange={valuesChange} />;
 <DualListBox options={flatOptions} simpleValue={false} onChange={optionsChange} />;
+<DualListBox options={readonlyFlatOptions} simpleValue={false} onChange={optionsChange} />;
 
 /** Selection error examples. */
 <DualListBox
@@ -61,11 +68,23 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
 
 /** Filtering examples. */
 <DualListBox options={flatOptions} canFilter={false} />;
+<DualListBox options={readonlyFlatOptions} canFilter={false} />;
 <DualListBox
     options={flatOptions}
     canFilter
     filter={{
         available: flatOptions.map(o => o.value),
+        selected: [],
+    }}
+    onFilterChange={() => {}}
+    filterPlaceholder={''}
+    filterCallback={(option: Option<string>) => true}
+/>;
+<DualListBox
+    options={readonlyFlatOptions}
+    canFilter
+    filter={{
+        available: readonlyFlatOptions.map(o => o.value),
         selected: [],
     }}
     onFilterChange={() => {}}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] **(N/A)** Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] **(N/A)** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Might be a better way to do this other than the duplication, I'm just not aware of a "maybe read-only, maybe not" type/util.