### PR TITLE
change type assignments to interfaces for augmentation purposes

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -172,7 +172,7 @@ declare class WebSocket extends EventEmitter {
 }
 
 declare const WebSocketAlias: typeof WebSocket;
-interface WebSocketAlias extends WebSocket {}
+interface WebSocketAlias extends WebSocket {} // tslint:disable-line no-empty-interface
 
 declare namespace WebSocket {
     /**
@@ -348,9 +348,9 @@ declare namespace WebSocket {
     }
 
     const WebSocketServer: typeof Server;
-    interface WebSocketServer extends Server {}
+    interface WebSocketServer extends Server {} // tslint:disable-line no-empty-interface
     const WebSocket: typeof WebSocketAlias;
-    interface WebSocket extends WebSocketAlias {}
+    interface WebSocket extends WebSocketAlias {} // tslint:disable-line no-empty-interface
 
     // WebSocket stream
     function createWebSocketStream(websocket: WebSocket, options?: DuplexOptions): Duplex;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -7,6 +7,7 @@
 //                 teidesu <https://github.com/teidesu>
 //                 Bartosz Wojtkowiak <https://github.com/wojtkowiak>
 //                 Kyle Hensel <https://github.com/k-yle>
+//                 Samuel Skeen <https://github.com/cwadrupldijjit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -171,7 +172,7 @@ declare class WebSocket extends EventEmitter {
 }
 
 declare const WebSocketAlias: typeof WebSocket;
-type WebSocketAlias = WebSocket;
+interface WebSocketAlias extends WebSocket {}
 
 declare namespace WebSocket {
     /**
@@ -347,9 +348,9 @@ declare namespace WebSocket {
     }
 
     const WebSocketServer: typeof Server;
-    type WebSocketServer = Server;
+    interface WebSocketServer extends Server {}
     const WebSocket: typeof WebSocketAlias;
-    type WebSocket = WebSocketAlias;
+    interface WebSocket extends WebSocketAlias {}
 
     // WebSocket stream
     function createWebSocketStream(websocket: WebSocket, options?: DuplexOptions): Duplex;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -324,7 +324,7 @@ declare module 'ws' {
 {
     const ws: wslib.WebSocket = new wslib.WebSocket('ws://www.host.com/path');
 
-    // $ExpectType string
+    // $ExpectType string | undefined
     ws.id;
     ws.id = 'foo';
 }

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -319,12 +319,20 @@ declare module 'ws' {
     interface WebSocket {
         id?: string;
     }
+
+    interface Server {
+        getWebSocketId(): string;
+    }
 }
 
 {
-    const ws: wslib.WebSocket = new wslib.WebSocket('ws://www.host.com/path');
+    const server = new wslib.WebSocketServer();
 
-    // $ExpectType string | undefined
-    ws.id;
-    ws.id = 'foo';
+    server.on('connection', (ws) => {
+
+        // $ExpectType string | undefined
+        ws.id;
+
+        ws.id = server.getWebSocketId();
+    });
 }

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -329,7 +329,6 @@ declare module 'ws' {
     const server = new wslib.WebSocketServer();
 
     server.on('connection', (ws) => {
-
         // $ExpectType string | undefined
         ws.id;
 

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -314,3 +314,17 @@ function f() {
         }
     });
 }
+
+declare module 'ws' {
+    interface WebSocket {
+        id?: string;
+    }
+}
+
+{
+    const ws: wslib.WebSocket = new wslib.WebSocket('ws://www.host.com/path');
+
+    // $ExpectType string
+    ws.id;
+    ws.id = 'foo';
+}


### PR DESCRIPTION
## Motivations for this change

I sought to augment the WebSocket implementation for a project I'm working on and I discovered that because of the `type` assignments (such as the `type WebSocket = WebSocketAlias;`) made such a thing impossible.  I imagine some implementations with WS could benefit from type augmentation, similar to how Express handles the `Request` and `Response` objects.

## PR Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A (implementation of WS is the same, type definition is tweaked slightly with no breaking changes)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (Also N/A)
