### PR TITLE
[mailchimp_marketing] Add types definition for updateListMemberTags

### DIFF
--- a/types/mailchimp__mailchimp_marketing/index.d.ts
+++ b/types/mailchimp__mailchimp_marketing/index.d.ts
@@ -2,7 +2,9 @@
 // Project: https://github.com/mailchimp/mailchimp-client-lib-codegen
 // Definitions by: Jan Müller <https://github.com/rattkin>
 //                 Jérémy Barbet <https://github.com/jeremybarbet>
+//                 Daniel Castro <https://github.com/odanieldcs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// API Documentation: https://mailchimp.com/developer/marketing/api/
 
 export function setConfig(config: Config): void;
 

--- a/types/mailchimp__mailchimp_marketing/index.d.ts
+++ b/types/mailchimp__mailchimp_marketing/index.d.ts
@@ -58,6 +58,17 @@ export interface SetListMemberBody {
     merge_fields?: Record<string, any> | undefined;
 }
 
+export type StatusTag = 'active' | 'inactive';
+
+export interface TagBody {
+    name: string;
+    status: StatusTag;
+}
+
+export interface MemberTagsBody {
+    tags: TagBody[];
+}
+
 /*~ If there are types, properties, or methods inside dotted names
  *~ of the module, declare them inside a 'namespace'.
  */
@@ -88,4 +99,6 @@ export namespace lists {
     ): Promise<void>;
 
     function deleteListMemberPermanent(listId: string, subscriberHash: string): Promise<void>;
+
+    function updateListMemberTags(listId: string, subscriberHash: string, body: any): Promise<void>;
 }

--- a/types/mailchimp__mailchimp_marketing/mailchimp__mailchimp_marketing-tests.ts
+++ b/types/mailchimp__mailchimp_marketing/mailchimp__mailchimp_marketing-tests.ts
@@ -20,6 +20,19 @@ const updateListMemberBody = {
     email_address: 'test',
 };
 
+const updateListMemberTagsBody = {
+    tags: [
+        {
+            name: 'test',
+            status: 'active',
+        },
+        {
+            name: 'test2',
+            status: 'inactive',
+        },
+    ],
+};
+
 // Promise<void>
 mailchimp.lists.setListMember('test', 'test', setListMemberBody);
 
@@ -34,3 +47,6 @@ mailchimp.lists.updateListMember('test', 'test', updateListMemberBody);
 
 // Promise<void>
 mailchimp.lists.deleteListMemberPermanent('test', 'test');
+
+// Promise<void>
+mailchimp.lists.updateListMemberTags('test', 'test', updateListMemberTagsBody);


### PR DESCRIPTION
Just add support to type definitions for method lists.updateListMemberTags.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
