### PR TITLE
fix: yargs-parser default export

### DIFF
--- a/types/yargs-parser/index.d.ts
+++ b/types/yargs-parser/index.d.ts
@@ -1,118 +1,109 @@
 // Type definitions for yargs-parser 21.0
 // Project: https://github.com/yargs/yargs-parser#readme
-// Definitions by: Miles Johnson <https://github.com/milesj>
+// Definitions by: Alan Agius <https://github.com/alan-agius4>,
+//                 Miles Johnson <https://github.com/milesj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-declare namespace yargsParser {
-    interface Arguments {
-        /** Non-option arguments */
-        _: Array<string | number>;
-        /** Arguments after the end-of-options flag `--` */
-        '--'?: Array<string | number>;
-        /** All remaining options */
-        [argName: string]: any;
-    }
-
-    interface DetailedArguments {
-        /** An object representing the parsed value of `args` */
-        argv: Arguments;
-        /** Populated with an error object if an exception occurred during parsing. */
-        error: Error | null;
-        /** The inferred list of aliases built by combining lists in opts.alias. */
-        aliases: { [alias: string]: string[] };
-        /** Any new aliases added via camel-case expansion. */
-        newAliases: { [alias: string]: boolean };
-        /** The configuration loaded from the yargs stanza in package.json. */
-        configuration: Configuration;
-    }
-
-    interface Configuration {
-        /** Should variables prefixed with --no be treated as negations? Default is `true` */
-        'boolean-negation': boolean;
-        /** Should hyphenated arguments be expanded into camel-case aliases? Default is `true` */
-        'camel-case-expansion': boolean;
-        /** Should arrays be combined when provided by both command line arguments and a configuration file. Default is `false`  */
-        'combine-arrays': boolean;
-        /** Should keys that contain . be treated as objects? Default is `true` */
-        'dot-notation': boolean;
-        /** Should arguments be coerced into an array when duplicated. Default is `true` */
-        'duplicate-arguments-array': boolean;
-        /** Should array arguments be coerced into a single array when duplicated. Default is `true` */
-        'flatten-duplicate-arrays': boolean;
-        /** Should arrays consume more than one positional argument following their flag. Default is `true` */
-        'greedy-arrays': boolean;
-        /** Should nargs consume dash options as well as positional arguments. Default is `false` */
-        'nargs-eats-options': boolean;
-        /** Should parsing stop at the first text argument? This is similar to how e.g. ssh parses its command line. Default is `false` */
-        'halt-at-non-option': boolean;
-        /** The prefix to use for negated boolean variables. Default is `'no-'` */
-        'negation-prefix': string;
-        /** Should keys that look like numbers be treated as such? Default is `true` */
-        'parse-numbers': boolean;
-        /** Should positional keys that look like numbers be treated as such? Default is `true` */
-        'parse-positional-numbers': boolean;
-        /** Should unparsed flags be stored in -- or _. Default is `false` */
-        'populate--': boolean;
-        /** Should a placeholder be added for keys not set via the corresponding CLI argument? Default is `false` */
-        'set-placeholder-key': boolean;
-        /** Should a group of short-options be treated as boolean flags? Default is `true` */
-        'short-option-groups': boolean;
-        /** Should aliases be removed before returning results? Default is `false` */
-        'strip-aliased': boolean;
-        /** Should dashed keys be removed before returning results? This option has no effect if camel-case-expansion is disabled. Default is `false` */
-        'strip-dashed': boolean;
-        /** Should unknown options be treated like regular arguments? An unknown option is one that is not configured in opts. Default is `false` */
-        'unknown-options-as-args': boolean;
-    }
-
-    interface Options {
-        /** An object representing the set of aliases for a key: `{ alias: { foo: ['f']} }`. */
-        alias?: { [key: string]: string | string[] } | undefined;
-        /**
-         * Indicate that keys should be parsed as an array: `{ array: ['foo', 'bar'] }`.
-         * Indicate that keys should be parsed as an array and coerced to booleans / numbers:
-         * { array: [ { key: 'foo', boolean: true }, {key: 'bar', number: true} ] }`.
-         */
-        array?:
-            | string[]
-            | Array<{ key: string; boolean?: boolean | undefined; number?: boolean | undefined }>
-            | undefined;
-        /** Arguments should be parsed as booleans: `{ boolean: ['x', 'y'] }`. */
-        boolean?: string[] | undefined;
-        /** Indicate a key that represents a path to a configuration file (this file will be loaded and parsed). */
-        config?: string | string[] | { [key: string]: boolean } | undefined;
-        /** Provide configuration options to the yargs-parser. */
-        configuration?: Partial<Configuration> | undefined;
-        /**
-         * Provide a custom synchronous function that returns a coerced value from the argument provided (or throws an error), e.g.
-         * `{ coerce: { foo: function (arg) { return modifiedArg } } }`.
-         */
-        coerce?: { [key: string]: (arg: any) => any } | undefined;
-        /** Indicate a key that should be used as a counter, e.g., `-vvv = {v: 3}`. */
-        count?: string[] | undefined;
-        /** Provide default values for keys: `{ default: { x: 33, y: 'hello world!' } }`. */
-        default?: { [key: string]: any } | undefined;
-        /** Environment variables (`process.env`) with the prefix provided should be parsed. */
-        envPrefix?: string | undefined;
-        /** Specify that a key requires n arguments: `{ narg: {x: 2} }`. */
-        narg?: { [key: string]: number } | undefined;
-        /** `path.normalize()` will be applied to values set to this key. */
-        normalize?: string[] | undefined;
-        /** Keys should be treated as strings (even if they resemble a number `-x 33`). */
-        string?: string[] | undefined;
-        /** Keys should be treated as numbers. */
-        number?: string[] | undefined;
-    }
-
-    interface Parser {
-        (argv: string | string[], opts?: Options): Arguments;
-        detailed(argv: string | string[], opts?: Options): DetailedArguments;
-        camelCase(str: string): string;
-        decamelize(str: string, joinString?: string): string;
-        looksLikeNumber(value: string | number | null | undefined): boolean;
-    }
+export interface Arguments {
+    /** Non-option arguments */
+    _: Array<string | number>;
+    /** Arguments after the end-of-options flag `--` */
+    '--'?: Array<string | number>;
+    /** All remaining options */
+    [argName: string]: any;
 }
 
