### PR TITLE
[node-pdftk] Fix configure opts typing

### DIFF
--- a/types/node-pdftk/index.d.ts
+++ b/types/node-pdftk/index.d.ts
@@ -277,10 +277,10 @@ export class PDFTK {
 }
 
 export interface ConfigureOptions {
-    bin: string;
-    Promise: PromiseConstructor;
-    ignoreWarnings: true;
-    tempDir: string;
+    bin?: string;
+    Promise?: PromiseConstructor;
+    ignoreWarnings?: true;
+    tempDir?: string;
 }
 
 export function input(file: string | Buffer | Buffer[] | Partial<Record<Letter, string | Buffer>>): PDFTK;

--- a/types/node-pdftk/node-pdftk-tests.ts
+++ b/types/node-pdftk/node-pdftk-tests.ts
@@ -7,6 +7,10 @@ PDFTK.configure({
     tempDir: './pdftk',
 });
 
+PDFTK.configure({
+    bin: '/usr/local/bin/pdftk',
+});
+
 [
     {
         input: 'string',


### PR DESCRIPTION
Why: when using the `import('node-pdftk').configure` function it's not mandatory to define all the options.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [example 1](https://github.com/jjwilly16/node-pdftk/blob/930fa33545b56ec92ceed7cc207b151a638961d0/test/options.tempDir.spec.js#L25), [example 2](https://github.com/jjwilly16/node-pdftk/blob/930fa33545b56ec92ceed7cc207b151a638961d0/index.js#L29-L50)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

