### PR TITLE
[spotify-api] Fix ReplacePlaylistTracksResponse to have snapshot_id

### DIFF
--- a/types/spotify-api/index.d.ts
+++ b/types/spotify-api/index.d.ts
@@ -778,7 +778,7 @@ declare namespace SpotifyApi {
      * PUT /v1/users/{user_id}/playlists/{playlist_id}/tracks
      * https://developer.spotify.com/web-api/replace-playlists-tracks/
      */
-    interface ReplacePlaylistTracksResponse extends VoidResponse {}
+    interface ReplacePlaylistTracksResponse extends PlaylistSnapshotResponse {}
 
     /**
      * Upload a Custom Playlist Cover Image

--- a/types/spotify-api/spotify-api-tests.ts
+++ b/types/spotify-api/spotify-api-tests.ts
@@ -9992,7 +9992,9 @@ const reorderTracksInPlaylist : SpotifyApi.ReorderPlaylistTracksResponse = {
  * PUT /v1/users/{user_id}/playlists/{playlist_id}/tracks
  * https://developer.spotify.com/web-api/replace-playlists-tracks/
  */
-const replacePlaylistTracks : SpotifyApi.ReplacePlaylistTracksResponse = {};
+const replacePlaylistTracks : SpotifyApi.ReplacePlaylistTracksResponse = {
+  "snapshot_id" : "t3+4ZWOqedj+bmcHHu1HKNqYfIyYAfXKlSHHykvS4KAm7hoVhDoCpn+KIuFZebZp"
+};
 
 
 


### PR DESCRIPTION
The new playlist snapshot ID is returned when replacing tracks in a playlist. I have verified this with the REST API.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.spotify.com/documentation/web-api/reference/#/operations/reorder-or-replace-playlists-tracks
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
