### PR TITLE
[react-slick] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/react-slick/react-slick-tests.tsx
+++ b/types/react-slick/react-slick-tests.tsx
@@ -67,12 +67,12 @@ const defaultSettings: Settings = {
 };
 
 class SliderTest extends React.Component {
-  private slider: Slider;
+  private slider: Slider | null = null;
   render() {
     return <div>
       <Slider
         {...defaultSettings}
-        ref={(component: Slider) => { this.slider = component; }}
+        ref={(component: Slider | null) => { this.slider = component; }}
       >
         <div><h3>1</h3></div>
         <div><h3>2</h3></div>
@@ -82,9 +82,9 @@ class SliderTest extends React.Component {
         <div><h3>6</h3></div>
       </Slider>
       <div style={{ textAlign: "center" }}>
-        <button className="button" onClick={(event) => { this.slider.slickPrev(); }}>Previous</button>
-        <button className="button" onClick={(event) => { this.slider.slickNext(); }}>Next</button>
-        <button className="button" onClick={(event) => { this.slider.slickGoTo(1); }}>First</button>
+        <button className="button" onClick={(event) => { this.slider!.slickPrev(); }}>Previous</button>
+        <button className="button" onClick={(event) => { this.slider!.slickNext(); }}>Next</button>
+        <button className="button" onClick={(event) => { this.slider!.slickGoTo(1); }}>First</button>
       </div>
     </div>;
   }


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464