### PR TITLE
[react-slider] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/react-slider/react-slider-tests.tsx
+++ b/types/react-slider/react-slider-tests.tsx
@@ -9,7 +9,7 @@ class Slider extends React.Component<ReactSliderProps> {
                 trackClassName="classnameForBar"
                 withTracks={false}
                 marks={5}
-                renderMark={props => <span {...props} />}
+                renderMark={props => <div {...props} />}
                 {...this.props}
             />
         );
@@ -40,12 +40,12 @@ function SingleThumbSliders() {
                 orientation="horizontal"
                 pageFn={step => step * 15}
                 pearling
-                renderMark={props => <span {...props} />}
+                renderMark={props => <div {...props} />}
                 renderThumb={(props, { index, value, valueNow }) => {
-                    return <span {...props}>{index + valueNow + value}</span>;
+                    return <div {...props}>{index + valueNow + value}</div>;
                 }}
                 renderTrack={(props, { index, value }) => {
-                    return <span {...props}>{index + value}</span>;
+                    return <div {...props}>{index + value}</div>;
                 }}
                 snapDragDisabled
                 step={2}
@@ -84,12 +84,12 @@ function MultipleThumbSliders() {
                 onBeforeChange={value => value.join()}
                 onChange={value => value.join()}
                 renderThumb={({ ref, ...props }, { value }) => (
-                    <span ref={ref} {...props}>
+                    <div ref={ref} {...props}>
                         {value.join()}
-                    </span>
+                    </div>
                 )}
                 renderTrack={(props, { value }) => {
-                    return <span {...props}>{value.join()}</span>;
+                    return <div {...props}>{value.join()}</div>;
                 }}
             />
 
@@ -116,7 +116,7 @@ interface CustomThumbProps extends React.HTMLProps<HTMLDivElement> {
 
 const CustomThumb = React.forwardRef<HTMLDivElement, CustomThumbProps>((props, ref) => {
     const { show, ...otherProps } = props;
-    return show ? <span ref={ref} {...otherProps} /> : null;
+    return show ? <div ref={ref} {...otherProps} /> : null;
 });
 
 function SliderWithCustomThumb() {


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464