### PR TITLE
Add missing types to react-email-editor

### DIFF
--- a/types/react-email-editor/index.d.ts
+++ b/types/react-email-editor/index.d.ts
@@ -118,12 +118,13 @@ export interface UnlayerOptions {
 
 export interface EmailEditorProps {
     readonly style?: CSSProperties | undefined;
-    readonly minHeight?: number | undefined;
+    readonly minHeight?: number | string | undefined;
     readonly options?: UnlayerOptions | undefined;
     readonly tools?: ToolsConfig | undefined;
     readonly appearance?: AppearanceConfig | undefined;
     readonly projectId?: number | undefined;
     onLoad?(): void;
+    onReady?(): void;
 }
 
 export interface HtmlExport {


### PR DESCRIPTION
As documented on https://docs.unlayer.com/docs/react-component

Added missing onReady function. 
minHeight is technically a string according to docs. However number will get coalesced to a string and instead of breaking backwards compatibility. just add string as another type.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
