### PR TITLE
Add to SQL formatting options to luxon

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -1,3 +1,6 @@
+import { Duration, DurationLike, DurationUnits } from "./duration";
+import { Interval } from "./interval";
+import { Zone } from "./zone";
 import {
     CalendarSystem,
     DateTimeFormatOptions,
@@ -7,9 +10,6 @@ import {
     ToISOTimeDurationOptions,
     ZoneOptions,
 } from '../index';
-import { Zone } from './zone';
-import { Duration, DurationLike, DurationUnits } from './duration';
-import { Interval } from './interval';
 
 export type DateTimeUnit = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second' | 'millisecond';
 export type ToRelativeUnit = 'years' | 'quarters' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds';
@@ -261,6 +261,11 @@ export interface ToSQLOptions {
      * @default false
      */
     includeZone?: boolean | undefined;
+    /**
+     * include the space between the time and the offset, such as '05:15:16.345 -04:00'
+     * @default true
+     */
+    includeOffsetSpace?: boolean;
 }
 
 export interface ToISODateOptions {

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -1,6 +1,3 @@
-import { Duration, DurationLike, DurationUnits } from "./duration";
-import { Interval } from "./interval";
-import { Zone } from "./zone";
 import {
     CalendarSystem,
     DateTimeFormatOptions,
@@ -10,6 +7,9 @@ import {
     ToISOTimeDurationOptions,
     ZoneOptions,
 } from '../index';
+import { Zone } from "./zone";
+import { Duration, DurationLike, DurationUnits } from "./duration";
+import { Interval } from "./interval";
 
 export type DateTimeUnit = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second' | 'millisecond';
 export type ToRelativeUnit = 'years' | 'quarters' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds';

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -7,9 +7,9 @@ import {
     ToISOTimeDurationOptions,
     ZoneOptions,
 } from '../index';
-import { Zone } from "./zone";
-import { Duration, DurationLike, DurationUnits } from "./duration";
-import { Interval } from "./interval";
+import { Zone } from './zone';
+import { Duration, DurationLike, DurationUnits } from './duration';
+import { Interval } from './interval';
 
 export type DateTimeUnit = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second' | 'millisecond';
 export type ToRelativeUnit = 'years' | 'quarters' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds';

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -125,6 +125,7 @@ dt.toSQL({ includeOffset: false, includeZone: true }); // $ExpectType string
 dt.toSQLDate(); // $ExpectType string
 dt.toSQLTime(); // $ExpectType string
 dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
+dt.toSQLTime({ includeOffsetSpace: false, includeZone: true }); // $ExpectType string
 dt.valueOf(); // $ExpectType number
 dt.toObject(); // $ExpectType ToObjectOutput
 dt.toObject({ includeConfig: true }); // $ExpectType ToObjectOutput


### PR DESCRIPTION
Add missing `includeOffsetSpace` prop to luxon toSQL formatting options

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://moment.github.io/luxon/api-docs/index.html#datetimetosqldate
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.