### PR TITLE
[aws-lambda] Add S3 Eventbridge Notification Handler

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -87,5 +87,6 @@ export * from "./trigger/sns";
 export * from "./trigger/sqs";
 export * from './trigger/msk';
 export * from "./trigger/secretsmanager";
+export * from "./trigger/s3-event-notification";
 
 export as namespace AWSLambda;

--- a/types/aws-lambda/test/s3-event-notification-tests.ts
+++ b/types/aws-lambda/test/s3-event-notification-tests.ts
@@ -19,445 +19,462 @@ import {
     S3ObjectTagsAddedNotificationEvent,
     S3ObjectTagsAddedNotificationEventDetail,
     S3ObjectTagsDeletedNotificationEvent,
-    S3ObjectTagsDeletedNotificationEventDetail
-} from "aws-lambda";
-
+    S3ObjectTagsDeletedNotificationEventDetail,
+} from 'aws-lambda';
 
 // EventBridgeEvent structure is tested in eventbridge-tests.ts
 // testing only source, detail and detail-type here
-declare let eventBridgeEventSource: 'aws.s3'
+declare let eventBridgeEventSource: 'aws.s3';
 
-const S3ObjectAccessTierChangedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectAccessTierChangedNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object Access Tier Changed" = event["detail-type"]
-    const detail: S3ObjectAccessTierChangedNotificationEventDetail = event.detail
+const S3ObjectAccessTierChangedNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectAccessTierChangedNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object Access Tier Changed' = event['detail-type'];
+    const detail: S3ObjectAccessTierChangedNotificationEventDetail = event.detail;
 
     const exampleEvent: S3ObjectAccessTierChangedNotificationEvent = {
-        version: "0",
-        id: "b0484f24-4f9d-3a49-de3b-e8b56b954cdd",
-        "detail-type": "Object Access Tier Changed",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: 'b0484f24-4f9d-3a49-de3b-e8b56b954cdd',
+        'detail-type': 'Object Access Tier Changed',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
+                key: 'example-key',
                 size: 5,
-                etag: "b1946ac92492d2347c6235b4d2611184",
-                "version-id": "NX.DRp5klxcEVaJ5RC_fO0994Hl.JHOY"
+                etag: 'b1946ac92492d2347c6235b4d2611184',
+                'version-id': 'NX.DRp5klxcEVaJ5RC_fO0994Hl.JHOY',
             },
-            "request-id": "2MMR4GXSXJGZ5THF",
-            requester: "s3.amazonaws.com",
-            "destination-access-tier": "ARCHIVE_ACCESS"
-        }
-    }
+            'request-id': '2MMR4GXSXJGZ5THF',
+            requester: 's3.amazonaws.com',
+            'destination-access-tier': 'ARCHIVE_ACCESS',
+        },
+    };
 
-    exampleEvent.detail["destination-access-tier"] = "DEEP_ARCHIVE_ACCESS"
+    exampleEvent.detail['destination-access-tier'] = 'DEEP_ARCHIVE_ACCESS';
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};
 
-
-const S3ObjectACLUpdatedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectACLUpdatedNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object ACL Updated" = event["detail-type"]
-    const detail: S3ObjectACLUpdatedNotificationEventDetail = event.detail
+const S3ObjectACLUpdatedNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectACLUpdatedNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object ACL Updated' = event['detail-type'];
+    const detail: S3ObjectACLUpdatedNotificationEventDetail = event.detail;
 
     const exampleEvent: S3ObjectACLUpdatedNotificationEvent = {
-        version: "0",
-        id: "7382f94d-cdb4-ae90-8411-e79d33d0d2c9",
-        "detail-type": "Object ACL Updated",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: '7382f94d-cdb4-ae90-8411-e79d33d0d2c9',
+        'detail-type': 'Object ACL Updated',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
-                etag: "b1946ac92492d2347c6235b4d2611184",
-                "version-id": "Xd_29e0Da7c0h8APYtG8ZsGpnPtNDewu"
+                key: 'example-key',
+                etag: 'b1946ac92492d2347c6235b4d2611184',
+                'version-id': 'Xd_29e0Da7c0h8APYtG8ZsGpnPtNDewu',
             },
-            "request-id": "8NZP164VNA76D82R",
-            requester: "123456789012",
-            "source-ip-address": "1.2.3.4"
-        }
-    }
+            'request-id': '8NZP164VNA76D82R',
+            requester: '123456789012',
+            'source-ip-address': '1.2.3.4',
+        },
+    };
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};
 
-const S3ObjectCreatedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectCreatedNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object Created" = event["detail-type"]
-    const detail: S3ObjectCreatedNotificationEventDetail = event.detail
+const S3ObjectCreatedNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectCreatedNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object Created' = event['detail-type'];
+    const detail: S3ObjectCreatedNotificationEventDetail = event.detail;
 
-    let exampleEvent: S3ObjectCreatedNotificationEvent = {
-        version: "0",
-        id: "17793124-05d4-b198-2fde-7ededc63b103",
-        "detail-type": "Object Created",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+    const exampleEvent: S3ObjectCreatedNotificationEvent = {
+        version: '0',
+        id: '17793124-05d4-b198-2fde-7ededc63b103',
+        'detail-type': 'Object Created',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
+                key: 'example-key',
                 size: 5,
-                etag: "b1946ac92492d2347c6235b4d2611184",
-                "version-id": "IYV3p45BT0ac8hjHg1houSdS1a.Mro8e",
-                sequencer: "00617F08299329D189"
+                etag: 'b1946ac92492d2347c6235b4d2611184',
+                'version-id': 'IYV3p45BT0ac8hjHg1houSdS1a.Mro8e',
+                sequencer: '00617F08299329D189',
             },
-            "request-id": "N4N7GDK58NMKJ12R",
-            requester: "123456789012",
-            "source-ip-address": "1.2.3.4",
-            reason: "PutObject"
-        }
-    }
+            'request-id': 'N4N7GDK58NMKJ12R',
+            requester: '123456789012',
+            'source-ip-address': '1.2.3.4',
+            reason: 'PutObject',
+        },
+    };
 
-    exampleEvent.detail.reason = "POST Object"
-    exampleEvent.detail.reason = "CopyObject"
-    exampleEvent.detail.reason = "CompleteMultipartUpload"
+    exampleEvent.detail.reason = 'POST Object';
+    exampleEvent.detail.reason = 'CopyObject';
+    exampleEvent.detail.reason = 'CompleteMultipartUpload';
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};
 
-const S3ObjectDeletedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectDeletedNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object Deleted" = event["detail-type"]
-    const detail: S3ObjectDeletedNotificationEventDetail = event.detail
+const S3ObjectDeletedNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectDeletedNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object Deleted' = event['detail-type'];
+    const detail: S3ObjectDeletedNotificationEventDetail = event.detail;
 
     const deleteObjectExampleEvent: S3ObjectDeletedNotificationEvent = {
-        version: "0",
-        id: "ad1de317-e409-eba2-9552-30113f8d88e3",
-        "detail-type": "Object Deleted",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: 'ad1de317-e409-eba2-9552-30113f8d88e3',
+        'detail-type': 'Object Deleted',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
-                etag: "d41d8cd98f00b204e9800998ecf8427e",
-                "version-id": "mtB0cV.jejK63XkRNceanNMC.qXPWLeK",
-                sequencer: "00617B398000000000"
+                key: 'example-key',
+                etag: 'd41d8cd98f00b204e9800998ecf8427e',
+                'version-id': 'mtB0cV.jejK63XkRNceanNMC.qXPWLeK',
+                sequencer: '00617B398000000000',
             },
