### PR TITLE
Fix link for currently requested definitions in README's

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -308,7 +308,7 @@ Entonces están equivocados. Puedes ayudar enviando un pull request para arregla
 
 #### Puedo pedir una definition?
 
-Aquí están las [definiciones solicitadas actualmente](https://github.com/DefinitelyTyped/DefinitelyTyped/labels/Definition%3ARequest).
+Aquí están las [definiciones solicitadas actualmente](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/categories/request-a-new-types-package).
 
 #### ¿Qué pasa con las type definitions para el DOM?
 

--- a/README.it.md
+++ b/README.it.md
@@ -362,7 +362,7 @@ Questo significa che non vanno bene e noi non ce ne siamo ancora accorti. Puoi c
 
 ####  Posso chiedere che venga implementata una definizione per un modulo che non le ha ancora?
 
-Se un modulo che utilizzi non ha ancora delle definizioni, puoi chiedere che vengano implementate aprendo un Issue. Qui trovi le [richieste di implementazione](https://github.com/DefinitelyTyped/DefinitelyTyped/labels/Definition%3ARequest) attuali.
+Se un modulo che utilizzi non ha ancora delle definizioni, puoi chiedere che vengano implementate aprendo un Issue. Qui trovi le [richieste di implementazione](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/categories/request-a-new-types-package) attuali.
 
 #### E per le definizioni dei tipi del DOM?
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -346,7 +346,7 @@ npm パッケージは数分で更新されます。もし1時間以上かかっ
 
 #### 型定義をリクエストしたいです。
 
-現在リクエストされている型定義は[こちら](https://github.com/DefinitelyTyped/DefinitelyTyped/labels/Definition%3ARequest)です。
+現在リクエストされている型定義は[こちら](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/categories/request-a-new-types-package)です。
 
 #### DOM に対する型定義はどうすればよいですか？
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -334,7 +334,7 @@ npm 의 패키지들은 수시간 안에 갱신될 겁니다. 만약 24 시간�
 
 #### 자료형 정의(Type definition)을 요청할 수 있나요?
 
-이미 요청된 자료형 정의(Type definition)들을 [여기서](https://github.com/DefinitelyTyped/DefinitelyTyped/labels/Definition%3ARequest) 보실 수 있습니다.
+이미 요청된 자료형 정의(Type definition)들을 [여기서](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/categories/request-a-new-types-package) 보실 수 있습니다.
 
 #### DOM 을 위한 자료형 정의(Type definitions)는요?
 

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ No. We've explored trying to make DT's code-formatting consistent before but rea
 
 #### Can I request a definition?
 
-Here are the [currently requested definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/labels/Definition%3ARequest).
+Here are the [currently requested definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/categories/request-a-new-types-package).
 
 #### What about type definitions for the DOM?
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -350,7 +350,7 @@ Então eles estão errados, e nós não notamos ainda. Você pode ajudar enviand
 
 #### Posso requisitar uma definição?
 
-Aqui estão as [definições requisitadas atualmente](https://github.com/DefinitelyTyped/DefinitelyTyped/labels/Definition%3ARequest).
+Aqui estão as [definições requisitadas atualmente](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/categories/request-a-new-types-package).
 
 #### Mas e as definições de tipo para a DOM?
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -329,7 +329,7 @@ Once a week the Definition Owners are synced to the file [.github/CODEOWNERS](ht
 
 #### Могу ли я запросить определение?
 
-Вот [текущие запрошенные определения](https://github.com/DefinitelyTyped/DefinitelyTyped/labels/Definition%3ARequest).
+Вот [текущие запрошенные определения](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/categories/request-a-new-types-package).
 
 #### Как насчет определений типов для DOM?
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -368,7 +368,7 @@ npm 包应该会在几分钟内更新。如果已经超过了一小时，请在 
 
 #### 我可以请求类型定义吗？
 
-这里是 [当前在请求的类型定义](https://github.com/DefinitelyTyped/DefinitelyTyped/labels/Definition%3ARequest)。
+这里是 [当前在请求的类型定义](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/categories/request-a-new-types-package)。
 
 #### DOM 上的类型定义是什么？
 


### PR DESCRIPTION
Closes #59292

Changes the link for currently requested definitions from the old issues tag to the new discussions category.
