### PR TITLE
[@wordpress/block-editor] Add explicit types for children

### DIFF
--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -302,9 +302,7 @@ be.withFontSizes('fontSize')(() => <h1>Hello World</h1>);
             label: 'Background Color',
         },
     ]}
->
-    Hello World
-</be.PanelColorSettings>;
+/>;
 
 //
 // plain-text


### PR DESCRIPTION
We plan to remove implicit children from `@types/react`. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

It's not clear if `PanelColorSettings` accepts `children`. The current typings [deliberately remove required `children` from the props](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e15defba58b6b1fbc55a9adac86157637eca06e5/types/wordpress__block-editor/components/panel-color-settings.d.ts#L7). But then `ComponentType` adds them back implicitly.

The [runtime tests for `PanelColorSettings` do not test `children`](https://github.com/WordPress/gutenberg/blob/%40wordpress/block-editor%406.2.0/packages/block-editor/src/components/panel-color-settings/test/index.js).

It's hard to check if the runtime does anything useful with the `children`.
<details>
<summary>Tracing `children` of `PanelColorSettings`</summary>

1. `PanelColorSettings` spreads children to `PanelColorGradientSettings`: https://github.com/WordPress/gutenberg/blob/%40wordpress/block-editor%406.2.0/packages/block-editor/src/components/panel-color-settings/index.js#L19
1. https://github.com/WordPress/gutenberg/blob/%40wordpress/block-editor%406.2.0/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js#L168
1. https://github.com/WordPress/gutenberg/blob/%40wordpress/block-editor%406.2.0/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js#L144
1. https://github.com/WordPress/gutenberg/blob/%40wordpress/block-editor%406.2.0/packages/components/src/panel/body.js#L89
1. https://github.com/WordPress/gutenberg/blob/%40wordpress/block-editor%406.2.0/packages/components/src/panel/body.js#L104
1. https://github.com/WordPress/gutenberg/blob/%40wordpress/block-editor%406.2.0/packages/components/src/button/index.js#L162

Unclear what  the type of  `Tag` is but it seems safe to assume it supports `children` (can be `a`).

</details>

Considering `PanelColorSettings.Props` does not accept `children` I think it's safe to assume `PanelColorSettings` should also not accept `children`. Therefore I'm adjusting the test to not use `children`