### PR TITLE
Webrtc Icecandidate

### DIFF
--- a/types/webrtc/IceCandidate.d.ts
+++ b/types/webrtc/IceCandidate.d.ts
@@ -3,24 +3,24 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate
 
 type RTCIceCandidateJSON = {
-  address: string
-  candidate: string
-  component: "rtp" | "rtcp"
-  foundation: string
-  port: number
-  priority: number
-  protocol: "tcp" | "udp"
-  relatedAddress: string | null
-  relatedPort: number | null
-  sdpMid: string
-  sdpMLineIndex: number | null
-  tcpType: "tcp" | null
-  type: string
-  usernameFragment: string
+    address: string
+    candidate: string
+    component: "rtp" | "rtcp"
+    foundation: string
+    port: number
+    priority: number
+    protocol: "tcp" | "udp"
+    relatedAddress: string | null
+    relatedPort: number | null
+    sdpMid: string
+    sdpMLineIndex: number | null
+    tcpType: "tcp" | null
+    type: string
+    usernameFragment: string
 }
 
 interface IRTCIceCandidate extends Readonly<RTCIceCandidateJSON> {
-  toJson(): RTCIceCandidateJSON;
+    toJson(): RTCIceCandidateJSON;
 }
 
 type RTCIceCandidate = RTCIceCandidateJSON | IRTCIceCandidate;

--- a/types/webrtc/IceCandidate.d.ts
+++ b/types/webrtc/IceCandidate.d.ts
@@ -1,0 +1,26 @@
+
+
+// https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate
+
+type RTCIceCandidateJSON = {
+  address: string
+  candidate: string
+  component: "rtp" | "rtcp"
+  foundation: string
+  port: number
+  priority: number
+  protocol: "tcp" | "udp"
+  relatedAddress: string | null
+  relatedPort: number | null
+  sdpMid: string
+  sdpMLineIndex: number | null
+  tcpType: "tcp" | null
+  type: string
+  usernameFragment: string
+}
+
+interface IRTCIceCandidate extends Readonly<RTCIceCandidateJSON> {
+  toJson(): RTCIceCandidateJSON;
+}
+
+type RTCIceCandidate = RTCIceCandidateJSON | IRTCIceCandidate;

--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -10,6 +10,7 @@
 // ES6 library ones.
 
 /// <reference path='MediaStream.d.ts' />
+/// <reference path='IceCandidate.d.ts' />
 
 // https://www.w3.org/TR/webrtc/#idl-def-rtcerrordetailtype
 type RTCErrorDetailType =


### PR DESCRIPTION
Webrtc is available from @types/web and typescript/lib-dom. However, in some cases a developer may want to restrict the available globals to only a subset. I do not know how to do this so I figured I could use an existing type definition. However, this definition was incomplete and is still incomplete. Missing many types related to ice. But at least its closer

https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate
