### PR TITLE
Allow for folder-nested page objects 

### DIFF
--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -1406,8 +1406,8 @@ export interface NightwatchKeys {
 export type NightwatchPage = {
     [name: string]: () => EnhancedPageObject<any, any, any>;
 } & {
-    [name: string]: NightwatchPage
-}
+    [name: string]: NightwatchPage;
+};
 
 export interface NightwatchAPI extends SharedCommands, WebDriverProtocol, NightwatchCustomCommands {
     baseURL: string;

--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -1401,15 +1401,19 @@ export interface NightwatchKeys {
     COMMAND: string;
 }
 
+export type NightwatchPage = {
+    [name: string]: () => EnhancedPageObject<any, any, any>;
+} & {
+    [name: string]: NightwatchPage
+}
+
 export interface NightwatchAPI extends SharedCommands, WebDriverProtocol, NightwatchCustomCommands {
     baseURL: string;
     assert: NightwatchAssertions;
     expect: Expect;
     verify: NightwatchAssertions;
 
-    page: {
-        [name: string]: () => EnhancedPageObject<any, any, any>;
-    } & NightwatchCustomPageObjects;
+    page: NightwatchPage & NightwatchCustomPageObjects;
 
     /**
      * SessionId of the session used by the Nightwatch api.

--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -10,6 +10,8 @@
 //                 Ravi Sawlani <https://github.com/gravityvi>
 //                 Binayak Ghosh <https://github.com/swrdfish>
 //                 Harshit Agrawal <https://github.com/harshit-bs>
+//                 David Mello <https://github.com/literallyMello>
+//                 Luke Bickell <https://github.com/lukebickell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.5
 

--- a/types/nightwatch/test/nightwatch-tests.ts
+++ b/types/nightwatch/test/nightwatch-tests.ts
@@ -222,6 +222,10 @@ const testPage = {
 
         browser.end();
     },
+
+    'Test nested page objects': () => {
+        const google = browser.page.subfolder1.subfolder2.subfolder3.google();
+    },
 };
 
 //


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Source code which provides context for the suggested changes: 

Nightwatch allows for folder organization of page objects like so:
```
pages
│   TopLevelPage.ts    
│
└───folder1
    │   FolderPage.ts
    │
    └───subfolder1
           SubFolderPage.ts
```
This results in the following:
```
browser.page.TopLevelPage()
browser.page.folder1.FolderPage()
browser.page.folder1.subfolder1.SubFolderPage()
```

This was previously not supported, but with the recursive type added in this PR, this is now possible.
