### PR TITLE
[react-native-material-menu] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/react-native-material-menu/react-native-material-menu-tests.tsx
+++ b/types/react-native-material-menu/react-native-material-menu-tests.tsx
@@ -6,7 +6,7 @@ import Menu, { MenuItem, MenuDivider } from 'react-native-material-menu';
 class App extends React.PureComponent {
     _menu: Menu | null = null;
 
-    setMenuRef = (ref: Menu) => (this._menu = ref);
+    setMenuRef = (ref: Menu | null) => (this._menu = ref);
 
     hideMenu = (onHidden?: () => void) => this._menu && this._menu.hide(onHidden);
 


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464