### PR TITLE
Add missing promises version for MemoryCookieStore to tough-cookie

### DIFF
--- a/types/tough-cookie/index.d.ts
+++ b/types/tough-cookie/index.d.ts
@@ -138,7 +138,7 @@ export namespace Cookie {
     interface Properties {
         key?: string | undefined;
         value?: string | undefined;
-        expires?: Date | undefined;
+        expires?: Date | 'Infinity' | undefined;
         maxAge?: number | 'Infinity' | '-Infinity' | undefined;
         domain?: string | undefined;
         path?: string | undefined;

--- a/types/tough-cookie/index.d.ts
+++ b/types/tough-cookie/index.d.ts
@@ -262,4 +262,26 @@ export abstract class Store {
     getAllCookies(cb: (err: Error | null, cookie: Cookie[]) => void): void;
 }
 
-export class MemoryCookieStore extends Store { }
+export class MemoryCookieStore extends Store {
+    findCookie(domain: string, path: string, key: string, cb: (err: Error | null, cookie: Cookie | null) => void): void;
+    findCookie(domain: string, path: string, key: string): Promise<Cookie | null>;
+
+    findCookies(domain: string, path: string, allowSpecialUseDomain: boolean, cb: (err: Error | null, cookie: Cookie[]) => void): void;
+    findCookies(domain: string, path: string, cb: (err: Error | null, cookie: Cookie[]) => void): void;
+    findCookies(domain: string, path: string, allowSpecialUseDomain?: boolean): Promise<Cookie[]>;
+
+    putCookie(cookie: Cookie, cb: (err: Error | null) => void): void;
+    putCookie(cookie: Cookie): Promise<void>;
+
+    updateCookie(oldCookie: Cookie, newCookie: Cookie, cb: (err: Error | null) => void): void;
+    updateCookie(oldCookie: Cookie, newCookie: Cookie): Promise<void>;
+
+    removeCookie(domain: string, path: string, key: string, cb: (err: Error | null) => void): void;
+    removeCookie(domain: string, path: string, key: string): Promise<void>;
+
+    removeCookies(domain: string, path: string, cb: (err: Error | null) => void): void;
+    removeCookies(domain: string, path: string): Promise<void>;
+
+    getAllCookies(cb: (err: Error | null, cookie: Cookie[]) => void): void;
+    getAllCookies(): Promise<Cookie[]>;
+}

--- a/types/tough-cookie/tough-cookie-tests.ts
+++ b/types/tough-cookie/tough-cookie-tests.ts
@@ -77,15 +77,22 @@ CookieJar.deserializeSync("test cookie"); // $ExpectType CookieJar
 
 const store = new MemoryCookieStore();
 store.findCookie('example.com', '/', 'foo', cbCookie); // $ExpectType void
+store.findCookie('example.com', '/', 'foo'); // $ExpectType Promise<Cookie | null>
 
 store.findCookies('example.com', '/', false, cbCookies); // $ExpectType void
+store.findCookies('example.com', '/', false); // $ExpectType Promise<Cookie[]>
 
 store.putCookie(cookie, cb); // $ExpectType void
+store.putCookie(cookie); // $ExpectType Promise<void>
 
 store.updateCookie(cookie, cookie, cb); // $ExpectType void
+store.updateCookie(cookie, cookie); // $ExpectType Promise<void>
 
 store.removeCookie('example.com', '/', 'foo', cb); // $ExpectType void
+store.removeCookie('example.com', '/', 'foo'); // $ExpectType Promise<void>
 
 store.removeCookies('example.com', '/', cb); // $ExpectType void
+store.removeCookies('example.com', '/'); // $ExpectType Promise<void>
 
 store.getAllCookies(cbCookies); // $ExpectType void
+store.getAllCookies(); // $ExpectType Promise<Cookie[]>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- - [fromCallback set promises](https://github.com/salesforce/tough-cookie/blob/2921fbdfe11e310b1b0835b4d050575578b4b2c3/lib/memstore.js#L179)
- - [optional allowSpecialUseDomain](https://github.com/salesforce/tough-cookie/blob/2921fbdfe11e310b1b0835b4d050575578b4b2c3/lib/memstore.js#L65)
- - Infinity expires: 
- - - [doc ref](https://github.com/salesforce/tough-cookie/blob/2921fbdfe11e310b1b0835b4d050575578b4b2c3/lib/memstore.js#L65): expires - Date - if set, the Expires= attribute of the cookie (defaults to the string "Infinity").
- - - [types above in already exists definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/407fe31012868fd2d0ba26e812bfe9ace80b0644/types/tough-cookie/index.d.ts#L89)