### PR TITLE
[react-intl-redux] Use same types as runtime peer dependencies

### DIFF
--- a/types/react-intl-redux/tsconfig.json
+++ b/types/react-intl-redux/tsconfig.json
@@ -16,6 +16,9 @@
         "typeRoots": [
             "../"
         ],
+        "paths": {
+            "react": ["react/v16"]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
react-intl-redux@0.1.1 depends on react-redux@4 and react-intl@2: https://github.com/ratson/react-intl-redux/blob/v0.1.1/package.json
- https://github.com/reduxjs/react-redux/blob/4.x/package.json#L99
- https://github.com/formatjs/formatjs/blob/2.x/package.json#L75

The change is motivated by planned [breaking changes to the React types once v18](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) is released. This package is no longer compatible with these changes.