### PR TITLE
@types/lodash: Overload `debounce` to provide correct return type when `leading` option is true

### DIFF
--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -394,6 +394,9 @@ declare module "../index" {
          */
         flush(): ReturnType<T> | undefined;
     }
+    interface DebouncedFuncLeading<T extends (...args: any[]) => any> extends DebouncedFunc<T> {
+      (...args: Parameters<T>): ReturnType<T>;
+    }
     interface LoDashStatic {
         /**
          * Creates a debounced function that delays invoking func until after wait milliseconds have elapsed since
@@ -415,12 +418,17 @@ declare module "../index" {
          * @param options.trailing Specify invoking on the trailing edge of the timeout.
          * @return Returns the new debounced function.
          */
+        debounce<T extends (...args: any) => any>(func: T, wait?: number, options?: { leading: true } & DebounceSettings): DebouncedFuncLeading<T>;
         debounce<T extends (...args: any) => any>(func: T, wait?: number, options?: DebounceSettings): DebouncedFunc<T>;
     }
     interface Function<T extends (...args: any) => any> {
         /**
          * @see _.debounce
          */
+        debounce(
+            wait?: number,
+            options?: { leading: true } & DebounceSettings
+        ): T extends (...args: any[]) => any ? Function<DebouncedFuncLeading<T>> : never;
         debounce(
             wait?: number,
             options?: DebounceSettings
@@ -430,6 +438,10 @@ declare module "../index" {
         /**
          * @see _.debounce
          */
+        debounce(
+            wait?: number,
+            options?: { leading: true } & DebounceSettings
+        ): T extends (...args: any[]) => any ? FunctionChain<DebouncedFuncLeading<T>> : never;
         debounce(
             wait?: number,
             options?: DebounceSettings

--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -368,6 +368,9 @@ declare module "../index" {
          */
         trailing?: boolean | undefined;
     }
+    interface DebounceSettingsLeading extends DebounceSettings {
+        leading: true;
+    }
     interface DebouncedFunc<T extends (...args: any[]) => any> {
         /**
          * Call the original function, but applying the debounce rules.
@@ -395,7 +398,8 @@ declare module "../index" {
         flush(): ReturnType<T> | undefined;
     }
     interface DebouncedFuncLeading<T extends (...args: any[]) => any> extends DebouncedFunc<T> {
-      (...args: Parameters<T>): ReturnType<T>;
+        (...args: Parameters<T>): ReturnType<T>;
+        flush(): ReturnType<T>;
     }
     interface LoDashStatic {
         /**
@@ -418,7 +422,7 @@ declare module "../index" {
          * @param options.trailing Specify invoking on the trailing edge of the timeout.
          * @return Returns the new debounced function.
          */
-        debounce<T extends (...args: any) => any>(func: T, wait?: number, options?: { leading: true } & DebounceSettings): DebouncedFuncLeading<T>;
+        debounce<T extends (...args: any) => any>(func: T, wait: number | undefined, options: DebounceSettingsLeading): DebouncedFuncLeading<T>;
         debounce<T extends (...args: any) => any>(func: T, wait?: number, options?: DebounceSettings): DebouncedFunc<T>;
     }
     interface Function<T extends (...args: any) => any> {
@@ -426,8 +430,8 @@ declare module "../index" {
          * @see _.debounce
          */
         debounce(
-            wait?: number,
-            options?: { leading: true } & DebounceSettings
+            wait: number | undefined,
+            options: DebounceSettingsLeading
         ): T extends (...args: any[]) => any ? Function<DebouncedFuncLeading<T>> : never;
         debounce(
             wait?: number,
@@ -439,8 +443,8 @@ declare module "../index" {
          * @see _.debounce
          */
         debounce(
-            wait?: number,
-            options?: { leading: true } & DebounceSettings
+            wait: number | undefined,
+            options: DebounceSettingsLeading
         ): T extends (...args: any[]) => any ? FunctionChain<DebouncedFuncLeading<T>> : never;
         debounce(
             wait?: number,

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3393,6 +3393,11 @@ fp.now(); // $ExpectType number
 {
     const func = (n: number, s: string): boolean => true;
     const options: _.DebounceSettings = {
+        leading: false,
+        maxWait: 100,
+        trailing: false,
+    };
+    const optionsWithLeading: _.DebounceSettingsLeading = {
         leading: true,
         maxWait: 100,
         trailing: false,
@@ -3403,9 +3408,16 @@ fp.now(); // $ExpectType number
     result.flush(); // $ExpectType boolean | undefined
     _.debounce(func, 42); // $ExpectType DebouncedFunc<(n: number, s: string) => boolean>
     _.debounce(func, 42, options); // $ExpectType DebouncedFunc<(n: number, s: string) => boolean>
+    _.debounce(func, 42, optionsWithLeading); // $ExpectType DebouncedFuncLeading<(n: number, s: string) => boolean>
 
+    _(func).debounce(); // $ExpectType Function<DebouncedFunc<(n: number, s: string) => boolean>>
+    _(func).debounce(42); // $ExpectType Function<DebouncedFunc<(n: number, s: string) => boolean>>
     _(func).debounce(42, options); // $ExpectType Function<DebouncedFunc<(n: number, s: string) => boolean>>
+    _(func).debounce(42, optionsWithLeading); // $ExpectType Function<DebouncedFuncLeading<(n: number, s: string) => boolean>>
+    _.chain(func).debounce(); // $ExpectType FunctionChain<DebouncedFunc<(n: number, s: string) => boolean>>
+    _.chain(func).debounce(42); // $ExpectType FunctionChain<DebouncedFunc<(n: number, s: string) => boolean>>
     _.chain(func).debounce(42, options); // $ExpectType FunctionChain<DebouncedFunc<(n: number, s: string) => boolean>>
+    _.chain(func).debounce(42, optionsWithLeading); // $ExpectType FunctionChain<DebouncedFuncLeading<(n: number, s: string) => boolean>>
     fp.debounce(42, func); // $ExpectType DebouncedFunc<(n: number, s: string) => boolean>
     fp.debounce(42)(func); // $ExpectType DebouncedFunc<(n: number, s: string) => boolean>
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.15#debounce
  - setting `leading: true` as part of the options means that the result of `debounce` can never be `undefined` since it will be immediately invoked the first time it's called, and all subsequent calls will either use this previous value or a new value if the timeout has been reached.
  - i've made a codesandbox here to demonstrate: https://codesandbox.io/s/cocky-booth-m74xft
  
first time contributing to the repo, so happy to make any changes necessary 🙇 

