### PR TITLE
[react-native-canvas] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/react-native-canvas/react-native-canvas-tests.tsx
+++ b/types/react-native-canvas/react-native-canvas-tests.tsx
@@ -12,7 +12,10 @@ const Example = ({ sample, children }: { sample: ImageSourcePropType; children: 
 );
 
 class CanvasTest extends React.Component {
-    handleImageData(canvas: Canvas) {
+    handleImageData(canvas: Canvas | null) {
+        if (canvas === null) {
+            return;
+        }
         canvas.width = 100;
         canvas.height = 100;
 
@@ -33,7 +36,10 @@ class CanvasTest extends React.Component {
         });
     }
 
-    handlePurpleRect(canvas: Canvas) {
+    handlePurpleRect(canvas: Canvas | null) {
+        if (canvas === null) {
+            return;
+        }
         canvas.width = 100;
         canvas.height = 100;
 
@@ -48,7 +54,10 @@ class CanvasTest extends React.Component {
         const { width } = context.measureText('yo');
     }
 
-    handleRedCircle(canvas: Canvas) {
+    handleRedCircle(canvas: Canvas | null) {
+        if (canvas === null) {
+            return;
+        }
         canvas.width = 100;
         canvas.height = 100;
 
@@ -59,7 +68,10 @@ class CanvasTest extends React.Component {
         context.fill();
     }
 
-    handleImageRect(canvas: Canvas) {
+    handleImageRect(canvas: Canvas | null) {
+        if (canvas === null) {
+            return;
+        }
         const image = new CanvasImage(canvas);
         canvas.width = 100;
         canvas.height = 100;
@@ -73,7 +85,10 @@ class CanvasTest extends React.Component {
         });
     }
 
-    handlePath(canvas: Canvas) {
+    handlePath(canvas: Canvas | null) {
+        if (canvas === null) {
+            return;
+        }
         canvas.width = 100;
         canvas.height = 100;
         const context = canvas.getContext('2d');
@@ -96,7 +111,10 @@ class CanvasTest extends React.Component {
         context.restore();
     }
 
-    handleGradient(canvas: Canvas) {
+    handleGradient(canvas: Canvas | null) {
+        if (canvas === null) {
+            return;
+        }
         canvas.width = 100;
         canvas.height = 100;
         const ctx = canvas.getContext('2d');
@@ -107,7 +125,10 @@ class CanvasTest extends React.Component {
         ctx.fillRect(0, 0, 100, 100);
     }
 
-    handleEmbedHTML(canvas: Canvas) {
+    handleEmbedHTML(canvas: Canvas | null) {
+        if (canvas === null) {
+            return;
+        }
         const image = new CanvasImage(canvas);
         canvas.width = 100;
         canvas.height = 100;
@@ -133,7 +154,10 @@ class CanvasTest extends React.Component {
         });
     }
 
-    handleToDataURL(canvas: Canvas) {
+    handleToDataURL(canvas: Canvas | null) {
+        if (canvas === null) {
+            return;
+        }
         canvas.width = 100;
         canvas.height = 100;
 


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464