-            "request-id": "20EB74C14654DC47",
-            requester: "s3.amazonaws.com",
-            "source-ip-address": "1.2.3.4",
-            reason: "DeleteObject",
-            "deletion-type": "Delete Marker Created"
-        }
-    }
-    deleteObjectExampleEvent.detail["deletion-type"] = "Permanently Deleted";
-
+            'request-id': '20EB74C14654DC47',
+            requester: 's3.amazonaws.com',
+            'source-ip-address': '1.2.3.4',
+            reason: 'DeleteObject',
+            'deletion-type': 'Delete Marker Created',
+        },
+    };
+    deleteObjectExampleEvent.detail['deletion-type'] = 'Permanently Deleted';
 
     const lifecycleExpirationExampleEvent2: S3ObjectDeletedNotificationEvent = {
-        version: "0",
-        id: "ad1de317-e409-eba2-9552-30113f8d88e3",
-        "detail-type": "Object Deleted",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: 'ad1de317-e409-eba2-9552-30113f8d88e3',
+        'detail-type': 'Object Deleted',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
-                etag: "d41d8cd98f00b204e9800998ecf8427e",
-                "version-id": "mtB0cV.jejK63XkRNceanNMC.qXPWLeK",
-                sequencer: "00617B398000000000"
+                key: 'example-key',
+                etag: 'd41d8cd98f00b204e9800998ecf8427e',
+                'version-id': 'mtB0cV.jejK63XkRNceanNMC.qXPWLeK',
+                sequencer: '00617B398000000000',
             },
-            "request-id": "20EB74C14654DC47",
-            requester: "s3.amazonaws.com",
-            reason: "Lifecycle Expiration",
-            "deletion-type": "Delete Marker Created"
-        }
-    }
-    lifecycleExpirationExampleEvent2.detail["deletion-type"] = "Permanently Deleted";
+            'request-id': '20EB74C14654DC47',
+            requester: 's3.amazonaws.com',
+            reason: 'Lifecycle Expiration',
+            'deletion-type': 'Delete Marker Created',
+        },
+    };
+    lifecycleExpirationExampleEvent2.detail['deletion-type'] = 'Permanently Deleted';
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};
 
-const S3ObjectRestoreCompletedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectRestoreCompletedNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object Restore Completed" = event["detail-type"]
-    const detail: S3ObjectRestoreCompletedNotificationEventDetail = event.detail
+const S3ObjectRestoreCompletedNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectRestoreCompletedNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object Restore Completed' = event['detail-type'];
+    const detail: S3ObjectRestoreCompletedNotificationEventDetail = event.detail;
 
     const exampleEvent: S3ObjectRestoreCompletedNotificationEvent = {
-        version: "0",
-        id: "6924de0d-13e2-6bbf-c0c1-b903b753565e",
-        "detail-type": "Object Restore Completed",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: '6924de0d-13e2-6bbf-c0c1-b903b753565e',
+        'detail-type': 'Object Restore Completed',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
+                key: 'example-key',
                 size: 5,
-                etag: "b1946ac92492d2347c6235b4d2611184",
-                "version-id": "KKsjUC1.6gIjqtvhfg5AdMI0eCePIiT3"
+                etag: 'b1946ac92492d2347c6235b4d2611184',
+                'version-id': 'KKsjUC1.6gIjqtvhfg5AdMI0eCePIiT3',
             },
-            "request-id": "189F19CB7FB1B6A4",
-            requester: "s3.amazonaws.com",
-            "restore-expiry-time": "2021-11-13T00:00:00Z",
-            "source-storage-class": "GLACIER"
-        }
-    }
+            'request-id': '189F19CB7FB1B6A4',
+            requester: 's3.amazonaws.com',
+            'restore-expiry-time': '2021-11-13T00:00:00Z',
+            'source-storage-class': 'GLACIER',
+        },
+    };
 
-    exampleEvent.detail["source-storage-class"] = "DEEP_ARCHIVE"
-    exampleEvent.detail["source-storage-class"] = "GLACIER_IR"
-    exampleEvent.detail["source-storage-class"] = "STANDARD"
-    exampleEvent.detail["source-storage-class"] = "ONEZONE_IA"
-    exampleEvent.detail["source-storage-class"] = "STANDARD_IA"
-    exampleEvent.detail["source-storage-class"] = "INTELLIGENT_TIERING"
-    exampleEvent.detail["source-storage-class"] = "OUTPOSTS"
-    exampleEvent.detail["source-storage-class"] = "REDUCED_REDUNDANCY"
+    exampleEvent.detail['source-storage-class'] = 'DEEP_ARCHIVE';
+    exampleEvent.detail['source-storage-class'] = 'GLACIER_IR';
+    exampleEvent.detail['source-storage-class'] = 'STANDARD';
+    exampleEvent.detail['source-storage-class'] = 'ONEZONE_IA';
+    exampleEvent.detail['source-storage-class'] = 'STANDARD_IA';
+    exampleEvent.detail['source-storage-class'] = 'INTELLIGENT_TIERING';
+    exampleEvent.detail['source-storage-class'] = 'OUTPOSTS';
+    exampleEvent.detail['source-storage-class'] = 'REDUCED_REDUNDANCY';
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};
 
-const S3ObjectRestoreExpiredNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectRestoreExpiredNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object Restore Expired" = event["detail-type"]
-    const detail: S3ObjectRestoreExpiredNotificationEventDetail = event.detail
+const S3ObjectRestoreExpiredNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectRestoreExpiredNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object Restore Expired' = event['detail-type'];
+    const detail: S3ObjectRestoreExpiredNotificationEventDetail = event.detail;
 
     const exampleEvent: S3ObjectRestoreExpiredNotificationEvent = {
-        version: "0",
-        id: "fc79357e-5b95-4caa-d604-ea69d02c0f34",
-        "detail-type": "Object Restore Expired",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: 'fc79357e-5b95-4caa-d604-ea69d02c0f34',
+        'detail-type': 'Object Restore Expired',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
-                etag: "b1946ac92492d2347c6235b4d2611184",
-                "version-id": "_vgOnRkretlur2Szh189LnGKvP975qk4"
+                key: 'example-key',
+                etag: 'b1946ac92492d2347c6235b4d2611184',
+                'version-id': '_vgOnRkretlur2Szh189LnGKvP975qk4',
             },
-            "request-id": "3293B6761671D228",
-            requester: "s3.amazonaws.com"
-        }
-    }
+            'request-id': '3293B6761671D228',
+            requester: 's3.amazonaws.com',
+        },
+    };
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};
 
-const S3ObjectRestoreInitiatedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectRestoreInitiatedNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object Restore Initiated" = event["detail-type"]
-    const detail: S3ObjectRestoreInitiatedNotificationEventDetail = event.detail
+const S3ObjectRestoreInitiatedNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectRestoreInitiatedNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object Restore Initiated' = event['detail-type'];
+    const detail: S3ObjectRestoreInitiatedNotificationEventDetail = event.detail;
 
     const exampleEvent: S3ObjectRestoreInitiatedNotificationEvent = {
-        version: "0",
-        id: "ed4edb9f-fe10-a6a0-c1a3-66aa1aba83b1",
-        "detail-type": "Object Restore Initiated",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: 'ed4edb9f-fe10-a6a0-c1a3-66aa1aba83b1',
+        'detail-type': 'Object Restore Initiated',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
+                key: 'example-key',
                 size: 5,
-                etag: "b1946ac92492d2347c6235b4d2611184",
-                "version-id": "KKsjUC1.6gIjqtvhfg5AdMI0eCePIiT3"
+                etag: 'b1946ac92492d2347c6235b4d2611184',
+                'version-id': 'KKsjUC1.6gIjqtvhfg5AdMI0eCePIiT3',
             },
-            "request-id": "5S39P9B0KSYERSCH",
-            requester: "123456789012",
-            "source-ip-address": "1.2.3.4",
-            "source-storage-class": "GLACIER"
-        }
-    }
+            'request-id': '5S39P9B0KSYERSCH',
+            requester: '123456789012',
+            'source-ip-address': '1.2.3.4',
+            'source-storage-class': 'GLACIER',
+        },
+    };
 
-    exampleEvent.detail["source-storage-class"] = "DEEP_ARCHIVE"
-    exampleEvent.detail["source-storage-class"] = "GLACIER_IR"
-    exampleEvent.detail["source-storage-class"] = "STANDARD"
-    exampleEvent.detail["source-storage-class"] = "ONEZONE_IA"
-    exampleEvent.detail["source-storage-class"] = "STANDARD_IA"
-    exampleEvent.detail["source-storage-class"] = "INTELLIGENT_TIERING"
-    exampleEvent.detail["source-storage-class"] = "OUTPOSTS"
-    exampleEvent.detail["source-storage-class"] = "REDUCED_REDUNDANCY"
+    exampleEvent.detail['source-storage-class'] = 'DEEP_ARCHIVE';
+    exampleEvent.detail['source-storage-class'] = 'GLACIER_IR';
+    exampleEvent.detail['source-storage-class'] = 'STANDARD';
+    exampleEvent.detail['source-storage-class'] = 'ONEZONE_IA';
+    exampleEvent.detail['source-storage-class'] = 'STANDARD_IA';
+    exampleEvent.detail['source-storage-class'] = 'INTELLIGENT_TIERING';
+    exampleEvent.detail['source-storage-class'] = 'OUTPOSTS';
+    exampleEvent.detail['source-storage-class'] = 'REDUCED_REDUNDANCY';
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};
 
-const S3ObjectStorageClassChangedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectStorageClassChangedNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object Storage Class Changed" = event["detail-type"]
-    const detail: S3ObjectStorageClassChangedNotificationEventDetail = event.detail
+const S3ObjectStorageClassChangedNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectStorageClassChangedNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object Storage Class Changed' = event['detail-type'];
+    const detail: S3ObjectStorageClassChangedNotificationEventDetail = event.detail;
 
     const exampleEvent: S3ObjectStorageClassChangedNotificationEvent = {
-        version: "0",
-        id: "e9a74d79-7549-f534-88d9-d2d9cd9bfd52",
-        "detail-type": "Object Storage Class Changed",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: 'e9a74d79-7549-f534-88d9-d2d9cd9bfd52',
+        'detail-type': 'Object Storage Class Changed',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
+                key: 'example-key',
                 size: 5,
-                etag: "b1946ac92492d2347c6235b4d2611184",
-                "version-id": "J1BDI6bMR4RgWJsmT15166nv0HhDT7zo"
+                etag: 'b1946ac92492d2347c6235b4d2611184',
+                'version-id': 'J1BDI6bMR4RgWJsmT15166nv0HhDT7zo',
             },
-            "request-id": "42E9A4AA619F920B",
-            requester: "s3.amazonaws.com",
-            "destination-storage-class": "GLACIER"
-        }
-    }
+            'request-id': '42E9A4AA619F920B',
+            requester: 's3.amazonaws.com',
+            'destination-storage-class': 'GLACIER',
+        },
+    };
 
-    exampleEvent.detail["destination-storage-class"] = "DEEP_ARCHIVE"
-    exampleEvent.detail["destination-storage-class"] = "GLACIER_IR"
-    exampleEvent.detail["destination-storage-class"] = "STANDARD"
-    exampleEvent.detail["destination-storage-class"] = "ONEZONE_IA"
-    exampleEvent.detail["destination-storage-class"] = "STANDARD_IA"
-    exampleEvent.detail["destination-storage-class"] = "INTELLIGENT_TIERING"
-    exampleEvent.detail["destination-storage-class"] = "OUTPOSTS"
-    exampleEvent.detail["destination-storage-class"] = "REDUCED_REDUNDANCY"
+    exampleEvent.detail['destination-storage-class'] = 'DEEP_ARCHIVE';
+    exampleEvent.detail['destination-storage-class'] = 'GLACIER_IR';
+    exampleEvent.detail['destination-storage-class'] = 'STANDARD';
+    exampleEvent.detail['destination-storage-class'] = 'ONEZONE_IA';
+    exampleEvent.detail['destination-storage-class'] = 'STANDARD_IA';
+    exampleEvent.detail['destination-storage-class'] = 'INTELLIGENT_TIERING';
+    exampleEvent.detail['destination-storage-class'] = 'OUTPOSTS';
+    exampleEvent.detail['destination-storage-class'] = 'REDUCED_REDUNDANCY';
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};
 
-const S3ObjectTagsAddedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectTagsAddedNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object Tags Added" = event["detail-type"]
-    const detail: S3ObjectTagsAddedNotificationEventDetail = event.detail
+const S3ObjectTagsAddedNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectTagsAddedNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object Tags Added' = event['detail-type'];
+    const detail: S3ObjectTagsAddedNotificationEventDetail = event.detail;
 
     const exampleEvent: S3ObjectTagsAddedNotificationEvent = {
-        version: "0",
-        id: "5b566166-43e6-d36e-ab5a-5083af1fda09",
-        "detail-type": "Object Tags Added",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: '5b566166-43e6-d36e-ab5a-5083af1fda09',
+        'detail-type': 'Object Tags Added',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
-                etag: "b1946ac92492d2347c6235b4d2611184",
-                "version-id": "Xd_29e0Da7c0h8APYtG8ZsGpnPtNDewu"
+                key: 'example-key',
+                etag: 'b1946ac92492d2347c6235b4d2611184',
+                'version-id': 'Xd_29e0Da7c0h8APYtG8ZsGpnPtNDewu',
             },
