### PR TITLE
[gatsby-plugin-breakpoints] Adjust tests to not assume implicit children

### DIFF
--- a/types/gatsby-plugin-breakpoints/gatsby-plugin-breakpoints-tests.tsx
+++ b/types/gatsby-plugin-breakpoints/gatsby-plugin-breakpoints-tests.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
     BreakpointConfig,
     BreakpointProvider,
@@ -49,6 +49,6 @@ function useContext() {
     return context;
 }
 // BreakpointProvider
-const ProviderComponent: React.FC = ({ children }) => {
+const ProviderComponent: React.FC<{ children?: ReactNode }> = ({ children }) => {
     return <BreakpointProvider queries={defaultQueries}>{children}</BreakpointProvider>;
 };


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.