### PR TITLE
[react-dom] Add /client entrypoint

### DIFF
--- a/types/react-dom/client.d.ts
+++ b/types/react-dom/client.d.ts
@@ -1,0 +1,42 @@
+/**
+ * WARNING: This entrypoint is only available starting with `react-dom@18.0.0-rc.1`
+ */
+
+// See https://github.com/facebook/react/blob/main/packages/react-dom/client.js to see how the exports are declared,
+
+import React = require('react');
+export interface HydrationOptions {
+    onHydrated?(suspenseInstance: Comment): void;
+    onDeleted?(suspenseInstance: Comment): void;
+    /**
+     * Prefix for `useId`.
+     */
+    identifierPrefix?: string;
+    onRecoverableError?: (error: unknown) => void;
+}
+
+export interface RootOptions {
+    /**
+     * Prefix for `useId`.
+     */
+    identifierPrefix?: string;
+    onRecoverableError?: (error: unknown) => void;
+}
+
+export interface Root {
+    render(children: React.ReactChild | Iterable<React.ReactNode>): void;
+    unmount(): void;
+}
+
+/**
+ * Replaces `ReactDOM.render` when the `.render` method is called and enables Concurrent Mode.
+ *
+ * @see https://reactjs.org/docs/concurrent-mode-reference.html#createroot
+ */
+export function createRoot(container: Element | Document | DocumentFragment | Comment, options?: RootOptions): Root;
+
+export function hydrateRoot(
+    container: Element | Document | DocumentFragment | Comment,
+    initialChildren: React.ReactChild | Iterable<React.ReactNode>,
+    options?: HydrationOptions,
+): Root;

--- a/types/react-dom/next.d.ts
+++ b/types/react-dom/next.d.ts
@@ -30,40 +30,4 @@ import ReactDOM = require('.');
 
 export {};
 
-declare module '.' {
-    interface HydrationOptions {
-        onHydrated?(suspenseInstance: Comment): void;
-        onDeleted?(suspenseInstance: Comment): void;
-        /**
-         * Prefix for `useId`.
-         */
-        identifierPrefix?: string;
-        onRecoverableError?: (error: unknown) => void;
-    }
-
-    interface RootOptions {
-        /**
-         * Prefix for `useId`.
-         */
-        identifierPrefix?: string;
-        onRecoverableError?: (error: unknown) => void;
-    }
-
-    interface Root {
-        render(children: React.ReactChild | Iterable<React.ReactNode>): void;
-        unmount(): void;
-    }
-
-    /**
-     * Replaces `ReactDOM.render` when the `.render` method is called and enables Concurrent Mode.
-     *
-     * @see https://reactjs.org/docs/concurrent-mode-reference.html#createroot
-     */
-    function createRoot(container: Element | Document | DocumentFragment | Comment, options?: RootOptions): Root;
-
-    function hydrateRoot(
-        container: Element | Document | DocumentFragment | Comment,
-        initialChildren: React.ReactChild | Iterable<React.ReactNode>,
-        options?: HydrationOptions,
-    ): Root;
-}
+declare module '.' {}

--- a/types/react-dom/test/next-tests.tsx
+++ b/types/react-dom/test/next-tests.tsx
@@ -1,19 +1,19 @@
 /// <reference types="../next"/>
 import React = require('react');
-import ReactDOM = require('react-dom');
+import ReactDOMClient = require('react-dom/client');
 
 function createRoot() {
-    const root = ReactDOM.createRoot(document);
+    const root = ReactDOMClient.createRoot(document);
 
     root.render(<div>initial render</div>);
 }
 
 function hydrateRoot() {
-    const legacyHydrateable = ReactDOM.createRoot(document, {
+    const legacyHydrateable = ReactDOMClient.createRoot(document, {
         identifierPrefix: 'legacy-app',
     });
 
-    const hydrateable = ReactDOM.hydrateRoot(document, <div>initial render</div>, {
+    const hydrateable = ReactDOMClient.hydrateRoot(document, <div>initial render</div>, {
         onHydrated: () => {
             console.log('hydrated');
         },
@@ -26,7 +26,7 @@ function hydrateRoot() {
         },
     });
     hydrateable.render(<div>render update</div>);
-    ReactDOM.hydrateRoot(document, {
+    ReactDOMClient.hydrateRoot(document, {
         // Forgot `initialChildren`
         // $ExpectError
         onHydrated: () => {


### PR DESCRIPTION
It's a bit unfortunate that the DT repo doesn't support prerelease channels. Let's just hope nobody actually imports from /client without install `react-dom@rc` (but then again we were already hoping for that with the `/next` entrypoint).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://github.com/reactwg/react-18/discussions/125
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
