### PR TITLE
Add types of es/ListBox at carbon-components-react package

### DIFF
--- a/types/carbon-components-react/OTHER_FILES.txt
+++ b/types/carbon-components-react/OTHER_FILES.txt
@@ -6,3 +6,6 @@ lib/components/ListBox/next/index.d.ts
 lib/components/ListBox/next/ListBoxSelection.d.ts
 lib/components/ListBox/next/ListBoxTrigger.d.ts
 lib/components/Portal/index.d.ts
+es/components/ListBox/next/index.d.ts
+es/components/ListBox/next/ListBoxSelection.d.ts
+es/components/ListBox/next/ListBoxTrigger.d.ts

--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -67,6 +67,7 @@ import UIShellLink from 'carbon-components-react/lib/components/UIShell/Link';
 import { Popover, PopoverContent } from 'carbon-components-react/lib/components/Popover';
 import { LayoutDirection } from "carbon-components-react/lib/components/Layout";
 import { Text } from "carbon-components-react/lib/components/Text";
+import ListBox from "carbon-components-react/es/components/ListBox"
 
 // test components for "as" props
 interface TestCompProps {
@@ -1189,4 +1190,11 @@ const dataTableSkeletonBasic = (
         labelText=""
         ref={inputRef}
     />;
+}
+
+//
+// ListBox
+//
+{
+    const listBox = <ListBox></ListBox>
 }

--- a/types/carbon-components-react/es/components/ListBox/ListBox.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/ListBox.d.ts
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { ReactDivAttr, ForwardRefReturn } from "../../../typings/shared";
+import { ListBoxFieldComponent } from "./ListBoxField";
+import { ListBoxMenuComponent } from "./ListBoxMenu";
+import { ListBoxMenuIconComponent } from "./ListBoxMenuIcon";
+import { ListBoxMenuItemComponent } from "./ListBoxMenuItem";
+import { ListBoxSize, ListBoxType } from "./ListBoxPropTypes";
+import { ListBoxSelectionComponent } from "./ListBoxSelection";
+
+type ExcludedAttributes = "onKeyDown" | "onKeyPress" | "ref";
+
+export interface ListBoxProps extends Omit<ReactDivAttr, ExcludedAttributes> {
+    disabled?: boolean | undefined, // required but has default value
+    invalid?: boolean | undefined,
+    invalidText?: React.ReactNode | undefined,
+    isOpen?: boolean | undefined,
+    light?: boolean | undefined,
+    size?: ListBoxSize | undefined,
+    type?: ListBoxType | undefined, // required but has default value
+    warn?: boolean | undefined,
+    warnText?: React.ReactNode | undefined,
+}
+
+export interface ListBoxComponent extends ForwardRefReturn<HTMLDivElement, ListBoxProps> {
+    readonly Field: ListBoxFieldComponent,
+    readonly Menu: ListBoxMenuComponent,
+    readonly MenuIcon: ListBoxMenuIconComponent,
+    readonly MenuItem: ListBoxMenuItemComponent,
+    readonly Selection: ListBoxSelectionComponent,
+}
+
+declare const ListBox: ListBoxComponent;
+
+export default ListBox;

--- a/types/carbon-components-react/es/components/ListBox/ListBoxField.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/ListBoxField.d.ts
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { ReactDivAttr } from "../../../typings/shared";
+
+export interface ListBoxFieldProps extends Omit<ReactDivAttr, "id"> {
+    id: string,
+}
+
+export interface ListBoxFieldComponent extends React.FC<ListBoxFieldProps> { }
+
+declare const ListBoxField: ListBoxFieldComponent;
+
+export default ListBoxField;

--- a/types/carbon-components-react/es/components/ListBox/ListBoxMenu.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/ListBoxMenu.d.ts
@@ -1,0 +1,11 @@
+import { ReactDivAttr, ForwardRefReturn } from "../../../typings/shared";
+
+export interface ListBoxMenuProps extends Omit<ReactDivAttr, "id"> {
+    id: string;
+}
+
+export interface ListBoxMenuComponent extends ForwardRefReturn<HTMLDivElement, ListBoxMenuProps> { }
+
+declare const ListBoxMenu: ListBoxMenuComponent;
+
+export default ListBoxMenu;

--- a/types/carbon-components-react/es/components/ListBox/ListBoxMenuIcon.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/ListBoxMenuIcon.d.ts
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { InternationalProps } from "../../../typings/shared";
+
+export type ListBoxMenuIconTranslationKey = "close.menu" | "open.menu";
+
+export interface ListBoxMenuIconProps extends InternationalProps<ListBoxMenuIconTranslationKey> {
+    isOpen: boolean,
+}
+
+export interface ListBoxMenuIconComponent extends React.FC<ListBoxMenuIconProps> { }
+
+declare const ListBoxMenuIcon: ListBoxMenuIconComponent;
+
+export default ListBoxMenuIcon;

--- a/types/carbon-components-react/es/components/ListBox/ListBoxMenuItem.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/ListBoxMenuItem.d.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { ReactDivAttr, ForwardRefReturn } from "../../../typings/shared";
+
+export interface ListBoxMenuItemProps extends ReactDivAttr {
+    isActive?: boolean | undefined, // required but has default value
+    isHighlighted?: boolean | undefined, // required but has default value
+}
+
+export interface ListBoxMenuItemForwardedRef {
+    menuItemOptionRef?: React.Ref<HTMLDivElement> | undefined;
+}
+
+export interface ListBoxMenuItemComponent extends ForwardRefReturn<ListBoxMenuItemForwardedRef, ListBoxMenuItemProps> { }
+
+declare const ListBoxMenuItem: ListBoxMenuItemComponent;
+
+export default ListBoxMenuItem;

--- a/types/carbon-components-react/es/components/ListBox/ListBoxPropTypes.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/ListBoxPropTypes.d.ts
@@ -1,0 +1,2 @@
+export type ListBoxSize = "sm" | "md" | "lg" | "xl";
+export type ListBoxType = "default" | "inline";

--- a/types/carbon-components-react/es/components/ListBox/ListBoxSelection.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/ListBoxSelection.d.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { InternationalProps } from "../../../typings/shared";
+
+export type ListBoxSelectionTranslationKey = "clear.all" | "clear.selection";
+
+export interface ListBoxSelectionProps extends InternationalProps<ListBoxSelectionTranslationKey> {
+    clearSelection(e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>): void,
+    disabled?: boolean | undefined,
+    onClearSelection?(event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>): void,
+    selectionCount?: number | undefined,
+}
+
+export interface ListBoxSelectionComponent extends React.FC<ListBoxSelectionProps> { }
+
+declare const ListBoxSelection: ListBoxSelectionComponent;
+
+export default ListBoxSelection;

--- a/types/carbon-components-react/es/components/ListBox/index.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/index.d.ts
@@ -1,0 +1,5 @@
+import * as PropTypes from "./ListBoxPropTypes";
+
+export * from "./ListBox";
+export { PropTypes };
+export { default } from './ListBox';

--- a/types/carbon-components-react/es/components/ListBox/next/ListBoxSelection.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/next/ListBoxSelection.d.ts
@@ -1,0 +1,10 @@
+import * as React from "react";
+import { ListBoxSelectionProps } from "../ListBoxSelection";
+import { ReactButtonAttr } from "../../../../typings/shared";
+
+type ExcludedButtonPropKeys = "aria-label" | "className" | "onClick" | "onKeyDown" | "tabIndex" | "title" | "type";
+export interface ListBoxSelectionNextProps extends ListBoxSelectionProps, Omit<ReactButtonAttr, ExcludedButtonPropKeys> { }
+
+declare const ListBoxSelection: React.FC<ListBoxSelectionNextProps>;
+
+export default ListBoxSelection;

--- a/types/carbon-components-react/es/components/ListBox/next/ListBoxTrigger.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/next/ListBoxTrigger.d.ts
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { InternationalProps, ReactButtonAttr } from "../../../../typings/shared";
+import { ListBoxMenuIconTranslationKey } from "../ListBoxMenuIcon";
+
+type ExcludedButtonPropKeys = "aria-label" | "className" | "tabIndex" | "title" | "type";
+export interface ListBoxTriggerProps
+    extends Omit<ReactButtonAttr, ExcludedButtonPropKeys>,
+        InternationalProps<ListBoxMenuIconTranslationKey> {
+    isOpen: boolean;
+}
+
+declare const ListBoxTrigger: React.FC<ListBoxTriggerProps>;
+
+export default ListBoxTrigger;

--- a/types/carbon-components-react/es/components/ListBox/next/index.d.ts
+++ b/types/carbon-components-react/es/components/ListBox/next/index.d.ts
@@ -1,0 +1,5 @@
+export * from "./ListBoxSelection";
+export * from "./ListBoxTrigger";
+
+export { default as ListBoxSelection } from "./ListBoxSelection";
+export { default as ListBoxTrigger } from "./ListBoxTrigger";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Hi! 
I have issue like this https://github.com/carbon-design-system/carbon/issues/11058
In summary, there is a problem that tree-shaking does not occur when the ListBox component of the carbon-components-react package is imported with commonJs.
So I'm trying to import a file of the components of the `es/*` folder for tree-shaking, but there are no definition files with `es/*` components. So I added definition file of ListBox components.
The only declaration file I currently need is ListBox, but should I add other files? If, necessary i will add other components though

Thanks
