### PR TITLE
[material-ui] Adjust tests to not assume implicit children

### DIFF
--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -4195,8 +4195,8 @@ const ListExampleMessages = () => (
   </div>
 );
 
-function wrapState(ComposedComponent: ComponentClass<__MaterialUI.List.SelectableProps>) {
-  return class SelectableList extends Component<{defaultValue: number}, {selectedIndex: number}> {
+function wrapState(ComposedComponent: ComponentClass<React.PropsWithChildren<__MaterialUI.List.SelectableProps>>) {
+  return class SelectableList extends Component<{children?: React.ReactNode, defaultValue: number}, {selectedIndex: number}> {
     static propTypes = {
       children: PropTypes.node.isRequired,
       defaultValue: PropTypes.number.isRequired,


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.