### PR TITLE
[react] Precisely type some HTML elements in their event callbacks

### DIFF
--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -40,6 +40,7 @@ interface HTMLButtonElement extends HTMLElement { }
 interface HTMLCanvasElement extends HTMLElement { }
 interface HTMLDataElement extends HTMLElement { }
 interface HTMLDataListElement extends HTMLElement { }
+interface HTMLDetailsElement extends HTMLElement { }
 interface HTMLDialogElement extends HTMLElement { }
 interface HTMLDivElement extends HTMLElement { }
 interface HTMLDListElement extends HTMLElement { }
@@ -60,10 +61,12 @@ interface HTMLLIElement extends HTMLElement { }
 interface HTMLLinkElement extends HTMLElement { }
 interface HTMLMapElement extends HTMLElement { }
 interface HTMLMetaElement extends HTMLElement { }
+interface HTMLMeterElement extends HTMLElement { }
 interface HTMLObjectElement extends HTMLElement { }
 interface HTMLOListElement extends HTMLElement { }
 interface HTMLOptGroupElement extends HTMLElement { }
 interface HTMLOptionElement extends HTMLElement { }
+interface HTMLOutputElement extends HTMLElement { }
 interface HTMLParagraphElement extends HTMLElement { }
 interface HTMLParamElement extends HTMLElement { }
 interface HTMLPreElement extends HTMLElement { }
@@ -83,6 +86,7 @@ interface HTMLTableRowElement extends HTMLElement { }
 interface HTMLTableSectionElement extends HTMLElement { }
 interface HTMLTemplateElement extends HTMLElement { }
 interface HTMLTextAreaElement extends HTMLElement { }
