### PR TITLE
[react-gateway] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-gateway/react-gateway-tests.tsx
+++ b/types/react-gateway/react-gateway-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Gateway, GatewayProvider, GatewayDest } from 'react-gateway';
 
-class GatewayComponent extends React.Component {
+class GatewayComponent extends React.Component<{ children?: React.ReactNode }> {
   render() {
     return (
       <div>{this.props.children}</div>


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.