### PR TITLE
[server] 🐛 correct misspelled `csurf` key to `csrf` for `config.security` object in `server(config)` method

### DIFF
--- a/types/server/server-tests.ts
+++ b/types/server/server-tests.ts
@@ -69,6 +69,7 @@ server(
         favicon: 'public/logo.png',
         parser: { body: { limit: '1mb' } },
         security: {
+            csrf: false,
             dnsPrefetchControl: { allow: true },
         },
         session: {

--- a/types/server/typings/options.d.ts
+++ b/types/server/typings/options.d.ts
@@ -61,7 +61,7 @@ export interface Options {
     security?:
         | false
         | helmet.IHelmetConfiguration & {
-              csurf?: false | CsurfOptions | undefined;
+              csrf?: false | CsurfOptions | undefined;
           } | undefined;
     log?:
         | LogLevel


### PR DESCRIPTION
# Fixes #59140

## Please fill in this template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
  - [`server`](https://github.com/franciscop/server)
- [x] Test the change in your own code. (Compile and run.)
  - **Before**:
![server-csrf-typescript-error](https://user-images.githubusercontent.com/16791848/156871889-b3602039-a167-4428-8c69-16a2b0f649e9.png)
  - **After**:
![server-csrf-typescript-error-resolved](https://user-images.githubusercontent.com/16791848/156871815-77d75d01-9956-4a41-8cbd-e689a87028f0.png)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test server`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests):
![npm-test-server-output](https://user-images.githubusercontent.com/16791848/156871602-1d864ddd-a192-4e74-8a8b-cce6f0080c2e.png)

## If changing an existing definition

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Source code](https://github.com/franciscop/server/blob/master/plugins/security/index.js#L8)
    > ```js
    > // ...
    >
    > module.exports = {
    >   name: 'security',
    >   options: {
    >     csrf: {
    >       // ...
    > ```
  - [Documentation](https://serverjs.io/documentation/options/#security)
    > ## Security
    > 
    > It combines Csurf and Helmet to give extra security:
    > 
    > ```js
    > server({
    >   security: {
    >     csrf: {
    >       ignoreMethods: ['GET', 'HEAD', 'OPTIONS'],
    >       value: req => req.body.csnowflakerf
    >     },
    >     frameguard: {
    >       action: 'deny'
    >     }
    >   }
    > });
    > ```
    >
    > ...
    >
    > Individual parts can also be disabled like this. This makes sense if you use other mechanisms to avoid CSRF, such as JWT:
    >
    > ```js
    > server({
    >   security: {
    >     csrf: false
    >   }
    > });
    > ```
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. _(Not applicable)_