### PR TITLE
[cache-manager] Fix `.wrap()` arguments to handle promise values

### DIFF
--- a/types/cache-manager/cache-manager-tests.ts
+++ b/types/cache-manager/cache-manager-tests.ts
@@ -66,9 +66,14 @@ async function promiseMemoryCache(cache: cacheManager.Cache) {
     const KEY = 'Key';
     const VALUE = 'string';
 
-    const numberWrap: number = await cache.wrap<number>(KEY, () => 1);
-    const stringWrap: string = await cache.wrap<string>(KEY, () => VALUE);
-    const stringWrapWithCacheConfig: string = await cache.wrap<string>(KEY, () => VALUE, { ttl: 10 });
+    const numberWrap: number = await cache.wrap(KEY, () => 1);
+    const numberWrapAsync: number = await cache.wrap(KEY, async () => 1);
+    
+    const stringWrap: string = await cache.wrap(KEY, () => VALUE);
+    const stringWrapAsync: string = await cache.wrap(KEY, async () => VALUE);
+    
+    const stringWrapWithCacheConfig: string = await cache.wrap(KEY, () => VALUE, { ttl: 10 });
+    const stringWrapWithCacheConfigAsync: string = await cache.wrap(KEY, async () => VALUE, { ttl: 10 });
 
     const setWithoutOptional = await cache.set(KEY, VALUE);
     const setWitOptional = await cache.set(KEY, VALUE, { ttl: 10 });

--- a/types/cache-manager/cache-manager-tests.ts
+++ b/types/cache-manager/cache-manager-tests.ts
@@ -68,10 +68,10 @@ async function promiseMemoryCache(cache: cacheManager.Cache) {
 
     const numberWrap: number = await cache.wrap(KEY, () => 1);
     const numberWrapAsync: number = await cache.wrap(KEY, async () => 1);
-    
+
     const stringWrap: string = await cache.wrap(KEY, () => VALUE);
     const stringWrapAsync: string = await cache.wrap(KEY, async () => VALUE);
-    
+
     const stringWrapWithCacheConfig: string = await cache.wrap(KEY, () => VALUE, { ttl: 10 });
     const stringWrapWithCacheConfigAsync: string = await cache.wrap(KEY, async () => VALUE, { ttl: 10 });
 

--- a/types/cache-manager/index.d.ts
+++ b/types/cache-manager/index.d.ts
@@ -50,7 +50,11 @@ export interface CacheOptions {
 }
 
 export type CallbackFunc<T> = (error: any, result: T) => void;
-export type WrapArgsType<T> = string | ((callback: CallbackFunc<T>) => void) | CachingConfig | CallbackFunc<T>;
+export type WrapArgsType<T> = 
+  | string 
+  | ((callback: CallbackFunc<T>) => void)
+  | CachingConfig 
+  | (() => PromiseLike<T> | T);
 
 export interface Cache {
     set<T>(key: string, value: T, options?: CachingConfig): Promise<T>;

--- a/types/cache-manager/index.d.ts
+++ b/types/cache-manager/index.d.ts
@@ -50,10 +50,10 @@ export interface CacheOptions {
 }
 
 export type CallbackFunc<T> = (error: any, result: T) => void;
-export type WrapArgsType<T> = 
-  | string 
+export type WrapArgsType<T> =
+  | string
   | ((callback: CallbackFunc<T>) => void)
-  | CachingConfig 
+  | CachingConfig
   | CallbackFunc<T>
   | (() => PromiseLike<T> | T);
 

--- a/types/cache-manager/index.d.ts
+++ b/types/cache-manager/index.d.ts
@@ -54,6 +54,7 @@ export type WrapArgsType<T> =
   | string 
   | ((callback: CallbackFunc<T>) => void)
   | CachingConfig 
+  | CallbackFunc<T>
   | (() => PromiseLike<T> | T);
 
 export interface Cache {


### PR DESCRIPTION
This PR will fix https://github.com/BryanDonovan/node-cache-manager/issues/180

Currently the types doesn't support Promises on the `.wrap` function, forcing the user to add the promise return type on the function template parameter. This fix add another return type for the `.wrap` arguments to match the library documentation and help TypeScript understand that is the function return type automatically.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/BryanDonovan/node-cache-manager/issues/180
