### PR TITLE
Add missing "trailing" option to "split" package

### DIFF
--- a/types/split/index.d.ts
+++ b/types/split/index.d.ts
@@ -11,12 +11,12 @@ import { ThroughStream } from 'through';
 // doc-strings taken from https://github.com/dominictarr/split, used under MIT license
 
 interface SplitOptions {
-    maxLength: number
+    maxLength: number;
     /**
      * By default the last buffer not delimited by a newline or `matcher` will be emitted.
      * To prevent this set `options.trailing` to `false`.
      */
-    trailing?: boolean
+    trailing?: boolean;
 }
 
 declare function split(matcher?: any, mapper?: any, options?: SplitOptions): ThroughStream;

--- a/types/split/index.d.ts
+++ b/types/split/index.d.ts
@@ -8,8 +8,15 @@
 
 import { ThroughStream } from 'through';
 
+// doc-strings taken from https://github.com/dominictarr/split, used under MIT license
+
 interface SplitOptions {
     maxLength: number
+    /**
+     * By default the last buffer not delimited by a newline or `matcher` will be emitted.
+     * To prevent this set `options.trailing` to `false`.
+     */
+    trailing?: boolean
 }
 
 declare function split(matcher?: any, mapper?: any, options?: SplitOptions): ThroughStream;

--- a/types/split/split-tests.ts
+++ b/types/split/split-tests.ts
@@ -1,15 +1,13 @@
-import stream = require("stream");
-import split = require("split");
+import stream = require('stream');
+import split = require('split');
 
 var testStream = new stream.Readable();
 
-testStream.pipe = function<T extends NodeJS.WritableStream>(dest: T) {
-    dest.write("This is \r\n new \r\n line");
+testStream.pipe = function <T extends NodeJS.WritableStream>(dest: T) {
+    dest.write('This is \r\n new \r\n line');
     return dest;
 };
 
-testStream.pipe(
-    split(/(\r?\n)/, null, {maxLength: 20, trailing: false})
-).on("data", function(line: Buffer) {
-    console.log("Line: " + line.toString('ascii') + "\r\n");
+testStream.pipe(split(/(\r?\n)/, null, { maxLength: 20, trailing: false })).on('data', (line: Buffer) => {
+    console.log('Line: ' + line.toString('ascii') + '\r\n');
 });

--- a/types/split/split-tests.ts
+++ b/types/split/split-tests.ts
@@ -8,6 +8,8 @@ testStream.pipe = function<T extends NodeJS.WritableStream>(dest: T) {
     return dest;
 };
 
-testStream.pipe(split(/(\r?\n)/, null, {maxLength: 20})).on("data", function(line: Buffer) {
+testStream.pipe(
+    split(/(\r?\n)/, null, {maxLength: 20, trailing: false})
+).on("data", function(line: Buffer) {
     console.log("Line: " + line.toString('ascii') + "\r\n");
 });


### PR DESCRIPTION
Adds the missing "trailing" option to the "split" package.

Additionally, I also ran `prettier` through the test package, since I was changing it anyway.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
  - I almost got caught out by the 4 spaces for indentation!
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [split's README.md](https://github.com/dominictarr/split)
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ Fixing existing version docs.