### PR TITLE
[node] Add missing timeout property on node's net.Socket

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -156,11 +156,6 @@ declare module 'net' {
          */
         setTimeout(timeout: number, callback?: () => void): this;
         /**
-         * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
-         * @since v10.7.0
-         */
-        readonly timeout?: number | undefined;
-        /**
          * Enable/disable the use of Nagle's algorithm.
          *
          * When a TCP connection is created, it will have Nagle's algorithm enabled.
@@ -290,6 +285,11 @@ declare module 'net' {
          * @since v0.5.10
          */
         readonly remotePort?: number | undefined;
+        /**
+         * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
+         * @since v10.7.0
+         */
+         readonly timeout?: number | undefined;
         /**
          * Half-closes the socket. i.e., it sends a FIN packet. It is possible the
          * server will still send some data.

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -159,7 +159,7 @@ declare module 'net' {
          * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
          * @since v10.7.0
          */
-        readonly timeout: number | undefined;
+        readonly timeout?: number | undefined;
         /**
          * Enable/disable the use of Nagle's algorithm.
          *

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -289,7 +289,7 @@ declare module 'net' {
          * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
          * @since v10.7.0
          */
-         readonly timeout?: number | undefined;
+        readonly timeout?: number | undefined;
         /**
          * Half-closes the socket. i.e., it sends a FIN packet. It is possible the
          * server will still send some data.

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -156,6 +156,11 @@ declare module 'net' {
          */
         setTimeout(timeout: number, callback?: () => void): this;
         /**
+         * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
+         * @since v10.7.0
+         */
+        readonly timeout: number | undefined;
+        /**
          * Enable/disable the use of Nagle's algorithm.
          *
          * When a TCP connection is created, it will have Nagle's algorithm enabled.

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -41,6 +41,32 @@ import { Socket } from 'node:dgram';
 }
 
 {
+    let _socket: net.Socket = new net.Socket({
+        fd: 1,
+        allowHalfOpen: false,
+        readable: false,
+        writable: false,
+    });
+
+    let bool: boolean;
+
+    bool = _socket.connecting;
+    bool = _socket.destroyed;
+
+    const _timeout: number | undefined = _socket.timeout;
+    _socket = _socket.setTimeout(500);
+
+    _socket = _socket.setNoDelay(true);
+    _socket = _socket.setKeepAlive(true, 10);
+    _socket = _socket.setEncoding('utf8');
+    _socket = _socket.resume();
+    _socket = _socket.resume();
+
+    _socket = _socket.end();
+    _socket = _socket.destroy();
+}
+
+{
     const constructorOpts: net.SocketConstructorOpts = {
         fd: 1,
         allowHalfOpen: false,
@@ -241,8 +267,6 @@ import { Socket } from 'node:dgram';
     _socket = _socket.prependOnceListener("ready", () => { });
     _socket = _socket.prependOnceListener("timeout", () => { });
 
-    bool = _socket.connecting;
-    bool = _socket.destroyed;
     _socket.destroy().destroy();
     _socket.readyState; // $ExpectType SocketReadyState
 }
@@ -306,6 +330,9 @@ import { Socket } from 'node:dgram';
         error = err;
     });
     _server = _server.prependOnceListener("listening", () => { });
+
+    _socket.destroy();
+    _server.close();
 }
 
 {

--- a/types/node/v12/net.d.ts
+++ b/types/node/v12/net.d.ts
@@ -100,7 +100,7 @@ declare module 'net' {
          * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
          * @since v10.7.0
          */
-        readonly timeout: number | undefined;
+        readonly timeout?: number | undefined;
 
         // Extended base methods
         end(cb?: () => void): this;

--- a/types/node/v12/net.d.ts
+++ b/types/node/v12/net.d.ts
@@ -96,6 +96,11 @@ declare module 'net' {
         readonly remoteAddress?: string | undefined;
         readonly remoteFamily?: string | undefined;
         readonly remotePort?: number | undefined;
+        /**
+         * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
+         * @since v10.7.0
+         */
+        readonly timeout: number | undefined;
 
         // Extended base methods
         end(cb?: () => void): this;

--- a/types/node/v12/test/net.ts
+++ b/types/node/v12/test/net.ts
@@ -15,6 +15,32 @@ import { LookupOneOptions } from 'dns';
 }
 
 {
+    let _socket: net.Socket = new net.Socket({
+        fd: 1,
+        allowHalfOpen: false,
+        readable: false,
+        writable: false,
+    });
+
+    let bool: boolean;
+
+    bool = _socket.connecting;
+    bool = _socket.destroyed;
+
+    const _timeout: number | undefined = _socket.timeout;
+    _socket = _socket.setTimeout(500);
+
+    _socket = _socket.setNoDelay(true);
+    _socket = _socket.setKeepAlive(true, 10);
+    _socket = _socket.setEncoding('utf8');
+    _socket = _socket.resume();
+    _socket = _socket.resume();
+
+    _socket = _socket.end();
+    _socket = _socket.destroy();
+}
+
+{
     let server = net.createServer();
     // Check methods which return server instances by chaining calls
     server = server.listen(0)
@@ -234,8 +260,6 @@ import { LookupOneOptions } from 'dns';
     _socket = _socket.prependOnceListener("ready", () => { });
     _socket = _socket.prependOnceListener("timeout", () => { });
 
-    bool = _socket.connecting;
-    bool = _socket.destroyed;
     _socket.destroy();
     _socket.readyState; // $ExpectType SocketReadyState
 }
@@ -299,4 +323,7 @@ import { LookupOneOptions } from 'dns';
         error = err;
     });
     _server = _server.prependOnceListener("listening", () => { });
