### PR TITLE
fix: Blob.stream return type which is incorrect and conflicts with lib.dom.d.ts

### DIFF
--- a/types/node/stream/consumers.d.ts
+++ b/types/node/stream/consumers.d.ts
@@ -8,7 +8,6 @@ interface Blob {
     readonly type: string;
     arrayBuffer(): Promise<ArrayBuffer>;
     slice(start?: number, end?: number, contentType?: string): Blob;
-    stream(): ReadableStream;
     text(): Promise<string>;
 }
 declare module 'stream/consumers' {

--- a/types/node/stream/consumers.d.ts
+++ b/types/node/stream/consumers.d.ts
@@ -8,7 +8,7 @@ interface Blob {
     readonly type: string;
     arrayBuffer(): Promise<ArrayBuffer>;
     slice(start?: number, end?: number, contentType?: string): Blob;
-    stream(): NodeJS.ReadableStream;
+    stream(): ReadableStream;
     text(): Promise<string>;
 }
 declare module 'stream/consumers' {

--- a/types/node/stream/consumers.d.ts
+++ b/types/node/stream/consumers.d.ts
@@ -1,17 +1,6 @@
-// Duplicates of interface in lib.dom.ts.
-// Duplicated here rather than referencing lib.dom.ts because doing so causes lib.dom.ts to be loaded for "test-all"
-// Which in turn causes tests to pass that shouldn't pass.
-//
-// This interface is not, and should not be, exported.
-interface Blob {
-    readonly size: number;
-    readonly type: string;
-    arrayBuffer(): Promise<ArrayBuffer>;
-    slice(start?: number, end?: number, contentType?: string): Blob;
-    text(): Promise<string>;
-}
 declare module 'stream/consumers' {
     import { Readable } from 'node:stream';
+    import { Blob } from 'buffer';
     function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
     function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
     function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;

--- a/types/node/stream/consumers.d.ts
+++ b/types/node/stream/consumers.d.ts
@@ -1,6 +1,17 @@
+// Duplicates of interface in lib.dom.ts.
+// Duplicated here rather than referencing lib.dom.ts because doing so causes lib.dom.ts to be loaded for "test-all"
+// Which in turn causes tests to pass that shouldn't pass.
+//
+// This interface is not, and should not be, exported.
+interface Blob {
+    readonly size: number;
+    readonly type: string;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    slice(start?: number, end?: number, contentType?: string): Blob;
+    text(): Promise<string>;
+}
 declare module 'stream/consumers' {
     import { Readable } from 'node:stream';
-    import { Blob } from 'buffer';
     function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
     function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
     function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;


### PR DESCRIPTION
I frequently run into following issue 

<img width="562" alt="image" src="https://user-images.githubusercontent.com/21236/156232057-e9d5426c-b35f-47ef-a544-ae8f538c1113.png">

Caused by incorrect type annotation of Blob

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2280eb45b474bf8e92ff34b1d2775afc03cffc6f/types/node/stream/consumers.d.ts#L11

Proposed changes replace that annotation with a more accurate one so that it:

1. Does not conflict with `lib.dom.d.ts`
2. Reflects actual state of things in node & specifically the fact that `Blob.prototype.stream` returns web stream and not a node one. See https://nodejs.org/api/buffer.html#blobstream

I do not know how current typedef ended this way. I think comment attempt to elaborate reason for this `Blob` interface definition, yet it does not explain why `stream()` method is typed incorrectly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
