### PR TITLE
Update BraintreeNode: Stronger types for search transactions function

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -133,6 +133,75 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
     escrowStatus === Transaction.EscrowStatus.Released;
     escrowStatus === Transaction.EscrowStatus.Refunded;
 
+    // Assert overlap between source and static field
+    'Api' === Transaction.Source.Api;
+    'Recurring' === Transaction.Source.Recurring;
+    'ControlPanel' === Transaction.Source.ControlPanel;
+
+    // Assert overlap between created using and static field
+    'token' === Transaction.CreatedUsing.Token;
+    'full_information' === Transaction.CreatedUsing.FullInformation;
+
+    gateway.transaction.search(search => {
+        search.id().is('foo');
+        search.type().in([Transaction.Type.Sale, Transaction.Type.Credit]);
+        search.type().in(Transaction.Type.All());
+        search.createdUsing().is(Transaction.CreatedUsing.Token);
+        search.createdUsing().in([Transaction.CreatedUsing.Token, Transaction.CreatedUsing.FullInformation]);
+        search.source().is(Transaction.Source.Api);
+        search.source().in([
+            Transaction.Source.Api,
+            Transaction.Source.ControlPanel
+        ]);
+
+        // Credit card
+        search.creditCardCardholderName().is("Patrick Smith");
+        search.creditCardExpirationDate().is("05/2012");
+        search.creditCardNumber().endsWith("1111");
+
+        // customer details
+        search.customerCompany().is("Braintree");
+        search.customerEmail().is("jen@example.com");
+        search.customerEmail().endsWith("example.com");
+        search.customerPhone().is("312.555.1234");
+        search.customerFax().is("614.555.5678");
+        search.customerWebsite().is("www.example.com");
+
+        // billing address
+        search.billingFirstName().is("Paul");
+        search.billingLastName().is("Smith");
+        search.billingCompany().is("Braintree");
+        search.billingStreetAddress().is("123 Main St");
+        search.billingExtendedAddress().is("Suite 123");
+        search.billingLocality().is("Chicago");
+        search.billingRegion().is("Illinois");
+        search.billingPostalCode().is("12345");
+        search.billingCountryName().is("United States of America");
+
+        search.orderId().is("myorder");
+        search.processorAuthorizationCode().is("123456");
+        search.paymentMethodToken().is("theToken");
+
+        search.creditCardCustomerLocation().is('US');
+        search.creditCardCustomerLocation().in(['US', 'International']);
+
+        search.creditcardCardType().in(CreditCard.CardType.All());
+        search.creditcardCardType().is(CreditCard.CardType.AmEx);
+
+        search.status().is(Transaction.Status.Authorized);
+        search.status().in([Transaction.Status.Authorized, Transaction.Status.Settled]);
+        search.status().in(Transaction.Status.All());
+
+        search.createdAt().min(new Date());
+        search.processorDeclinedAt().between(new Date(), new Date());
+        search.disputeDate().min(new Date());
+        search.voidedAt().max(new Date());
+        search.amount().between('100.00', '200.00');
+
+        search.refund().is(false);
+        search.refund().is(true);
+    });
+
     // Cannot assign to var
     await gateway.transaction
         .cloneTransaction(id, { amount: '100.00', options: { submitForSettlement: true } })

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -25,112 +25,114 @@ declare namespace braintree {
     }
 
     export type TextFieldSearchFn = () => {
-      is: (input: string) => void
-      isNot: (input: string) => void
-      startsWith: (input: string) => void
-      endsWith: (input: string) => void
-      contains: (input: string) => void
+        is: (input: string) => void;
+        isNot: (input: string) => void;
+        startsWith: (input: string) => void;
+        endsWith: (input: string) => void;
+        contains: (input: string) => void;
     };
 
