### PR TITLE
[types/nightwatch] Add PageObjectModel types to support POM pattern in Nightwatch test suites

### DIFF
--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -1194,7 +1194,7 @@ export interface ElementProperties {
      * @example
      * 'css selector'
      */
-    locateStrategy?: string;
+    locateStrategy?: LocateStrategy;
 
     /**
      * used to target a specific element in a query that results in multiple elements returned. Normally,
@@ -4693,15 +4693,6 @@ export interface WebDriverProtocolMobileRelated {
 }
 
 /**
- * Typed DOM element locator for PageElements collection for PageObjectModel
- * allowing specification of enumerated locate strategy and selector string.
- */
-export type ElementLocator = {
-    locateStrategy?: LocateStrategy;
-    selector: string;
-};
-
-/**
  * Map of DOM element locators as shorthand string selectors based on
  * global selector setting or ElementLocator
  *
@@ -4714,7 +4705,7 @@ export type ElementLocator = {
  *  }
  * }
  */
-export type PageElements = { [key: string]: string | ElementLocator };
+export type PageElements = { [key: string]: string | ElementProperties };
 
 /**
  * Type for defining page object models allowing for optional type-safe
@@ -4724,6 +4715,6 @@ export type PageObjectModel = {
     url?: string | ((...args: any) => string);
     elements?: PageElements;
     sections?: EnhancedPageObjectSections;
-    commands?: {} | {}[];
-    props?: {};
+    commands?: any;
+    props?: any;
 };

--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -1626,11 +1626,11 @@ export interface EnhancedElementInstance<T> {
     selector: string;
 }
 
-export type EnhancedSectionInstance<Commands = {}, Elements = {}, Sections extends EnhancedPageObjectSections  = {}> = EnhancedPageObject<
-    Commands,
-    Elements,
-    Sections
->;
+export type EnhancedSectionInstance<
+    Commands = {},
+    Elements = {},
+    Sections extends EnhancedPageObjectSections = {},
+> = EnhancedPageObject<Commands, Elements, Sections>;
 
 export interface EnhancedPageObjectSections {
     [name: string]: EnhancedSectionInstance<any, any, any>;
@@ -4691,3 +4691,39 @@ export interface WebDriverProtocolMobileRelated {
      */
     setContext(context: string, callback?: () => void): this;
 }
+
+/**
+ * Typed DOM element locator for PageElements collection for PageObjectModel
+ * allowing specification of enumerated locate strategy and selector string.
+ */
+export type ElementLocator = {
+    locateStrategy?: LocateStrategy;
+    selector: string;
+};
+
+/**
+ * Map of DOM element locators as shorthand string selectors based on
+ * global selector setting or ElementLocator
+ *
+ * @example
+ * const elements: PageElements {
+ * header: "h1",
+ * banner: {
+ *  locateStrategy: "css selector",
+ *  selector: "#bannerId"
+ *  }
+ * }
+ */
+export type PageElements = { [key: string]: string | ElementLocator };
+
+/**
+ * Type for defining page object models allowing for optional type-safe
+ * inclusion of url, elements, sections, commands, and props properties.
+ */
+export type PageObjectModel = {
+    url?: string | ((...args: any) => string);
+    elements?: PageElements;
+    sections?: EnhancedPageObjectSections;
+    commands?: {} | {}[];
+    props?: {};
+};

--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -4705,16 +4705,18 @@ export interface WebDriverProtocolMobileRelated {
  *  }
  * }
  */
-export type PageElements = { [key: string]: string | ElementProperties };
+export interface PageElements {
+    [key: string]: string | ElementProperties;
+}
 
 /**
  * Type for defining page object models allowing for optional type-safe
  * inclusion of url, elements, sections, commands, and props properties.
  */
-export type PageObjectModel = {
+export interface PageObjectModel {
     url?: string | ((...args: any) => string);
     elements?: PageElements;
     sections?: EnhancedPageObjectSections;
     commands?: any;
     props?: any;
-};
+}

