### PR TITLE
fix(@ember/debug): `registerWarnHandler` & `registerDeprecationHandler`

### DIFF
--- a/types/ember/test/debug.ts
+++ b/types/ember/test/debug.ts
@@ -34,23 +34,25 @@ debug('Too many tomsters!', 'foo'); // $ExpectError
 // next is not called, so no warnings get the default behavior
 registerWarnHandler(); // $ExpectError
 registerWarnHandler(() => {}); // $ExpectType void
-// $ExpectType void
-registerWarnHandler((message, { id }, next) => {
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next; // $ExpectType (message?: string | undefined, options?: { id: string; } | undefined) => void
+    options; // $ExpectType { id: string; } | undefined
+    next; // $ExpectType (message: string, options?: { id: string; } | undefined) => void
 });
-// $ExpectType void
-registerWarnHandler((message, { id }, next) => {
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next(); // $ExpectType void
+    options; // $ExpectType { id: string; } | undefined
+    next(); // $ExpectError
 });
-// $ExpectType void
-registerWarnHandler((message, { id }, next) => {
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next(message, { id }); // $ExpectType void
+    options; // $ExpectType { id: string; } | undefined
+    next(message); // $ExpectType void
+});
+registerWarnHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; } | undefined
+    next(message, options); // $ExpectType void
 });
 
 // next is not called, so no warnings get the default behavior

--- a/types/ember/test/debug.ts
+++ b/types/ember/test/debug.ts
@@ -58,12 +58,25 @@ registerWarnHandler((message, options, next) => { // $ExpectType void
 // next is not called, so no warnings get the default behavior
 registerDeprecationHandler(); // $ExpectError
 registerDeprecationHandler(() => {}); // $ExpectType void
-// $ExpectType void
-registerDeprecationHandler((message, { id, until }, next) => {
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    until; // $ExpectType string
-    next; // $ExpectType () => void
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next; // $ExpectType (message: string, options?: { id: string; until: string; } | undefined) => void
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(); // $ExpectError
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(message); // $ExpectType void
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(message, options); // $ExpectType void
 });
 
 // Test for truthiness

--- a/types/ember/v3/test/debug.ts
+++ b/types/ember/v3/test/debug.ts
@@ -56,12 +56,25 @@ registerWarnHandler((message, options, next) => { // $ExpectType void
 // next is not called, so no warnings get the default behavior
 registerDeprecationHandler(); // $ExpectError
 registerDeprecationHandler(() => {}); // $ExpectType void
-// $ExpectType void
-registerDeprecationHandler((message, { id, until }, next) => {
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    until; // $ExpectType string
-    next; // $ExpectType () => void
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next; // $ExpectType (message: string, options?: { id: string; until: string; } | undefined) => void
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(); // $ExpectError
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(message); // $ExpectType void
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(message, options); // $ExpectType void
 });
 
 // Test for truthiness

--- a/types/ember/v3/test/debug.ts
+++ b/types/ember/v3/test/debug.ts
@@ -32,23 +32,25 @@ debug('Too many tomsters!', 'foo'); // $ExpectError
 // next is not called, so no warnings get the default behavior
 registerWarnHandler(); // $ExpectError
 registerWarnHandler(() => {}); // $ExpectType void
-// $ExpectType void
-registerWarnHandler((message, { id }, next) => {
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next; // $ExpectType (message?: string | undefined, options?: { id: string; } | undefined) => void
+    options; // $ExpectType { id: string; } | undefined
+    next; // $ExpectType (message: string, options?: { id: string; } | undefined) => void
 });
-// $ExpectType void
-registerWarnHandler((message, { id }, next) => {
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next(); // $ExpectType void
+    options; // $ExpectType { id: string; } | undefined
+    next(); // $ExpectError
 });
-// $ExpectType void
-registerWarnHandler((message, { id }, next) => {
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next(message, { id }); // $ExpectType void
+    options; // $ExpectType { id: string; } | undefined
+    next(message); // $ExpectType void
+});
+registerWarnHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; } | undefined
+    next(message, options); // $ExpectType void
 });
 
 // next is not called, so no warnings get the default behavior

--- a/types/ember__debug/ember__debug-tests.ts
+++ b/types/ember__debug/ember__debug-tests.ts
@@ -73,11 +73,25 @@ registerWarnHandler((message, options, next) => { // $ExpectType void
 // next is not called, so no warnings get the default behavior
 registerDeprecationHandler(); // $ExpectError
 registerDeprecationHandler(() => {}); // $ExpectType void
-registerDeprecationHandler((message, { id, until }, next) => { // $ExpectType void
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    until; // $ExpectType string
-    next; // $ExpectType () => void
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next; // $ExpectType (message: string, options?: { id: string; until: string; } | undefined) => void
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(); // $ExpectError
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(message); // $ExpectType void
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(message, options); // $ExpectType void
 });
 
 deprecate(); // $ExpectError

--- a/types/ember__debug/ember__debug-tests.ts
+++ b/types/ember__debug/ember__debug-tests.ts
@@ -49,20 +49,25 @@ assert(); // $ExpectError
 // next is not called, so no warnings get the default behavior
 registerWarnHandler(); // $ExpectError
 registerWarnHandler(() => {}); // $ExpectType void
-registerWarnHandler((message, { id }, next) => { // $ExpectType void
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next; // $ExpectType (message?: string | undefined, options?: { id: string; } | undefined) => void
+    options; // $ExpectType { id: string; } | undefined
+    next; // $ExpectType (message: string, options?: { id: string; } | undefined) => void
 });
-registerWarnHandler((message, { id }, next) => { // $ExpectType void
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next(); // $ExpectType void
+    options; // $ExpectType { id: string; } | undefined
+    next(); // $ExpectError
 });
-registerWarnHandler((message, { id }, next) => { // $ExpectType void
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next(message, { id }); // $ExpectType void
+    options; // $ExpectType { id: string; } | undefined
+    next(message); // $ExpectType void
+});
+registerWarnHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; } | undefined
+    next(message, options); // $ExpectType void
 });
 
 // next is not called, so no warnings get the default behavior

