### PR TITLE
[redux-immutable] allow using Record.Factory in getDefaultState()

### DIFF
--- a/types/redux-immutable/index.d.ts
+++ b/types/redux-immutable/index.d.ts
@@ -7,8 +7,9 @@
 // TypeScript Version: 2.3
 
 import { ReducersMapObject, Reducer, Action } from 'redux';
-import { Collection } from 'immutable';
+import { Collection, Record } from 'immutable';
 
 export declare function combineReducers<S, A extends Action, T>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Keyed<T, S>): Reducer<S, A>;
 export declare function combineReducers<S, A extends Action>(reducers: ReducersMapObject<S, A>, getDefaultState?: () => Collection.Indexed<S>): Reducer<S, A>;
 export declare function combineReducers<S>(reducers: ReducersMapObject<S, any>, getDefaultState?: () => Collection.Indexed<S>): Reducer<S>;
+export declare function combineReducers<S, T extends object>(reducers: ReducersMapObject<S, any>, getDefaultState?: Record.Factory<T>): Reducer<S>;

--- a/types/redux-immutable/redux-immutable-tests.ts
+++ b/types/redux-immutable/redux-immutable-tests.ts
@@ -1,6 +1,6 @@
 
 import { combineReducers } from 'redux-immutable';
-import { Map, List } from 'immutable';
+import { Map, List, Record } from 'immutable';
 import { AnyAction } from 'redux';
 
 // Dummy State interface
@@ -31,11 +31,15 @@ combineReducers<State, { type: string; payload: number | string}>({
 });
 
 /**
- * Combine reducers should accepts a function (getDefaultState()) as a second parameter, that returns an immutable Collection.Keyed collection.
+ * Combine reducers should accept a function (getDefaultState()) as a second parameter, that returns an immutable Collection.Keyed collection.
  */
 combineReducers<State, AnyAction, string>({}, () => { return Map<string, State>(); });
 combineReducers<State, AnyAction, number>({}, () => { return Map<number, State>(); });
 /**
- * Combine reducers should accepts a function (getDefaultState()) as a second parameter, that returns an immutable Collection.Indexed collection.
+ * Combine reducers should accept a function (getDefaultState()) as a second parameter, that returns an immutable Collection.Indexed collection.
  */
 combineReducers<State>({}, () => { return List<State>(); });
+/**
+ * Combine reducers should accept an immutable Record factory as a second parameter.
+ */
+combineReducers<State, object>({}, Record({}));


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/59273

In Immutable.js v4.0, `Immutable.Record` objects no longer extend from `Immutable.Collection`. An additional type definition is needed for this to work with redux-immutable.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/immutable-js/immutable-js/releases/tag/v4.0.0
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.