### PR TITLE
[styled-components] Consider default props when using withTheme HOC.

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -339,7 +339,7 @@ export type BaseWithThemeFnInterface<T extends object> = <C extends React.Compon
     // this check is roundabout because the extends clause above would
     // not allow any component that accepts _more_ than theme as a prop
     component: React.ComponentProps<C> extends { theme?: T | undefined } ? C : never,
-) => React.ForwardRefExoticComponent<WithOptionalTheme<React.ComponentPropsWithRef<C>, T>>;
+) => React.ForwardRefExoticComponent<WithOptionalTheme<JSX.LibraryManagedAttributes<C, React.ComponentPropsWithRef<C>>, T>>;
 export type WithThemeFnInterface<T extends object> = BaseWithThemeFnInterface<AnyIfEmpty<T>>;
 export const withTheme: WithThemeFnInterface<DefaultTheme>;
 

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -490,6 +490,12 @@ const ComponentWithTheme = withTheme(Component);
 <ComponentWithTheme text={'hi'} theme={{ color: 'red' }} />; // ok
 <ThemeConsumer>{theme => <Component text="hi" theme={theme} />}</ThemeConsumer>;
 
+// should consider default props of a component
+const ComponentWithDefaultProps = ({ text }: WithThemeProps) => <div>{text}</div>;
+ComponentWithDefaultProps.defaultProps = { text: 'hi' };
+const ComponentWithDefaultPropsAndTheme = withTheme(ComponentWithDefaultProps);
+<ComponentWithDefaultPropsAndTheme />;
+
 /**
  * isStyledComponent utility
  */


### PR DESCRIPTION
The test for the fix explains the problem pretty well. When using the type definition for `styled-components` we had some problems when using the `withTheme` HOC for a component which has `defaultProps`. The following case currently results in an error, because `text` is not defined for `<ComponentWithDefaultPropsAndTheme />`
```
interface WithThemeProps { theme: { color: string; }; text: string; }

const ComponentWithDefaultProps = ({ text }: WithThemeProps) => <div>{text}</div>;
ComponentWithDefaultProps.defaultProps = { text: 'hi' };
const ComponentWithDefaultPropsAndTheme = withTheme(ComponentWithDefaultProps);
<ComponentWithDefaultPropsAndTheme />;
```

As far as I can tell this should not be the case. It should not be necessary to define the prop `text` in this case, because of the defined `defaultProps`. 
The provided URL shows an example where we created our own declaration file for the `styled-components` package, which includes the suggested change.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Graylog2/graylog2-server/blob/master/graylog2-web-interface/src/%40types/styled-components/index.d.ts
