### PR TITLE
fixed-data-table-2: Add onRowContextMenu to TableProps

### DIFF
--- a/types/fixed-data-table-2/fixed-data-table-2-tests.tsx
+++ b/types/fixed-data-table-2/fixed-data-table-2-tests.tsx
@@ -178,6 +178,7 @@ class MyTable5 extends React.Component {
                 onScrollEnd={(x: number, y: number) => { }}
                 onContentHeightChange={(newHeight: number) => { }}
                 onRowClick={(event: React.SyntheticEvent<Table>, rowIndex: number) => { }}
+                onRowContextMenu={(event: React.SyntheticEvent<Table>, rowIndex: number) => { }}
                 onRowDoubleClick={(event: React.SyntheticEvent<Table>, rowIndex: number) => { }}
                 onRowMouseDown={(event: React.SyntheticEvent<Table>, rowIndex: number) => { }}
                 onRowMouseEnter={(event: React.SyntheticEvent<Table>, rowIndex: number) => { }}

--- a/types/fixed-data-table-2/index.d.ts
+++ b/types/fixed-data-table-2/index.d.ts
@@ -304,7 +304,7 @@ export interface TableProps extends React.ClassAttributes<Table> {
      * Callback that is called when a row is clicked.
      */
     onRowClick?: TableRowEventHandler | undefined;
-    
+
     /**
      * Callback that is called when a contextual-menu event happens on a row.
      */

--- a/types/fixed-data-table-2/index.d.ts
+++ b/types/fixed-data-table-2/index.d.ts
@@ -304,6 +304,11 @@ export interface TableProps extends React.ClassAttributes<Table> {
      * Callback that is called when a row is clicked.
      */
     onRowClick?: TableRowEventHandler | undefined;
+    
+    /**
+     * Callback that is called when a contextual-menu event happens on a row.
+     */
+    onRowContextMenu?: TableRowEventHandler | undefined;
 
     /**
      * Callback that is called when a row is double clicked.


### PR DESCRIPTION
onRowContextMenu was missing on TableProps even though it is defined in the propTypes of FixedDataTable (see: https://github.com/schrodinger/fixed-data-table-2/blob/master/src/FixedDataTable.js)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
