### PR TITLE
@wordpress/block-editor: Adds allowedFormats property to RichText component

### DIFF
--- a/types/wordpress__block-editor/components/rich-text.d.ts
+++ b/types/wordpress__block-editor/components/rich-text.d.ts
@@ -7,6 +7,11 @@ import { displayShortcut, rawShortcut } from '@wordpress/keycodes';
 declare namespace RichText {
     interface Props<T extends keyof HTMLElementTagNameMap> extends Omit<HTMLProps<T>, 'onChange'> {
         /**
+         * By default, all registered formats are allowed. This setting can be used to fine-tune
+         * the allowed formats.
+         */
+        allowedFormats?: string[] | undefined;
+        /**
          * A list of autocompleters to use instead of the default.
          */
         autocompleters?: Array<Autocomplete.Completer<any>> | undefined;

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -321,6 +321,7 @@ be.withFontSizes('fontSize')(() => <h1>Hello World</h1>);
     value="Hello World"
     onChange={nextContent => console.log(nextContent.toUpperCase())}
     onReplace={blocks => blocks.forEach(b => console.log(b.clientId))}
+    allowedFormats={['core/bold', 'core/italic']}
 />;
 <be.RichText.Content value="foo" />;
 <be.RichText.Content tagName="p" style={{ color: 'blue' }} className="foo" value="Hello World" dir="rtl" />;


### PR DESCRIPTION
This adds the missing property `allowedFormats` for the `<RichText />` component.
This was already available in the `6.0.0` release of `@wordpress/block-editor` so no version increase of the type definitions is neccessary.

Documentation: https://github.com/WordPress/gutenberg/blob/%40wordpress/block-editor%406.0.0/packages/block-editor/src/components/rich-text/README.md#allowedformats-array

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