-            "request-id": "5EQMSMKAMC3Z1NH9",
-            requester: "123456789012",
-            "source-ip-address": "1.2.3.4"
-        }
-    }
+            'request-id': '5EQMSMKAMC3Z1NH9',
+            requester: '123456789012',
+            'source-ip-address': '1.2.3.4',
+        },
+    };
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};
 
-const S3ObjectTagsDeletedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectTagsDeletedNotificationEvent> = async (event, context, callback) => {
-    eventBridgeEventSource = event.source
-    const detailType: "Object Tags Deleted" = event["detail-type"]
-    const detail: S3ObjectTagsDeletedNotificationEventDetail = event.detail
+const S3ObjectTagsDeletedNotificationEventHandler: S3NotificationEventBridgeHandler<
+    S3ObjectTagsDeletedNotificationEvent
+> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source;
+    const detailType: 'Object Tags Deleted' = event['detail-type'];
+    const detail: S3ObjectTagsDeletedNotificationEventDetail = event.detail;
 
     const exampleEvent: S3ObjectTagsDeletedNotificationEvent = {
-        version: "0",
-        id: "16b4a621-0c02-2315-7a02-0182de80c2df",
-        "detail-type": "Object Tags Deleted",
-        source: "aws.s3",
-        account: "123456789012",
-        time: "2021-11-12T00:00:00Z",
-        region: "ca-central-1",
-        resources: ["arn:aws:s3:::example-bucket"],
+        version: '0',
+        id: '16b4a621-0c02-2315-7a02-0182de80c2df',
+        'detail-type': 'Object Tags Deleted',
+        source: 'aws.s3',
+        account: '123456789012',
+        time: '2021-11-12T00:00:00Z',
+        region: 'ca-central-1',
+        resources: ['arn:aws:s3:::example-bucket'],
         detail: {
-            version: "0",
+            version: '0',
             bucket: {
-                name: "example-bucket"
+                name: 'example-bucket',
             },
             object: {
-                key: "example-key",
-                etag: "b1946ac92492d2347c6235b4d2611184",
-                "version-id": "Xd_29e0Da7c0h8APYtG8ZsGpnPtNDewu"
+                key: 'example-key',
+                etag: 'b1946ac92492d2347c6235b4d2611184',
+                'version-id': 'Xd_29e0Da7c0h8APYtG8ZsGpnPtNDewu',
             },
-            "request-id": "FSYT108D6ZGFKMCW",
-            requester: "123456789012",
-            "source-ip-address": "1.2.3.4"
-        }
-    }
+            'request-id': 'FSYT108D6ZGFKMCW',
+            requester: '123456789012',
+            'source-ip-address': '1.2.3.4',
+        },
+    };
 
-    const result: void = undefined
+    const result: undefined = undefined;
     callback(new Error());
     callback(null, result);
     return result;
-}
+};

