### PR TITLE
update(prosemirror-transform): add `StepMap.empty` type

### DIFF
--- a/types/prosemirror-transform/index.d.ts
+++ b/types/prosemirror-transform/index.d.ts
@@ -101,6 +101,11 @@ export class StepMap implements Mappable {
      * sub-document to a larger document, or vice-versa.
      */
     static offset(n: number): StepMap;
+
+    /**
+     * A StepMap that contains no changed ranges.
+     */
+    static empty: StepMap;
 }
 /**
  * A mapping represents a pipeline of zero or more [step


### PR DESCRIPTION
Add type `StepMap.empty` exposed in `prosemirror-transform` 1.3.4

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

I attempted to run the tests, but I get the error. Searching for this error message reveals lots of PRs with the same problem. Does anyone know of a fix?
```
Error: ENOENT: no such file or directory, open '../notNeededPackages.json'
```

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-transform/commit/e1726e744c7b58d36583d0a27b52a95132c99738 https://github.com/ProseMirror/prosemirror-transform/pull/20
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
