### PR TITLE
@types/grecaptcha: Fix return type of v2 `grecaptcha.execute`

### DIFF
--- a/types/grecaptcha/index.d.ts
+++ b/types/grecaptcha/index.d.ts
@@ -38,7 +38,7 @@ declare namespace ReCaptchaV2 {
      * Programatically invoke the reCAPTCHA check. Used if the invisible reCAPTCHA is on a div instead of a button.
      * @param opt_widget_id Optional widget ID, defaults to the first widget created if unspecified.
      */
-    execute(opt_widget_id?: number): void;
+    execute(opt_widget_id?: number): PromiseLike<void>;
     /**
      * Programatically invoke the reCAPTCHA check. Used if the invisible reCAPTCHA is on a div instead of a button.
      * @param siteKey the key of your site


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: I believe the Google docs are returning the incorrect type, see the screenshot below for proof of the type
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

![Screen Shot 2022-03-13 at 18 37 01](https://user-images.githubusercontent.com/1935696/158072019-5a9f9dd0-a42b-4ca0-b521-793b41a22c14.png)