--- a/types/aws-lambda/test/s3-event-notification-tests.ts
+++ b/types/aws-lambda/test/s3-event-notification-tests.ts
@@ -1,0 +1,463 @@
+import {
+    S3NotificationEventBridgeHandler,
+    S3ObjectAccessTierChangedNotificationEvent,
+    S3ObjectAccessTierChangedNotificationEventDetail,
+    S3ObjectACLUpdatedNotificationEvent,
+    S3ObjectACLUpdatedNotificationEventDetail,
+    S3ObjectCreatedNotificationEvent,
+    S3ObjectCreatedNotificationEventDetail,
+    S3ObjectDeletedNotificationEvent,
+    S3ObjectDeletedNotificationEventDetail,
+    S3ObjectRestoreCompletedNotificationEvent,
+    S3ObjectRestoreCompletedNotificationEventDetail,
+    S3ObjectRestoreExpiredNotificationEvent,
+    S3ObjectRestoreExpiredNotificationEventDetail,
+    S3ObjectRestoreInitiatedNotificationEvent,
+    S3ObjectRestoreInitiatedNotificationEventDetail,
+    S3ObjectStorageClassChangedNotificationEvent,
+    S3ObjectStorageClassChangedNotificationEventDetail,
+    S3ObjectTagsAddedNotificationEvent,
+    S3ObjectTagsAddedNotificationEventDetail,
+    S3ObjectTagsDeletedNotificationEvent,
+    S3ObjectTagsDeletedNotificationEventDetail
+} from "aws-lambda";
+
+
+// EventBridgeEvent structure is tested in eventbridge-tests.ts
+// testing only source, detail and detail-type here
+declare let eventBridgeEventSource: 'aws.s3'
+
+const S3ObjectAccessTierChangedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectAccessTierChangedNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object Access Tier Changed" = event["detail-type"]
+    const detail: S3ObjectAccessTierChangedNotificationEventDetail = event.detail
+
+    const exampleEvent: S3ObjectAccessTierChangedNotificationEvent = {
+        version: "0",
+        id: "b0484f24-4f9d-3a49-de3b-e8b56b954cdd",
+        "detail-type": "Object Access Tier Changed",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                size: 5,
+                etag: "b1946ac92492d2347c6235b4d2611184",
+                "version-id": "NX.DRp5klxcEVaJ5RC_fO0994Hl.JHOY"
+            },
+            "request-id": "2MMR4GXSXJGZ5THF",
+            requester: "s3.amazonaws.com",
+            "destination-access-tier": "ARCHIVE_ACCESS"
+        }
+    }
+
+    exampleEvent.detail["destination-access-tier"] = "DEEP_ARCHIVE_ACCESS"
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}
+
+
+const S3ObjectACLUpdatedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectACLUpdatedNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object ACL Updated" = event["detail-type"]
+    const detail: S3ObjectACLUpdatedNotificationEventDetail = event.detail
+
+    const exampleEvent: S3ObjectACLUpdatedNotificationEvent = {
+        version: "0",
+        id: "7382f94d-cdb4-ae90-8411-e79d33d0d2c9",
+        "detail-type": "Object ACL Updated",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                etag: "b1946ac92492d2347c6235b4d2611184",
+                "version-id": "Xd_29e0Da7c0h8APYtG8ZsGpnPtNDewu"
+            },
+            "request-id": "8NZP164VNA76D82R",
+            requester: "123456789012",
+            "source-ip-address": "1.2.3.4"
+        }
+    }
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}
+
+const S3ObjectCreatedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectCreatedNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object Created" = event["detail-type"]
+    const detail: S3ObjectCreatedNotificationEventDetail = event.detail
+
+    let exampleEvent: S3ObjectCreatedNotificationEvent = {
+        version: "0",
+        id: "17793124-05d4-b198-2fde-7ededc63b103",
+        "detail-type": "Object Created",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                size: 5,
+                etag: "b1946ac92492d2347c6235b4d2611184",
+                "version-id": "IYV3p45BT0ac8hjHg1houSdS1a.Mro8e",
+                sequencer: "00617F08299329D189"
+            },
+            "request-id": "N4N7GDK58NMKJ12R",
+            requester: "123456789012",
+            "source-ip-address": "1.2.3.4",
+            reason: "PutObject"
+        }
+    }
+
+    exampleEvent.detail.reason = "POST Object"
+    exampleEvent.detail.reason = "CopyObject"
+    exampleEvent.detail.reason = "CompleteMultipartUpload"
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}
+
+const S3ObjectDeletedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectDeletedNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object Deleted" = event["detail-type"]
+    const detail: S3ObjectDeletedNotificationEventDetail = event.detail
+
+    const deleteObjectExampleEvent: S3ObjectDeletedNotificationEvent = {
+        version: "0",
+        id: "ad1de317-e409-eba2-9552-30113f8d88e3",
+        "detail-type": "Object Deleted",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                etag: "d41d8cd98f00b204e9800998ecf8427e",
+                "version-id": "mtB0cV.jejK63XkRNceanNMC.qXPWLeK",
+                sequencer: "00617B398000000000"
+            },
+            "request-id": "20EB74C14654DC47",
+            requester: "s3.amazonaws.com",
+            "source-ip-address": "1.2.3.4",
+            reason: "DeleteObject",
+            "deletion-type": "Delete Marker Created"
+        }
+    }
+    deleteObjectExampleEvent.detail["deletion-type"] = "Permanently Deleted";
+
+
+    const lifecycleExpirationExampleEvent2: S3ObjectDeletedNotificationEvent = {
+        version: "0",
+        id: "ad1de317-e409-eba2-9552-30113f8d88e3",
+        "detail-type": "Object Deleted",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                etag: "d41d8cd98f00b204e9800998ecf8427e",
+                "version-id": "mtB0cV.jejK63XkRNceanNMC.qXPWLeK",
+                sequencer: "00617B398000000000"
+            },
+            "request-id": "20EB74C14654DC47",
+            requester: "s3.amazonaws.com",
+            reason: "Lifecycle Expiration",
+            "deletion-type": "Delete Marker Created"
+        }
+    }
+    lifecycleExpirationExampleEvent2.detail["deletion-type"] = "Permanently Deleted";
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}
+
+const S3ObjectRestoreCompletedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectRestoreCompletedNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object Restore Completed" = event["detail-type"]
+    const detail: S3ObjectRestoreCompletedNotificationEventDetail = event.detail
+
+    const exampleEvent: S3ObjectRestoreCompletedNotificationEvent = {
+        version: "0",
+        id: "6924de0d-13e2-6bbf-c0c1-b903b753565e",
+        "detail-type": "Object Restore Completed",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                size: 5,
+                etag: "b1946ac92492d2347c6235b4d2611184",
+                "version-id": "KKsjUC1.6gIjqtvhfg5AdMI0eCePIiT3"
+            },
+            "request-id": "189F19CB7FB1B6A4",
+            requester: "s3.amazonaws.com",
+            "restore-expiry-time": "2021-11-13T00:00:00Z",
+            "source-storage-class": "GLACIER"
+        }
+    }
+
+    exampleEvent.detail["source-storage-class"] = "DEEP_ARCHIVE"
+    exampleEvent.detail["source-storage-class"] = "GLACIER_IR"
+    exampleEvent.detail["source-storage-class"] = "STANDARD"
+    exampleEvent.detail["source-storage-class"] = "ONEZONE_IA"
+    exampleEvent.detail["source-storage-class"] = "STANDARD_IA"
+    exampleEvent.detail["source-storage-class"] = "INTELLIGENT_TIERING"
+    exampleEvent.detail["source-storage-class"] = "OUTPOSTS"
+    exampleEvent.detail["source-storage-class"] = "REDUCED_REDUNDANCY"
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}
+
+const S3ObjectRestoreExpiredNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectRestoreExpiredNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object Restore Expired" = event["detail-type"]
+    const detail: S3ObjectRestoreExpiredNotificationEventDetail = event.detail
+
+    const exampleEvent: S3ObjectRestoreExpiredNotificationEvent = {
+        version: "0",
+        id: "fc79357e-5b95-4caa-d604-ea69d02c0f34",
+        "detail-type": "Object Restore Expired",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                etag: "b1946ac92492d2347c6235b4d2611184",
+                "version-id": "_vgOnRkretlur2Szh189LnGKvP975qk4"
+            },
+            "request-id": "3293B6761671D228",
+            requester: "s3.amazonaws.com"
+        }
+    }
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}
+
+const S3ObjectRestoreInitiatedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectRestoreInitiatedNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object Restore Initiated" = event["detail-type"]
+    const detail: S3ObjectRestoreInitiatedNotificationEventDetail = event.detail
+
+    const exampleEvent: S3ObjectRestoreInitiatedNotificationEvent = {
+        version: "0",
+        id: "ed4edb9f-fe10-a6a0-c1a3-66aa1aba83b1",
+        "detail-type": "Object Restore Initiated",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                size: 5,
+                etag: "b1946ac92492d2347c6235b4d2611184",
+                "version-id": "KKsjUC1.6gIjqtvhfg5AdMI0eCePIiT3"
+            },
+            "request-id": "5S39P9B0KSYERSCH",
+            requester: "123456789012",
+            "source-ip-address": "1.2.3.4",
+            "source-storage-class": "GLACIER"
+        }
+    }
+
+    exampleEvent.detail["source-storage-class"] = "DEEP_ARCHIVE"
+    exampleEvent.detail["source-storage-class"] = "GLACIER_IR"
+    exampleEvent.detail["source-storage-class"] = "STANDARD"
+    exampleEvent.detail["source-storage-class"] = "ONEZONE_IA"
+    exampleEvent.detail["source-storage-class"] = "STANDARD_IA"
+    exampleEvent.detail["source-storage-class"] = "INTELLIGENT_TIERING"
+    exampleEvent.detail["source-storage-class"] = "OUTPOSTS"
+    exampleEvent.detail["source-storage-class"] = "REDUCED_REDUNDANCY"
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}
+
+const S3ObjectStorageClassChangedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectStorageClassChangedNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object Storage Class Changed" = event["detail-type"]
+    const detail: S3ObjectStorageClassChangedNotificationEventDetail = event.detail
+
+    const exampleEvent: S3ObjectStorageClassChangedNotificationEvent = {
+        version: "0",
+        id: "e9a74d79-7549-f534-88d9-d2d9cd9bfd52",
+        "detail-type": "Object Storage Class Changed",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                size: 5,
+                etag: "b1946ac92492d2347c6235b4d2611184",
+                "version-id": "J1BDI6bMR4RgWJsmT15166nv0HhDT7zo"
+            },
+            "request-id": "42E9A4AA619F920B",
+            requester: "s3.amazonaws.com",
+            "destination-storage-class": "GLACIER"
+        }
+    }
+
+    exampleEvent.detail["destination-storage-class"] = "DEEP_ARCHIVE"
+    exampleEvent.detail["destination-storage-class"] = "GLACIER_IR"
+    exampleEvent.detail["destination-storage-class"] = "STANDARD"
+    exampleEvent.detail["destination-storage-class"] = "ONEZONE_IA"
+    exampleEvent.detail["destination-storage-class"] = "STANDARD_IA"
+    exampleEvent.detail["destination-storage-class"] = "INTELLIGENT_TIERING"
+    exampleEvent.detail["destination-storage-class"] = "OUTPOSTS"
+    exampleEvent.detail["destination-storage-class"] = "REDUCED_REDUNDANCY"
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}
+
+const S3ObjectTagsAddedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectTagsAddedNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object Tags Added" = event["detail-type"]
+    const detail: S3ObjectTagsAddedNotificationEventDetail = event.detail
+
+    const exampleEvent: S3ObjectTagsAddedNotificationEvent = {
+        version: "0",
+        id: "5b566166-43e6-d36e-ab5a-5083af1fda09",
+        "detail-type": "Object Tags Added",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                etag: "b1946ac92492d2347c6235b4d2611184",
+                "version-id": "Xd_29e0Da7c0h8APYtG8ZsGpnPtNDewu"
+            },
+            "request-id": "5EQMSMKAMC3Z1NH9",
+            requester: "123456789012",
+            "source-ip-address": "1.2.3.4"
+        }
+    }
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}
+
+const S3ObjectTagsDeletedNotificationEventHandler: S3NotificationEventBridgeHandler<S3ObjectTagsDeletedNotificationEvent> = async (event, context, callback) => {
+    eventBridgeEventSource = event.source
+    const detailType: "Object Tags Deleted" = event["detail-type"]
+    const detail: S3ObjectTagsDeletedNotificationEventDetail = event.detail
+
+    const exampleEvent: S3ObjectTagsDeletedNotificationEvent = {
+        version: "0",
+        id: "16b4a621-0c02-2315-7a02-0182de80c2df",
+        "detail-type": "Object Tags Deleted",
+        source: "aws.s3",
+        account: "123456789012",
+        time: "2021-11-12T00:00:00Z",
+        region: "ca-central-1",
+        resources: ["arn:aws:s3:::example-bucket"],
+        detail: {
+            version: "0",
+            bucket: {
+                name: "example-bucket"
+            },
+            object: {
+                key: "example-key",
+                etag: "b1946ac92492d2347c6235b4d2611184",
+                "version-id": "Xd_29e0Da7c0h8APYtG8ZsGpnPtNDewu"
+            },
+            "request-id": "FSYT108D6ZGFKMCW",
+            requester: "123456789012",
+            "source-ip-address": "1.2.3.4"
+        }
+    }
+
+    const result: void = undefined
+    callback(new Error());
+    callback(null, result);
+    return result;
+}

