### PR TITLE
Better handling of event definitions in @ckeditor/ckeditor5-utils Emitter

### DIFF
--- a/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
@@ -894,3 +894,91 @@ isVisible(document.documentElement);
 isVisible(null);
 // $ExpectType boolean
 isVisible();
+
+declare class Foo implements Emitter {
+    on<K extends string>(
+        event: K,
+        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
+        options?: {
+            priority?: PriorityString | number | undefined;
+        },
+    ): void;
+    on(
+        event: 'init',
+        callback: (this: this, info: EventInfo<this, 'init'>, arg: { init: true }) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    once<K extends string>(
+        event: K,
+        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
+        options?: {
+            priority?: PriorityString | number | undefined;
+        },
+    ): void;
+    once(
+        event: 'init',
+        callback: (this: this, info: EventInfo<this, 'init'>, arg: { init: true }) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
+    off(event: 'init', callback?: (this: this, info: EventInfo<this, 'init'>, arg: { init: true }) => void): void;
+    listenTo<P extends string, E extends Emitter>(
+        emitter: E,
+        event: P,
+        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
+        options?: { priority?: number | PriorityString | undefined },
+    ): void;
+    stopListening<E extends Emitter, P extends string>(
+        emitter?: E,
+        event?: P,
+        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
+    ): void;
+    fire(eventOrInfo: 'init', arg: { init: true }): unknown;
+    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    stopDelegating(event?: string, emitter?: Emitter): void;
+}
+
+const foo = new Foo();
+
+foo.on('init', (info, arg) => {
+    // $ExpectType EventInfo<Foo, "init">
+    info;
+    // $ExpectType { init: true; }
+    arg;
+});
+
+new Foo().on('foo', (info, ...args) => {
+    // $ExpectType EventInfo<Foo, "foo">
+    info;
+    // $ExpectType any[]
+    args;
+});
+
+foo.once('init', (info, arg) => {
+    // $ExpectType EventInfo<Foo, "init">
+    info;
+    // $ExpectType { init: true; }
+    arg;
+});
+
+new Foo().once('foo', (info, ...args) => {
+    // $ExpectType EventInfo<Foo, "foo">
+    info;
+    // $ExpectType any[]
+    args;
+});
+
+foo.off('init', (info, arg) => {
+    // $ExpectType EventInfo<Foo, "init">
+    info;
+    // $ExpectType { init: true; }
+    arg;
+});
+
+foo.off('foo', (info, ...args) => {
+    // $ExpectType EventInfo<Foo, "foo">
+    info;
+    // $ExpectType any[]
+    args;
+});

--- a/types/ckeditor__ckeditor5-utils/src/emittermixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/emittermixin.d.ts
@@ -22,9 +22,27 @@ export interface Emitter {
             priority?: PriorityString | number | undefined;
         },
     ): void;
+    on(
+        event: string,
+        callback: (this: this, info: EventInfo, ...args: any[]) => void,
+        options?: {
+            priority?: PriorityString | number | undefined;
+        },
+    ): void;
+    /**
+     * Registers a callback function to be executed on the next time the event is fired only. This is similar to
+     * calling {@link #on} followed by {@link #off} in the callback.
+     */
     once<K extends string>(
         event: K,
         callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
+        options?: {
+            priority?: PriorityString | number | undefined;
+        },
+    ): void;
+    once(
+        event: string,
+        callback: (this: this, info: EventInfo, ...args: any[]) => void,
         options?: {
             priority?: PriorityString | number | undefined;
         },
@@ -34,6 +52,7 @@ export interface Emitter {
      * Shorthand for {@link #stopListening `this.stopListening( this, event, callback )`}.
      */
     off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
+    off(event: string, callback?: (this: this, info: EventInfo, ...args: any[]) => void): void;
     /**
      * Registers a callback function to be executed when an event is fired in a specific (emitter) object.
      *


### PR DESCRIPTION
With the current definitions, this is valid.

```ts
class Foo implements Emitter {
    // Emitter implementation
    on<K extends string>(
        event: K,
        callback: (info: EventInfo<this, K>, ...args: any[]) => void,
	options: {priority: number}
    ):void
    // ...rest of implementation
}

new Foo().on('foo', (info, ...args) => {
    info; // EventInfo<Foo,'foo'>
    args: // any[]
});
```

But trying to type valid events raises an error cause a specific string
does not extends a generic string...

```ts
class Bar implements Emitter {
    on(
        'init',
        callback(info: EventInfo<this, 'init'>, arg: {bar: true}) => void,
        options: {priority: number}
    ):void;
}
```

This PR should fix that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
