### PR TITLE
[apple-mapkit-js-browser] Fix options type of Search.autocomplete

### DIFF
--- a/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
+++ b/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
@@ -137,7 +137,7 @@ const maxCameraDistance: number = newCameraZoomRange.maxCameraDistance;
 const search = new mapkit.Search({ limitToCountries: 'us,mx' });
 
 // Check that autocomplete accepts SearchAutocompleteOptions
-const number = search.autocomplete('Apple', (error, data) => {}, {
+search.autocomplete('Apple', (error, data) => {}, {
     limitToCountries: 'us,mx'
 });
 

--- a/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
+++ b/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
@@ -136,5 +136,10 @@ const maxCameraDistance: number = newCameraZoomRange.maxCameraDistance;
 // Check that limitToCountries accepts a string
 const search = new mapkit.Search({ limitToCountries: 'us,mx' });
 
+// Check that autocomplete accepts SearchAutocompleteOptions
+const number = search.autocomplete('Apple', (error, data) => {}, {
+    limitToCountries: 'us,mx'
+});
+
 // Check that all StyleConstructorOptions are optional
 const style = new mapkit.Style({});

--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -1843,7 +1843,7 @@ declare namespace mapkit {
         autocomplete(
             query: string,
             callback: SearchDelegate | AutocompleteSearchCallback,
-            options?: SearchOptions,
+            options?: SearchAutocompleteOptions,
         ): void;
         /**
          * Cancels a search request using its request ID.

--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -1838,7 +1838,13 @@ declare namespace mapkit {
          *
          * @param query A string that represents the user's search term in progress.
          * @param callback A callback function or delegate object.
-         * @param options Autocomplete takes the same options hash as search
+         * @param options With the options hash, you have the option to constrain
+         * the search to a desired area using the coordinate or region properties.
+         * A coordinate or region supplied here overrides the same property supplied
+         * to the `mapkit.Search` constructor. You also have the option to override
+         * the language provided to the seach constructor.
+         * For example, `{ language: ‘fr-CA‘ }` tells the server to send results
+         * localized to Canadian French.
          */
         autocomplete(
             query: string,


### PR DESCRIPTION
As discussed in #59330, this PR changes the type of the Search.autocomplete options parameter to the correct type: `SearchAutocompleteOptions` (see https://developer.apple.com/documentation/mapkitjs/mapkit/search/2974016-autocomplete).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.apple.com/documentation/mapkitjs/mapkit/search/2974016-autocomplete
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
