### PR TITLE
Refactor @ckeditor/ckeditor5-engine operations

### DIFF
--- a/types/ckeditor__ckeditor5-engine/OTHER_FILES.txt
+++ b/types/ckeditor__ckeditor5-engine/OTHER_FILES.txt
@@ -1,8 +1,1 @@
 src/dataprocessor/xmldataprocessor.d.ts
-src/model/operation/attributeoperation.d.ts
-src/model/operation/detachoperation.d.ts
-src/model/operation/mergeoperation.d.ts
-src/model/operation/nooperation.d.ts
-src/model/operation/renameoperation.d.ts
-src/model/operation/rootattributeoperation.d.ts
-src/model/operation/splitoperation.d.ts

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/attributeoperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/attributeoperation.d.ts
@@ -1,24 +1,82 @@
-import Operation from "./operation";
-import Range from "../range";
-import Document from "../document";
+import Document from '../document';
+import Range from '../range';
+import Operation from './operation';
 
-export default class AttributeOperation<O = any, N = any> extends Operation {
-    readonly key: string;
-    readonly newValue: N;
-    readonly oldValue: O;
-    readonly range: Range;
-    static readonly className: "AttributeOperation";
+/**
+ * Operation to change nodes' attribute.
+ *
+ * Using this class you can add, remove or change value of the attribute.
+ */
+export default class AttributeOperation<
+    O extends string | number | boolean | undefined = any,
+    N extends string | number | boolean | undefined = any,
+> extends Operation {
+    static readonly className: 'AttributeOperation';
 
+    /**
+     * Creates an operation that changes, removes or adds attributes.
+     *
+     * If only `newValue` is set, attribute will be added on a node. Note that all nodes in operation's range must not
+     * have an attribute with the same key as the added attribute.
+     *
+     * If only `oldValue` is set, then attribute with given key will be removed. Note that all nodes in operation's range
+     * must have an attribute with that key added.
+     *
+     * If both `newValue` and `oldValue` are set, then the operation will change the attribute value. Note that all nodes in
+     * operation's ranges must already have an attribute with given key and `oldValue` as value
+     */
     constructor(range: Range, key: string, oldValue: O, newValue: N, baseVersion: number | null);
-    clone(): this;
-    getReversed(): AttributeOperation;
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        __className: "AttributeOperation";
+
+    /**
+     * Range on which operation should be applied.
+     */
+    readonly range: Range;
+
+    /**
+     * Key of an attribute to change or remove.
+     */
+    readonly key: string;
+
+    /**
+     * Old value of the attribute with given key or `null`, if attribute was not set before.
+     */
+    readonly oldValue: O extends undefined ? null : O;
+
+    /**
+     * New value of the attribute with given key or `null`, if operation should remove attribute.
+     */
+    readonly newValue: N extends undefined ? null : N;
+
+    readonly type: 'addAttribute' | 'removeAttribute' | 'changeAttribute';
+
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone(): AttributeOperation<O, N>;
+
+    /**
+     * See {@link module:engine/model/operation/operation~Operation#getReversed `Operation#getReversed()`}.
+     */
+    getReversed(): AttributeOperation<O, N>;
+
+    toJSON(): ReturnType<Operation['toJSON']> & {
         key: string;
-        newValue: string;
-        oldValue: string | null;
-        range: ReturnType<Range["toJSON"]>;
+        newValue: N extends undefined ? null : N;
+        oldValue: O extends undefined ? null : O;
+        range: ReturnType<Range['toJSON']>;
     };
 
-    static fromJSON(json: Partial<ReturnType<AttributeOperation["toJSON"]>>, document?: Document): AttributeOperation;
+    /**
+     * Creates `AttributeOperation` object from deserilized object, i.e. from parsed JSON string.
+     */
+    static fromJSON(
+        json: {
+            baseVersion: number | null;
+            range: ReturnType<Range['toJSON']>;
+            key: string;
+            newValue: string | boolean | number | null;
+            oldValue: string | boolean | number | null;
+        },
+        document: Document,
+    ): AttributeOperation;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/detachoperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/detachoperation.d.ts
@@ -1,17 +1,33 @@
-import Position from "../position";
-import Operation from "./operation";
+import Position from '../position';
+import Operation from './operation';
 
+/**
+ * Operation to permanently remove node from detached root.
+ * Note this operation is only a local operation and won't be send to the other clients.
+ */
 export default class DetachOperation extends Operation {
-    howMany: number;
-    sourcePosition: Position;
-    type: "detach";
-
-    static readonly className: "DetachOperation";
-
+    /**
+     * Creates an insert operation.
+     */
     constructor(sourcePosition: Position, howMany: number);
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        __className: "DetachOperation";
-        sourcePosition: ReturnType<Position["toJSON"]>;
+
+    /**
+     * Position before the first {@link module:engine/model/item~Item model item} to detach.
+     */
+    readonly sourcePosition: Position;
+
+    /**
+     * Offset size of moved range.
+     */
+    readonly howMany: number;
+
+    readonly type: 'detach';
+
+    toJSON(): ReturnType<Operation['toJSON']> & {
+        sourcePosition: ReturnType<Position['toJSON']>;
+        type: 'detach';
         howMany: number;
     };
+
+    static readonly className: 'DetachOperation';
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/insertoperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/insertoperation.d.ts
@@ -1,29 +1,73 @@
-import { NodeSet } from "../node";
-import NodeList from "../nodelist";
-import Position from "../position";
-import Operation from "./operation";
-import MoveOperation from "./moveoperation";
-import Document from "../document";
+import Document from '../document';
+import { NodeSet } from '../node';
+import NodeList from '../nodelist';
+import Position from '../position';
+import MoveOperation from './moveoperation';
+import Operation from './operation';
 
+/**
+ * Operation to insert one or more nodes at given position in the model.
+ */
 export default class InsertOperation extends Operation {
-    howMany: number;
-    readonly nodeList: NodeList;
-    readonly position: Position;
-    shouldReceiveAttributes: boolean;
-    readonly type: "insert";
+    /**
+     * Creates an insert operation.
+     */
+    constructor(position: Position, nodes: NodeSet, baseVersion: number | null);
+
+    /**
+     * Position of insertion.
+     */
+    position: Position;
+
+    /**
+     * List of nodes to insert.
+     */
     readonly nodes: NodeList;
 
-    static readonly className: "InsertOperation";
+    /**
+     * Flag deciding how the operation should be transformed. If set to `true`, nodes might get additional attributes
+     * during operational transformation. This happens when the operation insertion position is inside of a range
+     * where attributes have changed.
+     */
+    shouldReceiveAttributes: boolean;
 
-    constructor(position: Position, nodes: NodeSet, baseVersion: number | null);
-    clone(): this;
+    readonly type: 'insert';
+
+    /**
+     * Total offset size of inserted nodes.
+     */
+    readonly howMany: number;
+
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone(): InsertOperation;
+
+    /**
+     * See {@link module:engine/model/operation/operation~Operation#getReversed `Operation#getReversed()`}.
+     */
     getReversed(): MoveOperation;
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        __className: "InsertOperation";
-        nodes: ReturnType<NodeList["toJSON"]>;
-        position: ReturnType<Position["toJSON"]>;
+
+    toJSON(): ReturnType<Operation['toJSON']> & {
+        position: ReturnType<Position['toJSON']>;
+        nodes: ReturnType<NodeList['toJSON']>;
+        howMany: number;
+        type: 'insert';
         shouldReceiveAttributes: boolean;
     };
 
-    static fromJSON(json: Partial<ReturnType<InsertOperation["toJSON"]>>, document?: Document): InsertOperation;
+    static readonly className: 'InsertOperation';
+
+    /**
+     * Creates `InsertOperation` object from deserilized object, i.e. from parsed JSON string.
+     */
+    static fromJSON(
+        json: {
+            nodes: ReturnType<NodeList['toJSON']>;
+            position: ReturnType<Position['toJSON']>;
+            baseVersion: number | null;
+            shouldReceiveAttributes: boolean;
+        },
+        document: Document,
+    ): InsertOperation;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/markeroperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/markeroperation.d.ts
@@ -1,16 +1,9 @@
-import MarkerCollection from "../markercollection";
-import Range from "../range";
-import Operation from "./operation";
-import Document from "../document";
+import MarkerCollection from '../markercollection';
+import Range from '../range';
+import Operation from './operation';
+import Document from '../document';
 
 export default class MarkerOperation extends Operation {
-    readonly name: string;
-    readonly oldRange: Range;
-    readonly newRange: Range;
-    readonly affectsData: boolean;
-    readonly type: "marker";
-    static readonly className: "MarkerOperation";
-
     constructor(
         name: string,
         oldRange: Range | null,
@@ -19,15 +12,61 @@ export default class MarkerOperation extends Operation {
         affectsData: boolean,
         baseVersion: number | null,
     );
-    clone(): this;
+
+    /**
+     * Marker name.
+     */
+    readonly name: string;
+
+    /**
+     * Marker range before the change.
+     */
+    readonly oldRange: Range | null;
+
+    /**
+     * Marker range after the change.
+     */
+    readonly newRange: Range | null;
+
+    /**
+     * Specifies whether the marker operation affects the data produced by the data pipeline
+     * (is persisted in the editor's data).
+     */
+    readonly affectsData: boolean;
+
+    readonly type: 'marker';
+
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone(): MarkerOperation;
+
+    /**
+     * See {@link module:engine/model/operation/operation~Operation#getReversed `Operation#getReversed()`}.
+     */
     getReversed(): MarkerOperation;
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        oldRange: ReturnType<Range["toJSON"]> | null;
-        newRange: ReturnType<Range["toJSON"]>;
-        __className: "MarkerOperation";
-        name: string;
+
+    toJSON(): ReturnType<Operation['toJSON']> & {
+        oldRange?: ReturnType<Range['toJSON']> | null;
+        newRange?: ReturnType<Range['toJSON']> | null;
+        type: 'marker';
         affectsData: boolean;
+        name: string;
     };
 
-    static fromJSON(json: Partial<ReturnType<MarkerOperation["toJSON"]>>, document?: Document): MarkerOperation;
+    static readonly className: 'MarkerOperation';
+
+    /**
+     * Creates `MarkerOperation` object from deserialized object, i.e. from parsed JSON string.
+     */
+    static fromJSON(
+        json: {
+            name: string;
+            oldRange?: ReturnType<Range['toJSON']>;
+            newRange?: ReturnType<Range['toJSON']>;
+            affectsData: boolean;
+            baseVersion: number | null;
+        },
+        document: Document,
+    ): MarkerOperation;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/mergeoperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/mergeoperation.d.ts
@@ -1,18 +1,21 @@
-import Document from "../document";
-import Position from "../position";
-import Range from "../range";
-import Operation from "./operation";
-import SplitOperation from "./splitoperation";
+import Document from '../document';
+import Position from '../position';
+import Range from '../range';
+import Operation from './operation';
+import SplitOperation from './splitoperation';
 
+/**
+ * Operation to merge two {@link module:engine/model/element~Element elements}.
+ *
+ * The merged element is the parent of {@link ~MergeOperation#sourcePosition} and it is merged into the parent of
+ * {@link ~MergeOperation#targetPosition}. All nodes from the merged element are moved to {@link ~MergeOperation#targetPosition}.
+ *
+ * The merged element is moved to the graveyard at {@link ~MergeOperation#graveyardPosition}.
+ */
 export default class MergeOperation extends Operation {
-    readonly deletionPosition: Position;
-    graveyardPosition: Position;
-    howMany: number;
-    readonly movedRange: Range;
-    sourcePosition: Position;
-    targetPosition: Position;
-    static readonly className: "MergeOperation";
-
+    /**
+     * Creates a merge operation.
+     */
     constructor(
         sourcePosition: Position,
         howMany: number,
@@ -20,15 +23,73 @@ export default class MergeOperation extends Operation {
         graveyardPosition: Position,
         baseVersion: number | null,
     );
-    clone(): this;
+
+    /**
+     * Position inside the merged element. All nodes from that element after that position will be moved to {@link ~#targetPosition}.
+     */
+    sourcePosition: Position;
+
+    /**
+     * Summary offset size of nodes which will be moved from the merged element to the new parent.
+     */
+    readonly howMany: number;
+
+    /**
+     * Position which the nodes from the merged elements will be moved to.
+     */
+    targetPosition: Position;
+
+    /**
+     * Position in graveyard to which the merged element will be moved.
+     */
+    readonly graveyardPosition: Position;
+
+    readonly type: 'merge';
+
+    /**
+     * Position before the merged element (which will be deleted).
+     */
+    readonly deletionPosition: Position;
+
+    /**
+     * Artificial range that contains all the nodes from the merged element that will be moved to {@link ~MergeOperation#sourcePosition}.
+     * The range starts at {@link ~MergeOperation#sourcePosition} and ends in the same parent, at `POSITIVE_INFINITY` offset.
+     */
+    readonly movedRange: Range;
+
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone(): MergeOperation;
+
+    /**
+     * See {@link module:engine/model/operation/operation~Operation#getReversed `Operation#getReversed()`}.
+     */
     getReversed(): SplitOperation;
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        __className: "MergeOperation";
+
+    static readonly className: 'MergeOperation';
+
+    toJSON(): ReturnType<Operation['toJSON']> & {
+        movedRange: ReturnType<Range['toJSON']>;
+        deletionPosition: ReturnType<Position['toJSON']>;
+        type: 'merge';
+        graveyardPosition: ReturnType<Position['toJSON']>;
+        targetPosition: ReturnType<Position['toJSON']>;
         howMany: number;
-        sourcePosition: ReturnType<Position["toJSON"]>;
-        targetPosition: ReturnType<Position["toJSON"]>;
-        graveyardPosition: ReturnType<Position["toJSON"]>;
+        sourcePosition: ReturnType<Position['toJSON']>;
     };
 
-    static fromJSON(json: Partial<ReturnType<MergeOperation["toJSON"]>>, document?: Document): MergeOperation;
+    /**
+     * Creates `MergeOperation` object from deserilized object, i.e. from parsed JSON string.
+     */
+    static fromJSON(
+        json: {
+            sourcePosition: ReturnType<Position['toJSON']>;
+            targetPosition: ReturnType<Position['toJSON']>;
+            graveyardPosition: ReturnType<Position['toJSON']>;
+            howMany: number;
+            baseVersion: number | null;
+        },
+        document: Document,
+    ): MergeOperation;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/moveoperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/moveoperation.d.ts
@@ -1,23 +1,77 @@
-import Document from "../document";
-import Position from "../position";
-import Operation from "./operation";
+import Document from '../document';
+import Position from '../position';
+import Operation from './operation';
 
+/**
+ * Operation to move a range of {@link module:engine/model/item~Item model items}
+ * to given {@link module:engine/model/position~Position target position}.
+ */
 export default class MoveOperation extends Operation {
-    howMany: number;
-    sourcePosition: Position;
-    targetPosition: Position;
-    static readonly className: "MoveOperation";
-
+    /**
+     * Creates a move operation.
+     */
     constructor(sourcePosition: Position, howMany: number, targetPosition: Position, baseVersion: number | null);
-    clone(): this;
+
+    /**
+     * Position before the first {@link module:engine/model/item~Item model item} to move.
+     */
+    sourcePosition: Position;
+
+    /**
+     * Offset size of moved range.
+     */
+    howMany: number;
+
+    /**
+     * Position at which moved nodes will be inserted.
+     */
+    targetPosition: Position;
+
+    readonly type: 'remove' | 'reinsert' | 'move';
+
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone(): MoveOperation;
+
+    /**
+     * Returns the start position of the moved range after it got moved. This may be different than
+     * {@link module:engine/model/operation/moveoperation~MoveOperation#targetPosition} in some cases, i.e. when a range is moved
+     * inside the same parent but {@link module:engine/model/operation/moveoperation~MoveOperation#targetPosition targetPosition}
+     * is after {@link module:engine/model/operation/moveoperation~MoveOperation#sourcePosition sourcePosition}.
+     *
+     *     vv              vv
+     *    abcdefg ===> adefbcg
+     *         ^          ^
+     *         targetPos  movedRangeStart
+     *         offset 6  offset 4
+     */
     getMovedRangeStart(): Position;
+
+    /**
+     * See {@link module:engine/model/operation/operation~Operation#getReversed `Operation#getReversed()`}.
+     */
     getReversed(): MoveOperation;
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        __className: "MoveOperation";
+
+    toJSON(): ReturnType<Operation['toJSON']> & {
+        sourcePosition: ReturnType<Position['toJSON']>;
+        targetPosition: ReturnType<Position['toJSON']>;
+        type: 'remove' | 'reinsert' | 'move';
         howMany: number;
-        sourcePosition: ReturnType<Position["toJSON"]>;
-        targetPosition: ReturnType<Position["toJSON"]>;
     };
 
-    static fromJSON(json: Partial<ReturnType<MoveOperation["toJSON"]>>, document?: Document): MoveOperation;
+    static readonly className: 'MoveOperation';
+
+    /**
+     * Creates `MoveOperation` object from deserilized object, i.e. from parsed JSON string.
+     */
+    static fromJSON(
+        json: {
+            sourcePosition: ReturnType<Position['toJSON']>;
+            targetPosition: ReturnType<Position['toJSON']>;
+            howMany: number;
+            baseVersion: number | null;
+        },
+        document: Document,
+    ): MoveOperation;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/nooperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/nooperation.d.ts
@@ -1,14 +1,25 @@
-import Document from "../document";
-import Operation from "./operation";
+import Operation from './operation';
 
+/**
+ * Operation which is doing nothing ("empty operation", "do-nothing operation", "noop"). This is an operation,
+ * which when executed does not change the tree model. It still has some parameters defined for transformation purposes.
+ *
+ * In most cases this operation is a result of transforming operations. When transformation returns
+ * {@link module:engine/model/operation/nooperation~NoOperation} it means that changes done by the transformed operation
+ * have already been applied.
+ */
 export default class NoOperation extends Operation {
-    clone(): this;
+    readonly type: 'noop';
+
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone(): NoOperation;
+
+    /**
+     * See {@link module:engine/model/operation/operation~Operation#getReversed `Operation#getReversed()`}.
+     */
     getReversed(): NoOperation;
 
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        __className: "NoOperation";
-    };
-    static readonly className: "NoOperation";
-
-    static fromJSON(json: Partial<ReturnType<NoOperation["toJSON"]>>, doc: Document): NoOperation;
+    static readonly className: 'NoOperation';
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/operation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/operation.d.ts
@@ -1,21 +1,65 @@
-import Batch from "../batch";
-import Document from "../document";
+import Batch from '../batch';
+import Document from '../document';
 
+// These methods are "abstract" in Operation, and derived classes are not mandated to implement them.
+export default interface Operation {
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone?(): Operation;
+
+    /**
+     * Creates and returns a reverse operation. Reverse operation when executed right after
+     * the original operation will bring back tree model state to the point before the original
+     * operation execution. In other words, it reverses changes done by the original operation.
+     *
+     * Keep in mind that tree model state may change since executing the original operation,
+     * so reverse operation will be "outdated". In that case you will need to transform it by
+     * all operations that were executed after the original operation.
+     */
+    getReversed?(): Operation;
+}
+/**
+ * Abstract base operation class.
+ */
 export default abstract class Operation {
-    baseVersion: number;
-    batch: Batch | null;
+    /**
+     * Base operation constructor.
+     */
+    constructor(baseVersion: number | null);
+
+    readonly baseVersion: number | null;
+
+    /**
+     * Defines whether operation is executed on attached or detached {@link module:engine/model/item~Item items}.
+     */
     readonly isDocumentOperation: boolean;
-    readonly type: string;
 
-    static className: string;
+    /**
+     * {@link module:engine/model/batch~Batch Batch} to which the operation is added or `null` if the operation is not
+     * added to any batch yet.
+     */
+    batch: Batch | null;
 
-    constructor(baseVersion: number);
-    clone(): this;
-    getReversed(): Operation;
-    abstract toJSON(): {
-        __className: string;
-        baseVersion: number;
+    /**
+     * Operation type.
+     */
+    abstract readonly type: string;
+
+    /**
+     * Custom toJSON method to solve child-parent circular dependencies.
+     */
+    toJSON(): {
+        baseVersion: number | null;
     };
 
-    static fromJSON?(json: Partial<ReturnType<Operation["toJSON"]>>, doc: Document): Operation;
+    /**
+     * Name of the operation class used for serialization.
+     */
+    static readonly className: string;
+
+    /**
+     * Creates Operation object from deserilized object, i.e. from parsed JSON string.
+     */
+    static fromJSON(json: { baseVersion: number | null }, doc: Document): Operation;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/operationfactory.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/operationfactory.d.ts
@@ -1,7 +1,31 @@
 import Document from '../document';
+import AttributeOperation from './attributeoperation';
+import InsertOperation from './insertoperation';
+import MarkerOperation from './markeroperation';
+import MergeOperation from './mergeoperation';
+import MoveOperation from './moveoperation';
+import NoOperation from './nooperation';
 import Operation from './operation';
+import RenameOperation from './renameoperation';
+import RootAttributeOperation from './rootattributeoperation';
+import SplitOperation from './splitoperation';
 
 export default abstract class OperationFactory {
     _(): void;
-    static fromJSON(json: Record<string, unknown>, document: Document): Operation;
+    static fromJSON(
+        json: { __className: typeof AttributeOperation['className'] },
+        document: Document,
+    ): AttributeOperation;
+    static fromJSON(json: { __className: typeof InsertOperation['className'] }, document: Document): InsertOperation;
+    static fromJSON(json: { __className: typeof MarkerOperation['className'] }, document: Document): MarkerOperation;
+    static fromJSON(json: { __className: typeof MoveOperation['className'] }, document: Document): MoveOperation;
+    static fromJSON(json: { __className: typeof NoOperation['className'] }, document: Document): NoOperation;
+    static fromJSON(json: { __className: typeof RenameOperation['className'] }, document: Document): RenameOperation;
+    static fromJSON(
+        json: { __className: typeof RootAttributeOperation['className'] },
+        document: Document,
+    ): RootAttributeOperation;
+    static fromJSON(json: { __className: typeof SplitOperation['className'] }, document: Document): SplitOperation;
+    static fromJSON(json: { __className: typeof MergeOperation['className'] }, document: Document): MergeOperation;
+    static fromJSON(json: { __className: typeof Operation['className'] | string }, document: Document): Operation;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/renameoperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/renameoperation.d.ts
@@ -1,21 +1,66 @@
-import Document from "../document";
-import Position from "../position";
-import Operation from "./operation";
+import Document from '../document';
+import Position from '../position';
+import Operation from './operation';
 
+/**
+ * Operation to change element's name.
+ *
+ * Using this class you can change element's name.
+ */
 export default class RenameOperation extends Operation {
-    newName: string;
-    oldName: string;
+    /**
+     * Creates an operation that changes element's name.
+     */
+    constructor(position: Position, oldName: string, newName: string, baseVersion: number | null);
+
+    /**
+     * Position before an element to change.
+     */
     position: Position;
 
-    constructor(position: Position, oldName: string, newName: string, baseVersion: number | null);
-    clone(): this;
+    /**
+     * Current name of the element.
+     */
+    readonly oldName: string;
+
+    /**
+     * New name for the element.
+     */
+    readonly newName: string;
+
+    readonly type: 'rename';
+
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone(): RenameOperation;
+
+    /**
+     * See {@link module:engine/model/operation/operation~Operation#getReversed `Operation#getReversed()`}.
+     */
     getReversed(): RenameOperation;
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        __className: "RenameOperation";
-        position: ReturnType<Position["toJSON"]>;
+
+    toJSON(): {
+        type: 'rename';
         newName: string;
         oldName: string;
+        position: ReturnType<Position['toJSON']>;
+        baseVersion: number | null;
     };
 
-    fromJSON(json: Partial<ReturnType<RenameOperation["toJSON"]>>, document: Document): RenameOperation;
+    static readonly className: 'RenameOperation';
+
+    /**
+     * Creates `RenameOperation` object from deserialized object, i.e. from parsed JSON string.
+     */
+
+    static fromJSON(
+        json: {
+            position: ReturnType<Position['toJSON']>;
+            oldName: string;
+            newName: string;
+            baseVersion: number | null;
+        },
+        document: Document,
+    ): RenameOperation;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/rootattributeoperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/rootattributeoperation.d.ts
@@ -1,28 +1,77 @@
-import Document from "../document";
-import RootElement from "../rootelement";
-import Operation from "./operation";
+import Document from '../document';
+import RootElement from '../rootelement';
+import Operation from './operation';
 
+/**
+ * Operation to change root element's attribute. Using this class you can add, remove or change value of the attribute.
+ *
+ * This operation is needed, because root elements can't be changed through
+ * @link module:engine/model/operation/attributeoperation~AttributeOperation}.
+ * It is because {@link module:engine/model/operation/attributeoperation~AttributeOperation}
+ * requires a range to change and root element can't
+ * be a part of range because every {@link module:engine/model/position~Position} has to be inside a root.
+ * {@link module:engine/model/position~Position} can't be created before a root element.
+ */
 export default class RootAttributeOperation<O = any, N = any> extends Operation {
-    readonly key: string;
-    readonly newValue: N;
-    readonly oldValue: O;
+    /**
+     * Creates an operation that changes, removes or adds attributes on root element.
+     */
+    constructor(root: RootElement, key: string, oldValue: O, newValue: N, baseVersion: number | null);
+
+    /**
+     * Root element to change.
+     */
     readonly root: RootElement;
 
-    static readonly className: "RootAttributeOperation";
+    /**
+     * Key of an attribute to change or remove.
+     */
+    readonly key: string;
 
-    constructor(root: RootElement, key: string, oldValue: O, newValue: N, baseVersion: number | null);
-    clone(): this;
+    /**
+     * Old value of the attribute with given key or `null` if adding a new attribute.
+     */
+    readonly oldValue: O;
+
+    /**
+     * New value to set for the attribute. If `null`, then the operation just removes the attribute.
+     */
+    readonly newValue: N;
+
+    readonly type: 'addRootAttribute' | 'removeRootAttribute' | 'changeRootAttribute';
+
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone(): RootAttributeOperation;
+
+    /**
+     * See {@link module:engine/model/operation/operation~Operation#getReversed `Operation#getReversed()`}.
+     */
     getReversed(): RootAttributeOperation;
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        __className: "RootAttributeOperation";
-        key: string;
+
+    toJSON(): {
+        type: 'addRootAttribute' | 'removeRootAttribute' | 'changeRootAttribute';
         newValue: N;
         oldValue: O;
-        root: string;
+        baseVersion: number | null;
+        root: ReturnType<RootElement['toJSON']>;
+        key: string;
     };
 
+    static readonly className: 'RootAttributeOperation';
+
+    /**
+     * Creates RootAttributeOperation object from deserilized object, i.e. from parsed JSON string.
+     */
     static fromJSON(
-        json: Partial<ReturnType<RootAttributeOperation["toJSON"]>>,
+        json: {
+            root: string;
+            key: string;
+            oldValue: unknown;
+            newValue: unknown;
+            baseVersion: number | null;
+        },
         document: Document,
     ): RootAttributeOperation;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/operation/splitoperation.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/operation/splitoperation.d.ts
@@ -1,19 +1,13 @@
-import Document from "../document";
-import Position from "../position";
-import Range from "../range";
-import MergeOperation from "./mergeoperation";
-import Operation from "./operation";
+import Document from '../document';
+import Position from '../position';
+import Range from '../range';
+import MergeOperation from './mergeoperation';
+import Operation from './operation';
 
 export default class SplitOperation extends Operation {
-    graveyardPosition: Position | null;
-    howMany: number;
-    insertionPosition: Position;
-    readonly moveTargetPosition: Position;
-    readonly movedRange: Range;
-    splitPosition: Position;
-
-    static readonly className: "SplitOperation";
-
+    /**
+     * Creates a split operation.
+     */
     constructor(
         splitPosition: Position,
         howMany: number,
@@ -21,16 +15,81 @@ export default class SplitOperation extends Operation {
         graveyardPosition: Position,
         baseVersion: number | null,
     );
-    clone(): this;
+
+    /**
+     * Position at which an element should be split.
+     */
+    splitPosition: Position;
+
+    /**
+     * Total offset size of elements that are in the split element after `position`.
+     */
+    readonly howMany: number;
+
+    /**
+     * Position at which the clone of split element (or element from graveyard) will be inserted.
+     */
+    readonly insertionPosition: Position;
+
+    /**
+     * Position in the graveyard root before the element which should be used as a parent of the nodes after `position`.
+     * If it is not set, a copy of the the `position` parent will be used.
+     *
+     * The default behavior is to clone the split element. Element from graveyard is used during undo.
+     */
+    graveyardPosition: Position | null;
+
+    readonly type: 'split';
+
+    /**
+     * Position inside the new clone of a split element.
+     *
+     * This is a position where nodes that are after the split position will be moved to.
+     */
+    readonly moveTargetPosition: Position;
+
+    /**
+     * Artificial range that contains all the nodes from the split element that will be moved to the new element.
+     * The range starts at {@link ~#splitPosition} and ends in the same parent, at `POSITIVE_INFINITY` offset.
+     */
+    readonly movedRange: Range;
+
+    /**
+     * Creates and returns an operation that has the same parameters as this operation.
+     */
+    clone(): SplitOperation;
+
+    /**
+     * See {@link module:engine/model/operation/operation~Operation#getReversed `Operation#getReversed()`}.
+     */
     getReversed(): MergeOperation;
-    toJSON(): ReturnType<Operation["toJSON"]> & {
-        __className: "SplitOperation";
-        howMany: number;
-        splitPosition: ReturnType<Position["toJSON"]>;
-        insertionPosition: ReturnType<Position["toJSON"]>;
-        graveyardPosition: ReturnType<Position["toJSON"]>;
+
+    toJSON(): {
+        splitPosition: ReturnType<Position['toJSON']>;
+        insertionPosition: ReturnType<Position['toJSON']>;
+        graveyardPosition?: ReturnType<Position['toJSON']>;
+        baseVersion: number | null;
     };
 
-    static fromJSON(json: Partial<ReturnType<SplitOperation["toJSON"]>>, document: Document): SplitOperation;
+    static readonly className: 'SplitOperation';
+
+    /**
+     * Helper function that returns a default insertion position basing on given `splitPosition`. The default insertion
+     * position is after the split element.
+     */
     static getInsertionPosition(splitPosition: Position): Position;
+
+    /**
+     * Creates `SplitOperation` object from deserilized object, i.e. from parsed JSON string.
+     */
+    static fromJSON(
+        json: {
+            splitPosition: ReturnType<Position['toJSON']>;
+            insertionPosition: ReturnType<Position['toJSON']>;
+            graveyardPosition: ReturnType<Position['toJSON']>;
+            howMany: number;
+            baseVersion: number | null;
+        },
+        document: Document,
+    ): SplitOperation;
 }


### PR DESCRIPTION
* Fixes every `toJSON` and `fromJSON` method, based on upstream.
* `clone()` and `getReversed()` are optional and abstract.
* Removed `__className` cause it's expected to be private.
* Add missing `type` attribute to all operations.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/tree/v32.0.0/packages/ckeditor5-engine/src/model/operation
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.