--- a/types/ember__debug/index.d.ts
+++ b/types/ember__debug/index.d.ts
@@ -30,7 +30,13 @@ export function registerDeprecationHandler(handler: (message: string, options: {
  * The following example demonstrates its usage by registering a handler that does nothing overriding Ember's
  * default warning behavior.
  */
-export function registerWarnHandler(handler: (message: string, options: { id: string }, next: (message?: string, options?: { id: string }) => void) => void): void;
+export function registerWarnHandler(
+    handler: (
+        message: string,
+        options: { id: string } | undefined,
+        next: (message: string, options?: { id: string }) => void,
+    ) => void,
+): void;
 
 /**
  * Run a function meant for debugging.

--- a/types/ember__debug/index.d.ts
+++ b/types/ember__debug/index.d.ts
@@ -23,7 +23,13 @@ export function debug(message: string): void;
  * The following example demonstrates its usage by registering a handler that throws an error if the
  * message contains the word "should", otherwise defers to the default handler.
  */
-export function registerDeprecationHandler(handler: (message: string, options: { id: string, until: string }, next: () => void) => void): void;
+export function registerDeprecationHandler(
+    handler: (
+        message: string,
+        options: { id: string; until: string } | undefined,
+        next: (message: string, options?: { id: string; until: string }) => void,
+    ) => void,
+): void;
 /**
  * Allows for runtime registration of handler functions that override the default warning behavior.
  * Warnings are invoked by calls made to [Ember.warn](http://emberjs.com/api/classes/Ember.html#method_warn).

--- a/types/ember__debug/v3/ember__debug-tests.ts
+++ b/types/ember__debug/v3/ember__debug-tests.ts
@@ -47,20 +47,25 @@ assert(); // $ExpectError
 // next is not called, so no warnings get the default behavior
 registerWarnHandler(); // $ExpectError
 registerWarnHandler(() => {}); // $ExpectType void
-registerWarnHandler((message, { id }, next) => { // $ExpectType void
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next; // $ExpectType (message?: string | undefined, options?: { id: string; } | undefined) => void
+    options; // $ExpectType { id: string; } | undefined
+    next; // $ExpectType (message: string, options?: { id: string; } | undefined) => void
 });
-registerWarnHandler((message, { id }, next) => { // $ExpectType void
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next(); // $ExpectType void
+    options; // $ExpectType { id: string; } | undefined
+    next(); // $ExpectError
 });
-registerWarnHandler((message, { id }, next) => { // $ExpectType void
+registerWarnHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    next(message, { id }); // $ExpectType void
+    options; // $ExpectType { id: string; } | undefined
+    next(message); // $ExpectType void
+});
+registerWarnHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; } | undefined
+    next(message, options); // $ExpectType void
 });
 
 // next is not called, so no warnings get the default behavior

--- a/types/ember__debug/v3/ember__debug-tests.ts
+++ b/types/ember__debug/v3/ember__debug-tests.ts
@@ -71,11 +71,25 @@ registerWarnHandler((message, options, next) => { // $ExpectType void
 // next is not called, so no warnings get the default behavior
 registerDeprecationHandler(); // $ExpectError
 registerDeprecationHandler(() => {}); // $ExpectType void
-registerDeprecationHandler((message, { id, until }, next) => { // $ExpectType void
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
     message; // $ExpectType string
-    id; // $ExpectType string
-    until; // $ExpectType string
-    next; // $ExpectType () => void
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next; // $ExpectType (message: string, options?: { id: string; until: string; } | undefined) => void
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(); // $ExpectError
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(message); // $ExpectType void
+});
+registerDeprecationHandler((message, options, next) => { // $ExpectType void
+    message; // $ExpectType string
+    options; // $ExpectType { id: string; until: string; } | undefined
+    next(message, options); // $ExpectType void
 });
 
 deprecate(); // $ExpectError

--- a/types/ember__debug/v3/index.d.ts
+++ b/types/ember__debug/v3/index.d.ts
@@ -36,7 +36,13 @@ export function registerDeprecationHandler(handler: (message: string, options: {
  * The following example demonstrates its usage by registering a handler that does nothing overriding Ember's
  * default warning behavior.
  */
-export function registerWarnHandler(handler: (message: string, options: { id: string }, next: (message?: string, options?: { id: string }) => void) => void): void;
+export function registerWarnHandler(
+    handler: (
+        message: string,
+        options: { id: string } | undefined,
+        next: (message: string, options?: { id: string }) => void,
+    ) => void,
+): void;
 
 /**
  * Run a function meant for debugging.

--- a/types/ember__debug/v3/index.d.ts
+++ b/types/ember__debug/v3/index.d.ts
@@ -29,7 +29,13 @@ export function inspect(obj: any): string;
  * The following example demonstrates its usage by registering a handler that throws an error if the
  * message contains the word "should", otherwise defers to the default handler.
  */
-export function registerDeprecationHandler(handler: (message: string, options: { id: string, until: string }, next: () => void) => void): void;
+export function registerDeprecationHandler(
+    handler: (
+        message: string,
+        options: { id: string; until: string } | undefined,
+        next: (message: string, options?: { id: string; until: string }) => void,
+    ) => void,
+): void;
 /**
  * Allows for runtime registration of handler functions that override the default warning behavior.
  * Warnings are invoked by calls made to [Ember.warn](http://emberjs.com/api/classes/Ember.html#method_warn).


### PR DESCRIPTION
- `registerWarnHandler`
  - `options` may be `undefined`
  - `next` expects `message`
- `registerDeprecationHandler`
  - `options` may be `undefined`
  - `next` expects `message` and `options?`

The upstream types I am basing this on haven't been defined as extensively in versions prior to `v4.4.0-alpha.3`, but AFAICT from the JS source, they were always expected like this. 

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/emberjs/ember.js/blob/v4.4.0-alpha.3/packages/%40ember/debug/lib/handlers.ts#L3-L9
  - https://github.com/emberjs/ember.js/blob/v4.4.0-alpha.3/packages/@ember/debug/lib/deprecate.ts#L36-L74
  - https://github.com/emberjs/ember.js/blob/v4.4.0-alpha.3/packages/%40ember/debug/lib/warn.ts#L13
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~