### PR TITLE
[luxon] Add method toUnixInteger to DateTime object

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 2.0
+// Type definitions for luxon 2.3
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>
@@ -11,6 +11,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Carson Full <https://github.com/carsonf>
 //                 Hugo Silva <https://github.com/hugofpsilva>
+//                 Martin Badin <https://github.com/martin-badin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export * from './src/luxon';

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -1354,6 +1354,11 @@ export class DateTime {
     toSeconds(): number;
 
     /**
+     * Returns the epoch seconds (as a whole number) of this DateTime.
+     */
+    toUnixInteger(): number;
+
+    /**
      * Returns an ISO 8601 representation of this DateTime appropriate for use in JSON.
      */
     toJSON(): string;

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -128,6 +128,7 @@ dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
 dt.valueOf(); // $ExpectType number
 dt.toObject(); // $ExpectType ToObjectOutput
 dt.toObject({ includeConfig: true }); // $ExpectType ToObjectOutput
+dt.toUnixInteger(); // $ExpectType number
 
 // $ExpectType string | null
 dt.toRelative({


### PR DESCRIPTION
Closes: #58953

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test luxon`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[datetime](https://github.com/moment/luxon/blob/master/src/datetime.js#L1761)>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.