### PR TITLE
[angular-translate] Add allowNamespaces

### DIFF
--- a/types/angular-translate/angular-translate-tests.ts
+++ b/types/angular-translate/angular-translate-tests.ts
@@ -25,7 +25,7 @@ app.config(($translateProvider: angular.translate.ITranslateProvider) => {
         BUTTON_LANG_DE: 'deutsch'
     });
     $translateProvider.preferredLanguage('en');
-
+    $translateProvider.allowNamespaces(true);
     $translateProvider.useLoader('customLoader');
     $translateProvider.forceAsyncReload(true);
 });

--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Angular Translate (pascalprecht.translate module) 2.16
+// Type definitions for Angular Translate (pascalprecht.translate module) 2.19
 // Project: https://github.com/PascalPrecht/angular-translate
 // Definitions by: Michel Salib <https://github.com/michelsalib>,
 //                 Gabriel Gil <https://github.com/GabrielGil>,
@@ -53,6 +53,7 @@ declare module 'angular' {
             (translationId: string[], interpolateParams?: any, interpolationId?: string, defaultTranslationText?: string, forceLanguage?: string, sanitizeStrategy?: string): angular.IPromise<{ [key: string]: string }>;
             cloakClassName(): string;
             cloakClassName(name: string): ITranslateProvider;
+            allowNamespaces(): boolean;
             fallbackLanguage(langKey?: string): string;
             fallbackLanguage(langKey?: string[]): string;
             instant(translationId: string, interpolateParams?: any, interpolationId?: string, forceLanguage?: string, sanitizeStrategy?: string): string;
@@ -94,6 +95,8 @@ declare module 'angular' {
             translations(key: string, translationTable: ITranslationTable): ITranslateProvider;
             cloakClassName(): string;
             cloakClassName(name: string): ITranslateProvider;
+            allowNamespaces(): boolean;
+            allowNamespaces(namespacesEnabled: boolean): ITranslateProvider;
             addInterpolation(factory: any): ITranslateProvider;
             useMessageFormatInterpolation(): ITranslateProvider;
             useInterpolation(factory: string): ITranslateProvider;


### PR DESCRIPTION
Added `allowNamespaces` available in latest [angular-translate@2.19.0](https://github.com/angular-translate/angular-translate/releases/tag/2.19.0).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/angular-translate/angular-translate/pull/1910
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.