### PR TITLE
Disable npm-naming for dropbox-chooser

### DIFF
--- a/types/dropbox-chooser/tslint.json
+++ b/types/dropbox-chooser/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
@types/dropbox-chooser has no matching npm package, until somebody mistakenly uploaded a starter project with the same name. Since this project has no relation to the real dropbox-chooser, this PR disables npm-naming to avoid the lint message warning about the conflict.