### PR TITLE
`@loadable/webpack-plugin`: Use `WebpackPluginInstance` instead of `Plugin`, for webpack@5

### DIFF
--- a/types/loadable__webpack-plugin/index.d.ts
+++ b/types/loadable__webpack-plugin/index.d.ts
@@ -29,7 +29,7 @@ interface PluginOptions {
 
 declare class LoadablePlugin implements webpack.WebpackPluginInstance {
     constructor(options?: PluginOptions);
-	apply: (compiler: webpack.Compiler) => void;
+    apply: (compiler: webpack.Compiler) => void;
 }
 
 export default LoadablePlugin;

--- a/types/loadable__webpack-plugin/index.d.ts
+++ b/types/loadable__webpack-plugin/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
-import webpack from 'webpack';
+import webpack = require('webpack');
 
 interface PluginOptions {
     /**
@@ -29,7 +29,7 @@ interface PluginOptions {
 
 declare class LoadablePlugin implements webpack.WebpackPluginInstance {
     constructor(options?: PluginOptions);
-    apply: (compiler: webpack.Compiler) => void;
+    apply(compiler: webpack.Compiler): void;
 }
 
 export default LoadablePlugin;

--- a/types/loadable__webpack-plugin/index.d.ts
+++ b/types/loadable__webpack-plugin/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
-import webpack = require('webpack');
+import * as webpack from 'webpack';
 
 interface PluginOptions {
     /**

--- a/types/loadable__webpack-plugin/index.d.ts
+++ b/types/loadable__webpack-plugin/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @loadable/webpack-plugin 5.7
 // Project: https://github.com/smooth-code/loadable-components
 // Definitions by: Spencer Miskoviak <https://github.com/skovy>
+//                 Max Duval <https://github.com/mxdvl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 

--- a/types/loadable__webpack-plugin/index.d.ts
+++ b/types/loadable__webpack-plugin/index.d.ts
@@ -27,8 +27,9 @@ interface PluginOptions {
     outputAsset?: boolean | undefined;
 }
 
-declare class LoadablePlugin extends webpack.Plugin {
+declare class LoadablePlugin implements webpack.WebpackPluginInstance {
     constructor(options?: PluginOptions);
+	apply: (compiler: webpack.Compiler) => void;
 }
 
 export default LoadablePlugin;

--- a/types/loadable__webpack-plugin/index.d.ts
+++ b/types/loadable__webpack-plugin/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.7
 
-import * as webpack from 'webpack';
+import webpack from 'webpack';
 
 interface PluginOptions {
     /**

--- a/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
+++ b/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
@@ -1,5 +1,5 @@
 import LoadablePlugin from '@loadable/webpack-plugin';
-import webpack from 'webpack';
+import webpack = require('webpack');
 
 let config: webpack.Configuration = {
   plugins: [new LoadablePlugin()],

--- a/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
+++ b/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
@@ -1,7 +1,7 @@
 import LoadablePlugin from '@loadable/webpack-plugin';
-import webpack = require('webpack');
+import { Configuration } from 'webpack';
 
-let config: webpack.Configuration = {
+let config: Configuration = {
   plugins: [new LoadablePlugin()],
 };
 

--- a/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
+++ b/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
@@ -1,7 +1,7 @@
 import LoadablePlugin from '@loadable/webpack-plugin';
-import { Configuration } from 'webpack';
+import webpack from 'webpack';
 
-let config: Configuration = {
+let config: webpack.Configuration = {
   plugins: [new LoadablePlugin()],
 };
 

--- a/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
+++ b/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
@@ -18,3 +18,7 @@ config = {
 config = {
   plugins: [new LoadablePlugin({ writeToDisk: { filename: 'stats.json' } })],
 };
+
+config = {
+    plugins: [new LoadablePlugin().apply]
+}

--- a/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
+++ b/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
@@ -1,7 +1,7 @@
 import LoadablePlugin from '@loadable/webpack-plugin';
-import { Configuration } from 'webpack';
+import * as webpack from 'webpack';
 
-let config: Configuration = {
+let config: webpack.Configuration = {
   plugins: [new LoadablePlugin()],
 };
 

--- a/types/loadable__webpack-plugin/package.json
+++ b/types/loadable__webpack-plugin/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "webpack": "^5"
+    }
+}

--- a/types/loadable__webpack-plugin/tsconfig.json
+++ b/types/loadable__webpack-plugin/tsconfig.json
@@ -5,7 +5,6 @@
             "es6"
         ],
         "noImplicitAny": true,
-        "esModuleInterop": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,

--- a/types/loadable__webpack-plugin/tsconfig.json
+++ b/types/loadable__webpack-plugin/tsconfig.json
@@ -14,9 +14,6 @@
             "../"
         ],
         "paths": {
-            "tapable": [
-                "tapable/v1"
-            ],
             "@loadable/*": [
                 "loadable__*"
             ]

--- a/types/loadable__webpack-plugin/tsconfig.json
+++ b/types/loadable__webpack-plugin/tsconfig.json
@@ -5,6 +5,7 @@
             "es6"
         ],
         "noImplicitAny": true,
+        "esModuleInterop": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
@@ -13,9 +14,6 @@
             "../"
         ],
         "paths": {
-            "webpack": [
-                "webpack/v4"
-            ],
             "tapable": [
                 "tapable/v1"
             ],


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [webpack/types.d.ts](https://github.com/webpack/webpack/blob/v5.0.0/types.d.ts#L9798) & [@loadable/webpack-plugin@5.12.2](https://unpkg.com/browse/@loadable/webpack-plugin@5.15.2/lib/index.js)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.