### PR TITLE
[gulp-connect-php] Add type definitions for gulp-connect-php

### DIFF
--- a/types/gulp-connect-php/gulp-connect-php-tests.ts
+++ b/types/gulp-connect-php/gulp-connect-php-tests.ts
@@ -1,8 +1,9 @@
 import connect = require('gulp-connect-php');
 
+// No arguments passsed
+connect.server();
 // Empty options and no callback
 connect.server({});
-
 // Empty options and callback
 connect.server({}, err => {
     if (err) throw err;

--- a/types/gulp-connect-php/gulp-connect-php-tests.ts
+++ b/types/gulp-connect-php/gulp-connect-php-tests.ts
@@ -1,0 +1,84 @@
+import connect = require('gulp-connect-php');
+
+// Empty options and no callback
+connect.server({});
+
+// Empty options and callback
+connect.server({}, err => {
+    if (err) throw err;
+});
+
+// All options and no callback
+connect.server({
+    port: 8080,
+    hostname: 'localhost',
+    base: '../',
+    open: true,
+    bin: '../php',
+    root: '/php',
+    stdio: 'inherit',
+    configCallback: (_type, collection) => collection,
+    debug: true,
+    ini: 'foo',
+    router: 'foo',
+});
+
+// Mutating config options with configCallback
+connect.server({
+    configCallback(type, collection) {
+        if (type === connect.OPTIONS_PHP_CLI_ARR) {
+            collection.push('--abc');
+        } else if (type === connect.OPTIONS_SPAWN_OBJ) {
+            collection.env = {
+                ...process.env,
+                CUSTOM_ENV_VAR: 'abc',
+            };
+        }
+        return collection;
+    },
+});
+
+connect.server({
+    configCallback(type) {
+        if (type === connect.OPTIONS_PHP_CLI_ARR) {
+            return ['--abc'];
+        } else {
+            return { foo: 'abc' };
+        }
+    },
+});
+
+// Killing server
+connect.closeServer(result => {
+    console.log('Kill result:', result);
+});
+
+// Instance of class
+const connectInstance = new connect();
+connectInstance.server({}, err => {
+    if (err) throw err;
+    console.log('Port:', connectInstance.port);
+    connectInstance.closeServer(result => {
+        console.log('Kill result:', result);
+    });
+});
+
+// Deprecated compat property
+// Shouldn't really be used like this, but these properties do exist
+connect.compat.server(
+    {
+        configCallback(type, collection) {
+            if (type === connect.compat.OPTIONS_SPAWN_OBJ) collection.foo = 'bar';
+            else if (type === connect.compat.OPTIONS_PHP_CLI_ARR) collection.push('--foo');
+
+            return collection;
+        },
+    },
+    err => {
+        if (err) throw err;
+        console.log('Port:', connect.compat.port);
+        connect.compat.closeServer(result => {
+            console.log('Kill result:', result);
+        });
+    },
+);

--- a/types/gulp-connect-php/gulp-connect-php-tests.ts
+++ b/types/gulp-connect-php/gulp-connect-php-tests.ts
@@ -29,10 +29,7 @@ connect.server({
         if (type === connect.OPTIONS_PHP_CLI_ARR) {
             collection.push('--abc');
         } else if (type === connect.OPTIONS_SPAWN_OBJ) {
-            collection.env = {
-                ...process.env,
-                CUSTOM_ENV_VAR: 'abc',
-            };
+            collection.env = { CUSTOM_ENV_VAR: 'abc' };
         }
         return collection;
     },
@@ -50,16 +47,17 @@ connect.server({
 
 // Killing server
 connect.closeServer(result => {
-    console.log('Kill result:', result);
+    result; // $ExpectType boolean | undefined
 });
 
 // Instance of class
 const connectInstance = new connect();
 connectInstance.server({}, err => {
+    err; // $ExpectType Error | undefined
     if (err) throw err;
-    console.log('Port:', connectInstance.port);
+    connectInstance.port; // $ExpectType number
     connectInstance.closeServer(result => {
-        console.log('Kill result:', result);
+        result; // $ExpectType boolean | undefined
     });
 });
 
@@ -75,10 +73,11 @@ connect.compat.server(
         },
     },
     err => {
+        err; // $ExpectType Error | undefined
         if (err) throw err;
-        console.log('Port:', connect.compat.port);
+        connect.compat.port; // $ExpectType number
         connect.compat.closeServer(result => {
-            console.log('Kill result:', result);
+            result; // $ExpectType boolean | undefined
         });
     },
 );

--- a/types/gulp-connect-php/index.d.ts
+++ b/types/gulp-connect-php/index.d.ts
@@ -1,0 +1,102 @@
+// Type definitions for gulp-connect-php 1.0
+// Project: https://github.com/micahblu/gulp-connect-php
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
+
+declare namespace PhpDevelopmentServerConnection {
+    interface Options {
+        /**
+         * The port to run on
+         * @default 8000
+         */
+        port?: number | undefined;
+        /**
+         * The hostname to run on
+         * @default "127.0.0.1"
+         */
+        hostname?: string | undefined;
+        /**
+         * @default "."
+         */
+        base?: string | undefined;
+        /**
+         * @default false
+         */
+        open?: boolean | undefined;
+        /**
+         * The PHP binary
+         * @default "php"
+         */
+        bin?: string | undefined;
+        root?: string | undefined;
+        stdio?: string | undefined;
+        /**
+         * Callback to modify config options
+         * @param type Either OPTIONS_SPAWN_OBJ or OPTIONS_PHP_CLI_ARR
+         * @param collection An object if type is OPTIONS_SPAWN_OBJ,
+         * or an array if type is OPTIONS_PHP_CLI_ARR
+         * @returns Possibly modified version of collection to use instead of original
+         */
+        configCallback?: ConfigCallback | null | undefined;
+        debug?: boolean | undefined;
+        /**
+         * Passed with `-c` flag
+         */
+        ini?: string | undefined;
+        router?: string | undefined;
+    }
+
+    type ConfigCallbackType = typeof OPTIONS_SPAWN_OBJ | typeof OPTIONS_PHP_CLI_ARR;
+
+    type ConfigCallback = (
+        type: ConfigCallbackType,
+        collection: Record<string, any> & string[],
+    ) => Record<string, any> | string[];
+
+    /**
+     * @deprecated Used only to create static server and closeServer functions
+     */
+    let compat: PhpDevelopmentServerConnection & {
+        OPTIONS_SPAWN_OBJ: typeof OPTIONS_SPAWN_OBJ;
+        OPTIONS_PHP_CLI_ARR: typeof OPTIONS_PHP_CLI_ARR;
+    };
+
+    /**
+     * @param options Options
+     * @param callback Called when the sever is connected. May be passed an error
+     */
+    let server: typeof PhpDevelopmentServerConnection.prototype.server;
+
+    /**
+     * Close/Shutdown the PHP development server
+     * @param callback Optional callback, passed the return of `ChildProcess.kill(...)` or nothing if not started
+     */
+    let closeServer: typeof PhpDevelopmentServerConnection.prototype.closeServer;
+
+    let OPTIONS_SPAWN_OBJ: 'spawn';
+    let OPTIONS_PHP_CLI_ARR: 'php_args';
+}
+
+declare class PhpDevelopmentServerConnection {
+    constructor(opts?: PhpDevelopmentServerConnection.Options);
+
+    /**
+     * @param options Options to override ones set in the constructor
+     * @param callback Called when the sever is connected. May be passed an error
+     */
+    server(options: PhpDevelopmentServerConnection.Options, callback?: (err?: Error) => void): void;
+
+    /**
+     * Close/Shutdown the PHP development server
+     * @param callback Optional callback, passed the return of `ChildProcess.kill(...)` or nothing if not started
+     */
+    closeServer(callback?: (killResult?: boolean) => void): void;
+
+    /**
+     * The port the server is running on
+     */
+    get port(): number;
+}
+
+export = PhpDevelopmentServerConnection;

--- a/types/gulp-connect-php/index.d.ts
+++ b/types/gulp-connect-php/index.d.ts
@@ -84,7 +84,7 @@ declare class PhpDevelopmentServerConnection {
      * @param options Options to override ones set in the constructor
      * @param callback Called when the sever is connected. May be passed an error
      */
-    server(options: PhpDevelopmentServerConnection.Options, callback?: (err?: Error) => void): void;
+    server(options?: PhpDevelopmentServerConnection.Options, callback?: (err?: Error) => void): void;
 
     /**
      * Close/Shutdown the PHP development server

--- a/types/gulp-connect-php/index.d.ts
+++ b/types/gulp-connect-php/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/micahblu/gulp-connect-php
 // Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-/// <reference types="node" />
 
 declare namespace PhpDevelopmentServerConnection {
     interface Options {

--- a/types/gulp-connect-php/index.d.ts
+++ b/types/gulp-connect-php/index.d.ts
@@ -66,13 +66,13 @@ declare namespace PhpDevelopmentServerConnection {
      * @param options Options
      * @param callback Called when the sever is connected. May be passed an error
      */
-    let server: typeof PhpDevelopmentServerConnection.prototype.server;
+    let server: PhpDevelopmentServerConnection['server'];
 
     /**
      * Close/Shutdown the PHP development server
      * @param callback Optional callback, passed the return of `ChildProcess.kill(...)` or nothing if not started
      */
-    let closeServer: typeof PhpDevelopmentServerConnection.prototype.closeServer;
+    let closeServer: PhpDevelopmentServerConnection['closeServer'];
 
     let OPTIONS_SPAWN_OBJ: 'spawn';
     let OPTIONS_PHP_CLI_ARR: 'php_args';

--- a/types/gulp-connect-php/tsconfig.json
+++ b/types/gulp-connect-php/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "gulp-connect-php-tests.ts"]
+}

--- a/types/gulp-connect-php/tslint.json
+++ b/types/gulp-connect-php/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Related discussion: #59385

Adds types for the npm package gulp-connect-php.

npm: https://www.npmjs.com/package/gulp-connect-php
GitHub: https://github.com/micahblu/gulp-connect-php

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test gulp-connect-php`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
