### PR TITLE
node/process: Don't require second signal on emit

### DIFF
--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -1405,7 +1405,7 @@ declare module 'process' {
                 emit(event: 'unhandledRejection', reason: unknown, promise: Promise<unknown>): boolean;
                 emit(event: 'warning', warning: Error): boolean;
                 emit(event: 'message', message: unknown, sendHandle: unknown): this;
-                emit(event: Signals, signal: Signals): boolean;
+                emit(event: Signals, signal?: Signals): boolean;
                 emit(event: 'multipleResolves', type: MultipleResolveType, promise: Promise<unknown>, value: unknown): this;
                 emit(event: 'worker', listener: WorkerListener): this;
                 on(event: 'beforeExit', listener: BeforeExitListener): this;

--- a/types/node/test/process.ts
+++ b/types/node/test/process.ts
@@ -24,6 +24,7 @@ import EventEmitter = require('node:events');
     process.once("warning", (warning: Error) => { });
     process.prependListener("message", (message: any, sendHandle: any) => { });
     process.prependOnceListener("SIGBREAK", () => { });
+    process.emit("SIGINT");
     process.on("newListener", (event: string | symbol, listener: Function) => { });
     process.once("removeListener", (event: string | symbol, listener: Function) => { });
     process.on("multipleResolves", (type: NodeJS.MultipleResolveType, prom: Promise<any>, value: any) => {});


### PR DESCRIPTION
Though official documentation that I can find is very sparse, there are various examples of process.emit('SIGINT'); or similar with a different signal, which fails according to this types definition that requires two Signals rather than just one.

Replaces #58477

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Example of `process.emit()`](https://stackoverflow.com/a/36099258)

