### PR TITLE
fix: useRef type incompatibility with ref property

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -137,10 +137,10 @@ declare namespace React {
         key?: Key | null | undefined;
     }
     interface RefAttributes<T> extends Attributes {
-        ref?: Ref<T> | undefined;
+        ref?: Ref<T | null>;
     }
     interface ClassAttributes<T> extends Attributes {
-        ref?: LegacyRef<T> | undefined;
+        ref?: LegacyRef<T | null>;
     }
 
     interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1035,8 +1035,9 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    function useRef<T>(initialValue: T): MutableRefObject<T>;
-    // convenience overload for refs given as a ref prop as they typically start with a null value
+    function useRef<T extends {}>(initialValue: T): MutableRefObject<T>;
+    // convenience overload for refs given as a ref prop with call with 0 arguments
+    // defaults to | null for compatibility with Component's ref property
     /**
      * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
      * (`initialValue`). The returned object will persist for the full lifetime of the component.
@@ -1050,9 +1051,8 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    function useRef<T>(initialValue: T|null): RefObject<T>;
-    // convenience overload for potentially undefined initialValue / call with 0 arguments
-    // has a default to stop it from defaulting to {} instead
+    function useRef<T = null>(): RefObject<T | null>;
+    // convenience overload for null initialValue
     /**
      * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
      * (`initialValue`). The returned object will persist for the full lifetime of the component.
@@ -1060,10 +1060,28 @@ declare namespace React {
      * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
      * value around similar to how you’d use instance fields in classes.
      *
+     * Usage note: if you need the result of useRef to be directly mutable, include `| null` in the type
+     * of the generic argument.
+     *
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+    function useRef<T = null>(initialValue: null): RefObject<T>;
+    // convenience overload for potentially undefined or null initialValue
+    /**
+     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+     * (`initialValue`). The returned object will persist for the full lifetime of the component.
+     *
+     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+     * value around similar to how you’d use instance fields in classes.
+     *
+     * Usage note: if you need the result of useRef to be directly mutable, include `| null` in the type
+     * of the generic argument.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#useref
+     */
+    function useRef<T>(initialValue: T): MutableRefObject<T>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -127,7 +127,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
 
     // these are not very useful (can't assign anything else to .current)
     // but it's the only safe way to resolve them
-    // $ExpectType MutableRefObject<null>
+    // $ExpectType RefObject<null>
     React.useRef(null);
     // $ExpectType MutableRefObject<undefined>
     React.useRef(undefined);
@@ -136,15 +136,22 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // it should _not_ be mutable if the generic argument doesn't include null
     // $ExpectType RefObject<number>
     React.useRef<number>(null);
+    // should _not_ be mutable if there's no argument
+    // $ExpectType RefObject<number | null>
+    React.useRef<number>();
     // but it should be mutable if it does (i.e. is not the convenience overload)
     // $ExpectType MutableRefObject<number | null>
+    React.useRef<number | null>(0);
+    // but not if the initial value is null
+    // $ExpectType RefObject<number | null>
     React.useRef<number | null>(null);
 
     // |undefined convenience overload
-    // with no contextual type or generic argument it should default to undefined only (not {} or unknown!)
-    // $ExpectType MutableRefObject<undefined>
+    // with no contextual type or generic argument it should default to unmutable null only (not {} or unknown!)
+    // $ExpectType RefObject<null>
     React.useRef();
-    // $ExpectType MutableRefObject<number | undefined>
+    // Should _not_ be mutable if there's no inital argument
+    // $ExpectType RefObject<number | null>
     React.useRef<number>();
     // don't just accept a potential undefined if there is a generic argument
     // $ExpectError
@@ -158,7 +165,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
 
     // should be contextually typed
     const a: React.MutableRefObject<number | undefined> = React.useRef(undefined);
