### PR TITLE
Update @ckeditor/ckeditor5-typing to v32

### DIFF
--- a/types/ckeditor__ckeditor5-typing/ckeditor__ckeditor5-typing-tests.ts
+++ b/types/ckeditor__ckeditor5-typing/ckeditor__ckeditor5-typing-tests.ts
@@ -1,7 +1,9 @@
 import { Editor } from '@ckeditor/ckeditor5-core';
-import { Element, Model, Range } from '@ckeditor/ckeditor5-engine';
+import { Element, Model, Range, StylesProcessor } from '@ckeditor/ckeditor5-engine';
 import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 import Position from '@ckeditor/ckeditor5-engine/src/model/position';
+import { KeyEventData } from '@ckeditor/ckeditor5-engine/src/view/observer/keyobserver';
+import View from '@ckeditor/ckeditor5-engine/src/view/view';
 import {
     Delete,
     getLastTextLine,
@@ -19,7 +21,7 @@ import {
     TextTransformationDescription
 } from '@ckeditor/ckeditor5-typing/src/texttransformation';
 import findAttributeRange from '@ckeditor/ckeditor5-typing/src/utils/findattributerange';
-import injectUnsafeKeystrokesHandling from '@ckeditor/ckeditor5-typing/src/utils/injectunsafekeystrokeshandling';
+import injectUnsafeKeystrokesHandling, { isNonTypingKeystroke } from '@ckeditor/ckeditor5-typing/src/utils/injectunsafekeystrokeshandling';
 
 class MyEditor extends Editor {}
 const editor = new MyEditor();
@@ -30,7 +32,6 @@ Typing.requires.map(Plugin => new Plugin(editor).init());
 
 const input = new Input(editor);
 input.init();
-input.isInput(new Batch());
 
 const del = new Delete(editor);
 del.init();
@@ -93,3 +94,6 @@ editor.commands.get('InputCommand');
 
 // $ExpectType DeleteCommand | undefined
 editor.commands.get('DeleteCommand');
+
+// $ExpectType boolean
+isNonTypingKeystroke(new KeyEventData(new View(new StylesProcessor()), new Event("foo")));

--- a/types/ckeditor__ckeditor5-typing/index.d.ts
+++ b/types/ckeditor__ckeditor5-typing/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for @ckeditor/ckeditor5-export-word 30.0
-// Project: https://ckeditor.com/docs/ckeditor5/latest/api/export-word.html
+// Type definitions for @ckeditor/ckeditor5-typing 32.0
+// Project: https://ckeditor.com/docs/ckeditor5/latest/api/typing.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.3

--- a/types/ckeditor__ckeditor5-typing/src/input.d.ts
+++ b/types/ckeditor__ckeditor5-typing/src/input.d.ts
@@ -1,10 +1,8 @@
-import { Plugin } from "@ckeditor/ckeditor5-core";
-import Batch from "@ckeditor/ckeditor5-engine/src/model/batch";
+import { Plugin } from '@ckeditor/ckeditor5-core';
 
 export default class Input extends Plugin {
-    static readonly pluginName: "Input";
+    static readonly pluginName: 'Input';
     init(): void;
-    isInput(batch: Batch): void;
 }
 
 declare module '@ckeditor/ckeditor5-core/src/plugincollection' {

--- a/types/ckeditor__ckeditor5-typing/src/utils/injectunsafekeystrokeshandling.d.ts
+++ b/types/ckeditor__ckeditor5-typing/src/utils/injectunsafekeystrokeshandling.d.ts
@@ -1,3 +1,6 @@
-import { Editor } from "@ckeditor/ckeditor5-core";
+import { Editor } from '@ckeditor/ckeditor5-core';
+import { KeyEventData } from '@ckeditor/ckeditor5-engine/src/view/observer/keyobserver';
 
 export default function injectUnsafeKeystrokesHandling(editor: Editor): void;
+
+export function isNonTypingKeystroke(keyData: KeyEventData): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/releases/tag/v32.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.