### PR TITLE
[@types/better-sqlite3] Update bindings for v7.5

### DIFF
--- a/types/better-sqlite3/better-sqlite3-tests.ts
+++ b/types/better-sqlite3/better-sqlite3-tests.ts
@@ -2,7 +2,7 @@ import Sqlite = require('better-sqlite3');
 
 const err = new Sqlite.SqliteError('ok', 'ok');
 const result: Sqlite.RunResult = { changes: 1, lastInsertRowid: 1 };
-const options: Sqlite.Options = { fileMustExist: true, readonly: true };
+const options: Sqlite.Options = { fileMustExist: true, readonly: true, nativeBinding: "/some/native/binding/path" };
 const registrationOptions: Sqlite.RegistrationOptions = {
     deterministic: true,
     safeIntegers: true,
@@ -54,6 +54,8 @@ const vtable: Sqlite.Statement = db.prepare('SELECT * FROM vtable');
 vtable.all();
 
 const stmt: Sqlite.Statement = db.prepare('SELECT * FROM test WHERE name == ?;');
+stmt.busy; // $ExpectType boolean
+
 stmt.get(['name']);
 stmt.all({ name: 'name' });
 for (const row of stmt.iterate('name')) {

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for better-sqlite3 7.4
+// Type definitions for better-sqlite3 7.5
 // Project: https://github.com/JoshuaWise/better-sqlite3
 // Definitions by: Ben Davies <https://github.com/Morfent>
 //                 Mathew Rumsey <https://github.com/matrumz>
@@ -20,6 +20,7 @@ declare namespace BetterSqlite3 {
         database: Database;
         source: string;
         reader: boolean;
+        busy: boolean;
 
         run(...params: BindParameters): Database.RunResult;
         get(...params: BindParameters): any;
@@ -109,6 +110,7 @@ declare namespace Database {
         fileMustExist?: boolean | undefined;
         timeout?: number | undefined;
         verbose?: ((message?: any, ...additionalArgs: any[]) => void) | undefined;
+        nativeBinding?: string | undefined;
     }
 
     interface SerializeOptions {


### PR DESCRIPTION
This updates the definitions for better-sqlite3:

* Add `nativeBindingPath` to `Database.Options`
* Add `busy` to `Statement`

Relevant discussion post: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/59049

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JoshuaWise/better-sqlite3/releases/tag/v7.5.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
