### PR TITLE
[@wordpress/hooks] Add type definition for `@wordpress/hooks`

### DIFF
--- a/types/wordpress__hooks/createAddHook.d.ts
+++ b/types/wordpress__hooks/createAddHook.d.ts
@@ -1,0 +1,9 @@
+import { Callback, StoreKey } from '.';
+import { Hooks } from './createHooks';
+
+export type AddHook = (hookName: string, namespace: string, callback: Callback, priority?: number) => void;
+
+/**
+ * Returns a function which, when invoked, will add a hook.
+ */
+export default function createAddHook(hooks: Hooks, storeKey: StoreKey): AddHook;

--- a/types/wordpress__hooks/createCurrentHook.d.ts
+++ b/types/wordpress__hooks/createCurrentHook.d.ts
@@ -1,0 +1,11 @@
+import { StoreKey } from '.';
+import { Hooks } from './createHooks';
+
+export type CurrentHook = () => string | null;
+
+/**
+ * Returns a function which, when invoked, will return the name of the
+ * currently running hook, or `null` if no hook of the given type is currently
+ * running.
+ */
+export default function createCurrentHook(hooks: Hooks, storeKey: StoreKey): CurrentHook;

--- a/types/wordpress__hooks/createDidHook.d.ts
+++ b/types/wordpress__hooks/createDidHook.d.ts
@@ -1,0 +1,10 @@
+import { StoreKey } from '.';
+import { Hooks } from './createHooks';
+
+export type DidHook = (hookName: string) => number | undefined;
+
+/**
+ * Returns a function which, when invoked, will return the number of times a
+ * hook has been called.
+ */
+export default function createDidHook(hooks: Hooks, storeKey: StoreKey): DidHook;

--- a/types/wordpress__hooks/createDoingHook.d.ts
+++ b/types/wordpress__hooks/createDoingHook.d.ts
@@ -1,0 +1,10 @@
+import { StoreKey } from '.';
+import { Hooks } from './createHooks';
+
+export type DoingHook = (hookName: string) => boolean;
+
+/**
+ * Returns a function which, when invoked, will return whether a hook is
+ * currently being executed.
+ */
+export default function createDoingHook(hooks: Hooks, storeKey: StoreKey): DoingHook;

--- a/types/wordpress__hooks/createHasHook.d.ts
+++ b/types/wordpress__hooks/createHasHook.d.ts
@@ -1,0 +1,10 @@
+import { StoreKey } from '.';
+import { Hooks } from './createHooks';
+
+export type HasHook = (hookName: string, namespace?: string) => boolean;
+
+/**
+ * Returns a function which, when invoked, will return whether any handlers are
+ * attached to a particular hook.
+ */
+export default function createHasHook(hooks: Hooks, storeKey: StoreKey): HasHook;

--- a/types/wordpress__hooks/createHooks.d.ts
+++ b/types/wordpress__hooks/createHooks.d.ts
@@ -1,0 +1,38 @@
+import { AddHook } from './createAddHook';
+import { RemoveHook } from './createRemoveHook';
+import { HasHook } from './createHasHook';
+import { RunHook } from './createRunHook';
+import { CurrentHook } from './createCurrentHook';
+import { DoingHook } from './createDoingHook';
+import { DidHook } from './createDidHook';
+import { Store } from '.';
+
+export class Hooks {
+    actions: Store;
+    defaultHooks: Store;
+    filters: Store;
+
+    addAction: AddHook;
+    addFilter: AddHook;
+    applyFilters: RunHook;
+    currentAction: CurrentHook;
+    currentFilter: CurrentHook;
+    didAction: DidHook;
+    didFilter: DidHook;
+    doAction: RunHook;
+    doingAction: DoingHook;
+    doingFilter: DoingHook;
+    hasAction: HasHook;
+    hasFilter: HasHook;
+    removeAction: RemoveHook;
+    removeAllActions: RemoveHook;
+    removeAllFilters: RemoveHook;
+    removeFilter: RemoveHook;
+
+    constructor();
+}
+
+/**
+ * Returns an instance of the hooks object.
+ */
+export default function createHooks(): Hooks;

--- a/types/wordpress__hooks/createRemoveHook.d.ts
+++ b/types/wordpress__hooks/createRemoveHook.d.ts
@@ -1,0 +1,10 @@
+import { StoreKey } from '.';
+import { Hooks } from './createHooks';
+
+export type RemoveHook = (hookName: string, namespace?: string) => number | undefined;
+
+/**
+ * Returns a function which, when invoked, will remove a specified hook or all
+ * hooks by the given name.
+ */
+export default function createRemoveHook(hooks: Hooks, storeKey: StoreKey, removeAll?: boolean): RemoveHook;

