### PR TITLE
rdf-dataset-ext: toStream returns streams

### DIFF
--- a/types/rdf-dataset-ext/addAll.d.ts
+++ b/types/rdf-dataset-ext/addAll.d.ts
@@ -1,3 +1,10 @@
-import { addAll } from '.';
+import { BaseQuad, DatasetCore, Quad } from "rdf-js";
 
-export = addAll;
+/**
+ * Iterates over iterable and adds all quads to dataset by calling `.add` for each quad.
+ *
+ * Returns the given dataset.
+ */
+declare function addAll<Q extends BaseQuad = Quad, D extends DatasetCore<Q> = DatasetCore<Q>>(dataset: D, iterable: Iterable<Q>): D;
+
+export =  addAll;

--- a/types/rdf-dataset-ext/deleteMatch.d.ts
+++ b/types/rdf-dataset-ext/deleteMatch.d.ts
@@ -1,3 +1,10 @@
-import { deleteMatch } from '.';
+import { BaseQuad, DatasetCore, Term } from "rdf-js";
+
+/**
+ * Deletes all quads in the given dataset which match the given subject, predicate, object, graph pattern.
+ *
+ * `.match` of dataset is used to find the matches and .delete to delete all matches. Returns the given dataset.
+ */
+declare function deleteMatch<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, subject?: Term, predicate?: Term, object?: Term, graph?: Term): D;
 
 export = deleteMatch;

--- a/types/rdf-dataset-ext/equals.d.ts
+++ b/types/rdf-dataset-ext/equals.d.ts
@@ -1,3 +1,12 @@
-import { equals } from '.';
+import { BaseQuad, DatasetCore } from "rdf-js";
+
+/**
+ * Tests if the datasets a and b contain the same quads without doing a normalization step beforehand.
+ *
+ * That means Blank Node labels must also match. The comparison is done by testing `.size` of both dataset for
+ * equality and by looping over all quads of a and check if b contains it using the `.has` method. Returns `true` if
+ * both datasets are equal. Otherwise `false `is returned.
+ */
+declare function equals(a: DatasetCore<BaseQuad>, b: DatasetCore<BaseQuad>): boolean;
 
 export = equals;

--- a/types/rdf-dataset-ext/fromStream.d.ts
+++ b/types/rdf-dataset-ext/fromStream.d.ts
@@ -1,3 +1,11 @@
-import { fromStream } from '.';
+import { BaseQuad, DatasetCore } from "rdf-js";
+import { EventEmitter } from "stream";
+
+/**
+ * Adds all quads from stream till the stream is finished.
+ *
+ * Errors emitted by the stream are forwarded as Promise rejects. Returns the given dataset.
+ */
+declare function fromStream<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, stream: EventEmitter): Promise<D>;
 
 export = fromStream;

--- a/types/rdf-dataset-ext/index.d.ts
+++ b/types/rdf-dataset-ext/index.d.ts
@@ -3,45 +3,20 @@
 // Definitions by: Chris Wilkinson <https://github.com/thewilkybarkid>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { EventEmitter } from 'events';
-import { BaseQuad, DatasetCore, Quad, Stream, Term } from 'rdf-js';
+import addAll = require('./addAll');
+import deleteMatch = require('./deleteMatch');
+import equals = require('./equals');
+import fromStream = require('./fromStream');
+import toCanonical = require('./toCanonical');
+import toStream = require('./toStream');
 
-/**
- * Iterates over iterable and adds all quads to dataset by calling `.add` for each quad.
- *
- * Returns the given dataset.
- */
-export function addAll<Q extends BaseQuad = Quad, D extends DatasetCore<Q> = DatasetCore<Q>>(dataset: D, iterable: Iterable<Q>): D;
+declare const datasetExt: {
+    addAll: typeof addAll,
+    deleteMatch: typeof deleteMatch,
+    equals: typeof equals,
+    fromStream: typeof fromStream,
+    toCanonical: typeof toCanonical,
+    toStream: typeof toStream
+};
 
