### PR TITLE
[node]: Add the `.values()` API to the ReadableStream interface

### DIFF
--- a/types/node/stream/web.d.ts
+++ b/types/node/stream/web.d.ts
@@ -139,7 +139,8 @@ declare module 'stream/web' {
         pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
         pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
         tee(): [ReadableStream<R>, ReadableStream<R>];
-        [Symbol.asyncIterator](options?: { preventCancel?: boolean }): AsyncIterableIterator<R>;
+        values(options?: { preventCancel?: boolean }): AsyncIterableIterator<R>;
+        [Symbol.asyncIterator](): AsyncIterableIterator<R>;
     }
     const ReadableStream: {
         prototype: ReadableStream;

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -534,6 +534,11 @@ async function testReadableStream() {
         },
     });
 
+    for await (const value of stream.values()) {
+      // $ExpectType number
+      value;
+    }
+
     // ERROR: 538:31  await-promise  Invalid 'for-await-of' of a non-AsyncIterable value.
     // for await (const value of stream) {
     //     // $ExpectType number


### PR DESCRIPTION
According to the node documentation of the `stream/web` module, ReadableStreams expose a `.values()` API for constructing an AsyncIterator with additional options.

See https://nodejs.org/api/webstreams.html#readablestreamvaluesoptions

This makes sure the node types package for `stream/web` includes this in the definition.

Checklist:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/webstreams.html#readablestreamvaluesoptions
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header~.
