### PR TITLE
[react-native-scrollable-tab-view] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-native-scrollable-tab-view/react-native-scrollable-tab-view-tests.tsx
+++ b/types/react-native-scrollable-tab-view/react-native-scrollable-tab-view-tests.tsx
@@ -3,6 +3,7 @@ import { Text, TextStyle, View, ViewStyle } from 'react-native';
 import ScrollableTabView, { ScrollableTabBar, TabProps, DefaultTabBar } from 'react-native-scrollable-tab-view';
 
 interface MyTextProps {
+    children?: React.ReactNode;
     style?: TextStyle | undefined;
 }
 
@@ -11,6 +12,7 @@ const MyText: React.FC<TabProps<MyTextProps>> = (props) => (
 );
 
 interface MyViewProps {
+    children?: React.ReactNode;
     style?: ViewStyle | undefined;
 }
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.