### PR TITLE
Fix: correct Mocha overloads order

### DIFF
--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -400,29 +400,14 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: Func): void;
-
-        /**
-         * [bdd, qunit, tdd] Describe a "hook" to execute the given callback `fn`. The name of the
-         * function is used as the name of the hook.
-         *
-         * - _Only available when invoked via the mocha CLI._
-         */
-        (fn: AsyncFunc): void;
+        (fn: Func | AsyncFunc): void;
 
         /**
          * [bdd, qunit, tdd] Describe a "hook" to execute the given `title` and callback `fn`.
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (name: string, fn?: Func): void;
-
-        /**
-         * [bdd, qunit, tdd] Describe a "hook" to execute the given `title` and callback `fn`.
-         *
-         * - _Only available when invoked via the mocha CLI._
-         */
-        (name: string, fn?: AsyncFunc): void;
+        (name: string, fn?: Func | AsyncFunc): void;
     }
 
     interface SuiteFunction {
@@ -494,15 +479,7 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: Func): Test;
-
-        /**
-         * Describe a specification or test-case with the given callback `fn` acting as a thunk.
-         * The name of the function is used as the name of the test.
-         *
-         * - _Only available when invoked via the mocha CLI._
-         */
-        (fn: AsyncFunc): Test;
+        (fn: Func | AsyncFunc): Test;
 
         /**
          * Describe a specification or test-case with the given `title` and callback `fn` acting
@@ -510,15 +487,7 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (title: string, fn?: Func): Test;
-
-        /**
-         * Describe a specification or test-case with the given `title` and callback `fn` acting
-         * as a thunk.
-         *
-         * - _Only available when invoked via the mocha CLI._
-         */
-        (title: string, fn?: AsyncFunc): Test;
+         (title: string, fn?: Func | AsyncFunc): Test;
 
         /**
          * Indicates this test should be executed exclusively.
@@ -550,16 +519,7 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: Func): Test;
-
-        /**
-         * [bdd, tdd, qunit] Describe a specification or test-case with the given callback `fn`
-         * acting as a thunk. The name of the function is used as the name of the test. Indicates
-         * this test should be executed exclusively.
-         *
-         * - _Only available when invoked via the mocha CLI._
-         */
-        (fn: AsyncFunc): Test;
+        (fn: Func | AsyncFunc): Test;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -567,15 +527,7 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (title: string, fn?: Func): Test;
-
-        /**
-         * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
-         * callback `fn` acting as a thunk. Indicates this test should be executed exclusively.
-         *
-         * - _Only available when invoked via the mocha CLI._
-         */
-        (title: string, fn?: AsyncFunc): Test;
+        (title: string, fn?: Func | AsyncFunc): Test;
     }
 
     interface PendingTestFunction {
@@ -586,16 +538,7 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: Func): Test;
-
-        /**
-         * [bdd, tdd, qunit] Describe a specification or test-case with the given callback `fn`
-         * acting as a thunk. The name of the function is used as the name of the test. Indicates
-         * this test should not be executed.
-         *
-         * - _Only available when invoked via the mocha CLI._
-         */
-        (fn: AsyncFunc): Test;
+        (fn: Func | AsyncFunc): Test;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -603,15 +546,7 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (title: string, fn?: Func): Test;
-
-        /**
-         * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
-         * callback `fn` acting as a thunk. Indicates this test should not be executed.
-         *
-         * - _Only available when invoked via the mocha CLI._
-         */
-        (title: string, fn?: AsyncFunc): Test;
+        (title: string, fn?: Func | AsyncFunc): Test;
     }
 
     /**
@@ -1875,112 +1810,56 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
-        beforeAll(fn?: Func): this;
+        beforeAll(fn?: Func | AsyncFunc): this;
 
         /**
          * Run `fn(test[, done])` before running tests.
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
-        beforeAll(fn?: AsyncFunc): this;
-
-        /**
-         * Run `fn(test[, done])` before running tests.
-         *
-         * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
-         */
-        beforeAll(title: string, fn?: Func): this;
-
-        /**
-         * Run `fn(test[, done])` before running tests.
-         *
-         * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
-         */
-        beforeAll(title: string, fn?: AsyncFunc): this;
+        beforeAll(title: string, fn?: Func | AsyncFunc): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
-        afterAll(fn?: Func): this;
+        afterAll(fn?: Func | AsyncFunc): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
-        afterAll(fn?: AsyncFunc): this;
-
-        /**
-         * Run `fn(test[, done])` after running tests.
-         *
-         * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
-         */
-        afterAll(title: string, fn?: Func): this;
-
-        /**
-         * Run `fn(test[, done])` after running tests.
-         *
-         * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
-         */
-        afterAll(title: string, fn?: AsyncFunc): this;
+        afterAll(title: string, fn?: Func | AsyncFunc): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
-        beforeEach(fn?: Func): this;
+        beforeEach(fn?: Func | AsyncFunc): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
-        beforeEach(fn?: AsyncFunc): this;
-
-        /**
-         * Run `fn(test[, done])` before each test case.
-         *
-         * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
-         */
-        beforeEach(title: string, fn?: Func): this;
-
-        /**
-         * Run `fn(test[, done])` before each test case.
-         *
-         * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
-         */
-        beforeEach(title: string, fn?: AsyncFunc): this;
+        beforeEach(title: string, fn?: Func | AsyncFunc): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
-        afterEach(fn?: Func): this;
+        afterEach(fn?: Func | AsyncFunc): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
-        afterEach(fn?: AsyncFunc): this;
-
-        /**
-         * Run `fn(test[, done])` after each test case.
-         *
-         * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
-         */
-        afterEach(title: string, fn?: Func): this;
-
-        /**
-         * Run `fn(test[, done])` after each test case.
-         *
-         * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
-         */
-        afterEach(title: string, fn?: AsyncFunc): this;
+        afterEach(title: string, fn?: Func | AsyncFunc): this;
 
         /**
          * Add a test `suite`.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/issues/48077
- ~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

Corrects function overloads for `it` and the like in Mocha so that the more specific async parameters come first per https://github.com/microsoft/TypeScript/issues/48077#issuecomment-1056342189 (thanks @MartinJohns!).

I tried switching to unions but hit test errors about `this` no longer being defined: https://github.com/DefinitelyTyped/DefinitelyTyped/runs/5394917747?check_suite_focus=true

```
Error: /home/runner/work/DefinitelyTyped/DefinitelyTyped/types/ember-mocha/ember-mocha-tests.ts:79:9
ERROR: 79:9    expect  TypeScript@4.7 compile error: 
'this' implicitly has type 'any' because it does not have a type annotation.
...
```

Throwing this PR up as a draft while there are test failures as reference for https://github.com/microsoft/TypeScript/issues/48088.