### PR TITLE
[react-scroll] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-scroll/test/react-scroll-tests.tsx
+++ b/types/react-scroll/test/react-scroll-tests.tsx
@@ -146,7 +146,7 @@ Events.scrollEvent.register('end', (to, element) => {
 Events.scrollEvent.remove('begin');
 Events.scrollEvent.remove('end');
 
-class CustomComponent extends React.Component {
+class CustomComponent extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return <div>{this.props.children}</div>;
     }


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.