-declare var yargsParser: yargsParser.Parser;
-export = yargsParser;
+export interface DetailedArguments {
+    /** An object representing the parsed value of `args` */
+    argv: Arguments;
+    /** Populated with an error object if an exception occurred during parsing. */
+    error: Error | null;
+    /** The inferred list of aliases built by combining lists in opts.alias. */
+    aliases: { [alias: string]: string[] };
+    /** Any new aliases added via camel-case expansion. */
+    newAliases: { [alias: string]: boolean };
+    /** The configuration loaded from the yargs stanza in package.json. */
+    configuration: Configuration;
+}
+
+export interface Configuration {
+    /** Should variables prefixed with --no be treated as negations? Default is `true` */
+    'boolean-negation': boolean;
+    /** Should hyphenated arguments be expanded into camel-case aliases? Default is `true` */
+    'camel-case-expansion': boolean;
+    /** Should arrays be combined when provided by both command line arguments and a configuration file. Default is `false`  */
+    'combine-arrays': boolean;
+    /** Should keys that contain . be treated as objects? Default is `true` */
+    'dot-notation': boolean;
+    /** Should arguments be coerced into an array when duplicated. Default is `true` */
+    'duplicate-arguments-array': boolean;
+    /** Should array arguments be coerced into a single array when duplicated. Default is `true` */
+    'flatten-duplicate-arrays': boolean;
+    /** Should arrays consume more than one positional argument following their flag. Default is `true` */
+    'greedy-arrays': boolean;
+    /** Should nargs consume dash options as well as positional arguments. Default is `false` */
+    'nargs-eats-options': boolean;
+    /** Should parsing stop at the first text argument? This is similar to how e.g. ssh parses its command line. Default is `false` */
+    'halt-at-non-option': boolean;
+    /** The prefix to use for negated boolean variables. Default is `'no-'` */
+    'negation-prefix': string;
+    /** Should keys that look like numbers be treated as such? Default is `true` */
+    'parse-numbers': boolean;
+    /** Should positional keys that look like numbers be treated as such? Default is `true` */
+    'parse-positional-numbers': boolean;
+    /** Should unparsed flags be stored in -- or _. Default is `false` */
+    'populate--': boolean;
+    /** Should a placeholder be added for keys not set via the corresponding CLI argument? Default is `false` */
+    'set-placeholder-key': boolean;
+    /** Should a group of short-options be treated as boolean flags? Default is `true` */
+    'short-option-groups': boolean;
+    /** Should aliases be removed before returning results? Default is `false` */
+    'strip-aliased': boolean;
+    /** Should dashed keys be removed before returning results? This option has no effect if camel-case-expansion is disabled. Default is `false` */
+    'strip-dashed': boolean;
+    /** Should unknown options be treated like regular arguments? An unknown option is one that is not configured in opts. Default is `false` */
+    'unknown-options-as-args': boolean;
+}
+
+export interface Options {
+    /** An object representing the set of aliases for a key: `{ alias: { foo: ['f']} }`. */
+    alias?: { [key: string]: string | string[] } | undefined;
+    /**
+     * Indicate that keys should be parsed as an array: `{ array: ['foo', 'bar'] }`.
+     * Indicate that keys should be parsed as an array and coerced to booleans / numbers:
+     * { array: [ { key: 'foo', boolean: true }, {key: 'bar', number: true} ] }`.
+     */
+    array?: string[] | Array<{ key: string; boolean?: boolean | undefined; number?: boolean | undefined }> | undefined;
+    /** Arguments should be parsed as booleans: `{ boolean: ['x', 'y'] }`. */
+    boolean?: string[] | undefined;
+    /** Indicate a key that represents a path to a configuration file (this file will be loaded and parsed). */
+    config?: string | string[] | { [key: string]: boolean } | undefined;
+    /** Provide configuration options to the yargs-parser. */
+    configuration?: Partial<Configuration> | undefined;
+    /**
+     * Provide a custom synchronous function that returns a coerced value from the argument provided (or throws an error), e.g.
+     * `{ coerce: { foo: function (arg) { return modifiedArg } } }`.
+     */
+    coerce?: { [key: string]: (arg: any) => any } | undefined;
+    /** Indicate a key that should be used as a counter, e.g., `-vvv = {v: 3}`. */
+    count?: string[] | undefined;
+    /** Provide default values for keys: `{ default: { x: 33, y: 'hello world!' } }`. */
+    default?: { [key: string]: any } | undefined;
+    /** Environment variables (`process.env`) with the prefix provided should be parsed. */
+    envPrefix?: string | undefined;
+    /** Specify that a key requires n arguments: `{ narg: {x: 2} }`. */
+    narg?: { [key: string]: number } | undefined;
+    /** `path.normalize()` will be applied to values set to this key. */
+    normalize?: string[] | undefined;
+    /** Keys should be treated as strings (even if they resemble a number `-x 33`). */
+    string?: string[] | undefined;
+    /** Keys should be treated as numbers. */
+    number?: string[] | undefined;
+}
+
+export function detailed(argv: string | string[], opts?: Options): DetailedArguments;
+export function camelCase(str: string): string;
+export function decamelize(str: string, joinString?: string): string;
+export function looksLikeNumber(value: string | number | null | undefined): boolean;
+export default function (argv: string | string[], opts?: Options): Arguments;

