### PR TITLE
[radium] Remove usage of implicit children in tests

### DIFF
--- a/types/radium/radium-tests.tsx
+++ b/types/radium/radium-tests.tsx
@@ -38,14 +38,12 @@ class TestComponentWithConfig extends React.Component<{ a?: number | undefined }
                                 textAlign: "center"
                             }
                         }}
-                    >
-                    </Radium.Style>
+                    />
                     <Radium.Style scopeSelector="test"
                         rules={{
                             background: "green"
                         }}
-                    >
-                    </Radium.Style>
+                    />
                 </Radium.StyleRoot>
             </div>
         )
@@ -71,14 +69,12 @@ class TestComponentWithConfigInStyleRoot
                                 textAlign: "center"
                             }
                         }}
-                    >
-                    </Radium.Style>
+                    />
                     <Radium.Style scopeSelector="test"
                         rules={{
                             background: "green"
                         }}
-                    >
-                    </Radium.Style>
+                    />
                 </Radium.StyleRoot>
             </div>
         )


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210. Style is not actually using children: https://github.com/FormidableLabs/radium/blob/v0.24.1/src/components/style.js#L97-L105

