### PR TITLE
Fix version header in @ckeditor/ckeditor5-find-and-replace

### DIFF
--- a/types/ckeditor__ckeditor5-find-and-replace/ckeditor__ckeditor5-find-and-replace-tests.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/ckeditor__ckeditor5-find-and-replace-tests.ts
@@ -20,6 +20,23 @@ ClassicEditor.create('', { plugins: [FindAndReplace] });
 FindAndReplace.requires.map(Plugin => new Plugin(editor));
 
 const state = new FindAndReplaceState(new Model());
+// $ExpectType string
+state.searchText;
+// $ExpectError
+state.searchText = "foo";
+// $ExpectType string
+state.replaceText;
+// $ExpectError
+state.replaceText = "foo";
+// $ExpectType boolean
+state.matchCase;
+// $ExpectError
+state.matchCase = true;
+state.clear(new Model());
+// $ExpectType Collection<Result, "id">
+state.results;
+// $ExpectError
+state.results = state.results;
 
 const plugin = editor.plugins.get('FindAndReplaceEditing');
 if (plugin instanceof FindAndReplaceEditing) {

--- a/types/ckeditor__ckeditor5-find-and-replace/index.d.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @ckeditor/ckeditor5-find-and-replace 29.0
+// Type definitions for @ckeditor/ckeditor5-find-and-replace 29.1
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/find-and-replace.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
`FindAndReplaceState` was extracted to another file in v29.1. https://github.com/ckeditor/ckeditor5/commit/68a77b7d94

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/commit/68a77b7d94
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.