### PR TITLE
Support nullary use of lodash cond function

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -220,7 +220,8 @@ declare module "../index" {
          */
         conformsTo(source: ConformsPredicateObject<TValue>): PrimitiveChain<boolean>;
     }
-    type CondPair<T, R> = [(val: T) => boolean, (val: T) => R];
+    type CondPairNullary<R> = [() => boolean, () => R];
+    type CondPairUnary<T, R> = [(val: T) => boolean, (val: T) => R];
     interface LoDashStatic {
         /**
          * Performs a [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero)

--- a/types/lodash/common/util.d.ts
+++ b/types/lodash/common/util.d.ts
@@ -79,7 +79,8 @@ declare module "../index" {
          * func({ 'a': '1', 'b': '2' });
          * // => 'no match'
          */
-        cond<T, R>(pairs: Array<CondPair<T, R>>): (Target: T) => R;
+        cond<R>(pairs: Array<CondPairNullary<R>>): () => R;
+        cond<T, R>(pairs: Array<CondPairUnary<T, R>>): (Target: T) => R;
     }
 
     type ConformsPredicateObject<T> = {

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -317,7 +317,10 @@ declare namespace _ {
     }
     type LodashConcat1x1<T> = (values: lodash.Many<T>) => T[];
     type LodashConcat1x2<T> = (array: lodash.Many<T>) => T[];
-    type LodashCond = <T, R>(pairs: Array<lodash.CondPair<T, R>>) => (Target: T) => R;
+    interface LodashCond {
+        <R>(pairs: Array<lodash.CondPairNullary<R>>): () => R;
+        <T, R>(pairs: Array<lodash.CondPairUnary<T, R>>): (Target: T) => R;
+    }
     interface LodashConformsTo {
         <T>(source: lodash.ConformsPredicateObject<T>): LodashConformsTo1x1<T>;
         <T>(source: lodash.__, object: T): LodashConformsTo1x2<T>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -6688,6 +6688,14 @@ fp.now(); // $ExpectType number
 
     _.cond([[pairPred1, pairRes1], [pairPred2, pairRes2]])("hello"); // $ExpectType number
     fp.cond([[pairPred1, pairRes1], [pairPred2, pairRes2]])("hello"); // $ExpectType number
+
+    const nullaryPred1 = () => true;
+    const nullaryPred2 = () => false;
+    const nullaryRes1 = () => 1;
+    const nullaryRes2 = () => 2;
+
+    _.cond([[nullaryPred1, nullaryRes1], [nullaryPred2, nullaryRes2]])(); // $ExpectType number
+    fp.cond([[nullaryPred1, nullaryRes1], [nullaryPred2, nullaryRes2]])(); // $ExpectType number
 }
 
 // _.constant


### PR DESCRIPTION
## Description

Current typings for `cond` expect unary functions both as arguments and as a return value.

```ts
const lengthCase = _.cond([
    [
        (str: string) => str.length > 3,
        (str: string) => str.toUpperCase()
    ],
    [
        (str: string) => str.length <= 3,
        (str: string) => str.toLowerCase()
    ]
]);

lengthCase('FooBar');  // 'FOOBAR'
lengthCase('Baz');  // 'baz'
```

However, it is entirely valid to use `cond` with nullary functions, such as when dealing with constants or closures:

```ts
let str = 'FooBar';

const lengthCase = _.cond([
    [
        () => str.length > 3,
        () => str.toUpperCase()
    ],
    [
        _.stubTrue,
        () => str.toLowerCase()
    ]
]);

lengthCase();  // 'FOOBAR'
```

This change adds typing support for these nullary cases, both in the fp and main lodash modules.


## Checklist

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.15#cond
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.  _(see below)_

### Note on version numbers

The guidance on version numbers is unclear to me. I have incremented the minor version because this PR introduces a small breaking change. Previous to this change, the type checker will pass code when someone used `cond`, relying on type inference, passing an argument to the returned function, but with parameter functions that are nullary. Example:

```ts
let str = 'FooBar';

const lengthCase = _.cond([
    [
        () => str.length >= 3,
        () => str.toUpperCase()
    ],
    [
        _.stubTrue,
        () => str.toLowerCase()
    ]
]);

lengthCase('Baz');  // <-- This should probably be nullary
```

With these proposed changes, this code now fails a type check. As it is a somewhat nonsensical use of `cond`, this seems like the correct behavior to me, however, it is possible some existing code is written this way and will fail once these changes are incorporated. Hence the version bump.

However, this change has nothing to do with bringing these types into parity with lodash 4.15, so perhaps the version change is incorrect? Happy to update the PR if that is the case.

If necessary, I can also update the PR so that the changes are non-breaking. This will mean that code like the preceding example will continue to pass type checks. As I said, I think this is a less correct approach, but perhaps backwards compatibility is a higher priority.