### PR TITLE
[tinymce] Move Writer and TreeWalker classes into correct namespaces

### DIFF
--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -1165,10 +1165,10 @@ export namespace dom {
 
         prev(): html.Node;
     }
-}
 
-export class TreeWalker implements TreeWalker {
-    constructor(startNode: html.Node, rootNode: html.Node);
+    class TreeWalker implements TreeWalker {
+        constructor(startNode: html.Node, rootNode: html.Node);
+    }
 }
 
 export namespace geom {
@@ -1339,10 +1339,10 @@ export namespace html {
 
         text(text: string, raw: boolean): void;
     }
-}
 
-export class Writer implements Writer {
-    constructor(settings: {});
+    class Writer implements Writer {
+        constructor(settings: {});
+    }
 }
 
 export namespace util {

--- a/types/tinymce/tinymce-tests.ts
+++ b/types/tinymce/tinymce-tests.ts
@@ -64,4 +64,9 @@ const settings: tinymce.Settings = {
 
 tinymce.init(settings);
 
-const t = new tinymce.util.Color('#FFFFFF');
+const c = new tinymce.util.Color('#FFFFFF');
+
+const n1 = new tinymce.html.Node('strong', 1);
+const n2 = new tinymce.html.Node('strong', 2);
+const treeWalker = new tinymce.dom.TreeWalker(n1, n2);
+treeWalker.current();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.tiny.cloud/docs/api/tinymce.dom/tinymce.dom.treewalker/ and https://www.tiny.cloud/docs/api/tinymce.html/tinymce.html.writer/.

https://github.com/DefinitelyTyped/DefinitelyTyped/commit/7c688d2998ccec8547fd9e9a34a9afda1b262806 seems to have accidentally moved the `TreeWalker` and `Writer` classes into the top level of the typings module. Per https://www.tiny.cloud/docs/api/tinymce.dom/tinymce.dom.treewalker/ and https://www.tiny.cloud/docs/api/tinymce.html/tinymce.html.writer/ they should be in `tinymce.dom` and `tinymce.html` respectively.
