### PR TITLE
[howler] fix: exported `Howler` should be `HowlerGlobal` instance

### DIFF
--- a/types/howler/howler-tests.ts
+++ b/types/howler/howler-tests.ts
@@ -1,4 +1,7 @@
-import { Howl } from 'howler';
+import { Howl, Howler } from 'howler';
+
+// Set global volume
+Howler.volume(0.8);
 
 const sound1 = new Howl({
     src: ['sound.mp3'],

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -277,7 +277,7 @@ declare global {
         orientation(): SpatialOrientation;
         orientation(x: number, y?: number, z?: number, xUp?: number, yUp?: number, zUp?: number): this;
     }
-    const Howler: typeof HowlerGlobal;
+    const Howler: HowlerGlobal;
 }
 
-export const Howler: typeof HowlerGlobal;
+export const Howler: HowlerGlobal;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

This PR addresses an issue in #58305, exporting and declaring `Howler` to be `HowlerGlobal` where it should actually be an instance of `HowlerGlobal`.
`Howler` has been added to tests.