### PR TITLE
Added types for `lcov-parse`

### DIFF
--- a/types/lcov-parse/index.d.ts
+++ b/types/lcov-parse/index.d.ts
@@ -1,0 +1,85 @@
+// Type definitions for lcov-parse 1.0
+// Project: https://github.com/davglass/lcov-parse
+// Definitions by: Rouslan Placella <https://github.com/roccivic>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace parse {
+    /**
+     * Line coverage detail
+     */
+    interface LcovLine {
+        line: number;
+        hit: number;
+    }
+    /**
+     * Function coverage detail
+     */
+    interface LcovFunc {
+        name: string;
+        line: number;
+        hit: number;
+    }
+    /**
+     * Branch coverage detail
+     */
+    interface LcovBranch {
+        line: number;
+        block: number;
+        branch: number;
+        taken: number;
+    }
+    /**
+     * Code coverage for lines, functions or branches in a file
+     */
+    interface LcovPart<T> {
+        hit: number;
+        found: number;
+        details: T[];
+    }
+    /**
+     * Code coverage for a file
+     */
+    interface LcovFile {
+        title: string;
+        file: string;
+        lines: LcovPart<LcovLine>;
+        functions: LcovPart<LcovFunc>;
+        branches: LcovPart<LcovBranch>;
+    }
+    /**
+     * Parses an LCOV code coverage string:
+     * ```
+     *  parse(lcovString, function(err, data) {
+     *      //process the data here
+     *  });
+     * ```
+     *
+     * @param str LCOV string to parse
+     * @param cb Callback: first arg is `null` or error string,
+     *                     second arg is parsed data or `undefined` if an error occurred
+     */
+    function source(str: string, cb: (err: null | string, data: LcovFile[] | undefined) => void): void;
+}
+
+/**
+ * Parses an LCOV code coverage file:
+ * ```
+ *  parse('./path/to/file.info', function(err, data) {
+ *      //process the data here
+ *  });
+ * ```
+ *
+ * The first argument can also be an LCOV string to parse:
+ * ```
+ *  parse(lcovString, function(err, data) {
+ *      //process the data here
+ *  });
+ * ```
+ *
+ * @param file Path to the LCOV file or string to parse
+ * @param cb Callback: first arg is `null` or error string,
+ *                     second arg is parsed data or `undefined` if an error occurred
+ */
+declare function parse(file: string, cb: (err: null | string, data: parse.LcovFile[] | undefined) => void): void;
+
+export = parse;

--- a/types/lcov-parse/lcov-parse-tests.ts
+++ b/types/lcov-parse/lcov-parse-tests.ts
@@ -1,0 +1,38 @@
+import parse = require('lcov-parse');
+
+const sample = `TN:
+SF:src/most.js
+FN:1,sum
+FN:5,product
+FNF:2
+FNH:1
+FNDA:1,sum
+FNDA:0,product
+DA:2,1
+DA:6,0
+DA:9,1
+LF:3
+LH:2
+BRF:0
+BRH:0
+end_of_record`;
+
+parse('', (err, data) => {
+    err; // $ExpectedType string
+    data; // $ExpectedType undefined
+});
+
+parse(sample, (err, data) => {
+    err; // $ExpectedType null
+    data; // $ExpectedType LcovFile[]
+});
+
+parse.source('', (err, data) => {
+    err; // $ExpectedType string
+    data; // $ExpectedType undefined
+});
+
+parse.source(sample, (err, data) => {
+    err; // $ExpectedType null
+    data; // $ExpectedType LcovFile[]
+});

--- a/types/lcov-parse/tsconfig.json
+++ b/types/lcov-parse/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "lcov-parse-tests.ts"
+    ]
+}

--- a/types/lcov-parse/tslint.json
+++ b/types/lcov-parse/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
