### PR TITLE
Restrict support-window workflow to DT

### DIFF
--- a/.github/workflows/support-window.yml
+++ b/.github/workflows/support-window.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 jobs:
   support-window:
+    if: github.repository == 'DefinitelyTyped/DefinitelyTyped'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
All of the other maintenance workflows do this, but this one didn't, which led to the SVG being changed on people's forks/PRs if they happen to have GHA enabled (which used to be the default).