### PR TITLE
Fix @ckeditor/ckeditor5-engine UIElement render method

### DIFF
--- a/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
@@ -98,7 +98,6 @@ import Matcher, { MatcherPattern } from '@ckeditor/ckeditor5-engine/src/view/mat
 import ViewNode from '@ckeditor/ckeditor5-engine/src/view/node';
 import ArrowKeysObserver from '@ckeditor/ckeditor5-engine/src/view/observer/arrowkeysobserver';
 import BubblingEventInfo from '@ckeditor/ckeditor5-engine/src/view/observer/bubblingeventinfo';
-import ClickObserver from '@ckeditor/ckeditor5-engine/src/view/observer/clickobserver';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import DomEventObserver from '@ckeditor/ckeditor5-engine/src/view/observer/domeventobserver';
 import FakeSelectionObserver from '@ckeditor/ckeditor5-engine/src/view/observer/fakeselectionobserver';
@@ -340,7 +339,7 @@ downcastHelper = downcastHelper.add(dispatcher => {
         evt.name; // $ExpectType "insert:paragraph"
         data; // $ExpectType { item: Element & { name: "paragraph"; }; range: Range; }
         schema; // $ExpectType Schema
-        writer; // $ExpectType DowncastWriter
+        writer; // $ExpectType DowncastWriter<Document>
         dispatcher; // $ExpectType DowncastDispatcher<{}>
         mapper; // $ExpectType Mapper
         consumable; // ExpectType ModelConsumable
@@ -1359,13 +1358,13 @@ downcastWriter.createRawElement();
 // prettier-ignore
 downcastWriter.createRawElement('div').render = function(domElement: HTMLElement, domConverter: DomConverter) {
     domConverter.setContentOf(domElement, '<b>This is the raw content of myRawElement.</b>');
-    // $ExpectType DowncastWriter
+    // $ExpectType DowncastWriter<Document>
     this;
 };
 // prettier-ignore
 downcastWriter.createRawElement('div', { id: 'foo' }, function(domElement, domConverter) {
     domConverter.setContentOf(domElement, '<b>This is the raw content of myRawElement.</b>');
-    // $ExpectType DowncastWriter
+    // $ExpectType DowncastWriter<Document>
     this;
 });
 
@@ -1652,3 +1651,19 @@ stylesProcessor.setNormalizer('margin', getPositionShorthandNormalizer('margin')
 
 // $ExpectType string[]
 getShorthandValues('');
+
+const myUIElement = downcastWriter.createUIElement('span');
+myUIElement.render = function render(domDocument, domConverter) {
+    const domElement = this.toDomElement(domDocument);
+
+    domConverter.setContentOf(domElement, '<b>this is ui element</b>');
+
+    return domElement;
+};
+
+downcastWriter.createUIElement('span', null, function callback(domDocument) {
+    const domElement = this.toDomElement(domDocument);
+    domElement.innerHTML = '<b>this is ui element</b>';
+
+    return domElement;
+});

--- a/types/ckeditor__ckeditor5-engine/src/view/downcastwriter.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/downcastwriter.d.ts
@@ -1,6 +1,6 @@
 import AttributeElement from './attributeelement';
 import ContainerElement from './containerelement';
-import Document from './document';
+import ViewDocument from './document';
 import DocumentFragment from './documentfragment';
 import DomConverter from './domconverter';
 import EditableElement from './editableelement';
@@ -31,10 +31,10 @@ import View from './view';
  * Read more about changing the view in the {@glink framework/guides/architecture/editing-engine#changing-the-view Changing the view}
  * section of the {@glink framework/guides/architecture/editing-engine Editing engine architecture} guide.
  */
-export default class DowncastWriter {
-    constructor(document: Document);
+export default class DowncastWriter<D extends ViewDocument = ViewDocument> {
+    constructor(document: D);
 
-    readonly document: Document;
+    readonly document: D;
 
     addClass(className: string | string[], element: Element): void;
     breakAttributes(positionOrRange: Position | Range): Position | Range;
@@ -111,8 +111,8 @@ export default class DowncastWriter {
     createText(data: string): Text;
     createUIElement(
         name: string,
-        attributes?: Record<string, string>,
-        renderFunction?: (this: DowncastWriter, domElement: HTMLElement) => void,
+        attributes?: Record<string, string> | null,
+        renderFunction?: (this: UIElement, domElement: Document) => void,
         options?: { isAllowedInsideAttributeElement?: boolean | undefined },
     ): UIElement;
     insert(

--- a/types/ckeditor__ckeditor5-engine/src/view/uielement.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/uielement.d.ts
@@ -1,6 +1,4 @@
-import Document from './document';
 import DomConverter from './domconverter';
-import DowncastWriter from './downcastwriter';
 import Element from './element';
 import View from './view';
 
@@ -23,8 +21,43 @@ import View from './view';
  * {@link module:engine/view/downcastwriter~DowncastWriter#createUIElement `downcastWriter#createUIElement()`} method.
  */
 export default class UIElement extends Element {
-    render(this: DowncastWriter, domDocument: Document, domConverter: DomConverter): HTMLElement;
+    /**
+     * Returns `null` because filler is not needed for UIElements.
+     */
+    getFillerOffset(): null;
+
+    /**
+     * Renders this {@link module:engine/view/uielement~UIElement} to DOM. This method is called by
+     * {@link module:engine/view/domconverter~DomConverter}.
+     * Do not use inheritance to create custom rendering method, replace `render()` method instead:
+     *
+     *    const myUIElement = downcastWriter.createUIElement( 'span' );
+     *    myUIElement.render = function( domDocument, domConverter ) {
+     *      const domElement = this.toDomElement( domDocument );
+     *
+     *      domConverter.setContentOf( domElement, '<b>this is ui element</b>' );
+     *
+     *      return domElement;
+     *    };
+     *
+     * If changes in your UI element should trigger some editor UI update you should call
+     * the {@link module:core/editor/editorui~EditorUI#update `editor.ui.update()`} method
+     * after rendering your UI element.
+     */
+    render(domDocument: Document, domConverter: DomConverter): HTMLElement;
+
+    /**
+     * Creates DOM element based on this view UIElement.
+     * Note that each time this method is called new DOM element is created.
+     */
     toDomElement(domDocument: Document): HTMLElement;
 }
 
+/**
+ * This function injects UI element handling to the given {@link module:engine/view/document~Document document}.
+ *
+ * A callback is added to {@link module:engine/view/document~Document#event:keydown document keydown event}.
+ * The callback handles the situation when right arrow key is pressed and selection is collapsed before a UI element.
+ * Without this handler, it would be impossible to "jump over" UI element using right arrow key.
+ */
 export function injectUiElementHandling(view: View): void;


### PR DESCRIPTION
`this` is `UIElement`, not `DowncastWriter`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/view/uielement.js#L145-L148
- https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-engine/src/view/downcastwriter.js#L314-L316
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.