### PR TITLE
Update types for @rails/activestorage v7.0.2

### DIFF
--- a/types/rails__activestorage/index.d.ts
+++ b/types/rails__activestorage/index.d.ts
@@ -11,10 +11,8 @@ export class DirectUpload {
     id: number;
     file: File;
     url: string;
-    serviceName: string;
-    attachmentName: string;
 
-    constructor(file: File, url: string, serviceName: string, attachmentName: string, delegate?: DirectUploadDelegate)
+    constructor(file: File, url: string, delegate?: DirectUploadDelegate)
 
     create(callback: (error: Error, blob: Blob) => void): void;
 }

--- a/types/rails__activestorage/rails__activestorage-tests.ts
+++ b/types/rails__activestorage/rails__activestorage-tests.ts
@@ -17,8 +17,6 @@ const delegate: ActiveStorage.DirectUploadDelegate = {
 const d = new ActiveStorage.DirectUpload(
     new File([], 'blank.txt'),
     '/rails/active_storage/direct_uploads',
-    'serviceName',
-    'attachmentName',
     delegate
 );
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rails/rails/commit/aaa64687e81873b26c964fada0b969621ae8cf8f#diff-544a39d8373af5b4e345d2807b94b3113fc3e919364b4ca4bf0a8e081ac7fcf1L611-L618
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


This PR basically reverts #57781 (following https://github.com/rails/rails/pull/44287).

Relevant discussion: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/59071

@Oleksii14 and @AlfonsoUceda, please review this PR if you can.

# Versioning
The original package `@rails/activestorage` has bumped its patch version with a breaking change. In DT we can't specify that typings are for `7.0.2` and not for `>= 7.0.0, < 7.0.2`. In DT we can only specify the major and minor versions.

Basically, users of `@types/rails__activestorage` should somehow understand themselves which version they need.

@sandersn, sorry for disturbing (didn't know whom to ask). Can you please clarify this?

Just wanted to confirm because this was not mentioned explicitly [enough] in the readme :scream: