### PR TITLE
Fix inputEncoding type missing in crypto.d.ts.

### DIFF
--- a/types/node/v16/crypto.d.ts
+++ b/types/node/v16/crypto.d.ts
@@ -1089,7 +1089,7 @@ declare module 'crypto' {
          */
         update(data: NodeJS.ArrayBufferView): Buffer;
         update(data: string, inputEncoding: Encoding): Buffer;
-        update(data: NodeJS.ArrayBufferView, inputEncoding: undefined, outputEncoding: Encoding): string;
+        update(data: NodeJS.ArrayBufferView, inputEncoding: Encoding | undefined, outputEncoding: Encoding): string;
         update(data: string, inputEncoding: Encoding | undefined, outputEncoding: Encoding): string;
         /**
          * Once the `decipher.final()` method has been called, the `Decipher` object can


### PR DESCRIPTION
The inputEncoding type in the Decipher.update method is incorrectly set to undefined, which also exists in version 14, I provided a fix for version 16.