### PR TITLE
[rrc] Adjust tests to not assume implicit children

### DIFF
--- a/types/rrc/rrc-tests.tsx
+++ b/types/rrc/rrc-tests.tsx
@@ -42,6 +42,7 @@ class RouteTwo extends React.Component<RouteComponentProps> {
 }
 
 interface LayoutProps {
+    children?: React.ReactNode;
     title: string;
     subtitle?: string | undefined;
 }
@@ -91,6 +92,7 @@ class RouteFour extends React.Component<RouteComponentProps> {
 }
 
 interface MyContainerProps {
+    children?: React.ReactNode;
     className?: string | undefined;
     color: number;
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.