-    export type MultiValueSearchFn<T>  = () => {
-      is: (input: T) => void
-      in: (input: T[]) => void
+    export type MultiValueSearchFn<T> = () => {
+        is: (input: T) => void;
+        in: (input: T[]) => void;
     };
 
     export type RangeFieldSearchFn<T> = () => {
-      is: (input: T) => void
-      /** Inclusive */
-      between: (lowerBound: T, upperBoundIncl: T) => void
-      min: (minimum: T) => void
-      max: (maximum: T) => void
+        is: (input: T) => void;
+        /** Inclusive */
+        between: (lowerBound: T, upperBoundIncl: T) => void;
+        min: (minimum: T) => void;
+        max: (maximum: T) => void;
     };
 
     export type EqualitySearchFn<T> = () => {
-      is: (input: T) => void
-      isNot: (input: T) => void
+        is: (input: T) => void;
+        isNot: (input: T) => void;
     };
 
     export type PartialMatchSearchFn<T> = () => {
-      startsWith: (input: T) => void
-      endsWith: (input: T) => void
+        startsWith: (input: T) => void;
+        endsWith: (input: T) => void;
     };
 
     export type KeyValueSearchFn<T> = () => {
-      is: (input: T) => void
+        is: (input: T) => void;
     };
 
     export type TransactionSearchFn = (search: {
-      // text fields https://github.com/braintree/braintree_node/blob/master/lib/braintree/transaction_search.js#L9
-      billingCompany: TextFieldSearchFn
-      billingCountryName: TextFieldSearchFn
-      billingExtendedAddress: TextFieldSearchFn
-      billingFirstName: TextFieldSearchFn
-      billingLastName: TextFieldSearchFn
-      billingLocality: TextFieldSearchFn
-      billingPostalCode: TextFieldSearchFn
-      billingRegion: TextFieldSearchFn
-      billingStreetAddress: TextFieldSearchFn
-      creditCardCardholderName: TextFieldSearchFn
-      creditCardUniqueIdentifier: TextFieldSearchFn
-      currency: TextFieldSearchFn
-      customerCompany: TextFieldSearchFn
-      customerEmail: TextFieldSearchFn
-      customerFax: TextFieldSearchFn
-      customerFirstName: TextFieldSearchFn
-      customerId: TextFieldSearchFn
-      customerLastName: TextFieldSearchFn
-      customerPhone: TextFieldSearchFn
-      customerWebsite: TextFieldSearchFn
-      id: TextFieldSearchFn
-      orderId: TextFieldSearchFn
-      paymentMethodToken: TextFieldSearchFn
-      paypalPayerEmail: TextFieldSearchFn
-      paypalPaymentId: TextFieldSearchFn
-      paypalAuthorizationId: TextFieldSearchFn
-      processorAuthorizationCode: TextFieldSearchFn
-      settlementBatchId: TextFieldSearchFn
-      shippingCompany: TextFieldSearchFn
-      shippingCountryName: TextFieldSearchFn
-      shippingExtendedAddress: TextFieldSearchFn
-      shippingFirstName: TextFieldSearchFn
-      shippingLastName: TextFieldSearchFn
-      shippingLocality: TextFieldSearchFn
-      shippingPostalCode: TextFieldSearchFn
-      shippingRegion: TextFieldSearchFn
-      shippingStreetAddress: TextFieldSearchFn
-      storeId: TextFieldSearchFn
+        // text fields https://github.com/braintree/braintree_node/blob/master/lib/braintree/transaction_search.js#L9
+        billingCompany: TextFieldSearchFn;
+        billingCountryName: TextFieldSearchFn;
+        billingExtendedAddress: TextFieldSearchFn;
+        billingFirstName: TextFieldSearchFn;
+        billingLastName: TextFieldSearchFn;
+        billingLocality: TextFieldSearchFn;
+        billingPostalCode: TextFieldSearchFn;
+        billingRegion: TextFieldSearchFn;
+        billingStreetAddress: TextFieldSearchFn;
+        creditCardCardholderName: TextFieldSearchFn;
+        creditCardUniqueIdentifier: TextFieldSearchFn;
+        currency: TextFieldSearchFn;
+        customerCompany: TextFieldSearchFn;
+        customerEmail: TextFieldSearchFn;
+        customerFax: TextFieldSearchFn;
+        customerFirstName: TextFieldSearchFn;
+        customerId: TextFieldSearchFn;
+        customerLastName: TextFieldSearchFn;
+        customerPhone: TextFieldSearchFn;
+        customerWebsite: TextFieldSearchFn;
+        id: TextFieldSearchFn;
+        orderId: TextFieldSearchFn;
+        paymentMethodToken: TextFieldSearchFn;
+        paypalPayerEmail: TextFieldSearchFn;
+        paypalPaymentId: TextFieldSearchFn;
+        paypalAuthorizationId: TextFieldSearchFn;
+        processorAuthorizationCode: TextFieldSearchFn;
+        settlementBatchId: TextFieldSearchFn;
+        shippingCompany: TextFieldSearchFn;
+        shippingCountryName: TextFieldSearchFn;
+        shippingExtendedAddress: TextFieldSearchFn;
+        shippingFirstName: TextFieldSearchFn;
+        shippingLastName: TextFieldSearchFn;
+        shippingLocality: TextFieldSearchFn;
+        shippingPostalCode: TextFieldSearchFn;
+        shippingRegion: TextFieldSearchFn;
+        shippingStreetAddress: TextFieldSearchFn;
+        storeId: TextFieldSearchFn;
 
-      creditCardExpirationDate: EqualitySearchFn<string>
-      creditCardNumber: PartialMatchSearchFn<string>
+        creditCardExpirationDate: EqualitySearchFn<string>;
+        creditCardNumber: PartialMatchSearchFn<string>;
 
-      createdUsing: MultiValueSearchFn<typeof Transaction.CreatedUsing[keyof typeof Transaction.CreatedUsing]>
-      creditcardCardType: MultiValueSearchFn<typeof CreditCard.CardType[keyof Omit<typeof CreditCard.CardType, 'All'>]>
-      creditCardCustomerLocation: MultiValueSearchFn<CustomerLocation>
+        createdUsing: MultiValueSearchFn<typeof Transaction.CreatedUsing[keyof typeof Transaction.CreatedUsing]>;
+        creditcardCardType: MultiValueSearchFn<
+            typeof CreditCard.CardType[keyof Omit<typeof CreditCard.CardType, 'All'>]
+        >;
+        creditCardCustomerLocation: MultiValueSearchFn<CustomerLocation>;
 
-      ids: MultiValueSearchFn<string>
-      user: MultiValueSearchFn<string>
-      paymentInstrumentType: MultiValueSearchFn<string>
-      merchantAccountId: MultiValueSearchFn<string>
-      status: MultiValueSearchFn<TransactionStatus>
-      source: MultiValueSearchFn<TransactionSource | string>
-      type: MultiValueSearchFn<typeof Transaction.Type[keyof Omit<typeof Transaction.Type, 'All'>]>
-      storeIds: MultiValueSearchFn<string>
+        ids: MultiValueSearchFn<string>;
+        user: MultiValueSearchFn<string>;
+        paymentInstrumentType: MultiValueSearchFn<string>;
+        merchantAccountId: MultiValueSearchFn<string>;
+        status: MultiValueSearchFn<TransactionStatus>;
+        source: MultiValueSearchFn<TransactionSource | string>;
+        type: MultiValueSearchFn<typeof Transaction.Type[keyof Omit<typeof Transaction.Type, 'All'>]>;
+        storeIds: MultiValueSearchFn<string>;
 
-      refund: KeyValueSearchFn<boolean>
+        refund: KeyValueSearchFn<boolean>;
 
-      // range fields
-      amount: RangeFieldSearchFn<string>
-      authorizationExpiredAt: RangeFieldSearchFn<Date>
-      authorizedAt: RangeFieldSearchFn<Date>
-      createdAt: RangeFieldSearchFn<Date>
-      disbursementDate: RangeFieldSearchFn<Date>
-      disputeDate: RangeFieldSearchFn<Date>
-      failedAt: RangeFieldSearchFn<Date>
-      gatewayRejectedAt: RangeFieldSearchFn<Date>
-      processorDeclinedAt: RangeFieldSearchFn<Date>
-      settledAt: RangeFieldSearchFn<Date>
-      submittedForSettlementAt: RangeFieldSearchFn<Date>
-      voidedAt: RangeFieldSearchFn<Date>
+        // range fields
+        amount: RangeFieldSearchFn<string>;
+        authorizationExpiredAt: RangeFieldSearchFn<Date>;
+        authorizedAt: RangeFieldSearchFn<Date>;
+        createdAt: RangeFieldSearchFn<Date>;
+        disbursementDate: RangeFieldSearchFn<Date>;
+        disputeDate: RangeFieldSearchFn<Date>;
+        failedAt: RangeFieldSearchFn<Date>;
+        gatewayRejectedAt: RangeFieldSearchFn<Date>;
+        processorDeclinedAt: RangeFieldSearchFn<Date>;
+        settledAt: RangeFieldSearchFn<Date>;
+        submittedForSettlementAt: RangeFieldSearchFn<Date>;
+        voidedAt: RangeFieldSearchFn<Date>;
     }) => void;
 
     export type GatewayConfig = KeyGatewayConfig | ClientGatewayConfig | AccessTokenGatewayConfig;
@@ -1375,18 +1377,18 @@ declare namespace braintree {
         static Type: {
             Credit: 'credit';
             Sale: 'sale';
-            All: () => Array<typeof Transaction.Type[keyof Omit<typeof Transaction.Type, 'All'>]>
+            All: () => Array<typeof Transaction.Type[keyof Omit<typeof Transaction.Type, 'All'>]>;
         };
 
         static Source: {
-            Api: 'Api',
-            ControlPanel: 'ControlPanel',
-            Recurring: 'Recurring'
+            Api: 'Api';
+            ControlPanel: 'ControlPanel';
+            Recurring: 'Recurring';
         };
 
         static CreatedUsing: {
-          Token: 'token',
-          FullInformation: 'full_information'
+            Token: 'token';
+            FullInformation: 'full_information';
         };
 
         static GatewayRejectionReason: {
@@ -1415,7 +1417,7 @@ declare namespace braintree {
             SettlementPending: 'settlement_pending';
             SubmittedForSettlement: 'submitted_for_settlement';
             Voided: 'voided';
-            All: () => Array<typeof Transaction.Status[keyof Omit<typeof Transaction.Status, 'All'>]>
+            All: () => Array<typeof Transaction.Status[keyof Omit<typeof Transaction.Status, 'All'>]>;
         };
 
         addOns?: AddOn[] | undefined;

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -24,6 +24,115 @@ declare namespace braintree {
         Sandbox = 'Sandbox',
     }
 
+    export type TextFieldSearchFn = () => {
+      is: (input: string) => void
+      isNot: (input: string) => void
+      startsWith: (input: string) => void
+      endsWith: (input: string) => void
+      contains: (input: string) => void
+    };
+
+    export type MultiValueSearchFn<T>  = () => {
+      is: (input: T) => void
+      in: (input: T[]) => void
+    };
+
+    export type RangeFieldSearchFn<T> = () => {
+      is: (input: T) => void
+      /** Inclusive */
+      between: (lowerBound: T, upperBoundIncl: T) => void
+      min: (minimum: T) => void
+      max: (maximum: T) => void
+    };
+
+    export type EqualitySearchFn<T> = () => {
+      is: (input: T) => void
+      isNot: (input: T) => void
+    };
+
+    export type PartialMatchSearchFn<T> = () => {
+      startsWith: (input: T) => void
+      endsWith: (input: T) => void
+    };
+
+    export type KeyValueSearchFn<T> = () => {
+      is: (input: T) => void
+    };
+
+    export type TransactionSearchFn = (search: {
+      // text fields https://github.com/braintree/braintree_node/blob/master/lib/braintree/transaction_search.js#L9
+      billingCompany: TextFieldSearchFn
+      billingCountryName: TextFieldSearchFn
+      billingExtendedAddress: TextFieldSearchFn
+      billingFirstName: TextFieldSearchFn
+      billingLastName: TextFieldSearchFn
+      billingLocality: TextFieldSearchFn
+      billingPostalCode: TextFieldSearchFn
+      billingRegion: TextFieldSearchFn
+      billingStreetAddress: TextFieldSearchFn
+      creditCardCardholderName: TextFieldSearchFn
+      creditCardUniqueIdentifier: TextFieldSearchFn
+      currency: TextFieldSearchFn
+      customerCompany: TextFieldSearchFn
+      customerEmail: TextFieldSearchFn
+      customerFax: TextFieldSearchFn
+      customerFirstName: TextFieldSearchFn
+      customerId: TextFieldSearchFn
+      customerLastName: TextFieldSearchFn
+      customerPhone: TextFieldSearchFn
+      customerWebsite: TextFieldSearchFn
+      id: TextFieldSearchFn
+      orderId: TextFieldSearchFn
+      paymentMethodToken: TextFieldSearchFn
+      paypalPayerEmail: TextFieldSearchFn
+      paypalPaymentId: TextFieldSearchFn
+      paypalAuthorizationId: TextFieldSearchFn
+      processorAuthorizationCode: TextFieldSearchFn
+      settlementBatchId: TextFieldSearchFn
+      shippingCompany: TextFieldSearchFn
+      shippingCountryName: TextFieldSearchFn
+      shippingExtendedAddress: TextFieldSearchFn
+      shippingFirstName: TextFieldSearchFn
+      shippingLastName: TextFieldSearchFn
+      shippingLocality: TextFieldSearchFn
+      shippingPostalCode: TextFieldSearchFn
+      shippingRegion: TextFieldSearchFn
+      shippingStreetAddress: TextFieldSearchFn
+      storeId: TextFieldSearchFn
+
+      creditCardExpirationDate: EqualitySearchFn<string>
+      creditCardNumber: PartialMatchSearchFn<string>
+
+      createdUsing: MultiValueSearchFn<typeof Transaction.CreatedUsing[keyof typeof Transaction.CreatedUsing]>
+      creditcardCardType: MultiValueSearchFn<typeof CreditCard.CardType[keyof Omit<typeof CreditCard.CardType, 'All'>]>
+      creditCardCustomerLocation: MultiValueSearchFn<CustomerLocation>
+
+      ids: MultiValueSearchFn<string>
+      user: MultiValueSearchFn<string>
+      paymentInstrumentType: MultiValueSearchFn<string>
+      merchantAccountId: MultiValueSearchFn<string>
+      status: MultiValueSearchFn<TransactionStatus>
+      source: MultiValueSearchFn<TransactionSource | string>
+      type: MultiValueSearchFn<typeof Transaction.Type[keyof Omit<typeof Transaction.Type, 'All'>]>
+      storeIds: MultiValueSearchFn<string>
+
+      refund: KeyValueSearchFn<boolean>
+
+      // range fields
+      amount: RangeFieldSearchFn<string>
+      authorizationExpiredAt: RangeFieldSearchFn<Date>
+      authorizedAt: RangeFieldSearchFn<Date>
+      createdAt: RangeFieldSearchFn<Date>
+      disbursementDate: RangeFieldSearchFn<Date>
+      disputeDate: RangeFieldSearchFn<Date>
+      failedAt: RangeFieldSearchFn<Date>
+      gatewayRejectedAt: RangeFieldSearchFn<Date>
+      processorDeclinedAt: RangeFieldSearchFn<Date>
+      settledAt: RangeFieldSearchFn<Date>
+      submittedForSettlementAt: RangeFieldSearchFn<Date>
+      voidedAt: RangeFieldSearchFn<Date>
+    }) => void;
+
     export type GatewayConfig = KeyGatewayConfig | ClientGatewayConfig | AccessTokenGatewayConfig;
 
     export interface KeyGatewayConfig {
@@ -235,7 +344,7 @@ declare namespace braintree {
         refund(transactionId: string, amount?: string): Promise<ValidatedResponse<Transaction>>;
         releaseFromEscrow(transactionId: string): Promise<Transaction>;
         sale(request: TransactionRequest): Promise<ValidatedResponse<Transaction>>;
-        search(searchFn: any): stream.Readable;
+        search(searchFn: TransactionSearchFn): stream.Readable;
         submitForPartialSettlement(
             authorizedTransactionId: string,
             amount: string,
@@ -385,7 +494,7 @@ declare namespace braintree {
             Switch: 'Switch';
             Visa: 'Visa';
             Unknown: 'Unknown';
-            All: () => string[];
+            All: () => Array<typeof CreditCard.CardType[keyof Omit<typeof CreditCard.CardType, 'All'>]>;
         };
 
         static CustomerLocation: {
@@ -1266,7 +1375,18 @@ declare namespace braintree {
         static Type: {
             Credit: 'credit';
             Sale: 'sale';
-            All: () => string[];
+            All: () => Array<typeof Transaction.Type[keyof Omit<typeof Transaction.Type, 'All'>]>
+        };
+
+        static Source: {
+            Api: 'Api',
+            ControlPanel: 'ControlPanel',
+            Recurring: 'Recurring'
+        };
+
+        static CreatedUsing: {
+          Token: 'token',
+          FullInformation: 'full_information'
         };
 
         static GatewayRejectionReason: {
@@ -1295,7 +1415,7 @@ declare namespace braintree {
             SettlementPending: 'settlement_pending';
             SubmittedForSettlement: 'submitted_for_settlement';
             Voided: 'voided';
-            All: () => string[];
+            All: () => Array<typeof Transaction.Status[keyof Omit<typeof Transaction.Status, 'All'>]>
         };
 
         addOns?: AddOn[] | undefined;


### PR DESCRIPTION
Make `TransactionGateway#search` having stronger types than `any`. 

Reference here: 
- [Braintree docs](https://developer.paypal.com/braintree/docs/reference/request/transaction/search)
- [Braintee github](https://github.com/braintree/braintree_node/blob/master/lib/braintree/transaction_search.js) 

--- 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [Braintree docs](https://developer.paypal.com/braintree/docs/reference/request/transaction/search)
- [Braintee github](https://github.com/braintree/braintree_node/blob/master/lib/braintree/transaction_search.js) 