### PR TITLE
Update forest-express-mongoose for TS 4.7

### DIFF
--- a/types/forest-express-mongoose/index.d.ts
+++ b/types/forest-express-mongoose/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Steve Bunlon <https://github.com/SteveBunlon>
 //                 Guillaume Gautreau <https://github.com/ghusse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.1
+// Minimum TypeScript Version: 4.1
 
 import { RequestHandler, Response, Request, NextFunction, Application } from 'express';
 import * as mongoose from 'mongoose';

--- a/types/forest-express-mongoose/index.d.ts
+++ b/types/forest-express-mongoose/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Steve Bunlon <https://github.com/SteveBunlon>
 //                 Guillaume Gautreau <https://github.com/ghusse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.1
 
 import { RequestHandler, Response, Request, NextFunction, Application } from 'express';
 import * as mongoose from 'mongoose';

--- a/types/forest-express-mongoose/package.json
+++ b/types/forest-express-mongoose/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "mongoose": "^6.2.9"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/forest-express-mongoose/package.json
+++ b/types/forest-express-mongoose/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "^5.10.5"
+        "mongoose": "^6.2.9"
     }
 }


### PR DESCRIPTION
Should fix the types for TS 4.7 once https://jira.mongodb.org/browse/NODE-4129 is done.