### PR TITLE
[ramda] fix and improve `when` function

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -2388,8 +2388,15 @@ export function view<S, A>(lens: Lens<S, A>, obj: S): A;
  * will return the result of calling the whenTrueFn function with the same argument. If the predicate is not satisfied,
  * the argument is returned as is.
  */
-export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U, a: T): T | U;
-export function when<T, U>(pred: (a: T) => boolean, whenTrueFn: (a: T) => U): (a: T) => T | U;
+export function when<Arg1, R,  Arg2 = Arg1, A = Arg1 & Arg2>(
+    pred: (a: Arg1) => boolean,
+    whenTrueFn: (a: Arg2) => R,
+    a: A
+): A | R;
+export function when<Arg1, R,  Arg2 = Arg1, A = Arg1 & Arg2>(
+    pred: (a: Arg1) => boolean,
+    whenTrueFn: (a: Arg2) => R,
+): (a: A) => A | R;
 
 /**
  * Takes a spec object and a test object and returns true if the test satisfies the spec.

--- a/types/ramda/test/when-tests.ts
+++ b/types/ramda/test/when-tests.ts
@@ -1,11 +1,11 @@
 import * as R from 'ramda';
 
 () => {
-  // $ExpectType (a: string) => string
-  const truncate = R.when(
-    (str: string) => str.length > 10,
-    (str: string) => str.slice(0, 10) + '…',
-  );
+    // $ExpectType (a: string) => string
+    const truncate = R.when(
+        (str: string) => str.length > 10,
+        (str: string) => str.slice(0, 10) + '…',
+    );
 
   // $ExpectType string
   truncate('12345'); // => '12345'
@@ -18,8 +18,45 @@ import * as R from 'ramda';
       R.add(1)
   );
 
-  // $ExpectType number | undefined
-  const nil = addOneIfNotNil(undefined);
-  // $ExpectType number | undefined
-  const two = addOneIfNotNil(1);
+    // $ExpectType (a: number) => string | number
+    const testBroaderType = R.when(
+        (x: number | undefined) => x != null,
+        (x: number | string) => 'some text',
+    );
+
+    // $Expect (a: number) => (string | number)
+    const testBroaderTypeCompatible = R.when<number, string>(
+        (x: number | undefined) => x != null,
+        (x: number | string) => 'some text',
+    );
+
+    // $ExpectError
+    testBroaderType(undefined);
+
+    // $ExpectError
+    testBroaderType('some string');
+
+    // $Expect (a: number) => number
+    const testSimple = R.when(
+        (x: number) => x != null,
+        (x: number) => 1,
+    );
+
+    // Expect (a: ({a: string, b: number} & {a: string, c: number})) => (string | ({a: string, b: number} & {a: string, c: number}))
+    const performActionOnObject = R.when(
+        (x: { a: string; b: number }) => x != null,
+        (x: { a: string; c: string }) => `a is: ${x.a}, c is: ${x.c}`,
+    );
+
+    // $Expect (a: {a: string, b: number, c: number}) => (string | {a: string, b: number, c: number})
+    const performActionOnObjectCompatible = R.when<{ a: string; b: number; c: number }, string>(
+        (x: { a: string; b: number }) => x != null,
+        (x: { a: string; c: number }) => 'some text',
+    );
+
+    // $Expect string | ({a: string, b: number} & {a: string, c: number})
+    const res = performActionOnObject({ a: 'some text', b: 1, c: 'another text' });
+
+    // $ExpectError
+    performActionOnObject({ a: 'some text', b: 1 });
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

<b>Improved `when` function and also reformatted `index.d.ts` with prettier as described in [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes)</b>
<b>It is braking change because If someone used `R.when` as `R.when<type1, type2>` passing type parameters explicitly - then it will not work because generic type is changed. My idea is to change types to satisfy typescript `"strict": true` option. So these changes now work with typescript `strict flag` and better represent function types.
Also fixing bug when you cannot pass function with broader type:
```ts
    const testBroaderType = R.when(
        (x: number | undefined) => x != null,
        (x: number | string) => 'some text',
    );
```
code above this show error in current `when function`</b>