### PR TITLE
[canvas-multiline-text] Fix issues with node-canvas

### DIFF
--- a/types/canvas-multiline-text/canvas-multiline-text-tests.ts
+++ b/types/canvas-multiline-text/canvas-multiline-text-tests.ts
@@ -1,6 +1,6 @@
 import drawMultilineText = require('canvas-multiline-text');
 
-// When no Context is given
+// When no Context is given then it should return 10 as the default
 // $ExpectType number
 drawMultilineText({} as any, 'Test', {
     minFontSize: 10,

--- a/types/canvas-multiline-text/index.d.ts
+++ b/types/canvas-multiline-text/index.d.ts
@@ -4,6 +4,8 @@
 //                 Kiara <https://github.com/DragonCat4012>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import { CanvasRenderingContext2D as NodeCanvasRenderingContext2D } from 'canvas';
+
 interface Options {
     rect?: {
         x: number;
@@ -12,12 +14,17 @@ interface Options {
         height: number;
     };
     font?: string;
+    stroke?: boolean;
     verbose?: boolean;
     lineHeight?: number;
     minFontSize?: number;
     maxFontSize?: number;
 }
 
-declare function drawMultilineText(ctx: CanvasRenderingContext2D, text: string, opts?: Options): number;
+declare function drawMultilineText(
+    ctx: CanvasRenderingContext2D | NodeCanvasRenderingContext2D,
+    text: string,
+    opts?: Options,
+): number;
 
 export = drawMultilineText;

--- a/types/canvas-multiline-text/package.json
+++ b/types/canvas-multiline-text/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "version": "1.0.3",
+  "dependencies": {
+    "canvas": "^2.9.0"
+  }
+}

--- a/types/canvas-multiline-text/package.json
+++ b/types/canvas-multiline-text/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "version": "1.0.3",
   "dependencies": {
     "canvas": "^2.9.0"
   }


### PR DESCRIPTION
If changing an existing definition:
- Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [x] This PR resolves a compatibility issue

The CanvasRenderingContext2D of the `node-canvas` package doesn't fully overlap with the CanvasRenderingContext2D that is implemented in the browser, while the old typings used the CanvasRenderingContext2D implemented in the browser. As this package is mainly targeted for use with `node-canvas` the typings should allow the usage in NodeJS and browser environments. This can be found in the [README](https://gitlab.com/davideblasutto/canvas-multiline-text#canvas-multiline-text) of the package.