### PR TITLE
add preserveTrailingSpaces option of Style

### DIFF
--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -152,6 +152,7 @@ export interface Style {
     decorationColor?: string | undefined;
     margin?: Margins | undefined;
     preserveLeadingSpaces?: boolean | undefined;
+    preserveTrailingSpaces?: boolean | undefined;
     opacity?: number | undefined;
     characterSpacing?: number | undefined;
     leadingIndent?: number | undefined;

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -1420,6 +1420,11 @@ const stylingProperties: TDocumentDefinitions = {
         { text: '        "json": "nested"', preserveLeadingSpaces: true },
         { text: '    }', preserveLeadingSpaces: true },
         { text: '}', preserveLeadingSpaces: true },
+        '\n\nFor preserving trailing spaces use preserveTrailingSpaces property:',
+        {
+            text: 'This is a paragraph with preserved trailing spaces.    ',
+            preserveTrailingSpaces: true,
+        },
         '\n\nfontFeatures property:',
         { text: 'Hello World 1234567890', fontFeatures: ['smcp'] },
         { text: 'Hello World 1234567890', fontFeatures: ['c2sc'] },


### PR DESCRIPTION
It should be the same as option `preserveLeadingSpaces`, see package [pdfmake](https://github.com/bpampuch/pdfmake/blob/de29c549fab7f9613573bb3d2fbbb17a73ee77af/src/TextInlines.js#L153)