### PR TITLE
[ramda] improve converge

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -69,6 +69,9 @@ import {
     ToTupleOfFunction,
     Tuple,
     CondPairTypeguard,
+    Fn,
+    IfFunctionsArgumentsDoNotOverlap,
+    LargestArgumentsList,
 } from './tools';
 
 export * from './tools';
@@ -807,78 +810,28 @@ export function contains<T>(a: T): (list: readonly T[]) => boolean;
  * are passed as arguments to the converging function to produce the return value.
  */
 export function converge<
-    TArgs extends any[],
     TResult,
-    R1,
-    R2,
-    R3,
-    R4,
-    R5,
-    R6,
-    R7,
-    RestFunctions extends Array<(...args: TArgs) => any>,
+    FunctionsList extends ReadonlyArray<Fn> &
+        IfFunctionsArgumentsDoNotOverlap<_Fns, 'Functions arguments types must overlap'>,
+    _Fns extends ReadonlyArray<Fn> = FunctionsList,
 >(
-    converging: (...args: [R1, R2, R3, R4, R5, R6, R7, ...ReturnTypesOfFns<RestFunctions>]) => TResult,
-    branches: [
-        (...args: TArgs) => R1,
-        (...args: TArgs) => R2,
-        (...args: TArgs) => R3,
-        (...args: TArgs) => R4,
-        (...args: TArgs) => R5,
-        (...args: TArgs) => R6,
-        (...args: TArgs) => R7,
-        ...RestFunctions,
-    ],
-): (...args: TArgs) => TResult;
-export function converge<TArgs extends any[], TResult, R1, R2, R3, R4, R5, R6, R7>(
-    converging: (...args: [R1, R2, R3, R4, R5, R6, R7] & { length: 7 }) => TResult,
-    branches: [
-        (...args: TArgs) => R1,
-        (...args: TArgs) => R2,
-        (...args: TArgs) => R3,
-        (...args: TArgs) => R4,
-        (...args: TArgs) => R5,
-        (...args: TArgs) => R6,
-        (...args: TArgs) => R7,
-    ],
-): (...args: TArgs) => TResult;
-export function converge<TArgs extends any[], TResult, R1, R2, R3, R4, R5, R6>(
-    converging: (...args: [R1, R2, R3, R4, R5, R6] & { length: 6 }) => TResult,
-    branches: [
-        (...args: TArgs) => R1,
-        (...args: TArgs) => R2,
-        (...args: TArgs) => R3,
-        (...args: TArgs) => R4,
-        (...args: TArgs) => R5,
-        (...args: TArgs) => R6,
-    ],
-): (...args: TArgs) => TResult;
-export function converge<TArgs extends any[], TResult, R1, R2, R3, R4, R5>(
-    converging: (...args: [R1, R2, R3, R4, R5] & { length: 5 }) => TResult,
-    branches: [
-        (...args: TArgs) => R1,
-        (...args: TArgs) => R2,
-        (...args: TArgs) => R3,
-        (...args: TArgs) => R4,
-        (...args: TArgs) => R5,
-    ],
-): (...args: TArgs) => TResult;
-export function converge<TArgs extends any[], TResult, R1, R2, R3, R4>(
-    converging: (...args: [R1, R2, R3, R4] & { length: 4 }) => TResult,
-    branches: [(...args: TArgs) => R1, (...args: TArgs) => R2, (...args: TArgs) => R3, (...args: TArgs) => R4],
-): (...args: TArgs) => TResult;
-export function converge<TArgs extends any[], TResult, R1, R2, R3>(
-    converging: (...args: [R1, R2, R3] & { length: 3 }) => TResult,
-    branches: [(...args: TArgs) => R1, (...args: TArgs) => R2, (...args: TArgs) => R3],
-): (...args: TArgs) => TResult;
-export function converge<TArgs extends any[], TResult, R1, R2>(
-    converging: (...args: [R1, R2] & { length: 2 }) => TResult,
-    branches: [(...args: TArgs) => R1, (...args: TArgs) => R2],
-): (...args: TArgs) => TResult;
-export function converge<TArgs extends any[], TResult, R1>(
-    converging: (...args: [R1] & { length: 1 }) => TResult,
-    branches: [(...args: TArgs) => R1],
-): (...args: TArgs) => TResult;
+    converging: (...args: ReturnTypesOfFns<FunctionsList>) => TResult,
+    branches: FunctionsList,
+): _.F.Curry<(...args: LargestArgumentsList<FunctionsList>) => TResult>;
+export function converge<
+    CArgs extends ReadonlyArray<any>,
+    TResult,
+    FunctionsList extends readonly [
+        ...{
+            [Index in keyof CArgs]: (...args: ReadonlyArray<any>) => CArgs[Index];
+        },
+    ] &
+        IfFunctionsArgumentsDoNotOverlap<_Fns, 'Functions arguments types must overlap'>,
+    _Fns extends ReadonlyArray<Fn> = FunctionsList,
+>(
+    converging: (...args: CArgs) => TResult,
+    branches: FunctionsList,
+): _.F.Curry<(...args: LargestArgumentsList<FunctionsList>) => TResult>;
 
 /**
  * Returns the number of items in a given `list` matching the predicate `f`
@@ -1054,9 +1007,7 @@ export function endsWith<T>(subList: readonly T[]): (list: readonly T[]) => bool
  */
 export function eqBy<T>(fn: (a: T) => unknown, a: T, b: T): boolean;
 export function eqBy<T>(fn: (a: T) => unknown, a: T): (b: T) => boolean;
