### PR TITLE
move `adapters` property from `TimeScale` to `CommonAxe`

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -308,11 +308,9 @@ const linearScaleChart: Chart = new Chart(ctx, {
             },
             xAxes: [{
                 type: 'time',
-                time: {
-                    adapters: {
-                        date: {
-                            locale: 'de'
-                        }
+                adapters: {
+                    date: {
+                        locale: 'de'
                     }
                 },
                 distribution: 'series',

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -770,6 +770,7 @@ declare namespace Chart {
         gridLines?: GridLineOptions | undefined;
         scaleLabel?: ScaleTitleOptions | undefined;
         time?: TimeScale | undefined;
+        adapters?: DateAdapterOptions | undefined;
         offset?: boolean | undefined;
         beforeUpdate?(scale?: any): void;
         beforeSetDimension?(scale?: any): void;
@@ -820,7 +821,6 @@ declare namespace Chart {
     }
 
     interface TimeScale extends ChartScales {
-        adapters?: DateAdapterOptions | undefined;
         displayFormats?: TimeDisplayFormat | undefined;
         isoWeekday?: boolean | undefined;
         max?: string | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chartjs.org/docs/2.9.4/axes/cartesian/time.html#configuration-options


`adapters` property should be at the same level as `type` or `distribution` property in Chart.js v2.

In Chart.js v3, `adapters` is a property of `TimeScaleOptions` and it comes with its own type definition: https://github.com/chartjs/Chart.js/blob/c057c96693819b41e7b89860f916c0aa361bafa5/types/index.esm.d.ts#L3206

