### PR TITLE
[react] Remove bivariance hack for RefCallback to reject non-nullable instances in callbacks

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -88,7 +88,7 @@ declare namespace React {
     interface RefObject<T> {
         readonly current: T | null;
     }
-    type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
+    type RefCallback<T> = (instance: T | null) => void;
     type Ref<T> = RefCallback<T> | RefObject<T> | null;
     type LegacyRef<T> = string | Ref<T>;
     /**

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -342,6 +342,14 @@ const divRef = React.createRef<HTMLDivElement>();
 <ForwardRef2 ref={divRef}/>;
 <ForwardRef2 ref='string'/>; // $ExpectError
 
+const htmlElementFnRef = (instance: HTMLElement | null) => {};
+const htmlElementRef = React.createRef<HTMLElement>();
+<div ref={htmlElementFnRef} />;
+<div ref={htmlElementRef} />;
+const unsoundDivFnRef = (instance: HTMLDivElement) => {};
+// `instance` is nullable
+<div ref={unsoundDivFnRef} />; // $ExpectError
+
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef}/>;
 <NewContext ref='string'/>;
@@ -407,7 +415,7 @@ imgProps.loading = 'nonsense';
 // $ExpectError
 imgProps.decoding = 'nonsense';
 type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
-// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
+// $ExpectType RefCallback<HTMLImageElement> | RefObject<HTMLImageElement> | null | undefined
 type ImgPropsWithRefRef = ImgPropsWithRef['ref'];
 type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
 // $ExpectType false

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -548,7 +548,7 @@ select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
 {
   const blockProps = be.useBlockProps({ ref: useRef("test") });
-  // $ExpectType (instance: unknown) => void
+  // $ExpectType RefCallback<unknown>
   blockProps.ref;
 }
 


### PR DESCRIPTION
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   ["React will call the ref callback with the DOM element when the component mounts, and call it with null when it unmounts"](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs)
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

