### PR TITLE
fix(node-fetch): restore form-data dependency to ^3.0.0

### DIFF
--- a/types/node-fetch/package.json
+++ b/types/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/form-data": "2.2.1"
+        "form-data": "2.5.0"
     }
 }

--- a/types/node-fetch/package.json
+++ b/types/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "form-data": "2.5.0"
+        "form-data": "^3.0.0"
     }
 }

--- a/types/node-fetch/package.json
+++ b/types/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/form-data": "^2.3.3"
+        "@types/form-data": "2.2.1"
     }
 }

--- a/types/node-fetch/package.json
+++ b/types/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "form-data": "^2.3.3"
+        "@types/form-data": "^2.3.3"
     }
 }


### PR DESCRIPTION
We recently restored the deleted node-fetch types. We lowered
the dependency on form-data from `^3.0.0` to `^2.3.3` since that's
what the dev dependency in `node-fetch@2` itself had but that older
version didn't ship its own types.

This PR restores the dependency to the same constraint it had when
we previously published `@types/node-fetch`. While it seems a bit
suspect to depend on a newer major version than `node-fetch` does,
the only change in `form-data` v3 is dropping `node@4` support, and
it's just a dev dependency upstream.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58693#issuecomment-1040589386

/cc @glasser @distracteddev

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)