### PR TITLE
[ramda] Add typeguards

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -605,10 +605,30 @@ export function concat(s1: string, s2: string): string;
 export function concat(s1: string): (s2: string) => string;
 
 /**
- * Returns a function, fn, which encapsulates if/else-if/else logic. R.cond takes a list of [predicate, transform] pairs.
- * All of the arguments to fn are applied to each of the predicates in turn until one returns a "truthy" value, at which
- * point fn returns the result of applying its arguments to the corresponding transformer. If none of the predicates
- * matches, fn returns undefined.
+ * Returns a function, `fn`, which encapsulates `if/else, if/else, ...` logic.
+ * `R.cond` takes a list of [predicate, transformer] pairs. All of the arguments
+ * to `fn` are applied to each of the predicates in turn until one returns a
+ * "truthy" value, at which point `fn` returns the result of applying its
+ * arguments to the corresponding transformer. If none of the predicates
+ * matches, `fn` returns undefined.
+ *
+ * **Please note:** This is not a direct substitute for a `switch` statement.
+ * Remember that both elements of every pair passed to `cond` are *functions*,
+ * and `cond` returns a function.
+ *
+ * See also {@link ifElse}, {@link unless}, {@link when}.
+ *
+ * @example
+ * ```typescript
+ * const fn = R.cond([
+ *   [R.equals(0),   R.always('water freezes at 0°C')],
+ *   [R.equals(100), R.always('water boils at 100°C')],
+ *   [R.T,           temp => 'nothing special happens at ' + temp + '°C']
+ * ]);
+ * fn(0); //=> 'water freezes at 0°C'
+ * fn(50); //=> 'nothing special happens at 50°C'
+ * fn(100); //=> 'water boils at 100°C'
+ * ```
  */
 export function cond<T extends any[], R>(pairs: Array<CondPair<T, R>>): (...args: T) => R;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -952,6 +952,19 @@ export function identity<T>(a: T): T;
 /**
  * Creates a function that will process either the onTrue or the onFalse function depending upon the result
  * of the condition predicate.
+ *
+ * See also {@link unless}, {@link when}, {@link cond}.
+ *
+ * @example
+ * ```typescript
+ * const incCount = R.ifElse(
+ *   R.has('count'),
+ *   R.over(R.lensProp('count'), R.inc),
+ *   R.assoc('count', 1)
+ * );
+ * incCount({ count: 1 }); //=> { count: 2 }
+ * incCount({});           //=> { count: 1 }
+ * ```
  */
 export function ifElse<T, TFiltered extends T, TOnTrueResult, TOnFalseResult>(
     pred: PredTypeguard<T, TFiltered>,

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -958,7 +958,7 @@ export function ifElse<T, TFiltered extends T, TOnTrueResult, TOnFalseResult>(
     onFalse: (a: Exclude<T, TFiltered>) => TOnFalseResult,
 ): (a: T) => TOnTrueResult | TOnFalseResult;
 export function ifElse<TArgs extends any[], TOnTrueResult, TOnFalseResult>(
-    fn: (...args: TArgs) => boolean,
+    fn: Pred<TArgs>,
     onTrue: (...args: TArgs) => TOnTrueResult,
     onFalse: (...args: TArgs) => TOnFalseResult,
 ): (...args: TArgs) => TOnTrueResult | TOnFalseResult;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -399,11 +399,22 @@ export function clone<T>(value: readonly T[]): T[];
 export function comparator<T>(pred: (a: T, b: T) => boolean): (x: T, y: T) => Ordering;
 
 /**
- * Takes a function f and returns a function g such that:
- * - applying g to zero or more arguments will give true if applying the same arguments to f gives
- *   a logical false value; and
- * - applying g to zero or more arguments will give false if applying the same arguments to f gives
- *   a logical true value.
+ * Takes a function `f` and returns a function `g` such that if called with the
+ * same arguments when `f` returns a "truthy" value, `g` returns `false` and
+ * when `f` returns a "falsy" value `g` returns `true`.
+ *
+ * `R.complement` may be applied to any functor
+ *
+ * See also {@link not}.
+ *
+ * @example
+ * ```typescript
+ * const isNotNil = R.complement(R.isNil);
+ * R.isNil(null); //=> true
+ * isNotNil(null); //=> false
+ * R.isNil(7); //=> false
+ * isNotNil(7); //=> true
+ * ```
  */
 export function complement<TArgs extends any[]>(pred: (...args: TArgs) => unknown): (...args: TArgs) => boolean;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -59,6 +59,7 @@ import {
     Path,
     Placeholder,
     Pred,
+    PredTypeguard,
     Reduced,
     ReturnTypesOfFns,
     ValueOfRecord,
@@ -953,7 +954,7 @@ export function identity<T>(a: T): T;
  * of the condition predicate.
  */
 export function ifElse<T, TFiltered extends T, TOnTrueResult, TOnFalseResult>(
-    pred: (a: T) => a is TFiltered,
+    pred: PredTypeguard<T, TFiltered>,
     onTrue: (a: TFiltered) => TOnTrueResult,
     onFalse: (a: Exclude<T, TFiltered>) => TOnFalseResult,
 ): (a: T) => TOnTrueResult | TOnFalseResult;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -350,6 +350,10 @@ export function bind<F extends (...args: readonly any[]) => any, T>(
  * f(30); //=> false
  * ```
  */
+export function both<T, TF1 extends T, TF2 extends T>(
+    pred1: PredTypeguard<T, TF1>,
+    pred2: PredTypeguard<T, TF2>,
+): (a: T) => a is TF1 & TF2;
 export function both<T extends Pred>(pred1: T, pred2: T): T;
 export function both<T extends Pred>(pred1: T): (pred2: T) => T;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -68,6 +68,7 @@ import {
     ToTupleOfArray,
     ToTupleOfFunction,
     Tuple,
+    CondPairTypeguard,
 } from './tools';
 
 export * from './tools';
@@ -616,6 +617,9 @@ export function concat(s1: string): (s2: string) => string;
  * Remember that both elements of every pair passed to `cond` are *functions*,
  * and `cond` returns a function.
  *
+ * **Please note:** When using this function with a typeguard as predicate,
+ * **all** predicates in all pairs must be typeguards.
+ *
  * See also {@link ifElse}, {@link unless}, {@link when}.
  *
  * @example
@@ -630,6 +634,136 @@ export function concat(s1: string): (s2: string) => string;
  * fn(100); //=> 'water boils at 100°C'
  * ```
  */
+export function cond<T, TF1 extends T, R>(pairs: [CondPairTypeguard<T, TF1, R>]): (value: T) => R;
+export function cond<T, TF1 extends T, TF2 extends T, R>(
+    pairs: [CondPairTypeguard<T, TF1, R>, CondPairTypeguard<T, TF2, R>],
+): (value: T) => R;
+export function cond<T, TF1 extends T, TF2 extends T, TF3 extends T, R>(
+    pairs: [CondPairTypeguard<T, TF1, R>, CondPairTypeguard<T, TF2, R>, CondPairTypeguard<T, TF3, R>],
+): (value: T) => R;
+export function cond<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, R>(
+    pairs: [
+        CondPairTypeguard<T, TF1, R>,
+        CondPairTypeguard<T, TF2, R>,
+        CondPairTypeguard<T, TF3, R>,
+        CondPairTypeguard<T, TF4, R>,
+    ],
+): (value: T) => R;
+export function cond<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T, R>(
+    pairs: [
+        CondPairTypeguard<T, TF1, R>,
+        CondPairTypeguard<T, TF2, R>,
+        CondPairTypeguard<T, TF3, R>,
+        CondPairTypeguard<T, TF4, R>,
+        CondPairTypeguard<T, TF5, R>,
+    ],
+): (value: T) => R;
+export function cond<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T, TF6 extends T, R>(
+    pairs: [
+        CondPairTypeguard<T, TF1, R>,
+        CondPairTypeguard<T, TF2, R>,
+        CondPairTypeguard<T, TF3, R>,
+        CondPairTypeguard<T, TF4, R>,
+        CondPairTypeguard<T, TF5, R>,
+        CondPairTypeguard<T, TF6, R>,
+    ],
+): (value: T) => R;
+export function cond<
+    T,
+    TF1 extends T,
+    TF2 extends T,
+    TF3 extends T,
+    TF4 extends T,
+    TF5 extends T,
+    TF6 extends T,
+    TF7 extends T,
+    R,
+>(
+    pairs: [
+        CondPairTypeguard<T, TF1, R>,
+        CondPairTypeguard<T, TF2, R>,
+        CondPairTypeguard<T, TF3, R>,
+        CondPairTypeguard<T, TF4, R>,
+        CondPairTypeguard<T, TF5, R>,
+        CondPairTypeguard<T, TF6, R>,
+        CondPairTypeguard<T, TF7, R>,
+    ],
+): (value: T) => R;
+export function cond<
+    T,
+    TF1 extends T,
+    TF2 extends T,
+    TF3 extends T,
+    TF4 extends T,
+    TF5 extends T,
+    TF6 extends T,
+    TF7 extends T,
+    TF8 extends T,
+    R,
+>(
+    pairs: [
+        CondPairTypeguard<T, TF1, R>,
+        CondPairTypeguard<T, TF2, R>,
+        CondPairTypeguard<T, TF3, R>,
+        CondPairTypeguard<T, TF4, R>,
+        CondPairTypeguard<T, TF5, R>,
+        CondPairTypeguard<T, TF6, R>,
+        CondPairTypeguard<T, TF7, R>,
+        CondPairTypeguard<T, TF8, R>,
+    ],
+): (value: T) => R;
+export function cond<
+    T,
+    TF1 extends T,
+    TF2 extends T,
+    TF3 extends T,
+    TF4 extends T,
+    TF5 extends T,
+    TF6 extends T,
+    TF7 extends T,
+    TF8 extends T,
+    TF9 extends T,
+    R,
+>(
+    pairs: [
+        CondPairTypeguard<T, TF1, R>,
+        CondPairTypeguard<T, TF2, R>,
+        CondPairTypeguard<T, TF3, R>,
+        CondPairTypeguard<T, TF4, R>,
+        CondPairTypeguard<T, TF5, R>,
+        CondPairTypeguard<T, TF6, R>,
+        CondPairTypeguard<T, TF7, R>,
+        CondPairTypeguard<T, TF8, R>,
+        CondPairTypeguard<T, TF9, R>,
+    ],
+): (value: T) => R;
+export function cond<
+    T,
+    TF1 extends T,
+    TF2 extends T,
+    TF3 extends T,
+    TF4 extends T,
+    TF5 extends T,
+    TF6 extends T,
+    TF7 extends T,
+    TF8 extends T,
+    TF9 extends T,
+    TF10 extends T,
+    R,
+>(
+    pairs: [
+        CondPairTypeguard<T, TF1, R>,
+        CondPairTypeguard<T, TF2, R>,
+        CondPairTypeguard<T, TF3, R>,
+        CondPairTypeguard<T, TF4, R>,
+        CondPairTypeguard<T, TF5, R>,
+        CondPairTypeguard<T, TF6, R>,
+        CondPairTypeguard<T, TF7, R>,
+        CondPairTypeguard<T, TF8, R>,
+        CondPairTypeguard<T, TF9, R>,
+        CondPairTypeguard<T, TF10, R>,
+    ],
+): (value: T) => R;
 export function cond<T extends any[], R>(pairs: Array<CondPair<T, R>>): (...args: T) => R;
 
 /**

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -114,7 +114,24 @@ export function all<T>(fn: (a: T) => boolean, list: readonly T[]): boolean;
 export function all<T>(fn: (a: T) => boolean): (list: readonly T[]) => boolean;
 
 /**
- * Given a list of predicates, returns a new predicate that will be true exactly when all of them are.
+ * Takes a list of predicates and returns a predicate that returns true for a
+ * given list of arguments if every one of the provided predicates is satisfied
+ * by those arguments.
+ *
+ * The function returned is a curried function whose arity matches that of the
+ * highest-arity predicate.
+ *
+ * See also {@link anyPass}.
+ *
+ * @example
+ * ```typescript
+ * const isQueen = R.propEq('rank', 'Q');
+ * const isSpade = R.propEq('suit', '♠︎');
+ * const isQueenOfSpades = R.allPass([isQueen, isSpade]);
+ *
+ * isQueenOfSpades({rank: 'Q', suit: '♣︎'}); //=> false
+ * isQueenOfSpades({rank: 'Q', suit: '♠︎'}); //=> true
+ * ```
  */
 export function allPass<F extends Pred>(preds: readonly F[]): F;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -333,9 +333,22 @@ export function bind<F extends (...args: readonly any[]) => any, T>(
 ): (thisObj: T) => (...args: Parameters<F>) => ReturnType<F>;
 
 /**
- * A function wrapping calls to the two functions in an && operation, returning the result of the first function
- * if it is false-y and the result of the second function otherwise. Note that this is short-circuited, meaning
- * that the second function will not be invoked if the first returns a false-y value.
+ * A function which calls the two provided functions and returns the `&&` of the
+ * results. It returns the result of the first function if it is false-y and
+ * the result of the second function otherwise. Note that this is
+ * short-circuited, meaning that the second function will not be invoked if the
+ * first returns a false-y value.
+ *
+ * See also {@link either}, {@link and}.
+ *
+ * @example
+ * ```typescript
+ * const gt10 = R.gt(R.__, 10)
+ * const lt20 = R.lt(R.__, 20)
+ * const f = R.both(gt10, lt20);
+ * f(15); //=> true
+ * f(30); //=> false
+ * ```
  */
 export function both<T extends Pred>(pred1: T, pred2: T): T;
 export function both<T extends Pred>(pred1: T): (pred2: T) => T;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -133,6 +133,37 @@ export function all<T>(fn: (a: T) => boolean): (list: readonly T[]) => boolean;
  * isQueenOfSpades({rank: 'Q', suit: '♠︎'}); //=> true
  * ```
  */
+export function allPass<T, TF1 extends T, TF2 extends T>(
+    preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>],
+): (a: T) => a is TF1 & TF2;
+export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
+    preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>],
+): (a: T) => a is TF1 & TF2 & TF3;
+export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
+    preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>],
+): (a: T) => a is TF1 & TF2 & TF3;
+export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T>(
+    preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>, PredTypeguard<T, TF4>],
+): (a: T) => a is TF1 & TF2 & TF3 & TF4;
+export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T>(
+    preds: [
+        PredTypeguard<T, TF1>,
+        PredTypeguard<T, TF2>,
+        PredTypeguard<T, TF3>,
+        PredTypeguard<T, TF4>,
+        PredTypeguard<T, TF5>,
+    ],
+): PredTypeguard<T, TF1 & TF2 & TF3 & TF4 & TF5>;
+export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T, TF6 extends T>(
+    preds: [
+        PredTypeguard<T, TF1>,
+        PredTypeguard<T, TF2>,
+        PredTypeguard<T, TF3>,
+        PredTypeguard<T, TF4>,
+        PredTypeguard<T, TF5>,
+        PredTypeguard<T, TF6>,
+    ],
+): PredTypeguard<T, TF1 & TF2 & TF3 & TF4 & TF5 & TF6>;
 export function allPass<F extends Pred>(preds: readonly F[]): F;
 
 /**
@@ -983,10 +1014,10 @@ export function identity<T>(a: T): T;
  * incCount({});           //=> { count: 1 }
  * ```
  */
-export function ifElse<T, TFiltered extends T, TOnTrueResult, TOnFalseResult>(
-    pred: PredTypeguard<T, TFiltered>,
-    onTrue: (a: TFiltered) => TOnTrueResult,
-    onFalse: (a: Exclude<T, TFiltered>) => TOnFalseResult,
+export function ifElse<T, TF extends T, TOnTrueResult, TOnFalseResult>(
+    pred: PredTypeguard<T, TF>,
+    onTrue: (a: TF) => TOnTrueResult,
+    onFalse: (a: Exclude<T, TF>) => TOnFalseResult,
 ): (a: T) => TOnTrueResult | TOnFalseResult;
 export function ifElse<TArgs extends any[], TOnTrueResult, TOnFalseResult>(
     fn: Pred<TArgs>,

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -192,7 +192,25 @@ export function any<T>(fn: (a: T) => boolean, list: readonly T[]): boolean;
 export function any<T>(fn: (a: T) => boolean): (list: readonly T[]) => boolean;
 
 /**
- * Given a list of predicates returns a new predicate that will be true exactly when any one of them is.
+ * Takes a list of predicates and returns a predicate that returns true for a
+ * given list of arguments if at least one of the provided predicates is
+ * satisfied by those arguments.
+ *
+ * The function returned is a curried function whose arity matches that of the
+ * highest-arity predicate.
+ *
+ * See also {@link allPass}.
+ *
+ * @example
+ * ```typescript
+ * const isClub = R.propEq('suit', '♣');
+ * const isSpade = R.propEq('suit', '♠');
+ * const isBlackCard = R.anyPass([isClub, isSpade]);
+ *
+ * isBlackCard({rank: '10', suit: '♣'}); //=> true
+ * isBlackCard({rank: 'Q', suit: '♠'}); //=> true
+ * isBlackCard({rank: 'Q', suit: '♦'}); //=> false
+ * ```
  */
 export function anyPass<F extends Pred>(preds: readonly F[]): F;
 
@@ -589,7 +607,7 @@ export function converge<
         (...args: TArgs) => R5,
         (...args: TArgs) => R6,
         (...args: TArgs) => R7,
-        ...RestFunctions
+        ...RestFunctions,
     ],
 ): (...args: TArgs) => TResult;
 export function converge<TArgs extends any[], TResult, R1, R2, R3, R4, R5, R6, R7>(
@@ -2793,7 +2811,7 @@ export function useWith<
         (arg: TArg5) => TR5,
         (arg: TArg6) => TR6,
         (arg: TArg7) => TR7,
-        ...RestFunctions
+        ...RestFunctions,
     ],
 ): (...args: TArgs) => TResult;
 export function useWith<TArg1, TR1, TArg2, TR2, TArg3, TR3, TArg4, TR4, TArg5, TR5, TArg6, TR6, TArg7, TR7, TResult>(

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -416,6 +416,9 @@ export function comparator<T>(pred: (a: T, b: T) => boolean): (x: T, y: T) => Or
  * isNotNil(7); //=> true
  * ```
  */
+export function complement<T, TFiltered extends T>(
+    pred: (value: T) => value is TFiltered,
+): (value: T) => value is Exclude<T, TFiltered>;
 export function complement<TArgs extends any[]>(pred: (...args: TArgs) => unknown): (...args: TArgs) => boolean;
 
 /**

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -212,6 +212,37 @@ export function any<T>(fn: (a: T) => boolean): (list: readonly T[]) => boolean;
  * isBlackCard({rank: 'Q', suit: '♦'}); //=> false
  * ```
  */
+export function anyPass<T, TF1 extends T, TF2 extends T>(
+    preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>],
+): (a: T) => a is TF1 | TF2;
+export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
+    preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>],
+): (a: T) => a is TF1 | TF2 | TF3;
+export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
+    preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>],
+): (a: T) => a is TF1 | TF2 | TF3;
+export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T>(
+    preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>, PredTypeguard<T, TF4>],
+): (a: T) => a is TF1 | TF2 | TF3 | TF4;
+export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T>(
+    preds: [
+        PredTypeguard<T, TF1>,
+        PredTypeguard<T, TF2>,
+        PredTypeguard<T, TF3>,
+        PredTypeguard<T, TF4>,
+        PredTypeguard<T, TF5>,
+    ],
+): PredTypeguard<T, TF1 | TF2 | TF3 | TF4 | TF5>;
+export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T, TF6 extends T>(
+    preds: [
+        PredTypeguard<T, TF1>,
+        PredTypeguard<T, TF2>,
+        PredTypeguard<T, TF3>,
+        PredTypeguard<T, TF4>,
+        PredTypeguard<T, TF5>,
+        PredTypeguard<T, TF6>,
+    ],
+): PredTypeguard<T, TF1 | TF2 | TF3 | TF4 | TF5 | TF6>;
 export function anyPass<F extends Pred>(preds: readonly F[]): F;
 
 /**

--- a/types/ramda/test/allPass-tests.ts
+++ b/types/ramda/test/allPass-tests.ts
@@ -19,4 +19,29 @@ import * as R from 'ramda';
 
     // $ExpectType boolean
     f(12); // => true
+
+    const isFooAndBar = (a: {}): a is { foo: number; bar: string } => true;
+    const isFooAndBuz = (a: {}): a is { foo: number; buz: string } => true;
+
+    // $ExpectType (a: {}) => a is { foo: number; bar: string; } & { foo: number; buz: string; }
+    const fIsFoo = R.allPass([isFooAndBar, isFooAndBuz]);
+
+    const is1To10 = (x: number): x is 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 => true;
+    const is6To12 = (x: number): x is 6 | 7 | 8 | 9 | 10 | 11 | 12 => true;
+    const isOdd1to15 = (x: number): x is 1 | 3 | 5 | 7 | 9 | 11 | 13 | 15 => true;
+
+    // $ExpectType (a: number) => a is 7 | 9
+    const fIsSpecialNumber = R.allPass([is1To10, is6To12, isOdd1to15]);
+
+    const isFoo = (x: any): x is { foo: number } => true;
+    const isBar = (x: any): x is { bar: string } => true;
+    const isFooBar = R.allPass([isFoo, isBar]);
+
+    const foobar: any = {};
+    if (isFooBar(foobar)) {
+        // $ExpectType number
+        foobar.foo;
+        // $ExpectType string
+        foobar.bar;
+    }
 };

--- a/types/ramda/test/anyPass-tests.ts
+++ b/types/ramda/test/anyPass-tests.ts
@@ -20,4 +20,29 @@ import * as R from 'ramda';
     f(8);
     // $ExpectType boolean
     f(9); // => false
+
+    const isFooAndBar = (a: {}): a is { foo: number; bar: string } => true;
+    const isFooAndBuz = (a: {}): a is { foo: number; buz: string } => true;
+
+    // $ExpectType (a: {}) => a is { foo: number; bar: string; } | { foo: number; buz: string; }
+    const fIsFoo = R.anyPass([isFooAndBar, isFooAndBuz]);
+
+    const is1or2 = (x: number): x is 1 | 2 => true;
+    const is2or3 = (x: number): x is 2 | 3 => true;
+    const is3 = (x: number): x is 3 => true;
+
+    // $ExpectType (a: number) => a is 1 | 2 | 3 || (a: number) => a is 2 | 1 | 3 || (a: number) => a is 2 | 3 | 1
+    const fIsSpecialNumber = R.anyPass([is1or2, is2or3, is3]);
+
+    const isFoo = (x: any): x is { foo: number; fuz: boolean } => true;
+    const isBar = (x: any): x is { bar: string; fuz: boolean } => true;
+    const isFooOrBar = R.anyPass([isFoo, isBar]);
+
+    const foobar: any = {};
+    if (isFooOrBar(foobar)) {
+        // $ExpectType boolean
+        foobar.fuz;
+        // $ExpectError
+        foobar.bar;
+    }
 };

--- a/types/ramda/test/both-tests.ts
+++ b/types/ramda/test/both-tests.ts
@@ -17,4 +17,28 @@ import * as R from 'ramda';
     f(100); // => true
     // $ExpectType boolean
     f(101); // => false
+
+    const isFooAndBar = (a: {}): a is { foo: number; bar: string } => true;
+    const isFooAndBuz = (a: {}): a is { foo: number; buz: string } => true;
+
+    // $ExpectType (a: {}) => a is { foo: number; bar: string; } & { foo: number; buz: string; }
+    const fIsFoo = R.both(isFooAndBar, isFooAndBuz);
+
+    const is1To3 = (x: number): x is 1 | 2 | 3 => true;
+    const is2To5 = (x: number): x is 2 | 3 | 4 | 5 => true;
+
+    // $ExpectType (a: number) => a is 2 | 3
+    const fIsSpecialNumber = R.both(is1To3, is2To5);
+
+    const isFoo = (x: any): x is { foo: number } => true;
+    const isBar = (x: any): x is { bar: string } => true;
+    const isFooBar = R.both(isFoo, isBar);
+
+    const foobar: any = {};
+    if (isFooBar(foobar)) {
+        // $ExpectType number
+        foobar.foo;
+        // $ExpectType string
+        foobar.bar;
+    }
 };

--- a/types/ramda/test/complement-tests.ts
+++ b/types/ramda/test/complement-tests.ts
@@ -20,6 +20,11 @@ import * as R from 'ramda';
     isLengthNotEqual('FOO', 'BAR');
     isLengthNotEqual('BAZ', 4); // => true
 
-    // $ExpectType (value: any) => boolean
+    // $ExpectType (value: any) => value is any
     R.complement(R.isNil);
+
+    const isStringAndNotNumber = (value: string | number): value is string => true;
+
+    // $ExpectType (value: string | number) => value is number
+    const isNumberAndNotString = R.complement(isStringAndNotNumber);
 };

--- a/types/ramda/test/cond-tests.ts
+++ b/types/ramda/test/cond-tests.ts
@@ -27,4 +27,9 @@ import * as R from 'ramda';
 
     // $ExpectType string
     g(1, '');
+
+    R.cond([
+        [(a: string | number): a is number => true, a => a * 2],
+        [(a: string | number): a is string => true, a => a.length],
+    ]);
 };

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -274,7 +274,13 @@ export type Path = Array<number | string>;
 export type Placeholder = A.x & { '@@functional/placeholder': true };
 
 /**
- * <needs description>
+ * Takes a lists of arguments and returns either `true` or `false`.
+ *
+ * Classical predicates only take one argument, but since ramda
+ * supports multiple arguments, we also use them like that.
+ *
+ * Note that these predicates, don't represent typeguards,
+ * meaning when this type is used, we can't get type narrowing.
  */
 export type Pred<T extends any[] = any[]> = (...a: T) => boolean;
 

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -72,6 +72,12 @@ export interface CharList extends String {
 
 export type CondPair<T extends any[], R> = [(...val: T) => boolean, (...val: T) => R];
 
+/**
+ * R.cond's [predicate, transform] pair in a typeguarded version
+ */
+
+export type CondPairTypeguard<T, TFiltered extends T, R> = [(value: T) => value is TFiltered, (value: TFiltered) => R];
+
 // ---------------------------------------------------------------------------------------
 // D
 

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -281,8 +281,20 @@ export type Placeholder = A.x & { '@@functional/placeholder': true };
  *
  * Note that these predicates, don't represent typeguards,
  * meaning when this type is used, we can't get type narrowing.
+ *
+ * @see {@link PredTypeguard} for the typeguard version of this.
  */
 export type Pred<T extends any[] = any[]> = (...a: T) => boolean;
+
+/**
+ * Takes an argument and returns either `true` or `false`.
+ *
+ * This is usually used as an overload before {@link Pred}.
+ * If you would this type alone, the function would **required**
+ * to be a typeguard, meaning a simple function just returning
+ * a `boolean` wouldn't satisfy this constrain.
+ */
+export type PredTypeguard<T, TTypeguarded extends T> = (a: T) => a is TTypeguarded;
 
 // ---------------------------------------------------------------------------------------
 // R


### PR DESCRIPTION
This adds a tool type for predicates, that are type guards, as well as adding overloads to a bunch of functions, that can benefit from type guards, by enabling passing either follow up functions that use a narrowed types, or becoming type guards themselves.

- [x] `allPass`
- [x] `anyPass`
- [x] `both`
- [x] `complement`
- [x] `cond`

Ideally have a look at the individual commits. I tried to keep things clean.

In theory those could be breaking changes **if** someone used one of those functions, with a type guard as an argument, in a way, where they would act as a type guard, but did something, that would be invalid given the type guard (because before this, there wouldn't have been type narrowing). But since that breaking change would only mean, you'd discover something that is essentially a bug in your code, I guess that's fine.

All those changes will be pretty unrelated to each other, so might as well merge the first bunch for now. Will open another PR later with the more functions that could can have type guard support. If this ends up to big and get messy I might just separate it into individual PRs, but lets try it like this for now.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.