### PR TITLE
[react-native-zss-rich-text-editor] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/react-native-zss-rich-text-editor/react-native-zss-rich-text-editor-tests.tsx
+++ b/types/react-native-zss-rich-text-editor/react-native-zss-rich-text-editor-tests.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 export class WyswygComponent extends React.Component<Props> {
-  private editorInst: RichTextEditor;
+  private editorInst: RichTextEditor | null = null;
 
   render() {
     const {value} = this.props;
@@ -17,7 +17,7 @@ export class WyswygComponent extends React.Component<Props> {
     />;
   }
 
-  private readonly saveEditorReference = (ref: RichTextEditor) => {
+  private readonly saveEditorReference = (ref: RichTextEditor | null) => {
     this.editorInst = ref;
   }
 }


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464