### PR TITLE
[react-map-gl] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/react-map-gl/react-map-gl-tests.tsx
+++ b/types/react-map-gl/react-map-gl-tests.tsx
@@ -189,12 +189,18 @@ class MyMap extends React.Component<{}, State> {
         );
     }
 
-    private readonly setRefInteractive = (el: InteractiveMap) => {
+    private readonly setRefInteractive = (el: InteractiveMap | null) => {
+        if (el === null) {
+            return;
+        }
         this.map = el;
         this.mapboxMap = el.getMap();
     }
 
-    private readonly setRefStatic = (el: StaticMap) => {
+    private readonly setRefStatic = (el: StaticMap | null) => {
+        if (el === null) {
+            return;
+        }
         this.mapboxMap = el.getMap();
     }
 }


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464