### PR TITLE
[react-native-mutli-slider] Don't use children in tests for customMarker

### DIFF
--- a/types/react-native-multi-slider/react-native-multi-slider-tests.tsx
+++ b/types/react-native-multi-slider/react-native-multi-slider-tests.tsx
@@ -59,7 +59,7 @@ class SliderTest extends React.Component {
                         borderRadius: 20,
                         slipDisplacement: 40,
                     }}
-                    customMarker={(props) => <View {...props} />}
+                    customMarker={({ markerStyle, pressed, pressedMarkerStyle, value}) => <View style={pressed ? pressedMarkerStyle : markerStyle}>value: {value}</View>}
                     sliderLength={280}
                 />
             </React.Fragment>


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210. CustomMarker is not actually using children: https://github.com/JackDanielsAndCode/react-native-multi-slider/blob/aec71369ed558812de7546f753494222d12df498/Slider.js#L242-L247
