### PR TITLE
[ramda] Fix problem introduced by Typescript 4.7 prerelease

### DIFF
--- a/types/ramda/test/fromPairs-tests.ts
+++ b/types/ramda/test/fromPairs-tests.ts
@@ -14,7 +14,11 @@ import * as R from 'ramda';
         [2, 'b'],
     ]); // => { '1': 'a', '2': 'b' }
 
-    // $ExpectType { [index: string]: 2 | 3 | 1; }
+    /**
+     * Typescript implementation of union order is not guaranteed and can
+     * change. Therefor using `||` here, which is a feature of $ExpectType
+     */
+    // $ExpectType { [index: string]: 2 | 3 | 1; } || { [index: string]: 2 | 1 | 3; }
     R.fromPairs([
         ['a', 1],
         ['b', 2],

--- a/types/ramda/test/keys-tests.ts
+++ b/types/ramda/test/keys-tests.ts
@@ -1,8 +1,11 @@
 import * as R from 'ramda';
 
 () => {
-    // Order of string keys matters. c, a, b ¯\_(ツ)_/¯
-    // $ExpectType ("c" | "a" | "b")[]
+    /**
+     * Typescript implementation of union order is not guaranteed and can
+     * change. Therefor using `||` here, which is a feature of $ExpectType
+     */
+    // $ExpectType ("c" | "a" | "b")[] || ("a" | "b" | "c")[]
     const objKeys = R.keys({ a: 1, b: 2, c: 3 });
     const numberKeys = R.keys(1); // $ExpectType string[]
     const arrayKeys = R.keys([]); // List of array members

--- a/types/ramda/test/map-tests.ts
+++ b/types/ramda/test/map-tests.ts
@@ -49,8 +49,11 @@ import * as R from 'ramda';
 
     type KeyOfUnion<T> = T extends infer U ? keyof U : never;
 
-    // Order of string keys matters. c, a, b ¯\_(ツ)_/¯
-    // $ExpectType Record<"c" | "a" | "b", void>
+    /**
+     * Typescript implementation of union order is not guaranteed and can
+     * change. Therefor using `||` here, which is a feature of $ExpectType
+     */
+    // $ExpectType Record<"c" | "a" | "b", void> || Record<"a" | "b" | "c", void>
     R.map<A | C, Record<KeyOfUnion<A | C>, void>>(
         // $ExpectType (value: string | number) => void
         value => {

--- a/types/ramda/test/zipObj-tests.ts
+++ b/types/ramda/test/zipObj-tests.ts
@@ -1,19 +1,19 @@
 import * as R from 'ramda';
 
 () => {
-    // Order of string keys matters. c, a, b ¯\_(ツ)_/¯
-    // $ExpectType { c: number; a: number; b: number; }
+    /**
+     * Typescript implementation of union order is not guaranteed and can
+     * change. Therefor using `||` here, which is a feature of $ExpectType
+     */
+    // $ExpectType { c: number; a: number; b: number; } || { a: number; b: number; c: number; }
     R.zipObj(['a', 'b', 'c'], [1, 2, 3]); // => {a: 1, b: 2, c: 3}
 
-    // Order of string keys matters. c, a, b ¯\_(ツ)_/¯
-    // $ExpectType { c: number; a: number; b: number; }
+    // $ExpectType { c: number; a: number; b: number; } || { a: number; b: number; c: number; }
     R.zipObj(['a', 'b', 'c'])([1, 2, 3]); // => {a: 1, b: 2, c: 3}
 
-    // Order of numeric keys matters. 2, 3, 1 ¯\_(ツ)_/¯
-    // $ExpectType { 2: string; 3: string; 1: string; }
+    // $ExpectType { 2: string; 3: string; 1: string; } || { 2: string; 1: string; 3: string; }
     R.zipObj([1, 2, 3], ['a', 'b', 'c']); // => {1: 'a', 2: 'b', 3: 'c'}
 
-    // Order of numeric keys matters. 2, 3, 1 ¯\_(ツ)_/¯
-    // $ExpectType { 2: string; 3: string; 1: string; }
+    // $ExpectType { 2: string; 3: string; 1: string; } || { 2: string; 1: string; 3: string; }
     R.zipObj([1, 2, 3])(['a', 'b', 'c']); // => {1: 'a', 2: 'b', 3: 'c'}
 };


### PR DESCRIPTION
Typescript doesn't guarantee a union order and the recent release changed that order. Even if the release is reverted, this might happen again.

The culprit here is `$ExpectType` which is just not a very smart tool, since it just does basic string comparsion.

Long running solutions would either be:
- Not testing agains prereleases (thats a big decision, since all of DefinitelyTyped depends on this and it still won't rule out, this happening in the future)
- Changing tools

But since a reasonable Alternative to `$ExpectType` doesn't seem on the horizont and Typescript won't do use the favor of never changing union order, just so `$ExpectType` works, this might be our best shot for now.

The idea for this solution came from @sandersn on Discord.
