### PR TITLE
[@orbit-ui/react-components] Use same types as runtime peer dependencies

### DIFF
--- a/types/orbit-ui__react-components/tsconfig.json
+++ b/types/orbit-ui__react-components/tsconfig.json
@@ -13,7 +13,8 @@
         "forceConsistentCasingInFileNames": true,
         "jsx": "react",
         "paths": {
-            "@orbit-ui/*": ["orbit-ui__*"]
+            "@orbit-ui/*": ["orbit-ui__*"],
+            "react": ["react/v16"]
         }
     },
     "files": ["index.d.ts", "orbit-ui__react-components-tests.tsx"]


### PR DESCRIPTION
While [`@orbit-ui/react-components` apparently supports any React version](https://unpkg.com/@orbit-ui/react-components@11.1.0/package.json) (which is almost certainly incorrect), [`semantic-ui-react` only supports React 16](https://unpkg.com/semantic-ui-react@0.88.1/package.json). 


Motivated by breaking changes in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210 that cause compilation failures in semantic-ui-react.