### PR TITLE
[react-notifaction-system] Ref instances are nullable

### DIFF
--- a/types/react-notification-system/index.d.ts
+++ b/types/react-notification-system/index.d.ts
@@ -7,14 +7,6 @@
 import * as React from "react";
 
 declare namespace NotificationSystem {
-
-    export interface System extends React.Component<Attributes, State> {
-        addNotification(notification: Notification): Notification;
-        removeNotification(uidOrNotification: number | string | Notification): void;
-        clearNotifications(): void;
-        editNotification(uidOrNotification: number | string | Notification, newNotification: Notification): void;
-    }
-
     export type CallBackFunction = (notification: Notification) => void;
 
     export interface Notification {
@@ -69,7 +61,7 @@ declare namespace NotificationSystem {
         ActionWrapper?: WrapperStyle | undefined;
     }
 
-    export interface Attributes extends React.ClassAttributes<System> {
+    export interface Attributes {
         noAnimation?: boolean | undefined;
         style?: Style | boolean | undefined;
         allowHTML?: boolean | undefined;
@@ -81,5 +73,13 @@ declare namespace NotificationSystem {
 }
 
 
-declare var NotificationSystem: React.ClassicComponentClass<NotificationSystem.Attributes>;
+declare class NotificationSystem extends React.Component<NotificationSystem.Attributes, NotificationSystem.State> {
+    addNotification(notification: NotificationSystem.Notification): NotificationSystem.Notification;
+    removeNotification(uidOrNotification: number | string | NotificationSystem.Notification): void;
+    clearNotifications(): void;
+    editNotification(
+        uidOrNotification: number | string | NotificationSystem.Notification,
+        newNotification: NotificationSystem.Notification,
+    ): void;
+}
 export = NotificationSystem;

--- a/types/react-notification-system/react-notification-system-tests.tsx
+++ b/types/react-notification-system/react-notification-system-tests.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import NotificationSystem = require('react-notification-system');
 
 class MyComponent extends React.Component {
-    private notificationSystem: NotificationSystem.System = null;
+    private notificationSystem: NotificationSystem = null;
 
     private notification: NotificationSystem.Notification = {
         title: 'Notification title',
@@ -54,7 +54,7 @@ class MyComponent extends React.Component {
             }
         };
 
-        const ref = (instance: NotificationSystem.System) => {
+        const ref = (instance: NotificationSystem) => {
             this.notificationSystem = instance
         }
 


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464