### PR TITLE
tcp-port-used: Fix TcpPortUsedOptions Typings

### DIFF
--- a/types/tcp-port-used/index.d.ts
+++ b/types/tcp-port-used/index.d.ts
@@ -5,10 +5,10 @@
 
 export interface TcpPortUsedOptions {
     port: number;
-    host: string;
-    status: boolean;
-    retryTimeMs: number;
-    timeOutMs: number;
+    host?: string;
+    status?: boolean;
+    retryTimeMs?: number;
+    timeOutMs?: number;
 }
 
 export function check(port: number | TcpPortUsedOptions, host?: string): Promise<boolean>;


### PR DESCRIPTION
Made some fields of the TcpPortUsedOptions optional in the package `tcp-port-used`
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Intentional library design - example shown here: https://github.com/stdarg/tcp-port-used/blob/master/index.js#L95-L98