### PR TITLE
[react-breadcrumbs] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-breadcrumbs/react-breadcrumbs-tests.tsx
+++ b/types/react-breadcrumbs/react-breadcrumbs-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Breadcrumbs, Breadcrumb } from "react-breadcrumbs";
 
-class Wrapper extends React.Component {
+class Wrapper extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return <div>{this.props.children}</div>;
     }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.