### PR TITLE
[redux-form] Adjust tests to not assume implicit children

### DIFF
--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -103,6 +103,7 @@ const ItemListObj = formValues({ fooBar : "foo" })(
 /* Custom FormSection */
 
 interface MyFormSectionProps {
+    children?: React.ReactNode;
     foo: string;
 }
 
@@ -111,6 +112,7 @@ const MyFormSection: React.FunctionComponent<MyFormSectionProps> = ({ children, 
 /* Custom Field */
 
 interface MyFieldCustomProps {
+    children?: React.ReactNode;
     foo: string;
 }
 type MyFieldProps = MyFieldCustomProps & WrappedFieldProps;
@@ -151,6 +153,7 @@ const FieldImmutableCustom = ImmutableField as new () => GenericField<MyFieldCus
 /* Custom Fields */
 
 interface MyFieldsCustomProps {
+    children?: React.ReactNode;
     foo: string;
 }
 type MyFieldsProps = MyFieldsCustomProps & WrappedFieldsProps;
@@ -162,7 +165,7 @@ const FieldsCustom = Fields as new () => GenericFields<MyFieldsCustomProps>;
 
 /* FieldArray */
 
-const MyArrayField: React.FunctionComponent<WrappedFieldArrayProps> = ({
+const MyArrayField: React.FunctionComponent<React.PropsWithChildren<WrappedFieldArrayProps>> = ({
     children
 }) => null;
 
@@ -173,6 +176,7 @@ interface MyFieldValue {
 }
 
 interface MyFieldArrayCustomProps {
+    children?: React.ReactNode;
     foo: string;
     bar: number;
 }

--- a/types/redux-form/v7/redux-form-tests.tsx
+++ b/types/redux-form/v7/redux-form-tests.tsx
@@ -101,6 +101,7 @@ const ItemListObj = formValues({ fooBar : "foo" })(
 /* Custom FormSection */
 
 interface MyFormSectionProps {
+    children?: React.ReactNode;
     foo: string;
 }
 
@@ -109,6 +110,7 @@ const MyFormSection: React.FunctionComponent<MyFormSectionProps> = ({ children, 
 /* Custom Field */
 
 interface MyFieldCustomProps {
+    children?: React.ReactNode;
     foo: string;
 }
 type MyFieldProps = MyFieldCustomProps & WrappedFieldProps;
@@ -149,6 +151,7 @@ const FieldImmutableCustom = ImmutableField as new () => GenericField<MyFieldCus
 /* Custom Fields */
 
 interface MyFieldsCustomProps {
+    children?: React.ReactNode;
     foo: string;
 }
 type MyFieldsProps = MyFieldsCustomProps & WrappedFieldsProps;
@@ -160,7 +163,7 @@ const FieldsCustom = Fields as new () => GenericFields<MyFieldsCustomProps>;
 
 /* FieldArray */
 
-const MyArrayField: React.FunctionComponent<WrappedFieldArrayProps> = ({
+const MyArrayField: React.FunctionComponent<React.PropsWithChildren<WrappedFieldArrayProps>> = ({
     children
 }) => null;
 
@@ -170,6 +173,7 @@ interface MyFieldValue {
     num: number;
 }
 interface MyFieldArrayCustomProps {
+    children?: React.ReactNode;
     foo: string;
     bar: number;
 }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.