### PR TITLE
fix(json-stable-stringify): Updating docs and adding cycles option.

### DIFF
--- a/types/json-stable-stringify/index.d.ts
+++ b/types/json-stable-stringify/index.d.ts
@@ -3,6 +3,11 @@
 // Definitions by: Matt Frantz <https://github.com/mhfrantz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/**
+ * Deterministic version of JSON.stringify() so you can get a consistent hash from stringified results.
+ *
+ * @returns Deterministic json result.
+ */
 declare function stringify(obj: any, opts?: stringify.Comparator | stringify.Options): string;
 
 declare namespace stringify {
@@ -16,9 +21,27 @@ declare namespace stringify {
     type Replacer = (key: string, value: any) => any;
 
     interface Options {
-        cmp?: Comparator | undefined;
-        space?: number | string | undefined;
-        replacer?: Replacer | undefined;
+        /**
+         * Custom comparator for key
+         */
+        cmp?: Comparator;
+
+        /**
+         * Indent the output for pretty-printing.
+         *
+         * Supported is either a string or a number of spaces.
+         */
+        space?: string | number;
+
+        /**
+         * Option to replace values to simpler values
+         */
+        replacer?: Replacer;
+
+        /**
+         * true to allow cycles, by marking the entries as __cycle__.
+         */
+        cycles?: boolean;
     }
 }
 

--- a/types/json-stable-stringify/json-stable-stringify-tests.ts
+++ b/types/json-stable-stringify/json-stable-stringify-tests.ts
@@ -45,3 +45,8 @@ const obj = { c: 8, b: [{z: 6, y: 5, x: 4}, 7], a: 3 };
   const s: string = stringify(obj, { replacer: removeStrings });
   console.log(s);
 }
+
+{
+  // We can specify the cycles
+  stringify(obj, { cycles: true }); // $ExpectType string
+}


### PR DESCRIPTION
This PR adds documentation to the exposed methods of [json-stable-stringify](https://github.com/substack/json-stable-stringify) and adds the missing and undocumented [`cycles`](https://github.com/substack/json-stable-stringify/blob/e43ca2a1dcfc39bf1514684492767ef6040d1f3e/index.js#L8) option which will show [`__cycle__`](https://github.com/substack/json-stable-stringify/blob/e43ca2a1dcfc39bf1514684492767ef6040d1f3e/index.js#L48) if a cycle is detected (instead of throwing an error).