### PR TITLE
fix(remark-prism): Increase option flexibility

### DIFF
--- a/types/remark-prism/index.d.ts
+++ b/types/remark-prism/index.d.ts
@@ -1,27 +1,29 @@
 // Type definitions for remark-prism 1.3
 // Project: https://github.com/sergioramos/remark-prism#readme
 // Definitions by: Hojun Bun <https://github.com/bunhojun>
+//                 Stephen Weiss <https://github.com/stephencweiss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.0
 
 import { Plugin } from 'unified';
 
+type SupportedPlugins =
+    | 'autolinker'
+    | 'command-line'
+    | 'data-uri-highlight'
+    | 'diff-highlight'
+    | 'inline-color'
+    | 'keep-markup'
+    | 'line-numbers'
+    | 'show-invisibles'
+    | 'treeview';
+
 declare namespace remarkPrism {
     type Prism = Plugin<[Options?]>;
 
     interface Options {
-        transformInlineCode?: boolean | undefined;
-        plugins?: [
-            'autolinker'?,
-            'command-line'?,
-            'data-uri-highlight'?,
-            'diff-highlight'?,
-            'inline-color'?,
-            'keep-markup'?,
-            'line-numbers'?,
-            'show-invisibles'?,
-            'treeview'?,
-        ];
+        transformInlineCode?: boolean;
+        plugins?: SupportedPlugins[];
     }
 }
 

--- a/types/remark-prism/remark-prism-tests.ts
+++ b/types/remark-prism/remark-prism-tests.ts
@@ -18,3 +18,8 @@ const options: remarkPrism.Options = {
     ],
 };
 remark().use(remarkPrism, options);
+
+const partialOptions: remarkPrism.Options = {
+    plugins: ['show-invisibles', 'autolinker'],
+};
+remark().use(remarkPrism, partialOptions);


### PR DESCRIPTION
This PR increases the flexibility of the options, particularly
in the plugins.

The types for remark-prism no longer require _all_ of the
plugins to be used, or for them to be used in a particular
order when they are used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/sergioramos/remark-prism/blob/master/src/highlight.js#L154-L163>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
