### PR TITLE
fix(mailchimp__mailchimp_transactional): expose types when using 'export = ' syntax

### DIFF
--- a/types/mailchimp__mailchimp_transactional/index.d.ts
+++ b/types/mailchimp__mailchimp_transactional/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Pieter Scheffers <https://github.com/PieterScheffers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace MailChimpTransactional {
+declare namespace Mailchimp {
     type OutputFormat = 'json' | 'xml' | 'php' | 'yaml';
 
     type SendingStatus = 'sent' | 'queued' | 'scheduled' | 'rejected' | 'invalid';
@@ -172,5 +172,5 @@ declare namespace MailChimpTransactional {
     }
 }
 
-declare function instance(apiKey: string): MailChimpTransactional.ApiClient;
-export = instance;
+declare function Mailchimp(apiKey: string): Mailchimp.ApiClient;
+export = Mailchimp;

--- a/types/mailchimp__mailchimp_transactional/mailchimp__mailchimp_transactional-tests.ts
+++ b/types/mailchimp__mailchimp_transactional/mailchimp__mailchimp_transactional-tests.ts
@@ -14,3 +14,5 @@ mailchimp.messages.send({
         ],
     },
 });
+
+export default mailchimp;


### PR DESCRIPTION
The types were private because the namespace was not exported. This is solved with this PR. Now the types can be correctly used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59174#issuecomment-1062156527
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
