### PR TITLE
Chrome remote interface - Devtools protocol dependency version update

### DIFF
--- a/types/chrome-remote-interface/package.json
+++ b/types/chrome-remote-interface/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "devtools-protocol": "0.0.927104"
+        "devtools-protocol": "0.0.975498"
     }
 }


### PR DESCRIPTION
Updated devtools-protocol dependency to the latest version in order to support ProtocolProxyApi.PageApi.loadEventFired.