### PR TITLE
[react-native-ad-manager] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-native-ad-manager/test/react-native-ad-manager-tests.tsx
+++ b/types/react-native-ad-manager/test/react-native-ad-manager-tests.tsx
@@ -4,6 +4,7 @@ import { Interstitial, Banner, NativeAdsManager, AdLoadedEvent, AdFailedToLoadEv
 import NativeAdView from './NativeAdView';
 
 const BannerExample: React.FunctionComponent<{
+    children?: React.ReactNode;
     style?: ViewStyle | undefined;
     title: string;
 }> = ({ style, title, children, ...props }) => (


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.