### PR TITLE
update(bootstrap-fileinput): v5.2 update and fix

### DIFF
--- a/types/bootstrap-fileinput/bootstrap-fileinput-tests.ts
+++ b/types/bootstrap-fileinput/bootstrap-fileinput-tests.ts
@@ -20,6 +20,10 @@ $('document').on('ready', () => {
             overwriteInitial: false,
             theme: 'fas',
             deleteUrl: 'http://localhost/file-delete.php',
+            preProcessUpload: (fileId, file) => {
+                return file;
+            },
+            browseOnZoneClick: true,
         })
         .on('fileuploaded', (event, previewId, index, fileId) => {
             console.log('File Uploaded', `ID: ${fileId}, Thumb ID: ${previewId}`);

--- a/types/bootstrap-fileinput/index.d.ts
+++ b/types/bootstrap-fileinput/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for bootstrap-fileinput 5.0
+// Type definitions for bootstrap-fileinput 5.2
 // Project: https://github.com/kartik-v/bootstrap-fileinput
 // Definitions by: Ché Coxshall <https://github.com/CheCoxshall>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
@@ -199,6 +199,12 @@ declare namespace BootstrapFileInput {
          * When set to false, a next batch of files selected for upload will clear these thumbnails from preview.
          */
         showUploadedThumbs?: boolean | undefined;
+        /**
+         * Whether to enable file browse/select on clicking of the preview zone.
+         * @default false
+         * @see {@link https://plugins.krajee.com/file-input/plugin-options#browseOnZoneClick}
+         */
+        browseOnZoneClick?: boolean | undefined;
         /**
          * Whether to automatically replace the files in the preview after the maxFileCount limit is reached and a new set of file(s) is/are selected.
          * This will only work if a valid maxFileCount is set.
@@ -848,6 +854,11 @@ declare namespace BootstrapFileInput {
          * Defaults to UTF-8.
          */
         textEncoding?: string | undefined;
+        /**
+         * Callback to pre process upload which will return a converted or encrypted file content.
+         * See {@link https://plugins.krajee.com/file-input/plugin-options#preProcessUpload}
+         */
+        preProcessUpload?: ((fileId: string, file: File) => File) | undefined;
         /**
          * additional ajax settings to pass to the plugin before submitting the ajax request for upload.
          * Applicable only for ajax uploads.


### PR DESCRIPTION
- missing `browseOnZoneClick`
- v5.2 updates

https://github.com/kartik-v/bootstrap-fileinput/compare/v5.0.9...v5.2.7

/cc @khoait

Thanks!

Fixes #58925

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.