### PR TITLE
Extend expected types for element prop from react-infinite-scroller

### DIFF
--- a/types/react-infinite-scroller/index.d.ts
+++ b/types/react-infinite-scroller/index.d.ts
@@ -18,7 +18,7 @@ declare namespace InfiniteScroll {
          * Name of the element that the component should render as.
          * Defaults to 'div'.
          */
-        element?: string | undefined;
+        element?: React.ReactNode | string | undefined;
         /**
          * Whether there are more items to be loaded. Event listeners are removed if false.
          * Defaults to false.

--- a/types/react-infinite-scroller/react-infinite-scroller-tests.tsx
+++ b/types/react-infinite-scroller/react-infinite-scroller-tests.tsx
@@ -50,6 +50,24 @@ class Test3 extends React.Component {
     }
 }
 
+const Test4Component = ({}) => <div></div>;
+class Test4 extends React.Component {
+    inputRef = React.createRef<HTMLDivElement>();
+
+    render() {
+        return (
+            <div ref={this.inputRef}>
+                <InfiniteScroll
+                  element={Test4Component}
+                  loadMore={(page) => {}}
+                >
+                    <span>Test 4</span>
+                </InfiniteScroll>
+            </div>
+        );
+    }
+}
+
 class InfiniteScrollOverride extends InfiniteScroll {
     getParentElement(el: HTMLElement) {
         if (document.getElementById("scroll-header")) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [element prop type definition](https://github.com/danbovey/react-infinite-scroller/blob/e57d2c21b5be35c1bcb67b9eebb0474796d2212a/src/InfiniteScroll.js#L7)
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `element` prop can be a component, it does not necessarily have to be a `string` representation of an HTML element. The `element` prop is passed through to `React.createElement` [here](https://github.com/danbovey/react-infinite-scroller/blob/e57d2c21b5be35c1bcb67b9eebb0474796d2212a/src/InfiniteScroll.js#L284).