### PR TITLE
[kakaomaps] Supports drawing holes in polygon via the `setPath` method

### DIFF
--- a/types/kakaomaps/index.d.ts
+++ b/types/kakaomaps/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://apis.map.kakao.com/web/documentation/
 // Definitions by: MinByeongDon <https://github.com/MinByeongDon>
 //                 PositiveKo <https://github.com/positiveko>
+//                 Sanghyeon Lee <https://github.com/yongdamsh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 declare namespace kakao.maps {
   // # Core
@@ -329,8 +330,8 @@ declare namespace kakao.maps {
     setMap(map: Map|null): void;
     getMap(): Map|null;
     setOptions(options: PolygonOptions): void;
-    setPath(path: LatLng[]): void;
-    getPath(): LatLng[];
+    setPath(path: LatLng[]|LatLng[][]): void;
+    getPath(): LatLng[]|LatLng[][];
     getLength(): number;
     getArea(): number;
     setZIndex(zIndex: number): void;

--- a/types/kakaomaps/kakaomaps-tests.ts
+++ b/types/kakaomaps/kakaomaps-tests.ts
@@ -4,3 +4,28 @@ const options = {
     level: 3
 };
 const map = new kakao.maps.Map(container, options);
+
+// example: https://apis.map.kakao.com/web/sample/donut/
+const polygon = new kakao.maps.Polygon({ map });
+
+const path = [
+	new kakao.maps.LatLng(33.45086654081833, 126.56906858718982),
+	new kakao.maps.LatLng(33.45010890948828, 126.56898629127468),
+	new kakao.maps.LatLng(33.44979857909499, 126.57049357211622),
+	new kakao.maps.LatLng(33.450137483918496, 126.57202991943016),
+	new kakao.maps.LatLng(33.450706188506054, 126.57223147947938),
+	new kakao.maps.LatLng(33.45164068091554, 126.5713126693152)
+];
+
+const hole = [
+	new kakao.maps.LatLng(33.4506262491095, 126.56997323165163),
+	new kakao.maps.LatLng(33.45029422800042, 126.57042659659218),
+	new kakao.maps.LatLng(33.45032339792896, 126.5710395101452),
+	new kakao.maps.LatLng(33.450622037218295, 126.57136070280123),
+	new kakao.maps.LatLng(33.450964416902046, 126.57129448564594),
+	new kakao.maps.LatLng(33.4510527150534, 126.57075627706975)
+];
+
+polygon.setPath(path); // $ExpectType void
+polygon.setPath([path, hole]); // $ExpectType void
+polygon.setPath(path, hole); // $ExpectError

--- a/types/kakaomaps/kakaomaps-tests.ts
+++ b/types/kakaomaps/kakaomaps-tests.ts
@@ -9,21 +9,21 @@ const map = new kakao.maps.Map(container, options);
 const polygon = new kakao.maps.Polygon({ map });
 
 const path = [
-	new kakao.maps.LatLng(33.45086654081833, 126.56906858718982),
-	new kakao.maps.LatLng(33.45010890948828, 126.56898629127468),
-	new kakao.maps.LatLng(33.44979857909499, 126.57049357211622),
-	new kakao.maps.LatLng(33.450137483918496, 126.57202991943016),
-	new kakao.maps.LatLng(33.450706188506054, 126.57223147947938),
-	new kakao.maps.LatLng(33.45164068091554, 126.5713126693152)
+    new kakao.maps.LatLng(33.45086654081833, 126.56906858718982),
+    new kakao.maps.LatLng(33.45010890948828, 126.56898629127468),
+    new kakao.maps.LatLng(33.44979857909499, 126.57049357211622),
+    new kakao.maps.LatLng(33.450137483918496, 126.57202991943016),
+    new kakao.maps.LatLng(33.450706188506054, 126.57223147947938),
+    new kakao.maps.LatLng(33.45164068091554, 126.5713126693152)
 ];
 
 const hole = [
-	new kakao.maps.LatLng(33.4506262491095, 126.56997323165163),
-	new kakao.maps.LatLng(33.45029422800042, 126.57042659659218),
-	new kakao.maps.LatLng(33.45032339792896, 126.5710395101452),
-	new kakao.maps.LatLng(33.450622037218295, 126.57136070280123),
-	new kakao.maps.LatLng(33.450964416902046, 126.57129448564594),
-	new kakao.maps.LatLng(33.4510527150534, 126.57075627706975)
+    new kakao.maps.LatLng(33.4506262491095, 126.56997323165163),
+    new kakao.maps.LatLng(33.45029422800042, 126.57042659659218),
+    new kakao.maps.LatLng(33.45032339792896, 126.5710395101452),
+    new kakao.maps.LatLng(33.450622037218295, 126.57136070280123),
+    new kakao.maps.LatLng(33.450964416902046, 126.57129448564594),
+    new kakao.maps.LatLng(33.4510527150534, 126.57075627706975)
 ];
 
 polygon.setPath(path); // $ExpectType void


### PR DESCRIPTION
When creating a polygon instance, we can pass multiple coordinate arrays, but it is not defined in the `setPath` method, so a union type is added.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://apis.map.kakao.com/web/sample/donut/

