### PR TITLE
Add 'ignorerounding' flag to Option object in `audiosprite`

### DIFF
--- a/types/audiosprite/index.d.ts
+++ b/types/audiosprite/index.d.ts
@@ -33,6 +33,7 @@ declare namespace audiosprite {
         channels?: Channels | undefined;
         rawparts?: string | undefined;
         logger?: Logger | undefined;
+        ignorerounding?: boolean | undefined;
     }
 
     interface Logger {

--- a/types/audiosprite/index.d.ts
+++ b/types/audiosprite/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for audiosprite 0.6
+// Type definitions for audiosprite 0.7.2
 // Project: https://github.com/tonistiigi/audiosprite
 // Definitions by: Gyusun Yeom <https://github.com/Perlmint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/audiosprite/index.d.ts
+++ b/types/audiosprite/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for audiosprite 0.7.2
+// Type definitions for audiosprite 0.7
 // Project: https://github.com/tonistiigi/audiosprite
 // Definitions by: Gyusun Yeom <https://github.com/Perlmint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [See here](https://www.npmjs.com/package/audiosprite#:~:text=specified%20formats.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Bdefault%3A%20%22%22%5D%0A%20%20%2D%2D-,ignorerounding,-%2C%20%2Di%20%20Bypass%20sound). Audiosprite has had support for this field for multiple years but the DefinitelyTyped typings do not include it.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
