### PR TITLE
[jscodeshift] fileInfo.path is not necessarily absolute

### DIFF
--- a/types/jscodeshift/src/core.d.ts
+++ b/types/jscodeshift/src/core.d.ts
@@ -26,7 +26,7 @@ declare namespace core {
     }
 
     interface FileInfo {
-        /** The path to the current file, relative to `process.cwd()`. */
+        /** The path to the current file. */
         path: string;
         /** The source code of the current file. */
         source: string;

--- a/types/jscodeshift/src/core.d.ts
+++ b/types/jscodeshift/src/core.d.ts
@@ -26,7 +26,7 @@ declare namespace core {
     }
 
     interface FileInfo {
-        /** The absolute path to the current file. */
+        /** The path to the current file, relative to `process.cwd()`. */
         path: string;
         /** The source code of the current file. */
         source: string;


### PR DESCRIPTION
Learned the hard way today that `fileInfo.path` is actually a relative path, not absolute. You have to `path.join(process.cwd(), fileInfo.path` to get the absolute path.

Kind of a weird example since it's on ASTExplorer, but here's an example:

https://astexplorer.net/#/gist/5ed235d552b110c50e3bd98c8f2e4c1e/833c7a2aef6b5d8b5d814df085fa0129ff1b77b0

Can also be confirmed by running jscodeshift locally.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jscodeshift#fileinfo _(note: these docs don't actually specify that it's a relative path, but simply [running jscodeshift](https://astexplorer.net/#/gist/5ed235d552b110c50e3bd98c8f2e4c1e/833c7a2aef6b5d8b5d814df085fa0129ff1b77b0) confirms this)_
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.