### PR TITLE
fix(clamscan): Readable stream reference & remove dom types dependency

### DIFF
--- a/types/clamscan/clamscan-tests.ts
+++ b/types/clamscan/clamscan-tests.ts
@@ -1,5 +1,5 @@
 import NodeClam = require('clamscan');
-import { PassThrough } from 'stream';
+import { PassThrough, Readable } from 'stream';
 
 import axios from 'axios';
 
@@ -7,38 +7,38 @@ const fakeVirusUrl = 'https://secure.eicar.org/eicar.com.txt';
 
 (async () => {
     try {
-      const clamscan = await new NodeClam().init({
-      debugMode: false,
-      clamdscan: {
-        bypassTest: true,
-        host: 'localhost',
-        port: 3310,
-      },
-    });
+        const clamscan = await new NodeClam().init({
+            debugMode: false,
+            clamdscan: {
+                bypassTest: true,
+                host: 'localhost',
+                port: 3310,
+            },
+        });
 
-    const version = await clamscan.getVersion();
-    console.log('Version: ', version);
+        const version = await clamscan.getVersion();
+        console.log('Version: ', version);
 
-    const { data } = await axios.get(fakeVirusUrl, {
-      responseType: 'stream',
-    });
+        const { data } = await axios.get<Readable>(fakeVirusUrl, {
+            responseType: 'stream',
+        });
 
-    const { isInfected, viruses } = await clamscan.scanStream(new PassThrough().pipe(data));
+        const { isInfected, viruses } = await clamscan.scanStream(data.pipe(new PassThrough()));
 
-    if (isInfected) {
-      console.log(
-        `You've downloaded a virus (${viruses.join(
-          ''
-        )})! Don't worry, it's only a test one and is not malicious...`
-      );
-    } else if (isInfected === null) {
-      console.log("Something didn't work right...");
-    } else if (!isInfected) {
-      console.log(`The file (${fakeVirusUrl}) you downloaded was just fine... Carry on...`);
+        if (isInfected) {
+            console.log(
+                `You've downloaded a virus (${viruses.join(
+                    '',
+                )})! Don't worry, it's only a test one and is not malicious...`,
+            );
+        } else if (isInfected === null) {
+            console.log("Something didn't work right...");
+        } else if (!isInfected) {
+            console.log(`The file (${fakeVirusUrl}) you downloaded was just fine... Carry on...`);
+        }
+        process.exit(0);
+    } catch (err) {
+        console.error(err);
+        process.exit(1);
     }
-    process.exit(0);
-  } catch (err) {
-    console.error(err);
-    process.exit(1);
-  }
 })();

--- a/types/clamscan/index.d.ts
+++ b/types/clamscan/index.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="node" />
 
-import { Transform } from 'stream';
+import { Readable, Transform } from 'stream';
 
 declare namespace NodeClam {
     interface Options {
@@ -203,13 +203,13 @@ declare class NodeClam {
      *
      * @see {@link https://github.com/kylefarris/clamscan#scanstreamstreamcallback}
      */
-    scanStream(stream: ReadableStream): Promise<
+    scanStream(stream: Readable): Promise<
         NodeClam.Response<{
             file: string;
             isInfected: boolean;
         }>
     >;
-    scanStream(stream: ReadableStream, cb?: (err: NodeClam.NodeClamError | null, isInfected: boolean) => void): void;
+    scanStream(stream: Readable, cb?: (err: NodeClam.NodeClamError | null, isInfected: boolean) => void): void;
 }
 
 export = NodeClam;

--- a/types/clamscan/tsconfig.json
+++ b/types/clamscan/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6", "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Replace `ReadableStream` from dom.d.ts with `stream.Readable` from @types/node.

Apologies for the mostly whitespace diff in clamscan-tests.ts. It autoformatted using the project's prettier config, so I figured it was ok to commit.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