--- a/types/nightwatch/test/nightwatch-tests.ts
+++ b/types/nightwatch/test/nightwatch-tests.ts
@@ -276,7 +276,7 @@ function localStorageValueCommand(this: NightwatchAPI, key: string, callback?: (
 
     this.execute(
         // tslint:disable-next-line:only-arrow-functions
-        function (key) {
+        function(key) {
             return window.localStorage.getItem(key);
         },
         [key], // arguments array to be passed
@@ -352,7 +352,7 @@ function text(this: NightwatchAssertion<string>, selector: string, expectedText:
 
     this.value = result => result;
 
-    this.command = function (callback) {
+    this.command = function(callback) {
         this.api.element('css selector', selector, elementResult => {
             if (elementResult.status) {
                 callback(null);

--- a/types/nightwatch/test/nightwatch-tests.ts
+++ b/types/nightwatch/test/nightwatch-tests.ts
@@ -4,8 +4,8 @@ import {
     EnhancedSectionInstance,
     NightwatchAPI,
     NightwatchAssertion,
-    NightwatchBrowser,
     NightwatchTests,
+    PageObjectModel,
 } from 'nightwatch';
 
 //
@@ -64,10 +64,8 @@ const testGeneral: NightwatchTests = {
     },
 
     'test user defined globals': () => {
-        browser
-        .url(`http://${browser.globals.username}:${browser.globals.password}@example.com`)
-        .end();
-    }
+        browser.url(`http://${browser.globals.username}:${browser.globals.password}@example.com`).end();
+    },
 };
 
 //
@@ -125,7 +123,7 @@ interface MenuSection
         { apps: AppsSection }
     > {}
 
-const googlePage = {
+const googlePage: PageObjectModel = {
     commands: [
         {
             submit(this: GooglePage) {
@@ -151,7 +149,7 @@ const googlePage = {
 
 // export = googlePage;
 
-const iFrame = {
+const iFrame: PageObjectModel = {
     elements: {
         iframe: '#mce_0_ifr',
         textbox: 'body#tinymce p',
@@ -278,7 +276,7 @@ function localStorageValueCommand(this: NightwatchAPI, key: string, callback?: (
 
     this.execute(
         // tslint:disable-next-line:only-arrow-functions
-        function(key) {
+        function (key) {
             return window.localStorage.getItem(key);
         },
         [key], // arguments array to be passed
@@ -354,7 +352,7 @@ function text(this: NightwatchAssertion<string>, selector: string, expectedText:
 
     this.value = result => result;
 
-    this.command = function(callback) {
+    this.command = function (callback) {
         this.api.element('css selector', selector, elementResult => {
             if (elementResult.status) {
                 callback(null);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

The addition of the PageObjectModel and PageElements interface will allow for stricter type checking when using Nightwatch's implementation of the page object model pattern in TypeScript. Below is an example.

```ts
import { EnhancedPageObject, PageElements, PageObjectModel } from "nightwatch";

const elements: PageElements = {
  submitButton: "#submitBtn", // shorthand string selector pattern using configured global locator strategy
  pageHeader: { // longhand version allowing explicit type-safe locator strategy
    locateStrategy: "css selector",
    selector: "#ctl00_lblPageHeader",
  },
};

const nameAddressAndTelephone: PageObjectModel = {
  url(this: EnhancedPageObject) {
    return `${this.api.launch_url}/default.aspx`;
  },
  elements: elements,
};

export default nameAddressAndTelephone;

export type NameAddressAndTelephonePage =
  EnhancedPageObject<PageObjectModel>;
```
Usage in a Nightwatch test
```ts
const telephonePage: NameAddressAndTelephonePage = browser.page.myself.persona.NameAddressAndTelephone();
telephonePage.waitForElementVisible("@pageHeader", 15000);
```
