### PR TITLE
[react-native] Remove Image width and height props

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3646,18 +3646,6 @@ interface ImagePropsAndroid {
      * @platform android
      */
     fadeDuration?: number | undefined;
-
-    /**
-     * Required if loading images via 'uri' from drawable folder on Android.
-     * Explanation: https://medium.com/@adamjacobb/react-native-performance-images-adf5843e120
-     */
-    width?: number | undefined;
-
-    /**
-     * Required if loading images via 'uri' from drawable folder on Android
-     * Explanation: https://medium.com/@adamjacobb/react-native-performance-images-adf5843e120
-     */
-    height?: number | undefined;
 }
 
 /**


### PR DESCRIPTION
Revert #30834 maybe because facebook/react-native#28151
I can't find a commit to verify this for sure
But on versions 0.64.3 and 0.67.3 I won't be able to reproduce the situation described here https://medium.com/@adamjacobb/react-native-performance-images-adf5843e120
Everything works fine purely on styles, without additional properties

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).