### PR TITLE
[react-highlight-words] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-highlight-words/react-highlight-words-tests.tsx
+++ b/types/react-highlight-words/react-highlight-words-tests.tsx
@@ -6,7 +6,7 @@ const findChunks = ({
     textToHighlight
 }: FindChunks) => [];
 
-const CustomHighlight: React.FC = ({children}) => (<span>{children}</span>);
+const CustomHighlight: React.FC<{ children?: React.ReactNode; }> = ({children}) => (<span>{children}</span>);
 
 class HighlighterTest extends React.Component {
     render() {

--- a/types/react-leaflet/v1/react-leaflet-tests.tsx
+++ b/types/react-leaflet/v1/react-leaflet-tests.tsx
@@ -781,7 +781,7 @@ const CenterControlExample = () => (
     </Map>
 );
 
-class LegendControl extends MapControl<MapControlProps & { className?: string | undefined }> {
+class LegendControl extends MapControl<MapControlProps & { children?: React.ReactNode, className?: string | undefined }> {
     componentWillMount() {
         const legend = new L.Control({ position: 'bottomright' });
         const jsx = (


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.