### PR TITLE
Update connect-mongodb-session for TS 4.7

### DIFF
--- a/types/connect-mongodb-session/index.d.ts
+++ b/types/connect-mongodb-session/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Nattapong Sirilappanich <https://github.com/NattapongSiri>
 //                 Ravi van Rooijen <https://github.com/HoldYourWaffle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.1
+// Minimum TypeScript Version: 4.1
 
 import session = require('express-session');
 import { MongoClient, MongoClientOptions } from 'mongodb';

--- a/types/connect-mongodb-session/index.d.ts
+++ b/types/connect-mongodb-session/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Nattapong Sirilappanich <https://github.com/NattapongSiri>
 //                 Ravi van Rooijen <https://github.com/HoldYourWaffle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.1
 
 import session = require('express-session');
 import { MongoClient, MongoClientOptions } from 'mongodb';

--- a/types/connect-mongodb-session/package.json
+++ b/types/connect-mongodb-session/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "mongodb": "^4.4.1"
+        "mongodb": "^4.5.0"
     }
 }

--- a/types/connect-mongodb-session/package.json
+++ b/types/connect-mongodb-session/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^3.6.20"
+        "mongodb": "^4.4.1"
     }
 }


### PR DESCRIPTION
Should work once https://jira.mongodb.org/browse/NODE-4129 comes to pass. (This really just moves the package to use mongodb's builtin types instead of the ones no longer on DT).