### PR TITLE
Smooch User type - support metadata as generic property-value store

### DIFF
--- a/types/smooch/index.d.ts
+++ b/types/smooch/index.d.ts
@@ -873,6 +873,7 @@ declare namespace Smooch {
         email: string;
         avatarUrl: string;
         metadata: unknown;
+        properties: unknown;
     }
 
     interface ConversationParticipant {

--- a/types/smooch/index.d.ts
+++ b/types/smooch/index.d.ts
@@ -872,9 +872,7 @@ declare namespace Smooch {
         surname: string;
         email: string;
         avatarUrl: string;
-        metadata: {
-            justGotUpdated: boolean;
-        };
+        metadata: unknown;
     }
 
     interface ConversationParticipant {

--- a/types/smooch/smooch-tests.ts
+++ b/types/smooch/smooch-tests.ts
@@ -24,3 +24,9 @@ Smooch.updateConversation('conversation-id', { lastUpdatedAt: null, iconUrl: nul
 // We should still not be able to provide the wrong type for one of updateConversation's options
 // $ExpectError
 Smooch.updateConversation('conversation-id', { lastUpdatedAt: 'may', iconUrl: 42 });
+
+// updateUser should allow custom data to be submitted via the metadata property
+Smooch.updateUser({ metadata: { myCustomProperty: 21 } });
+// But updateUser should NOT allow custom data to be added outside of the metadata property
+// $ExpectError
+Smooch.updateUser({ anIncorrectProperty: 21 });

--- a/types/smooch/smooch-tests.ts
+++ b/types/smooch/smooch-tests.ts
@@ -27,6 +27,8 @@ Smooch.updateConversation('conversation-id', { lastUpdatedAt: 'may', iconUrl: 42
 
 // updateUser should allow custom data to be submitted via the metadata property
 Smooch.updateUser({ metadata: { myCustomProperty: 21 } });
+// updateUser should also allow custom data to be submitted via the properties property
+Smooch.updateUser({ properties: { myCustomProperty: 21 } });
 // But updateUser should NOT allow custom data to be added outside of the metadata property
 // $ExpectError
 Smooch.updateUser({ anIncorrectProperty: 21 });


### PR DESCRIPTION
Update Smooch's user type to support use of `metadata` or `properties` property as generic property-value storage mechanism.

When I originally wrote these types from the documentation, I took the 'justGotUpdated' property in the updateUser example code literally. However, as I applied the new type definitions to existing code using Smooch, I realized `metadata` / `properties` was actually a space where clients could define their own custom data.

Wasn't sure of the best practices for supporting "property bags" like this where the client can specify whatever keys and data they wish - I thought `unknown` would be the most "conservative" in that it wouldn't make any promises the compiler couldn't guarantee (in calls to `getUser`), while also allowing anything to be submitted there (in calls to `updateUser`).

I struggled to find a single source of truth documentation online that went into more detail than the [readme](https://github.com/zendesk/sunshine-conversations-web#updateuseruser) from which most of these types are derived. However, I found [this](https://docs.smooch.io/guide/v1/managing-user-information/#web-messenger) which suggests that this info can be submitted via `properties`, and [this](https://github.com/zendesk/sunshine-conversations-javascript/blob/master/docs/UserUpdateBody.md) which suggests that it can be submitted via `metadata`. I tested and confirmed that both work. When fetching data it is always returned via `metadata` and I considered creating a separate type for updateUser (including both `metadata` and `properties`) vs getUser (including only `metadata`), but ultimately decided that was overkill as the type of `properties` was `unknown` anyway.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.smooch.io/guide/v1/managing-user-information/#web-messenger https://github.com/zendesk/sunshine-conversations-javascript/blob/master/docs/UserUpdateBody.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
