### PR TITLE
Remove @types/socket.io dependency from @types/micro

### DIFF
--- a/types/micro/micro-tests.ts
+++ b/types/micro/micro-tests.ts
@@ -1,5 +1,5 @@
 import micro, { json, RequestHandler, buffer, text, send, createError } from 'micro';
-import socketIO = require('socket.io');
+import { Server as HttpServer } from 'http;
 
 // Json sample
 
@@ -10,7 +10,7 @@ export const jsonHandler: RequestHandler = async (req, res) => {
     return 'Data logged to your console';
 };
 
-// socket.io chat app sample
+// `http` Server sample
 
 const html = '<div>some html stuff</div>';
 
@@ -19,7 +19,7 @@ const server = micro(async (req, res) => {
     res.end(html);
 });
 
-const io = socketIO(server);
+const httpServer: HttpServer = server;
 
 server.listen(4000);
 

--- a/types/micro/micro-tests.ts
+++ b/types/micro/micro-tests.ts
@@ -1,5 +1,5 @@
 import micro, { json, RequestHandler, buffer, text, send, createError } from 'micro';
-import { Server as HttpServer } from 'http;
+import { Server as HttpServer } from 'http';
 
 // Json sample
 

--- a/types/micro/package.json
+++ b/types/micro/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "dependencies": {
+    "devDependencies": {
         "@types/socket.io": "2.1.13"
     }
 }

--- a/types/micro/package.json
+++ b/types/micro/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "devDependencies": {
-        "@types/socket.io": "2.1.13"
-    }
-}


### PR DESCRIPTION
I noticed when installing `@types/micro` that it was bringing in `@types/socket.io` as well, which was odd since `micro` doesn't use Socket.io at all. Turns out only the test file in this repo referenced `socket.io`, so I believe the dependency should removed so that the Socket.io types are not pulled into projects unnecessarily.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
