### PR TITLE
Add BluetoothDevice.forget() to Web Bluetooth

### DIFF
--- a/types/web-bluetooth/index.d.ts
+++ b/types/web-bluetooth/index.d.ts
@@ -146,6 +146,7 @@ interface BluetoothDevice extends EventTarget, BluetoothDeviceEventHandlers, Cha
     readonly name?: string | undefined;
     readonly gatt?: BluetoothRemoteGATTServer | undefined;
     readonly uuids?: string[] | undefined;
+    forget(): Promise<void>;
     watchAdvertisements(): Promise<void>;
     unwatchAdvertisements(): void;
     readonly watchingAdvertisements: boolean;


### PR DESCRIPTION
This PR adds the new "BluetoothDevice.forget()" method. See https://github.com/WebBluetoothCG/web-bluetooth/pull/574

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
