### PR TITLE
[react-native] Drop usage of deprecated ReactType

### DIFF
--- a/types/react-native/v0.65/index.d.ts
+++ b/types/react-native/v0.65/index.d.ts
@@ -360,7 +360,7 @@ export interface HostComponent<P> extends Pick<React.ComponentClass<P>, Exclude<
 
 // see react-jsx.d.ts
 export function createElement<P>(
-    type: React.ReactType,
+    type: React.ElementType,
     props?: P,
     ...children: React.ReactNode[]
 ): React.ReactElement<P>;


### PR DESCRIPTION
[`react-native` uses React 17.0.2](https://unpkg.com/react-native@0.65.2/package.json). `ElementType` is available starting with [`@types/react@17.0.0`](https://unpkg.com/@types/react@17.0.0/index.d.ts).

Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210