### PR TITLE
[@paypal/checkout-server-sdk] don't use enum for CheckoutPaymentIntent

### DIFF
--- a/types/paypal__checkout-server-sdk/lib/orders/lib.d.ts
+++ b/types/paypal__checkout-server-sdk/lib/orders/lib.d.ts
@@ -188,10 +188,7 @@ export interface CardResponse {
 }
 
 // https://developer.paypal.com/docs/api/orders/v2/#definition-checkout_payment_intent
-export enum CheckoutPaymentIntent {
-    CAPTURE = 'CAPTURE',
-    AUTHORIZE = 'AUTHORIZE',
-}
+export type CheckoutPaymentIntent = 'CAPTURE' | 'AUTHORIZE';
 
 // https://developer.paypal.com/docs/api/orders/v2/#definition-confirm_order_request
 export interface ConfirmOrderRequest {

--- a/types/paypal__checkout-server-sdk/paypal__checkout-server-sdk-tests.ts
+++ b/types/paypal__checkout-server-sdk/paypal__checkout-server-sdk-tests.ts
@@ -24,7 +24,7 @@ const ordersPatchRequest = new paypal.orders.OrdersPatchRequest('orderId'); // $
 const ordersValidateRequest = new paypal.orders.OrdersValidateRequest('orderId'); // $ExpectType OrdersValidateRequest
 
 ordersCreateRequest.requestBody({
-    intent: paypal.orders.CheckoutPaymentIntent.CAPTURE,
+    intent: 'CAPTURE',
     purchase_units: [
         {
             amount: {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [no search results for CheckoutPaymentIntent](https://github.com/paypal/Checkout-NodeJS-SDK/search?q=CheckoutPaymentIntent)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

The types are defined with `enum`, but using enum implies that there's a runtime object with these properties on it, but AFAICT the library doesn't export one at runtime.

There's actually a lot of these in this lib that all probably need to be changed, but I wanted to start with a small change before trying to make bigger ones.