### PR TITLE
Fixed paypal__checkout-server-sdk OrdersPatch.RequestData type

### DIFF
--- a/types/paypal__checkout-server-sdk/lib/orders/lib.d.ts
+++ b/types/paypal__checkout-server-sdk/lib/orders/lib.d.ts
@@ -714,9 +714,7 @@ export class OrdersGetRequest extends BaseOrderRequest<OrdersGet.RequestHeaders,
 export namespace OrdersPatch {
     type RequestHeaders = BaseOrderHeaders;
 
-    interface RequestData {
-        patch_request: Patch[];
-    }
+    type RequestData = Patch[];
 }
 
 export class OrdersPatchRequest extends BaseOrderRequest<OrdersPatch.RequestHeaders> {

--- a/types/paypal__checkout-server-sdk/paypal__checkout-server-sdk-tests.ts
+++ b/types/paypal__checkout-server-sdk/paypal__checkout-server-sdk-tests.ts
@@ -40,6 +40,15 @@ ordersCreateRequest.requestBody({
     },
 });
 
+ordersPatchRequest.requestBody([
+    {
+        from: '',
+        op: paypal.orders.Operation.REPLACE,
+        path: `/purchase_units/@reference_id=='default'/shipping/type`,
+        value: 'SHIPPING',
+    },
+]);
+
 async () => {
     const ordersAuthorizeResponse = await client.execute(ordersAuthorizeRequest);
     const ordersCaptureResponse = await client.execute(ordersCaptureRequest);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [see here](https://developer.paypal.com/api/orders/v2/#orders_patch)

The body of the PATCH request to orders api must only contain the array of operations. Currently it requires an object with property 'patch-request' containing the array, which the PayPal server will not understand (400 error). Passing just the array will fail the type check.
