### PR TITLE
SuperTest: Fixes return type of host method

### DIFF
--- a/types/supertest/index.d.ts
+++ b/types/supertest/index.d.ts
@@ -36,7 +36,11 @@ declare namespace supertest {
     }
     function agent(app?: any, options?: AgentOptions): SuperAgentTest;
 
-    type SuperAgentTest = SuperTest<Test> &
+    interface SuperTest<T extends superagent.SuperAgentRequest> extends superagent.SuperAgent<T> {}
+    interface SuperTestWithHost<T extends superagent.SuperAgentRequest> extends SuperTest<T> {
+        host(host: string): this;
+    }
+    type SuperAgentTest = SuperTestWithHost<Test> &
         Pick<
             Request,
             | 'use'
@@ -59,7 +63,4 @@ declare namespace supertest {
             | 'pfx'
             | 'cert'
         >;
-    interface SuperTest<T extends superagent.SuperAgentRequest> extends superagent.SuperAgent<T> {
-        host(host: string): T;
-    }
 }

--- a/types/supertest/supertest-tests.ts
+++ b/types/supertest/supertest-tests.ts
@@ -44,7 +44,7 @@ supertest.agent(app, {
 supertest.agent(app).set({ host: 'google.com' });
 
 // agent has host methods
-supertest.agent(app).host('something.test'); // $ExpectType Test
+supertest.agent(app).host('something.test').get('/'); // $ExpectType Test
 
 // functional expect
 (request.get('/') as supertest.Test).expect(hasPreviousAndNextKeys).end((err: any, res: supertest.Response) => {

--- a/types/supertest/tslint.json
+++ b/types/supertest/tslint.json
@@ -4,6 +4,7 @@
         "ban-types": false,
         "dt-header": false,
         "no-empty-interface": false,
+        "no-outside-dependencies": false,
         "no-unnecessary-type-assertion": false,
         "unified-signatures": false
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test supertest`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/visionmedia/supertest/blob/a70c1a09c9b4ee47b77b6b3f32f77fc7eee24107/lib/agent.js#L39-L42) and [relevant source unit test](https://github.com/visionmedia/supertest/blob/a70c1a09c9b4ee47b77b6b3f32f77fc7eee24107/test/supertest.js#L975-L977).

The `host` method of the `supertest` library has had an incorrect definition of the `host` method available. It's been incorrectly available on the default export

```ts
import request from 'supertest'
import express from 'express'

const app = express()
request(app).host('foo.com') // does not actually exist
request.agent(app).host('foo.com') // only exists when using `agent` API
```

And the return type has been incorrect, indicating that a request was being returned instead of the `SuperTest` object.

This PR fixes both of those problems.