-export function eqBy<T>(
-    fn: (a: T) => unknown,
-): {
+export function eqBy<T>(fn: (a: T) => unknown): {
     (a: T, b: T): boolean;
     (a: T): (b: T) => boolean;
 };

--- a/types/ramda/test/converge-tests.ts
+++ b/types/ramda/test/converge-tests.ts
@@ -16,7 +16,9 @@ import * as R from 'ramda';
 
     // $ExpectType string
     const indented = format({ indent: 2, value: 'foo\nbar\nbaz\n' }); // => '  foo\n  bar\n  baz\n'
+};
 
+() => {
     const add = (a: number, b: number) => a + b;
     const multiply = (a: number, b: number) => a * b;
     const subtract = (a: number, b: number) => a - b;
@@ -33,8 +35,20 @@ import * as R from 'ramda';
     // $ExpectType Curry<(a: number, b: number) => number>
     const fn = R.converge(multiply, [add, subtract]);
 
+    // $ExpectType number
+    fn(1, 2);
+
+    // $ExpectError
+    fn('1', 2);
+
+    // $ExpectError
+    fn(1, 2, 3);
+
     // $ExpectError
     const fnMismatchedTypes = R.converge(concat, [add, subtract]);
+
+    // $ExpectError
+    R.converge(multiply, [add, subtract, add]);
 
     // $ExpectError
     const fnWrongNumberOfBranchesV1 = R.converge(concat, []);
@@ -45,6 +59,9 @@ import * as R from 'ramda';
     // because fifth function in branches has arity of 3 result function also must have largest arity
     // $ExpectType Curry<(a: number, b: number, c: number) => number>
     const fn10 = R.converge(add10, [add, add, add, add, add3, add, add, add, add, add]);
+
+    // $ExpectType number
+    fn10(1, 2, 3);
 
     const args1 = (a1: number | string) => 1;
     const args2 = (a1: number | bigint, a2: { q: string }) => 2;
@@ -90,7 +107,4 @@ import * as R from 'ramda';
 
     // $ExpectType number
     const average = getAverage([1, 3, 0, 4]); // => 2
-
-    // $ExpectType Curry<(a: number, b: number) => <U>(b: U) => number | U>
-    const withGenericMultiLevelTypeInference = R.converge((...args) => R.or(...args), [add] as const);
 };

--- a/types/ramda/test/converge-tests.ts
+++ b/types/ramda/test/converge-tests.ts
@@ -74,7 +74,7 @@ import * as R from 'ramda';
 
     // unable to infer types correctly because generic `R.or` has overloads with different number of arguments
     // $ExpectType Curry<(a: number, b: number) => <U>(b: U) => unknown>
-    const withGenericWorongInferred = R.converge(R.or, [add, subtract] as const);
+    const withGenericWrongInferred = R.converge(R.or, [add, subtract] as const);
 
     // need to use wrapper `(...args) => convergingFunction(...args)` if converging function
     // is generic that has overloads with different number of arguments

