### PR TITLE
[jsreport-core] added unoconv options to template

### DIFF
--- a/types/jsreport-core/index.d.ts
+++ b/types/jsreport-core/index.d.ts
@@ -27,6 +27,10 @@ declare namespace JsReport {
         /** recipe used for printing previously assembled document */
         recipe: Recipe | string;
         pathToEngine?: string | undefined;
+        unoconv?: {
+            format?: string | undefined;
+            enabled?: boolean | undefined;
+        };
     }
 
     interface Template extends TemplateBase {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - See lines 33 and 507 of this file [jsreport-api.xml.txt](https://github.com/DefinitelyTyped/DefinitelyTyped/files/8307345/jsreport-api.xml.txt) which can only be downloaded using a running JS Report instance as mentioned [on this page](https://jsreport.net/learn/api#:~:text=Another%20option%20to%20inspect%20the%20valid%20template%20properties%20is%20to%20use%20OData%20metadata%20definition.)