### PR TITLE
[pleasejs] Add missing make_contrast type

### DIFF
--- a/types/pleasejs/index.d.ts
+++ b/types/pleasejs/index.d.ts
@@ -16,10 +16,19 @@ declare namespace PleaseJS{
 
         /***
          * make a color scheme
+         * @param {HSV} base_color
          * @param {MakeSchemeOption} options
          * @returns {Array}
          */
         make_scheme(base_color: HSV, options?: MakeSchemeOption): Array<string | RGB | HSV>;
+
+        /***
+         * make a contrasting color scheme
+         * @param {HSV} base_color
+         * @param {MakeContrastOption} options
+         * @returns {string|RGB|HSV}
+         */
+        make_contrast(base_color: HSV, options?: MakeContrastOption): string | RGB | HSV;
 
         /***
          * convert color name into hex string
@@ -100,6 +109,11 @@ declare namespace PleaseJS{
 
     export interface MakeSchemeOption{
         scheme_type: string;
+        format: string;
+    }
+
+    export interface MakeContrastOption{
+        golden: boolean;
         format: string;
     }
 

--- a/types/pleasejs/pleasejs-tests.ts
+++ b/types/pleasejs/pleasejs-tests.ts
@@ -25,6 +25,24 @@ Please.make_scheme(
     }
 );
 
+Please.make_contrast({
+    h: 92,
+    s: .4,
+    v: .2
+});
+
+Please.make_contrast(
+    {
+        h: 92,
+        s: .4,
+        v: .2
+    },
+    {
+        golden: false,
+        format: 'rgb'
+    }
+);
+
 Please.NAME_to_HEX("red");
 
 Please.NAME_to_HSV("red");


### PR DESCRIPTION
A exposed helper from PleaseJS is not typed: `make_contrast`.

PleaseJS code source: https://github.com/Fooidge/PleaseJS/blob/bb4631ba8891ee26962589572ffaaffc57a87b1f/src/Please.js#L660

Also take the opportunity of this PR to add a missing JSDoc param on `make_scheme` helper.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