--- a/types/ramda/test/converge-tests.ts
+++ b/types/ramda/test/converge-tests.ts
@@ -5,101 +5,92 @@ import * as R from 'ramda';
         indent: number;
         value: string;
     }
+
     const indentN = R.pipe(R.times(R.always(' ')), R.join(''), R.replace(/^(?!$)/gm));
 
-    // $ExpectType (args_0: FormatSpec) => string
-    const format = R.converge(R.call, [({ indent }: FormatSpec) => indentN(indent), ({ value }: FormatSpec) => value]);
+    // $ExpectType Curry<(args_0: FormatSpec) => string>
+    const format = R.converge(R.call, [
+        ({ indent }: FormatSpec) => indentN(indent),
+        ({ value }: FormatSpec) => value,
+    ] as const);
 
-    format({ indent: 2, value: 'foo\nbar\nbaz\n' }); // => '  foo\n  bar\n  baz\n'
-};
+    // $ExpectType string
+    const indented = format({ indent: 2, value: 'foo\nbar\nbaz\n' }); // => '  foo\n  bar\n  baz\n'
 
-() => {
-    function add(a: number, b: number) {
-        return a + b;
-    }
+    const add = (a: number, b: number) => a + b;
+    const multiply = (a: number, b: number) => a * b;
+    const subtract = (a: number, b: number) => a - b;
+    const concat = (a: string, b: string) => a + b;
 
-    function multiply(a: number, b: number) {
-        return a * b;
-    }
+    const add3 = (a: number, b: number, c: number) => a + b + c;
+    const add10 = (...args: [number, number, number, number, number, number, number, number, number, number]) =>
+        R.sum(args);
 
-    function subtract(a: number, b: number) {
-        return a - b;
-    }
+    // $Expect Curry<() => void>
+    const emptyFunction = R.converge(() => {}, []);
 
-    function concat(a: string, b: string) {
-        return a + b;
-    }
-
-    // ≅ multiply( add(1, 2), subtract(1, 2) );
-    // $ExpectType (a: number, b: number) => number
+    // fn(1, 2) ≅ multiply( add(1, 2), subtract(1, 2) );
+    // $ExpectType Curry<(a: number, b: number) => number>
     const fn = R.converge(multiply, [add, subtract]);
 
     // $ExpectError
-    R.converge(concat, [add, subtract]);
+    const fnMismatchedTypes = R.converge(concat, [add, subtract]);
 
     // $ExpectError
-    R.converge(multiply, [add, subtract, add]);
+    const fnWrongNumberOfBranchesV1 = R.converge(concat, []);
 
     // $ExpectError
-    R.converge(concat, []);
+    const fnWrongNumberOfBranchesV2 = R.converge(add10, [add, add, add, add, add, add, add, add, add, add, add, add]);
 
+    // because fifth function in branches has arity of 3 result function also must have largest arity
+    // $ExpectType Curry<(a: number, b: number, c: number) => number>
+    const fn10 = R.converge(add10, [add, add, add, add, add3, add, add, add, add, add]);
+
+    const args1 = (a1: number | string) => 1;
+    const args2 = (a1: number | bigint, a2: { q: string }) => 2;
+    const args3 = (a1: number | symbol, a2: { w: number }, a3: number) => 3;
+
+    // resulted function must accept types of parameters that will satisfy every function in branches, so intersection must be used
+    // $ExpectType Curry<(a1: number, a2: { w: number; } & { q: string; }, a3: number) => number>
+    const intersectionOfArguments = R.converge(add3, [args1, args2, args3]);
+
+    const argsIncompatible = (a1: string) => 1;
+
+    // types: `string`, `number | symbol`, and `number | bigint` - do not have common type
     // $ExpectError
-    R.converge(() => {}, []);
+    const intersectionOfArgumentsIncompatible = R.converge(add3, [argsIncompatible, args2, args3]);
 
     // $ExpectType number
-    fn(1, 2);
+    const resultNumber = intersectionOfArguments(1, { q: 'text', w: 22 }, 11);
 
     // $ExpectError
-    fn('1', 2);
+    const errorArguments = intersectionOfArguments(1, { q: 'text' }, 11);
 
-    // $ExpectError
-    fn(1, 2, 3);
+    const addGeneric = <T>(a: T, b: T): T => b;
 
-    function add10(
-        a: number,
-        b: number,
-        c: number,
-        d: number,
-        e: number,
-        f: number,
-        g: number,
-        h: number,
-        i: number,
-        j: number,
-    ) {
-        return a + b + c + d + e + f + g + h + i + j;
-    }
+    // need to use const if converging function is generic
+    // $ExpectType Curry<(a: number, b: number) => number>
+    const withGeneric0 = R.converge(addGeneric, [multiply, subtract] as const);
 
-    // $ExpectType (a: number, b: number) => number
-    const fn10 = R.converge(add10, [
-        multiply,
-        add,
-        subtract,
-        multiply,
-        add,
-        subtract,
-        multiply,
-        add,
-        subtract,
-        multiply,
-    ]);
+    // unable to infer types correctly because generic `R.or` has overloads with different number of arguments
+    // $ExpectType Curry<(a: number, b: number) => <U>(b: U) => unknown>
+    const withGenericWorongInferred = R.converge(R.or, [add, subtract] as const);
 
-    // TODO This should throw error, because the number of branches is not the same as converge arity
-    const fnWrongNumberOfBranches = R.converge(add10, [
-        multiply,
-        add,
-        subtract,
-        multiply,
-        add,
-        subtract,
-        multiply,
-        add,
-        subtract,
-        multiply,
-        add,
-        subtract,
-    ]);
+    // need to use wrapper `(...args) => convergingFunction(...args)` if converging function
+    // is generic that has overloads with different number of arguments
+    // $ExpectType Curry<(a: number, b: number, c: number) => number>
+    const withGeneric1 = R.converge((...args) => R.or(...args), [add, add3] as const);
+
+    // or explicitly set type for converging function arguments
+    // $ExpectType Curry<(a: number, b: number) => number>
+    const withGeneric2 = R.converge((...args: [number, number]) => R.or(...args), [add, subtract]);
+
+    // $ExpectType Curry<(list: readonly number[] & ArrayLike<unknown>) => number>
+    const getAverage = R.converge((...args) => R.divide(...args), [R.sum, R.length] as const);
 
     // $ExpectType number
-    fn10(1, 2);
+    const average = getAverage([1, 3, 0, 4]); // => 2
+
+    // $ExpectType Curry<(a: number, b: number) => <U>(b: U) => number | U>
+    const withGenericMultiLevelTypeInference = R.converge((...args) => R.or(...args), [add] as const);
 };

