### PR TITLE
[react] Revert "Remove bivariance hack"

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -88,7 +88,8 @@ declare namespace React {
     interface RefObject<T> {
         readonly current: T | null;
     }
-    type RefCallback<T> = (instance: T | null) => void;
+    // Bivariance hack for consistent unsoundness with RefObject
+    type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
     type Ref<T> = RefCallback<T> | RefObject<T> | null;
     type LegacyRef<T> = string | Ref<T>;
     /**

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -420,7 +420,7 @@ imgProps.loading = 'nonsense';
 // $ExpectError
 imgProps.decoding = 'nonsense';
 type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
-// $ExpectType RefCallback<HTMLImageElement> | RefObject<HTMLImageElement> | null | undefined
+// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
 type ImgPropsWithRefRef = ImgPropsWithRef['ref'];
 type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
 // $ExpectType false

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -346,9 +346,14 @@ const htmlElementFnRef = (instance: HTMLElement | null) => {};
 const htmlElementRef = React.createRef<HTMLElement>();
 <div ref={htmlElementFnRef} />;
 <div ref={htmlElementRef} />;
-const unsoundDivFnRef = (instance: HTMLDivElement) => {};
-// `instance` is nullable
-<div ref={unsoundDivFnRef} />; // $ExpectError
+// `current` is nullable
+const unsoundDivFnRef = (current: HTMLDivElement) => {};
+declare const unsoundDivObjectRef: { current: HTMLDivElement };
+// `current` is nullable but type-checks
+// this is consistent with ref objects
+// If this ever not type-checks, `<div ref={unsoundDivObjectRef}` should also fail type-checking
+<div ref={unsoundDivFnRef} />;
+<div ref={unsoundDivObjectRef} />;
 
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef}/>;

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -549,10 +549,7 @@ select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 {
   const blockProps = be.useBlockProps({ ref: useRef("test") });
 
-  blockProps.ref(current => {
-      // $ExpectType unknown
-      current;
-  });
+  blockProps.ref((current: unknown) => {});
 }
 
 // $ExpectType Record<string, unknown>

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -548,8 +548,11 @@ select('core/block-editor').getAdjacentBlockClientId('foo', 1);
 
 {
   const blockProps = be.useBlockProps({ ref: useRef("test") });
-  // $ExpectType RefCallback<unknown>
-  blockProps.ref;
+
+  blockProps.ref(current => {
+      // $ExpectType unknown
+      current;
+  });
 }
 
 // $ExpectType Record<string, unknown>


### PR DESCRIPTION
Reverts https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936

The change is way too [disruptive in the ecosystem](https://github.com/mui/material-ui/pull/31894). What convinced me that we should keep the bivarianceHack is the fact that ref objects are still unsound. 

How I see it, is that it's better for type consumers to have consistent unsoundness over inconsistent soundness (only ref callbacks are sound). More context in https://github.com/mui/material-ui/pull/31894#issuecomment-1075356797