+interface HTMLTimeElement extends HTMLElement { }
 interface HTMLTitleElement extends HTMLElement { }
 interface HTMLTrackElement extends HTMLElement { }
 interface HTMLUListElement extends HTMLElement { }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2777,7 +2777,7 @@ declare namespace React {
         bdi: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         bdo: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         big: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
-        blockquote: DetailedHTMLFactory<BlockquoteHTMLAttributes<HTMLElement>, HTMLElement>;
+        blockquote: DetailedHTMLFactory<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
         body: DetailedHTMLFactory<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
         br: DetailedHTMLFactory<HTMLAttributes<HTMLBRElement>, HTMLBRElement>;
         button: DetailedHTMLFactory<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
@@ -2790,8 +2790,8 @@ declare namespace React {
         data: DetailedHTMLFactory<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement>;
         datalist: DetailedHTMLFactory<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement>;
         dd: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
-        del: DetailedHTMLFactory<DelHTMLAttributes<HTMLElement>, HTMLElement>;
-        details: DetailedHTMLFactory<DetailsHTMLAttributes<HTMLElement>, HTMLElement>;
+        del: DetailedHTMLFactory<DelHTMLAttributes<HTMLModElement>, HTMLModElement>;
+        details: DetailedHTMLFactory<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement>;
         dfn: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         dialog: DetailedHTMLFactory<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
         div: DetailedHTMLFactory<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
@@ -2832,14 +2832,14 @@ declare namespace React {
         menu: DetailedHTMLFactory<MenuHTMLAttributes<HTMLElement>, HTMLElement>;
         menuitem: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         meta: DetailedHTMLFactory<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement>;
-        meter: DetailedHTMLFactory<MeterHTMLAttributes<HTMLElement>, HTMLElement>;
+        meter: DetailedHTMLFactory<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement>;
         nav: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         noscript: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         object: DetailedHTMLFactory<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement>;
         ol: DetailedHTMLFactory<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement>;
         optgroup: DetailedHTMLFactory<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement>;
         option: DetailedHTMLFactory<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement>;
-        output: DetailedHTMLFactory<OutputHTMLAttributes<HTMLElement>, HTMLElement>;
+        output: DetailedHTMLFactory<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement>;
         p: DetailedHTMLFactory<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>;
         param: DetailedHTMLFactory<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement>;
         picture: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
@@ -2871,7 +2871,7 @@ declare namespace React {
         tfoot: DetailedHTMLFactory<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
         th: DetailedHTMLFactory<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement>;
         thead: DetailedHTMLFactory<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
-        time: DetailedHTMLFactory<TimeHTMLAttributes<HTMLElement>, HTMLElement>;
+        time: DetailedHTMLFactory<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement>;
         title: DetailedHTMLFactory<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement>;
         tr: DetailedHTMLFactory<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
         track: DetailedHTMLFactory<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
@@ -3108,7 +3108,7 @@ declare global {
             bdi: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             bdo: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             big: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            blockquote: React.DetailedHTMLProps<React.BlockquoteHTMLAttributes<HTMLElement>, HTMLElement>;
+            blockquote: React.DetailedHTMLProps<React.BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
             body: React.DetailedHTMLProps<React.HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
             br: React.DetailedHTMLProps<React.HTMLAttributes<HTMLBRElement>, HTMLBRElement>;
             button: React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
@@ -3121,8 +3121,8 @@ declare global {
             data: React.DetailedHTMLProps<React.DataHTMLAttributes<HTMLDataElement>, HTMLDataElement>;
             datalist: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDataListElement>, HTMLDataListElement>;
             dd: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            del: React.DetailedHTMLProps<React.DelHTMLAttributes<HTMLElement>, HTMLElement>;
-            details: React.DetailedHTMLProps<React.DetailsHTMLAttributes<HTMLElement>, HTMLElement>;
+            del: React.DetailedHTMLProps<React.DelHTMLAttributes<HTMLModElement>, HTMLModElement>;
+            details: React.DetailedHTMLProps<React.DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement>;
             dfn: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             dialog: React.DetailedHTMLProps<React.DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
             div: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
@@ -3163,7 +3163,7 @@ declare global {
             menu: React.DetailedHTMLProps<React.MenuHTMLAttributes<HTMLElement>, HTMLElement>;
             menuitem: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             meta: React.DetailedHTMLProps<React.MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement>;
-            meter: React.DetailedHTMLProps<React.MeterHTMLAttributes<HTMLElement>, HTMLElement>;
+            meter: React.DetailedHTMLProps<React.MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement>;
             nav: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             noindex: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             noscript: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
@@ -3171,7 +3171,7 @@ declare global {
             ol: React.DetailedHTMLProps<React.OlHTMLAttributes<HTMLOListElement>, HTMLOListElement>;
             optgroup: React.DetailedHTMLProps<React.OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement>;
             option: React.DetailedHTMLProps<React.OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement>;
-            output: React.DetailedHTMLProps<React.OutputHTMLAttributes<HTMLElement>, HTMLElement>;
+            output: React.DetailedHTMLProps<React.OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement>;
             p: React.DetailedHTMLProps<React.HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>;
             param: React.DetailedHTMLProps<React.ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement>;
             picture: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
@@ -3203,7 +3203,7 @@ declare global {
             tfoot: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
             th: React.DetailedHTMLProps<React.ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement>;
             thead: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
-            time: React.DetailedHTMLProps<React.TimeHTMLAttributes<HTMLElement>, HTMLElement>;
+            time: React.DetailedHTMLProps<React.TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement>;
             title: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTitleElement>, HTMLTitleElement>;
             tr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
             track: React.DetailedHTMLProps<React.TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -59,3 +59,40 @@ const testCases = [
         <img src="test" width={100} height={100} />
     </picture>,
 ];
+
+// Needed to check these HTML elements in event callbacks.
+// "Imported" from typescript's lib.dom.d.ts.
+declare global {
+    interface HTMLDetailsElement {
+        open: boolean;
+    }
+
+    interface HTMLMeterElement {
+        optimum: number;
+    }
+
+    interface HTMLModElement {
+        cite: string;
+    }
+
+    interface HTMLOutputElement {
+        value: string;
+    }
+
+    interface HTMLQuoteElement {
+        cite: string;
+    }
+
+    interface HTMLTimeElement {
+        dateTime: string;
+    }
+}
+
+const eventCallbacksTestCases = [
+    <blockquote onClick={e => e.currentTarget.cite} />,
+    <del onClick={e => e.currentTarget.cite} />,
+    <details onClick={e => e.currentTarget.open} />,
+    <meter onClick={e => e.currentTarget.optimum} />,
+    <output onClick={e => e.currentTarget.value} />,
+    <time onClick={e => e.currentTarget.dateTime} />,
+];


### PR DESCRIPTION
The following HTML elements were typed as `HTMLElement` in their event
callbacks, instead of their more specialized interfaces:

- `<blockquote>`
- `<del>`
- `<details>`
- `<meter>`
- `<output>`
- `<time>`

Fixes: #58891

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [lib.dom.d.ts](https://github.com/microsoft/TypeScript/blob/5f017df609b61f017baa61ff7679aabb39d089fb/lib/lib.dom.d.ts) (lines: `HTMLDetailsElement` at [L6315](https://github.com/microsoft/TypeScript/blob/5f017df609b61f017baa61ff7679aabb39d089fb/lib/lib.dom.d.ts#L6315), `HTMLMeterElement` at [L7597](https://github.com/microsoft/TypeScript/blob/5f017df609b61f017baa61ff7679aabb39d089fb/lib/lib.dom.d.ts#L7597), `HTMLModElement` at [L7617](https://github.com/microsoft/TypeScript/blob/5f017df609b61f017baa61ff7679aabb39d089fb/lib/lib.dom.d.ts#L7617), `HTMLOutputElement` at [L7868](https://github.com/microsoft/TypeScript/blob/5f017df609b61f017baa61ff7679aabb39d089fb/lib/lib.dom.d.ts#L7868), `HTMLQuoteElement` at [L8008](https://github.com/microsoft/TypeScript/blob/5f017df609b61f017baa61ff7679aabb39d089fb/lib/lib.dom.d.ts#L8008), and `HTMLTimeElement` at [L8718](https://github.com/microsoft/TypeScript/blob/5f017df609b61f017baa61ff7679aabb39d089fb/lib/lib.dom.d.ts#L8718))
