### PR TITLE
[draft-js] Adjust tests to not assume implicit children

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -45,7 +45,7 @@ type SyntheticKeyboardEvent = React.KeyboardEvent<{}>;
 
 const HANDLE_REGEX = /\@[\w]+/g;
 
-class HandleSpan extends React.Component {
+class HandleSpan extends React.Component<{ children?: React.ReactNode }> {
   render() {
     return <span>{this.props.children}</span>
   }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.