### PR TITLE
Fix return type of Archive#open

### DIFF
--- a/types/libarchive.js/libarchive.js-tests.ts
+++ b/types/libarchive.js/libarchive.js-tests.ts
@@ -4,8 +4,8 @@ let testFile: File = new File([""], "filename");
 const testArchive = new Archive(testFile, { workerUrl: 'test'});
 
 Archive.init({ workerUrl: 'test' });
-Archive.open(testFile);
-Archive.open(testFile, { workerUrl: 'test' });
+Archive.open(testFile).then(e => void e);
+Archive.open(testFile, { workerUrl: 'test' }).then(e => void e);
 
 const FilesObject1: { [key: string]: any } = {
     test2: testFile

--- a/types/libarchive.js/src/libarchive.d.ts
+++ b/types/libarchive.js/src/libarchive.d.ts
@@ -5,7 +5,7 @@ export interface FilesObject { [key: string]: FilesObject | CompressedFile | Fil
 export class Archive {
   static init(options?: { workerUrl: string }): { workerUrl: string };
 
-  static open(file: File, options?: { workerUrl: string }): Archive;
+  static open(file: File, options?: { workerUrl: string }): Promise<Archive>;
 
   constructor(file: File, options: { workerUrl: string });
 


### PR DESCRIPTION
`Archive.open(f, o)` calls `new Archive(f, o)` and returns `archive.open()`, which returns a `Promise<Archive>`.
So this method is actually asynchronous.

Refs:
https://github.com/nika-begiashvili/libarchivejs#readme

https://github.com/nika-begiashvili/libarchivejs/blob/d2c4d676e5de69aebb1a68cd084a9419b653eae4/src/libarchive.js#L24-L30

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nika-begiashvili/libarchivejs/blob/d2c4d676e5de69aebb1a68cd084a9419b653eae4/src/libarchive.js#L24-L30
