### PR TITLE
react-datepicker: no `null` in max/min date

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -100,9 +100,9 @@ export interface ReactDatePickerProps<CustomModifierNames extends string = never
     focusSelectedMonth?: boolean | undefined;
     isClearable?: boolean | undefined;
     locale?: string | Locale | undefined;
-    maxDate?: Date | null | undefined;
+    maxDate?: Date | undefined;
     maxTime?: Date | undefined;
-    minDate?: Date | null | undefined;
+    minDate?: Date | undefined;
     minTime?: Date | undefined;
     monthsShown?: number | undefined;
     name?: string | undefined;


### PR DESCRIPTION
When one passes `null` as `maxDate`/`minDate` property, it is treated not as "no bound" (as `undefined` is), but as "invalid date" instead, and breaks some features such as keyboard navigation. This is very unlikely to be expected, so it'd be better to change the type for this props to `Date | undefined`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
