### PR TITLE
[@jsreport/nodejs-client] fixed importing the client interface in parent

### DIFF
--- a/types/jsreport__nodejs-client/index.d.ts
+++ b/types/jsreport__nodejs-client/index.d.ts
@@ -6,7 +6,7 @@
 import JsReport = require('jsreport');
 import { ServerResponse } from 'http';
 
-declare namespace JsReportNodeJsClient {
+declare namespace createJsReportClient {
     interface ClientRenderResponse extends ServerResponse {
         body(): Promise<Buffer>;
     }
@@ -17,6 +17,6 @@ declare namespace JsReportNodeJsClient {
     }
 }
 
-declare function createJsReportClient(url: string, username: string, password: string): JsReportNodeJsClient.Client;
-declare function createJsReportClient(url: string): JsReportNodeJsClient.Client;
+declare function createJsReportClient(url: string, username: string, password: string): createJsReportClient.Client;
+declare function createJsReportClient(url: string): createJsReportClient.Client;
 export = createJsReportClient;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Neither of the above options applies in this case. I created this type definition and messed up a bit as this is my first one. This resolves the ability to `import jsreportClient, { Client } from '@jsreport/nodejs-client'` so that you can use `const foo: Client;`