### PR TITLE
[chrome] Add missing definitions of functions (mainly MV3)

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3561,11 +3561,23 @@ declare namespace chrome.extension {
     /**
      * Retrieves the state of the extension's access to the 'file://' scheme (as determined by the user-controlled 'Allow access to File URLs' checkbox.
      * Since Chrome 12.
+     * @return The `isAllowedFileSchemeAccess` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function isAllowedFileSchemeAccess(): Promise<boolean>;
+    /**
+     * Retrieves the state of the extension's access to the 'file://' scheme (as determined by the user-controlled 'Allow access to File URLs' checkbox.
+     * Since Chrome 12.
      * @param callback The callback parameter should be a function that looks like this:
      * function(boolean isAllowedAccess) {...};
      * Parameter isAllowedAccess: True if the extension can access the 'file://' scheme, false otherwise.
      */
     export function isAllowedFileSchemeAccess(callback: (isAllowedAccess: boolean) => void): void;
+    /**
+     * Retrieves the state of the extension's access to Incognito-mode (as determined by the user-controlled 'Allowed in Incognito' checkbox.
+     * Since Chrome 12.
+     * @return The `isAllowedIncognitoAccess` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function isAllowedIncognitoAccess(): Promise<boolean>;
     /**
      * Retrieves the state of the extension's access to Incognito-mode (as determined by the user-controlled 'Allowed in Incognito' checkbox.
      * Since Chrome 12.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1048,7 +1048,7 @@ declare namespace chrome.browsingData {
      * Reports which types of data are currently selected in the 'Clear browsing data' settings UI. Note: some of the data types included in this API are not available in the settings UI, and some UI settings control more than one data type listed here.
      * @return The `settings` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
      */
-     export function settings(): Promise<SettingsResult>;
+    export function settings(): Promise<SettingsResult>;
     /**
      * Since Chrome 26.
      * Reports which types of data are currently selected in the 'Clear browsing data' settings UI. Note: some of the data types included in this API are not available in the settings UI, and some UI settings control more than one data type listed here.
@@ -1270,7 +1270,7 @@ declare namespace chrome.commands {
      * Returns all the registered extension commands for this extension and their shortcut (if active).
      * @return The `getAll` method provides its result via callback or returned as a `Promise` (MV3 only).
      */
-     export function getAll(): Promise<Command[]>;
+    export function getAll(): Promise<Command[]>;
     /**
      * Returns all the registered extension commands for this extension and their shortcut (if active).
      * @param callback Called to return the registered commands.
@@ -4456,7 +4456,7 @@ declare namespace chrome.i18n {
      * @return The `getAcceptLanguages` method provides its result via callback or returned as a `Promise` (MV3 only).
      * @since MV3
      */
-     export function getAcceptLanguages(): Promise<string[]>;
+    export function getAcceptLanguages(): Promise<string[]>;
     /**
      * Gets the accept-languages of the browser. This is different from the locale used by the browser; to get the locale, use i18n.getUILanguage.
      * @param callback The callback parameter should be a function that looks like this:
@@ -4481,7 +4481,7 @@ declare namespace chrome.i18n {
      * @return The `detectLanguage` method provides its result via callback or returned as a `Promise` (MV3 only).
      * @since MV3
      */
-     export function detectLanguage(text: string): Promise<LanguageDetectionResult>;
+    export function detectLanguage(text: string): Promise<LanguageDetectionResult>;
     /** Detects the language of the provided text using CLD.
      * @param text User input string to be translated.
      * @param callback The callback parameter should be a function that looks like this: function(object result) {...};

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1035,7 +1035,7 @@ declare namespace chrome.browsingData {
         serviceWorkers?: boolean | undefined;
     }
 
-    export interface SettingsCallback {
+    export interface SettingsResult {
         options: RemovalOptions;
         /** All of the types will be present in the result, with values of true if they are both selected to be removed and permitted to be removed, otherwise false. */
         dataToRemove: DataTypeSet;
@@ -1046,10 +1046,24 @@ declare namespace chrome.browsingData {
     /**
      * Since Chrome 26.
      * Reports which types of data are currently selected in the 'Clear browsing data' settings UI. Note: some of the data types included in this API are not available in the settings UI, and some UI settings control more than one data type listed here.
+     * @return The `settings` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+     export function settings(): Promise<SettingsResult>;
+    /**
+     * Since Chrome 26.
+     * Reports which types of data are currently selected in the 'Clear browsing data' settings UI. Note: some of the data types included in this API are not available in the settings UI, and some UI settings control more than one data type listed here.
      * @param callback The callback parameter should be a function that looks like this:
      * function(object result) {...};
      */
-    export function settings(callback: (result: SettingsCallback) => void): void;
+    export function settings(callback: (result: SettingsResult) => void): void;
+    /**
+     * @deprecated Deprecated since Chrome 88.
+     * Support for Flash has been removed. This function has no effect.
+     *
+     * Clears plugins' data.
+     * @return The `removePluginData` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removePluginData(options: RemovalOptions): Promise<void>;
     /**
      * @deprecated Deprecated since Chrome 88.
      * Support for Flash has been removed. This function has no effect.
@@ -1063,6 +1077,12 @@ declare namespace chrome.browsingData {
     /**
      * Since Chrome 72.
      * Clears websites' service workers.
+     * @return The `removeServiceWorkers` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeServiceWorkers(options: RemovalOptions): Promise<void>;
+    /**
+     * Since Chrome 72.
+     * Clears websites' service workers.
      * @param callback Called when the browser's service workers have been cleared.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
@@ -1070,11 +1090,21 @@ declare namespace chrome.browsingData {
     export function removeServiceWorkers(options: RemovalOptions, callback?: () => void): void;
     /**
      * Clears the browser's stored form data (autofill).
+     * @return The `removeFormData` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeFormData(options: RemovalOptions): Promise<void>;
+    /**
+     * Clears the browser's stored form data (autofill).
      * @param callback Called when the browser's form data has been cleared.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function removeFormData(options: RemovalOptions, callback?: () => void): void;
+    /**
+     * Clears websites' file system data.
+     * @return The `removeFileSystems` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeFileSystems(options: RemovalOptions): Promise<void>;
     /**
      * Clears websites' file system data.
      * @param callback Called when websites' file systems have been cleared.
@@ -1085,11 +1115,22 @@ declare namespace chrome.browsingData {
     /**
      * Clears various types of browsing data stored in a user's profile.
      * @param dataToRemove The set of data types to remove.
+     * @return The `remove` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function remove(options: RemovalOptions, dataToRemove: DataTypeSet): Promise<void>;
+    /**
+     * Clears various types of browsing data stored in a user's profile.
+     * @param dataToRemove The set of data types to remove.
      * @param callback Called when deletion has completed.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function remove(options: RemovalOptions, dataToRemove: DataTypeSet, callback?: () => void): void;
+    /**
+     * Clears the browser's stored passwords.
+     * @return The `removePasswords` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removePasswords(options: RemovalOptions): Promise<void>;
     /**
      * Clears the browser's stored passwords.
      * @param callback Called when the browser's passwords have been cleared.
@@ -1099,11 +1140,21 @@ declare namespace chrome.browsingData {
     export function removePasswords(options: RemovalOptions, callback?: () => void): void;
     /**
      * Clears the browser's cookies and server-bound certificates modified within a particular timeframe.
+     * @return The `removeCookies` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeCookies(options: RemovalOptions, callback?: () => void): Promise<void>;
+    /**
+     * Clears the browser's cookies and server-bound certificates modified within a particular timeframe.
      * @param callback Called when the browser's cookies and server-bound certificates have been cleared.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function removeCookies(options: RemovalOptions, callback?: () => void): void;
+    /**
+     * Clears websites' WebSQL data.
+     * @return The `removeWebSQL` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeWebSQL(options: RemovalOptions): Promise<void>;
     /**
      * Clears websites' WebSQL data.
      * @param callback Called when websites' WebSQL databases have been cleared.
@@ -1113,11 +1164,31 @@ declare namespace chrome.browsingData {
     export function removeWebSQL(options: RemovalOptions, callback?: () => void): void;
     /**
      * Clears websites' appcache data.
+     * @return The `removeAppcache` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeAppcache(options: RemovalOptions): Promise<void>;
+    /**
+     * Clears websites' appcache data.
      * @param callback Called when websites' appcache data has been cleared.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function removeAppcache(options: RemovalOptions, callback?: () => void): void;
+    /** Clears websites' cache storage data.
+     * @return The `removeCacheStorage` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeCacheStorage(options: RemovalOptions): Promise<void>
+    /** Clears websites' cache storage data.
+     * @param callback Called when websites' appcache data has been cleared.
+     * If you specify the callback parameter, it should be a function that looks like this:
+     * function() {...};
+     */
+    export function removeCacheStorage(options: RemovalOptions, callback?: () => void): void
+    /**
+     * Clears the browser's list of downloaded files (not the downloaded files themselves).
+     * @return The `removeDownloads` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeDownloads(options: RemovalOptions): Promise<void>
     /**
      * Clears the browser's list of downloaded files (not the downloaded files themselves).
      * @param callback Called when the browser's list of downloaded files has been cleared.
@@ -1127,11 +1198,21 @@ declare namespace chrome.browsingData {
     export function removeDownloads(options: RemovalOptions, callback?: () => void): void;
     /**
      * Clears websites' local storage data.
+     * @return The `removeLocalStorage` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeLocalStorage(options: RemovalOptions): Promise<void>;
+    /**
+     * Clears websites' local storage data.
      * @param callback Called when websites' local storage has been cleared.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function removeLocalStorage(options: RemovalOptions, callback?: () => void): void;
+    /**
+     * Clears the browser's cache.
+     * @return The `removeCache` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeCache(options: RemovalOptions): Promise<void>;
     /**
      * Clears the browser's cache.
      * @param callback Called when the browser's cache has been cleared.
@@ -1141,11 +1222,21 @@ declare namespace chrome.browsingData {
     export function removeCache(options: RemovalOptions, callback?: () => void): void;
     /**
      * Clears the browser's history.
+     * @return The `removeHistory` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeHistory(options: RemovalOptions): Promise<void>;
+    /**
+     * Clears the browser's history.
      * @param callback Called when the browser's history has cleared.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function removeHistory(options: RemovalOptions, callback?: () => void): void;
+    /**
+     * Clears websites' IndexedDB data.
+     * @return The `removeIndexedDB` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeIndexedDB(options: RemovalOptions): Promise<void>;
     /**
      * Clears websites' IndexedDB data.
      * @param callback Called when websites' IndexedDB data has been cleared.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4522,10 +4522,20 @@ declare namespace chrome.history {
 
     /**
      * Searches the history for the last visit time of each page matching the query.
+     * @return The `search` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function search(query: HistoryQuery): Promise<HistoryItem[]>;
+    /**
+     * Searches the history for the last visit time of each page matching the query.
      * @param callback The callback parameter should be a function that looks like this:
      * function(array of HistoryItem results) {...};
      */
-    export function search(query: HistoryQuery, callback: (results: HistoryItem[]) => void): void;
+    export function search(query: HistoryQuery, callback?: (results: HistoryItem[]) => void): void;
+    /**
+     * Adds a URL to the history at the current time with a transition type of "link".
+     * @return The `addUrl` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function addUrl(details: Url): Promise<void>;
     /**
      * Adds a URL to the history at the current time with a transition type of "link".
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
@@ -4534,10 +4544,20 @@ declare namespace chrome.history {
     export function addUrl(details: Url, callback?: () => void): void;
     /**
      * Removes all items within the specified date range from the history. Pages will not be removed from the history unless all visits fall within the range.
+     * @return The `deleteRange` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function deleteRange(range: Range): Promise<void>;
+    /**
+     * Removes all items within the specified date range from the history. Pages will not be removed from the history unless all visits fall within the range.
      * @param callback The callback parameter should be a function that looks like this:
      * function() {...};
      */
-    export function deleteRange(range: Range, callback: () => void): void;
+    export function deleteRange(range: Range, callback?: () => void): void;
+    /**
+     * Deletes all items from the history.
+     * @return The `deleteAll` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function deleteAll(): Promise<void>;
     /**
      * Deletes all items from the history.
      * @param callback The callback parameter should be a function that looks like this:
@@ -4546,10 +4566,20 @@ declare namespace chrome.history {
     export function deleteAll(callback: () => void): void;
     /**
      * Retrieves information about visits to a URL.
+     * @return The `getVisits` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function getVisits(details: Url): Promise<VisitItem[]>;
+    /**
+     * Retrieves information about visits to a URL.
      * @param callback The callback parameter should be a function that looks like this:
      * function(array of VisitItem results) {...};
      */
     export function getVisits(details: Url, callback: (results: VisitItem[]) => void): void;
+    /**
+     * Removes all occurrences of the given URL from the history.
+     * @return The `deleteUrl` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function deleteUrl(details: Url): Promise<void>;
     /**
      * Removes all occurrences of the given URL from the history.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2076,6 +2076,13 @@ declare module chrome {
          * Attaches debugger to the given target.
          * @param target Debugging target to which you want to attach.
          * @param requiredVersion Required debugging protocol version ("0.1"). One can only attach to the debuggee with matching major version and greater or equal minor version. List of the protocol versions can be obtained in the documentation pages.
+         * @return The `attach` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         */
+         export function attach(target: Debuggee, requiredVersion: string): Promise<void>;
+        /**
+         * Attaches debugger to the given target.
+         * @param target Debugging target to which you want to attach.
+         * @param requiredVersion Required debugging protocol version ("0.1"). One can only attach to the debuggee with matching major version and greater or equal minor version. List of the protocol versions can be obtained in the documentation pages.
          * @param callback Called once the attach operation succeeds or fails. Callback receives no arguments. If the attach fails, runtime.lastError will be set to the error message.
          * If you specify the callback parameter, it should be a function that looks like this:
          * function() {...};
@@ -2084,11 +2091,30 @@ declare module chrome {
         /**
          * Detaches debugger from the given target.
          * @param target Debugging target from which you want to detach.
+         * @return The `detach` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         */
+        export function detach(target: Debuggee): Promise<void>;
+        /**
+         * Detaches debugger from the given target.
+         * @param target Debugging target from which you want to detach.
          * @param callback Called once the detach operation succeeds or fails. Callback receives no arguments. If the detach fails, runtime.lastError will be set to the error message.
          * If you specify the callback parameter, it should be a function that looks like this:
          * function() {...};
          */
         export function detach(target: Debuggee, callback?: () => void): void;
+        /**
+         * Sends given command to the debugging target.
+         * @param target Debugging target to which you want to send the command.
+         * @param method Method name. Should be one of the methods defined by the remote debugging protocol.
+         * @param commandParams Since Chrome 22.
+         * JSON object with request parameters. This object must conform to the remote debugging params scheme for given method.
+         * @return The `sendCommand` method provides its result via callback or returned as a `Promise` (MV3 only).
+         */
+        export function sendCommand(
+            target: Debuggee,
+            method: string,
+            commandParams?: Object,
+        ): Promise<Object>;
         /**
          * Sends given command to the debugging target.
          * @param target Debugging target to which you want to send the command.
@@ -2105,6 +2131,12 @@ declare module chrome {
             commandParams?: Object,
             callback?: (result?: Object) => void,
         ): void;
+        /**
+         * Since Chrome 28.
+         * Returns the list of available debug targets.
+         * @return The `getTargets` method provides its result via callback or returned as a `Promise` (MV3 only).
+         */
+        export function getTargets(): Promise<TargetInfo[]>;
         /**
          * Since Chrome 28.
          * Returns the list of available debug targets.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3010,10 +3010,21 @@ declare namespace chrome.downloads {
 
     /**
      * Find DownloadItem. Set query to the empty object to get all DownloadItem. To get a specific DownloadItem, set only the id field. To page through a large number of items, set orderBy: ['-startTime'], set limit to the number of items per page, and set startedAfter to the startTime of the last item from the last page.
+     * @return The `search` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function search(query: DownloadQuery): Promise<DownloadItem[]>;
+    /**
+     * Find DownloadItem. Set query to the empty object to get all DownloadItem. To get a specific DownloadItem, set only the id field. To page through a large number of items, set orderBy: ['-startTime'], set limit to the number of items per page, and set startedAfter to the startTime of the last item from the last page.
      * @param callback The callback parameter should be a function that looks like this:
      * function(array of DownloadItem results) {...};
      */
     export function search(query: DownloadQuery, callback: (results: DownloadItem[]) => void): void;
+    /**
+     * Pause the download. If the request was successful the download is in a paused state. Otherwise runtime.lastError contains an error message. The request will fail if the download is not active.
+     * @param downloadId The id of the download to pause.
+     * @return The `pause` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function pause(downloadId: number): Promise<void>;
     /**
      * Pause the download. If the request was successful the download is in a paused state. Otherwise runtime.lastError contains an error message. The request will fail if the download is not active.
      * @param downloadId The id of the download to pause.
@@ -3022,6 +3033,12 @@ declare namespace chrome.downloads {
      * function() {...};
      */
     export function pause(downloadId: number, callback?: () => void): void;
+    /**
+     * Retrieve an icon for the specified download. For new downloads, file icons are available after the onCreated event has been received. The image returned by this function while a download is in progress may be different from the image returned after the download is complete. Icon retrieval is done by querying the underlying operating system or toolkit depending on the platform. The icon that is returned will therefore depend on a number of factors including state of the download, platform, registered file types and visual theme. If a file icon cannot be determined, runtime.lastError will contain an error message.
+     * @param downloadId The identifier for the download.
+     * @return The `getFileIcon` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function getFileIcon(downloadId: number, options?: GetFileIconOptions): Promise<string>;
     /**
      * Retrieve an icon for the specified download. For new downloads, file icons are available after the onCreated event has been received. The image returned by this function while a download is in progress may be different from the image returned after the download is complete. Icon retrieval is done by querying the underlying operating system or toolkit depending on the platform. The icon that is returned will therefore depend on a number of factors including state of the download, platform, registered file types and visual theme. If a file icon cannot be determined, runtime.lastError will contain an error message.
      * @param downloadId The identifier for the download.
@@ -3045,6 +3062,12 @@ declare namespace chrome.downloads {
     /**
      * Resume a paused download. If the request was successful the download is in progress and unpaused. Otherwise runtime.lastError contains an error message. The request will fail if the download is not active.
      * @param downloadId The id of the download to resume.
+     * @return The `resume` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function resume(downloadId: number): Promise<void>;
+    /**
+     * Resume a paused download. If the request was successful the download is in progress and unpaused. Otherwise runtime.lastError contains an error message. The request will fail if the download is not active.
+     * @param downloadId The id of the download to resume.
      * @param callback  Called when the resume request is completed.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
@@ -3053,11 +3076,23 @@ declare namespace chrome.downloads {
     /**
      * Cancel a download. When callback is run, the download is cancelled, completed, interrupted or doesn't exist anymore.
      * @param downloadId The id of the download to cancel.
+     * @return The `cancel` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function cancel(downloadId: number): Promise<void>;
+    /**
+     * Cancel a download. When callback is run, the download is cancelled, completed, interrupted or doesn't exist anymore.
+     * @param downloadId The id of the download to cancel.
      * @param callback Called when the cancel request is completed.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function cancel(downloadId: number, callback?: () => void): void;
+    /**
+     * Download a URL. If the URL uses the HTTP[S] protocol, then the request will include all cookies currently set for its hostname. If both filename and saveAs are specified, then the Save As dialog will be displayed, pre-populated with the specified filename. If the download started successfully, callback will be called with the new DownloadItem's downloadId. If there was an error starting the download, then callback will be called with downloadId=undefined and runtime.lastError will contain a descriptive string. The error strings are not guaranteed to remain backwards compatible between releases. Extensions must not parse it.
+     * @param options What to download and how.
+     * @return The `download` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function download(options: DownloadOptions): Promise<number>;
     /**
      * Download a URL. If the URL uses the HTTP[S] protocol, then the request will include all cookies currently set for its hostname. If both filename and saveAs are specified, then the Save As dialog will be displayed, pre-populated with the specified filename. If the download started successfully, callback will be called with the new DownloadItem's downloadId. If there was an error starting the download, then callback will be called with downloadId=undefined and runtime.lastError will contain a descriptive string. The error strings are not guaranteed to remain backwards compatible between releases. Extensions must not parse it.
      * @param options What to download and how.
@@ -3080,16 +3115,32 @@ declare namespace chrome.downloads {
     export function showDefaultFolder(): void;
     /**
      * Erase matching DownloadItem from history without deleting the downloaded file. An onErased event will fire for each DownloadItem that matches query, then callback will be called.
+     * @return The `erase` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function erase(query: DownloadQuery): Promise<number[]>;
+    /**
+     * Erase matching DownloadItem from history without deleting the downloaded file. An onErased event will fire for each DownloadItem that matches query, then callback will be called.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
      * function(array of integer erasedIds) {...};
      */
     export function erase(query: DownloadQuery, callback: (erasedIds: number[]) => void): void;
     /**
      * Remove the downloaded file if it exists and the DownloadItem is complete; otherwise return an error through runtime.lastError.
+     * @return The `removeFile` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function removeFile(downloadId: number): Promise<void>;
+    /**
+     * Remove the downloaded file if it exists and the DownloadItem is complete; otherwise return an error through runtime.lastError.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function removeFile(downloadId: number, callback?: () => void): void;
+    /**
+     * Prompt the user to accept a dangerous download. Can only be called from a visible context (tab, window, or page/browser action popup). Does not automatically accept dangerous downloads. If the download is accepted, then an onChanged event will fire, otherwise nothing will happen. When all the data is fetched into a temporary file and either the download is not dangerous or the danger has been accepted, then the temporary file is renamed to the target filename, the |state| changes to 'complete', and onChanged fires.
+     * @param downloadId The identifier for the DownloadItem.
+     * @return The `acceptDanger` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function acceptDanger(downloadId: number): Promise<void>;
     /**
      * Prompt the user to accept a dangerous download. Can only be called from a visible context (tab, window, or page/browser action popup). Does not automatically accept dangerous downloads. If the download is accepted, then an onChanged event will fire, otherwise nothing will happen. When all the data is fetched into a temporary file and either the download is not dangerous or the danger has been accepted, then the temporary file is renamed to the target filename, the |state| changes to 'complete', and onChanged fires.
      * @param downloadId The identifier for the DownloadItem.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4453,6 +4453,12 @@ declare namespace chrome.i18n {
 
     /**
      * Gets the accept-languages of the browser. This is different from the locale used by the browser; to get the locale, use i18n.getUILanguage.
+     * @return The `getAcceptLanguages` method provides its result via callback or returned as a `Promise` (MV3 only).
+     * @since MV3
+     */
+     export function getAcceptLanguages(): Promise<string[]>;
+    /**
+     * Gets the accept-languages of the browser. This is different from the locale used by the browser; to get the locale, use i18n.getUILanguage.
      * @param callback The callback parameter should be a function that looks like this:
      * function(array of string languages) {...};
      * Parameter languages: Array of the accept languages of the browser, such as en-US,en,zh-CN
@@ -4470,6 +4476,12 @@ declare namespace chrome.i18n {
      */
     export function getUILanguage(): string;
 
+    /** Detects the language of the provided text using CLD.
+     * @param text User input string to be translated.
+     * @return The `detectLanguage` method provides its result via callback or returned as a `Promise` (MV3 only).
+     * @since MV3
+     */
+     export function detectLanguage(text: string): Promise<LanguageDetectionResult>;
     /** Detects the language of the provided text using CLD.
      * @param text User input string to be translated.
      * @param callback The callback parameter should be a function that looks like this: function(object result) {...};

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1268,6 +1268,11 @@ declare namespace chrome.commands {
 
     /**
      * Returns all the registered extension commands for this extension and their shortcut (if active).
+     * @return The `getAll` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+     export function getAll(): Promise<Command[]>;
+    /**
+     * Returns all the registered extension commands for this extension and their shortcut (if active).
      * @param callback Called to return the registered commands.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function(array of Command commands) {...};

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4139,7 +4139,13 @@ declare namespace chrome.fontSettings {
 
     export interface FontDetails {
         /** The generic font family for the font. */
-        genericFamily: string;
+        genericFamily:
+            | 'cursive'
+            | 'fantasy'
+            | 'fixed'
+            | 'sansserif'
+            | 'serif'
+            | 'standard';
         /** Optional. The script for the font. If omitted, the global script font setting is affected.  */
         script?: string | undefined;
     }
@@ -4189,16 +4195,32 @@ declare namespace chrome.fontSettings {
 
     /**
      * Sets the default font size.
+     * @return The `setDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function setDefaultFontSize(details: DefaultFontSizeDetails): Promise<void>
+    /**
+     * Sets the default font size.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function setDefaultFontSize(details: DefaultFontSizeDetails, callback?: Function): void;
     /**
      * Gets the font for a given script and generic font family.
+     * @return The `getFont` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function getFont(details: FontDetails): Promise<FontDetailsResult>
+    /**
+     * Gets the font for a given script and generic font family.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
      * function(object details) {...};
      */
     export function getFont(details: FontDetails, callback?: (details: FontDetailsResult) => void): void;
+    /**
+     * Gets the default font size.
+     * @param details This parameter is currently unused.
+     * @return The `getDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function getDefaultFontSize(details?: Object): Promise<FontSizeDetails>;
     /**
      * Gets the default font size.
      * @param details This parameter is currently unused.
@@ -4209,16 +4231,33 @@ declare namespace chrome.fontSettings {
     /**
      * Gets the minimum font size.
      * @param details This parameter is currently unused.
+     * @return The `getMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function getMinimumFontSize(details?: object): Promise<FontSizeDetails>;
+    /**
+     * Gets the minimum font size.
+     * @param details This parameter is currently unused.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
      * function(object details) {...};
      */
-    export function getMinimumFontSize(details?: FontSizeDetails, callback?: (options: FontSizeDetails) => void): void;
+    export function getMinimumFontSize(details?: object, callback?: (options: FontSizeDetails) => void): void;
+    /**
+     * Sets the minimum font size.
+     * @return The `setMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function setMinimumFontSize(details: SetFontSizeDetails): Promise<void>;
     /**
      * Sets the minimum font size.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function setMinimumFontSize(details: SetFontSizeDetails, callback?: Function): void;
+    /**
+     * Gets the default size for fixed width fonts.
+     * @param details This parameter is currently unused.
+     * @return The `getDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function getDefaultFixedFontSize(details?: Object): Promise<FontSizeDetails>;
     /**
      * Gets the default size for fixed width fonts.
      * @param details This parameter is currently unused.
@@ -4229,10 +4268,21 @@ declare namespace chrome.fontSettings {
     /**
      * Clears the default font size set by this extension, if any.
      * @param details This parameter is currently unused.
+     * @return The `clearDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function clearDefaultFontSize(details?: Object): Promise<void>;
+    /**
+     * Clears the default font size set by this extension, if any.
+     * @param details This parameter is currently unused.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function clearDefaultFontSize(details?: Object, callback?: Function): void;
+    /**
+     * Sets the default size for fixed width fonts.
+     * @return The `setDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function setDefaultFixedFontSize(details: SetFontSizeDetails): Promise<void>;
     /**
      * Sets the default size for fixed width fonts.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
@@ -4241,10 +4291,20 @@ declare namespace chrome.fontSettings {
     export function setDefaultFixedFontSize(details: SetFontSizeDetails, callback?: Function): void;
     /**
      * Clears the font set by this extension, if any.
+     * @return The `clearFont` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function clearFont(details: FontDetails): Promise<void>;
+    /**
+     * Clears the font set by this extension, if any.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function clearFont(details: FontDetails, callback?: Function): void;
+    /**
+     * Sets the font for a given script and generic font family.
+     * @return The `setFont` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function setFont(details: SetFontDetails): Promise<void>;
     /**
      * Sets the font for a given script and generic font family.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
@@ -4254,16 +4314,33 @@ declare namespace chrome.fontSettings {
     /**
      * Clears the minimum font size set by this extension, if any.
      * @param details This parameter is currently unused.
+     * @return The `clearMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function clearMinimumFontSize(details?: Object): Promise<void>;
+    /**
+     * Clears the minimum font size set by this extension, if any.
+     * @param details This parameter is currently unused.
      * @param callback If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
     export function clearMinimumFontSize(details?: Object, callback?: Function): void;
     /**
      * Gets a list of fonts on the system.
+     * @return The `getFontList` method provides its result via callback or returned as a `Promise` (MV3 only).
+     */
+    export function getFontList(): Promise<FontName[]>;
+    /**
+     * Gets a list of fonts on the system.
      * @param callback The callback parameter should be a function that looks like this:
      * function(array of FontName results) {...};
      */
-    export function getFontList(callback: (results: FontName[]) => void): void;
+    export function getFontList(callback?: (results: FontName[]) => void): void;
+    /**
+     * Clears the default fixed font size set by this extension, if any.
+     * @param details This parameter is currently unused.
+     * @return The `clearDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+     */
+    export function clearDefaultFixedFontSize(details: Object): Promise<void>;
     /**
      * Clears the default fixed font size set by this extension, if any.
      * @param details This parameter is currently unused.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1313,6 +1313,20 @@ async function testCommands() {
     chrome.commands.getAll((commands) => {})
 }
 
+// https://developer.chrome.com/docs/extensions/reference/i18n
+function testI18n() {
+    chrome.i18n.getAcceptLanguages((languages) => {});
+    chrome.i18n.getMessage("dummy-id", "Hello World!");
+    chrome.i18n.getUILanguage();
+    chrome.i18n.detectLanguage("dummy-id", (result) => {});
+}
+
+// https://developer.chrome.com/docs/extensions/reference/i18n
+async function testI18nForPromise() {
+    await chrome.i18n.getAcceptLanguages();
+    await chrome.i18n.detectLanguage("dummy-id");
+}
+
 function testPageCapture() {
   chrome.pageCapture.saveAsMHTML({ tabId: 0 }, (data: Blob | undefined) => {});
 }

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1380,3 +1380,39 @@ async function testExtensionForPromise() {
     await chrome.extension.isAllowedFileSchemeAccess()
     await chrome.extension.isAllowedIncognitoAccess()
 }
+
+// https://developer.chrome.com/docs/extensions/reference/fontSettings
+function testFontSettings() {
+    chrome.fontSettings.setDefaultFontSize({ pixelSize: 1 }, () => {})
+    chrome.fontSettings.getFont({}, (details) => {}) // $ExpectError
+    chrome.fontSettings.getFont({ genericFamily: '' }, (details) => {}) // $ExpectError
+    chrome.fontSettings.getFont({ genericFamily: 'cursive' }, (details) => {})
+    chrome.fontSettings.getDefaultFontSize({}, (options) => {})
+    chrome.fontSettings.getMinimumFontSize({}, (options) => {})
+    chrome.fontSettings.setMinimumFontSize({ pixelSize: 1 }, () => {})
+    chrome.fontSettings.getDefaultFixedFontSize({}, (details) => {})
+    chrome.fontSettings.clearDefaultFontSize({}, () => {})
+    chrome.fontSettings.setDefaultFixedFontSize({ pixelSize: 1 }, () => {})
+    chrome.fontSettings.clearFont({ genericFamily: 'cursive' }, () => {})
+    chrome.fontSettings.setFont({ genericFamily: 'cursive', fontId: '' }, () => {})
+    chrome.fontSettings.clearMinimumFontSize({}, () => {})
+    chrome.fontSettings.getFontList((results) => {})
+    chrome.fontSettings.clearDefaultFixedFontSize({}, () => {})
+}
+
+// https://developer.chrome.com/docs/extensions/reference/fontSettings
+async function testFontSettingsForPromise() {
+    await chrome.fontSettings.setDefaultFontSize({ pixelSize: 1 })
+    await chrome.fontSettings.getFont({ genericFamily: 'cursive' })
+    await chrome.fontSettings.getDefaultFontSize({})
+    await chrome.fontSettings.getMinimumFontSize({})
+    await chrome.fontSettings.setMinimumFontSize({ pixelSize: 1 })
+    await chrome.fontSettings.getDefaultFixedFontSize({})
+    await chrome.fontSettings.clearDefaultFontSize({})
+    await chrome.fontSettings.setDefaultFixedFontSize({ pixelSize: 1 })
+    await chrome.fontSettings.clearFont({ genericFamily: 'cursive' })
+    await chrome.fontSettings.setFont({ genericFamily: 'cursive', fontId: '' })
+    await chrome.fontSettings.clearMinimumFontSize({})
+    await chrome.fontSettings.getFontList()
+    await chrome.fontSettings.clearDefaultFixedFontSize({})
+}

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1363,3 +1363,20 @@ async function testDownloadsForPromise() {
     await chrome.downloads.removeFile(1)
     await chrome.downloads.acceptDanger(1)
 }
+
+// https://developer.chrome.com/docs/extensions/reference/extension
+function testExtension() {
+    chrome.extension.getBackgroundPage()
+    chrome.extension.getURL('/')
+    chrome.extension.setUpdateUrlData('')
+    chrome.extension.getViews({})
+    chrome.extension.isAllowedFileSchemeAccess((isAllowedAccess) => {})
+    chrome.extension.isAllowedIncognitoAccess((isAllowedAccess) => {})
+    chrome.extension.getExtensionTabs(1)
+}
+
+// https://developer.chrome.com/docs/extensions/reference/extension
+async function testExtensionForPromise() {
+    await chrome.extension.isAllowedFileSchemeAccess()
+    await chrome.extension.isAllowedIncognitoAccess()
+}

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1330,3 +1330,36 @@ async function testI18nForPromise() {
 function testPageCapture() {
   chrome.pageCapture.saveAsMHTML({ tabId: 0 }, (data: Blob | undefined) => {});
 }
+
+// https://developer.chrome.com/docs/extensions/reference/downloads
+function testDownloads() {
+    chrome.downloads.search({}, (results) => {})
+    chrome.downloads.pause(1, () => {})
+    chrome.downloads.getFileIcon(1, (iconURL) => {})
+    chrome.downloads.getFileIcon(1, {}, (iconURL) => {})
+    chrome.downloads.resume(1, () => {})
+    chrome.downloads.cancel(1, () => {})
+    chrome.downloads.download({ url: 'https://example.com' }, (downloadId) => {})
+    chrome.downloads.open(1)
+    chrome.downloads.show(1)
+    chrome.downloads.showDefaultFolder()
+    chrome.downloads.erase({}, (erasedIds) => {})
+    chrome.downloads.removeFile(1, () => {})
+    chrome.downloads.acceptDanger(1, () => {})
+    chrome.downloads.drag(1)
+    chrome.downloads.setShelfEnabled(true)
+}
+
+// https://developer.chrome.com/docs/extensions/reference/downloads
+async function testDownloadsForPromise() {
+    await chrome.downloads.search({})
+    await chrome.downloads.pause(1)
+    await chrome.downloads.getFileIcon(1)
+    await chrome.downloads.getFileIcon(1, {})
+    await chrome.downloads.resume(1)
+    await chrome.downloads.cancel(1)
+    await chrome.downloads.download({ url: 'https://example.com' })
+    await chrome.downloads.erase({})
+    await chrome.downloads.removeFile(1)
+    await chrome.downloads.acceptDanger(1)
+}

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -632,6 +632,14 @@ function testDebugger() {
     });
 }
 
+// https://developer.chrome.com/extensions/debugger
+async function testDebuggerForPromise() {
+    await chrome.debugger.attach({ tabId: 123 }, '1.23');
+    await chrome.debugger.detach({ tabId: 123 });
+    await chrome.debugger.sendCommand({ targetId: 'abc' }, 'Debugger.Cmd', { param1: 'x' });
+    await chrome.debugger.getTargets();
+}
+
 // https://developer.chrome.com/extensions/declarativeContent
 function testDeclarativeContent() {
     const activeIcon: ImageData = new ImageData(32, 32);

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1299,6 +1299,12 @@ async function testBrowsingDataForPromise() {
     await chrome.browsingData.removeIndexedDB({})
 }
 
+// https://developer.chrome.com/docs/extensions/reference/commands
+async function testCommands() {
+    await chrome.commands.getAll()
+    chrome.commands.getAll((commands) => {})
+}
+
 function testPageCapture() {
   chrome.pageCapture.saveAsMHTML({ tabId: 0 }, (data: Blob | undefined) => {});
 }

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1258,10 +1258,45 @@ function testEnterpriseDeviceAttributes() {
   chrome.enterprise.deviceAttributes.getDeviceHostname((hostName) => {});
 }
 
+// https://developer.chrome.com/docs/extensions/reference/browsingData
 function testBrowsingData() {
     chrome.browsingData.removeServiceWorkers(); // $ExpectError
     chrome.browsingData.removeServiceWorkers({});
     chrome.browsingData.removeServiceWorkers({}, () => {});
+    chrome.browsingData.settings((result) => {})
+    chrome.browsingData.removePluginData({}, () => {})
+    chrome.browsingData.removeServiceWorkers({}, () => {})
+    chrome.browsingData.removeFormData({}, () => {})
+    chrome.browsingData.removeFileSystems({}, () => {})
+    chrome.browsingData.remove({}, {}, () => {})
+    chrome.browsingData.removePasswords({}, () => {})
+    chrome.browsingData.removeCookies({}, () => {})
+    chrome.browsingData.removeWebSQL({}, () => {})
+    chrome.browsingData.removeAppcache({}, () => {})
+    chrome.browsingData.removeCacheStorage({}, () => {})
+    chrome.browsingData.removeDownloads({}, () => {})
+    chrome.browsingData.removeCache({}, () => {})
+    chrome.browsingData.removeHistory({}, () => {})
+    chrome.browsingData.removeIndexedDB({}, () => {})
+}
+
+// https://developer.chrome.com/docs/extensions/reference/browsingData
+async function testBrowsingDataForPromise() {
+    await chrome.browsingData.settings()
+    await chrome.browsingData.removePluginData({})
+    await chrome.browsingData.removeServiceWorkers({})
+    await chrome.browsingData.removeFormData({})
+    await chrome.browsingData.removeFileSystems({})
+    await chrome.browsingData.remove({}, {})
+    await chrome.browsingData.removePasswords({})
+    await chrome.browsingData.removeCookies({})
+    await chrome.browsingData.removeWebSQL({})
+    await chrome.browsingData.removeAppcache({})
+    await chrome.browsingData.removeCacheStorage({})
+    await chrome.browsingData.removeDownloads({})
+    await chrome.browsingData.removeCache({})
+    await chrome.browsingData.removeHistory({})
+    await chrome.browsingData.removeIndexedDB({})
 }
 
 function testPageCapture() {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1416,3 +1416,26 @@ async function testFontSettingsForPromise() {
     await chrome.fontSettings.getFontList()
     await chrome.fontSettings.clearDefaultFixedFontSize({})
 }
+
+// https://developer.chrome.com/docs/extensions/reference/history
+function testHistory() {
+    chrome.history.search({}, (results) => {}) // $ExpectError
+    chrome.history.search({ text: ''}, (results) => {})
+    chrome.history.addUrl({}, () => {}) // $ExpectError
+    chrome.history.addUrl({ url: 'https://example.com'}, () => {})
+    chrome.history.deleteRange({}, () => {}) // $ExpectError
+    chrome.history.deleteRange({ startTime: 1646172000000, endTime: 1646258400000}, () => {})
+    chrome.history.deleteAll(() => {})
+    chrome.history.deleteUrl({ url: 'https://example.com'}, () => {})
+    chrome.history.getVisits({ url: 'https://example.com'}, () => {})
+}
+
+// https://developer.chrome.com/docs/extensions/reference/history
+async function testHistoryForPromise() {
+    await chrome.history.search({ text: ''})
+    await chrome.history.addUrl({ url: 'https://example.com'})
+    await chrome.history.deleteRange({ startTime: 1646172000000, endTime: 1646258400000})
+    await chrome.history.deleteAll()
+    await chrome.history.deleteUrl({ url: 'https://example.com'})
+    await chrome.history.getVisits({ url: 'https://example.com'})
+}


### PR DESCRIPTION
This pull request adds definitions for missing functions in a number of `chrome.*` namespaces.

I have noticed that some of the definitions for chrome are out of date and don't include the new [MV3](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#promises) promise-based signatures, so I decided to update the definitions myself. I have not not updated all namespaces, so there is still work to be done updating the rest of the definitions.
While updating the definitions, I have noticed a few incorrect parameter types or completely missing functions, so I went ahead and added them too.
I have tried to to keep using the same style already found in the files.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: See bellow.

All new/modified signatures in this PR are from the official documentation (https://developer.chrome.com/docs/extensions/reference).
Note that the definitions in the linked resources incorrectly say that returning a promise "is coming soon and not yet in a stable release of Chrome". This is not true, and I have tested all function signatures using the latest stable Chrome version (v99) before adding them.
Links to individual documentation pages in case they are needed:
* chrome.browsingData - https://developer.chrome.com/docs/extensions/reference/browsingData
* chrome.commands - https://developer.chrome.com/docs/extensions/reference/commands
* chrome.debugger - https://developer.chrome.com/docs/extensions/reference/debugger
* chrome.downloads - https://developer.chrome.com/docs/extensions/reference/downloads
* chrome.extension - https://developer.chrome.com/docs/extensions/reference/extension
* chrome.fontSettings - https://developer.chrome.com/docs/extensions/reference/fontSettings
* chrome.history - https://developer.chrome.com/docs/extensions/reference/history
* chrome.i18n - https://developer.chrome.com/docs/extensions/reference/i18n