### PR TITLE
Revert revert of ramda change, bump to 0.28

### DIFF
--- a/types/ramda/OTHER_FILES.txt
+++ b/types/ramda/OTHER_FILES.txt
@@ -36,6 +36,7 @@ es/construct.d.ts
 es/constructN.d.ts
 es/contains.d.ts
 es/converge.d.ts
+es/count.d.ts
 es/countBy.d.ts
 es/curry.d.ts
 es/curryN.d.ts
@@ -290,6 +291,7 @@ src/construct.d.ts
 src/constructN.d.ts
 src/contains.d.ts
 src/converge.d.ts
+src/count.d.ts
 src/countBy.d.ts
 src/curry.d.ts
 src/curryN.d.ts

--- a/types/ramda/es/count.d.ts
+++ b/types/ramda/es/count.d.ts
@@ -1,0 +1,2 @@
+import { count } from '../index';
+export default count;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -31,6 +31,7 @@
 //                 Mikael Couzic <https://github.com/couzic>
 //                 Nikita Balikhin <https://github.com/NEWESTERS>
 //                 Wang Zengdi <https://github.com/adispring>
+//                 Marcus Blättermann <https://github.com/essenmitsosse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.2
 
@@ -556,6 +557,12 @@ export function converge<
     branches: [((...args: TArgs) => R1)]
 ): (...args: TArgs) => TResult;
 // tslint:enable:max-line-length
+
+/**
+ * Returns the number of items in a given `list` matching the predicate `f`
+ */
+export function count<T>(fn: (a: T) => boolean, list: readonly T[]): number;
+export function count<T>(fn: (a: T) => boolean): (list: readonly T[]) => number;
 
 /**
  * Counts the elements of a list according to how many match each value

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ramda 0.27
+// Type definitions for ramda 0.28
 // Project: https://ramdajs.com
 // Definitions by: Scott O'Malley <https://github.com/TheHandsomeCoder>
 //                 Erwin Poeze <https://github.com/donnut>

--- a/types/ramda/src/count.d.ts
+++ b/types/ramda/src/count.d.ts
@@ -1,0 +1,2 @@
+import { count } from '../index';
+export default count;

--- a/types/ramda/test/count-tests.ts
+++ b/types/ramda/test/count-tests.ts
@@ -1,0 +1,18 @@
+import * as R from 'ramda';
+
+() => {
+  const numbers = [1.0, 1.1, 1.2, 2.0, 3.0, 2.2];
+  const letters = R.split('', 'abcABCaaaBBc');
+  R.count(R.gt(2))(numbers); // => 2
+  R.count(R.equals('a'))(letters); // => 4
+
+  // Mismatch between `predicate` and `list`
+  // $ExpectError
+  R.count(R.gt(2))(letters);
+  // $ExpectError
+  R.count(R.equals('a'))(numbers);
+
+  // Predicate doesn't return `boolean`
+  // $ExpectError
+  R.count(R.add(2));
+};

--- a/types/ramda/tsconfig.json
+++ b/types/ramda/tsconfig.json
@@ -54,6 +54,7 @@
         "test/constructN-tests.ts",
         "test/contains-tests.ts",
         "test/converge-tests.ts",
+        "test/count-tests.ts",
         "test/countBy-tests.ts",
         "test/curry-tests.ts",
         "test/curryN-tests.ts",


### PR DESCRIPTION
Reverts #59002 then applies #58980 for the version bump.