### PR TITLE
[react-relay] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -717,7 +717,7 @@ requestSubscription(
 ReactRelayContext.Consumer.prototype;
 ReactRelayContext.Provider.prototype;
 
-const MyRelayContextProvider: React.FunctionComponent = ({children}) => {
+const MyRelayContextProvider: React.FunctionComponent<{ children?: React.ReactNode }> = ({children}) => {
     return (
         <ReactRelayContext.Provider
             value={{


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.