### PR TITLE
node/fs: Add read with fewer params

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ f(1);
 f("one");
 ```
 
-For more details, see [dtslint](https://github.com/Microsoft/dtslint#write-tests) readme.
+For more details, see [dtslint](https://github.com/Microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests) readme.
 
 #### Linter: `tslint.json`
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ f(1);
 f("one");
 ```
 
-For more details, see [dtslint](https://github.com/Microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests) readme.
+For more details, see [dtslint](https://github.com/Microsoft/dtslint#write-tests) readme.
 
 #### Linter: `tslint.json`
 

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2247,7 +2247,6 @@ declare module 'fs' {
          */
         position?: ReadPosition | null | undefined;
     }
-    // tslint:disable-next-line:no-unnecessary-generics
     export interface ReadAsyncOptions<TBuffer extends NodeJS.ArrayBufferView> extends ReadSyncOptions {
         buffer?: TBuffer;
     }

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2248,7 +2248,7 @@ declare module 'fs' {
         position?: ReadPosition | null | undefined;
     }
     // tslint:disable-next-line:no-unnecessary-generics
-    export interface readAsyncOptions<TBuffer extends NodeJS.ArrayBufferView> extends ReadSyncOptions {
+    export interface ReadAsyncOptions<TBuffer extends NodeJS.ArrayBufferView> extends ReadSyncOptions {
         buffer?: TBuffer;
     }
     /**
@@ -2287,7 +2287,7 @@ declare module 'fs' {
      */
     export function read<TBuffer extends NodeJS.ArrayBufferView>(
         fd: number,
-        options: readAsyncOptions<TBuffer>,
+        options: ReadAsyncOptions<TBuffer>,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
     ): void;
     export function read(
@@ -2314,7 +2314,7 @@ declare module 'fs' {
         }>;
         function __promisify__<TBuffer extends NodeJS.ArrayBufferView>(
             fd: number,
-            options: readAsyncOptions<TBuffer>,
+            options: ReadAsyncOptions<TBuffer>,
             callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
         ): void;
         function __promisify__(

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2247,6 +2247,10 @@ declare module 'fs' {
          */
         position?: ReadPosition | null | undefined;
     }
+    // tslint:disable-next-line:no-unnecessary-generics
+    export interface readAsyncOptions<TBuffer extends NodeJS.ArrayBufferView> extends ReadSyncOptions {
+        buffer?: TBuffer;
+    }
     /**
      * Read data from the file specified by `fd`.
      *
@@ -2272,6 +2276,25 @@ declare module 'fs' {
         position: ReadPosition | null,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
     ): void;
+    /**
+     * Similar to the above `fs.read` function, this version takes an optional `options` object.
+     * If not otherwise specified in an `options` object,
+     * `buffer` defaults to `Buffer.alloc(16384)`,
+     * `offset` defaults to `0`,
+     * `length` defaults to `buffer.byteLength`,  `- offset` after https://github.com/nodejs/node/pull/40349 is merged
+     * `position` defaults to `null`
+     * @since v12.17.0, 13.11.0
+     */
+    export function read<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        options: readAsyncOptions<TBuffer>,
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
+    ): void;
+    export function read<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        // tslint:disable-next-line:no-unnecessary-generics
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
+    ): void;
     export namespace read {
         /**
          * @param fd A file descriptor.
@@ -2290,6 +2313,16 @@ declare module 'fs' {
             bytesRead: number;
             buffer: TBuffer;
         }>;
+        function __promisify__<TBuffer extends NodeJS.ArrayBufferView>(
+            fd: number,
+            options: readAsyncOptions<TBuffer>,
+            callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
+        ): void;
+        function __promisify__<TBuffer extends NodeJS.ArrayBufferView>(
+            fd: number,
+            // tslint:disable-next-line:no-unnecessary-generics
+            callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
+        ): void;
     }
     /**
      * Returns the number of `bytesRead`.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2290,10 +2290,9 @@ declare module 'fs' {
         options: readAsyncOptions<TBuffer>,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
     ): void;
-    export function read<TBuffer extends NodeJS.ArrayBufferView>(
+    export function read(
         fd: number,
-        // tslint:disable-next-line:no-unnecessary-generics
-        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => void
     ): void;
     export namespace read {
         /**
@@ -2318,10 +2317,9 @@ declare module 'fs' {
             options: readAsyncOptions<TBuffer>,
             callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
         ): void;
-        function __promisify__<TBuffer extends NodeJS.ArrayBufferView>(
+        function __promisify__(
             fd: number,
-            // tslint:disable-next-line:no-unnecessary-generics
-            callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
+            callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => void
         ): void;
     }
     /**

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2281,7 +2281,7 @@ declare module 'fs' {
      * If not otherwise specified in an `options` object,
      * `buffer` defaults to `Buffer.alloc(16384)`,
      * `offset` defaults to `0`,
-     * `length` defaults to `buffer.byteLength`,  `- offset` after https://github.com/nodejs/node/pull/40349 is merged
+     * `length` defaults to `buffer.byteLength`, `- offset` as of Node 17.6.0
      * `position` defaults to `null`
      * @since v12.17.0, 13.11.0
      */

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2314,13 +2314,17 @@ declare module 'fs' {
         }>;
         function __promisify__<TBuffer extends NodeJS.ArrayBufferView>(
             fd: number,
-            options: ReadAsyncOptions<TBuffer>,
-            callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void
-        ): void;
+            options: ReadAsyncOptions<TBuffer>
+        ): Promise<{
+            bytesRead: number;
+            buffer: TBuffer;
+        }>;
         function __promisify__(
-            fd: number,
-            callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => void
-        ): void;
+            fd: number
+        ): Promise<{
+            bytesRead: number;
+            buffer: NodeJS.ArrayBufferView;
+        }>;
     }
     /**
      * Returns the number of `bytesRead`.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2233,6 +2233,20 @@ declare module 'fs' {
      */
     export function writeSync(fd: number, string: string, position?: number | null, encoding?: BufferEncoding | null): number;
     export type ReadPosition = number | bigint;
+    export interface ReadSyncOptions {
+        /**
+         * @default 0
+         */
+        offset?: number | undefined;
+        /**
+         * @default `length of buffer`
+         */
+        length?: number | undefined;
+        /**
+         * @default null
+         */
+        position?: ReadPosition | null | undefined;
+    }
     /**
      * Read data from the file specified by `fd`.
      *
@@ -2276,20 +2290,6 @@ declare module 'fs' {
             bytesRead: number;
             buffer: TBuffer;
         }>;
-    }
-    export interface ReadSyncOptions {
-        /**
-         * @default 0
-         */
-        offset?: number | undefined;
-        /**
-         * @default `length of buffer`
-         */
-        length?: number | undefined;
-        /**
-         * @default null
-         */
-        position?: ReadPosition | null | undefined;
     }
     /**
      * Returns the number of `bytesRead`.

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -93,8 +93,18 @@ import { CopyOptions, cpSync, cp } from 'fs';
 }
 
 {
+    // 6-param version using no default options:
     fs.read(1, new DataView(new ArrayBuffer(1)), 0, 1, 0, (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: DataView) => { });
     fs.read(1, Buffer.from('test'), 1, 2, 123n, () => { });
+    // 3-param version using no default options:
+    fs.read(1, {buffer: new DataView(new ArrayBuffer(1)), offset: 0, length: 1, position: 0}, (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: DataView) => { });
+    fs.read(1, {buffer: Buffer.from('test'), offset: 1, length: 2, position: 123n}, () => { });
+    // 3-param version using some default options:
+    fs.read(1, {length: 1, position: 0}, (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => { });
+    fs.read(1, {buffer: Buffer.from('test'), position: 123n}, () => { });
+    // 2-param version using all-default options:
+    fs.read(1, (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => { });
+    fs.read(1, () => { });
 }
 
 {


### PR DESCRIPTION
This PR is intended to fix https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58710.

The test suite for existing code included a test in which a DataView was passed for the `buffer` param, and the test verified that this narrowing of the type carried through to the callback.  This type is now part of an Options object and though I may be just too new to Typescript, I don't know how to specify an exportable interface type inline to be able to have the generic type used multiple times in the same function definition as is done for the 6-param version, without separately defining the interface in a way that required disabling a linting rule normally preventing use of that generic.  If there is a better way to do that, I'm open to changes, or if carrying the narrowing through isn't needed we can weaken the tests.  I think it's a decent test to check for, but if weakening that particular test is needed to get the 3-param version definition in, it would still be an improvement over the status quo preventing use of that version of the function in Typescript.  Disabling the linting rule on the one line seemed the least obtrusive option within my present Typescript skill set.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://nodejs.org/api/fs.html#fsreadfd-options-callback](https://nodejs.org/api/fs.html#fsreadfd-options-callback)
