### PR TITLE
Fixes for @ckeditor/ckeditor5-engine

### DIFF
--- a/types/ckeditor__ckeditor5-engine/OTHER_FILES.txt
+++ b/types/ckeditor__ckeditor5-engine/OTHER_FILES.txt
@@ -6,12 +6,6 @@ src/model/operation/nooperation.d.ts
 src/model/operation/renameoperation.d.ts
 src/model/operation/rootattributeoperation.d.ts
 src/model/operation/splitoperation.d.ts
-src/model/utils/deletecontent.d.ts
-src/model/utils/getselectedcontent.d.ts
-src/model/utils/insertcontent.d.ts
-src/model/utils/modifyselection.d.ts
-src/view/observer/arrowkeysobserver.d.ts
-src/view/observer/bubblingeventinfo.d.ts
 src/view/observer/fakeselectionobserver.d.ts
 src/view/observer/focusobserver.d.ts
 src/view/observer/inputobserver.d.ts

--- a/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
@@ -8,12 +8,40 @@ import Model from '../model/model';
 import { StylesProcessor } from '../view/stylesmap';
 import View from '../view/view';
 
+/**
+ * Controller for the editing pipeline. The editing pipeline controls {@link ~EditingController#model model} rendering,
+ * including selection handling. It also creates the {@link ~EditingController#view view} which builds a
+ * browser-independent virtualization over the DOM elements. The editing controller also attaches default converters.
+ */
 export default class EditingController implements Observable {
+    /**
+     * Creates an editing controller instance.
+     */
     constructor(model: Model, stylesProcessor: StylesProcessor);
-    readonly downcastDispatcher: DowncastDispatcher;
-    readonly mapper: Mapper;
+    /**
+     * Editor model.
+     */
     readonly model: Model;
+
+    /**
+     * Editing view controller.
+     */
     readonly view: View;
+
+    /**
+     * Mapper which describes the model-view binding.
+     */
+    readonly mapper: Mapper;
+
+    /**
+     * Downcast dispatcher that converts changes from the model to {@link #view the editing view}.
+     */
+    readonly downcastDispatcher: DowncastDispatcher;
+
+    /**
+     * Removes all event listeners attached to the `EditingController`. Destroys all objects created
+     * by `EditingController` that need to be destroyed.
+     */
     destroy(): void;
 
     set(option: Record<string, unknown>): void;

--- a/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/downcastdispatcher.d.ts
@@ -114,7 +114,7 @@ export default class DowncastDispatcher<T = {}> implements Emitter {
     convertMarkerAdd(markerName: string, markerRange: Range, writer: DowncastWriter): void;
     convertMarkerRemove(markerName: string, markerRange: Range, writer: DowncastWriter): void;
     convertRemove(position: Position, length: number, name: string, writer: DowncastWriter): void;
-    convertSelection(selection: Selection, markers: MarkerCollection, writer: DowncastWriter): void;
+    convertSelection(selection: Selection | DocumentSelection, markers: MarkerCollection, writer: DowncastWriter): void;
     reconvertElement(element: Element, writer: DowncastWriter): void;
 
     on<N extends string>(

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcastdispatcher.d.ts
@@ -8,7 +8,9 @@ import Range from '../model/range';
 import Schema, { SchemaContextDefinition } from '../model/schema';
 import Writer from '../model/writer';
 import ViewDocumentFragment from '../view/documentfragment';
+import DocumentSelection from '../view/documentselection';
 import ViewElement from '../view/element';
+import ViewSelection from '../view/selection';
 import ViewText from '../view/text';
 import ViewConsumable from './viewconsumable';
 
@@ -62,6 +64,14 @@ export type UpcastEventArgs<K extends string = string> = K extends keyof UpcastE
     ? [UpcastEventDataTypes[K], UpcastConversionApi]
     : K extends 'viewCleanup'
     ? [ViewDocumentFragment | ViewElement]
+    : K extends 'selectionChange'
+    ? [
+          {
+              oldSelection: DocumentSelection | ViewSelection;
+              newSelection: DocumentSelection | ViewSelection;
+              domSelection: Selection;
+          },
+      ]
     : K extends `element:${infer N}`
     ? [UpcastConversionData<ViewElement & { name: N }>, UpcastConversionApi]
     : K extends `${infer NS}:${string}`

--- a/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/conversion/upcasthelpers.d.ts
@@ -4,7 +4,13 @@ import { MatcherPattern } from '../view/matcher';
 import ConversionHelpers from './conversionhelpers';
 import { UpcastConversionApi, UpcastDispatcherCallback } from './upcastdispatcher';
 import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import Model from '../model/model';
+import Mapper from './mapper';
+import ViewDocument from '../view/document';
 
+/**
+ * Upcast conversion helper functions.
+ */
 export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
     /**
      * View element to model element conversion helper.
@@ -54,6 +60,7 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
         model: string | ModelElement | ((el: ViewElement, api: UpcastConversionApi) => ModelElement | null);
         converterPriority?: PriorityString | number | undefined;
     }): this;
+
     /**
      * View element to model attribute conversion helper.
      *
@@ -126,7 +133,6 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
      *
      * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
      * to the conversion process.
-     *
      */
     elementToAttribute(config?: {
         view: MatcherPattern;
@@ -135,6 +141,7 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
             | { key: string; value: string | ((viewElement: ViewElement, api: UpcastConversionApi) => string | null) };
         converterPriority?: PriorityString | number | undefined;
     }): this;
+
     /**
      * View attribute to model attribute conversion helper.
      *
@@ -275,6 +282,7 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
 
         converterPriority?: PriorityString | number | undefined;
     }): this;
+
     /**
      * View element to model marker conversion helper.
      *
@@ -319,6 +327,7 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
      * to the conversion process.
      */
     elementToMarker(config: { view: MatcherPattern; model: string | ((el: ViewElement) => string) }): this;
+
     /**
      * View-to-model marker conversion helper.
      *
@@ -385,8 +394,37 @@ export default class UpcastHelpers extends ConversionHelpers<UpcastHelpers> {
     }): this;
 }
 
+/**
+ * Function factory, creates a converter that converts {@link module:engine/view/documentfragment~DocumentFragment view document fragment}
+ * or all children of {@link module:engine/view/element~Element} into
+ * {@link module:engine/model/documentfragment~DocumentFragment model document fragment}.
+ * This is the "entry-point" converter for upcast (view to model conversion). This converter starts the conversion of all children
+ * of passed view document fragment. Those children {@link module:engine/view/node~Node view nodes} are then handled by other converters.
+ *
+ * This also a "default", last resort converter for all view elements that has not been converted by other converters.
+ * When a view element is being converted to the model but it does not have converter specified, that view element
+ * will be converted to {@link module:engine/model/documentfragment~DocumentFragment model document fragment} and returned.
+ */
 export function convertToModelFragment(): UpcastDispatcherCallback<
     'element' | `element:${string}` | 'documentFragment'
 >;
 
+/**
+ * Function factory, creates a converter that converts {@link module:engine/view/text~Text} to {@link module:engine/model/text~Text}.
+ */
 export function convertText(): UpcastDispatcherCallback<'text'>;
+
+/**
+ * Function factory, creates a callback function which converts a {@link module:engine/view/selection~Selection
+ * view selection} taken from the {@link module:engine/view/document~Document#event:selectionChange} event
+ * and sets in on the {@link module:engine/model/document~Document#selection model}.
+ *
+ * **Note**: because there is no view selection change dispatcher nor any other advanced view selection to model
+ * conversion mechanism, the callback should be set directly on view document.
+ *
+ *    view.document.on( 'selectionChange', convertSelectionChange( modelDocument, mapper ) );
+ */
+export function convertSelectionChange(
+    model: Model,
+    mapper: Mapper,
+): UpcastDispatcherCallback<'selectionChange', ViewDocument>;

--- a/types/ckeditor__ckeditor5-engine/src/dataprocessor/basichtmlwriter.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/dataprocessor/basichtmlwriter.d.ts
@@ -1,5 +1,12 @@
-import { HtmlWriter } from "./htmlwriter";
+import { HtmlWriter } from './htmlwriter';
 
+/**
+ * Basic HTML writer. It uses the native `innerHTML` property for basic conversion
+ * from a document fragment to an HTML string.
+ */
 export default class BasicHtmlWriter implements HtmlWriter {
+    /**
+     * Returns an HTML string created from the document fragment.
+     */
     getHtml(fragment: DocumentFragment): string;
 }

--- a/types/ckeditor__ckeditor5-engine/src/dataprocessor/htmldataprocessor.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/dataprocessor/htmldataprocessor.d.ts
@@ -2,17 +2,61 @@ import Document from '../view/document';
 import DocumentFragment from '../view/documentfragment';
 import DomConverter from '../view/domconverter';
 import { MatcherPattern } from '../view/matcher';
-import Node from '../view/node';
-import { DataProcessor } from './dataprocessor';
 import BasicHtmlWriter from './basichtmlwriter';
+import { DataProcessor } from './dataprocessor';
 
+/**
+ * The HTML data processor class.
+ * This data processor implementation uses HTML as input and output data.
+ */
 export default class HtmlDataProcessor implements DataProcessor {
+    /**
+     * Creates a new instance of the HTML data processor class.
+     */
     constructor(document: Document);
-    domParser: DOMParser;
+    /**
+     * A DOM parser instance used to parse an HTML string to an HTML document.
+     */
+    readonly domParser: DOMParser;
+
+    /**
+     * A DOM converter used to convert DOM elements to view elements.
+     */
     domConverter: DomConverter;
-    htmlWriter: BasicHtmlWriter;
-    registerRawContentMatcher(pattern: MatcherPattern): void;
+
+    /**
+     * A basic HTML writer instance used to convert DOM elements to an HTML string.
+     */
+    readonly htmlWriter: BasicHtmlWriter;
+
+    /**
+     * Converts a provided {@link module:engine/view/documentfragment~DocumentFragment document fragment}
+     * to data format &mdash; in this case to an HTML string.
+     */
     toData(viewFragment: DocumentFragment): string;
-    toView(data: string): Node | DocumentFragment | null;
+
+    /**
+     * Converts the provided HTML string to a view tree.
+     */
+    toView(data: string): DocumentFragment;
+
+    /**
+     * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as raw data
+     * and not processed during the conversion from the DOM to the view elements.
+     *
+     * The raw data can be later accessed by a
+     * {@link module:engine/view/element~Element#getCustomProperty custom property of a view element} called `"$rawContent"`.
+     */
+    registerRawContentMatcher(pattern: MatcherPattern): void;
+
+    /**
+     * If the processor is set to use marked fillers, it will insert `&nbsp;` fillers wrapped in `<span>` elements
+     * (`<span data-cke-filler="true">&nbsp;</span>`) instead of regular `&nbsp;` characters.
+     *
+     * This mode allows for a more precise handling of the block fillers (so they do not leak into the editor content) but
+     * bloats the editor data with additional markup.
+     *
+     * This mode may be required by some features and will be turned on by them automatically.
+     */
     useFillerType(type: 'default' | 'marked'): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/dataprocessor/xmldataprocessor.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/dataprocessor/xmldataprocessor.d.ts
@@ -1,19 +1,75 @@
 import Document from '../view/document';
-import ViewDocumentFragment from '../view/documentfragment';
+import DocumentFragment from '../view/documentfragment';
 import DomConverter from '../view/domconverter';
 import { MatcherPattern } from '../view/matcher';
-import ViewNode from '../view/node';
-import { DataProcessor } from './dataprocessor';
 import BasicHtmlWriter from './basichtmlwriter';
+import { DataProcessor } from './dataprocessor';
 
-export default class XmlDataProcessor<N extends string[] = []> implements DataProcessor {
-    constructor(document: Document, options?: { namespaces?: N });
-    readonly namespaces: N;
+/**
+ * The XML data processor class.
+ * This data processor implementation uses XML as input and output data.
+ * This class is needed because unlike HTML, XML allows to use any tag with any value.
+ * For example, `<link>Text</link>` is a valid XML but invalid HTML.
+ */
+export default class XmlDataProcessor implements DataProcessor {
+    /**
+     * Creates a new instance of the XML data processor class.
+     */
+    constructor(document: Document, options?: { namespaces?: string[] });
+    /**
+     * A list of namespaces allowed to use in the XML input.
+     *
+     * For example, registering namespaces [ 'attribute', 'container' ] allows to use `<attirbute:tagName></attribute:tagName>`
+     * and `<container:tagName></container:tagName>` input. It is mainly for debugging.
+     */
+    readonly namespaces: string[];
+
+    /**
+     * DOM parser instance used to parse an XML string to an XML document.
+     */
     readonly domParser: DOMParser;
+
+    /**
+     * DOM converter used to convert DOM elements to view elements.
+     */
     readonly domConverter: DomConverter;
+
+    /**
+     * A basic HTML writer instance used to convert DOM elements to an XML string.
+     * There is no need to use a dedicated XML writer because the basic HTML writer works well in this case.
+     */
     readonly htmlWriter: BasicHtmlWriter;
-    toData(viewFragment: ViewDocumentFragment): string;
-    toView(data: string): ViewNode | ViewDocumentFragment | null;
+
+    /**
+     * Converts the provided {@link module:engine/view/documentfragment~DocumentFragment document fragment}
+     * to data format &mdash; in this case an XML string.
+     */
+    toData(viewFragment: DocumentFragment): string;
+
+    /**
+     * Converts the provided XML string to a view tree.
+     */
+    toView(data: string): DocumentFragment;
+
+    /**
+     * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as raw data
+     * and not processed during the conversion from XML to view elements.
+     *
+     * The raw data can be later accessed by a
+     * {@link module:engine/view/element~Element#getCustomProperty custom property of a view element} called `"$rawContent"`.
+     */
     registerRawContentMatcher(pattern: MatcherPattern): void;
+
+    /**
+     * If the processor is set to use marked fillers, it will insert `&nbsp;` fillers wrapped in `<span>` elements
+     * (`<span data-cke-filler="true">&nbsp;</span>`) instead of regular `&nbsp;` characters.
+     *
+     * This mode allows for a more precise handling of block fillers (so they do not leak into editor content) but
+     * bloats the editor data with additional markup.
+     *
+     * This mode may be required by some features and will be turned on by them automatically.
+     *
+     * @param {'default'|'marked'} type Whether to use the default or the marked `&nbsp;` block fillers.
+     */
     useFillerType(type: 'default' | 'marked'): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
@@ -34,7 +34,11 @@ export default class Model implements Observable {
     createRangeIn(element: Element): Range;
     createRangeOn(item: Item): Range;
     createSelection(
-        selectable?: Selectable,
+        selectable?: Selectable | Selectable[],
+        options?: { backward?: boolean | undefined },
+    ): Selection;
+    createSelection(
+        selectable?: Selectable | Selectable[],
         placeOrOffset?: number | 'before' | 'end' | 'after' | 'on' | 'in',
         options?: { backward?: boolean | undefined },
     ): Selection;

--- a/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/selection.d.ts
@@ -28,7 +28,6 @@ export type Selectable =
     | Text
     | null
     | Iterable<Range>;
-
 export default class Selection implements Emitter {
     constructor(
         selectable?: Selectable | null,
@@ -70,7 +69,7 @@ export default class Selection implements Emitter {
     is<K extends string>(type: 'element' | 'model:element', name: K): this is (Element | RootElement) & { name: K };
     is<K extends string>(type: 'rootElement' | 'model:rootElement', name: K): this is RootElement & { name: K };
     is(type: string, name?: string): boolean;
-    isEqual(otherSelection: Selection): boolean;
+    isEqual(otherSelection: Selection | DocumentSelection): boolean;
     removeAttribute(key: string): void;
     setAttribute(key: string, value: string | boolean | number): void;
     setFocus(itemOrPosition: Position): void;

--- a/types/ckeditor__ckeditor5-engine/src/model/treewalker.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/treewalker.d.ts
@@ -1,9 +1,9 @@
-import Element from "./element";
-import Position from "./position";
-import Range from "./range";
-import TextProxy from "./textproxy";
+import Element from './element';
+import Position from './position';
+import Range from './range';
+import TextProxy from './textproxy';
 
-export type TreeWalkerValueType = "elementStart" | "elementEnd" | "character" | "text";
+export type TreeWalkerValueType = 'elementStart' | 'elementEnd' | 'character' | 'text';
 
 export type TreeWalkerValue =
     | {
@@ -11,17 +11,17 @@ export type TreeWalkerValue =
           length: number;
           nextPosition: Position;
           previousPosition: Position;
-          type: "character" | "text";
+          type: 'character' | 'text';
       }
     | {
           item: Element;
           length: number;
           nextPosition: Position;
           previousPosition: Position;
-          type: "elementStart" | "elementEnd";
+          type: 'elementStart' | 'elementEnd';
       };
 
-export type TreeWalkerDirection = "forward" | "backward";
+export type TreeWalkerDirection = 'forward' | 'backward';
 
 export type TreeWalkerOptions =
     | {
@@ -41,15 +41,76 @@ export type TreeWalkerOptions =
           startPosition: Position;
       };
 
-export default class TreeWalker implements Iterable<TreeWalkerValue> {
-    readonly boundaries: Range;
+/**
+ * Position iterator class. It allows to iterate forward and backward over the document.
+ */
+export default class TreeWalker implements Iterator<TreeWalkerValue>, Iterable<TreeWalkerValue> {
+    /**
+     * Creates a range iterator. All parameters are optional, but you have to specify either `boundaries` or `startPosition`.
+     */
+    constructor(options: TreeWalkerOptions);
+
+    /**
+     * Walking direction. Defaults `'forward'`.
+     */
     readonly direction: TreeWalkerDirection;
-    readonly ignoreElementEnd: boolean;
+
+    /**
+     * Iterator boundaries.
+     *
+     * When the iterator is walking `'forward'` on the end of boundary or is walking `'backward'`
+     * on the start of boundary, then `{ done: true }` is returned.
+     *
+     * If boundaries are not defined they are set before first and after last child of the root node.
+     */
+    readonly boundaries: Range | null;
+
+    /**
+     * Iterator position. This is always static position, even if the initial position was a
+     * {@link module:engine/model/liveposition~LivePosition live position}. If start position is not defined then position depends
+     * on {@link #direction}. If direction is `'forward'` position starts form the beginning, when direction
+     * is `'backward'` position starts from the end.
+     */
     readonly position: Position;
-    readonly shallow: boolean;
+
+    /**
+     * Flag indicating whether all consecutive characters with the same attributes should be
+     * returned as one {@link module:engine/model/textproxy~TextProxy} (`true`) or one by one (`false`).
+     */
     readonly singleCharacters: boolean;
 
-    constructor(options: TreeWalkerOptions);
+    /**
+     * Flag indicating whether iterator should enter elements or not. If the iterator is shallow child nodes of any
+     * iterated node will not be returned along with `elementEnd` tag.
+     */
+    readonly shallow: boolean;
+
+    /**
+     * Flag indicating whether iterator should ignore `elementEnd` tags. If the option is true walker will not
+     * return a parent node of the start position. If this option is `true` each {@link module:engine/model/element~Element} will
+     * be returned once, while if the option is `false` they might be returned twice:
+     * for `'elementStart'` and `'elementEnd'`.
+     */
+    readonly ignoreElementEnd: boolean;
+
+    /**
+     * Iterable interface.
+     */
     [Symbol.iterator](): Iterator<TreeWalkerValue>;
+
+    /**
+     * Moves {@link #position} in the {@link #direction} skipping values as long as the callback function returns `true`.
+     *
+     * For example:
+     *
+     *     walker.skip( value => value.type == 'text' ); // <paragraph>[]foo</paragraph> -> <paragraph>foo[]</paragraph>
+     *     walker.skip( () => true ); // Move the position to the end: <paragraph>[]foo</paragraph> -> <paragraph>foo</paragraph>[]
+     *     walker.skip( () => false ); // Do not move the position.
+     */
     skip(skip: (value: TreeWalkerValue) => boolean): void;
+
+    /**
+     * Gets the next tree walker's value.
+     */
+    next(): { done: false; value: TreeWalkerValue } | { done: true; value: undefined };
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/utils/deletecontent.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/utils/deletecontent.d.ts
@@ -1,7 +1,15 @@
-import DocumentSelection from "../documentselection";
-import Model from "../model";
-import Selection from "../selection";
+import DocumentSelection from '../documentselection';
+import Model from '../model';
+import Selection from '../selection';
 
+/**
+ * Deletes content of the selection and merge siblings. The resulting selection is always collapsed.
+ *
+ * **Note:** Use {@link module:engine/model/model~Model#deleteContent} instead of this function.
+ * This function is only exposed to be reusable in algorithms
+ * which change the {@link module:engine/model/model~Model#deleteContent}
+ * method's behavior.
+ */
 export default function deleteContent(
     model: Model,
     selection: Selection | DocumentSelection,

--- a/types/ckeditor__ckeditor5-engine/src/model/utils/getselectedcontent.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/utils/getselectedcontent.d.ts
@@ -1,6 +1,21 @@
-import DocumentFragment from "../documentfragment";
-import DocumentSelection from "../documentselection";
-import Model from "../model";
-import Selection from "../selection";
+import DocumentFragment from '../documentfragment';
+import DocumentSelection from '../documentselection';
+import Model from '../model';
+import Selection from '../selection';
 
+/**
+ * Gets a clone of the selected content.
+ *
+ * For example, for the following selection:
+ *
+ * ```html
+ * <p>x</p><quote><p>y</p><h>fir[st</h></quote><p>se]cond</p><p>z</p>
+ * ```
+ *
+ * It will return a document fragment with such a content:
+ *
+ * ```html
+ * <quote><h>st</h></quote><p>se</p>
+ * ```
+ */
 export default function getSelectedContent(model: Model, selection: Selection | DocumentSelection): DocumentFragment;

--- a/types/ckeditor__ckeditor5-engine/src/model/utils/insertcontent.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/utils/insertcontent.d.ts
@@ -1,12 +1,34 @@
-import DocumentFragment from "../documentfragment";
-import { Item } from "../item";
-import Model from "../model";
-import Range from "../range";
-import { Selectable } from "../selection";
+import DocumentFragment from '../documentfragment';
+import { Item } from '../item';
+import Model from '../model';
+import Range from '../range';
+import { Selectable } from '../selection';
 
+/**
+ * Inserts content into the editor (specified selection) as one would expect the paste functionality to work.
+ *
+ * It takes care of removing the selected content, splitting elements (if needed), inserting elements and merging elements appropriately.
+ *
+ * Some examples:
+ *
+ *     <p>x^</p> + <p>y</p> => <p>x</p><p>y</p> => <p>xy[]</p>
+ *     <p>x^y</p> + <p>z</p> => <p>x</p>^<p>y</p> + <p>z</p> => <p>x</p><p>z</p><p>y</p> => <p>xz[]y</p>
+ *     <p>x^y</p> + <img /> => <p>x</p>^<p>y</p> + <img /> => <p>x</p><img /><p>y</p>
+ *     <p>x</p><p>^</p><p>z</p> + <p>y</p> => <p>x</p><p>y[]</p><p>z</p> (no merging)
+ *     <p>x</p>[<img />]<p>z</p> + <p>y</p> => <p>x</p>^<p>z</p> + <p>y</p> => <p>x</p><p>y[]</p><p>z</p>
+ *
+ * If an instance of {@link module:engine/model/selection~Selection} is passed as `selectable` it will be modified
+ * to the insertion selection (equal to a range to be selected after insertion).
+ *
+ * If `selectable` is not passed, the content will be inserted using the current selection of the model document.
+ *
+ * **Note:** Use {@link module:engine/model/model~Model#insertContent} instead of this function.
+ * This function is only exposed to be reusable in algorithms which change the {@link module:engine/model/model~Model#insertContent}
+ * method's behavior.
+ */
 export default function insertContent(
     model: Model,
     content: DocumentFragment | Item,
     selectable?: Selectable,
-    placeOrOffset?: number | "before" | "end" | "after" | "on" | "in",
+    placeOrOffset?: number | 'before' | 'end' | 'after' | 'on' | 'in',
 ): Range;

--- a/types/ckeditor__ckeditor5-engine/src/model/utils/modifyselection.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/utils/modifyselection.d.ts
@@ -1,9 +1,36 @@
-import DocumentSelection from "../documentselection";
-import Model from "../model";
-import Selection from "../selection";
+import DocumentSelection from '../documentselection';
+import Model from '../model';
+import Selection from '../selection';
 
+/**
+ * Modifies the selection. Currently, the supported modifications are:
+ *
+ * * Extending. The selection focus is moved in the specified `options.direction` with a step specified in `options.unit`.
+ * Possible values for `unit` are:
+ *  * `'character'` (default) - moves selection by one user-perceived character. In most cases this means moving by one
+ *  character in `String` sense. However, unicode also defines "combing marks". These are special symbols, that combines
+ *  with a symbol before it ("base character") to create one user-perceived character. For example, `q̣̇` is a normal
+ *  letter `q` with two "combining marks": upper dot (`Ux0307`) and lower dot (`Ux0323`). For most actions, i.e. extending
+ *  selection by one position, it is correct to include both "base character" and all of it's "combining marks". That is
+ *  why `'character'` value is most natural and common method of modifying selection.
+ *  * `'codePoint'` - moves selection by one unicode code point. In contrary to, `'character'` unit, this will insert
+ *  selection between "base character" and "combining mark", because "combining marks" have their own unicode code points.
+ *  However, for technical reasons, unicode code points with values above `UxFFFF` are represented in native `String` by
+ *  two characters, called "surrogate pairs". Halves of "surrogate pairs" have a meaning only when placed next to each other.
+ *  For example `𨭎` is represented in `String` by `\uD862\uDF4E`. Both `\uD862` and `\uDF4E` do not have any meaning
+ *  outside the pair (are rendered as ? when alone). Position between them would be incorrect. In this case, selection
+ *  extension will include whole "surrogate pair".
+ *  * `'word'` - moves selection by a whole word.
+ *
+ * **Note:** if you extend a forward selection in a backward direction you will in fact shrink it.
+ *
+ * **Note:** Use {@link module:engine/model/model~Model#modifySelection} instead of this function.
+ * This function is only exposed to be reusable in algorithms
+ * which change the {@link module:engine/model/model~Model#modifySelection}
+ * method's behavior.
+ */
 export default function modifySelection(
     model: Model,
     selection: Selection | DocumentSelection,
-    options?: { direction?: "forward" | "backward"; unit?: "character" | "codePoint" | "word" },
+    options?: { direction?: 'forward' | 'backward'; unit?: 'character' | 'codePoint' | 'word' },
 ): void;

--- a/types/ckeditor__ckeditor5-engine/src/model/writer.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/writer.d.ts
@@ -36,7 +36,7 @@ export default class Writer {
     createDocumentFragment(): DocumentFragment;
     createElement(name: string, attributes?: Record<string, string | number | boolean>): Element;
     createPositionAfter(item: Item): Position;
-    createPositionAt(itemOrPosition: Item, offset?: number | 'end' | 'before' | 'after'): Position;
+    createPositionAt(itemOrPosition: DocumentFragment | Item, offset?: number | 'end' | 'before' | 'after'): Position;
     createPositionAt(itemOrPosition: Position): Position;
     createPositionBefore(item: Item): Position;
     createPositionFromPath(root: Element | DocumentFragment, path: number[], stickiness?: PositionStickiness): Position;

--- a/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
@@ -16,8 +16,7 @@ export default class Document implements BubblingEmitter, Observable {
     readonly stylesProcessor: StylesProcessor;
     get isReadOnly(): boolean;
     protected set isReadOnly(value: boolean);
-    get isFocused(): boolean;
-    protected set isFocused(value: boolean);
+    isFocused: boolean;
     get isSelecting(): boolean;
     protected set isSelecting(value: boolean);
     get isComposing(): boolean;

--- a/types/ckeditor__ckeditor5-engine/src/view/domconverter.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/domconverter.d.ts
@@ -33,7 +33,7 @@ export default class DomConverter {
     );
     readonly document: ViewDocument;
     readonly renderingMode: 'data' | 'editing';
-    readonly blockFillerMode: BlockFillerMode;
+    blockFillerMode: BlockFillerMode;
     readonly preElements: ['pre'];
     readonly blockElements: [
         'address',
@@ -117,14 +117,23 @@ export default class DomConverter {
     domRangeToView(domRange: Range): ViewRange | null;
     domSelectionToView(domSelection: Selection): ViewSelection;
     domToView(
-        domNode: Node | DocumentFragment,
+        domNode: DocumentFragment,
         options?: {
             bind?: boolean | undefined;
             withChildren?: boolean | undefined;
             keepOriginalCase?: boolean | undefined;
             skipComments?: boolean | undefined;
         },
-    ): ViewNode | ViewDocumentFragment | null;
+    ): ViewDocumentFragment;
+    domToView(
+        domNode: Node,
+        options?: {
+            bind?: boolean | undefined;
+            withChildren?: boolean | undefined;
+            keepOriginalCase?: boolean | undefined;
+            skipComments?: boolean | undefined;
+        },
+    ): ViewNode | null;
     fakeSelectionToView(domElement: HTMLElement): ViewSelection | undefined;
     findCorrespondingDomText(viewText: ViewText): Text | null;
     findCorrespondingViewText(domText: Text): ViewText | null;
@@ -153,10 +162,19 @@ export default class DomConverter {
      * be created. For bound elements and document fragments the method will return corresponding items.
      */
     viewToDom(
-        viewNode: ViewNode | ViewDocumentFragment,
+        viewNode: ViewDocumentFragment,
         domDocument: Document,
         options?: { bind?: boolean | undefined; withChildren?: boolean | undefined },
-    ): Node | DocumentFragment;
+    ): DocumentFragment;
+    /**
+     * Converts the view to the DOM. For all text nodes, not bound elements and document fragments new items will
+     * be created. For bound elements and document fragments the method will return corresponding items.
+     */
+    viewToDom(
+        viewNode: ViewNode,
+        domDocument: Document,
+        options?: { bind?: boolean | undefined; withChildren?: boolean | undefined },
+    ): Node;
     /**
      * Sets the attribute on a DOM element.
      *
@@ -177,4 +195,4 @@ export default class DomConverter {
     removeDomElementAttribute(domElement: HTMLElement, key: string): void;
 }
 
-export type BlockFillerMode = 'br' | 'nbsp' | 'markednbsp';
+export type BlockFillerMode = 'br' | 'nbsp' | 'markedNbsp';

--- a/types/ckeditor__ckeditor5-engine/src/view/observer/arrowkeysobserver.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/observer/arrowkeysobserver.d.ts
@@ -1,3 +1,10 @@
-import Observer from "./observer";
+import Observer from './observer';
 
-export default class ArrowKeysObserver extends Observer {}
+/**
+ * Arrow keys observer introduces the {@link module:engine/view/document~Document#event:arrowKey `Document#arrowKey`} event.
+ *
+ * Note that this observer is attached by the {@link module:engine/view/view~View} and is available by default.
+ */
+export default class ArrowKeysObserver extends Observer {
+    observe(): void;
+}

--- a/types/ckeditor__ckeditor5-engine/src/view/observer/bubblingeventinfo.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/observer/bubblingeventinfo.d.ts
@@ -1,12 +1,27 @@
-import EventInfo from "@ckeditor/ckeditor5-utils/src/eventinfo";
-import Document from "../document";
-import Node from "../node";
-import Range from "../range";
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import Document from '../document';
+import Node from '../node';
+import Range from '../range';
 
+/**
+ * The event object passed to bubbling event callbacks. It is used to provide information about the event as well as a tool to
+ * manipulate it.
+ */
 export default class BubblingEventInfo extends EventInfo {
-    readonly currentTarget: Document | Node | null;
-    readonly eventPhase: "none" | "capturing" | "atTarget" | "bubbling";
+    constructor(source: Document, name: string, startRange: Range);
+
+    /**
+     * The view range that the bubbling should start from.
+     */
     readonly startRange: Range;
 
-    constructor(source: Document, name: string, startRange: Range);
+    /**
+     * The current event phase.
+     */
+    readonly eventPhase: 'none' | 'capturing' | 'atTarget' | 'bubbling';
+
+    /**
+     * The current bubbling target.
+     */
+    readonly currentTarget: Document | Node;
 }

--- a/types/ckeditor__ckeditor5-engine/src/view/rooteditableelement.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/rooteditableelement.d.ts
@@ -1,8 +1,7 @@
-import Document from "./document";
-import EditableElement from "./editableelement";
+import Document from './document';
+import EditableElement from './editableelement';
 
 export default class RootEditableElement extends EditableElement {
-    readonly rootName: string;
-
     constructor(document: Document, name: string);
+    rootName: string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* For `convertSelection`, https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/controller/editingcontroller.js#L73 and https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/controller/editingcontroller.js#L95
* Add `convertSelectionChange` to `upcastHelpers`: https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/conversion/upcasthelpers.js#L497
* Fix `createSelection`: https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/model/model.js#L782
* Fix `isEqual`: https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/conversion/upcasthelpers.js#L509
* Fix RootEditableElement['rootName'] is editable: https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/controller/editingcontroller.js#L122
* `blockFillerMode` is editable: https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js#L121
* `markedNbsp`, not `markednbsp`: https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js#L121
* `writer.createPositionAt` accepts `DocumentFragment`: https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/model/utils/insertcontent.js#L164
* Fix `Iterable` and `Iterator` for `TreeWalker`: https://github.com/ckeditor/ckeditor5/blob/v32.0.0/packages/ckeditor5-engine/src/model/treewalker.js
* `Document[isFocusable]` is not protected: https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/view/observer/focusobserver.js#L33
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.