### PR TITLE
fix(auth0): amend SignInToken shape to align with API

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -951,16 +951,17 @@ async () => {
     const options: auth0.PasswordlessOptions = {};
     options.forwardedFor = '{YOUR_IP}';
 
-    let token: auth0.SignInToken;
-    token = await authentication.passwordless.signIn(signInUserData);
-    token = await authentication.passwordless.signIn(signInUserData, options);
+    // $ExpectType SignInToken
+    await authentication.passwordless.signIn(signInUserData);
+    // $ExpectType SignInToken
+    await authentication.passwordless.signIn(signInUserData, options);
     authentication.passwordless.signIn(signInUserData, (err, data) => {
         err; // $ExpectType Error
-        token = data;
+        data; // $ExpectType SignInToken
     });
     authentication.passwordless.signIn(signInUserData, options, (err, data) => {
         err; // $ExpectType Error
-        token = data;
+        data; // $ExpectType SignInToken
     });
 
     await authentication.passwordless.sendEmail(emailUserData);

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1003,11 +1003,15 @@ export interface SocialSignInOptions {
     connection: string;
 }
 
+/**
+ * @see {https://auth0.com/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints#post-oauth-token}
+ */
 export interface SignInToken {
     access_token: string;
-    id_token?: string | undefined;
-    token_type?: string | undefined;
-    expiry: number;
+    refresh_token?: string | undefined;
+    id_token: string;
+    token_type: string;
+    expires_in: number;
 }
 
 export interface RequestSMSCodeOptions extends RequestSMSOptions {


### PR DESCRIPTION
Aligned to response data from API call:
https://auth0.com/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints#post-oauth-token

`refresh_token` set as optional property, as there is no way to deduce
this for me from docs or implementation alone

Thanks!

Closes #59442
/cc @kchow1985

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).