--- a/types/aws-lambda/trigger/s3-event-notification.d.ts
+++ b/types/aws-lambda/trigger/s3-event-notification.d.ts
@@ -1,0 +1,240 @@
+import {EventBridgeEvent} from './eventbridge';
+import {Handler} from "../handler";
+
+export interface S3ObjectAccessTierChangedNotificationEventDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "size": number,
+        "etag": string
+        "version-id": string,
+    },
+    "request-id": string,
+    "requester": string,
+    "destination-access-tier": "ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS" // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Tiering.html
+}
+
+export interface S3ObjectACLUpdatedNotificationEventDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "etag": string
+        "version-id": string,
+    },
+    "request-id": string,
+    "requester": string,
+    "source-ip-address": string,
+}
+
+export interface S3ObjectCreatedNotificationEventDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "size": number,
+        "etag": string,
+        "version-id": string,
+        "sequencer": string
+    },
+    "request-id": string,
+    "requester": string,
+    "source-ip-address": string,
+    "reason": "PutObject" | "POST Object" | "CopyObject" | "CompleteMultipartUpload"
+}
+
+export interface S3ObjectDeletedNotificationEventLifecycleExpirationDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "etag": string,
+        "version-id": string,
+        "sequencer": string
+    },
+    "request-id": string,
+    "requester": string,
+    "reason": "Lifecycle Expiration",
+    "deletion-type": "Permanently Deleted" | "Delete Marker Created"
+}
+
+export interface S3ObjectDeletedNotificationEventDeleteObjectDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "etag": string,
+        "version-id": string,
+        "sequencer": string
+    },
+    "request-id": string,
+    "requester": string,
+    "source-ip-address": string
+    "reason": "DeleteObject",
+    "deletion-type": "Permanently Deleted" | "Delete Marker Created"
+}
+
+export type S3ObjectDeletedNotificationEventDetail =
+    S3ObjectDeletedNotificationEventLifecycleExpirationDetail
+    | S3ObjectDeletedNotificationEventDeleteObjectDetail;
+
+export interface S3ObjectRestoreCompletedNotificationEventDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "size": number
+        "version-id": string,
+        "etag": string
+    },
+    "request-id": string,
+    "requester": "s3.amazonaws.com",
+    "restore-expiry-time": string,
+    "source-storage-class": "STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR" // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
+}
+
+export interface S3ObjectRestoreExpiredNotificationEventDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "version-id": string,
+        "etag": string
+    },
+    "request-id": string,
+    "requester": "s3.amazonaws.com",
+}
+
+export interface S3ObjectRestoreInitiatedNotificationEventDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "size": number
+        "version-id": string,
+        "etag": string
+    },
+    "request-id": string,
+    "requester": string,
+    "source-ip-address": string,
+    "source-storage-class": "STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR" // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
+}
+
+export interface S3ObjectStorageClassChangedNotificationEventDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "size": number
+        "version-id": string,
+        "etag": string
+    },
+    "request-id": string,
+    "requester": string,
+    "destination-storage-class": "STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR" // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
+}
+
+export interface S3ObjectTagsAddedNotificationEventDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "version-id": string,
+        "etag": string
+    },
+    "request-id": string,
+    "requester": string,
+    "source-ip-address": string
+}
+
+export interface S3ObjectTagsDeletedNotificationEventDetail {
+    "version": "0",
+    "bucket": {
+        "name": string
+    },
+    "object": {
+        "key": string,
+        "version-id": string,
+        "etag": string
+    },
+    "request-id": string,
+    "requester": string,
+    "source-ip-address": string
+}
+
+export interface S3ObjectAccessTierChangedNotificationEvent extends EventBridgeEvent<"Object Access Tier Changed", S3ObjectAccessTierChangedNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export interface S3ObjectACLUpdatedNotificationEvent extends EventBridgeEvent<"Object ACL Updated", S3ObjectACLUpdatedNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export interface S3ObjectCreatedNotificationEvent extends EventBridgeEvent<"Object Created", S3ObjectCreatedNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export interface S3ObjectDeletedNotificationEvent extends EventBridgeEvent<"Object Deleted", S3ObjectDeletedNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export interface S3ObjectRestoreCompletedNotificationEvent extends EventBridgeEvent<"Object Restore Completed", S3ObjectRestoreCompletedNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export interface S3ObjectRestoreExpiredNotificationEvent extends EventBridgeEvent<"Object Restore Expired", S3ObjectRestoreExpiredNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export interface S3ObjectRestoreInitiatedNotificationEvent extends EventBridgeEvent<"Object Restore Initiated", S3ObjectRestoreInitiatedNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export interface S3ObjectStorageClassChangedNotificationEvent extends EventBridgeEvent<"Object Storage Class Changed", S3ObjectStorageClassChangedNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export interface S3ObjectTagsAddedNotificationEvent extends EventBridgeEvent<"Object Tags Added", S3ObjectTagsAddedNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export interface S3ObjectTagsDeletedNotificationEvent extends EventBridgeEvent<"Object Tags Deleted", S3ObjectTagsDeletedNotificationEventDetail> {
+    source: 'aws.s3'
+}
+
+export type S3NotificationEvent =
+    S3ObjectAccessTierChangedNotificationEvent |
+    S3ObjectACLUpdatedNotificationEvent |
+    S3ObjectCreatedNotificationEvent |
+    S3ObjectDeletedNotificationEvent |
+    S3ObjectRestoreCompletedNotificationEvent |
+    S3ObjectRestoreExpiredNotificationEvent |
+    S3ObjectRestoreInitiatedNotificationEvent |
+    S3ObjectStorageClassChangedNotificationEvent |
+    S3ObjectTagsAddedNotificationEvent |
+    S3ObjectTagsDeletedNotificationEvent
+
+export type S3NotificationEventBridgeHandler<EventType extends S3NotificationEvent = S3NotificationEvent> = Handler<EventBridgeEvent<EventType['detail-type'], EventType["detail"]> & {
+    source: 'aws.s3'
+}, void>;