-    const b: React.MutableRefObject<number | undefined> = React.useRef();
+    const b: React.RefObject<number | null | undefined> = React.useRef();
     const c: React.MutableRefObject<number | null> = React.useRef(null);
     const d: React.RefObject<number> = React.useRef(null);
 

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -459,14 +459,14 @@ const ForwardingRefComponent2 = React.forwardRef<HTMLElement>((props, ref) => {
 const MemoizedForwardingRefComponent = React.memo(ForwardingRefComponent);
 const LazyComponent = React.lazy(() => Promise.resolve({ default: RefComponent }));
 
-type ClassComponentAsRef = React.ElementRef<typeof RefComponent>; // $ExpectType RefComponent
+type ClassComponentAsRef = React.ElementRef<typeof RefComponent>; // $ExpectType RefComponent | null
 type FunctionComponentWithoutPropsAsRef = React.ElementRef<typeof RefCarryingComponent>; // $ExpectType never
 type FunctionComponentWithPropsAsRef = React.ElementRef<typeof FunctionComponent>; // $ExpectType never
-type HTMLIntrinsicAsRef = React.ElementRef<'div'>; // $ExpectType HTMLDivElement
-type SVGIntrinsicAsRef = React.ElementRef<'svg'>; // $ExpectType SVGSVGElement
-type ForwardingRefComponentAsRef = React.ElementRef<typeof ForwardingRefComponent>; // $ExpectType RefComponent
-type MemoizedForwardingRefComponentAsRef = React.ElementRef<typeof MemoizedForwardingRefComponent>; // $ExpectType RefComponent
-type LazyComponentAsRef = React.ElementRef<typeof LazyComponent>; // $ExpectType RefComponent
+type HTMLIntrinsicAsRef = React.ElementRef<'div'>; // $ExpectType HTMLDivElement | null
+type SVGIntrinsicAsRef = React.ElementRef<'svg'>; // $ExpectType SVGSVGElement | null
+type ForwardingRefComponentAsRef = React.ElementRef<typeof ForwardingRefComponent>; // $ExpectType RefComponent | null
+type MemoizedForwardingRefComponentAsRef = React.ElementRef<typeof MemoizedForwardingRefComponent>; // $ExpectType RefComponent | null
+type LazyComponentAsRef = React.ElementRef<typeof LazyComponent>; // $ExpectType RefComponent | null
 
 //
 // Attributes

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -407,7 +407,7 @@ imgProps.loading = 'nonsense';
 // $ExpectError
 imgProps.decoding = 'nonsense';
 type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
-// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
+// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement | null> | null | undefined
 type ImgPropsWithRefRef = ImgPropsWithRef['ref'];
 type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
 // $ExpectType false

--- a/types/yaireo__tagify/dist/react.tagify.d.ts
+++ b/types/yaireo__tagify/dist/react.tagify.d.ts
@@ -26,7 +26,7 @@ import {
     TagifySettings,
 } from '@yaireo/tagify';
 
-import { MutableRefObject, ReactElement } from 'react';
+import { RefObject, ReactElement } from 'react';
 
 declare namespace Tags {
     /**
@@ -352,7 +352,7 @@ declare namespace Tags {
          * value after the initial render is not supported.
          * @default undefined
          */
-        tagifyRef?: MutableRefObject<Tagify<T> | undefined> | undefined;
+        tagifyRef?: RefObject<Tagify<T> | null>;
 
         /**
          * Same as `defaultValue`. Initial value, i.e. the initial tags that are


### PR DESCRIPTION
fixed #58408 
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

Behavior as follows:
- [ Changed ] If useRef is called with no initial argument it'll no longer break typing checking by defining it as MutableRef<T | undefined>, instead it'll be defined as RefObject<T | null> which is compatible with React Components' ref property field (see issue #58408 )
- [ Changed ] Before if null was given as initial value with a null typing it would incorrectly assume it to be MutableRef even though it's the pattern used to declare Components' References (immutable), now it properly returns RefObject. For empty starting values for non Component/Element reference should use `undefined` instead.