### PR TITLE
[react-table] Add SortByFnPartial for use via orderByFn

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -814,7 +814,7 @@ export type UseSortByOptions<D extends object> = Partial<{
     maxMultiSortColCount: number;
     disableSortRemove: boolean;
     disabledMultiRemove: boolean;
-    orderByFn: (rows: Array<Row<D>>, sortFns: Array<SortByFn<D>>, directions: boolean[]) => Array<Row<D>>;
+    orderByFn: (rows: Array<Row<D>>, sortFns: Array<SortByFnPartial<D>>, directions: boolean[]) => Array<Row<D>>;
     sortTypes: Record<string, SortByFn<D>>;
     autoResetSortBy?: boolean | undefined;
 }>;
@@ -852,6 +852,7 @@ export interface UseSortByColumnProps<D extends object> {
     isSortedDesc: boolean | undefined;
 }
 
+export type SortByFnPartial<D extends object> = (rowA: Row<D>, rowB: Row<D>) => number;
 export type SortByFn<D extends object> = (rowA: Row<D>, rowB: Row<D>, columnId: IdType<D>, desc?: boolean) => number;
 
 export type DefaultSortTypes = 'alphanumeric' | 'datetime' | 'basic' | 'string' | 'number';
@@ -885,7 +886,7 @@ export type TableDispatch<A = any> = (action: A) => void;
 // utils
 export function defaultOrderByFn<D extends object = {}>(
     arr: Array<Row<D>>,
-    funcs: Array<SortByFn<D>>,
+    funcs: Array<SortByFnPartial<D>>,
     dirs: boolean[],
 ): Array<Row<D>>;
 

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -814,7 +814,7 @@ export type UseSortByOptions<D extends object> = Partial<{
     maxMultiSortColCount: number;
     disableSortRemove: boolean;
     disabledMultiRemove: boolean;
-    orderByFn: (rows: Array<Row<D>>, sortFns: Array<SortByFnPartial<D>>, directions: boolean[]) => Array<Row<D>>;
+    orderByFn: (rows: Array<Row<D>>, sortFns: Array<OrderByFn<D>>, directions: boolean[]) => Array<Row<D>>;
     sortTypes: Record<string, SortByFn<D>>;
     autoResetSortBy?: boolean | undefined;
 }>;
@@ -852,7 +852,7 @@ export interface UseSortByColumnProps<D extends object> {
     isSortedDesc: boolean | undefined;
 }
 
-export type SortByFnPartial<D extends object> = (rowA: Row<D>, rowB: Row<D>) => number;
+export type OrderByFn<D extends object> = (rowA: Row<D>, rowB: Row<D>) => number;
 export type SortByFn<D extends object> = (rowA: Row<D>, rowB: Row<D>, columnId: IdType<D>, desc?: boolean) => number;
 
 export type DefaultSortTypes = 'alphanumeric' | 'datetime' | 'basic' | 'string' | 'number';
@@ -886,7 +886,7 @@ export type TableDispatch<A = any> = (action: A) => void;
 // utils
 export function defaultOrderByFn<D extends object = {}>(
     arr: Array<Row<D>>,
-    funcs: Array<SortByFnPartial<D>>,
+    funcs: Array<OrderByFn<D>>,
     dirs: boolean[],
 ): Array<Row<D>>;
 

--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -63,6 +63,7 @@ import {
     UseSortByOptions,
     UseSortByState,
     useTable,
+    defaultOrderByFn,
 } from 'react-table';
 
 // test heavily based up https://github.com/tannerlinsley/react-table/blob/master/examples/kitchen-sink-controlled/src/App.js
@@ -390,7 +391,8 @@ function Table({ columns, data, updateMyData, skipPageReset = false }: Table<Dat
             // Do not reset hidden columns when columns change. Allows
             // for creating columns during render.
             autoResetHiddenColumns: false,
-            autoResetResize: false
+            autoResetResize: false,
+            orderByFn: defaultOrderByFn,
         },
         useGroupBy,
         useFilters,


### PR DESCRIPTION
The current type definition for `orderByFn` does not appear to match the implementation.

When the `useSortBy` plugin calls the [orderByFn](https://github.com/TanStack/react-table/blob/v7/src/plugin-hooks/useSortBy.js#L322), it's actually passing in a partial using `rowA` and `rowB`. This is also exemplified in the [defaultOrderBy](https://github.com/TanStack/react-table/blob/v7/src/plugin-hooks/useSortBy.js#L385) function, which does not pass in columnId or desc.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/TanStack/react-table/blob/v7/src/plugin-hooks/useSortBy.js#L385
https://github.com/TanStack/react-table/blob/v7/src/plugin-hooks/useSortBy.js#L322
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.