--- a/types/wordpress__hooks/createRunHook.d.ts
+++ b/types/wordpress__hooks/createRunHook.d.ts
@@ -1,0 +1,11 @@
+import { StoreKey } from '.';
+import { Hooks } from './createHooks';
+
+export type RunHook = (hookName: string, ...args: unknown[]) => unknown;
+
+/**
+ * Returns a function which, when invoked, will execute all callbacks
+ * registered to a hook of the specified type, optionally returning the final
+ * value of the call chain.
+ */
+export default function createRunHook(hooks: Hooks, storeKey: StoreKey, returnFirstArg?: boolean): RunHook;

--- a/types/wordpress__hooks/index.d.ts
+++ b/types/wordpress__hooks/index.d.ts
@@ -1,0 +1,73 @@
+// Type definitions for @wordpress/hooks 3.3
+// Project: https://github.com/WordPress/gutenberg/tree/trunk/packages/hooks
+// Definitions by: Martin Badin <https://github.com/martin-badin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { default as createHooks, Hooks } from './createHooks';
+
+export type Callback = (...args: any[]) => any;
+
+interface Handler {
+    callback: Callback;
+    namespace: string;
+    priority: number;
+}
+
+interface Hook {
+    handlers: Handler[];
+    runs: number;
+}
+
+interface Current {
+    name: string;
+    currentIndex: number;
+}
+
+export type Store = Record<string, Hook> & { __current: Current[] };
+
+export type StoreKey = 'actions' | 'filters';
+
+declare const hooks: Hooks;
+
+declare const {
+    addAction,
+    addFilter,
+    removeAction,
+    removeFilter,
+    hasAction,
+    hasFilter,
+    removeAllActions,
+    removeAllFilters,
+    doAction,
+    applyFilters,
+    currentAction,
+    currentFilter,
+    doingAction,
+    doingFilter,
+    didAction,
+    didFilter,
+    actions,
+    filters,
+}: Hooks;
+
+export {
+    createHooks,
+    addAction,
+    addFilter,
+    removeAction,
+    removeFilter,
+    hasAction,
+    hasFilter,
+    removeAllActions,
+    removeAllFilters,
+    doAction,
+    applyFilters,
+    currentAction,
+    currentFilter,
+    doingAction,
+    doingFilter,
+    didAction,
+    didFilter,
+    actions,
+    filters,
+};

--- a/types/wordpress__hooks/tsconfig.json
+++ b/types/wordpress__hooks/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@wordpress/*": ["wordpress__*"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "wordpress__hooks-tests.ts"
+    ]
+}

--- a/types/wordpress__hooks/tslint.json
+++ b/types/wordpress__hooks/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/wordpress__hooks/wordpress__hooks-tests.ts
+++ b/types/wordpress__hooks/wordpress__hooks-tests.ts
@@ -1,0 +1,62 @@
+import {
+    addAction,
+    addFilter,
+    applyFilters,
+    createHooks,
+    didAction,
+    didFilter,
+    doAction,
+    doingAction,
+    doingFilter,
+    hasAction,
+    hasFilter,
+    removeAction,
+    removeAllActions,
+    removeAllFilters,
+    removeFilter,
+} from '@wordpress/hooks';
+
+const callback = () => {};
+const priority = 10;
+const arg1 = 'arg1';
+
+// $ExpectType Hooks
+const hooks = createHooks();
+
+hooks.addAction('hookName', 'namespace', callback); // $ExpectType void
+
+addAction('hookName', 'namespace', callback); // $ExpectType void
+addAction('hookName', 'namespace', callback, priority); // $ExpectType void
+
+addFilter('hookName', 'namespace', callback); // $ExpectType void
+addFilter('hookName', 'namespace', callback, priority); // $ExpectType void
+
+removeAction('hookName'); // $ExpectType number | undefined
+removeAction('hookName', 'namespace'); // $ExpectType number | undefined
+
+removeFilter('hookName'); // $ExpectType number | undefined
+removeFilter('hookName', 'namespace'); // $ExpectType number | undefined
+
+removeAllActions('hookName'); // $ExpectType number | undefined
+
+removeAllFilters('hookName'); // $ExpectType number | undefined
+
+doAction('hookName'); // $ExpectType unknown
+doAction('hookName', arg1); // $ExpectType unknown
+
+applyFilters('hookName'); // $ExpectType unknown
+applyFilters('hookName', arg1); // $ExpectType unknown
+
+doingAction('hookName'); // $ExpectType boolean
+
+doingFilter('hookName'); // $ExpectType boolean
+
+didAction('hookName'); // $ExpectType number | undefined
+
+didFilter('hookName'); // $ExpectType number | undefined
+
+hasAction('hookName'); // $ExpectType boolean
+hasAction('hookName', 'namespace'); // $ExpectType boolean
+
+hasFilter('hookName'); // $ExpectType boolean
+hasFilter('hookName', 'namespace'); // $ExpectType boolean


### PR DESCRIPTION
Add a new type definition for `@wordpress/hooks`

Documentation: https://github.com/WordPress/gutenberg/tree/trunk/packages/hooks

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test wordpress__hooks`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.