### PR TITLE
[sinonjs]: add missing `'queueMicrotask'` method name to `FakeMethod` type

### DIFF
--- a/types/sinonjs__fake-timers/index.d.ts
+++ b/types/sinonjs__fake-timers/index.d.ts
@@ -339,7 +339,7 @@ export interface FakeTimerInstallOpts {
     now?: number | Date | undefined;
 
     /**
-     * An array with names of methods/properties to fake. By default, `@sinonjs/fake-timers` does not replace `nextTick()` and `queueMicrotask()`.
+     * An array with names of global methods and APIs to fake. By default, `@sinonjs/fake-timers` does not replace `nextTick()` and `queueMicrotask()`.
      * For instance, `FakeTimers.install({ toFake: ['setTimeout', 'nextTick'] })` will fake only `setTimeout()` and `nextTick()`
      */
     toFake?: FakeMethod[] | undefined;

--- a/types/sinonjs__fake-timers/index.d.ts
+++ b/types/sinonjs__fake-timers/index.d.ts
@@ -339,7 +339,7 @@ export interface FakeTimerInstallOpts {
     now?: number | Date | undefined;
 
     /**
-     * An array with names of APIs to hijack. When not set, `@sinonjs/fake-timers` will fake all APIs except `nextTick()` and `queueMicrotask()`.
+     * An array with names of methods/properties to fake. By default, `@sinonjs/fake-timers` does not replace `nextTick()` and `queueMicrotask()`.
      * For instance, `FakeTimers.install({ toFake: ['setTimeout', 'nextTick'] })` will fake only `setTimeout()` and `nextTick()`
      */
     toFake?: FakeMethod[] | undefined;

--- a/types/sinonjs__fake-timers/index.d.ts
+++ b/types/sinonjs__fake-timers/index.d.ts
@@ -339,8 +339,8 @@ export interface FakeTimerInstallOpts {
     now?: number | Date | undefined;
 
     /**
-     * An array with names of function and object names to hijack. When not set, @sinonjs/fake-timers will automatically fake all methods except `nextTick()`
-     * and `queueMicrotask()`. For instance, `FakeTimers.install({ toFake: ['setTimeout', 'nextTick'] })` will fake only `setTimeout()` and `nextTick()`
+     * An array with names of APIs to hijack. When not set, `@sinonjs/fake-timers` will fake all APIs except `nextTick()` and `queueMicrotask()`.
+     * For instance, `FakeTimers.install({ toFake: ['setTimeout', 'nextTick'] })` will fake only `setTimeout()` and `nextTick()`
      */
     toFake?: FakeMethod[] | undefined;
 

--- a/types/sinonjs__fake-timers/index.d.ts
+++ b/types/sinonjs__fake-timers/index.d.ts
@@ -25,10 +25,11 @@ export type FakeMethod =
     | 'cancelAnimationFrame'
     | 'requestIdleCallback'
     | 'cancelIdleCallback'
-    | 'performance';
+    | 'performance'
+    | 'queueMicrotask';
 
 /**
- * Global methods avaliable to every clock and also as standalone methods (inside `timers` global object).
+ * Global methods available to every clock and also as standalone methods (inside `timers` global object).
  */
 export interface GlobalTimers<TTimerId extends TimerId> {
     /**
@@ -274,7 +275,7 @@ export type BrowserClock = FakeClock<number>;
  */
 export type NodeClock = FakeClock<NodeTimer> & {
     /**
-     * Mimicks process.hrtime().
+     * Mimics process.hrtime().
      *
      * @param prevTime   Previous system time to calculate time elapsed.
      * @returns High resolution real time as [seconds, nanoseconds].
@@ -338,8 +339,8 @@ export interface FakeTimerInstallOpts {
     now?: number | Date | undefined;
 
     /**
-     * An array with explicit function names to hijack. When not set, @sinonjs/fake-timers will automatically fake all methods except nextTick
-     * e.g., FakeTimers.install({ toFake: ["setTimeout", "nextTick"]}) will fake only setTimeout and nextTick
+     * An array with names of function and object names to hijack. When not set, @sinonjs/fake-timers will automatically fake all methods except `nextTick()`
+     * and `queueMicrotask()`. For instance, `FakeTimers.install({ toFake: ['setTimeout', 'nextTick'] })` will fake only `setTimeout()` and `nextTick()`
      */
     toFake?: FakeMethod[] | undefined;
 

--- a/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
+++ b/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
@@ -29,7 +29,7 @@ const browserInstalledClock = FakeTimers.install({
     now: 0,
     shouldAdvanceTime: true,
     shouldClearNativeTimers: true,
-    toFake: ['setTimeout', 'nextTick', 'hrtime', 'performance'],
+    toFake: ['setTimeout', 'requestAnimationFrame', 'queueMicrotask', 'performance'],
 }) as FakeTimers.BrowserClock & FakeTimers.InstalledClock;
 
 const nodeInstalledClock = FakeTimers.install({
@@ -38,7 +38,7 @@ const nodeInstalledClock = FakeTimers.install({
     now: new Date(0),
     shouldAdvanceTime: true,
     shouldClearNativeTimers: false,
-    toFake: ['setTimeout', 'nextTick', 'hrtime'],
+    toFake: ['setTimeout', 'nextTick', 'hrtime', 'performance'],
 }) as FakeTimers.NodeClock & FakeTimers.InstalledClock;
 
 const browserNow: number = browserClock.now;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Source code which provides context for the suggested changes: [here](https://github.com/sinonjs/fake-timers/blob/f8a09c9096715789147b1132c645281eb0c3e341/src/fake-timers-src.js#L1659-L1666)

Seems like the list of fakeable methods (`FakeMethod` union type) is missing `'queueMicrotask'`. Unfortunately it isn’t not mentioned in Sinon’s docs. The code base is huge, but in the link above one can see how `config.toFake` is normalised. It defaults to the list of keys of `clock.methods`, with `'nextTick'` and `'queueMicrotask'` (!) being excluded from the default list of faked methods. If a user would provide `config.toFake` list including `'queueMicrotask'`, the defaults will be overridden and `queueMicrotask()` will be faked. Or?

I have fixed a couple of minor typos too.