### PR TITLE
[react-toastr] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/react-toastr/react-toastr-tests.tsx
+++ b/types/react-toastr/react-toastr-tests.tsx
@@ -4,9 +4,9 @@ import { ToastContainer, ToastMessageAnimated } from 'react-toastr';
 const toastMessageFactory = React.createFactory(ToastMessageAnimated);
 
 class Test extends React.Component {
-    ref: ToastContainer;
+    ref: ToastContainer | null = null;
 
-    toastRef = (ref: ToastContainer) => {
+    toastRef = (ref: ToastContainer | null) => {
         this.ref = ref;
     }
 


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464