### PR TITLE
[react-portal] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-portal/v3/react-portal-tests.tsx
+++ b/types/react-portal/v3/react-portal-tests.tsx
@@ -32,7 +32,7 @@ export default class App extends React.Component {
   }
 }
 
-export class PseudoModal extends React.Component<{ closePortal?(): void }> {
+export class PseudoModal extends React.Component<{ children?: React.ReactNode; closePortal?(): void }> {
   render() {
     return (
       <div>


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.