### PR TITLE
Feat/react 18 local jsx namespace

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -45,7 +45,7 @@ type SyntheticKeyboardEvent = React.KeyboardEvent<{}>;
 
 const HANDLE_REGEX = /\@[\w]+/g;
 
-class HandleSpan extends React.Component {
+class HandleSpan extends React.Component<{ children?: React.ReactNode }> {
   render() {
     return <span>{this.props.children}</span>
   }

--- a/types/gatsby-plugin-breakpoints/gatsby-plugin-breakpoints-tests.tsx
+++ b/types/gatsby-plugin-breakpoints/gatsby-plugin-breakpoints-tests.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
     BreakpointConfig,
     BreakpointProvider,
@@ -49,6 +49,6 @@ function useContext() {
     return context;
 }
 // BreakpointProvider
-const ProviderComponent: React.FC = ({ children }) => {
+const ProviderComponent: React.FC<{ children?: ReactNode }> = ({ children }) => {
     return <BreakpointProvider queries={defaultQueries}>{children}</BreakpointProvider>;
 };

--- a/types/material-ui-datatables/material-ui-datatables-tests.tsx
+++ b/types/material-ui-datatables/material-ui-datatables-tests.tsx
@@ -80,5 +80,4 @@ const test = (<DataTable
     tableWrapperStyle={tableWrapperStyle}
     headerToolbarMode={headerToolbarMode}
     filterValue={filterValue}
-    showHeaderToolbarFilterIcon={showHeaderToolbarFilterIcon}>
-</DataTable>);
+    showHeaderToolbarFilterIcon={showHeaderToolbarFilterIcon} />);

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -4195,8 +4195,8 @@ const ListExampleMessages = () => (
   </div>
 );
 
-function wrapState(ComposedComponent: ComponentClass<__MaterialUI.List.SelectableProps>) {
-  return class SelectableList extends Component<{defaultValue: number}, {selectedIndex: number}> {
+function wrapState(ComposedComponent: ComponentClass<React.PropsWithChildren<__MaterialUI.List.SelectableProps>>) {
+  return class SelectableList extends Component<{children?: React.ReactNode, defaultValue: number}, {selectedIndex: number}> {
     static propTypes = {
       children: PropTypes.node.isRequired,
       defaultValue: PropTypes.number.isRequired,

--- a/types/orbit-ui__react-components/tsconfig.json
+++ b/types/orbit-ui__react-components/tsconfig.json
@@ -13,7 +13,10 @@
         "forceConsistentCasingInFileNames": true,
         "jsx": "react",
         "paths": {
-            "@orbit-ui/*": ["orbit-ui__*"]
+            "@orbit-ui/*": ["orbit-ui__*"],
+            "react": [
+                "react/v16"
+            ]
         }
     },
     "files": ["index.d.ts", "orbit-ui__react-components-tests.tsx"]

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -17,10 +17,9 @@ export interface ReactElementLike {
     key: string | number | null;
 }
 
-export interface ReactNodeArray extends Array<ReactNodeLike> {}
+export interface ReactNodeArray extends Iterable<ReactNodeLike> {}
 
 export type ReactNodeLike =
-    | {}
     | ReactElementLike
     | ReactNodeArray
     | string

--- a/types/radium/radium-tests.tsx
+++ b/types/radium/radium-tests.tsx
@@ -38,14 +38,12 @@ class TestComponentWithConfig extends React.Component<{ a?: number | undefined }
                                 textAlign: "center"
                             }
                         }}
-                    >
-                    </Radium.Style>
+                    />
                     <Radium.Style scopeSelector="test"
                         rules={{
                             background: "green"
                         }}
-                    >
-                    </Radium.Style>
+                    />
                 </Radium.StyleRoot>
             </div>
         )
@@ -71,14 +69,12 @@ class TestComponentWithConfigInStyleRoot
                                 textAlign: "center"
                             }
                         }}
-                    >
-                    </Radium.Style>
+                    />
                     <Radium.Style scopeSelector="test"
                         rules={{
                             background: "green"
                         }}
-                    >
-                    </Radium.Style>
+                    />
                 </Radium.StyleRoot>
             </div>
         )

--- a/types/react-breadcrumbs/react-breadcrumbs-tests.tsx
+++ b/types/react-breadcrumbs/react-breadcrumbs-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Breadcrumbs, Breadcrumb } from "react-breadcrumbs";
 
-class Wrapper extends React.Component {
+class Wrapper extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return <div>{this.props.children}</div>;
     }

--- a/types/react-dnd-multi-backend/react-dnd-multi-backend-tests.tsx
+++ b/types/react-dnd-multi-backend/react-dnd-multi-backend-tests.tsx
@@ -3,7 +3,7 @@ import { DndProvider } from 'react-dnd';
 import MultiBackend, { createTransition, TouchTransition, Backends, Preview, PreviewGenerator } from 'react-dnd-multi-backend';
 import HTML5ToTouchEsm from 'react-dnd-multi-backend/dist/esm/HTML5toTouch';
 import HTML5ToTouchCjs from 'react-dnd-multi-backend/dist/cjs/HTML5toTouch';
-import TouchBackend from 'react-dnd-touch-backend';
+import { TouchBackend } from 'react-dnd-touch-backend';
 
 const context = {};
 

--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -2,7 +2,7 @@ import {
     AbstractView, Component, ComponentClass,
     ReactElement, ReactInstance, ClassType,
     DOMElement, FunctionComponentElement, CElement,
-    ReactHTMLElement, DOMAttributes, SFC
+    ReactHTMLElement, DOMAttributes, FC
 } from 'react';
 
 import * as ReactTestUtils from ".";
@@ -194,7 +194,7 @@ export function isElementOfType<P extends DOMAttributes<{}>, T extends Element>(
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */
 export function isElementOfType<P>(
-    element: ReactElement, type: SFC<P>): element is FunctionComponentElement<P>;
+    element: ReactElement, type: FC<P>): element is FunctionComponentElement<P>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
  */

--- a/types/react-gateway/react-gateway-tests.tsx
+++ b/types/react-gateway/react-gateway-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Gateway, GatewayProvider, GatewayDest } from 'react-gateway';
 
