### PR TITLE
[node] Add typings for stream.isReadable and stream.isErrored

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -1238,6 +1238,19 @@ declare module 'stream' {
             ref(): void;
             unref(): void;
         }
+
+        /**
+         * Returns whether the stream has encountered an error.
+         * @since v17.3.0
+         */
+        function isErrored(stream: Readable | Writable | NodeJS.ReadableStream | NodeJS.WritableStream): boolean;
+
+        /**
+         * Returns whether the stream is readable.
+         * @since v17.4.0
+         */
+        function isReadable(stream: Readable | NodeJS.ReadableStream): boolean;
+
         const promises: typeof streamPromises;
         const consumers: typeof streamConsumers;
     }

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -1,4 +1,4 @@
-import { Readable, Writable, Transform, finished, pipeline, Duplex, addAbortSignal } from 'node:stream';
+import { Readable, Writable, Transform, finished, pipeline, Duplex, addAbortSignal, isErrored, isReadable } from 'node:stream';
 import { promisify } from 'node:util';
 import { createReadStream, createWriteStream } from 'node:fs';
 import { createGzip, constants } from 'node:zlib';
@@ -523,6 +523,17 @@ addAbortSignal(new AbortSignal(), new Readable());
     Readable.isDisturbed(readable); // $ExpectType boolean
     const readableDidRead: boolean = readable.readableDidRead;
     const readableAborted: boolean = readable.readableAborted;
+}
+
+{
+    isErrored(new Readable()); // $ExpectType boolean
+    isErrored(new Duplex()); // $ExpectType boolean
+    isErrored(new Writable()); // $ExpectType boolean
+}
+
+{
+    isReadable(new Readable()); // $ExpectType boolean
+    isReadable(new Duplex()); // $ExpectType boolean
 }
 
 async function testReadableStream() {

--- a/types/node/v16/stream.d.ts
+++ b/types/node/v16/stream.d.ts
@@ -1238,6 +1238,19 @@ declare module 'stream' {
             ref(): void;
             unref(): void;
         }
+
+        /**
+         * Returns whether the stream has encountered an error.
+         * @since v16.14.0
+         */
+        function isErrored(stream: Readable | Writable | NodeJS.ReadableStream | NodeJS.WritableStream): boolean;
+
+        /**
+         * Returns whether the stream is readable.
+         * @since v16.14.0
+         */
+        function isReadable(stream: Readable | NodeJS.ReadableStream): boolean;
+
         const promises: typeof streamPromises;
         const consumers: typeof streamConsumers;
     }

--- a/types/node/v16/test/stream.ts
+++ b/types/node/v16/test/stream.ts
@@ -1,4 +1,4 @@
-import { Readable, Writable, Transform, finished, pipeline, Duplex, addAbortSignal } from 'node:stream';
+import { Readable, Writable, Transform, finished, pipeline, Duplex, addAbortSignal, isErrored, isReadable } from 'node:stream';
 import { promisify } from 'node:util';
 import { createReadStream, createWriteStream } from 'node:fs';
 import { createGzip, constants } from 'node:zlib';
@@ -523,6 +523,17 @@ addAbortSignal(new AbortSignal(), new Readable());
     Readable.isDisturbed(readable); // $ExpectType boolean
     const readableDidRead: boolean = readable.readableDidRead;
     const readableAborted: boolean = readable.readableAborted;
+}
+
+{
+    isErrored(new Readable()); // $ExpectType boolean
+    isErrored(new Duplex()); // $ExpectType boolean
+    isErrored(new Writable()); // $ExpectType boolean
+}
+
+{
+    isReadable(new Readable()); // $ExpectType boolean
+    isReadable(new Duplex()); // $ExpectType boolean
 }
 
 async function testReadableStream() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [17.x](https://nodejs.org/api/stream.html#streamisreadablestream) [16.x](https://nodejs.org/docs/latest-v16.x/api/stream.html#streamisreadablestream)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
