### PR TITLE
node/fs: Allow Object w/ toString() to match docs, w/tests

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -28,7 +28,7 @@ declare module 'fs' {
      * Valid types for path values in "fs".
      */
     interface objectWithToString extends Object {
-        toString: () => string;
+        toString(): string;
     }
     export type StringLike = string | objectWithToString;
     export type PathLike = string | Buffer | URL;

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -27,6 +27,10 @@ declare module 'fs' {
     /**
      * Valid types for path values in "fs".
      */
+    interface objectWithToString extends Object {
+        toString: () => string;
+    }
+    export type StringLike = string | objectWithToString;
     export type PathLike = string | Buffer | URL;
     export type PathOrFileDescriptor = PathLike | number;
     export type TimeLike = string | number | Date;
@@ -2162,7 +2166,7 @@ declare module 'fs' {
      */
     export function write(
         fd: number,
-        string: string,
+        string: StringLike,
         position: number | undefined | null,
         encoding: BufferEncoding | undefined | null,
         callback: (err: NodeJS.ErrnoException | null, written: number, str: string) => void
@@ -2173,13 +2177,13 @@ declare module 'fs' {
      * @param string A string to write.
      * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
      */
-    export function write(fd: number, string: string, position: number | undefined | null, callback: (err: NodeJS.ErrnoException | null, written: number, str: string) => void): void;
+    export function write(fd: number, string: StringLike, position: number | undefined | null, callback: (err: NodeJS.ErrnoException | null, written: number, str: string) => void): void;
     /**
      * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
      * @param fd A file descriptor.
      * @param string A string to write.
      */
-    export function write(fd: number, string: string, callback: (err: NodeJS.ErrnoException | null, written: number, str: string) => void): void;
+    export function write(fd: number, string: StringLike, callback: (err: NodeJS.ErrnoException | null, written: number, str: string) => void): void;
     export namespace write {
         /**
          * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
@@ -2207,7 +2211,7 @@ declare module 'fs' {
          */
         function __promisify__(
             fd: number,
-            string: string,
+            string: StringLike,
             position?: number | null,
             encoding?: BufferEncoding | null
         ): Promise<{
@@ -2231,7 +2235,7 @@ declare module 'fs' {
      * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
      * @param encoding The expected string encoding.
      */
-    export function writeSync(fd: number, string: string, position?: number | null, encoding?: BufferEncoding | null): number;
+    export function writeSync(fd: number, string: StringLike, position?: number | null, encoding?: BufferEncoding | null): number;
     export type ReadPosition = number | bigint;
     /**
      * Read data from the file specified by `fd`.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -17,6 +17,7 @@ declare module 'fs/promises' {
         StatOptions,
         WriteVResult,
         ReadVResult,
+        StringLike,
         PathLike,
         RmDirOptions,
         RmOptions,
@@ -356,7 +357,7 @@ declare module 'fs/promises' {
             buffer: TBuffer;
         }>;
         write(
-            data: string,
+            string: StringLike,
             position?: number | null,
             encoding?: BufferEncoding | null
         ): Promise<{

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -10,6 +10,10 @@ import { CopyOptions, cpSync, cp } from 'fs';
         "Do unto others as you would have them do unto you.",
         assert.ifError);
 
+    const testObj = {
+        toString: function() { return 'testing' },
+    }
+    fs.write(1234, testObj, () => { });
     fs.write(1234, "test", () => { });
 
     fs.writeFile("Harry Potter",
@@ -442,7 +446,10 @@ async () => {
 
     await handle.read(new Uint32Array(), 1, 2, 3);
     await handle.read(Buffer.from('hurr'));
-
+    const testObj = {
+        toString: function() { return 'testing' },
+    }
+    await handle.write(testObj);
     await handle.write('hurr', 0, 'utf-8');
     await handle.write(Buffer.from('hurr'), 0, 42, 10);
 };

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -11,8 +11,8 @@ import { CopyOptions, cpSync, cp } from 'fs';
         assert.ifError);
 
     const testObj = {
-        toString: function() { return 'testing' },
-    }
+        toString: () => 'testing',
+    };
     fs.write(1234, testObj, () => { });
     fs.write(1234, "test", () => { });
 
@@ -447,8 +447,8 @@ async () => {
     await handle.read(new Uint32Array(), 1, 2, 3);
     await handle.read(Buffer.from('hurr'));
     const testObj = {
-        toString: function() { return 'testing' },
-    }
+        toString: () => 'testing',
+    };
     await handle.write(testObj);
     await handle.write('hurr', 0, 'utf-8');
     await handle.write(Buffer.from('hurr'), 0, 42, 10);


### PR DESCRIPTION
This PR attempts to address https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58714, allowing developers to use the affected fs.write() functions as documented. 

The biggest weakness here is that TypeScript does not seem to have a way of checking for non-inheritance similar to Javascript's `hasOwnProperty()` (or the draft replacement, `hasOwn()`) and the accepted type definition could be narrowed if it did (e.g. if I'm just not aware of a way to do that).  However, the effect is similar to Typescript's lack of distinction between `int` and `float`, where use of the broader `number` will occasionally result in type-related runtime errors if an `int` is actually required.

Allowing developers to use Node APIs as documented presents a smoother transition path into TypeScript. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://nodejs.org/api/fs.html#fswritefd-string-position-encoding-callback](https://nodejs.org/api/fs.html#fswritefd-string-position-encoding-callback)
