### PR TITLE
[material-ui-datatables] Remove usage of children in tests

### DIFF
--- a/types/material-ui-datatables/material-ui-datatables-tests.tsx
+++ b/types/material-ui-datatables/material-ui-datatables-tests.tsx
@@ -80,5 +80,4 @@ const test = (<DataTable
     tableWrapperStyle={tableWrapperStyle}
     headerToolbarMode={headerToolbarMode}
     filterValue={filterValue}
-    showHeaderToolbarFilterIcon={showHeaderToolbarFilterIcon}>
-</DataTable>);
+    showHeaderToolbarFilterIcon={showHeaderToolbarFilterIcon} />);


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210. DataTable is not actually using children: https://github.com/hyojin/material-ui-datatables/tree/f091d4a44532db82752a439428500272bc60872c#usage
