### PR TITLE
[object-fit-images] Fix name: objectFillImages -> objectFitImages

### DIFF
--- a/types/object-fit-images/index.d.ts
+++ b/types/object-fit-images/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: Ranjit Singh <https://github.com/rann91>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export as namespace objectFillImages;
+export as namespace objectFitImages;
 
-export = objectFillImages;
+export = objectFitImages;
 
-declare function objectFillImages(
+declare function objectFitImages(
     images?: string | HTMLElement | HTMLElement[] | NodeList | null,
     options?: { watchMQ?: boolean | undefined; skipTest?: boolean | undefined },
 ): void;

--- a/types/object-fit-images/object-fit-images-tests.ts
+++ b/types/object-fit-images/object-fit-images-tests.ts
@@ -3,4 +3,4 @@ img.setAttribute('src', 'https://i.picsum.photos/id/565/536/354.jpg');
 
 document.appendChild(img);
 
-objectFillImages(img);
+objectFitImages(img);


### PR DESCRIPTION
object-fit-images does not have `objectFillImages` function.
There is `objectFitImages`.
https://github.com/fregante/object-fit-images/blob/master/dist/ofi.js#L2

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [the implementation of the package](https://github.com/fregante/object-fit-images/blob/master/dist/ofi.js#L2)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - The type definition is incorrect when the conventional type definition is published.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
