### PR TITLE
uri-js: Add optional base attribute to constuctor

### DIFF
--- a/types/urijs/index.d.ts
+++ b/types/urijs/index.d.ts
@@ -27,9 +27,9 @@ export = URI;
 export as namespace URI;
 
 declare const URI: {
-    (value?: string | URI.URIOptions | HTMLElement): URI;
+    (value?: string | URI.URIOptions | HTMLElement, base?: string | URI): URI;
 
-    new(value?: string | URI.URIOptions | HTMLElement): URI;
+    new(value?: string | URI.URIOptions | HTMLElement, base?: string | URI): URI;
 
     addQuery(data: URI.QueryDataMap, prop: string, value: string): object;
     addQuery(data: URI.QueryDataMap, qryObj: object): object;

--- a/types/urijs/test/urijs-dom.test.ts
+++ b/types/urijs/test/urijs-dom.test.ts
@@ -7,6 +7,7 @@ declare var $: (arg?: any) => JQuery;
 {
     URI();
     URI('http://user:pass@example.org:80/foo/bar.html?foo=bar&bar=baz#frag');
+    URI('/foo.html', 'https://example.org');
     URI({
         protocol: 'http',
         username: 'user',
@@ -21,6 +22,7 @@ declare var $: (arg?: any) => JQuery;
 
     new URI();
     new URI('http://user:pass@example.org:80/foo/bar.html?foo=bar&bar=baz#frag');
+    new URI('/foo.html', 'https://example.org');
     new URI({
         protocol: 'http',
         username: 'user',


### PR DESCRIPTION
It's part of the code here: https://github.com/medialize/URI.js/blob/efae1e56bd80d78478ffb8bcb8a75ee2c0f1031b/src/URI.js#L35 It's not well documented in the original project however.

You can see that the constructor argument of `base` is past to `absoluteTo` which shares the same parameter types as `base`

https://github.com/medialize/URI.js/blob/efae1e56bd80d78478ffb8bcb8a75ee2c0f1031b/src/URI.js#L74

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
