### PR TITLE
[react-codemirror] Ref instances are nullable

### DIFF
--- a/types/react-codemirror/index.d.ts
+++ b/types/react-codemirror/index.d.ts
@@ -11,7 +11,6 @@
 declare namespace ReactCodeMirror {
     interface ReactCodeMirrorProps {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<ReactCodeMirror> | undefined;
         /** Automatically focuses the editor when it is mounted (default false) */
         autoFocus?: boolean | undefined;
         /** Automatically persist changes to underlying textarea (default false) */
@@ -41,19 +40,15 @@ declare namespace ReactCodeMirror {
         /** The editor value */
         value?: string | undefined;
     }
+}
 
-    interface ReactCodeMirror extends React.Component<ReactCodeMirrorProps> {
+declare module "react-codemirror" {
+    class RCM extends React.Component<ReactCodeMirror.ReactCodeMirrorProps> {
         /** Focuses the CodeMirror instance. */
         focus(): void;
 
         /** Returns the CodeMirror instance, if available. */
         getCodeMirror(): CodeMirror.Editor;
     }
-
-    interface ReactCodeMirrorClass extends React.ComponentClass<ReactCodeMirrorProps> { }
-}
-
-declare module "react-codemirror" {
-    const RCM: ReactCodeMirror.ReactCodeMirrorClass;
     export = RCM;
 }

--- a/types/react-codemirror/react-codemirror-tests.tsx
+++ b/types/react-codemirror/react-codemirror-tests.tsx
@@ -4,11 +4,11 @@ import * as ReactDOM from "react-dom";
 import Codemirror = require("react-codemirror");
 
 class CodemirrorTest extends React.Component {
-    private editorRef: ReactCodeMirror.ReactCodeMirror;
+    private editorRef: Codemirror | null = null;
 
     componentDidMount() {
-        this.editorRef.focus();
-        this.editorRef.getCodeMirror();
+        this.editorRef!.focus();
+        this.editorRef!.getCodeMirror();
     }
 
     render() {
@@ -35,7 +35,7 @@ class CodemirrorTest extends React.Component {
                         onScroll={onScroll}
                         options={options}
                         preserveScrollPosition={true}
-                        ref={(r: ReactCodeMirror.ReactCodeMirror) => this.editorRef = r}
+                        ref={(r: Codemirror | null) => this.editorRef = r}
                         value="foo bar" />
         </div>;
     }


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464