### PR TITLE
add types for navigator-languages-parser

### DIFF
--- a/types/navigator-languages-parser/index.d.ts
+++ b/types/navigator-languages-parser/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for navigator-languages-parser 0.10
+// Project: https://github.com/artka54/navigator-languages-parser
+// Definitions by: mike castleman <https://github.com/mlc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// tslint:disable-next-line no-unnecessary-class
+declare class NavigatorLanguagesParser {
+    private static _getUsersPreferredLanguages(): string[] | undefined;
+
+    static parseLanguages(acceptedLangs: readonly string[], defaultLang: string): string;
+    static parseLanguages(acceptedLangs: readonly string[], defaultLang?: false): string | undefined;
+}
+
+export = NavigatorLanguagesParser;

--- a/types/navigator-languages-parser/navigator-languages-parser-tests.ts
+++ b/types/navigator-languages-parser/navigator-languages-parser-tests.ts
@@ -1,0 +1,9 @@
+import NavigatorLanguagesParser = require('navigator-languages-parser');
+
+NavigatorLanguagesParser.parseLanguages(['en', 'es'], 'en'); // $ExpectType string
+
+NavigatorLanguagesParser.parseLanguages(['en', 'es']); // $ExpectType string | undefined
+
+NavigatorLanguagesParser.parseLanguages(['en', 'es'], false); // $ExpectType string | undefined
+
+NavigatorLanguagesParser.parseLanguages(['en', 'es'], true); // $ExpectError

--- a/types/navigator-languages-parser/tsconfig.json
+++ b/types/navigator-languages-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "navigator-languages-parser-tests.ts"
+    ]
+}

--- a/types/navigator-languages-parser/tslint.json
+++ b/types/navigator-languages-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
[navigator-languages-parser](https://github.com/artka54/navigator-languages-parser) is a small library for handling the `navigator.languages` property. This PR adds types for it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
