### PR TITLE
Remove export; GLTFParser is not exported from GLTFLoader.js

### DIFF
--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -77,7 +77,7 @@ export interface GLTFReference {
     meshes?: number;
 }
 
-export class GLTFParser {
+class GLTFParser {
     json: any;
 
     options: {


### PR DESCRIPTION
See three.js source code
https://github.com/mrdoob/three.js/blob/659b6895c4da6ad2285c2c2a7af4638248174a4c/examples/jsm/loaders/GLTFLoader.js#L4398

And related issue
https://github.com/mrdoob/three.js/issues/15477


