### PR TITLE
[jsrsasign] Add missing `prv` key to ECDSA constructor

### DIFF
--- a/types/jsrsasign/jsrsasign-tests.ts
+++ b/types/jsrsasign/jsrsasign-tests.ts
@@ -1,6 +1,6 @@
 import { KJUR, KEYUTIL, b64toBA, b64tohex, RSAKey, X509 } from 'jsrsasign';
 
-const ec = new KJUR.crypto.ECDSA({ curve: 'secp256r1' });
+const ec = new KJUR.crypto.ECDSA({ curve: 'secp256r1', pub: '1a2b3c', prv: '1a2b3c' });
 ec.generateKeyPairHex();
 ec.getPublicKeyXYHex();
 ec.parseSigHex('30...');

--- a/types/jsrsasign/modules/KJUR/crypto/ECDSA.d.ts
+++ b/types/jsrsasign/modules/KJUR/crypto/ECDSA.d.ts
@@ -14,7 +14,7 @@ declare namespace jsrsasign.KJUR.crypto {
      * - secp384r1, NIST P-384, P-384 (*)
      */
     class ECDSA {
-        constructor(publicKey?: { curve: string; pub?: string | undefined });
+        constructor(publicKey?: { curve?: string | undefined; pub?: string | undefined; prv?: string | undefined });
 
         getBigRandom(limit: number): BigInteger;
         setNamedCurve(curveName: string): void;


### PR DESCRIPTION
Related discussion: #59489

Adds the missing `prv` key to the ECDSA class's constructor

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test jsrsasign`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/kjur/jsrsasign/blob/3f970510fe4bbf69c0f9ed4b8485a275dcabe3b9/src/ecdsa-modified-1.0.js#L639-L649>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
