### PR TITLE
[react-howler] Refactor and add missing proptypes (v5.2)

### DIFF
--- a/types/react-howler/index.d.ts
+++ b/types/react-howler/index.d.ts
@@ -11,9 +11,9 @@ declare enum HOWLER_STATE {
     UNLOADED = 'unloaded',
     LOADING = 'loading',
     LOADED = 'loaded',
-}
+};
 
-export { HowlCallback, HowlErrorCallback }
+export { HowlCallback, HowlErrorCallback };
 
 export interface PropTypes {
     src: HowlOptions['src'];
@@ -35,7 +35,7 @@ export interface PropTypes {
     onEnd?: HowlCallback | undefined;
     onSeek?: HowlCallback | undefined;
     onPlayError?: HowlErrorCallback | undefined;
-}
+};
 
 declare class ReactHowler extends React.Component<PropTypes> {
     stop(id?: number): void;
@@ -47,6 +47,6 @@ declare class ReactHowler extends React.Component<PropTypes> {
     howlerState(): HOWLER_STATE;
 
     howler: Howl;
-}
+};
 
 export default ReactHowler;

--- a/types/react-howler/index.d.ts
+++ b/types/react-howler/index.d.ts
@@ -11,7 +11,7 @@ declare enum HOWLER_STATE {
     UNLOADED = 'unloaded',
     LOADING = 'loading',
     LOADED = 'loaded',
-};
+}
 
 export { HowlCallback, HowlErrorCallback };
 
@@ -21,11 +21,11 @@ export interface PropTypes {
     playing?: boolean | undefined;
     loop?: HowlOptions['loop'];
     mute?: HowlOptions['mute'];
-    volume?:  HowlOptions['volume'];
+    volume?: HowlOptions['volume'];
     rate?: HowlOptions['rate'];
     html5?: HowlOptions['html5'];
     format?: HowlOptions['format'];
-    xhr?: HowlOptions['xhr'] | undefined,
+    xhr?: HowlOptions['xhr'] | undefined;
     onPlay?: HowlCallback | undefined;
     onPause?: HowlCallback | undefined;
     onVolume?: HowlCallback | undefined;
@@ -35,7 +35,7 @@ export interface PropTypes {
     onEnd?: HowlCallback | undefined;
     onSeek?: HowlCallback | undefined;
     onPlayError?: HowlErrorCallback | undefined;
-};
+}
 
 declare class ReactHowler extends React.Component<PropTypes> {
     stop(id?: number): void;
@@ -47,6 +47,6 @@ declare class ReactHowler extends React.Component<PropTypes> {
     howlerState(): HOWLER_STATE;
 
     howler: Howl;
-};
+}
 
 export default ReactHowler;

--- a/types/react-howler/index.d.ts
+++ b/types/react-howler/index.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for react-howler 3.7
+// Type definitions for react-howler 5.2
 // Project: https://github.com/thangngoc89/react-howler
 // Definitions by: Danijel Maksimovic <https://github.com/maksimovicdanijel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 
 import * as React from 'react';
-import { Howl } from 'howler';
+import { Howl, HowlOptions, HowlCallback, HowlErrorCallback } from 'howler';
 
 declare enum HOWLER_STATE {
     UNLOADED = 'unloaded',
@@ -13,25 +13,31 @@ declare enum HOWLER_STATE {
     LOADED = 'loaded',
 }
 
-interface Props {
-    src: string | string[];
-    format?: string[] | undefined;
-    playing?: boolean | undefined;
-    mute?: boolean | undefined;
-    loop?: boolean | undefined;
+export { HowlCallback, HowlErrorCallback }
+
+export interface PropTypes {
+    src: HowlOptions['src'];
     preload?: boolean | undefined;
-    volume?: number | undefined;
-    onEnd?: (() => void) | undefined;
-    onPause?: (() => void) | undefined;
-    onPlay?: ((id: number) => void) | undefined;
-    onVolume?: ((id: number) => void) | undefined;
-    onStop?: ((id: number) => void) | undefined;
-    onLoad?: (() => void) | undefined;
-    onLoadError?: ((id: number) => void) | undefined;
-    html5?: boolean | undefined;
+    playing?: boolean | undefined;
+    loop?: HowlOptions['loop'];
+    mute?: HowlOptions['mute'];
+    volume?:  HowlOptions['volume'];
+    rate?: HowlOptions['rate'];
+    html5?: HowlOptions['html5'];
+    format?: HowlOptions['format'];
+    xhr?: HowlOptions['xhr'] | undefined,
+    onPlay?: HowlCallback | undefined;
+    onPause?: HowlCallback | undefined;
+    onVolume?: HowlCallback | undefined;
+    onStop?: HowlCallback | undefined;
+    onLoad?: HowlCallback | undefined;
+    onLoadError?: HowlErrorCallback | undefined;
+    onEnd?: HowlCallback | undefined;
+    onSeek?: HowlCallback | undefined;
+    onPlayError?: HowlErrorCallback | undefined;
 }
 
-declare class ReactHowler extends React.Component<Props> {
+declare class ReactHowler extends React.Component<PropTypes> {
     stop(id?: number): void;
 
     duration(id?: number): number;

--- a/types/react-howler/react-howler-tests.tsx
+++ b/types/react-howler/react-howler-tests.tsx
@@ -15,22 +15,24 @@ export class ReactHowlerTest extends React.Component {
             <div>
                 <ReactHowler
                     src={'some-source-url.mp3'}
+                    preload={false}
                     playing={false}
-                    mute={true}
-                    onPlay={id => console.log('playing sound with id ', id)}
-                    onLoad={() => console.log('sound loaded')}
-                    onLoadError={id =>
-                        console.log('error loading sound with id ', id)
-                    }
-                    onEnd={() => console.log('sound ended')}
-                    onPause={() => console.log('sound paused')}
-                    onStop={id => console.log('sound with id paused', id)}
-                    volume={0.5}
-                    onVolume={id => console.log('volume changed', id)}
                     loop={true}
+                    mute={true}
+                    volume={0.5}
+                    rate={1}
                     html5={true}
                     format={['mp3']}
-                    preload={false}
+                    xhr={{ method: 'GET' }}
+                    onPlay={id => console.log('playing sound with id ', id)}
+                    onPause={id => console.log('sound paused with id ', id)}
+                    onVolume={id => console.log('sound volume with id ', id)}
+                    onStop={id => console.log('sound stopped with id ', id)}
+                    onLoad={() => console.log('sound loaded')}
+                    onLoadError={id => console.log('error loading sound with id ', id)}
+                    onEnd={id => console.log('sound ended')}
+                    onSeek={id => console.log('sound seeked with id ', id)}
+                    onPlayError={id => console.log('error playing sound with id', id)}
                     ref={this.player}
                 />
             </div>


### PR DESCRIPTION
Update version to `5.2`.
Rename `Props` to `PropTypes` and export.
Export `HowlCallback` and `HowlErrorCallback` for external use.
Rearrange order of `PropTypes` to be the same as in the documentaion.
Add missing `PropTypes` options: `xhr`, `rate`, `onSeek`, and `onPlayError`.
Update test with changes.