### PR TITLE
[rebass] Adjust tests to not assume implicit children

### DIFF
--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -4,7 +4,7 @@ import { Box, Flex, Text, Heading, Button, Link, Image, Card, BoxProps } from 'r
 import { Box as StyledBox } from 'rebass/styled-components';
 import 'styled-components/macro';
 
-const CustomComponent: React.FunctionComponent = ({ children }) => {
+const CustomComponent: React.FunctionComponent<{ children?: React.ReactNode }> = ({ children }) => {
     return <div>{children}</div>;
 };
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.