### PR TITLE
node/v12: add missing "readFloatBE"

### DIFF
--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -529,6 +529,7 @@ declare class Buffer extends Uint8Array {
     readInt32LE(offset?: number): number;
     readInt32BE(offset?: number): number;
     readFloatLE(offset?: number): number;
+    readFloatBE(offset?: number): number;
     readDoubleLE(offset?: number): number;
     readDoubleBE(offset?: number): number;
     reverse(): this;

--- a/types/node/v12/test/global.ts
+++ b/types/node/v12/test/global.ts
@@ -52,3 +52,74 @@ const a: NodeJS.TypedArray = new Buffer(123);
     writableFinished = writable.writableFinished;
     writable.destroyed;
 }
+
+{
+  const obj = {
+    valueOf() {
+      return 'hello';
+    }
+  };
+  Buffer.from(obj);
+}
+
+const buff = Buffer.from("Hello World!");
+
+// reads
+
+buff.readInt8();
+buff.readInt8(0);
+buff.readUInt8();
+buff.readUInt8(0);
+buff.readUInt16BE();
+buff.readUInt16BE(0);
+buff.readUInt32LE();
+buff.readUInt32LE(0);
+buff.readUInt32BE();
+buff.readUInt32BE(0);
+buff.readInt8();
+buff.readInt8(0);
+buff.readInt16LE();
+buff.readInt16LE(0);
+buff.readInt16BE();
+buff.readInt16BE(0);
+buff.readInt32LE();
+buff.readInt32LE(0);
+buff.readInt32BE();
+buff.readInt32BE(0);
+buff.readFloatLE();
+buff.readFloatLE(0);
+buff.readFloatBE();
+buff.readFloatBE(0);
+buff.readDoubleLE();
+buff.readDoubleBE(0);
+
+// writes
+
+buff.writeInt8(0xab);
+buff.writeInt8(0xab, 0);
+buff.writeUInt8(0xab);
+buff.writeUInt8(0xab, 0);
+buff.writeUInt16LE(0xabcd);
+buff.writeUInt16LE(0xabcd, 0);
+buff.writeUInt16BE(0xabcd);
+buff.writeUInt16BE(0xabcd, 0);
+buff.writeUInt32LE(0xabcd);
+buff.writeUInt32LE(0xabcd, 0);
+buff.writeUInt32BE(0xabcd);
+buff.writeUInt32BE(0xabcd, 0);
+buff.writeInt16LE(0xabcd);
+buff.writeInt16LE(0xabcd, 0);
+buff.writeInt16BE(0xabcd);
+buff.writeInt16BE(0xabcd, 0);
+buff.writeInt32LE(0xabcd);
+buff.writeInt32LE(0xabcd, 0);
+buff.writeInt32BE(0xabcd);
+buff.writeInt32BE(0xabcd, 0);
+buff.writeFloatLE(0xabcd);
+buff.writeFloatLE(0xabcd, 0);
+buff.writeFloatBE(0xabcd);
+buff.writeFloatBE(0xabcd, 0);
+buff.writeDoubleLE(123.123);
+buff.writeDoubleLE(123.123, 0);
+buff.writeDoubleBE(123.123);
+buff.writeDoubleBE(123.123, 0);


### PR DESCRIPTION
```
error TS2551: Property 'readFloatBE' does not exist on type 'Buffer'.

Did you mean 'readFloatLE'?
```

'readFloatBE' was erroneously removed in #58626.

This change restores it and copies Buffer tests from v14.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.