### PR TITLE
[react-flatpickr] Support nullable instances in ref

### DIFF
--- a/types/react-flatpickr/index.d.ts
+++ b/types/react-flatpickr/index.d.ts
@@ -24,7 +24,7 @@ export interface DateTimePickerProps extends Omit<Partial<HTMLInputElement>, 'va
     onDayCreate?: flatpickr.Options.Hook | undefined;
     value?: string | Date | number | ReadonlyArray<string | Date | number> | undefined;
     className?: string | undefined;
-    render?: ((props: Omit<DateTimePickerProps, 'options' | 'render'>, ref: (node: HTMLInputElement) => void) => ReactElement) | undefined;
+    render?: ((props: Omit<DateTimePickerProps, 'options' | 'render'>, ref: (node: HTMLInputElement | null) => void) => ReactElement) | undefined;
 }
 
 export default class DatePicker extends Component<DateTimePickerProps> {


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464