### PR TITLE
Updated Missing Props for react-avatar-editor

### DIFF
--- a/types/react-avatar-editor/index.d.ts
+++ b/types/react-avatar-editor/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for react-avatar-editor 10.3
+// Type definitions for react-avatar-editor 12.0
 // Project: https://github.com/mosch/react-avatar-editor
 // Definitions by: Diogo Corrêa <https://github.com/diogocorrea>
 //                 Gabriel Prates <https://github.com/gabsprates>
 //                 Laurent Senta <https://github.com/lsenta>
 //                 David Spiess <https://github.com/davidspiess>
 //                 John Grisham <https://github.com/JohnGrisham>
+//                 Joshua Hintze <https://github.com/GimpMaster>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -29,6 +30,7 @@ export interface AvatarEditorProps {
     image: string | File;
     width?: number | undefined;
     height?: number | undefined;
+    backgroundColor?: string | undefined;
     border?: number | number[] | undefined;
     borderRadius?: number | undefined;
     color?: number[] | undefined;

--- a/types/react-avatar-editor/react-avatar-editor-tests.tsx
+++ b/types/react-avatar-editor/react-avatar-editor-tests.tsx
@@ -36,6 +36,7 @@ class AvatarEditorTest extends React.Component {
                 <AvatarEditor image="" className="helloworld" />
                 <AvatarEditor image="" width={1} />
                 <AvatarEditor image="" height={1} />
+                <AvatarEditor image="" backgroundColor="green" />
                 <AvatarEditor image="" border={1} />
                 <AvatarEditor image="" border={[1, 2]} />
                 <AvatarEditor image="" borderRadius={1} />


### PR DESCRIPTION
Addes missing backgroundColor type

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: See bug report here: https://github.com/mosch/react-avatar-editor/issues/364
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
