### PR TITLE
[@types/mailchimp_mailchimp_transactional] fix: update type to match documentation

### DIFF
--- a/types/mailchimp__mailchimp_transactional/index.d.ts
+++ b/types/mailchimp__mailchimp_transactional/index.d.ts
@@ -24,7 +24,7 @@ declare namespace Mailchimp {
 
     interface Recipient {
         email: string;
-        name: string;
+        name?: string;
         type: RecipientType;
     }
 

--- a/types/mailchimp__mailchimp_transactional/mailchimp__mailchimp_transactional-tests.ts
+++ b/types/mailchimp__mailchimp_transactional/mailchimp__mailchimp_transactional-tests.ts
@@ -11,13 +11,6 @@ mailchimp.messages.send({
     message: {
         to: [
             { name: 'John Doe', email: 'johndoe@example.com', type: 'to' },
-        ],
-    },
-});
-
-mailchimp.messages.send({
-    message: {
-        to: [
             { email: 'johndoe@example.com', type: 'to' },
         ],
     },

--- a/types/mailchimp__mailchimp_transactional/mailchimp__mailchimp_transactional-tests.ts
+++ b/types/mailchimp__mailchimp_transactional/mailchimp__mailchimp_transactional-tests.ts
@@ -15,4 +15,12 @@ mailchimp.messages.send({
     },
 });
 
+mailchimp.messages.send({
+    message: {
+        to: [
+            { email: 'johndoe@example.com', type: 'to' },
+        ],
+    },
+});
+
 export default mailchimp;


### PR DESCRIPTION
Please fill in this template.

- [x] Make `Recipient.name` optional according to the official documentation.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mailchimp.com/developer/transactional/api/messages/send-new-message/

**Some additional information if required:**
The documentation linked above and shown in the picture below show that the `name` prop is optional.  This simple PR just updates this to match the type listed on the documentation. I've tested it on my own app as well; the API accepts the recipient without a `name` prop. 

<img width="479" alt="image" src="https://user-images.githubusercontent.com/8990518/159828079-7a6d8159-87bd-413e-ad8d-8306397421aa.png">


