### PR TITLE
error-cause: Update types to match TS lib

### DIFF
--- a/types/error-cause/Error.d.ts
+++ b/types/error-cause/Error.d.ts
@@ -1,9 +1,9 @@
-import BaseError from './base/Error';
+import BaseError, { ErrorType } from './base/Error';
 
 declare class Error extends BaseError {
-    constructor(reason?: string, options?: { cause?: unknown });
+    constructor(reason?: string, options?: { cause?: ErrorType | undefined });
 
-    cause: unknown;
+    cause: ErrorType | undefined;
 }
 
 export default Error;

--- a/types/error-cause/EvalError.d.ts
+++ b/types/error-cause/EvalError.d.ts
@@ -1,9 +1,9 @@
 import BaseEvalError from './base/EvalError';
 
 declare class EvalError extends BaseEvalError {
-    constructor(reason?: string, options?: { cause?: unknown });
+    constructor(reason?: string, options?: { cause?: Error | undefined });
 
-    cause: unknown;
+    cause: Error | undefined;
 }
 
 export default EvalError;

--- a/types/error-cause/RangeError.d.ts
+++ b/types/error-cause/RangeError.d.ts
@@ -1,9 +1,9 @@
 import BaseRangeError from './base/RangeError';
 
 declare class RangeError extends BaseRangeError {
-    constructor(reason?: string, options?: { cause?: unknown });
+    constructor(reason?: string, options?: { cause?: Error | undefined });
 
-    cause: unknown;
+    cause: Error | undefined;
 }
 
 export default RangeError;

--- a/types/error-cause/ReferenceError.d.ts
+++ b/types/error-cause/ReferenceError.d.ts
@@ -1,9 +1,9 @@
 import BaseReferenceError from './base/ReferenceError';
 
 declare class ReferenceError extends BaseReferenceError {
-    constructor(reason?: string, options?: { cause?: unknown });
+    constructor(reason?: string, options?: { cause?: Error | undefined });
 
-    cause: unknown;
+    cause: Error | undefined;
 }
 
 export default ReferenceError;

--- a/types/error-cause/SyntaxError.d.ts
+++ b/types/error-cause/SyntaxError.d.ts
@@ -1,9 +1,9 @@
 import BaseSyntaxError from './base/SyntaxError';
 
 declare class SyntaxError extends BaseSyntaxError {
-    constructor(reason?: string, options?: { cause?: unknown });
+    constructor(reason?: string, options?: { cause?: Error | undefined });
 
-    cause: unknown;
+    cause: Error | undefined;
 }
 
 export default SyntaxError;

--- a/types/error-cause/TypeError.d.ts
+++ b/types/error-cause/TypeError.d.ts
@@ -1,9 +1,9 @@
 import BaseTypeError from './base/TypeError';
 
 declare class TypeError extends BaseTypeError {
-    constructor(reason?: string, options?: { cause?: unknown });
+    constructor(reason?: string, options?: { cause?: Error | undefined });
 
-    cause: unknown;
+    cause: Error | undefined;
 }
 
 export default TypeError;

--- a/types/error-cause/URIError.d.ts
+++ b/types/error-cause/URIError.d.ts
@@ -1,9 +1,9 @@
 import BaseURIError from './base/URIError';
 
 declare class URIError extends BaseURIError {
-    constructor(reason?: string, options?: { cause?: unknown });
+    constructor(reason?: string, options?: { cause?: Error | undefined });
 
-    cause: unknown;
+    cause: Error | undefined;
 }
 
 export default URIError;

--- a/types/error-cause/auto.d.ts
+++ b/types/error-cause/auto.d.ts
@@ -1,7 +1,7 @@
 interface Error {
-    cause: unknown;
+    cause: Error | undefined;
 }
 
 interface ErrorConstructor {
-    new (reason: string, options?: { cause?: unknown }): Error;
+    new (reason: string, options?: { cause?: Error | undefined }): Error;
 }

--- a/types/error-cause/base/Error.d.ts
+++ b/types/error-cause/base/Error.d.ts
@@ -1,3 +1,5 @@
 declare const BaseError: ErrorConstructor;
 
+export type ErrorType = Error;
+
 export default BaseError;

--- a/types/error-cause/test/Error.test.ts
+++ b/types/error-cause/test/Error.test.ts
@@ -7,8 +7,6 @@ new Error('reason');
 // $ExpectType Error
 new Error('reason', {});
 // $ExpectType Error
-new Error('reason', { cause: null });
-// $ExpectType Error
-new Error('reason', { cause: 'stupidity' });
+new Error('reason', { cause: undefined });
 // $ExpectType Error
 new Error('reason', { cause: new Error() });

--- a/types/error-cause/test/EvalError.test.ts
+++ b/types/error-cause/test/EvalError.test.ts
@@ -7,8 +7,8 @@ new EvalError('reason');
 // $ExpectType EvalError
 new EvalError('reason', {});
 // $ExpectType EvalError
