### PR TITLE
[adm-zip] Add missing parameters

### DIFF
--- a/types/adm-zip/index.d.ts
+++ b/types/adm-zip/index.d.ts
@@ -144,9 +144,28 @@ declare class AdmZip {
      * @param targetPath Target location.
      * @param overwrite If the file already exists at the target path, the file
      *   will be overwriten if this is `true`. Default: `false`.
+     * @param keepOriginalPermission The file will be set as the permission from
+     *   the entry if this is true. Default: `false`.
+     */
+    extractAllTo(targetPath: string, overwrite?: boolean, keepOriginalPermission?: boolean): void;
+    /**
+     * Extracts the entire archive to the given location.
+     * @param targetPath Target location.
+     * @param overwrite If the file already exists at the target path, the file
+     *   will be overwriten if this is `true`. Default: `false`.
      * @param callback The callback function will be called after extraction.
      */
     extractAllToAsync(targetPath: string, overwrite?: boolean, callback?: (error: Error) => void): void;
+    /**
+     * Extracts the entire archive to the given location.
+     * @param targetPath Target location.
+     * @param overwrite If the file already exists at the target path, the file
+     *   will be overwriten if this is `true`. Default: `false`.
+     * @param keepOriginalPermission The file will be set as the permission from
+     *   the entry if this is true. Default: `false`.
+     * @param callback The callback function will be called after extraction.
+     */
+    extractAllToAsync(targetPath: string, overwrite?: boolean, keepOriginalPermission?: boolean, callback?: (error: Error) => void): void;
     /**
      * Writes the newly created zip file to disk at the specified location or
      * if a zip was opened and no `targetFileName` is provided, it will


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cthackers/adm-zip/issues/407#issuecomment-1037543996
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
