### PR TITLE
[react-leaflet] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-leaflet/react-leaflet-tests.tsx
+++ b/types/react-leaflet/react-leaflet-tests.tsx
@@ -775,7 +775,7 @@ const CenterControlExample = () => (
     </Map>
 );
 
-class LegendControl extends MapControl<MapControlProps & { className?: string | undefined }> {
+class LegendControl extends MapControl<MapControlProps & { children?: React.ReactNode, className?: string | undefined }> {
     componentWillMount() {
         const legend = new L.Control({ position: 'bottomright' });
         const jsx = (


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.