### PR TITLE
add missing node globals: Event, EventTarget

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -642,7 +642,53 @@ declare module 'events' {
                 eventNames(): Array<string | symbol>;
             }
         }
+
+        interface EventInit {
+            bubbles?: boolean;
+            cancelable?: boolean;
+            composed?: boolean;
+        }
+
+        /** An event which takes place in Node. */
+        class Event {
+            new(type: string, options?: EventInit): Event;
+            /** Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise. */
+            readonly bubbles: boolean;
+            cancelBubble: boolean;
+            /** Returns true or false depending on how event was initialized. Its return value does not always carry meaning, but true can indicate that part of the operation during which event was dispatched, can be canceled by invoking the preventDefault() method. */
+            readonly cancelable: boolean;
+            /** Returns true or false depending on how event was initialized. True if event invokes listeners past a ShadowRoot node that is the root of its target, and false otherwise. */
+            readonly composed: boolean;
+            /** Returns the object whose event listener's callback is currently being invoked. */
+            readonly currentTarget: EventTarget | null;
+            /** Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise. */
+            readonly defaultPrevented: boolean;
+            /** Returns the event's phase, which is one of NONE, CAPTURING_PHASE, AT_TARGET, and BUBBLING_PHASE. */
+            readonly eventPhase: number;
+            /** Returns true if event was dispatched by the user agent, and false otherwise. */
+            readonly isTrusted: boolean;
+            readonly srcElement: EventTarget | null;
+            /** Returns the object to which event is dispatched (its target). */
+            readonly target: EventTarget | null;
+            /** Returns the event's timestamp as the number of milliseconds measured relative to the time origin. */
+            readonly timeStamp: DOMHighResTimeStamp;
+            /** Returns the type of event, e.g. "click", "hashchange", or "submit". */
+            readonly type: string;
+            /** Returns the invocation target objects of event's path (objects on which listeners will be invoked), except for any nodes in shadow trees of which the shadow root's mode is "closed" that are not reachable from event's currentTarget. */
+            composedPath(): EventTarget[];
+            /** If invoked when the cancelable attribute value is true, and while executing a listener for the event with passive set to false, signals to the operation that caused event to be dispatched that it needs to be canceled. */
+            preventDefault(): void;
+            /** Invoking this method prevents event from reaching any registered event listeners after the current one finishes running and, when dispatched in a tree, also prevents event from reaching any other objects. */
+            stopImmediatePropagation(): void;
+            /** When dispatched in a tree, invoking this method prevents event from reaching any objects other than the current object. */
+            stopPropagation(): void;
+            static readonly AT_TARGET: number;
+            static readonly BUBBLING_PHASE: number;
+            static readonly CAPTURING_PHASE: number;
+            static readonly NONE: number;
+        }
     }
+
     export = EventEmitter;
 }
 declare module 'node:events' {

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -687,6 +687,56 @@ declare module 'events' {
             static readonly CAPTURING_PHASE: number;
             static readonly NONE: number;
         }
+
+        interface EventTargetCallback {
+            (event: Event): void;
+        }
+
+        interface EventListener {
+            ({ handleEvent }: { handleEvent: EventTargetCallback }): void;
+        }
+
+        interface EventListenerOptions {
+            capture?: boolean;
+        }
+
+        interface AddEventListenerOptions extends EventListenerOptions {
+            once?: boolean;
+            passive?: boolean;
+            signal?: AbortSignal;
+        }
+
+        /** EventTarget is a DOM interface implemented by objects that can receive events and may have listeners for them. */
+        class EventTarget {
+            /**
+             * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
+             *
+             * The options argument sets listener-specific options. For compatibility this can be a boolean, in which case the method behaves exactly as if the value was specified as options's capture.
+             *
+             * When set to true, options's capture prevents callback from being invoked when the event's eventPhase attribute value is BUBBLING_PHASE. When false (or not present), callback will not be invoked when event's eventPhase attribute value is CAPTURING_PHASE. Either way, callback will be invoked if event's eventPhase attribute value is AT_TARGET.
+             *
+             * When set to true, options's passive indicates that the callback will not cancel the event by invoking preventDefault(). This is used to enable performance optimizations described in § 2.8 Observing event listeners.
+             *
+             * When set to true, options's once indicates that the callback will only be invoked once after which the event listener will be removed.
+             *
+             * If an AbortSignal is passed for options's signal, then the event listener will be removed when signal is aborted.
+             *
+             * The event listener is appended to target's event listener list and is not appended if it has the same type, callback, and capture.
+             */
+            addEventListener(
+                type: string,
+                callback: EventTargetCallback | EventListener,
+                options?: AddEventListenerOptions,
+            ): void;
+            /** Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise. */
+            dispatchEvent(event: Event): boolean;
+            /** Removes the event listener in target's event listener list with the same type, callback, and options. */
+            removeEventListener(
+                type: string,
+                callback: EventTargetCallback | EventListener,
+                options?: EventListenerOptions,
+            ): void;
+        }
     }
 
     export = EventEmitter;

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -651,7 +651,7 @@ declare module 'events' {
 
         /** An event which takes place in Node. */
         class Event {
-            new(type: string, options?: EventInit): Event;
+            constructor(type: string, options?: EventInit);
             /** Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise. */
             readonly bubbles: boolean;
             cancelBubble: boolean;

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -127,5 +127,4 @@ async function test() {
 
     const event = new Event('test');
     event.preventDefault();
-    event.NONE;
 }

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -124,4 +124,8 @@ async function test() {
 
     const eventEmitter = new events.EventEmitter();
     events.EventEmitter.setMaxListeners(42, eventTarget, eventEmitter);
+
+    const event = new Event('test');
+    event.preventDefault();
+    event.NONE;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test node`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/globals.html#event
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/59001



The tests are failing because of conflicting declarations, unfortunately I don't know how to fix that problem, any ideas?

```
 npm test node

> definitely-typed@0.0.3 test
> dtslint types "node"

dtslint@0.0.110
Error: Errors in typescript@4.7 for external dependencies:
../../../../../.dts/typescript-installs/4.7/node_modules/typescript/lib/lib.dom.d.ts(4918,11): error TS2300: Duplicate identifier 'Event'.
../../../../../.dts/typescript-installs/4.7/node_modules/typescript/lib/lib.dom.d.ts(4960,13): error TS2300: Duplicate identifier 'Event'.
../../../../../.dts/typescript-installs/4.7/node_modules/typescript/lib/lib.dom.d.ts(5015,11): error TS2300: Duplicate identifier 'EventTarget'.
../../../../../.dts/typescript-installs/4.7/node_modules/typescript/lib/lib.dom.d.ts(5038,13): error TS2300: Duplicate identifier 'EventTarget'.

    at testTypesVersion (/home/simon/.cache/repos/DefinitelyTyped/node_modules/@definitelytyped/dtslint/dist/index.js:194:15)
    at async runTests (/home/simon/.cache/repos/DefinitelyTyped/node_modules/@definitelytyped/dtslint/dist/index.js:170:13)
    at async main (/home/simon/.cache/repos/DefinitelyTyped/node_modules/@definitelytyped/dtslint/dist/index.js:79:9)
```