### PR TITLE
[react-resizeable] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-resizable/react-resizable-tests.tsx
+++ b/types/react-resizable/react-resizable-tests.tsx
@@ -9,7 +9,7 @@ const resizeCallback = (
     console.log(data.node);
 };
 
-class TestResizableComponent extends React.Component {
+class TestResizableComponent extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return (
             <Resizable
@@ -32,7 +32,7 @@ class TestResizableComponent extends React.Component {
     }
 }
 
-class TestResizableBoxComponent extends React.Component {
+class TestResizableBoxComponent extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return (
             <ResizableBox


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.