--- a/types/ramda/test/converge-tests.ts
+++ b/types/ramda/test/converge-tests.ts
@@ -8,41 +8,40 @@ import * as R from 'ramda';
 
     const indentN = R.pipe(R.times(R.always(' ')), R.join(''), R.replace(/^(?!$)/gm));
 
+    // $ExpectType Curry<(args_0: FormatSpec) => any>
+    const format = R.converge(R.call, [({ indent }: FormatSpec) => indentN(indent), ({ value }: FormatSpec) => value]);
+
+    format({ indent: 2, value: 'foo\nbar\nbaz\n' }); // => '  foo\n  bar\n  baz\n'
+
     // $ExpectType Curry<(args_0: FormatSpec) => string>
-    const format = R.converge(R.call, [
+    const format2 = R.converge(R.call, [
         ({ indent }: FormatSpec) => indentN(indent),
         ({ value }: FormatSpec) => value,
     ] as const);
 
     // $ExpectType string
-    const indented = format({ indent: 2, value: 'foo\nbar\nbaz\n' }); // => '  foo\n  bar\n  baz\n'
+    const indented = format2({ indent: 2, value: 'foo\nbar\nbaz\n' }); // => '  foo\n  bar\n  baz\n'
 };
 
 () => {
-    const add = (a: number, b: number) => a + b;
-    const multiply = (a: number, b: number) => a * b;
-    const subtract = (a: number, b: number) => a - b;
-    const concat = (a: string, b: string) => a + b;
+    function add(a: number, b: number) {
+        return a + b;
+    }
 
-    const add3 = (a: number, b: number, c: number) => a + b + c;
-    const add10 = (...args: [number, number, number, number, number, number, number, number, number, number]) =>
-        R.sum(args);
+    function multiply(a: number, b: number) {
+        return a * b;
+    }
 
-    // $Expect Curry<() => void>
-    const emptyFunction = R.converge(() => {}, []);
+    function subtract(a: number, b: number) {
+        return a - b;
+    }
 
-    // fn(1, 2) ≅ multiply( add(1, 2), subtract(1, 2) );
+    function concat(a: string, b: string) {
+        return a + b;
+    }
+
     // $ExpectType Curry<(a: number, b: number) => number>
     const fn = R.converge(multiply, [add, subtract]);
-
-    // $ExpectType number
-    fn(1, 2);
-
-    // $ExpectError
-    fn('1', 2);
-
-    // $ExpectError
-    fn(1, 2, 3);
 
     // $ExpectError
     const fnMismatchedTypes = R.converge(concat, [add, subtract]);
@@ -53,15 +52,67 @@ import * as R from 'ramda';
     // $ExpectError
     const fnWrongNumberOfBranchesV1 = R.converge(concat, []);
 
+    // $Expect Curry<() => void>
+    const emptyFunction = R.converge(() => {}, []);
+
+    // $ExpectType number
+    fn(1, 2);
+
     // $ExpectError
-    const fnWrongNumberOfBranchesV2 = R.converge(add10, [add, add, add, add, add, add, add, add, add, add, add, add]);
+    fn('1', 2);
+
+    // $ExpectError
+    fn(1, 2, 3);
+
+    function add10(
+        a: number,
+        b: number,
+        c: number,
+        d: number,
+        e: number,
+        f: number,
+        g: number,
+        h: number,
+        i: number,
+        j: number,
+    ) {
+        return a + b + c + d + e + f + g + h + i + j;
+    }
+
+    // $ExpectType Curry<(a: number, b: number) => number>
+    const fn10 = R.converge(add10, [
+        multiply,
+        add,
+        subtract,
+        multiply,
+        add,
+        subtract,
+        multiply,
+        add,
+        subtract,
+        multiply,
+    ]);
+
+    const add3 = (a: number, b: number, c: number) => a + b + c;
+
+    // $ExpectError
+    const fnWrongNumberOfBranches = R.converge(add3, [
+        // Error because we have 4 branches, but expect 3 arguments (add3)
+        multiply,
+        add,
+        subtract,
+        multiply,
+    ]);
+
+    // $ExpectType number
+    fn10(1, 2);
 
     // because fifth function in branches has arity of 3 result function also must have largest arity
     // $ExpectType Curry<(a: number, b: number, c: number) => number>
-    const fn10 = R.converge(add10, [add, add, add, add, add3, add, add, add, add, add]);
+    const fn10WithAdd3 = R.converge(add10, [add, add, add, add, add3, add, add, add, add, add]);
 
     // $ExpectType number
-    fn10(1, 2, 3);
+    fn10WithAdd3(1, 2, 3);
 
     const args1 = (a1: number | string) => 1;
     const args2 = (a1: number | bigint, a2: { q: string }) => 2;
@@ -71,17 +122,17 @@ import * as R from 'ramda';
     // $ExpectType Curry<(a1: number, a2: { w: number; } & { q: string; }, a3: number) => number>
     const intersectionOfArguments = R.converge(add3, [args1, args2, args3]);
 
-    const argsIncompatible = (a1: string) => 1;
-
-    // types: `string`, `number | symbol`, and `number | bigint` - do not have common type
-    // $ExpectError
-    const intersectionOfArgumentsIncompatible = R.converge(add3, [argsIncompatible, args2, args3]);
-
     // $ExpectType number
     const resultNumber = intersectionOfArguments(1, { q: 'text', w: 22 }, 11);
 
     // $ExpectError
     const errorArguments = intersectionOfArguments(1, { q: 'text' }, 11);
+
+    const argsIncompatible = (a1: string) => 1;
+
+    // types: `string`, `number | symbol`, and `number | bigint` - do not have common type
+    // $ExpectError
+    const intersectionOfArgumentsIncompatible = R.converge(add3, [argsIncompatible, args2, args3]);
 
     const addGeneric = <T>(a: T, b: T): T => b;
 


### PR DESCRIPTION
When testing i assume `strict` typescript compiler option is enabled(basically just commented four previous options and add `"strict": true` to `tsconfig.json`)

Problems:
 - Almost all tests in `test-converge.ts` fail with `strict` mode enabled
 - According to documentation of [converge](https://ramdajs.com/docs/#converge) it can accept functions with different arities and return function with max arity, which does not work with the current types implementation:
```ts
const fn = R.converge(multiply, [add, add3]); // typescript complains in current version
``` 
 - length is not checked with more than 7 functions
 - does not work with `strict` mode at all, complaining about length, etc...

Add correct typing that better resembles behavior according to documentation:
 - resulted function now has the maximum number of arguments and their types are intersected accordingly(when not possible showing error)
 - now `converge` works with any number of arguments in the same way.
 - added two overloads which cover usage in case of generics, for example add `as const` to array of functions and first generic will be used, which gives more control(for example if we wanna use source of truth array of functions instead of converging function, and in this way types will be created relying on array of functions).
 - added more utilities, here is [playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAYgdlAvFAFAOgwQwE4HMDOAXFJnCANoC6AlEgHwlkDcAsAFDuiQnbYCMAGQj58AFQAWpAPLYAogEcArpgA2AHnZQoovlAgAPYBDgATfFABKETCYD2cFSACCvTCDWkQdADSbtAJj1DYzNLazsHZ1d3Tzo-BmQdcgAiFWNcYHFkyiCjU3NRfxS0uAysyj8AfihgbEUIP2JC4vTM7NyQ8wAGKqgAM1V8BrYtJsCDPNDscPtHKHIASzg+iGxYBex8YG8oDDQllbWrLYqRqGqefiERCWk5JVU1HR3j4Diz4jgIADdV1g42AB6QFQADu4mMUBKZT0DxU5gWwDBCxUKig03wihUSIWAFtcRATAtMEY5rV6uwAMb2LaXQTCMSSOAyBTKFQAfVEwmAfGIOCuDNuzPubLUVB2VASNTqw2BUAWfSgQ2pcFMlyhrXESEQyC6JHhtnl+MJxNJIH6g2GKtp-PpNyZLLhnO5-j5vDtjLurMe5DgWJUlAllClA3hVppSNt109wu9HK5WwAzG6BfavXCxYH5n7UcGkNKKWxrZH3dGhY62c6tgAWFMe8sin05lQ7Zut-1Z33+9uonstqBtgfdoe5qXk4accDQAAK2DxiIWv3zACNbLY0qQoAAfJW1Ja4bdD3HL1aH5cLXBLJE7-AgY-rw+KUwQPpLQmH5vsdhygAi9RqhpcMIc5gMAAAG5jLtgpAmO+QHmKC0BfHBhqUhClIANZQLipBsnMCo1BC0zyuYlKYEMUC2IqV6rMqwALPYlHLgAVhAlKRmqYBzriC6-JO3AAJJwEYmxscAmDLmkTx8DshRSuQOg5BMnTzIUpxaFo1Tjn4oyqf4SnBPkql8OpGlaTKOlQMQCkmR0RnkLYLFiaZml6QZkzmA5TnsS5GmudpZx+bpoZDJZ1mKXZoTkLO870b8vnVAp+mRZ5MU8XFEC+X55mFkFGnECFwx+QVlr-N+ILiMAwBgEQwJbJgmG2L82B9Cotigmg1K4oCmCAtWACc-X+AAHImABsXSAnwfD9WNibVgArAA7Px0ACfgThkE8Up6spRm6AAZNo5wFtAJVhmVQIgvgSyUtAnhQEdoj0IwIA7IhA4QO+TImGkhELKR5HDEBUBCSJdEMXA0myf4Upg7RYkSVJzwBAwe2hAF2WgxtW06GjhkYxZgVBdUhSWcV2Obe4ckpad5NmdofD07pOiPQEYWfc1l0gwSeAQC42AAOqIuIQh9MAGhnKz6PmFYNizFE0ExGQPh+IUtNyxEjgC24Hgq-E+bTPLkTzJZewAN700bWvmuQQmwfo8oIBhEAgFRjOUMQ9sGLTLtu4qZPE658OiexkPSXbz76FmzTe9H7x5U0fCRw7lD-H5AC+fhp1+bA86suD89E+CS1o0sE7LMyRDryteL4UvjBXYTG9r0R614BvIFGgoOo26gozTMt02c1S84XAvC5kYsS4Usl8AnVnYQXRdCyL0-Q6jl3lVAAASqzQB9QzQJkJJL3zNfmHYwgDrYSKwZARmMbY2CwWs7tgDgmAEuDq3YV0ujIDHivNwJdxTzGDP8OUUAAB6lRc48y6IEQBy8L6ZglH6Y8qwIHbxgXAgECDEz5iAagsBXZMHYHbOQ7BV0tCwPgVOP+1YiEoOLmg7MihyGUJPBQo83DqFQLofghhuIugLWYefVhZC+FBjoJAkEuD6HcBEWNcR49JEYOkewqhsicGCN-iIpaqjgEgFARorB6COHcK4VgnRNCFFCKUV0YaRiSFmOwJ2Nx1ieFuP4fIvRedhFdH6i49RljVheM7L42heD9F8D1MgiRStTFhO8SkjxaTbECJiQEpR00QlJLFJ43h5itFWOKe4zJfjsk8z4Egs+aiClSPCeU9JnDykRMqdExR0BcR8EIQkhpIDCkpK8REmRciukOJ6XwJhAzjHJLaUUnxFjtETPsbEsRczXEjPaS0lZZSfGdPWTk6ZKitmhMWTs5ZpTmlLIyWs-xNTDHnMaXcy5VD9m3Kud895Byfl8KOY84RfBnEvKGU01JvyvlQshX8j5NzYXQoBQ87JxYoBoTYhhAAsv-YgIiAHgP+GijFmEcWuj-nU8gJkiURnRehbFXRkx-36fMGSUB9I0rgLSElDLayMPzFSnY-gdiJhzkWWlPKcULTxaIgV1KqQSvpTisaMqzmsrFcSpVXQloyueayoVGrFWYpxcNGVoL9XspFYarlSJJUzRlcE5Agr2XWu5UquJeK4lyoNZyt1xrpqeoJc6jlCqbV0v9eS3plK2XCqgKK31tr3VMt6Sy4NVqE3htJTMz1syLWxvjaGv1WbpXYT4JsvN6bC2Jv9Sq0taq01xtddWrNOrS16obYmHY1YdgLR2GNHYS0m2ZuxSCz17aY0iq7T2vtA6xW-wEDgQuWwXC4A4cYYA+ABAAxnhrKurclbtzoFKZ6Q9rYK1NmcdAWA8BECdocKAK78C0EQAwTw9ctB7AOKeV47Ach4K0MQ1hj6dgLr5suvAa7hKbu3WoV4R78roj3bbOd4qw02BMASlAmBPgpOfa+qtJATAmHzFhnDbTlxke4Xh1AmAoAAGooDLmoAR9DLLSO7Io7syklHVjUaw-RxjAnKTMamVCbdXR4lQFA0u4AK7IMbq3VsNQZ6TbkCAu7Vj1Df4qHEwS6T3I5MEig4piWKm5hqanBpojOx1OKk04C6pDCdNbEQfmfT4HV1GYUzBszttbOEZMJ2molm7NEaicckGzngCMrc4ugzEGvPQaU75+Y-nWM2ZCwFjLkArMmHC0C7gUWui5vc7JhL66kumaQ6lzL6Xgs5dCyYbLEBcvNda-VlrjW2uNfy45wr4ny2lcMxVkzynqsWYa1ljruWgtpes9NrrC2ptzbyw57pYmXNqqG+V4zPnxsre68t2rRHZvHaa0t9Dh30O9fW0VvV23PMjb2y3PzZ2rvzYOxdk773zsrZu6Jor5qHvycq2Nl7NXJuXa+79t70Ofunch2FtbAPxOOqk3FjzIPRspYm51o7iOYcE5+8T6HorkcEZ5SZ3FG3otBonY2jNlPxPkqK9GoVlbUNFowlTplRXU304LQCTVmKqd8qK7mjtQ6mcuZLUV8tkvGf0qp7Wor9aBdS6V+J1td3vWWoZxTzXLnTU06cbr-NGuReo+IEVtHCvc7sCAA) with tests and examples how it works.
 - now `converge` works in `strict` mode which means it will work with any other compiler options in the same way.

This is a breaking change. I think it is better to update all other functions to work with `strict` mode and then merge it. [Here](https://github.com/ramda/ramda/issues/3257) is other functions which fails with `strict` enabled.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.