### PR TITLE
Update bluetooth advertisement types in @types/web-bluetooth

### DIFF
--- a/types/web-bluetooth/index.d.ts
+++ b/types/web-bluetooth/index.d.ts
@@ -137,8 +137,12 @@ interface BluetoothRemoteGATTServer {
 }
 
 interface BluetoothDeviceEventHandlers {
-    onadvertisementreceived: (this: this, ev: Event) => any;
+    onadvertisementreceived: (this: this, ev: BluetoothAdvertisingEvent) => any;
     ongattserverdisconnected: (this: this, ev: Event) => any;
+}
+
+interface WatchAdvertisementsOptions {
+    signal?: AbortSignal;
 }
 
 interface BluetoothDevice extends EventTarget, BluetoothDeviceEventHandlers, CharacteristicEventHandlers, ServiceEventHandlers {
@@ -147,11 +151,11 @@ interface BluetoothDevice extends EventTarget, BluetoothDeviceEventHandlers, Cha
     readonly gatt?: BluetoothRemoteGATTServer | undefined;
     readonly uuids?: string[] | undefined;
     forget(): Promise<void>;
-    watchAdvertisements(): Promise<void>;
+    watchAdvertisements(options?: WatchAdvertisementsOptions): Promise<void>;
     unwatchAdvertisements(): void;
     readonly watchingAdvertisements: boolean;
     addEventListener(type: "gattserverdisconnected", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
-    addEventListener(type: "advertisementreceived", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "advertisementreceived", listener: (this: this, ev: BluetoothAdvertisingEvent) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }
 


### PR DESCRIPTION
- Add options parm to `BluetoothDevice.watchAdvertisements`.
- Update type of `advertisementreceived` event listeners.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://webbluetoothcg.github.io/web-bluetooth/>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
