### PR TITLE
[jasmine] Use type-safe spies for spyOnProperty

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -191,7 +191,10 @@ declare function spyOn<T, K extends keyof T = keyof T>(
  * @param property The name of the property to replace with a `Spy`.
  * @param accessType The access type (get|set) of the property to `Spy` on.
  */
-declare function spyOnProperty<T>(object: T, property: keyof T, accessType?: "get" | "set"): jasmine.Spy;
+declare function spyOnProperty<T, K extends keyof T = keyof T>(
+    object: T, property: K, accessType?: "get"): jasmine.Spy<() => T[K]>;
+declare function spyOnProperty<T, K extends keyof T = keyof T>(
+    object: T, property: K, accessType: "set"): jasmine.Spy<(value: T[K]) => void>;
 
 /**
  * Installs spies on all writable and configurable properties of an object.

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -192,9 +192,9 @@ declare function spyOn<T, K extends keyof T = keyof T>(
  * @param accessType The access type (get|set) of the property to `Spy` on.
  */
 declare function spyOnProperty<T, K extends keyof T = keyof T>(
-    object: T, property: K, accessType?: "get"): jasmine.Spy<() => T[K]>;
+    object: T, property: K, accessType?: "get"): jasmine.Spy<(this: T) => T[K]>;
 declare function spyOnProperty<T, K extends keyof T = keyof T>(
-    object: T, property: K, accessType: "set"): jasmine.Spy<(value: T[K]) => void>;
+    object: T, property: K, accessType: "set"): jasmine.Spy<(this: T, value: T[K]) => void>;
 
 /**
  * Installs spies on all writable and configurable properties of an object.

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1996,9 +1996,16 @@ describe("better typed spys", () => {
             const getSpy = spyOnProperty(obj, "prop");
             getSpy.and.returnValue("spy");
             getSpy.and.returnValue(123); // $ExpectError
+            getSpy.and.callFake(function() {
+                this.otherProp; // $ExpectType number
+                return "spy";
+            });
             const setSpy = spyOnProperty(obj, "prop", "set");
             setSpy.calls.first().args; // $ExpectType [string] || [value: string]
             setSpy.calls.first().returnValue; // $ExpectType void
+            setSpy.and.callFake(function(value: string) {
+                this.otherProp; // $ExpectType number
+            });
         });
     });
     describe("createSpyObj", () => {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1990,6 +1990,17 @@ describe("better typed spys", () => {
             spyOn<Base>(new Super(), "service2"); // $ExpectError
         });
     });
+    describe("spyOnProperty", () => {
+        it("works", () => {
+            const obj = {prop: "test", otherProp: 1};
+            const getSpy = spyOnProperty(obj, "prop");
+            getSpy.and.returnValue("spy");
+            getSpy.and.returnValue(123); // $ExpectError
+            const setSpy = spyOnProperty(obj, "prop", "set");
+            setSpy.calls.first().args; // $ExpectType [string] || [value: string]
+            setSpy.calls.first().returnValue; // $ExpectType void
+        });
+    });
     describe("createSpyObj", () => {
         it("returns the correct spy types", () => {
             const foo = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/api/edge/global.html#spyOnProperty
