### PR TITLE
[react-datepicker] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -131,7 +131,12 @@ const topLogger: Modifier<'topLogger'> = {
     previousYearAriaLabel=""
     previousYearButtonLabel=""
     readOnly
-    ref={handleRef}
+    ref={instance => {
+        if (instance !== null) {
+            // $ExpectType ReactDatePicker<"offset" | "preventOverflow", true>
+            instance;
+        }
+    }}
     renderCustomHeader={({
         monthDate,
         date,
@@ -200,7 +205,7 @@ const topLogger: Modifier<'topLogger'> = {
 
 <DatePicker formatWeekDay={() => <div />} onChange={() => null} />;
 
-function handleRef(ref: DatePicker) {
+function handleRef(ref: DatePicker | null) {
     if (ref) {
         ref.setBlur();
         ref.setFocus();
@@ -224,7 +229,7 @@ const props: ReactDatePickerProps = {
 <DatePicker<'topLogger'>
     onChange={() => {}}
     popperModifiers={[{ name: 'arrow', options: { padding: 5 } }, topLogger]}
-    ref={handleRef}
+    ref={(instance: DatePicker<'topLogger'> | null) => {}}
 />;
 
 const DatePickerCustomHeader = ({


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464