### PR TITLE
[mdx] components should be compatible with React.FC

### DIFF
--- a/types/mdx/mdx-tests.tsx
+++ b/types/mdx/mdx-tests.tsx
@@ -176,32 +176,32 @@ const MyComponentAlias: MDXContent = MyMDXComponent;
             return <div />;
         },
         nested: {
-            components: props => {
+            components: (props) => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: props => {
+                deeply: (props) => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: props => {
+                    infinity: (props) => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: props => {
+                        beyond: (props) => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    },
-                },
+                    }
+                }
             },
         },
         // $ExpectError
@@ -235,32 +235,32 @@ const MyComponentAlias: MDXContent = MyMDXComponent;
             return <div />;
         },
         nested: {
-            components: props => {
+            components: (props) => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: props => {
+                deeply: (props) => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: props => {
+                    infinity: (props) => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: props => {
+                        beyond: (props) => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    },
-                },
+                    }
+                }
             },
         },
         // $ExpectError
@@ -294,32 +294,32 @@ const MyComponentAlias: MDXContent = MyMDXComponent;
             return <div />;
         },
         nested: {
-            components: props => {
+            components: (props) => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: props => {
+                deeply: (props) => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: props => {
+                    infinity: (props) => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: props => {
+                        beyond: (props) => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    },
-                },
+                    }
+                }
             },
         },
         // $ExpectError
@@ -353,32 +353,32 @@ const MyComponentAlias: MDXContent = MyMDXComponent;
             return <div />;
         },
         nested: {
-            components: props => {
+            components: (props) => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: props => {
+                deeply: (props) => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: props => {
+                    infinity: (props) => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: props => {
+                        beyond: (props) => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    },
-                },
+                    }
+                }
             },
         },
         // $ExpectError
@@ -412,32 +412,32 @@ const MyComponentAlias: MDXContent = MyMDXComponent;
             return <div />;
         },
         nested: {
-            components: props => {
+            components: (props) => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: props => {
+                deeply: (props) => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: props => {
+                    infinity: (props) => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: props => {
+                        beyond: (props) => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    },
-                },
+                    }
+                }
             },
         },
         // $ExpectError
@@ -471,32 +471,32 @@ const MyComponentAlias: MDXContent = MyMDXComponent;
             return <div />;
         },
         nested: {
-            components: props => {
+            components: (props) => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: props => {
+                deeply: (props) => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: props => {
+                    infinity: (props) => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: props => {
+                        beyond: (props) => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    },
-                },
+                    }
+                }
             },
         },
         // $ExpectError
@@ -530,32 +530,32 @@ const MyComponentAlias: MDXContent = MyMDXComponent;
             return <div />;
         },
         nested: {
-            components: props => {
+            components: (props) => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: props => {
+                deeply: (props) => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: props => {
+                    infinity: (props) => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: props => {
+                        beyond: (props) => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    },
-                },
+                    }
+                }
             },
         },
         // $ExpectError

--- a/types/mdx/mdx-tests.tsx
+++ b/types/mdx/mdx-tests.tsx
@@ -69,6 +69,10 @@ class CustomImageComponent {
     }
 }
 
+type FunctionComponent<P = {}> = (props: P) => JSX.Element | null; // simplistic FC type, mimicking React.FC
+
+const CustomVideoComponent: FunctionComponent<VideoProps> = () => <div>Dummy video component</div>;
+
 // Tests — The `mdx` imports.
 
 function MyMDXPage(props: MDXModule) {
@@ -166,8 +170,7 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div {...props} />;
         },
         img: CustomImageComponent,
-        // $ExpectError
-        video: CustomImageComponent,
+        video: CustomVideoComponent,
         wrapper(props) {
             // $ExpectType any
             props;

--- a/types/mdx/mdx-tests.tsx
+++ b/types/mdx/mdx-tests.tsx
@@ -91,7 +91,6 @@ function MyMDXPage(props: MDXModule) {
 }
 
 const MyComponentAlias: MDXContent = MyMDXComponent;
-const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
 
 // Tests — All mdx file exports.
 
@@ -119,32 +118,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -177,32 +176,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -236,32 +235,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -295,32 +294,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -354,32 +353,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -413,32 +412,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -472,32 +471,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -531,32 +530,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError

--- a/types/mdx/types.d.ts
+++ b/types/mdx/types.d.ts
@@ -1,7 +1,7 @@
 // Internal helper types
 
 // tslint:disable-next-line: strict-export-declare-modifiers
-type FunctionComponent<Props> = (props: Props) => JSX.Element;
+type FunctionComponent<Props> = (props: Props) => JSX.Element | null;
 // tslint:disable-next-line: strict-export-declare-modifiers
 type ClassComponent<Props> = new (props: Props) => JSX.ElementClass;
 // tslint:disable-next-line: strict-export-declare-modifiers
@@ -18,15 +18,14 @@ interface NestedMDXComponents {
  *
  * The key is the name of the element to override. The value is the component to render instead.
  */
-export type MDXComponents = NestedMDXComponents &
-    {
-        [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]> | keyof JSX.IntrinsicElements;
-    } & {
-        /**
-         * If a wrapper component is defined, the MDX content will be wrapped inside of it.
-         */
-        wrapper?: Component<any>;
-    };
+export type MDXComponents = NestedMDXComponents & {
+    [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]> | keyof JSX.IntrinsicElements;
+} & {
+    /**
+     * If a wrapper component is defined, the MDX content will be wrapped inside of it.
+     */
+    wrapper?: Component<any>;
+};
 
 /**
  * The props that may be passed to an MDX component.

--- a/types/mdx/types.d.ts
+++ b/types/mdx/types.d.ts
@@ -18,14 +18,15 @@ interface NestedMDXComponents {
  *
  * The key is the name of the element to override. The value is the component to render instead.
  */
-export type MDXComponents = NestedMDXComponents & {
-    [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]> | keyof JSX.IntrinsicElements;
-} & {
-    /**
-     * If a wrapper component is defined, the MDX content will be wrapped inside of it.
-     */
-    wrapper?: Component<any>;
-};
+export type MDXComponents = NestedMDXComponents &
+    {
+        [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]> | keyof JSX.IntrinsicElements;
+    } & {
+        /**
+         * If a wrapper component is defined, the MDX content will be wrapped inside of it.
+         */
+        wrapper?: Component<any>;
+    };
 
 /**
  * The props that may be passed to an MDX component.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mdxjs.com/docs/using-mdx/#components
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Further explanation

As currently typed, `mdx`'s `FunctionComponent<Props>` is not compatible with `react`'s `FunctionComponent<Props>`, which leads to confusion and needless code changes on the consumer side. The core of the problem is that react allows function components (just like class components) to return `null`:
![image](https://user-images.githubusercontent.com/543372/160822189-34dcbf7a-969a-47b7-8ff4-6c59e5b96d78.png)

This means that in a codebase utilizing `React.FC`, one cannot map their existing react components to MDX, even if they don't actually ever return null:
![image](https://user-images.githubusercontent.com/543372/160822393-6de357c3-424d-4e3d-b796-39ab7cff537f.png)

This seems like a needless limitation as mdx works perfectly even if the component does return `null`, as expected. 