### PR TITLE
braintree-web: add additional call signatures for functions that have overloads

### DIFF
--- a/types/braintree-web/modules/apple-pay.d.ts
+++ b/types/braintree-web/modules/apple-pay.d.ts
@@ -179,8 +179,8 @@ export class ApplePaySession {
  * @description Accept Apple Pay on the Web. *This component is currently in beta and is subject to change.*
  */
 export interface ApplePay {
-    create(options: { client: Client }): Promise<any>;
-    create(options: { client: Client }, callback?: callback): void;
+    create(options: { client: Client }): Promise<ApplePay>;
+    create(options: { client: Client }, callback?: callback<ApplePay>): void;
 
     /**
      * @description The current version of the SDK, i.e. `3.0.2`.
@@ -193,7 +193,8 @@ export interface ApplePay {
      * - countryCode
      * - currencyCode
      * - merchantCapabilities
-     * - supportedNetworks     * @example
+     * - supportedNetworks
+     * @example
      * var applePay = require('braintree-web/apple-pay');
      *
      * applePay.create({client: clientInstance}, function (createErr, applePayInstance) {
@@ -217,6 +218,7 @@ export interface ApplePay {
      * - Do not localize the name.     * Your Apple merchant identifier. This is the Apple Merchant ID created on the Apple Developer Portal.
      * Defaults to the merchant identifier specified in the Braintree Control Panel.
      * You can use this field to override the merchant identifier for this transaction.     * Pass the merchant session to your Apple Pay session's completeMerchantValidation method.
+     * If no callback is provided this returns a promise
      * @example
      * var applePay = require('braintree-web/apple-pay');
      *
@@ -244,9 +246,16 @@ export interface ApplePay {
         options: { validationURL: string; displayName?: string | undefined; merchantIdentifier?: string | undefined },
         callback: callback,
     ): void;
+    performValidation(options: {
+        validationURL: string;
+        displayName?: string | undefined;
+        merchantIdentifier?: string | undefined;
+    }): Promise<any>;
 
     /**
-     * Tokenizes an Apple Pay payment.     * @example
+     * Tokenizes an Apple Pay payment.
+     * If no callback is provided this will return a promise
+     * @example
      * var applePay = require('braintree-web/apple-pay');
      *
      * applePay.create({client: clientInstance}, function (createErr, applePayInstance) {
@@ -267,5 +276,6 @@ export interface ApplePay {
      *  };
      * });
      */
-    tokenize(options: { token: any }, callback: callback): void;
+    tokenize(options: { token: any }, callback: callback<ApplePayPayload>): void;
+    tokenize(options: { token: any }): Promise<ApplePayPayload>;
 }

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -412,6 +412,43 @@ braintree.client.create(
             };
         });
 
+        braintree.applePay.create({ client: clientInstance }).then(applePayInstance => {
+            const request = {
+                countryCode: 'US',
+                currencyCode: 'USD',
+                supportedNetworks: ['visa', 'masterCard'],
+                merchantCapabilities: ['supports3DS'],
+                total: { label: 'Your Label', amount: '10.00' },
+            };
+
+            const session = new braintree.ApplePaySession(1, request);
+
+            session.onvalidatemerchant = event => {
+                applePayInstance
+                    .performValidation({ validationURL: event.validationURL })
+                    .then(merchantSession => {
+                        session.completeMerchantValidation(merchantSession);
+                    })
+                    .catch(error => {
+                        console.error(error);
+                        session.abort();
+                        return;
+                    });
+            };
+
+            session.onpaymentauthorized = event => {
+                applePayInstance
+                    .tokenize({ token: event.payment.token })
+                    .then(payload => {
+                        console.log(payload.nonce);
+                        session.completePayment(braintree.ApplePaySession.STATUS_SUCCESS);
+                    })
+                    .catch(error => {
+                        session.completePayment(braintree.ApplePaySession.STATUS_FAILURE);
+                    });
+            };
+        });
+
         braintree.paypal.create(
             {
                 client: clientInstance,
@@ -740,46 +777,52 @@ braintree.client.create(
         });
 
         // Local Payment
-        braintree.localPayment.create({
-            client: clientInstance
-        }, (err, localPaymentInstance) => {
-            localPaymentInstance
-                .startPayment({
-                    amount: 11.00,
-                    currencyCode: 'EUR',
-                    paymentType: 'sofort',
-                    onPaymentStart: (data, next) => {
-                        if (data.paymentId) {
-                            // Implementation
+        braintree.localPayment.create(
+            {
+                client: clientInstance,
+            },
+            (err, localPaymentInstance) => {
+                localPaymentInstance
+                    .startPayment({
+                        amount: 11.0,
+                        currencyCode: 'EUR',
+                        paymentType: 'sofort',
+                        onPaymentStart: (data, next) => {
+                            if (data.paymentId) {
+                                // Implementation
+                            }
+                            next();
+                        },
+                    })
+                    .then((payload: braintree.LocalPaymentTokenizePayload) => {
+                        console.log(payload.nonce);
+                    })
+                    .catch((error: braintree.BraintreeError) => {
+                        console.error('Error!', error);
+                    });
+
+                localPaymentInstance.tokenize(
+                    {
+                        btLpPayerId: '1234',
+                        btLpPaymentId: '1234',
+                        btLpToken: '1234',
+                    },
+                    (error, data) => {
+                        if (error) {
+                            console.error('Tokenize Error!', error);
+                            return;
                         }
-                        next();
-                    }
-                })
-                .then((payload: braintree.LocalPaymentTokenizePayload) => {
-                    console.log(payload.nonce);
-                })
-                .catch((error: braintree.BraintreeError) => {
-                    console.error('Error!', error);
+
+                        // Implementation
+                        console.log(data.nonce);
+                    },
+                );
+
+                localPaymentInstance.teardown(err => {
+                    // Implementation
                 });
-
-            localPaymentInstance.tokenize({
-                btLpPayerId: '1234',
-                btLpPaymentId: '1234',
-                btLpToken: '1234'
-            }, (error, data) => {
-                if (error) {
-                    console.error('Tokenize Error!', error);
-                    return;
-                }
-
-                // Implementation
-                console.log(data.nonce);
-            });
-
-            localPaymentInstance.teardown(err => {
-                // Implementation
-            });
-        });
+            },
+        );
     },
 );
 


### PR DESCRIPTION
Various functions of the braintree web apple pay instance have multiple call signatures. Whereby if a callback function is not specified, it returns a promise.
I've updated the `tokenize` and `performValidation` functions to have an overload that has no callback parameter, and returns a promise. 
Additionally, I've added the correct returns types to the callback and promises for these functions, as well as the `create` function.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Documentation supporting my changes](https://braintree.github.io/braintree-web/current/ApplePay.html)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
