### PR TITLE
hellosign-sdk: checkbox fields now support boolean values

### DIFF
--- a/types/hellosign-sdk/hellosign-sdk-tests.ts
+++ b/types/hellosign-sdk/hellosign-sdk-tests.ts
@@ -125,7 +125,7 @@ const signatureRequestResponse: HelloSign.SignatureRequestResponse = {
             {
                 name: 'name',
                 type: 'checkbox',
-                value: 'value',
+                value: true,
                 required: true,
                 api_id: 'api_id',
                 editor: 'editor',

--- a/types/hellosign-sdk/index.d.ts
+++ b/types/hellosign-sdk/index.d.ts
@@ -155,8 +155,15 @@ declare namespace HelloSign {
         custom_fields?:
             | Array<{
                   name: string;
-                  type: 'text' | 'checkbox';
+                  type: 'text';
                   value: string;
+                  required: boolean;
+                  api_id: string;
+                  editor: string;
+              } | {
+                  name: string;
+                  type: 'checkbox';
+                  value: boolean;
                   required: boolean;
                   api_id: string;
                   editor: string;
@@ -225,7 +232,7 @@ declare namespace HelloSign {
         custom_fields?:
             | Array<{
                   name: string;
-                  value: string;
+                  value: string | boolean;
                   editor?: string | undefined;
                   required?: boolean | undefined;
               }>
@@ -531,7 +538,7 @@ declare namespace HelloSign {
         custom_fields?:
             | Array<{
                   name: string;
-                  value: string;
+                  value: string | boolean;
                   editor?: string | undefined;
                   required?: boolean | undefined;
               }>


### PR DESCRIPTION
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: (https://app.hellosign.com/api/signature_request/create_embedded_with_template)

Hellosign's custom fields can include both text fields and checkbox fields, with strings passed into text fields and booleans passed into checkbox fields, as per https://app.hellosign.com/api/signature_request/create_embedded_with_template

Previously, the 'value' attribute of custom fields was typed as only a string. In order to support custom textbox fields, it should be a string or a boolean, and that's the change that this PR makes.