### PR TITLE
[react-router] Adjust tests to not assume implicit children

### DIFF
--- a/types/react-router/test/Prompt.tsx
+++ b/types/react-router/test/Prompt.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Prompt } from 'react-router';
 
-const PromptTest: React.FC = ({ children }) => {
+const PromptTest: React.FC = () => {
   return (
     <Prompt
       message={(location, action) => {

--- a/types/react-router/test/examples-from-react-router-website/StaticRouter.tsx
+++ b/types/react-router/test/examples-from-react-router-website/StaticRouter.tsx
@@ -5,6 +5,7 @@ import { StaticRouter, Route } from 'react-router-dom';
 import { StaticContext, StaticRouterContext } from 'react-router';
 
 interface RouteStatusProps {
+    children?: React.ReactNode;
     statusCode: number;
 }
 

--- a/types/react-router/ts4.0/test/Prompt.tsx
+++ b/types/react-router/ts4.0/test/Prompt.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Prompt } from 'react-router';
 
-const PromptTest: React.FC = ({ children }) => {
+const PromptTest: React.FC = () => {
   return (
     <Prompt
       message={(location, action) => {

--- a/types/react-router/ts4.0/test/examples-from-react-router-website/StaticRouter.tsx
+++ b/types/react-router/ts4.0/test/examples-from-react-router-website/StaticRouter.tsx
@@ -5,6 +5,7 @@ import { StaticRouter, Route } from 'react-router-dom';
 import { StaticContext, StaticRouterContext } from 'react-router';
 
 interface RouteStatusProps {
+    children?: React.ReactNode;
     statusCode: number;
 }
 

--- a/types/react-router/v3/react-router-tests.tsx
+++ b/types/react-router/v3/react-router-tests.tsx
@@ -47,7 +47,7 @@ interface MasterContext {
     router: InjectedRouter;
 }
 
-class Master extends Component {
+class Master extends Component<{ children?: React.ReactNode }> {
     static contextTypes: ValidationMap<any> = {
         router: routerShape
     };
@@ -124,6 +124,7 @@ class UserList extends React.Component<UserListProps & WithRouterProps> {
 const UserListWithRouter = withRouter(UserList);
 
 interface AvatarProps {
+    children?: React.ReactNode;
     user: string;
 }
 


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.