### PR TITLE
[meteor,styled-components] Fix TS 4.7 compat issues

### DIFF
--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -174,7 +174,7 @@ declare module 'meteor/mongo' {
              * Constructor for a Collection
              * @param name The name of the collection. If null, creates an unmanaged (unsynchronized) local collection.
              */
-            new <T, U = T>(
+            new <T extends MongoNpmModule.Document, U = T>(
                 name: string | null,
                 options?: {
                     /**
@@ -199,7 +199,7 @@ declare module 'meteor/mongo' {
                 },
             ): Collection<T, U>;
         }
-        interface Collection<T, U = T> {
+        interface Collection<T extends MongoNpmModule.Document, U = T> {
             allow<Fn extends Transform<T> = undefined>(options: {
                 insert?: ((userId: string, doc: DispatchTransform<Fn, T, U>) => boolean) | undefined;
                 update?:

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -116,11 +116,11 @@ export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
 
 type Attrs<P, A extends Partial<P>, T> = ((props: ThemedStyledProps<P, T>) => A) | A;
 
-export type ThemedGlobalStyledClassProps<P, T> = WithOptionalTheme<P, T> & {
+export type ThemedGlobalStyledClassProps<P extends { theme?: T | undefined }, T> = WithOptionalTheme<P, T> & {
     suppressMultiMountWarning?: boolean | undefined;
 };
 
-export interface GlobalStyleComponent<P, T> extends React.ComponentClass<ThemedGlobalStyledClassProps<P, T>> {}
+export interface GlobalStyleComponent<P extends { theme?: T | undefined }, T> extends React.ComponentClass<ThemedGlobalStyledClassProps<P, T>> {}
 
 // remove the call signature from StyledComponent so Interpolation can still infer InterpolationFunction
 type StyledComponentInterpolation =


### PR DESCRIPTION
Fixes issues with TypeScript 4.7 canary (https://github.com/microsoft/TypeScript/pull/48366 specifically) that are blocking https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210

Needed to combine `meteor` and `styled-components` due to cyclic dependencies.