--- a/types/yargs-parser/yargs-parser-tests.ts
+++ b/types/yargs-parser/yargs-parser-tests.ts
@@ -1,4 +1,4 @@
-import parse, { Arguments } from 'yargs-parser';
+import parse, { Arguments, detailed, camelCase, decamelize, looksLikeNumber } from 'yargs-parser';
 
 parse('--foo -bar');
 
@@ -126,19 +126,19 @@ parse(['--foo', '-bar'], {
     number: ['foo', 'bar'],
 });
 
-parse.detailed('--foo -bar');
+detailed('--foo -bar');
 
-parse.detailed(['--foo', '-bar']);
+detailed(['--foo', '-bar']);
 
-parse.detailed(['--foo'], {});
-
-// $ExpectType string
-parse.camelCase('value');
+detailed(['--foo'], {});
 
 // $ExpectType string
-parse.decamelize('value');
+camelCase('value');
+
+// $ExpectType string
+decamelize('value');
 
 // $ExpectType boolean
-parse.looksLikeNumber(1);
+looksLikeNumber(1);
 
 function test(args: Arguments) {}

--- a/types/yargs/helpers.d.ts
+++ b/types/yargs/helpers.d.ts
@@ -1,4 +1,4 @@
-import * as Parser from 'yargs-parser';
+import Parser from 'yargs-parser';
 
 export function applyExtends(config: Record<string, any>, cwd: string, mergeExtends: boolean): Record<string, any>;
 export function hideBin(argv: string[]): string[];


### PR DESCRIPTION
This change corrects the export of yargs-parser https://github.com/yargs/yargs-parser/blob/0fdbfa1fe960f76d520f75437e97c79727804908/lib/index.ts#L62

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yargs/yargs-parser/blob/0fdbfa1fe960f76d520f75437e97c79727804908/lib/index.ts#L62
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
