### PR TITLE
Fix ioredis xadd typelib to allow use of MAXLEN set of parameters

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -1930,7 +1930,7 @@ declare namespace IORedis {
 
         xack(key: KeyType, group: string, ...ids: string[]): Pipeline;
 
-        xadd(key: KeyType, id: string, ...args: string[]): Pipeline;
+        xadd(key: KeyType, id: string, ...args: ValueType[]): Pipeline;
 
         xclaim(
             key: KeyType,


### PR DESCRIPTION
As the type stands, `number` types are not allowed, preventing the MAXLEN `threshold` and LIMIT `count` parameters being passed in. 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://redis.io/commands/xadd

