### PR TITLE
Add missing `Evented` methods

### DIFF
--- a/types/ember__routing/router-service.d.ts
+++ b/types/ember__routing/router-service.d.ts
@@ -288,6 +288,61 @@ export default class RouterService extends Service {
         callback: (transition: Transition) => void
     ): RouterService;
 
+     // https://api.emberjs.com/ember/3.28/classes/Evented/methods/off?anchor=off
+    /**
+     * Removes a callback for an event.
+     *
+     * The `routeWillChange` event is fired at the beginning of any attempted transition with a `Transition` object as the sole argument.
+     * This action can be used for aborting, redirecting, or decorating the transition from the currently active routes.
+     *
+     * The `routeDidChange` event only fires once a transition has settled.
+     * This includes aborts and error substates.
+     *
+     * @param name     the name of the event 'routeWillChange' | 'routeDidChange'
+     * @param callback the callback to remove
+     */
+    off(
+        name: 'routeDidChange' | 'routeWillChange',
+        callback: (transition: Transition) => void
+    ): RouterService;
+
+    /**
+     * https://api.emberjs.com/ember/3.28/classes/Evented/methods/off?anchor=has
+     *
+     * Checks to see if object has any subscriptions for named event.
+     *
+     * @param name
+     */
+    has(name: string): boolean;
+
+    /**
+     * https://api.emberjs.com/ember/3.28/classes/Evented/methods/off?anchor=one
+     *
+     * Subscribes a function to a named event and then cancels the subscription after the first time the
+     * event is triggered. It is good to use one when you only care about the first time an event has taken place.
+     *
+     * @param name     the name of the event
+     * @param callback the callback to execute
+     */
+    one(
+        name: 'routeDidChange' | 'routeWillChange',
+        callback: (transition: Transition) => void
+    ): RouterService;
+
+    /**
+     * https://api.emberjs.com/ember/3.28/classes/Evented/methods/off?anchor=trigger
+     *
+     * Triggers a named event for the object.
+     * Any additional arguments will be passed as parameters to the functions that are subscribed to the event.
+     *
+     * @param name the name of the event
+     * @param args arguments to pass to the event
+     */
+    trigger(
+        name: string,
+        args: any
+    ): void;
+
     /**
      * Takes a string URL and returns a `RouteInfo` for the leafmost route represented
      * by the URL. Returns `null` if the URL is not recognized. This method expects to

--- a/types/ember__routing/test/router-service.ts
+++ b/types/ember__routing/test/router-service.ts
@@ -12,6 +12,23 @@ router.transitionTo(
     { queryParams: {} },
 );
 
+const routeWillChangeHandler = () => {};
+
+// $ExpectType RouterService
+router.on('routeWillChange', routeWillChangeHandler);
+
+// $ExpectType boolean
+router.has('routeWillChange');
+
+// $ExpectType RouterService
+router.off('routeWillChange', routeWillChangeHandler);
+
+// $ExpectType RouterService
+router.one('routeWillChange', routeWillChangeHandler);
+
+// $ExpectType void
+router.trigger('routeWillChange', 'boo');
+
 const transition = router.transitionTo('someRoute');
 
 // $ExpectType Transition<unknown>


### PR DESCRIPTION
Currently the type definition for the RouterService only includes `on` from the `Evented` class, but all methods are added through `.reopen(Evented)` here https://github.com/emberjs/ember.js/blob/v4.1.0/packages/%40ember/-internals/routing/lib/services/router.ts#L519

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.emberjs.com/ember/3.28/classes/Evented