### PR TITLE
[braintree-web]:  in tokenize method, update options type

### DIFF
--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -308,9 +308,10 @@ export interface HostedFields {
         vault?: boolean | undefined;
         cardholderName?: string | undefined;
         billingAddress?: any;
+        fieldsToTokenize?: string[];
     }): Promise<HostedFieldsTokenizePayload>;
     tokenize(
-        options: { vault?: boolean | undefined; cardholderName?: string | undefined; billingAddress?: any },
+        options: { vault?: boolean | undefined; cardholderName?: string | undefined; billingAddress?: any; fieldsToTokenize?: string[] },
         callback: callback<HostedFieldsTokenizePayload>,
     ): void;
     tokenize(callback: callback<HostedFieldsTokenizePayload>): void;

--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -308,10 +308,10 @@ export interface HostedFields {
         vault?: boolean | undefined;
         cardholderName?: string | undefined;
         billingAddress?: any;
-        fieldsToTokenize?: string[];
+        fieldsToTokenize?: string[] | undefined;
     }): Promise<HostedFieldsTokenizePayload>;
     tokenize(
-        options: { vault?: boolean | undefined; cardholderName?: string | undefined; billingAddress?: any; fieldsToTokenize?: string[] },
+        options: { vault?: boolean | undefined; cardholderName?: string | undefined; billingAddress?: any; fieldsToTokenize?: string[] | undefined},
         callback: callback<HostedFieldsTokenizePayload>,
     ): void;
     tokenize(callback: callback<HostedFieldsTokenizePayload>): void;


### PR DESCRIPTION
Updates `tokenize` method `options` parameter type on the braintree-web package.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Hosted Fields Reference](https://braintree.github.io/braintree-web/current/HostedFields.html#main)
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header~~. Hosted Fields already had fieldsToTokenize in the options parameter of tokenize method in an earlier version than the current typings indicate, hence not updating the version listed by the typings.