-new EvalError('reason', { cause: null });
+new EvalError('reason', { cause: undefined });
 // $ExpectType EvalError
-new EvalError('reason', { cause: 'stupidity' });
+new EvalError('reason', { cause: new Error() });
 // $ExpectType EvalError
 new EvalError('reason', { cause: new EvalError() });

--- a/types/error-cause/test/RangeError.test.ts
+++ b/types/error-cause/test/RangeError.test.ts
@@ -7,8 +7,8 @@ new RangeError('reason');
 // $ExpectType RangeError
 new RangeError('reason', {});
 // $ExpectType RangeError
-new RangeError('reason', { cause: null });
+new RangeError('reason', { cause: undefined });
 // $ExpectType RangeError
-new RangeError('reason', { cause: 'stupidity' });
+new RangeError('reason', { cause: new Error() });
 // $ExpectType RangeError
 new RangeError('reason', { cause: new RangeError() });

--- a/types/error-cause/test/ReferenceError.test.ts
+++ b/types/error-cause/test/ReferenceError.test.ts
@@ -7,8 +7,8 @@ new ReferenceError('reason');
 // $ExpectType ReferenceError
 new ReferenceError('reason', {});
 // $ExpectType ReferenceError
-new ReferenceError('reason', { cause: null });
+new ReferenceError('reason', { cause: undefined });
 // $ExpectType ReferenceError
-new ReferenceError('reason', { cause: 'stupidity' });
+new ReferenceError('reason', { cause: new Error() });
 // $ExpectType ReferenceError
 new ReferenceError('reason', { cause: new ReferenceError() });

--- a/types/error-cause/test/SyntaxError.test.ts
+++ b/types/error-cause/test/SyntaxError.test.ts
@@ -7,8 +7,8 @@ new SyntaxError('reason');
 // $ExpectType SyntaxError
 new SyntaxError('reason', {});
 // $ExpectType SyntaxError
-new SyntaxError('reason', { cause: null });
+new SyntaxError('reason', { cause: undefined });
 // $ExpectType SyntaxError
-new SyntaxError('reason', { cause: 'stupidity' });
+new SyntaxError('reason', { cause: new Error() });
 // $ExpectType SyntaxError
 new SyntaxError('reason', { cause: new SyntaxError() });

--- a/types/error-cause/test/TypeError.test.ts
+++ b/types/error-cause/test/TypeError.test.ts
@@ -7,8 +7,6 @@ new TypeError('reason');
 // $ExpectType TypeError
 new TypeError('reason', {});
 // $ExpectType TypeError
-new TypeError('reason', { cause: null });
-// $ExpectType TypeError
-new TypeError('reason', { cause: 'stupidity' });
+new TypeError('reason', { cause: undefined });
 // $ExpectType TypeError
 new TypeError('reason', { cause: new TypeError() });

--- a/types/error-cause/test/URIError.test.ts
+++ b/types/error-cause/test/URIError.test.ts
@@ -7,8 +7,8 @@ new URIError('reason');
 // $ExpectType URIError
 new URIError('reason', {});
 // $ExpectType URIError
-new URIError('reason', { cause: null });
+new URIError('reason', { cause: undefined });
 // $ExpectType URIError
-new URIError('reason', { cause: 'stupidity' });
+new URIError('reason', { cause: new Error() });
 // $ExpectType URIError
 new URIError('reason', { cause: new URIError() });

--- a/types/error-cause/test/auto.test.ts
+++ b/types/error-cause/test/auto.test.ts
@@ -1,7 +1,5 @@
 import 'error-cause/auto';
 
-declare const Ø: any;
-
 // $ExpectType Error
 new Error();
 // $ExpectType Error
@@ -9,8 +7,6 @@ new Error('reason');
 // $ExpectType Error
 new Error('reason', {});
 // $ExpectType Error
-new Error('reason', { cause: null });
+new Error('reason', { cause: undefined });
 // $ExpectType Error
-new Error('reason', { cause: 'stupidity' });
-// $ExpectType Error
-new Error('reason', { cause: Ø as Error });
+new Error('reason', { cause: new Error() });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/blob/ae582a22ee1bb052e19b7c1bc4cac60509b574e0/src/lib/es2022.error.d.ts

The initial choice of representing cause as `unknown` was made to be conservative, but now it breaks these defs in environments with typescript's `es2022` libs turned on.

Here's the error I saw locally:
```
$ /Users/conartist6/dev/repos/macrome/node_modules/.bin/tsc
node_modules/.pnpm/@types+error-cause@1.0.1/node_modules/@types/error-cause/Error.d.ts:4:5 - error TS2416: Property 'cause' in type 'Error' is not assignable to the same property in base type 'Error'.
  Type 'unknown' is not assignable to type 'Error | undefined'.

4     cause: unknown;
      ~~~~~


Found 1 error in node_modules/.pnpm/@types+error-cause@1.0.1/node_modules/@types/error-cause/Error.d.ts:4
```