+
+    _socket.destroy();
+    _server.close();
 }

--- a/types/node/v14/net.d.ts
+++ b/types/node/v14/net.d.ts
@@ -101,7 +101,7 @@ declare module 'net' {
          * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
          * @since v10.7.0
          */
-        readonly timeout: number | undefined;
+        readonly timeout?: number | undefined;
 
         // Extended base methods
         end(cb?: () => void): this;

--- a/types/node/v14/net.d.ts
+++ b/types/node/v14/net.d.ts
@@ -97,6 +97,11 @@ declare module 'net' {
         readonly remoteAddress?: string | undefined;
         readonly remoteFamily?: string | undefined;
         readonly remotePort?: number | undefined;
+        /**
+         * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
+         * @since v10.7.0
+         */
+        readonly timeout: number | undefined;
 
         // Extended base methods
         end(cb?: () => void): this;

--- a/types/node/v14/test/net.ts
+++ b/types/node/v14/test/net.ts
@@ -37,6 +37,32 @@ import { LookupOneOptions } from 'node:dns';
 }
 
 {
+    let _socket: net.Socket = new net.Socket({
+        fd: 1,
+        allowHalfOpen: false,
+        readable: false,
+        writable: false,
+    });
+
+    let bool: boolean;
+
+    bool = _socket.connecting;
+    bool = _socket.destroyed;
+
+    const _timeout: number | undefined = _socket.timeout;
+    _socket = _socket.setTimeout(500);
+
+    _socket = _socket.setNoDelay(true);
+    _socket = _socket.setKeepAlive(true, 10);
+    _socket = _socket.setEncoding('utf8');
+    _socket = _socket.resume();
+    _socket = _socket.resume();
+
+    _socket = _socket.end();
+    _socket = _socket.destroy();
+}
+
+{
     const constructorOpts: net.SocketConstructorOpts = {
         fd: 1,
         allowHalfOpen: false,
@@ -237,8 +263,6 @@ import { LookupOneOptions } from 'node:dns';
     _socket = _socket.prependOnceListener("ready", () => { });
     _socket = _socket.prependOnceListener("timeout", () => { });
 
-    bool = _socket.connecting;
-    bool = _socket.destroyed;
     _socket.destroy();
     _socket.readyState; // $ExpectType SocketReadyState
 }
@@ -302,4 +326,7 @@ import { LookupOneOptions } from 'node:dns';
         error = err;
     });
     _server = _server.prependOnceListener("listening", () => { });