-/**
- * Deletes all quads in the given dataset which match the given subject, predicate, object, graph pattern.
- *
- * `.match` of dataset is used to find the matches and .delete to delete all matches. Returns the given dataset.
- */
-export function deleteMatch<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, subject?: Term, predicate?: Term, object?: Term, graph?: Term): D;
-
-/**
- * Tests if the datasets a and b contain the same quads without doing a normalization step beforehand.
- *
- * That means Blank Node labels must also match. The comparison is done by testing `.size` of both dataset for
- * equality and by looping over all quads of a and check if b contains it using the `.has` method. Returns `true` if
- * both datasets are equal. Otherwise `false `is returned.
- */
-export function equals(a: DatasetCore<BaseQuad>, b: DatasetCore<BaseQuad>): boolean;
-
-/**
- * Adds all quads from stream till the stream is finished.
- *
- * Errors emitted by the stream are forwarded as Promise rejects. Returns the given dataset.
- */
-export function fromStream<D extends DatasetCore<BaseQuad> = DatasetCore>(dataset: D, stream: EventEmitter): Promise<D>;
-
-/**
- * Returns the canonical representation of the dataset as string.
- */
-export function toCanonical(dataset: DatasetCore<BaseQuad>): string;
-
-/**
- * Creates a `Stream` which emits all quads of the given dataset. Returns the created stream.
- */
-export function toStream<Q extends BaseQuad = Quad>(dataset: DatasetCore<Q>): Stream<Q>;
+export = datasetExt;

--- a/types/rdf-dataset-ext/rdf-dataset-ext-tests.ts
+++ b/types/rdf-dataset-ext/rdf-dataset-ext-tests.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { Readable, EventEmitter } from 'stream';
 import { BaseQuad, DatasetCore, Quad, Stream, Term } from 'rdf-js';
 import grouped = require('rdf-dataset-ext');
 import addAll = require('rdf-dataset-ext/addAll');
@@ -78,9 +78,9 @@ const toCanonical4: string = grouped.toCanonical(dataset2);
 
 // toStream
 
-const toStream1: Stream = toStream(dataset1);
-const toStream2: Stream<BaseQuad> = toStream(dataset2);
-const toStream3: Stream<BaseQuad> = toStream<BaseQuad>(dataset2);
-const toStream4: Stream = grouped.toStream(dataset1);
-const toStream5: Stream<BaseQuad> = grouped.toStream(dataset2);
-const toStream6: Stream<BaseQuad> = grouped.toStream<BaseQuad>(dataset2);
+const toStream1: Readable & Stream = toStream(dataset1);
+const toStream2: Readable & Stream<BaseQuad> = toStream(dataset2);
+const toStream3: Readable & Stream<BaseQuad> = toStream<BaseQuad>(dataset2);
+const toStream4: Readable & Stream = grouped.toStream(dataset1);
+const toStream5: Readable & Stream<BaseQuad> = grouped.toStream(dataset2);
+const toStream6: Readable & Stream<BaseQuad> = grouped.toStream<BaseQuad>(dataset2);

--- a/types/rdf-dataset-ext/toCanonical.d.ts
+++ b/types/rdf-dataset-ext/toCanonical.d.ts
@@ -1,3 +1,8 @@
-import { toCanonical } from '.';
+import { BaseQuad, DatasetCore } from "rdf-js";
+
+/**
+ * Returns the canonical representation of the dataset as string.
+ */
+declare function toCanonical(dataset: DatasetCore<BaseQuad>): string;
 
 export = toCanonical;

--- a/types/rdf-dataset-ext/toStream.d.ts
+++ b/types/rdf-dataset-ext/toStream.d.ts
@@ -1,5 +1,5 @@
 import { BaseQuad, DatasetCore, Quad, Stream } from 'rdf-js';
-import { Readable } from 'stream';
+import { Readable } from 'readable-stream';
 
 /**
  * Creates a `Stream` which emits all quads of the given dataset. Returns the created stream.

--- a/types/rdf-dataset-ext/toStream.d.ts
+++ b/types/rdf-dataset-ext/toStream.d.ts
@@ -1,8 +1,9 @@
 import { BaseQuad, DatasetCore, Quad, Stream } from 'rdf-js';
+import { Readable } from 'stream';
 
 /**
  * Creates a `Stream` which emits all quads of the given dataset. Returns the created stream.
  */
-declare function toStream<Q extends BaseQuad = Quad>(dataset: DatasetCore<Q>): Stream<Q>;
+declare function toStream<Q extends BaseQuad = Quad>(dataset: DatasetCore<Q>): Stream<Q> & Readable;
 
 export = toStream;

--- a/types/rdf-dataset-ext/toStream.d.ts
+++ b/types/rdf-dataset-ext/toStream.d.ts
@@ -1,3 +1,8 @@
-import { toStream } from '.';
+import { BaseQuad, DatasetCore, Quad, Stream } from 'rdf-js';
+
+/**
+ * Creates a `Stream` which emits all quads of the given dataset. Returns the created stream.
+ */
+declare function toStream<Q extends BaseQuad = Quad>(dataset: DatasetCore<Q>): Stream<Q>;
 
 export = toStream;


### PR DESCRIPTION
Most importantly, I changed the return type of `toStream` and I also moved the exports to individual modules as they appear in the package, where `index.js` re-exports as an object. The current ESM-style exports were inaccurate

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/rdf-ext/rdf-dataset-ext/blob/master/toStream.js#L1>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

