### PR TITLE
Fix @ckeditor/ckeditor5-alignment command name

### DIFF
--- a/types/ckeditor__ckeditor5-alignment/ckeditor__ckeditor5-alignment-tests.ts
+++ b/types/ckeditor__ckeditor5-alignment/ckeditor__ckeditor5-alignment-tests.ts
@@ -49,4 +49,4 @@ editor.plugins.get('AlignmentEditing');
 editor.plugins.get('AlignmentUI');
 
 // $ExpectType AlignmentCommand | undefined
-editor.commands.get('AlignmentCommand');
+editor.commands.get('alignment');

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentcommand.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentcommand.d.ts
@@ -18,9 +18,3 @@ export default class AlignmentCommand extends Command {
      */
     execute(options?: { value?: AlignmentCommand['value'] }): void;
 }
-
-declare module '@ckeditor/ckeditor5-core/src/commandcollection' {
-    interface Commands {
-        AlignmentCommand: AlignmentCommand;
-    }
-}

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentediting.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentediting.d.ts
@@ -1,10 +1,13 @@
 import { Plugin } from '@ckeditor/ckeditor5-core';
+import AlignmentCommand from './alignmentcommand';
+
 /**
  * The alignment editing feature. It introduces the {@link module:alignment/alignmentcommand~AlignmentCommand command} and adds
  * the `alignment` attribute for block elements in the {@link module:engine/model/model~Model model}.
  */
 export default class AlignmentEditing extends Plugin {
     static readonly pluginName: 'AlignmentEditing';
+
     init(): void;
 }
 
@@ -24,5 +27,11 @@ export interface AlignmentFormat {
 declare module '@ckeditor/ckeditor5-core/src/plugincollection' {
     interface Plugins {
         AlignmentEditing: AlignmentEditing;
+    }
+}
+
+declare module '@ckeditor/ckeditor5-core/src/commandcollection' {
+    interface Commands {
+        alignment: AlignmentCommand;
     }
 }

--- a/types/ckeditor__ckeditor5-alignment/src/alignmentui.d.ts
+++ b/types/ckeditor__ckeditor5-alignment/src/alignmentui.d.ts
@@ -1,4 +1,5 @@
 import { Plugin } from '@ckeditor/ckeditor5-core';
+import { EditorWithUI } from '@ckeditor/ckeditor5-core/src/editor/editorwithui';
 
 /**
  * The default alignment UI plugin.
@@ -7,13 +8,28 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
  * and the `'alignment'` dropdown.
  */
 export default class AlignmentUI extends Plugin {
+    static readonly pluginName: 'AlignmentUI';
+
+    /**
+     * Returns the localized option titles provided by the plugin.
+     *
+     * The following localized titles corresponding with
+     * {@link module:alignment/alignment~AlignmentConfig#options} are available:
+     *
+     * * `'left'`,
+     * * `'right'`,
+     * * `'center'`,
+     * * `'justify'`.
+     */
     readonly localizedOptionTitles: {
         left: string;
         right: string;
         center: string;
         justify: string;
     };
-    static readonly pluginName: 'AlignmentUI';
+
+    readonly editor: EditorWithUI;
+
     init(): void;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-alignment/src/alignmentediting.js#L82
- https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-alignment/src/alignmentui.js#L68 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.