### PR TITLE
Add types for unbzip2-stream

### DIFF
--- a/types/unbzip2-stream/index.d.ts
+++ b/types/unbzip2-stream/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for unbzip2-stream 1.4
+// Project: https://github.com/regular/unbzip2-stream
+// Definitions by: Andrew Plummer <https://github.com/plumdog>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import through = require('through');
+
+declare function bz2(): through.ThroughStream;
+
+export = bz2;

--- a/types/unbzip2-stream/tsconfig.json
+++ b/types/unbzip2-stream/tsconfig.json
@@ -14,8 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/unbzip2-stream/tsconfig.json
+++ b/types/unbzip2-stream/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "unbzip2-stream-tests.ts"
+    ]
+}

--- a/types/unbzip2-stream/tslint.json
+++ b/types/unbzip2-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/unbzip2-stream/unbzip2-stream-tests.ts
+++ b/types/unbzip2-stream/unbzip2-stream-tests.ts
@@ -1,4 +1,4 @@
-import stream from "stream";
-import bz2 from "unbzip2-stream";
+import { Readable } from "stream";
+import bz2 = require('unbzip2-stream');
 
-stream.Readable.from('test').pipe(bz2()).pipe(process.stdout);
+Readable.from('test').pipe(bz2()).pipe(process.stdout);

--- a/types/unbzip2-stream/unbzip2-stream-tests.ts
+++ b/types/unbzip2-stream/unbzip2-stream-tests.ts
@@ -1,0 +1,4 @@
+import stream from "stream";
+import bz2 from "unbzip2-stream";
+
+stream.Readable.from('test').pipe(bz2()).pipe(process.stdout);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---
NPM module: https://www.npmjs.com/package/unbzip2-stream
Github: https://github.com/regular/unbzip2-stream/blob/master/index.js

Things I'm not sure about:
- is my test reasonable?
- is setting `"esModuleInterop": true` correct in this case? I set it because `npm test unbzip2-stream` told me to.