### PR TITLE
fix: reexport PackageGraphNode from @lerna/package-graph

### DIFF
--- a/types/lerna__package-graph/index.d.ts
+++ b/types/lerna__package-graph/index.d.ts
@@ -53,4 +53,4 @@ declare class PackageGraph extends Map {
      */
     remove(candidateNode: PackageGraphNode): void;
 }
-export { PackageGraph };
+export { PackageGraph, PackageGraphNode };

--- a/types/lerna__package-graph/lerna__package-graph-tests.ts
+++ b/types/lerna__package-graph/lerna__package-graph-tests.ts
@@ -1,5 +1,7 @@
-import { PackageGraph } from '@lerna/package-graph';
+import { PackageGraph, PackageGraphNode } from '@lerna/package-graph';
 
 new PackageGraph([]);
 
-new PackageGraph([], 'allDependencies', false);
+const testGraph: PackageGraph = new PackageGraph([], 'allDependencies', false);
+const testNode: PackageGraphNode = testGraph.get('test-package');
+testGraph.prune(testNode);

--- a/types/lerna__query-graph/index.d.ts
+++ b/types/lerna__query-graph/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Package } from '@lerna/package';
-import { PackageGraphNode } from '@lerna/package-graph/lib/package-graph-node';
+import { PackageGraphNode } from '@lerna/package-graph';
 
 export interface QueryGraphConfig {
     /**

--- a/types/lerna__query-graph/lerna__query-graph-tests.ts
+++ b/types/lerna__query-graph/lerna__query-graph-tests.ts
@@ -1,4 +1,9 @@
+import { Package } from '@lerna/package';
+import { PackageGraphNode } from '@lerna/package-graph';
 import { QueryGraph, toposort } from '@lerna/query-graph';
 
-new QueryGraph([]);
+const graph: QueryGraph = new QueryGraph([]);
+const graphNode: PackageGraphNode = new PackageGraphNode(Package.lazy('./'));
+graph.markAsDone(graphNode);
+
 toposort([], { graphType: 'allDependencies' });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test @lerna/package-graph`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url](https://github.com/lerna/lerna/blob/a47fc294393a3e9507a8207a5a2f07648a524722/core/package-graph/index.js#L9)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
