### PR TITLE
[react-virtualized] Remove redundant props from `List`

### DIFF
--- a/types/react-virtualized/dist/es/List.d.ts
+++ b/types/react-virtualized/dist/es/List.d.ts
@@ -1,8 +1,7 @@
-import { PureComponent, Validator, Requireable } from 'react';
+import { PureComponent } from 'react';
 import { Grid, GridCoreProps, GridCellProps, OverscanIndicesGetter } from './Grid';
-import { Index, IndexRange, OverscanIndexRange, Alignment } from '../../index';
-import { CellMeasurerCache, CellPosition } from './CellMeasurer';
-import { OnScrollParams } from './ScrollSync';
+import { IndexRange, OverscanIndexRange, Alignment } from '../../index';
+import { CellPosition } from './CellMeasurer';
 
 export type ListRowProps = Pick<GridCellProps, Exclude<keyof GridCellProps, 'rowIndex'>> & {
     index: GridCellProps['rowIndex'];
@@ -13,21 +12,6 @@ export type ListRowRenderer = (props: ListRowProps) => React.ReactNode;
 export type RenderedRows = OverscanIndexRange & IndexRange;
 
 export type ListProps = GridCoreProps & {
-    deferredMeasurementCache?: CellMeasurerCache | undefined;
-    /**
-     * Removes fixed height from the scrollingContainer so that the total height
-     * of rows can stretch the window. Intended for use with WindowScroller
-     */
-    autoHeight?: boolean | undefined;
-    /** Optional CSS class name */
-    className?: string | undefined;
-    /**
-     * Used to estimate the total height of a List before all of its rows have actually been measured.
-     * The estimated total height is adjusted as rows are rendered.
-     */
-    estimatedRowSize?: number | undefined;
-    /** Height constraint for list (determines how many actual rows are rendered) */
-    height: number;
     /** Optional renderer to be used in place of rows when rowCount is 0 */
     noRowsRenderer?: (() => JSX.Element) | undefined;
     /**
@@ -35,40 +19,10 @@ export type ListProps = GridCoreProps & {
      * ({ startIndex, stopIndex }): void
      */
     onRowsRendered?: ((info: RenderedRows) => void) | undefined;
-    /**
-     * Number of rows to render above/below the visible bounds of the list.
-     * These rows can help for smoother scrolling on touch devices.
-     */
-    overscanRowCount?: number | undefined;
-    /**
-     * Callback invoked whenever the scroll offset changes within the inner scrollable region.
-     * This callback can be used to sync scrolling between lists, tables, or grids.
-     * ({ clientHeight, scrollHeight, scrollTop }): void
-     */
-    onScroll?: ((params: OnScrollParams) => void) | undefined;
-    /** See Grid#overscanIndicesGetter */
-    overscanIndicesGetter?: OverscanIndicesGetter | undefined;
-    /**
-     * Either a fixed row height (number) or a function that returns the height of a row given its index.
-     * ({ index: number }): number
-     */
-    rowHeight: number | ((info: Index) => number);
     /** Responsible for rendering a row given an index; ({ index: number }): node */
     rowRenderer: ListRowRenderer;
-    /** Number of rows in list. */
-    rowCount: number;
-    /** See Grid#scrollToAlignment */
-    scrollToAlignment?: string | undefined;
     /** Row index to ensure visible (by forcefully scrolling if necessary) */
     scrollToIndex?: number | undefined;
-    /** Vertical offset. */
-    scrollTop?: number | undefined;
-    /** Optional inline style */
-    style?: React.CSSProperties | undefined;
-    /** Tab index for focus */
-    tabIndex?: number | null | undefined;
-    /** Width of list */
-    width: number;
 };
 /**
  * It is inefficient to create and manage a large list of DOM elements within a scrolling container


### PR DESCRIPTION
#58648 updated `Grid`'s prop types, but those didn't propagate to `List` because it duplicates them. This removes the duplicated props and just pulls them off of `Grid`.

This means the autocomplete documentation may refer to `Grid` instead of `List` in a few cases. Let me know if that's an issue and I can restore those.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test react-virtualized`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
