### PR TITLE
Ember: introduce Helper `Signature`

### DIFF
--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -20,7 +20,9 @@ declare const Empty: unique symbol;
  *   will break existing declarations, but is not legal for end users to import
  *   themselves, so ***DO NOT RELY ON IT***.
  */
-export type EmptyObject = { [Empty]?: true };
+export interface EmptyObject {
+    [Empty]?: true;
+}
 
 type DefaultPositional = unknown[];
 type DefaultNamed = EmptyObject;
@@ -47,10 +49,10 @@ type ArgsFor<S> = 'Args' extends keyof S
       }
     : { Named: DefaultNamed; Positional: [] };
 
-type LegacyArgsFor<T> = {
+interface LegacyArgsFor<T> {
     Named: GetOrElse<T, 'NamedArgs', DefaultNamed>;
     Positional: GetOrElse<T, 'PositionalArgs', DefaultPositional>;
-};
+}
 
 /**
  * Given any allowed shorthand form of a signature, desugars it to its full
@@ -69,12 +71,12 @@ type LegacyArgsFor<T> = {
 // we designed the first pass of this. In the future, we will be able to make
 // all `ExpandSignature` types fully general to work with *any* invokable. But
 // "future" here probably means Ember v5. :sobbing:
-export type ExpandSignature<T> = {
+export interface ExpandSignature<T> {
     Args: keyof T extends 'Args' | 'Return' // Is this a `Signature`?
         ? ArgsFor<T> // Then use `Signature` args
         : LegacyArgsFor<T>; // Otherwise fall back to classic `Args`.
     Return: 'Return' extends keyof T ? T['Return'] : unknown;
-};
+}
 
 type NamedArgs<S> = ExpandSignature<S>['Args']['Named'];
 type PositionalArgs<S> = ExpandSignature<S>['Args']['Positional'];

--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -26,7 +26,6 @@ export interface EmptyObject {
 
 type DefaultPositional = unknown[];
 type DefaultNamed = EmptyObject;
-type DefaultReturn = unknown;
 
 /**
  * The public shape of a helper.

--- a/types/ember__component/test/helper.ts
+++ b/types/ember__component/test/helper.ts
@@ -1,8 +1,8 @@
 import Helper, { helper } from '@ember/component/helper';
 
-class Timestamp extends Helper<{
-    PositionalArgs: [offset: Date],
-    Return: Date,
+class DeprecatedSignatureForm extends Helper<{
+    PositionalArgs: [offset: Date];
+    Return: Date;
 }> {
     timer?: ReturnType<typeof setInterval> | undefined;
     now = new Date();
@@ -21,12 +21,80 @@ class Timestamp extends Helper<{
     }
 }
 
-// $ExpectType FunctionBasedHelper<{ PositionalArgs: [number, number]; NamedArgs: Record<string, unknown>; Return: number; }>
-const addHelper = helper(function add([a, b]: [number, number]) {
+interface DemoSig {
+    Args: {
+        Named: {
+            name: string;
+            age: number;
+        };
+        Positional: [i18nizer: (s: string) => string];
+    };
+    Return: string;
+}
+
+class SignatureForm extends Helper<DemoSig> {
+    compute([i18nizer]: [i18nizer: (s: string) => string], { name, age }: { name: string; age: number }): string {
+        return i18nizer(`${name} is ${age} years old`);
+    }
+}
+
+class BadPosSigForm extends Helper<DemoSig> {
+    compute(
+        // $ExpectError
+        [i18nizer, extra]: [i18nizer: (s: string) => string],
+        { name, age }: { name: string; age: number },
+    ): string {
+        return i18nizer(`${name} is ${age} years old`);
+    }
+}
+
+class BadNamedSigForm extends Helper<DemoSig> {
+    compute(
+        [i18nizer]: [i18nizer: (s: string) => string],
+        // $ExpectError
+        { name, age, potato }: { name: string; age: number },
+    ): string {
+        return i18nizer(`${name} is ${age} years old`);
+    }
+}
+
+class BadReturnForm extends Helper<DemoSig> {
+    compute([i18nizer]: [i18nizer: (s: string) => string], { name, age }: { name: string; age: number }): string {
+        // $ExpectError
+        return Boolean(i18nizer(`${name} is ${age} years old`));
+    }
+}
+
+// $ExpectType FunctionBasedHelper<{ Args: { Positional: [number, number]; Named: DefaultNamed; }; Return: number; }>
+const inferenceOnPositional = helper(function add([a, b]: [number, number]) {
     return a + b;
 });
 
-// $ExpectType FunctionBasedHelper<{ PositionalArgs: [string]; NamedArgs: { delim?: string; }; Return: string; }>
+const coolHelper = helper(([], named) => {
+    // $ExpectType DefaultNamed
+    named;
+});
+
+// $ExpectType FunctionBasedHelper<{ Args: { Positional: DefaultPositional; Named: { cool: boolean; }; }; Return: 123 | "neat"; }>
+const typeInferenceOnNamed = helper(([], { cool }: { cool: boolean }) => {
+    // $ExpectType boolean
+    cool;
+
+    return cool ? 123 : 'neat';
+});
+
+// $ExpectType FunctionBasedHelper<{ Args: { Positional: [string]; Named: { delim?: string; }; }; Return: string; }>
 const dasherizeHelper = helper(function dasherize([str]: [string], { delim = '-' }: { delim?: string }) {
     return str.split(/[\s\n\_\.]+/g).join(delim);
 });
+
+const signatureForm = helper<DemoSig>(([i18nizer], { name, age }) => i18nizer(`${name} is ${age} years old`));
+
+// $ExpectError
+const badPosArgsSig = helper<DemoSig>(([i18nizer, extra], { name, age }) => i18nizer(`${name} is ${age} years old`));
+
+// $ExpectError
+const badNamedArgsSig = helper<DemoSig>(([i18nizer], { name, age, potato }) => i18nizer(`${name} is ${age} years old`));
+
+// $ExpectError
+const badReturnSig = helper<DemoSig>(([i18nizer], { name, age }) => Boolean(i18nizer(`${name} is ${age} years old`)));

--- a/types/ember__component/test/helper.ts
+++ b/types/ember__component/test/helper.ts
@@ -65,13 +65,13 @@ class BadReturnForm extends Helper<DemoSig> {
     }
 }
 
-// $ExpectType FunctionBasedHelper<{ Args: { Positional: [number, number]; Named: DefaultNamed; }; Return: number; }>
+// $ExpectType FunctionBasedHelper<{ Args: { Positional: [number, number]; Named: EmptyObject; }; Return: number; }>
 const inferenceOnPositional = helper(function add([a, b]: [number, number]) {
     return a + b;
 });
 
 const coolHelper = helper(([], named) => {
-    // $ExpectType DefaultNamed
+    // $ExpectType EmptyObject
     named;
 });
 


### PR DESCRIPTION
This aligns the `Helper` signature here with the form used for Ember Components (see #59447), while providing backwards-compatible support for the previous form of the signature. This makes it easier for tools like [Glint][glint] to use the types directly instead of supplying its own overrides.

[glint]: https://github.com/typed-ember/glint/tree/main

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: emberjs/rfcs#748 (this does not explicitly address helpers… but then, *nothing* does: we are in the process of stabilizing all of these concepts, so this is as expected; a forthcoming RFC will use the knowledge we gain *through this PR* to stabilize it in Ember!)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
