### PR TITLE
[lodash] Extend typescript support of lodash.isPlainObject function

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -1114,7 +1114,7 @@ declare module "../index" {
          * @param value The value to check.
          * @return Returns true if value is a plain object, else false.
          */
-        isPlainObject(value?: any): boolean;
+        isPlainObject(value?: any): value is Record<string, unknown>;
     }
     interface LoDashImplicitWrapper<TValue> {
         /**


### PR DESCRIPTION
Initially this changes inspired by impelentation of `_.isSet` function.

When I'm using typescript each time after I check raw object with `_.isPlainObject` function inside operator I should cast raw object to plain by `Record<string, unknown>` to properly work with. 

Sample, this case I can't access `foo` property because of non fully check after which typesctipr doesn't really know which type the object is:

```typescript
const rawObject = {foo: 'bar'};
if (_.isPlainObject(rawObject)) {
	rawObject.f̼o̼o̼ = 'baz';
}
```

To make it work I should made a cast and this case accessing `foo` property is possible:

```typescript
const rawObject = {foo: 'bar'};
if (_.isPlainObject(rawObject)) {
	const typedObject = rawObject as Record<string, unknown>;
	typedObject.foo = 'baz';
}
```

Proposed changes change allow to cast raw object ot plain on a check and easily access `foo` property with such construction:

```typescript
const rawObject = {foo: 'bar'};
if (_.isPlainObject(rawObject)) {
	rawObject.foo = 'baz';
}
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

