### PR TITLE
[@types/set-cookie-parser] Update Cookie interface and add more jsdoc

### DIFF
--- a/types/set-cookie-parser/index.d.ts
+++ b/types/set-cookie-parser/index.d.ts
@@ -62,36 +62,87 @@ declare namespace parse {
          * cookie value
          */
         value: string;
+        
         /**
-         * cookie path
+         * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.3|Domain Set-Cookie attribute}. By default, no
+         * domain is set, and most clients will consider the cookie to apply to only
+         * the current domain.
          */
-        path?: string | undefined;
+        domain?: string;
+        
         /**
-         * absolute expiration date for the cookie
+         * Specifies the value for the {@link https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.4|`Path` `Set-Cookie` attribute}.
          */
-        expires?: Date | undefined;
+        path?: string;
+
         /**
-         * relative max age of the cookie in seconds from when the client receives it (integer or undefined)
-         * Note: when using with express's res.cookie() method, multiply maxAge by 1000 to convert to miliseconds
+         * Specifies the `Date` object to be the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.1|`Expires` `Set-Cookie` attribute}. By default,
+         * no expiration is set, and most clients will consider this a "non-persistent cookie" and will delete
+         * it on a condition like exiting a web browser application.
+         *
+         * *Note* the {@link https://tools.ietf.org/html/rfc6265#section-5.3|cookie storage model specification}
+         * states that if both `expires` and `maxAge` are set, then `maxAge` takes precedence, but it is
+         * possible not all clients by obey this, so if both are set, they should
+         * point to the same date and time.
          */
-        maxAge?: number | undefined;
+        expires?: Date;
+        
         /**
-         * domain for the cookie,
-         * may begin with "." to indicate the named domain or any subdomain of it
+         * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.6|`HttpOnly` `Set-Cookie` attribute}.
+         * When truthy, the `HttpOnly` attribute is set, otherwise it is not. By
+         * default, the `HttpOnly` attribute is not set.
+         *
+         * *Note* be careful when setting this to true, as compliant clients will
+         * not allow client-side JavaScript to see the cookie in `document.cookie`.
          */
-        domain?: string | undefined;
+        httpOnly?: boolean;
+        
         /**
-         * indicates that this cookie should only be sent over HTTPs
+         * Specifies the number (in seconds) to be the value for the `Max-Age`
+         * `Set-Cookie` attribute. The given number will be converted to an integer
+         * by rounding down. By default, no maximum age is set.
+         *
+         * *Note* the {@link https://tools.ietf.org/html/rfc6265#section-5.3|cookie storage model specification}
+         * states that if both `expires` and `maxAge` are set, then `maxAge` takes precedence, but it is
+         * possible not all clients by obey this, so if both are set, they should
+         * point to the same date and time.
          */
-        secure?: boolean | undefined;
+        maxAge?: number;
+        
         /**
-         * indicates that this cookie should not be accessible to client-side JavaScript
+         * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.4|`Path` `Set-Cookie` attribute}.
+         * By default, the path is considered the "default path".
          */
-        httpOnly?: boolean | undefined;
+        path?: string;
+        
         /**
-         * indicates a cookie ought not to be sent along with cross-site requests
+         * Specifies the boolean or string to be the value for the {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|`SameSite` `Set-Cookie` attribute}.
+         *
+         * - `true` will set the `SameSite` attribute to `Strict` for strict same
+         * site enforcement.
+         * - `false` will not set the `SameSite` attribute.
+         * - `'lax'` will set the `SameSite` attribute to Lax for lax same site
+         * enforcement.
+         * - `'strict'` will set the `SameSite` attribute to Strict for strict same
+         * site enforcement.
+         *  - `'none'` will set the SameSite attribute to None for an explicit
+         *  cross-site cookie.
+         *
+         * More information about the different enforcement levels can be found in {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|the specification}.
+         *
+         * *note* This is an attribute that has not yet been fully standardized, and may change in the future. This also means many clients may ignore this attribute until they understand it.
          */
-        sameSite?: string | undefined;
+        
+        sameSite?: true | false | 'lax' | 'strict' | 'none';
+        /**
+         * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.5|`Secure` `Set-Cookie` attribute}. When truthy, the
+         * `Secure` attribute is set, otherwise it is not. By default, the `Secure` attribute is not set.
+         *
+         * *Note* be careful when setting this to `true`, as compliant clients will
+         * not send the cookie back to the server in the future if the browser does
+         * not have an HTTPS connection.
+         */
+        secure?: boolean;
     }
 
     interface CookieMap {

--- a/types/set-cookie-parser/index.d.ts
+++ b/types/set-cookie-parser/index.d.ts
@@ -69,11 +69,6 @@ declare namespace parse {
          * the current domain.
          */
         domain?: string;
-        
-        /**
-         * Specifies the value for the {@link https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.4|`Path` `Set-Cookie` attribute}.
-         */
-        path?: string;
 
         /**
          * Specifies the `Date` object to be the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.1|`Expires` `Set-Cookie` attribute}. By default,


### PR DESCRIPTION
When using this with [h3](https://github.com/unjs/h3/blob/main/src/types/cookie.ts) `@types/set-cookie-parser` defines it too broad when in fact it is one of `boolean | "lax" | "strict" | "none"` and this PR addresses this by adding more precise type definitions

```
Type 'string' is not assignable to type 'boolean | "lax" | "strict" | "none"'.ts(2322)
[index.d.ts(193, 5): ]()The expected type comes from property 'sameSite' which is declared here on type 'CookieSerializeOptions'
```