### PR TITLE
fix(relay-runtime): RelayRecordSource should use default export

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -137,7 +137,7 @@ export { RelayNetwork as Network } from './lib/network/RelayNetwork';
 export { RelayObservable as Observable } from './lib/network/RelayObservable';
 import QueryResponseCache from './lib/network/RelayQueryResponseCache';
 export { QueryResponseCache };
-export { RelayRecordSource as RecordSource } from './lib/store/RelayRecordSource';
+export { default as RecordSource } from './lib/store/RelayRecordSource';
 export { RelayModernRecord as Record } from './lib/store/RelayModernRecord';
 export { default as Store } from './lib/store/RelayModernStore';
 

--- a/types/relay-runtime/lib/store/RelayRecordSource.d.ts
+++ b/types/relay-runtime/lib/store/RelayRecordSource.d.ts
@@ -2,7 +2,7 @@ import { MutableRecordSource, RecordMap, Record } from './RelayStoreTypes';
 import { DataID } from '../util/RelayRuntimeTypes';
 import { RecordState } from './RelayRecordState';
 
-export class RelayRecordSource implements MutableRecordSource {
+export default class RelayRecordSource implements MutableRecordSource {
     constructor(records?: RecordMap);
 
     static create(records?: RecordMap): MutableRecordSource;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/main/packages/relay-runtime/store/RelayRecordSource.js

There is a mismatch between original source code and types defined here. Originally `store/RelayRecordSource` uses a default export, but types use a named export. This PR corrects this.
