### PR TITLE
[react-howler] Refactor and add missing proptypes

### DIFF
--- a/types/react-howler/index.d.ts
+++ b/types/react-howler/index.d.ts
@@ -13,7 +13,13 @@ declare enum HOWLER_STATE {
     LOADED = 'loaded',
 }
 
-interface Props {
+export interface PropTyoesXHR {
+  method?: string | undefined;
+  headers?: Record<string, string> | undefined;
+  withCredentials?: boolean | undefined;
+}
+
+export interface PropTypes {
     src: string | string[];
     format?: string[] | undefined;
     playing?: boolean | undefined;
@@ -29,9 +35,14 @@ interface Props {
     onLoad?: (() => void) | undefined;
     onLoadError?: ((id: number) => void) | undefined;
     html5?: boolean | undefined;
+    rate?: number | undefined;
+    format?: string[] | undefined;
+    xhr?: PropsXHR | undefined;
+    onSeek?: ((id: number) => void) | undefined;
+    onPlayError?: ((id: number) => void) | undefined;
 }
 
-declare class ReactHowler extends React.Component<Props> {
+declare class ReactHowler extends React.Component<PropTypes> {
     stop(id?: number): void;
 
     duration(id?: number): number;

--- a/types/react-howler/react-howler-tests.tsx
+++ b/types/react-howler/react-howler-tests.tsx
@@ -18,6 +18,9 @@ export class ReactHowlerTest extends React.Component {
                     playing={false}
                     mute={true}
                     onPlay={id => console.log('playing sound with id ', id)}
+                    onPlayError={id =>
+                        console.log('error playing sound with id ', id)
+                    }
                     onLoad={() => console.log('sound loaded')}
                     onLoadError={id =>
                         console.log('error loading sound with id ', id)
@@ -25,6 +28,7 @@ export class ReactHowlerTest extends React.Component {
                     onEnd={() => console.log('sound ended')}
                     onPause={() => console.log('sound paused')}
                     onStop={id => console.log('sound with id paused', id)}
+                    onSeek={id => console.log('sound with id seeked', id)}
                     volume={0.5}
                     onVolume={id => console.log('volume changed', id)}
                     loop={true}
@@ -32,6 +36,9 @@ export class ReactHowlerTest extends React.Component {
                     format={['mp3']}
                     preload={false}
                     ref={this.player}
+                    rate={1}
+                    format={["mp3"]}
+                    xhr={{ method: "GET" }}
                 />
             </div>
         );

--- a/types/react-howler/react-howler-tests.tsx
+++ b/types/react-howler/react-howler-tests.tsx
@@ -18,13 +18,9 @@ export class ReactHowlerTest extends React.Component {
                     playing={false}
                     mute={true}
                     onPlay={id => console.log('playing sound with id ', id)}
-                    onPlayError={id =>
-                        console.log('error playing sound with id ', id)
-                    }
+                    onPlayError={id => console.log('error playing sound with id ', id)}
                     onLoad={() => console.log('sound loaded')}
-                    onLoadError={id =>
-                        console.log('error loading sound with id ', id)
-                    }
+                    onLoadError={id => console.log('error loading sound with id ', id)}
                     onEnd={() => console.log('sound ended')}
                     onPause={() => console.log('sound paused')}
                     onStop={id => console.log('sound with id paused', id)}
@@ -37,7 +33,7 @@ export class ReactHowlerTest extends React.Component {
                     preload={false}
                     ref={this.player}
                     rate={1}
-                    format={["mp3"]}
+                    format={['mp3']}
                     xhr={{ method: "GET" }}
                 />
             </div>


### PR DESCRIPTION
Change `Props` to `PropTypes`.
Export `PropTypes`.
Add missing proptypes: `rate`, `format`, `xhr`, `onSeek`, and `onPlayError`.
