### PR TITLE
hellosign-embedded: Fix duplicate event in off method

### DIFF
--- a/types/hellosign-embedded/hellosign-embedded-tests.ts
+++ b/types/hellosign-embedded/hellosign-embedded-tests.ts
@@ -57,6 +57,8 @@ client.off(HelloSign.events.CLOSE);
 const cb = () => {};
 client.off(HelloSign.events.CLOSE, cb);
 
+client.off('cancel');
+
 // getters
 client.isOpen;
 client.isReady;

--- a/types/hellosign-embedded/index.d.ts
+++ b/types/hellosign-embedded/index.d.ts
@@ -191,7 +191,7 @@ export declare module HelloSign {
         once(name: Events['SEND'], cb: (data: SendEventPayload) => void): void;
         once(name: Events['SIGN'], cb: (data: SignEventPayload) => void): void;
 
-        off(name: Events['CLOSE'] | Events['CLOSE'] | Events['CREATE_TEMPLATE'] | Events['DECLINE'] |
+        off(name: Events['CLOSE'] | Events['CANCEL'] | Events['CREATE_TEMPLATE'] | Events['DECLINE'] |
               Events['ERROR'] | Events['FINISH'] | Events['MESSAGE'] | Events['OPEN'] | Events['READY'] |
               Events['REASSIGN'] | Events['SEND'] | Events['SIGN'],
             cb?: CB): void;


### PR DESCRIPTION
This fixes a problem where the `CLOSE` event was added twice in the `off()` method. It's now replaced by `CANCEL` which was missing in the list.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hellosign/hellosign-embedded/wiki/API-Documentation-(v2)#event-cancel