### PR TITLE
fix(node): missing property `readyState` on net.Socket

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -59,6 +59,7 @@ declare module 'net' {
         path: string;
     }
     type SocketConnectOpts = TcpSocketConnectOpts | IpcSocketConnectOpts;
+    type SocketReadyState = 'opening' | 'open' | 'readOnly' | 'writeOnly' | 'closed';
     /**
      * This class is an abstraction of a TCP socket or a streaming `IPC` endpoint
      * (uses named pipes on Windows, and Unix domain sockets otherwise). It is also
@@ -262,6 +263,12 @@ declare module 'net' {
          * @since v0.9.6
          */
         readonly localPort?: number;
+        /**
+         * This property represents the state of the connection as a string.
+         * @see {https://nodejs.org/api/net.html#socketreadystate}
+         * @since v0.5.0
+         */
+        readonly readyState: SocketReadyState;
         /**
          * The string representation of the remote IP address. For example,`'74.125.127.100'` or `'2001:4860:a005::68'`. Value may be `undefined` if
          * the socket is destroyed (for example, if the client disconnected).

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -244,6 +244,7 @@ import { Socket } from 'node:dgram';
     bool = _socket.connecting;
     bool = _socket.destroyed;
     _socket.destroy().destroy();
+    _socket.readyState; // $ExpectType SocketReadyState
 }
 
 {

--- a/types/node/v12/net.d.ts
+++ b/types/node/v12/net.d.ts
@@ -56,6 +56,7 @@ declare module 'net' {
     }
 
     type SocketConnectOpts = TcpSocketConnectOpts | IpcSocketConnectOpts;
+    type SocketReadyState = 'opening' | 'open' | 'readOnly' | 'writeOnly' | 'closed';
 
     class Socket extends stream.Duplex {
         constructor(options?: SocketConstructorOpts);
@@ -86,6 +87,12 @@ declare module 'net' {
         readonly destroyed: boolean;
         readonly localAddress: string;
         readonly localPort: number;
+        /**
+         * This property represents the state of the connection as a string.
+         * @see {https://nodejs.org/api/net.html#socketreadystate}
+         * @since v0.5.0
+         */
+        readonly readyState: SocketReadyState;
         readonly remoteAddress?: string | undefined;
         readonly remoteFamily?: string | undefined;
         readonly remotePort?: number | undefined;

--- a/types/node/v12/test/net.ts
+++ b/types/node/v12/test/net.ts
@@ -237,6 +237,7 @@ import { LookupOneOptions } from 'dns';
     bool = _socket.connecting;
     bool = _socket.destroyed;
     _socket.destroy();
+    _socket.readyState; // $ExpectType SocketReadyState
 }
 
 {

--- a/types/node/v14/net.d.ts
+++ b/types/node/v14/net.d.ts
@@ -56,6 +56,7 @@ declare module 'net' {
     }
 
     type SocketConnectOpts = TcpSocketConnectOpts | IpcSocketConnectOpts;
+    type SocketReadyState = 'opening' | 'open' | 'readOnly' | 'writeOnly' | 'closed';
 
     class Socket extends stream.Duplex {
         constructor(options?: SocketConstructorOpts);
@@ -87,6 +88,12 @@ declare module 'net' {
         readonly destroyed: boolean;
         readonly localAddress: string;
         readonly localPort: number;
+        /**
+         * This property represents the state of the connection as a string.
+         * @see {https://nodejs.org/api/net.html#socketreadystate}
+         * @since v0.5.0
+         */
+        readonly readyState: SocketReadyState;
         readonly remoteAddress?: string | undefined;
         readonly remoteFamily?: string | undefined;
         readonly remotePort?: number | undefined;

--- a/types/node/v14/test/net.ts
+++ b/types/node/v14/test/net.ts
@@ -240,6 +240,7 @@ import { LookupOneOptions } from 'node:dns';
     bool = _socket.connecting;
     bool = _socket.destroyed;
     _socket.destroy();
+    _socket.readyState; // $ExpectType SocketReadyState
 }
 
 {

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -59,6 +59,7 @@ declare module 'net' {
         path: string;
     }
     type SocketConnectOpts = TcpSocketConnectOpts | IpcSocketConnectOpts;
+    type SocketReadyState = 'opening' | 'open' | 'readOnly' | 'writeOnly' | 'closed';
     /**
      * This class is an abstraction of a TCP socket or a streaming `IPC` endpoint
      * (uses named pipes on Windows, and Unix domain sockets otherwise). It is also
@@ -262,6 +263,12 @@ declare module 'net' {
          * @since v0.9.6
          */
         readonly localPort?: number;
+        /**
+         * This property represents the state of the connection as a string.
+         * @see {https://nodejs.org/api/net.html#socketreadystate}
+         * @since v0.5.0
+         */
+        readonly readyState: SocketReadyState;
         /**
          * The string representation of the remote IP address. For example,`'74.125.127.100'` or `'2001:4860:a005::68'`. Value may be `undefined` if
          * the socket is destroyed (for example, if the client disconnected).

--- a/types/node/v16/test/net.ts
+++ b/types/node/v16/test/net.ts
@@ -244,6 +244,7 @@ import { Socket } from 'node:dgram';
     bool = _socket.connecting;
     bool = _socket.destroyed;
     _socket.destroy();
+    _socket.readyState; // $ExpectType SocketReadyState
 }
 
 {


### PR DESCRIPTION
As per issue: #59394
https://nodejs.org/api/net.html#socketreadystate
Added undocumented 'closed':
https://github.com/nodejs/node/blob/85e3624473c5230552229145537369ea0e235693/lib/net.js#L566

Thanks!

/cc @camo-f

Fixes #59394

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).