### PR TITLE
Add new parameter `defParamCharset` to busboy options added on v1.5

### DIFF
--- a/types/busboy/busboy-tests.ts
+++ b/types/busboy/busboy-tests.ts
@@ -6,6 +6,7 @@ const bb = busboy({
     highWaterMark: 1000,
     fileHwm: 1000,
     defCharset: 'utf8',
+    defParamCharset: 'latin1',
     preservePath: true,
     limits: {
         fieldNameSize: 200,

--- a/types/busboy/index.d.ts
+++ b/types/busboy/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for busboy 1.3
+// Type definitions for busboy 1.5
 // Project: https://github.com/mscdex/busboy
 // Definitions by: Jacob Baskin <https://github.com/jacobbaskin>
 //                 BendingBender <https://github.com/BendingBender>
@@ -88,6 +88,14 @@ declare namespace busboy {
          * @default 'utf8'
          */
         defCharset?: string | undefined;
+
+        /**
+         * For multipart forms, the default character set to use for values of part header parameters (e.g. filename)
+         * that are not extended parameters (that contain an explicit charset
+         *
+         * @default 'latin1'
+         */
+        defParamCharset?: string | undefined;
 
         /**
          * If paths in filenames from file parts in a 'multipart/form-data' request shall be preserved.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [defParamCharset option added on v1.5](https://github.com/mscdex/busboy/compare/v1.3.0...v1.5.0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R140)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

