### PR TITLE
braintree-web: update apple pay createPaymentRequest parameters to be optional 

### DIFF
--- a/types/braintree-web/modules/apple-pay.d.ts
+++ b/types/braintree-web/modules/apple-pay.d.ts
@@ -208,7 +208,10 @@ export interface ApplePay {
      *   // { total: { }, countryCode: 'US', currencyCode: 'USD', merchantCapabilities: [ ], supportedNetworks: [ ] }
      *
      */
-    createPaymentRequest(paymentRequest: ApplePayPaymentRequest): ApplePayPaymentRequest;
+    createPaymentRequest(
+        paymentRequest: Omit<ApplePayPaymentRequest, 'countryCode' | 'currencyCode' | 'merchantCapabilities' | 'supportedNetworks'> & 
+        Partial<Pick<ApplePayPaymentRequest,  'countryCode' | 'currencyCode' | 'merchantCapabilities' | 'supportedNetworks'>>
+    ): ApplePayPaymentRequest;
 
     /**
      * Validates the merchant website, as required by ApplePaySession before payment can be authorized.     * - The canonical name for your store.

--- a/types/braintree-web/modules/apple-pay.d.ts
+++ b/types/braintree-web/modules/apple-pay.d.ts
@@ -209,8 +209,16 @@ export interface ApplePay {
      *
      */
     createPaymentRequest(
-        paymentRequest: Omit<ApplePayPaymentRequest, 'countryCode' | 'currencyCode' | 'merchantCapabilities' | 'supportedNetworks'> & 
-        Partial<Pick<ApplePayPaymentRequest,  'countryCode' | 'currencyCode' | 'merchantCapabilities' | 'supportedNetworks'>>
+        paymentRequest: Omit<
+            ApplePayPaymentRequest,
+            'countryCode' | 'currencyCode' | 'merchantCapabilities' | 'supportedNetworks'
+        > &
+            Partial<
+                Pick<
+                    ApplePayPaymentRequest,
+                    'countryCode' | 'currencyCode' | 'merchantCapabilities' | 'supportedNetworks'
+                >
+            >,
     ): ApplePayPaymentRequest;
 
     /**

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -355,7 +355,6 @@ braintree.client.create(
 
         // Check that apple pay createPaymentRequest fields are optional
         braintree.applePay.create({ client: clientInstance }, (createErr, applePayInstance) => {
-            
             const request = {
                 total: { label: 'Your Label', amount: '10.00' },
             };
@@ -363,7 +362,7 @@ braintree.client.create(
             const paymentRequest = applePayInstance.createPaymentRequest(request);
             console.log(paymentRequest);
             // { total: { }, countryCode: 'US', currencyCode: 'USD', merchantCapabilities: [ ], supportedNetworks: [ ] }
-        })
+        });
 
         braintree.applePay.create({ client: clientInstance }, (createErr, applePayInstance) => {
             const request = {
@@ -752,46 +751,52 @@ braintree.client.create(
         });
 
         // Local Payment
-        braintree.localPayment.create({
-            client: clientInstance
-        }, (err, localPaymentInstance) => {
-            localPaymentInstance
-                .startPayment({
-                    amount: 11.00,
-                    currencyCode: 'EUR',
-                    paymentType: 'sofort',
-                    onPaymentStart: (data, next) => {
-                        if (data.paymentId) {
-                            // Implementation
+        braintree.localPayment.create(
+            {
+                client: clientInstance,
+            },
+            (err, localPaymentInstance) => {
+                localPaymentInstance
+                    .startPayment({
+                        amount: 11.0,
+                        currencyCode: 'EUR',
+                        paymentType: 'sofort',
+                        onPaymentStart: (data, next) => {
+                            if (data.paymentId) {
+                                // Implementation
+                            }
+                            next();
+                        },
+                    })
+                    .then((payload: braintree.LocalPaymentTokenizePayload) => {
+                        console.log(payload.nonce);
+                    })
+                    .catch((error: braintree.BraintreeError) => {
+                        console.error('Error!', error);
+                    });
+
+                localPaymentInstance.tokenize(
+                    {
+                        btLpPayerId: '1234',
+                        btLpPaymentId: '1234',
+                        btLpToken: '1234',
+                    },
+                    (error, data) => {
+                        if (error) {
+                            console.error('Tokenize Error!', error);
+                            return;
                         }
-                        next();
-                    }
-                })
-                .then((payload: braintree.LocalPaymentTokenizePayload) => {
-                    console.log(payload.nonce);
-                })
-                .catch((error: braintree.BraintreeError) => {
-                    console.error('Error!', error);
+
+                        // Implementation
+                        console.log(data.nonce);
+                    },
+                );
+
+                localPaymentInstance.teardown(err => {
+                    // Implementation
                 });
-
-            localPaymentInstance.tokenize({
-                btLpPayerId: '1234',
-                btLpPaymentId: '1234',
-                btLpToken: '1234'
-            }, (error, data) => {
-                if (error) {
-                    console.error('Tokenize Error!', error);
-                    return;
-                }
-
-                // Implementation
-                console.log(data.nonce);
-            });
-
-            localPaymentInstance.teardown(err => {
-                // Implementation
-            });
-        });
+            },
+        );
     },
 );
 

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -353,6 +353,18 @@ braintree.client.create(
             },
         );
 
+        // Check that apple pay createPaymentRequest fields are optional
+        braintree.applePay.create({ client: clientInstance }, (createErr, applePayInstance) => {
+            
+            const request = {
+                total: { label: 'Your Label', amount: '10.00' },
+            };
+
+            const paymentRequest = applePayInstance.createPaymentRequest(request);
+            console.log(paymentRequest);
+            // { total: { }, countryCode: 'US', currencyCode: 'USD', merchantCapabilities: [ ], supportedNetworks: [ ] }
+        })
+
         braintree.applePay.create({ client: clientInstance }, (createErr, applePayInstance) => {
             const request = {
                 countryCode: 'US',


### PR DESCRIPTION
For Apple Pay, braintree provides a `createPaymentRequest` function which takes a request object and populates it with data from the braintree server. Currently the fields provided by the function are considered as mandatory parameters. This of course isn't actually true.

So I've updated the parameter type to make these fields optional, rather than mandatory. 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://braintree.github.io/braintree-web/current/ApplePay.html#createPaymentRequest)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

