### PR TITLE
[mocha] Fix missing 'pending' value in Runnable.state type

### DIFF
--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -1144,7 +1144,7 @@ declare namespace Mocha {
         pending: boolean;
         duration?: number | undefined;
         parent?: Suite | undefined;
-        state?: 'failed' | 'passed' | undefined;
+        state?: 'failed' | 'passed' | 'pending' | undefined;
         timer?: any;
         ctx?: Context | undefined;
         callback?: Done | undefined;

--- a/types/mocha/mocha-tests.ts
+++ b/types/mocha/mocha-tests.ts
@@ -1457,3 +1457,9 @@ class TestClass2 {
 class TestClass3 {
 }
 // end of augmentations used by mocha-typescript
+
+function test_runnable_state(runnable: LocalMocha.Runnable) {
+    runnable.state = 'pending';
+    runnable.state = 'failed';
+    runnable.state = 'passed';
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [source](https://github.com/mochajs/mocha/blob/241964b71c7839263a33a18f0f36a0c6c43f73e2/lib/runnable.js#L453-L456), [documentation](https://mochajs.org/api/runnable)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
      The `'pending'` value was already introduced in Mocha [v8.0.0](https://github.com/mochajs/mocha/blob/v8.0.0/lib/runnable.js#L447-L450)
