### PR TITLE
Fix @types/livereload typedef

### DIFF
--- a/types/livereload/index.d.ts
+++ b/types/livereload/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Hector Osuna <https://github.com/FanGoH/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Server as WebSocketServer } from 'ws';
+import { Server as WebSocketServer, WebSocket } from 'ws';
 import { Server as httpServer } from 'http';
 import { Server as httpsServer, ServerOptions } from 'https';
 import { EventEmitter } from 'events';
@@ -44,7 +44,7 @@ interface CreateServerConfig extends ServerConfig {
 }
 
 /** Live Reload Server object, provides main functionality */
-declare class LiveReloadServer extends EventEmitter {
+export class LiveReloadServer extends EventEmitter {
     config: ServerConfig;
     watcher: FSWatcher;
     server: WebSocketServer;

--- a/types/livereload/index.d.ts
+++ b/types/livereload/index.d.ts
@@ -9,7 +9,7 @@ import { Server as httpsServer, ServerOptions } from 'https';
 import { EventEmitter } from 'events';
 import { FSWatcher } from 'fs';
 
-interface ServerConfig {
+export interface ServerConfig {
     /** Protocol Version defaults to "7" */
     version?: string | undefined;
     /** Sets server port number: Defaults to 35729 */
@@ -37,7 +37,7 @@ interface ServerConfig {
 }
 
 /** Create Server Parameters */
-interface CreateServerConfig extends ServerConfig {
+export interface CreateServerConfig extends ServerConfig {
     https?: ServerOptions | undefined;
     server?: httpServer | httpsServer | undefined;
     noListen?: boolean | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
The definition was wrong: 
    The type `WebSocket` was missing from the imports.
