### PR TITLE
[react-google-recaptcha] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
+++ b/types/react-google-recaptcha/react-google-recaptcha-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import ReCAPTCHA, { ReCAPTCHA as ReCAPTCHA2 } from 'react-google-recaptcha';
 
-const handleRef = (ref: ReCAPTCHA): void => { return; };
+const handleRef = (ref: ReCAPTCHA | null): void => { return; };
 
 const basicRecapchta = <ReCAPTCHA ref={handleRef} sitekey="xxx" onChange={a => a} className="mockclass" />;
 const invisibleRecaptcha: React.FC = () => {


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464