+
+    _socket.destroy();
+    _server.close();
 }

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -156,11 +156,6 @@ declare module 'net' {
          */
         setTimeout(timeout: number, callback?: () => void): this;
         /**
-         * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
-         * @since v10.7.0
-         */
-        readonly timeout?: number | undefined;
-        /**
          * Enable/disable the use of Nagle's algorithm.
          *
          * When a TCP connection is created, it will have Nagle's algorithm enabled.
@@ -290,6 +285,11 @@ declare module 'net' {
          * @since v0.5.10
          */
         readonly remotePort?: number | undefined;
+        /**
+         * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
+         * @since v10.7.0
+         */
+         readonly timeout?: number | undefined;
         /**
          * Half-closes the socket. i.e., it sends a FIN packet. It is possible the
          * server will still send some data.

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -159,7 +159,7 @@ declare module 'net' {
          * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
          * @since v10.7.0
          */
-        readonly timeout: number | undefined;
+        readonly timeout?: number | undefined;
         /**
          * Enable/disable the use of Nagle's algorithm.
          *

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -289,7 +289,7 @@ declare module 'net' {
          * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
          * @since v10.7.0
          */
-         readonly timeout?: number | undefined;
+        readonly timeout?: number | undefined;
         /**
          * Half-closes the socket. i.e., it sends a FIN packet. It is possible the
          * server will still send some data.

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -156,6 +156,11 @@ declare module 'net' {
          */
         setTimeout(timeout: number, callback?: () => void): this;
         /**
+         * The socket timeout in milliseconds as set by socket.setTimeout(). It is undefined if a timeout has not been set.
+         * @since v10.7.0
+         */
+        readonly timeout: number | undefined;
+        /**
          * Enable/disable the use of Nagle's algorithm.
          *
          * When a TCP connection is created, it will have Nagle's algorithm enabled.

--- a/types/node/v16/test/net.ts
+++ b/types/node/v16/test/net.ts
@@ -18,6 +18,32 @@ import { Socket } from 'node:dgram';
 }
 
 {
+    let _socket: net.Socket = new net.Socket({
+        fd: 1,
+        allowHalfOpen: false,
+        readable: false,
+        writable: false,
+    });
+
+    let bool: boolean;
+
+    bool = _socket.connecting;
+    bool = _socket.destroyed;
+
+    const _timeout: number | undefined = _socket.timeout;
+    _socket = _socket.setTimeout(500);
+
+    _socket = _socket.setNoDelay(true);
+    _socket = _socket.setKeepAlive(true, 10);
+    _socket = _socket.setEncoding('utf8');
+    _socket = _socket.resume();
+    _socket = _socket.resume();
+
+    _socket = _socket.end();
+    _socket = _socket.destroy();
+}
+
+{
     let server = net.createServer();
     // Check methods which return server instances by chaining calls
     server = server.listen(0)
@@ -241,8 +267,6 @@ import { Socket } from 'node:dgram';
     _socket = _socket.prependOnceListener("ready", () => { });
     _socket = _socket.prependOnceListener("timeout", () => { });
 
-    bool = _socket.connecting;
-    bool = _socket.destroyed;
     _socket.destroy();
     _socket.readyState; // $ExpectType SocketReadyState
 }
@@ -306,6 +330,9 @@ import { Socket } from 'node:dgram';
         error = err;
     });
     _server = _server.prependOnceListener("listening", () => { });
+
+    _socket.destroy();
+    _server.close();
 }
 
 {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

### Changelog
- Add missing `socket.timeout` property to node's Socket instance: https://nodejs.org/api/net.html#sockettimeout
- Add more type tests for node's Socket instance