--- a/types/aws-lambda/trigger/s3-event-notification.d.ts
+++ b/types/aws-lambda/trigger/s3-event-notification.d.ts
@@ -1,240 +1,280 @@
-import {EventBridgeEvent} from './eventbridge';
-import {Handler} from "../handler";
+import { EventBridgeEvent } from './eventbridge';
+import { Handler } from '../handler';
 
 export interface S3ObjectAccessTierChangedNotificationEventDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "size": number,
-        "etag": string
-        "version-id": string,
-    },
-    "request-id": string,
-    "requester": string,
-    "destination-access-tier": "ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS" // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Tiering.html
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        size: number;
+        etag: string;
+        'version-id': string;
+    };
+    'request-id': string;
+    requester: string;
+    'destination-access-tier': 'ARCHIVE_ACCESS' | 'DEEP_ARCHIVE_ACCESS'; // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Tiering.html
 }
 
 export interface S3ObjectACLUpdatedNotificationEventDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "etag": string
-        "version-id": string,
-    },
-    "request-id": string,
-    "requester": string,
-    "source-ip-address": string,
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        etag: string;
+        'version-id': string;
+    };
+    'request-id': string;
+    requester: string;
+    'source-ip-address': string;
 }
 
 export interface S3ObjectCreatedNotificationEventDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "size": number,
-        "etag": string,
-        "version-id": string,
-        "sequencer": string
-    },
-    "request-id": string,
-    "requester": string,
-    "source-ip-address": string,
-    "reason": "PutObject" | "POST Object" | "CopyObject" | "CompleteMultipartUpload"
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        size: number;
+        etag: string;
+        'version-id': string;
+        sequencer: string;
+    };
+    'request-id': string;
+    requester: string;
+    'source-ip-address': string;
+    reason: 'PutObject' | 'POST Object' | 'CopyObject' | 'CompleteMultipartUpload';
 }
 
 export interface S3ObjectDeletedNotificationEventLifecycleExpirationDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "etag": string,
-        "version-id": string,
-        "sequencer": string
-    },
-    "request-id": string,
-    "requester": string,
-    "reason": "Lifecycle Expiration",
-    "deletion-type": "Permanently Deleted" | "Delete Marker Created"
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        etag: string;
+        'version-id': string;
+        sequencer: string;
+    };
+    'request-id': string;
+    requester: string;
+    reason: 'Lifecycle Expiration';
+    'deletion-type': 'Permanently Deleted' | 'Delete Marker Created';
 }
 
 export interface S3ObjectDeletedNotificationEventDeleteObjectDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "etag": string,
-        "version-id": string,
-        "sequencer": string
-    },
-    "request-id": string,
-    "requester": string,
-    "source-ip-address": string
-    "reason": "DeleteObject",
-    "deletion-type": "Permanently Deleted" | "Delete Marker Created"
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        etag: string;
+        'version-id': string;
+        sequencer: string;
+    };
+    'request-id': string;
+    requester: string;
+    'source-ip-address': string;
+    reason: 'DeleteObject';
+    'deletion-type': 'Permanently Deleted' | 'Delete Marker Created';
 }
 
 export type S3ObjectDeletedNotificationEventDetail =
-    S3ObjectDeletedNotificationEventLifecycleExpirationDetail
+    | S3ObjectDeletedNotificationEventLifecycleExpirationDetail
     | S3ObjectDeletedNotificationEventDeleteObjectDetail;
 
 export interface S3ObjectRestoreCompletedNotificationEventDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "size": number
-        "version-id": string,
-        "etag": string
-    },
-    "request-id": string,
-    "requester": "s3.amazonaws.com",
-    "restore-expiry-time": string,
-    "source-storage-class": "STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR" // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        size: number;
+        'version-id': string;
+        etag: string;
+    };
+    'request-id': string;
+    requester: 's3.amazonaws.com';
+    'restore-expiry-time': string;
+    'source-storage-class':
+        | 'STANDARD'
+        | 'REDUCED_REDUNDANCY'
+        | 'STANDARD_IA'
+        | 'ONEZONE_IA'
+        | 'INTELLIGENT_TIERING'
+        | 'GLACIER'
+        | 'DEEP_ARCHIVE'
+        | 'OUTPOSTS'
+        | 'GLACIER_IR'; // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
 }
 
 export interface S3ObjectRestoreExpiredNotificationEventDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "version-id": string,
-        "etag": string
-    },
-    "request-id": string,
-    "requester": "s3.amazonaws.com",
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        'version-id': string;
+        etag: string;
+    };
+    'request-id': string;
+    requester: 's3.amazonaws.com';
 }
 
 export interface S3ObjectRestoreInitiatedNotificationEventDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "size": number
-        "version-id": string,
-        "etag": string
-    },
-    "request-id": string,
-    "requester": string,
-    "source-ip-address": string,
-    "source-storage-class": "STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR" // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        size: number;
+        'version-id': string;
+        etag: string;
+    };
+    'request-id': string;
+    requester: string;
+    'source-ip-address': string;
+    'source-storage-class':
+        | 'STANDARD'
+        | 'REDUCED_REDUNDANCY'
+        | 'STANDARD_IA'
+        | 'ONEZONE_IA'
+        | 'INTELLIGENT_TIERING'
+        | 'GLACIER'
+        | 'DEEP_ARCHIVE'
+        | 'OUTPOSTS'
+        | 'GLACIER_IR'; // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
 }
 
 export interface S3ObjectStorageClassChangedNotificationEventDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "size": number
