### PR TITLE
[express-async-errors] Added type definition

### DIFF
--- a/types/express-async-errors/express-async-errors-tests.ts
+++ b/types/express-async-errors/express-async-errors-tests.ts
@@ -1,0 +1,2 @@
+import expressAsyncErrors = require('express-async-errors');
+expressAsyncErrors; // $ExpectType object

--- a/types/express-async-errors/express-async-errors-tests.ts
+++ b/types/express-async-errors/express-async-errors-tests.ts
@@ -1,2 +1,2 @@
 import expressAsyncErrors = require('express-async-errors');
-expressAsyncErrors; // $ExpectType object
+expressAsyncErrors; // $ExpectType ObjectConstructor

--- a/types/express-async-errors/index.d.ts
+++ b/types/express-async-errors/index.d.ts
@@ -3,5 +3,4 @@
 // Definitions by: Stephen Melvin <https://github.com/sbmelvin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare const _: object;
-export = _;
+export {};

--- a/types/express-async-errors/index.d.ts
+++ b/types/express-async-errors/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for express-async-errors 3.1
+// Project: https://github.com/davidbanham/express-async-errors
+// Definitions by: Stephen Melvin <https://github.com/sbmelvin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const _: object;
+export = _;

--- a/types/express-async-errors/index.d.ts
+++ b/types/express-async-errors/index.d.ts
@@ -3,5 +3,4 @@
 // Definitions by: Stephen Melvin <https://github.com/sbmelvin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare const _: object;
-export = _;
+export = Object;

--- a/types/express-async-errors/tsconfig.json
+++ b/types/express-async-errors/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-async-errors-tests.ts"
+    ]
+}

--- a/types/express-async-errors/tslint.json
+++ b/types/express-async-errors/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
[express-async-errors](https://www.npmjs.com/package/express-async-errors) is a package that is used by importing/requiring only. As the module does not export anything, the result of `require` is an empty object. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