-class GatewayComponent extends React.Component {
+class GatewayComponent extends React.Component<{ children?: React.ReactNode }> {
   render() {
     return (
       <div>{this.props.children}</div>

--- a/types/react-highlight-words/react-highlight-words-tests.tsx
+++ b/types/react-highlight-words/react-highlight-words-tests.tsx
@@ -6,7 +6,7 @@ const findChunks = ({
     textToHighlight
 }: FindChunks) => [];
 
-const CustomHighlight: React.FC = ({children}) => (<span>{children}</span>);
+const CustomHighlight: React.FC<{ children?: React.ReactNode; }> = ({children}) => (<span>{children}</span>);
 
 class HighlighterTest extends React.Component {
     render() {

--- a/types/react-intl-redux/tsconfig.json
+++ b/types/react-intl-redux/tsconfig.json
@@ -16,6 +16,9 @@
         "typeRoots": [
             "../"
         ],
+        "paths": {
+            "react": ["react/v16"]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,

--- a/types/react-leaflet/react-leaflet-tests.tsx
+++ b/types/react-leaflet/react-leaflet-tests.tsx
@@ -775,7 +775,7 @@ const CenterControlExample = () => (
     </Map>
 );
 
-class LegendControl extends MapControl<MapControlProps & { className?: string | undefined }> {
+class LegendControl extends MapControl<MapControlProps & { children?: React.ReactNode, className?: string | undefined }> {
     componentWillMount() {
         const legend = new L.Control({ position: 'bottomright' });
         const jsx = (

--- a/types/react-leaflet/v1/react-leaflet-tests.tsx
+++ b/types/react-leaflet/v1/react-leaflet-tests.tsx
@@ -781,7 +781,7 @@ const CenterControlExample = () => (
     </Map>
 );
 
-class LegendControl extends MapControl<MapControlProps & { className?: string | undefined }> {
+class LegendControl extends MapControl<MapControlProps & { children?: React.ReactNode, className?: string | undefined }> {
     componentWillMount() {
         const legend = new L.Control({ position: 'bottomright' });
         const jsx = (

--- a/types/react-native-ad-manager/test/react-native-ad-manager-tests.tsx
+++ b/types/react-native-ad-manager/test/react-native-ad-manager-tests.tsx
@@ -4,6 +4,7 @@ import { Interstitial, Banner, NativeAdsManager, AdLoadedEvent, AdFailedToLoadEv
 import NativeAdView from './NativeAdView';
 
 const BannerExample: React.FunctionComponent<{
+    children?: React.ReactNode;
     style?: ViewStyle | undefined;
     title: string;
 }> = ({ style, title, children, ...props }) => (

--- a/types/react-native-multi-slider/react-native-multi-slider-tests.tsx
+++ b/types/react-native-multi-slider/react-native-multi-slider-tests.tsx
@@ -59,7 +59,7 @@ class SliderTest extends React.Component {
                         borderRadius: 20,
                         slipDisplacement: 40,
                     }}
-                    customMarker={(props) => <View {...props} />}
+                    customMarker={({ markerStyle, pressed, pressedMarkerStyle, value}) => <View style={pressed ? pressedMarkerStyle : markerStyle}>value: {value}</View>}
                     sliderLength={280}
                 />
             </React.Fragment>

--- a/types/react-native-onboarding-swiper/react-native-onboarding-swiper-tests.tsx
+++ b/types/react-native-onboarding-swiper/react-native-onboarding-swiper-tests.tsx
@@ -131,6 +131,7 @@ export default App;
 
 // mock Button component
 const Button: React.FC<{
+    children?: React.ReactNode;
     title: string | JSX.Element;
     buttonStyle: StyleProp<ViewStyle>;
     containerViewStyle: StyleProp<ViewStyle>;

--- a/types/react-native-scrollable-tab-view/react-native-scrollable-tab-view-tests.tsx
+++ b/types/react-native-scrollable-tab-view/react-native-scrollable-tab-view-tests.tsx
@@ -3,6 +3,7 @@ import { Text, TextStyle, View, ViewStyle } from 'react-native';
 import ScrollableTabView, { ScrollableTabBar, TabProps, DefaultTabBar } from 'react-native-scrollable-tab-view';
 
 interface MyTextProps {
+    children?: React.ReactNode;
     style?: TextStyle | undefined;
 }
 
@@ -11,6 +12,7 @@ const MyText: React.FC<TabProps<MyTextProps>> = (props) => (
 );
 
 interface MyViewProps {
+    children?: React.ReactNode;
     style?: ViewStyle | undefined;
 }
 

--- a/types/react-portal/v3/react-portal-tests.tsx
+++ b/types/react-portal/v3/react-portal-tests.tsx
@@ -32,7 +32,7 @@ export default class App extends React.Component {
   }
 }
 
-export class PseudoModal extends React.Component<{ closePortal?(): void }> {
+export class PseudoModal extends React.Component<{ children?: React.ReactNode; closePortal?(): void }> {
   render() {
     return (
       <div>

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -707,7 +707,7 @@ requestSubscription(
 ReactRelayContext.Consumer.prototype;
 ReactRelayContext.Provider.prototype;
 
-const MyRelayContextProvider: React.FunctionComponent = ({children}) => {
+const MyRelayContextProvider: React.FunctionComponent<{ children?: React.ReactNode }> = ({children}) => {
     return (
         <ReactRelayContext.Provider
             value={{

--- a/types/react-resizable/react-resizable-tests.tsx
+++ b/types/react-resizable/react-resizable-tests.tsx
@@ -9,7 +9,7 @@ const resizeCallback = (
     console.log(data.node);
 };
 
-class TestResizableComponent extends React.Component {
+class TestResizableComponent extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return (
             <Resizable
@@ -32,7 +32,7 @@ class TestResizableComponent extends React.Component {
     }
 }
 
-class TestResizableBoxComponent extends React.Component {
+class TestResizableBoxComponent extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return (
             <ResizableBox

--- a/types/react-router-navigation-core/tsconfig.json
+++ b/types/react-router-navigation-core/tsconfig.json
@@ -6,6 +6,9 @@
         ],
         "types": [],
         "paths": {
+            "react": [
+                "react/v16"
+            ],
             "react-navigation": [
                 "react-navigation/v1"
             ],

--- a/types/react-router-navigation/tsconfig.json
+++ b/types/react-router-navigation/tsconfig.json
@@ -6,6 +6,9 @@
         ],
         "types": [],
         "paths": {
+            "react": [
+                "react/v16"
+            ],
             "react-navigation": [
                 "react-navigation/v1"
             ],

--- a/types/react-router/test/Prompt.tsx
+++ b/types/react-router/test/Prompt.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Prompt } from 'react-router';
 
-const PromptTest: React.FC = ({ children }) => {
+const PromptTest: React.FC = () => {
   return (
     <Prompt
       message={(location, action) => {

--- a/types/react-router/test/examples-from-react-router-website/StaticRouter.tsx
+++ b/types/react-router/test/examples-from-react-router-website/StaticRouter.tsx
@@ -5,6 +5,7 @@ import { StaticRouter, Route } from 'react-router-dom';
 import { StaticContext, StaticRouterContext } from 'react-router';
 
 interface RouteStatusProps {
+    children?: React.ReactNode;
     statusCode: number;
 }
 

--- a/types/react-router/ts4.0/test/Prompt.tsx
+++ b/types/react-router/ts4.0/test/Prompt.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Prompt } from 'react-router';
 
-const PromptTest: React.FC = ({ children }) => {
+const PromptTest: React.FC = () => {
   return (
     <Prompt
       message={(location, action) => {

--- a/types/react-router/ts4.0/test/examples-from-react-router-website/StaticRouter.tsx
+++ b/types/react-router/ts4.0/test/examples-from-react-router-website/StaticRouter.tsx
@@ -5,6 +5,7 @@ import { StaticRouter, Route } from 'react-router-dom';
 import { StaticContext, StaticRouterContext } from 'react-router';
 
 interface RouteStatusProps {
+    children?: React.ReactNode;
     statusCode: number;
 }
 

--- a/types/react-router/v3/react-router-tests.tsx
+++ b/types/react-router/v3/react-router-tests.tsx
@@ -47,7 +47,7 @@ interface MasterContext {
     router: InjectedRouter;
 }
 
-class Master extends Component {
+class Master extends Component<{ children?: React.ReactNode }> {
     static contextTypes: ValidationMap<any> = {
         router: routerShape
     };
@@ -124,6 +124,7 @@ class UserList extends React.Component<UserListProps & WithRouterProps> {
 const UserListWithRouter = withRouter(UserList);
 
 interface AvatarProps {
+    children?: React.ReactNode;
     user: string;
 }
 

--- a/types/react-scroll/test/react-scroll-tests.tsx
+++ b/types/react-scroll/test/react-scroll-tests.tsx
@@ -146,7 +146,7 @@ Events.scrollEvent.register('end', (to, element) => {
 Events.scrollEvent.remove('begin');
 Events.scrollEvent.remove('end');
 
-class CustomComponent extends React.Component {
+class CustomComponent extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return <div>{this.props.children}</div>;
     }

--- a/types/react-virtualized/dist/es/CellMeasurer.d.ts
+++ b/types/react-virtualized/dist/es/CellMeasurer.d.ts
@@ -48,7 +48,7 @@ export type MeasuredCellParent = {
 
 export type CellMeasurerChildProps = {
     measure: () => void,
-    registerChild?: (element?: React.ReactNode) => void
+    registerChild?: (element?: Element) => void
 }
 
 export type CellMeasurerProps = {

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -347,7 +347,7 @@ export class DynamicHeightList extends PureComponent<any> {
         return (
             <CellMeasurer cache={this._cache} columnIndex={0} key={key} rowIndex={index} parent={parent}>
                 {({ measure, registerChild }) => (
-                    <div ref={registerChild} className={classNames} style={style}>
+                    <div ref={registerChild as React.Ref<HTMLDivElement>} className={classNames} style={style}>
                         <img
                             onLoad={measure}
                             src={source}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -466,8 +466,7 @@ declare namespace React {
          *
          * @see https://reactjs.org/docs/context.html
          */
-        // TODO (TypeScript 3.0): unknown
-        context: any;
+        context: unknown;
 
         constructor(props: Readonly<P> | P);
         /**
@@ -864,8 +863,7 @@ declare namespace React {
     // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
     type ReducerStateWithoutAction<R extends ReducerWithoutAction<any>> =
         R extends ReducerWithoutAction<infer S> ? S : never;
-    // TODO (TypeScript 3.0): ReadonlyArray<unknown>
-    type DependencyList = ReadonlyArray<any>;
+    type DependencyList = ReadonlyArray<unknown>;
 
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
     type EffectCallback = () => (void | Destructor);

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -496,12 +496,7 @@ declare namespace React {
         forceUpdate(callback?: () => void): void;
         render(): ReactNode;
 
-        // React.Props<T> is now deprecated, which means that the `children`
-        // property is not available on `P` by default, even though you can
-        // always pass children as variadic arguments to `createElement`.
-        // In the future, if we can define its call signature conditionally
-        // on the existence of `children` in `P`, then we should remove this.
-        readonly props: Readonly<P> & Readonly<{ children?: ReactNode | undefined }>;
+        readonly props: Readonly<P>;
         state: Readonly<S>;
         /**
          * @deprecated
@@ -547,7 +542,7 @@ declare namespace React {
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {
-        (props: PropsWithChildren<P>, context?: any): ReactElement<any, any> | null;
+        (props: P, context?: any): ReactElement<any, any> | null;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
         defaultProps?: Partial<P> | undefined;
@@ -567,7 +562,7 @@ declare namespace React {
     type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
 
     interface ForwardRefRenderFunction<T, P = {}> {
-        (props: PropsWithChildren<P>, ref: ForwardedRef<T>): ReactElement | null;
+        (props: P, ref: ForwardedRef<T>): ReactElement | null;
         displayName?: string | undefined;
         // explicit rejected with `never` required due to
         // https://github.com/microsoft/TypeScript/issues/36826
@@ -861,7 +856,7 @@ declare namespace React {
 
     function memo<P extends object>(
         Component: FunctionComponent<P>,
-        propsAreEqual?: (prevProps: Readonly<PropsWithChildren<P>>, nextProps: Readonly<PropsWithChildren<P>>) => boolean
+        propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean
     ): NamedExoticComponent<P>;
     function memo<T extends ComponentType<any>>(
         Component: T,

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1291,26 +1291,6 @@ declare namespace React {
     // Props / DOM Attributes
     // ----------------------------------------------------------------------
 
-    /**
-     * @deprecated. This was used to allow clients to pass `ref` and `key`
-     * to `createElement`, which is no longer necessary due to intersection
-     * types. If you need to declare a props object before passing it to
-     * `createElement` or a factory, use `ClassAttributes<T>`:
-     *
-     * ```ts
-     * var b: Button | null;
-     * var props: ButtonProps & ClassAttributes<Button> = {
-     *     ref: b => button = b, // ok!
-     *     label: "I'm a Button"
-     * };
-     * ```
-     */
-    interface Props<T> {
-        children?: ReactNode | undefined;
-        key?: Key | undefined;
-        ref?: LegacyRef<T> | undefined;
-    }
-
     interface HTMLProps<T> extends AllHTMLAttributes<T>, ClassAttributes<T> {
     }
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -66,6 +66,213 @@ export = React;
 export as namespace React;
 
 declare namespace React {
+    namespace JSX {
+        interface Element extends ReactElement<any, any> {}
+        interface ElementClass extends Component<any> {
+            render(): ReactNode;
+        }
+        interface ElementAttributesProperty {
+            props: {};
+        }
+        interface ElementChildrenAttribute {
+            children: {};
+        }
+
+        // We can't recurse forever because `type` can't be self-referential;
+        // let's assume it's reasonable to do a single React.lazy() around a single React.memo() / vice-versa
+        type LibraryManagedAttributes<C, P> = C extends
+            | MemoExoticComponent<infer T>
+            | LazyExoticComponent<infer T>
+            ? T extends MemoExoticComponent<infer U> | LazyExoticComponent<infer U>
+                ? ReactManagedAttributes<U, P>
+                : ReactManagedAttributes<T, P>
+            : ReactManagedAttributes<C, P>;
+
+        interface IntrinsicAttributes extends Attributes {}
+        interface IntrinsicClassAttributes<T> extends ClassAttributes<T> {}
+
+        interface IntrinsicElements {
+            // HTML
+            a: DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
+            abbr: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            address: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            area: DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement>;
+            article: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            aside: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            audio: DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement>;
+            b: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            base: DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement>;
+            bdi: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            bdo: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            big: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            blockquote: DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLElement>, HTMLElement>;
+            body: DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
+            br: DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement>;
+            button: DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
+            canvas: DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement>;
+            caption: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            cite: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            code: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            col: DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+            colgroup: DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+            data: DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement>;
+            datalist: DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement>;
+            dd: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            del: DetailedHTMLProps<DelHTMLAttributes<HTMLElement>, HTMLElement>;
+            details: DetailedHTMLProps<DetailsHTMLAttributes<HTMLElement>, HTMLElement>;
+            dfn: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            dialog: DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
+            div: DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+            dl: DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
+            dt: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            em: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            embed: DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement>;
+            fieldset: DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement>;
+            figcaption: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            figure: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            footer: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            form: DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
+            h1: DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h2: DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h3: DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h4: DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h5: DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h6: DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            head: DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement>;
+            header: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            hgroup: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            hr: DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement>;
+            html: DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement>;
+            i: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            iframe: DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>;
+            img: DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
+            input: DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+            ins: DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement>;
+            kbd: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            keygen: DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement>;
+            label: DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>;
+            legend: DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement>;
+            li: DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>;
+            link: DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement>;
+            main: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            map: DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement>;
+            mark: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            menu: DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement>;
+            menuitem: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            meta: DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement>;
+            meter: DetailedHTMLProps<MeterHTMLAttributes<HTMLElement>, HTMLElement>;
+            nav: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            noindex: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            noscript: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            object: DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement>;
+            ol: DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement>;
+            optgroup: DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement>;
+            option: DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement>;
+            output: DetailedHTMLProps<OutputHTMLAttributes<HTMLElement>, HTMLElement>;
+            p: DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>;
+            param: DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement>;
+            picture: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            pre: DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>;
+            progress: DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement>;
+            q: DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
+            rp: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            rt: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            ruby: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            s: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            samp: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            slot: DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement>;
+            script: DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement>;
+            section: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            select: DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement>;
+            small: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            source: DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement>;
+            span: DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>;
+            strong: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            style: DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement>;
+            sub: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            summary: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            sup: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            table: DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>;
+            template: DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement>;
+            tbody: DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+            td: DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement>;
+            textarea: DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>;
+            tfoot: DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+            th: DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement>;
+            thead: DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+            time: DetailedHTMLProps<TimeHTMLAttributes<HTMLElement>, HTMLElement>;
+            title: DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement>;
+            tr: DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
+            track: DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
+            u: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            ul: DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
+            var: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            video: DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
+            wbr: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+            webview: DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
+
+            // SVG
+            svg: SVGProps<SVGSVGElement>;
+
+            animate: SVGProps<SVGElement>; // TODO: It is SVGAnimateElement but is not in TypeScript's lib.dom.d.ts for now.
+            animateMotion: SVGProps<SVGElement>;
+            animateTransform: SVGProps<SVGElement>; // TODO: It is SVGAnimateTransformElement but is not in TypeScript's lib.dom.d.ts for now.
+            circle: SVGProps<SVGCircleElement>;
+            clipPath: SVGProps<SVGClipPathElement>;
+            defs: SVGProps<SVGDefsElement>;
+            desc: SVGProps<SVGDescElement>;
+            ellipse: SVGProps<SVGEllipseElement>;
+            feBlend: SVGProps<SVGFEBlendElement>;
+            feColorMatrix: SVGProps<SVGFEColorMatrixElement>;
+            feComponentTransfer: SVGProps<SVGFEComponentTransferElement>;
+            feComposite: SVGProps<SVGFECompositeElement>;
+            feConvolveMatrix: SVGProps<SVGFEConvolveMatrixElement>;
+            feDiffuseLighting: SVGProps<SVGFEDiffuseLightingElement>;
+            feDisplacementMap: SVGProps<SVGFEDisplacementMapElement>;
+            feDistantLight: SVGProps<SVGFEDistantLightElement>;
+            feDropShadow: SVGProps<SVGFEDropShadowElement>;
+            feFlood: SVGProps<SVGFEFloodElement>;
+            feFuncA: SVGProps<SVGFEFuncAElement>;
+            feFuncB: SVGProps<SVGFEFuncBElement>;
+            feFuncG: SVGProps<SVGFEFuncGElement>;
+            feFuncR: SVGProps<SVGFEFuncRElement>;
+            feGaussianBlur: SVGProps<SVGFEGaussianBlurElement>;
+            feImage: SVGProps<SVGFEImageElement>;
+            feMerge: SVGProps<SVGFEMergeElement>;
+            feMergeNode: SVGProps<SVGFEMergeNodeElement>;
+            feMorphology: SVGProps<SVGFEMorphologyElement>;
+            feOffset: SVGProps<SVGFEOffsetElement>;
+            fePointLight: SVGProps<SVGFEPointLightElement>;
+            feSpecularLighting: SVGProps<SVGFESpecularLightingElement>;
+            feSpotLight: SVGProps<SVGFESpotLightElement>;
+            feTile: SVGProps<SVGFETileElement>;
+            feTurbulence: SVGProps<SVGFETurbulenceElement>;
+            filter: SVGProps<SVGFilterElement>;
+            foreignObject: SVGProps<SVGForeignObjectElement>;
+            g: SVGProps<SVGGElement>;
+            image: SVGProps<SVGImageElement>;
+            line: SVGProps<SVGLineElement>;
+            linearGradient: SVGProps<SVGLinearGradientElement>;
+            marker: SVGProps<SVGMarkerElement>;
+            mask: SVGProps<SVGMaskElement>;
+            metadata: SVGProps<SVGMetadataElement>;
+            mpath: SVGProps<SVGElement>;
+            path: SVGProps<SVGPathElement>;
+            pattern: SVGProps<SVGPatternElement>;
+            polygon: SVGProps<SVGPolygonElement>;
+            polyline: SVGProps<SVGPolylineElement>;
+            radialGradient: SVGProps<SVGRadialGradientElement>;
+            rect: SVGProps<SVGRectElement>;
+            stop: SVGProps<SVGStopElement>;
+            switch: SVGProps<SVGSwitchElement>;
+            symbol: SVGProps<SVGSymbolElement>;
+            text: SVGProps<SVGTextElement>;
+            textPath: SVGProps<SVGTextPathElement>;
+            tspan: SVGProps<SVGTSpanElement>;
+            use: SVGProps<SVGUseElement>;
+            view: SVGProps<SVGViewElement>;
+        }
+    }
     //
     // React Elements
     // ----------------------------------------------------------------------
@@ -3029,207 +3236,3 @@ type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps
         : C extends { defaultProps: infer D; }
             ? Defaultize<P, D>
             : P;
-
-declare global {
-    namespace JSX {
-        interface Element extends React.ReactElement<any, any> { }
-        interface ElementClass extends React.Component<any> {
-            render(): React.ReactNode;
-        }
-        interface ElementAttributesProperty { props: {}; }
-        interface ElementChildrenAttribute { children: {}; }
-
-        // We can't recurse forever because `type` can't be self-referential;
-        // let's assume it's reasonable to do a single React.lazy() around a single React.memo() / vice-versa
-        type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
-            ? T extends React.MemoExoticComponent<infer U> | React.LazyExoticComponent<infer U>
-                ? ReactManagedAttributes<U, P>
-                : ReactManagedAttributes<T, P>
-            : ReactManagedAttributes<C, P>;
-
-        interface IntrinsicAttributes extends React.Attributes { }
-        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
-
-        interface IntrinsicElements {
-            // HTML
-            a: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
-            abbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            address: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            area: React.DetailedHTMLProps<React.AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement>;
-            article: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            aside: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            audio: React.DetailedHTMLProps<React.AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement>;
-            b: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            base: React.DetailedHTMLProps<React.BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement>;
-            bdi: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            bdo: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            big: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            blockquote: React.DetailedHTMLProps<React.BlockquoteHTMLAttributes<HTMLElement>, HTMLElement>;
-            body: React.DetailedHTMLProps<React.HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
-            br: React.DetailedHTMLProps<React.HTMLAttributes<HTMLBRElement>, HTMLBRElement>;
-            button: React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
-            canvas: React.DetailedHTMLProps<React.CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement>;
-            caption: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            cite: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            code: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            col: React.DetailedHTMLProps<React.ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
-            colgroup: React.DetailedHTMLProps<React.ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
-            data: React.DetailedHTMLProps<React.DataHTMLAttributes<HTMLDataElement>, HTMLDataElement>;
-            datalist: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDataListElement>, HTMLDataListElement>;
-            dd: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            del: React.DetailedHTMLProps<React.DelHTMLAttributes<HTMLElement>, HTMLElement>;
-            details: React.DetailedHTMLProps<React.DetailsHTMLAttributes<HTMLElement>, HTMLElement>;
-            dfn: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            dialog: React.DetailedHTMLProps<React.DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
-            div: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
-            dl: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
-            dt: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            em: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            embed: React.DetailedHTMLProps<React.EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement>;
-            fieldset: React.DetailedHTMLProps<React.FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement>;
-            figcaption: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            figure: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            footer: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            form: React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
-            h1: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
-            h2: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
-            h3: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
-            h4: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
-            h5: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
-            h6: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
-            head: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadElement>, HTMLHeadElement>;
-            header: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            hgroup: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            hr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHRElement>, HTMLHRElement>;
-            html: React.DetailedHTMLProps<React.HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement>;
-            i: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            iframe: React.DetailedHTMLProps<React.IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>;
-            img: React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
-            input: React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
-            ins: React.DetailedHTMLProps<React.InsHTMLAttributes<HTMLModElement>, HTMLModElement>;
-            kbd: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            keygen: React.DetailedHTMLProps<React.KeygenHTMLAttributes<HTMLElement>, HTMLElement>;
-            label: React.DetailedHTMLProps<React.LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>;
-            legend: React.DetailedHTMLProps<React.HTMLAttributes<HTMLLegendElement>, HTMLLegendElement>;
-            li: React.DetailedHTMLProps<React.LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>;
-            link: React.DetailedHTMLProps<React.LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement>;
-            main: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            map: React.DetailedHTMLProps<React.MapHTMLAttributes<HTMLMapElement>, HTMLMapElement>;
-            mark: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            menu: React.DetailedHTMLProps<React.MenuHTMLAttributes<HTMLElement>, HTMLElement>;
-            menuitem: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            meta: React.DetailedHTMLProps<React.MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement>;
-            meter: React.DetailedHTMLProps<React.MeterHTMLAttributes<HTMLElement>, HTMLElement>;
-            nav: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            noindex: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            noscript: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            object: React.DetailedHTMLProps<React.ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement>;
-            ol: React.DetailedHTMLProps<React.OlHTMLAttributes<HTMLOListElement>, HTMLOListElement>;
-            optgroup: React.DetailedHTMLProps<React.OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement>;
-            option: React.DetailedHTMLProps<React.OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement>;
-            output: React.DetailedHTMLProps<React.OutputHTMLAttributes<HTMLElement>, HTMLElement>;
-            p: React.DetailedHTMLProps<React.HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>;
-            param: React.DetailedHTMLProps<React.ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement>;
-            picture: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            pre: React.DetailedHTMLProps<React.HTMLAttributes<HTMLPreElement>, HTMLPreElement>;
-            progress: React.DetailedHTMLProps<React.ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement>;
-            q: React.DetailedHTMLProps<React.QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
-            rp: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            rt: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            ruby: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            s: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            samp: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            slot: React.DetailedHTMLProps<React.SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement>;
-            script: React.DetailedHTMLProps<React.ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement>;
-            section: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            select: React.DetailedHTMLProps<React.SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement>;
-            small: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            source: React.DetailedHTMLProps<React.SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement>;
-            span: React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>;
-            strong: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            style: React.DetailedHTMLProps<React.StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement>;
-            sub: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            summary: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            sup: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            table: React.DetailedHTMLProps<React.TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>;
-            template: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement>;
-            tbody: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
-            td: React.DetailedHTMLProps<React.TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement>;
-            textarea: React.DetailedHTMLProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>;
-            tfoot: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
-            th: React.DetailedHTMLProps<React.ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement>;
-            thead: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
-            time: React.DetailedHTMLProps<React.TimeHTMLAttributes<HTMLElement>, HTMLElement>;
-            title: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTitleElement>, HTMLTitleElement>;
-            tr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
-            track: React.DetailedHTMLProps<React.TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
-            u: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            ul: React.DetailedHTMLProps<React.HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
-            "var": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            video: React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
-            wbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            webview: React.DetailedHTMLProps<React.WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
-
-            // SVG
-            svg: React.SVGProps<SVGSVGElement>;
-
-            animate: React.SVGProps<SVGElement>; // TODO: It is SVGAnimateElement but is not in TypeScript's lib.dom.d.ts for now.
-            animateMotion: React.SVGProps<SVGElement>;
-            animateTransform: React.SVGProps<SVGElement>; // TODO: It is SVGAnimateTransformElement but is not in TypeScript's lib.dom.d.ts for now.
-            circle: React.SVGProps<SVGCircleElement>;
-            clipPath: React.SVGProps<SVGClipPathElement>;
-            defs: React.SVGProps<SVGDefsElement>;
-            desc: React.SVGProps<SVGDescElement>;
-            ellipse: React.SVGProps<SVGEllipseElement>;
-            feBlend: React.SVGProps<SVGFEBlendElement>;
-            feColorMatrix: React.SVGProps<SVGFEColorMatrixElement>;
-            feComponentTransfer: React.SVGProps<SVGFEComponentTransferElement>;
-            feComposite: React.SVGProps<SVGFECompositeElement>;
-            feConvolveMatrix: React.SVGProps<SVGFEConvolveMatrixElement>;
-            feDiffuseLighting: React.SVGProps<SVGFEDiffuseLightingElement>;
-            feDisplacementMap: React.SVGProps<SVGFEDisplacementMapElement>;
-            feDistantLight: React.SVGProps<SVGFEDistantLightElement>;
-            feDropShadow: React.SVGProps<SVGFEDropShadowElement>;
-            feFlood: React.SVGProps<SVGFEFloodElement>;
-            feFuncA: React.SVGProps<SVGFEFuncAElement>;
-            feFuncB: React.SVGProps<SVGFEFuncBElement>;
-            feFuncG: React.SVGProps<SVGFEFuncGElement>;
-            feFuncR: React.SVGProps<SVGFEFuncRElement>;
-            feGaussianBlur: React.SVGProps<SVGFEGaussianBlurElement>;
-            feImage: React.SVGProps<SVGFEImageElement>;
-            feMerge: React.SVGProps<SVGFEMergeElement>;
-            feMergeNode: React.SVGProps<SVGFEMergeNodeElement>;
-            feMorphology: React.SVGProps<SVGFEMorphologyElement>;
-            feOffset: React.SVGProps<SVGFEOffsetElement>;
-            fePointLight: React.SVGProps<SVGFEPointLightElement>;
-            feSpecularLighting: React.SVGProps<SVGFESpecularLightingElement>;
-            feSpotLight: React.SVGProps<SVGFESpotLightElement>;
-            feTile: React.SVGProps<SVGFETileElement>;
-            feTurbulence: React.SVGProps<SVGFETurbulenceElement>;
-            filter: React.SVGProps<SVGFilterElement>;
-            foreignObject: React.SVGProps<SVGForeignObjectElement>;
-            g: React.SVGProps<SVGGElement>;
-            image: React.SVGProps<SVGImageElement>;
-            line: React.SVGProps<SVGLineElement>;
-            linearGradient: React.SVGProps<SVGLinearGradientElement>;
-            marker: React.SVGProps<SVGMarkerElement>;
-            mask: React.SVGProps<SVGMaskElement>;
-            metadata: React.SVGProps<SVGMetadataElement>;
-            mpath: React.SVGProps<SVGElement>;
-            path: React.SVGProps<SVGPathElement>;
-            pattern: React.SVGProps<SVGPatternElement>;
-            polygon: React.SVGProps<SVGPolygonElement>;
-            polyline: React.SVGProps<SVGPolylineElement>;
-            radialGradient: React.SVGProps<SVGRadialGradientElement>;
-            rect: React.SVGProps<SVGRectElement>;
-            stop: React.SVGProps<SVGStopElement>;
-            switch: React.SVGProps<SVGSwitchElement>;
-            symbol: React.SVGProps<SVGSymbolElement>;
-            text: React.SVGProps<SVGTextElement>;
-            textPath: React.SVGProps<SVGTextPathElement>;
-            tspan: React.SVGProps<SVGTSpanElement>;
-            use: React.SVGProps<SVGUseElement>;
-            view: React.SVGProps<SVGViewElement>;
-        }
-    }
-}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -551,12 +551,6 @@ declare namespace React {
         propTypes?: never | undefined;
     }
 
-    /**
-     * @deprecated Use ForwardRefRenderFunction. forwardRef doesn't accept a
-     *             "real" component.
-     */
-    interface RefForwardingComponent <T, P = {}> extends ForwardRefRenderFunction<T, P> {}
-
     interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         new (props: P, context?: any): Component<P, S>;
         propTypes?: WeakValidationMap<P> | undefined;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -150,11 +150,6 @@ declare namespace React {
         P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>
     > extends ReactElement<P, Exclude<T, number>> { }
 
-    /**
-     * @deprecated Please use `FunctionComponentElement`
-     */
-    type SFCElement<P> = FunctionComponentElement<P>;
-
     interface FunctionComponentElement<P> extends ReactElement<P, FunctionComponent<P>> {
         ref?: ('ref' extends keyof P ? P extends { ref?: infer R | undefined } ? R : never : never) | undefined;
     }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -514,14 +514,6 @@ declare namespace React {
     // Class Interfaces
     // ----------------------------------------------------------------------
 
-    /**
-     * @deprecated as of recent React versions, function components can no
-     * longer be considered 'stateless'. Please use `FunctionComponent` instead.
-     *
-     * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
-     */
-    type SFC<P = {}> = FunctionComponent<P>;
-
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -522,14 +522,6 @@ declare namespace React {
      */
     type SFC<P = {}> = FunctionComponent<P>;
 
-    /**
-     * @deprecated as of recent React versions, function components can no
-     * longer be considered 'stateless'. Please use `FunctionComponent` instead.
-     *
-     * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
-     */
-    type StatelessComponent<P = {}> = FunctionComponent<P>;
-
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -75,10 +75,6 @@ declare namespace React {
             [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K] ? K : never
         }[keyof JSX.IntrinsicElements] |
         ComponentType<P>;
-    /**
-     * @deprecated Please use `ElementType`
-     */
-    type ReactType<P = any> = ElementType<P>;
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type JSXElementConstructor<P> =

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -227,7 +227,7 @@ declare namespace React {
      * @deprecated Use either `ReactNode[]` if you need an array or `Iterable<ReactNode>` if its passed to a host component.
      */
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
-    type ReactFragment = {} | Iterable<ReactNode>;
+    type ReactFragment = Iterable<ReactNode>;
     type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;
 
     //

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1072,8 +1072,10 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usecallback
      */
-    // TODO (TypeScript 3.0): <T extends (...args: never[]) => unknown>
-    function useCallback<T extends (...args: any[]) => any>(callback: T, deps: DependencyList): T;
+    // A specific function type would not trigger implicit any.
+    // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52873#issuecomment-845806435 for a comparison between `Function` and more specific types.
+    // tslint:disable-next-line ban-types
+    function useCallback<T extends Function>(callback: T, deps: DependencyList): T;
     /**
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
      *

--- a/types/react/jsx-dev-runtime.d.ts
+++ b/types/react/jsx-dev-runtime.d.ts
@@ -1,2 +1,12 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import * as React from './';
+
+export namespace JSX {
+    interface Element extends React.JSX.Element {}
+    interface ElementClass extends React.JSX.ElementClass {}
+    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
+    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
+    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
+    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
+    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
+    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
+}

--- a/types/react/jsx-runtime.d.ts
+++ b/types/react/jsx-runtime.d.ts
@@ -1,2 +1,12 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import * as React from './';
+
+export namespace JSX {
+    interface Element extends React.JSX.Element {}
+    interface ElementClass extends React.JSX.ElementClass {}
+    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
+    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
+    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
+    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
+    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
+    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
+}

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -102,9 +102,8 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // inline object, to (manually) check if autocomplete works
     React.useReducer(reducer, { age: 42, name: 'The Answer' });
 
-    // TODO (TypeScript 3.0): Decide whether implicit `any` should trigger `noImplicitAny` or if it should default to `unknown` or `never`
-    // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52873
-    // $ExpectType (value: any) => any
+    // Implicit any
+    // $ExpectError
     const anyCallback = React.useCallback(value => {
         // $ExpectType any
         return value;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -227,16 +227,6 @@ LegacyStatelessComponent2.defaultProps = {
     foo: 42
 };
 
-const FunctionComponent3: React.FunctionComponent<SCProps> =
-    // allows usage of props.children
-    // allows null return
-    props => props.foo ? DOM.div(null, props.foo, props.children) : null;
-
-const LegacyStatelessComponent3: React.SFC<SCProps> =
-    // allows usage of props.children
-    // allows null return
-    props => props.foo ? DOM.div(null, props.foo, props.children) : null;
-
 // allows null as props
 const FunctionComponent4: React.FunctionComponent = props => null;
 
@@ -768,7 +758,7 @@ declare var x: React.DOMElement<{
 }, Element>;
 
 // React 16 should be able to render its children directly
-class RenderChildren extends React.Component {
+class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
     render() {
         const { children } = this.props;
         return children !== undefined ? children : null;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -247,8 +247,6 @@ const functionComponentFactoryElement: React.FunctionComponentElement<SCProps> =
 
 const legacyStatelessComponentFactory: React.SFCFactory<SCProps> =
     React.createFactory(FunctionComponent);
-const legacyStatelessComponentFactoryElement: React.SFCElement<SCProps> =
-    legacyStatelessComponentFactory(props);
 
 const domFactory: React.DOMFactory<React.DOMAttributes<{}>, Element> =
     React.createFactory("div");
@@ -261,8 +259,6 @@ const elementNoState: React.CElement<Props, ModernComponentNoState> = React.crea
 const elementNullProps: React.CElement<{}, ModernComponentNoPropsAndState> = React.createElement(ModernComponentNoPropsAndState, null);
 const functionComponentElement: React.FunctionComponentElement<SCProps> = React.createElement(FunctionComponent, scProps);
 const functionComponentElementNullProps: React.FunctionComponentElement<SCProps> = React.createElement(FunctionComponent4, null);
-const legacyStatelessComponentElement: React.SFCElement<SCProps> = React.createElement(FunctionComponent, scProps);
-const legacyStatelessComponentElementNullProps: React.SFCElement<SCProps> = React.createElement(FunctionComponent4, null);
 const domElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> = React.createElement("div");
 const domElementNullProps = React.createElement("div", null);
 const htmlElement = React.createElement("input", { type: "text" });
@@ -304,8 +300,6 @@ const clonedElement3: React.CElement<Props, ModernComponent> =
     });
 const clonedfunctionComponentElement: React.FunctionComponentElement<SCProps> =
     React.cloneElement(functionComponentElement, { foo: 44 });
-const clonedlegacyStatelessComponentElement: React.SFCElement<SCProps> =
-    React.cloneElement(legacyStatelessComponentElement, { foo: 44 });
 // Clone base DOMElement
 const clonedDOMElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> =
     React.cloneElement(domElement, {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -219,14 +219,6 @@ FunctionComponent2.defaultProps = {
     foo: 42
 };
 
-const LegacyStatelessComponent2: React.SFC<SCProps> =
-    // props is contextually typed
-    props => DOM.div(null, props.foo);
-LegacyStatelessComponent2.displayName = "LegacyStatelessComponent2";
-LegacyStatelessComponent2.defaultProps = {
-    foo: 42
-};
-
 // allows null as props
 const FunctionComponent4: React.FunctionComponent = props => null;
 
@@ -276,10 +268,6 @@ const customDomElementNullProps = React.createElement(customDomElement, null);
 // https://github.com/Microsoft/TypeScript/issues/15019
 
 function foo3(child: React.ComponentClass<{ name: string }> | React.FunctionComponent<{ name: string }> | string) {
-    React.createElement(child, { name: "bar" });
-}
-
-function foo4(child: React.ComponentClass<{ name: string }> | React.SFC<{ name: string }> | string) {
     React.createElement(child, { name: "bar" });
 }
 
@@ -770,10 +758,6 @@ React.createElement(Memoized2, { bar: 'string' });
 
 const specialSfc1: React.ExoticComponent<any> = Memoized1;
 const functionComponent: React.FunctionComponent<any> = Memoized2;
-const sfc: React.SFC<any> = Memoized2;
-// this $ExpectError is failing on TypeScript@next
-// // $ExpectError Property '$$typeof' is missing in type
-// const specialSfc2: React.SpecialSFC = props => null;
 
 const propsWithChildren: React.PropsWithChildren<Props> = {
     hello: "world",

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -13,15 +13,9 @@ FunctionComponent.defaultProps = {
 };
 <FunctionComponent />;
 <slot name="slot1"></slot>;
-
-const FunctionComponent2: React.FunctionComponent<SCProps> = ({ foo, children }) => {
-    return <div>{foo}{children}</div>;
-};
-FunctionComponent2.displayName = "FunctionComponent4";
-FunctionComponent2.defaultProps = {
-    foo: 42
-};
-<FunctionComponent2>24</FunctionComponent2>;
+// `FunctionComponent` has no `children`
+// $ExpectError
+<FunctionComponent>24</FunctionComponent>;
 
 const VoidFunctionComponent: React.VoidFunctionComponent<SCProps> = ({ foo }: SCProps) => {
     return <div>{foo}</div>;
@@ -256,8 +250,8 @@ const Memoized4 = React.memo(React.forwardRef((props: {}, ref: React.Ref<HTMLDiv
 <Memoized4 ref={memoized4Ref}/>;
 
 const Memoized5 = React.memo<{ test: boolean }>(
-    prop => <>{prop.test && prop.children}</>,
-    (prevProps, nextProps) => nextProps.test ? prevProps.children === nextProps.children : prevProps.test
+    prop => <>{prop.test}</>,
+    (prevProps, nextProps) => nextProps.test === prevProps.test
 );
 
 <Memoized5 test/>;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -407,14 +407,14 @@ type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
 // $ExpectType false
 type ImgPropsHasRef = 'ref' extends keyof ImgPropsWithoutRef ? true : false;
 
-const HasClassName: React.ReactType<{ className?: string | undefined }> = 'a';
-const HasFoo: React.ReactType<{ foo: boolean }> = 'a'; // $ExpectError
-const HasFoo2: React.ReactType<{ foo: boolean }> = (props: { foo: boolean }) => null;
-const HasFoo3: React.ReactType<{ foo: boolean }> = (props: { foo: string }) => null; // $ExpectError
-const HasHref: React.ReactType<{ href?: string | undefined }> = 'a';
-const HasHref2: React.ReactType<{ href?: string | undefined }> = 'div'; // $ExpectError
+const HasClassName: React.ElementType<{ className?: string | undefined }> = 'a';
+const HasFoo: React.ElementType<{ foo: boolean }> = 'a'; // $ExpectError
+const HasFoo2: React.ElementType<{ foo: boolean }> = (props: { foo: boolean }) => null;
+const HasFoo3: React.ElementType<{ foo: boolean }> = (props: { foo: string }) => null; // $ExpectError
+const HasHref: React.ElementType<{ href?: string | undefined }> = 'a';
+const HasHref2: React.ElementType<{ href?: string | undefined }> = 'div'; // $ExpectError
 
-const CustomElement: React.ReactType = 'my-undeclared-element'; // $ExpectError
+const CustomElement: React.ElementType = 'my-undeclared-element'; // $ExpectError
 
 // custom elements now need to be declared as intrinsic elements
 declare global {
@@ -425,7 +425,7 @@ declare global {
     }
 }
 
-const CustomElement2: React.ReactType = 'my-declared-element';
+const CustomElement2: React.ElementType = 'my-declared-element';
 
 interface TestPropTypesProps {
     foo: string;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -324,7 +324,7 @@ class NewContext extends React.Component {
     }
 }
 
-const ForwardRef = React.forwardRef((props: JSX.IntrinsicElements['div'], ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}/>);
+const ForwardRef = React.forwardRef((props: React.JSX.IntrinsicElements['div'], ref?: React.Ref<HTMLDivElement>) => <div {...props} ref={ref}/>);
 const ForwardRef2 = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <ForwardRef {...props} ref={ref}/>);
 const divFnRef = (ref: HTMLDivElement|null) => { /* empty */ };
 const divRef = React.createRef<HTMLDivElement>();
@@ -345,7 +345,7 @@ const ForwardNewContext = React.forwardRef((_props: {}, ref?: React.Ref<NewConte
 <ForwardNewContext ref='string'/>; // $ExpectError
 
 const ForwardRef3 = React.forwardRef(
-    (props: JSX.IntrinsicElements['div'] & Pick<JSX.IntrinsicElements['div'] & { theme?: {} | undefined }, 'ref'|'theme'>, ref?: React.Ref<HTMLDivElement>) =>
+    (props: React.JSX.IntrinsicElements['div'] & Pick<React.JSX.IntrinsicElements['div'] & { theme?: {} | undefined }, 'ref'|'theme'>, ref?: React.Ref<HTMLDivElement>) =>
         <div {...props} ref={ref}/>
 );
 
@@ -417,7 +417,7 @@ const HasHref2: React.ElementType<{ href?: string | undefined }> = 'div'; // $Ex
 const CustomElement: React.ElementType = 'my-undeclared-element'; // $ExpectError
 
 // custom elements now need to be declared as intrinsic elements
-declare global {
+declare module 'react' {
     namespace JSX {
         interface IntrinsicElements {
             'my-declared-element': {};
@@ -457,7 +457,7 @@ function CustomSelect(props: {
         React.ComponentPropsWithoutRef<typeof CustomSelectOption>
       >
     >;
-  }): JSX.Element {
+  }): React.JSX.Element {
     return (
       <div>
         <ul>{props.children}</ul>
@@ -475,7 +475,7 @@ function CustomSelect(props: {
 function CustomSelectOption(props: {
     value: string;
     children: React.ReactNode;
-}): JSX.Element {
+}): React.JSX.Element {
     return <li data-value={props.value}>{props.children}</li>;
 }
 function Example() {

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -296,9 +296,9 @@ class LegacyContext extends React.Component {
     static contextTypes = { foo: PropTypes.node.isRequired };
 
     render() {
-        // $ExpectType any
-        this.context.foo;
-        return this.context.foo;
+        // $ExpectType unknown
+        this.context;
+        return (this.context as any).foo;
     }
 }
 

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -4,7 +4,7 @@ import { Box, Flex, Text, Heading, Button, Link, Image, Card, BoxProps } from 'r
 import { Box as StyledBox } from 'rebass/styled-components';
 import 'styled-components/macro';
 
-const CustomComponent: React.FunctionComponent = ({ children }) => {
+const CustomComponent: React.FunctionComponent<{ children?: React.ReactNode }> = ({ children }) => {
     return <div>{children}</div>;
 };
 

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -103,6 +103,7 @@ const ItemListObj = formValues({ fooBar : "foo" })(
 /* Custom FormSection */
 
 interface MyFormSectionProps {
+    children?: React.ReactNode;
     foo: string;
 }
 
@@ -111,6 +112,7 @@ const MyFormSection: React.FunctionComponent<MyFormSectionProps> = ({ children, 
 /* Custom Field */
 
 interface MyFieldCustomProps {
+    children?: React.ReactNode;
     foo: string;
 }
 type MyFieldProps = MyFieldCustomProps & WrappedFieldProps;
@@ -151,6 +153,7 @@ const FieldImmutableCustom = ImmutableField as new () => GenericField<MyFieldCus
 /* Custom Fields */
 
 interface MyFieldsCustomProps {
+    children?: React.ReactNode;
     foo: string;
 }
 type MyFieldsProps = MyFieldsCustomProps & WrappedFieldsProps;
@@ -162,7 +165,7 @@ const FieldsCustom = Fields as new () => GenericFields<MyFieldsCustomProps>;
 
 /* FieldArray */
 
-const MyArrayField: React.FunctionComponent<WrappedFieldArrayProps> = ({
+const MyArrayField: React.FunctionComponent<React.PropsWithChildren<WrappedFieldArrayProps>> = ({
     children
 }) => null;
 
@@ -173,6 +176,7 @@ interface MyFieldValue {
 }
 
 interface MyFieldArrayCustomProps {
+    children?: React.ReactNode;
     foo: string;
     bar: number;
 }

--- a/types/redux-form/v7/redux-form-tests.tsx
+++ b/types/redux-form/v7/redux-form-tests.tsx
@@ -101,6 +101,7 @@ const ItemListObj = formValues({ fooBar : "foo" })(
 /* Custom FormSection */
 
 interface MyFormSectionProps {
+    children?: React.ReactNode;
     foo: string;
 }
 
@@ -109,6 +110,7 @@ const MyFormSection: React.FunctionComponent<MyFormSectionProps> = ({ children, 
 /* Custom Field */
 
 interface MyFieldCustomProps {
+    children?: React.ReactNode;
     foo: string;
 }
 type MyFieldProps = MyFieldCustomProps & WrappedFieldProps;
@@ -149,6 +151,7 @@ const FieldImmutableCustom = ImmutableField as new () => GenericField<MyFieldCus
 /* Custom Fields */
 
 interface MyFieldsCustomProps {
+    children?: React.ReactNode;
     foo: string;
 }
 type MyFieldsProps = MyFieldsCustomProps & WrappedFieldsProps;
@@ -160,7 +163,7 @@ const FieldsCustom = Fields as new () => GenericFields<MyFieldsCustomProps>;
 
 /* FieldArray */
 
-const MyArrayField: React.FunctionComponent<WrappedFieldArrayProps> = ({
+const MyArrayField: React.FunctionComponent<React.PropsWithChildren<WrappedFieldArrayProps>> = ({
     children
 }) => null;
 
@@ -170,6 +173,7 @@ interface MyFieldValue {
     num: number;
 }
 interface MyFieldArrayCustomProps {
+    children?: React.ReactNode;
     foo: string;
     bar: number;
 }

--- a/types/rrc/rrc-tests.tsx
+++ b/types/rrc/rrc-tests.tsx
@@ -42,6 +42,7 @@ class RouteTwo extends React.Component<RouteComponentProps> {
 }
 
 interface LayoutProps {
+    children?: React.ReactNode;
     title: string;
     subtitle?: string | undefined;
 }
@@ -91,6 +92,7 @@ class RouteFour extends React.Component<RouteComponentProps> {
 }
 
 interface MyContainerProps {
+    children?: React.ReactNode;
     className?: string | undefined;
     color: number;
 }

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -302,9 +302,7 @@ be.withFontSizes('fontSize')(() => <h1>Hello World</h1>);
             label: 'Background Color',
         },
     ]}
->
-    Hello World
-</be.PanelColorSettings>;
+/>;
 
 //
 // plain-text


### PR DESCRIPTION
addresses https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/57377

This is based on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210 and is actually targeting that branch. I'm just creating a separate draft here to kick off the integration test suite so we can check out, with @eps1lon, how this plays out before including this in that mentioned branch that targets the final React 18 release.