### PR TITLE
[react-transition-group] nodeRef prop type aligned to React ref prop one

### DIFF
--- a/types/react-transition-group/Transition.d.ts
+++ b/types/react-transition-group/Transition.d.ts
@@ -129,7 +129,7 @@ interface BaseTransitionProps<RefElement extends undefined | HTMLElement> {
      * When changing `key` prop of `Transition` in a `TransitionGroup` a new `nodeRef` need to be provided to `Transition` with changed `key`
      * prop (@see https://github.com/reactjs/react-transition-group/blob/master/test/Transition-test.js).
      */
-    nodeRef?: React.Ref<RefElement> | undefined;
+    nodeRef?: React.LegacyRef<RefElement> | undefined;
 
     [prop: string]: any;
 }

--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -5,6 +5,7 @@
 //                 Masafumi Koba <https://github.com/ybiquitous>
 //                 tu4mo <https://github.com/tu4mo>
 //                 Ben Grynhaus <https://github.com/bengry>
+//                 Giuseppe Montuoro <https://github.com/goldmont>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -13,7 +13,8 @@ const Container: React.FunctionComponent<ContainerProps> = (props: ContainerProp
 };
 
 const Test: React.FunctionComponent = () => {
-    const nodeRef = React.useRef<HTMLDivElement>(null);
+
+    const nodeRef = React.useRef<HTMLDivElement | null>(null);
 
     function handleEnter(node: HTMLElement, isAppearing: boolean) {}
     function handleEnterNoNode(isAppearing: boolean) {}

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -13,7 +13,6 @@ const Container: React.FunctionComponent<ContainerProps> = (props: ContainerProp
 };
 
 const Test: React.FunctionComponent = () => {
-
     const nodeRef = React.useRef<HTMLDivElement | null>(null);
 
     function handleEnter(node: HTMLElement, isAppearing: boolean) {}
@@ -128,6 +127,7 @@ const Test: React.FunctionComponent = () => {
                 className="animated-list"
                 childFactory={(child: React.ReactElement) => child}
             >
+
                 <Transition
                     in
                     mountOnEnter
@@ -217,6 +217,7 @@ const Test: React.FunctionComponent = () => {
                 <CSSTransition timeout={500} nodeRef={nodeRef} onEnter={handleEnterNoNode}>
                     <div ref={nodeRef}>{'test'}</div>
                 </CSSTransition>
+
             </TransitionGroup>
         </>
     );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/59176
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.