### PR TITLE
chore: use `jest-matcher-utils` in `@types/jest`

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -485,35 +485,6 @@ declare namespace jest {
         each: Each;
     }
 
-    type PrintLabel = (string: string) => string;
-
-    type MatcherHintColor = (arg: string) => string;
-
-    interface MatcherHintOptions {
-        comment?: string | undefined;
-        expectedColor?: MatcherHintColor | undefined;
-        isDirectExpectCall?: boolean | undefined;
-        isNot?: boolean | undefined;
-        promise?: string | undefined;
-        receivedColor?: MatcherHintColor | undefined;
-        secondArgument?: string | undefined;
-        secondArgumentColor?: MatcherHintColor | undefined;
-    }
-
-    interface ChalkFunction {
-        (text: TemplateStringsArray, ...placeholders: any[]): string;
-        (...text: any[]): string;
-    }
-
-    interface ChalkColorSupport {
-        level: 0 | 1 | 2 | 3;
-        hasBasic: boolean;
-        has256: boolean;
-        has16m: boolean;
-    }
-
-    type MatcherColorFn = ChalkFunction & { supportsColor: ChalkColorSupport };
-
     type EqualityTester = (a: any, b: any) => boolean | undefined;
 
     interface MatcherUtils {
@@ -527,41 +498,7 @@ declare namespace jest {
         readonly expand: boolean;
         readonly testPath: string;
         readonly currentTestName: string;
-        utils: {
-            readonly EXPECTED_COLOR: MatcherColorFn;
-            readonly RECEIVED_COLOR: MatcherColorFn;
-            readonly INVERTED_COLOR: MatcherColorFn;
-            readonly BOLD_WEIGHT: MatcherColorFn;
-            readonly DIM_COLOR: MatcherColorFn;
-            readonly SUGGEST_TO_CONTAIN_EQUAL: string;
-            diff(a: any, b: any, options?: import("jest-diff").DiffOptions): string | null;
-            ensureActualIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
-            ensureExpectedIsNumber(actual: any, matcherName: string, options?: MatcherHintOptions): void;
-            ensureNoExpected(actual: any, matcherName: string, options?: MatcherHintOptions): void;
-            ensureNumbers(actual: any, expected: any, matcherName: string, options?: MatcherHintOptions): void;
-            ensureExpectedIsNonNegativeInteger(expected: any, matcherName: string, options?: MatcherHintOptions): void;
-            matcherHint(
-                matcherName: string,
-                received?: string,
-                expected?: string,
-                options?: MatcherHintOptions
-            ): string;
-            matcherErrorMessage(
-              hint: string,
-              generic: string,
-              specific: string
-            ): string;
-            pluralize(word: string, count: number): string;
-            printReceived(object: any): string;
-            printExpected(value: any): string;
-            printWithType(name: string, value: any, print: (value: any) => string): string;
-            stringify(object: {}, maxDepth?: number): string;
-            highlightTrailingWhitespace(text: string): string;
-
-            printDiffOrStringify(expected: any, received: any, expectedLabel: string, receivedLabel: string, expand: boolean): string;
-
-            getLabelPrinter(...strings: string[]): PrintLabel;
-
+        utils: typeof import('jest-matcher-utils') & {
             iterableEquality: EqualityTester;
             subsetEquality: EqualityTester;
         };

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -858,7 +858,7 @@ expect.extend({
 
         const receivedPrinted: string = this.utils.printReceived({});
 
-        const printedWithType: string = this.utils.printWithType('name', {}, (value: {}) => '');
+        const printedWithType: string = this.utils.printWithType('name', {}, (value) => '');
 
         const stringified: string = this.utils.stringify({});
         const stringifiedWithMaxDepth: string = this.utils.stringify({}, 3);

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "jest-diff": "^27.0.0",
+        "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
     },
     "exports": {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

In an ongoing quest to make #44365 mergable, let's try to load more types from Jest itself. This time `this.utils` inside custom matchers.

I was unable to test this, just getting `Error: ENOENT: no such file or directory, open '../notNeededPackages.json'` when attempting to run `npm install && npm test jest` 🤷 

EDIT: `npm run test-all` works