### PR TITLE
[wordpress__block-editor] Fix tests assuming instances in ref callbacks are non-nullable

### DIFF
--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -550,7 +550,7 @@ select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
 {
   const blockProps = be.useBlockProps({ ref: useRef("test") });
-  // $ExpectType (instance: unknown) => void
+  // $ExpectType RefCallback<unknown>
   blockProps.ref;
 }
 


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464