### PR TITLE
[@babel/core] Fixed `babel.parse` return type

### DIFF
--- a/types/babel__core/babel__core-tests.ts
+++ b/types/babel__core/babel__core-tests.ts
@@ -36,8 +36,12 @@ babel.transformFile('filename.js', options, (err, result) => {
 
 babel.transformFileSync('filename.js', options)!.code;
 
+function checkParseResult(_config: t.File) {}
+
 const sourceCode = 'if (true) return;';
 const parsedAst = babel.parse(sourceCode, options);
+
+checkParseResult(parsedAst!);
 
 babel.transformFromAst(parsedAst!, sourceCode, options, (err, result) => {
     const { code, map, ast } = result!;

--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -17,7 +17,7 @@ import * as t from '@babel/types';
 export { ParserOptions, GeneratorOptions, t as types, template, traverse, NodePath, Visitor };
 
 export type Node = t.Node;
-export type ParseResult = t.File | t.Program;
+export type ParseResult = ReturnType<typeof import('@babel/parser').parse>;
 export const version: string;
 export const DEFAULT_EXTENSIONS: ['.js', '.jsx', '.es6', '.es', '.mjs'];
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Link to the **approved** PR in the Babel itself: https://github.com/babel/babel/pull/14333/files#diff-6d48e19ee7d3ce790d9febf4d9b8d23a90dbee1abe2dc0be0adbf7a924d7d9b4R7