### PR TITLE
[keyv] Add typings for `Keyv.opts` class property

### DIFF
--- a/types/keyv/index.d.ts
+++ b/types/keyv/index.d.ts
@@ -8,18 +8,31 @@
 /// <reference types="node" />
 import { EventEmitter } from 'events';
 
-declare class Keyv<TValue = any> extends EventEmitter {
+type WithRequiredProperties<T, K extends keyof T> = T & Required<Pick<T, K>>;
+
+declare class Keyv<TValue = any, TOpts extends { [key: string]: any } = {}> extends EventEmitter {
+    /**
+     * `this.opts` is an object containing at least the properties listed
+     * below. However, `Keyv.Options` allows arbitrary properties as well.
+     * These properties can be specified as the second type parameter to `Keyv`.
+     */
+    public opts: WithRequiredProperties<
+        Keyv.Options<TValue>,
+        'deserialize' | 'namespace' | 'serialize' | 'store' | 'uri'
+    > &
+        TOpts;
+
     /**
      * @param opts The options object is also passed through to the storage adapter. Check your storage adapter docs for any extra options.
      */
-    constructor(opts?: Keyv.Options<TValue>);
+    constructor(opts?: Keyv.Options<TValue> & TOpts);
     /**
      * @param uri The connection string URI.
      *
      * Merged into the options object as options.uri.
      * @param opts The options object is also passed through to the storage adapter. Check your storage adapter docs for any extra options.
      */
-    constructor(uri?: string, opts?: Keyv.Options<TValue>);
+    constructor(uri?: string, opts?: Keyv.Options<TValue> & TOpts);
 
     /** Returns the value. */
     get<TRaw extends boolean = false>(key: string, options?: { raw?: TRaw }):

--- a/types/keyv/index.d.ts
+++ b/types/keyv/index.d.ts
@@ -16,7 +16,7 @@ declare class Keyv<TValue = any, TOpts extends { [key: string]: any } = {}> exte
      * below. However, `Keyv.Options` allows arbitrary properties as well.
      * These properties can be specified as the second type parameter to `Keyv`.
      */
-    public opts: WithRequiredProperties<
+    opts: WithRequiredProperties<
         Keyv.Options<TValue>,
         'deserialize' | 'namespace' | 'serialize' | 'store' | 'uri'
     > &

--- a/types/keyv/keyv-tests.ts
+++ b/types/keyv/keyv-tests.ts
@@ -61,17 +61,17 @@ new Keyv();
     // Base options accessible and typed correctly with TOpts unused
     const keyv = new Keyv<string>();
     keyv.opts.namespace; // $ExpectType string
-    keyv.opts.deserialize; // $ExpectType (data: string) => DeserializedData<string>
+    keyv.opts.deserialize; // $ExpectType (data: string) => DeserializedData<string> | undefined
     keyv.opts.serialize; // $ExpectType (data: DeserializedData<string>) => string
     keyv.opts.store; // $ExpectType Store<string>
 
     // Base options accessible and typed correctly with TOpts used
     const customOptsKeyv = new Keyv<string, { customProperty: string }>();
     customOptsKeyv.opts.namespace; // $ExpectType string
-    customOptsKeyv.opts.deserialize; // $ExpectType (data: string) => DeserializedData<string>
+    customOptsKeyv.opts.deserialize; // $ExpectType (data: string) => DeserializedData<string> | undefined
     customOptsKeyv.opts.serialize; // $ExpectType (data: DeserializedData<string>) => string
     customOptsKeyv.opts.store; // $ExpectType Store<string>
 
     // TOpts typings are correct when used
-    customOptsKeyv.opts.customProperty; // $ExpectType string;
+    customOptsKeyv.opts.customProperty; // $ExpectType string
 }

--- a/types/keyv/keyv-tests.ts
+++ b/types/keyv/keyv-tests.ts
@@ -56,3 +56,22 @@ new Keyv();
     await keyv.delete('foo'); // $ExpectType boolean
     await keyv.clear(); // $ExpectType void
 })();
+
+{
+    // Base options accessible and typed correctly with TOpts unused
+    const keyv = new Keyv<string>();
+    keyv.opts.namespace; // $ExpectType string
+    keyv.opts.deserialize; // $ExpectType (data: string) => DeserializedData<string>
+    keyv.opts.serialize; // $ExpectType (data: DeserializedData<string>) => string
+    keyv.opts.store; // $ExpectType Store<string>
+
+    // Base options accessible and typed correctly with TOpts used
+    const customOptsKeyv = new Keyv<string, { customProperty: string }>();
+    customOptsKeyv.opts.namespace; // $ExpectType string
+    customOptsKeyv.opts.deserialize; // $ExpectType (data: string) => DeserializedData<string>
+    customOptsKeyv.opts.serialize; // $ExpectType (data: DeserializedData<string>) => string
+    customOptsKeyv.opts.store; // $ExpectType Store<string>
+
+    // TOpts typings are correct when used
+    customOptsKeyv.opts.customProperty; // $ExpectType string;
+}


### PR DESCRIPTION
Keyv instances have a property `this.opts` (an object) which contains both a known set of properties which are always assigned (`deserialize`, `namespace`, `serialize`, `store`, and `uri`) as well as a set of optional properties, as well as a set of arbitrary properties which can be provided by the implementor.

This commit exposes the `Keyv.opts` property and allows the implementor to optionally type the arbitrary options they've provided via a new, second type parameter to the `Keyv` class.

The known set of properties comes from assignments that happen in the `constructor`:
https://github.com/jaredwray/keyv/blob/master/packages/keyv/src/index.js#L36-L49

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredwray/keyv/blob/master/packages/keyv/src/index.js#L36-L49