-        "version-id": string,
-        "etag": string
-    },
-    "request-id": string,
-    "requester": string,
-    "destination-storage-class": "STANDARD" | "REDUCED_REDUNDANCY" | "STANDARD_IA" | "ONEZONE_IA" | "INTELLIGENT_TIERING" | "GLACIER" | "DEEP_ARCHIVE" | "OUTPOSTS" | "GLACIER_IR" // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        size: number;
+        'version-id': string;
+        etag: string;
+    };
+    'request-id': string;
+    requester: string;
+    'destination-storage-class':
+        | 'STANDARD'
+        | 'REDUCED_REDUNDANCY'
+        | 'STANDARD_IA'
+        | 'ONEZONE_IA'
+        | 'INTELLIGENT_TIERING'
+        | 'GLACIER'
+        | 'DEEP_ARCHIVE'
+        | 'OUTPOSTS'
+        | 'GLACIER_IR'; // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
 }
 
 export interface S3ObjectTagsAddedNotificationEventDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "version-id": string,
-        "etag": string
-    },
-    "request-id": string,
-    "requester": string,
-    "source-ip-address": string
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        'version-id': string;
+        etag: string;
+    };
+    'request-id': string;
+    requester: string;
+    'source-ip-address': string;
 }
 
 export interface S3ObjectTagsDeletedNotificationEventDetail {
-    "version": "0",
-    "bucket": {
-        "name": string
-    },
-    "object": {
-        "key": string,
-        "version-id": string,
-        "etag": string
-    },
-    "request-id": string,
-    "requester": string,
-    "source-ip-address": string
+    version: '0';
+    bucket: {
+        name: string;
+    };
+    object: {
+        key: string;
+        'version-id': string;
+        etag: string;
+    };
+    'request-id': string;
+    requester: string;
+    'source-ip-address': string;
 }
 
-export interface S3ObjectAccessTierChangedNotificationEvent extends EventBridgeEvent<"Object Access Tier Changed", S3ObjectAccessTierChangedNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectAccessTierChangedNotificationEvent
+    extends EventBridgeEvent<'Object Access Tier Changed', S3ObjectAccessTierChangedNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
-export interface S3ObjectACLUpdatedNotificationEvent extends EventBridgeEvent<"Object ACL Updated", S3ObjectACLUpdatedNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectACLUpdatedNotificationEvent
+    extends EventBridgeEvent<'Object ACL Updated', S3ObjectACLUpdatedNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
-export interface S3ObjectCreatedNotificationEvent extends EventBridgeEvent<"Object Created", S3ObjectCreatedNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectCreatedNotificationEvent
+    extends EventBridgeEvent<'Object Created', S3ObjectCreatedNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
-export interface S3ObjectDeletedNotificationEvent extends EventBridgeEvent<"Object Deleted", S3ObjectDeletedNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectDeletedNotificationEvent
+    extends EventBridgeEvent<'Object Deleted', S3ObjectDeletedNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
-export interface S3ObjectRestoreCompletedNotificationEvent extends EventBridgeEvent<"Object Restore Completed", S3ObjectRestoreCompletedNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectRestoreCompletedNotificationEvent
+    extends EventBridgeEvent<'Object Restore Completed', S3ObjectRestoreCompletedNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
-export interface S3ObjectRestoreExpiredNotificationEvent extends EventBridgeEvent<"Object Restore Expired", S3ObjectRestoreExpiredNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectRestoreExpiredNotificationEvent
+    extends EventBridgeEvent<'Object Restore Expired', S3ObjectRestoreExpiredNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
-export interface S3ObjectRestoreInitiatedNotificationEvent extends EventBridgeEvent<"Object Restore Initiated", S3ObjectRestoreInitiatedNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectRestoreInitiatedNotificationEvent
+    extends EventBridgeEvent<'Object Restore Initiated', S3ObjectRestoreInitiatedNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
-export interface S3ObjectStorageClassChangedNotificationEvent extends EventBridgeEvent<"Object Storage Class Changed", S3ObjectStorageClassChangedNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectStorageClassChangedNotificationEvent
+    extends EventBridgeEvent<'Object Storage Class Changed', S3ObjectStorageClassChangedNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
-export interface S3ObjectTagsAddedNotificationEvent extends EventBridgeEvent<"Object Tags Added", S3ObjectTagsAddedNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectTagsAddedNotificationEvent
+    extends EventBridgeEvent<'Object Tags Added', S3ObjectTagsAddedNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
-export interface S3ObjectTagsDeletedNotificationEvent extends EventBridgeEvent<"Object Tags Deleted", S3ObjectTagsDeletedNotificationEventDetail> {
-    source: 'aws.s3'
+export interface S3ObjectTagsDeletedNotificationEvent
+    extends EventBridgeEvent<'Object Tags Deleted', S3ObjectTagsDeletedNotificationEventDetail> {
+    source: 'aws.s3';
 }
 
 export type S3NotificationEvent =
-    S3ObjectAccessTierChangedNotificationEvent |
-    S3ObjectACLUpdatedNotificationEvent |
-    S3ObjectCreatedNotificationEvent |
-    S3ObjectDeletedNotificationEvent |
-    S3ObjectRestoreCompletedNotificationEvent |
-    S3ObjectRestoreExpiredNotificationEvent |
-    S3ObjectRestoreInitiatedNotificationEvent |
-    S3ObjectStorageClassChangedNotificationEvent |
-    S3ObjectTagsAddedNotificationEvent |
-    S3ObjectTagsDeletedNotificationEvent
+    | S3ObjectAccessTierChangedNotificationEvent
+    | S3ObjectACLUpdatedNotificationEvent
+    | S3ObjectCreatedNotificationEvent
+    | S3ObjectDeletedNotificationEvent
+    | S3ObjectRestoreCompletedNotificationEvent
+    | S3ObjectRestoreExpiredNotificationEvent
+    | S3ObjectRestoreInitiatedNotificationEvent
+    | S3ObjectStorageClassChangedNotificationEvent
+    | S3ObjectTagsAddedNotificationEvent
+    | S3ObjectTagsDeletedNotificationEvent;
 
-export type S3NotificationEventBridgeHandler<EventType extends S3NotificationEvent = S3NotificationEvent> = Handler<EventBridgeEvent<EventType['detail-type'], EventType["detail"]> & {
-    source: 'aws.s3'
-}, void>;
+export type S3NotificationEventBridgeHandler<EventType extends S3NotificationEvent = S3NotificationEvent> = Handler<
+    EventBridgeEvent<EventType['detail-type'], EventType['detail']> & {
+        source: 'aws.s3';
+    },
+    void
+>;

--- a/types/aws-lambda/tsconfig.json
+++ b/types/aws-lambda/tsconfig.json
@@ -41,6 +41,7 @@
         "test/sns-tests.ts",
         "test/sqs-tests.ts",
         "test/msk-tests.ts",
-        "test/secretsmanager-tests.ts"
+        "test/secretsmanager-tests.ts",
+        "test/s3-event-notification-tests.ts"
     ]
 }


### PR DESCRIPTION
Since end of 2021 S3 can send events via EventBridge and lambda can be a recipient. So I made up the handler types with the fitting event structure depending on the S3 event type. 

If there are any questions or remarks feel free to ask.

Cheers,
Sven

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://aws.amazon.com/de/blogs/aws/new-use-amazon-s3-event-notifications-with-amazon-eventbridge/
https://docs.aws.amazon.com/AmazonS3/latest/userguide//EventBridge.html
