### PR TITLE
add definitions for ecef-projector 1.0.1

### DIFF
--- a/types/ecef-projector/ecef-projector-tests.ts
+++ b/types/ecef-projector/ecef-projector-tests.ts
@@ -1,0 +1,7 @@
+import { project, unproject } from 'ecef-projector';
+
+// $ExpectType number[]
+const ll = project(35.0, 135.0, 10.1);
+
+// $ExpectType number[]
+const ret = unproject(2222222, 1000, 1111);

--- a/types/ecef-projector/index.d.ts
+++ b/types/ecef-projector/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for ecef-projector 1.0.1
+// Project: https://github.com/lakowske/ecef-projector/blob/master/README.md
+// Definitions by: Takao Funami <https://github.com/funami>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function project(latitude: number, longitude: number, altitude: number): number[];
+export function unproject(x: number, y: number, z: number): number[];

--- a/types/ecef-projector/tsconfig.json
+++ b/types/ecef-projector/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "index.d.ts",
+      "ecef-projector-tests.ts"
+  ]
+}

--- a/types/ecef-projector/tsconfig.json
+++ b/types/ecef-projector/tsconfig.json
@@ -6,8 +6,8 @@
       ],
       "noImplicitAny": true,
       "noImplicitThis": true,
-      "strictNullChecks": true,
       "strictFunctionTypes": true,
+      "strictNullChecks": true,
       "baseUrl": "../",
       "typeRoots": [
           "../"

--- a/types/ecef-projector/tslint.json
+++ b/types/ecef-projector/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dtslint.json" }

--- a/types/ecef-projector/tslint.json
+++ b/types/ecef-projector/tslint.json
@@ -1,1 +1,1 @@
-{ "extends": "@definitelytyped/dtslint/dtslint.json" }
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
