### PR TITLE
Fix typo in react-email-editor

### DIFF
--- a/types/react-email-editor/index.d.ts
+++ b/types/react-email-editor/index.d.ts
@@ -49,7 +49,7 @@ export interface ConditionalMergeTag {
 export type MergeTag = SimpleMergeTag | ConditionalMergeTag | GroupedMergeTag;
 
 export interface DesignTagConfig {
-    readonly delimeter: [string, string];
+    readonly delimiter: [string, string];
 }
 
 export interface DisplayCondition {

--- a/types/react-email-editor/react-email-editor-tests.tsx
+++ b/types/react-email-editor/react-email-editor-tests.tsx
@@ -120,7 +120,7 @@ class App extends React.Component {
               current_user_name: 'John Doe',
             },
             designTagsConfig: {
-              delimeter: ['[[', ']]'],
+              delimiter: ['[[', ']]'],
             },
             tools: TOOLS_CONFIG,
             blocks: [],


### PR DESCRIPTION
The right name for the delimiter property in `DesignTagConfig` is `delimiter` in place of `delimeter`.

See Unlayer's documentation: https://docs.unlayer.com/docs/design-tags#changing-delimiter

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- N/A ~~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
