### PR TITLE
[intercom-web] Add support for custom attributes

### DIFF
--- a/types/intercom-web/index.d.ts
+++ b/types/intercom-web/index.d.ts
@@ -37,12 +37,14 @@ declare namespace Intercom_ {
         utm_term?: string | undefined;
         company?: IntercomCompany | undefined;
         companies?: IntercomCompany[] | undefined;
-        avatar?:
-            | {
-                  type: 'avatar';
-                  image_url: string;
-              }
-            | undefined;
+        avatar?: IntercomAvatar | undefined;
+
+        // Custom attributes
+        [custom_attribute: string]:
+            | IntercomCompany
+            | IntercomCompany[]
+            | IntercomAvatar
+            | IntercomCustomAttribute;
     }
 
     interface IntercomCommandSignature {
@@ -84,7 +86,20 @@ declare namespace Intercom_ {
         size?: number | undefined;
         website?: string | undefined;
         industry?: string | undefined;
+        [custom_attribute: string]: IntercomCustomAttribute;
     }
+
+    interface IntercomAvatar {
+        type: 'avatar';
+        image_url: string;
+    }
+
+    type IntercomCustomAttribute =
+        | string
+        | number
+        | boolean
+        | null
+        | undefined;
 }
 
 declare var Intercom: Intercom_.IntercomStatic;

--- a/types/intercom-web/intercom-web-tests.ts
+++ b/types/intercom-web/intercom-web-tests.ts
@@ -119,5 +119,21 @@ intercomSettings = {
     vertical_padding: 20,
 };
 
+/*
+From https://www.intercom.com/help/en/articles
+        /179-send-custom-user-attributes-to-intercom
+*/
+intercomSettings = {
+    email: 'bob@example.com',
+    user_id: '123',
+    app_id: 'abc1234',
+    created_at: 1234567890,
+    subdomain: 'intercom',
+    teammates: 4,
+    active_accounts: 12,
+    last_order_at: 1350466020,
+    custom_domain: null,
+};
+
 // $ExpectError
-Intercom('update', { some: 'invalid properties' });
+Intercom('update', { some: { value: 'invalid properties' } });


### PR DESCRIPTION
String, number, boolean, and null values are accepted as custom user attributes in `boot` and `update` calls. Intercom doc: https://www.intercom.com/help/en/articles/179-send-custom-user-attributes-to-intercom

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.intercom.com/help/en/articles/179-send-custom-user-attributes-to-intercom>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
