### PR TITLE
[ramda] fix: allow readonly in `fromPairs`

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -812,7 +812,7 @@ export function forEachObjIndexed<T>(fn: (value: T[keyof T], key: keyof T, obj: 
 /**
  * Creates a new object out of a list key-value pairs.
  */
-export function fromPairs<V>(pairs: Array<KeyValuePair<string, V>> | Array<KeyValuePair<number, V>>): { [index: string]: V };
+export function fromPairs<V>(pairs: ReadonlyArray<Readonly<KeyValuePair<string, V>>> | ReadonlyArray<Readonly<KeyValuePair<number, V>>>): { [index: string]: V };
 
 /**
  * Splits a list into sublists stored in an object, based on the result of

--- a/types/ramda/test/fromPairs-tests.ts
+++ b/types/ramda/test/fromPairs-tests.ts
@@ -1,10 +1,12 @@
 import * as R from 'ramda';
 
 () => {
+  // $ExpectType { [index: string]: number; }
   R.fromPairs([['a', 1], ['b', 2], ['c', 3]]); // => {a: 1, b: 2, c: 3}
 
   // $ExpectType { [index: string]: string; }
   R.fromPairs([[1, "a"], [2, "b"]]); // => { '1': 'a', '2': 'b' }
 
+  // $ExpectType { [index: string]: 2 | 3 | 1; }
   R.fromPairs([['a', 1], ['b', 2], ['c', 3]] as const); // => {a: 1, b: 2, c: 3}
 };

--- a/types/ramda/test/fromPairs-tests.ts
+++ b/types/ramda/test/fromPairs-tests.ts
@@ -5,4 +5,6 @@ import * as R from 'ramda';
 
   // $ExpectType { [index: string]: string; }
   R.fromPairs([[1, "a"], [2, "b"]]); // => { '1': 'a', '2': 'b' }
+
+  R.fromPairs([['a', 1], ['b', 2], ['c', 3]] as const); // => {a: 1, b: 2, c: 3}
 };


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes ([Playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEpwGZQiOAcimRABNlCBuAKBoGMIA7VeZKKOAXjgG1DKAGiIAjQsML1CAXRTpGLGLQbNWcGAFM1PDADpc+AArJgUVAAp2UXSGRhz54JpDDgASm4A+PsFfPZaHAKrG5uVEA)):
```ts
import * as R from 'ramda';
const arr = ['a', 'b', 'c'] as const;
const currentlyFails = R.fromPairs(arr.map((item, i) => [i, item] as const));
```
This is a contrived example, but it shouldn't be a breaking change, plus there _are_ those who want this to work