### PR TITLE
Add download-package-tarball

### DIFF
--- a/types/download-package-tarball/download-package-tarball-tests.ts
+++ b/types/download-package-tarball/download-package-tarball-tests.ts
@@ -1,0 +1,17 @@
+import download = require('download-package-tarball');
+
+// $ExpectType Promise<void>
+download({
+    url: 'https://api.github.com/repos/kesla/node-snappy/tarball/master',
+    dir: '/dir/where/file/will/be/downloaded',
+    gotOpts: {
+        headers: {
+            beep: 'boop'
+        }
+    }
+}).then(() => {
+    console.log('file is now downloaded!');
+}).catch(err => {
+    console.log('oh crap the file could not be downloaded properly');
+    console.log(err);
+});

--- a/types/download-package-tarball/index.d.ts
+++ b/types/download-package-tarball/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for download-package-tarball 1.0
+// Project: https://github.com/kesla/download-package-tarball
+// Definitions by: Christoph Thiede <https://github.com/LinqLover>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { GotOptions } from 'got';
+
+interface DownloadOptions {
+    url: string;
+    gotOpts?: GotOptions<string | null>;
+    dir: string;
+}
+
+/** Download a node package as a tarball, for example from github or npm. */
+declare function download(options: DownloadOptions): Promise<void>;
+
+export = download;

--- a/types/download-package-tarball/tsconfig.json
+++ b/types/download-package-tarball/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "download-package-tarball-tests.ts"
+    ]
+}

--- a/types/download-package-tarball/tslint.json
+++ b/types/download-package-tarball/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

This is the second attempt of #56875, currently waiting for this issue to be resolved:

> > @LinqLover The CI build failed! Please [review the logs for more information](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/3dd3484ed0d5648c7361dc44add4295bc221b72b/checks?check_suite_id=4205250598).
> > 
> > Once you've pushed the fixes, the build will automatically re-run. Thanks!
> > 
> > **Note: builds which are failing do not end up on the list of PRs for the DT maintainers to review.**
> 
> The CI failed for the same reason as described here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56874#issuecomment-955046643
> 
> ```
> Error in download-package-tarball
> Error: /home/runner/work/DefinitelyTyped/DefinitelyTyped/types/download-package-tarball: Contains the word 'download', which is banned by npm.
>     at assertPathIsNotBanned (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/dtslint/bin/index.js:232:15)
>     at /home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/dtslint/bin/index.js:136:13
>     at Generator.next (<anonymous>)
>     at fulfilled (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/dtslint/bin/index.js:6:58)
> ```
> 
> What shall I do, open another PR against tslint? :)

(https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56875#issuecomment-955060997)

For now marked as draft according to @peterblazejewicz's recommendation.