### PR TITLE
Migrate acl from @types/mongodb to mongodb

### DIFF
--- a/types/acl/index.d.ts
+++ b/types/acl/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/optimalbits/node_acl
 // Definitions by: Qubo <https://github.com/tkQubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.1
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="node"/>
 

--- a/types/acl/index.d.ts
+++ b/types/acl/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/optimalbits/node_acl
 // Definitions by: Qubo <https://github.com/tkQubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.2
+// TypeScript Version: 4.1
 
 /// <reference types="node"/>
 

--- a/types/acl/package.json
+++ b/types/acl/package.json
@@ -2,6 +2,6 @@
     "private": true,
     "dependencies": {
         "@types/redis": "^2.8.0",
-        "mongodb": "^4.4.1"
+        "mongodb": "^4.5.0"
     }
 }

--- a/types/acl/package.json
+++ b/types/acl/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^3.6.20",
-        "@types/redis": "^2.8.0"
+        "@types/redis": "^2.8.0",
+        "mongodb": "^4.4.1"
     }
 }


### PR DESCRIPTION
This should fix acl's types in TS 4.7 once mongodb's types are fixed, per https://jira.mongodb.org/browse/NODE-4129