### PR TITLE
arrayify-stream: Accept all EventEmitters instead of just Readables

### DIFF
--- a/types/arrayify-stream/arrayify-stream-tests.ts
+++ b/types/arrayify-stream/arrayify-stream-tests.ts
@@ -1,5 +1,6 @@
 import arrayifyStream from 'arrayify-stream';
 import { Readable } from 'stream';
+import { EventEmitter } from 'events';
 
 async function test() {
     const readable = new Readable();
@@ -8,6 +9,12 @@ async function test() {
 
     const result: Promise<any[]> = arrayifyStream(readable);
     const arr: any[] = await result;
+
+    const emitter = new EventEmitter();
+    const prom = arrayifyStream(emitter);
+    emitter.emit('data', '123');
+    emitter.emit('end');
+    await prom;
 
     // $ExpectError
     arrayifyStream();

--- a/types/arrayify-stream/index.d.ts
+++ b/types/arrayify-stream/index.d.ts
@@ -5,11 +5,11 @@
 
 /// <reference types="node" />
 
-import { Readable } from 'stream';
+import { EventEmitter } from 'events';
 
 /**
  * Converts a Node readable stream into an array that is returned as a promise.
  */
-declare function arrayifyStream(input: Readable): Promise<any[]>;
+declare function arrayifyStream(input: EventEmitter): Promise<any[]>;
 
 export = arrayifyStream;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rubensworks/arrayify-stream.js/blob/master/index.js

`Readable` was always too strict. `EventEmitter` suffices.
