### PR TITLE
@types/gtag.js - Add additional "get" callback types according to the API

### DIFF
--- a/types/gtag.js/gtag.js-tests.ts
+++ b/types/gtag.js/gtag.js-tests.ts
@@ -20,7 +20,9 @@ gtag('set', {
 gtag('set', 'developer_id', true);
 gtag('set', 'page_path', '/new_page.html');
 
-gtag('get', 'GA-TRACKING_ID', 'client_id', _clientId => {});
+gtag('get', 'GA-TRACKING_ID', 'client_id', (
+  clientId // $ExpectType string | CustomParams | undefined
+) => {});
 
 gtag('consent', 'default', {
   ad_storage: 'denied',

--- a/types/gtag.js/index.d.ts
+++ b/types/gtag.js/index.d.ts
@@ -15,7 +15,7 @@ declare namespace Gtag {
       eventName: EventNames | string,
       eventParams?: ControlParams | EventParams | CustomParams,
     ): void;
-    (command: 'get', targetId: string, fieldName: FieldNames | string, callback?: (field: string) => any): void;
+    (command: 'get', targetId: string, fieldName: FieldNames | string, callback?: (field: string | CustomParams | undefined) => any): void;
     (command: 'consent', consentArg: ConsentArg | string, consentParams: ConsentParams): void;
   }
 


### PR DESCRIPTION
* Added `CustomParams` and `undefined` types to the "get" command callback parameter. These types are possible according to the [API documentation](https://developers.google.com/tag-platform/gtagjs/reference#get). The requested field may be `CustomParams` if getting [user_properties](https://developers.google.com/analytics/devguides/collection/ga4/reference/config#user_properties)
* Updated tests and `npm test gtag.js` passes

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [API documentation](https://developers.google.com/tag-platform/gtagjs/reference#get)
  - [user_properties documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/config#user_properties)
