### PR TITLE
[imagemin-svgo] Use correct version of svgo dependency

### DIFF
--- a/types/gulp-imagemin/gulp-imagemin-tests.ts
+++ b/types/gulp-imagemin/gulp-imagemin-tests.ts
@@ -5,41 +5,53 @@ const plugins = [
     gulpImagemin.gifsicle({ interlaced: true }),
     gulpImagemin.mozjpeg({ progressive: true }),
     gulpImagemin.optipng({ optimizationLevel: 5 }),
-    gulpImagemin.svgo({ floatPrecision: 2 })
+    gulpImagemin.svgo({
+        floatPrecision: 2,
+        plugins: [
+            {
+                name: 'removeViewBox',
+                active: true,
+            },
+            {
+                name: 'cleanupIDs',
+                active: false,
+            },
+        ],
+    }),
 ];
 
 gulp.task('build', () => {
-    return gulp.src('*.{gif,jpg,png,svg}')
-        .pipe(gulpImagemin())
-        .pipe(gulp.dest('dist'));
+    return gulp.src('*.{gif,jpg,png,svg}').pipe(gulpImagemin()).pipe(gulp.dest('dist'));
 });
 
 gulp.task('build', () => {
-    return gulp.src('*.{gif,jpg,png,svg}')
-        .pipe(gulpImagemin(plugins))
-        .pipe(gulp.dest('dist'));
+    return gulp.src('*.{gif,jpg,png,svg}').pipe(gulpImagemin(plugins)).pipe(gulp.dest('dist'));
 });
 
 gulp.task('build', () => {
-    return gulp.src('*.{gif,jpg,png,svg}')
+    return gulp
+        .src('*.{gif,jpg,png,svg}')
         .pipe(gulpImagemin({ silent: true }))
         .pipe(gulp.dest('dist'));
 });
 
 gulp.task('build', () => {
-    return gulp.src('*.{gif,jpg,png,svg}')
+    return gulp
+        .src('*.{gif,jpg,png,svg}')
         .pipe(gulpImagemin(plugins, { silent: true }))
         .pipe(gulp.dest('dist'));
 });
 
 gulp.task('build', () => {
-    return gulp.src('*.{gif,jpg,png,svg}')
+    return gulp
+        .src('*.{gif,jpg,png,svg}')
         .pipe(gulpImagemin({ verbose: true }))
         .pipe(gulp.dest('dist'));
 });
 
 gulp.task('build', () => {
-    return gulp.src('*.{gif,jpg,png,svg}')
+    return gulp
+        .src('*.{gif,jpg,png,svg}')
         .pipe(gulpImagemin(plugins, { verbose: true }))
         .pipe(gulp.dest('dist'));
 });

--- a/types/gulp-imagemin/index.d.ts
+++ b/types/gulp-imagemin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for gulp-imagemin 7.0
+// Type definitions for gulp-imagemin 8.0
 // Project: https://github.com/sindresorhus/gulp-imagemin#readme
 // Definitions by: Romain Faust <https://github.com/romain-faust>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/gulp-imagemin/tsconfig.json
+++ b/types/gulp-imagemin/tsconfig.json
@@ -6,9 +6,6 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "paths": {
-            "svgo": ["svgo/v1"]
-        },
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",

--- a/types/imagemin-svgo/imagemin-svgo-tests.ts
+++ b/types/imagemin-svgo/imagemin-svgo-tests.ts
@@ -9,7 +9,8 @@ imagemin(['*.svg'], {
             floatPrecision: 2,
             plugins: [
                 {
-                    removeViewBox: false,
+                    name: 'removeViewBox',
+                    active: true,
                 },
             ],
             multipass: false,

--- a/types/imagemin-svgo/index.d.ts
+++ b/types/imagemin-svgo/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Plugin } from 'imagemin';
-import { Options as SvgoOptions } from 'svgo';
+import { OptimizeOptions as SvgoOptions } from 'svgo';
 
 /**
  * SVGO imagemin plugin

--- a/types/imagemin-svgo/tsconfig.json
+++ b/types/imagemin-svgo/tsconfig.json
@@ -6,9 +6,6 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "paths": {
-            "svgo": ["svgo/v1"]
-        },
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",


### PR DESCRIPTION
`imagemin-svgo` package uses `svgo` dependency with the version above then 2.0.0
Documentation: https://github.com/imagemin/imagemin-svgo/blob/main/package.json#L32

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test imagemin-svgo`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[imagemin-svgo](https://github.com/imagemin/imagemin-svgo/blob/main/package.json#L32)>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.