### PR TITLE
[react-native-onboarding-swiper] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-native-onboarding-swiper/react-native-onboarding-swiper-tests.tsx
+++ b/types/react-native-onboarding-swiper/react-native-onboarding-swiper-tests.tsx
@@ -131,6 +131,7 @@ export default App;
 
 // mock Button component
 const Button: React.FC<{
+    children?: React.ReactNode;
     title: string | JSX.Element;
     buttonStyle: StyleProp<ViewStyle>;
     containerViewStyle: StyleProp<ViewStyle>;


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.