### PR TITLE
[react-native] 0.68.0 add type definition for ScrollView automaticallyAdjustKeyboardInsets 

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6331,6 +6331,12 @@ export interface ScrollViewPropsIOS {
     automaticallyAdjustContentInsets?: boolean | undefined; // true
 
     /**
+     * Controls whether the ScrollView should automatically adjust it's contentInset
+     * and scrollViewInsets when the Keyboard changes it's size. The default value is false.
+     */
+    automaticallyAdjustKeyboardInsets?: boolean | undefined;
+
+    /**
      * Controls whether iOS should automatically adjust the scroll indicator
      * insets. The default value is true. Available on iOS 13 and later.
      */

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1444,6 +1444,13 @@ const ScrollViewMaintainVisibleContentPositionTest = () => (
     <ScrollView maintainVisibleContentPosition={{ autoscrollToTopThreshold: 1, minIndexForVisible: 10 }}></ScrollView>
 );
 
+const ScrollViewInsetsTest = () => (
+  <>
+    <ScrollView automaticallyAdjustKeyboardInsets />
+    <ScrollView automaticallyAdjustKeyboardInsets={false} />
+  </>
+);
+
 const MaxFontSizeMultiplierTest = () => <Text maxFontSizeMultiplier={0}>Text</Text>;
 
 const ShareTest = () => {


### PR DESCRIPTION
Summary:

React Native version 0.68.0 brings a new property to `ScrollView` component: `automaticallyAdjustKeyboardInsets`. It was shipped in https://github.com/facebook/react-native/commit/49a1460a379e3a71358fb38888477ce6ea17e81a commit and made it into the release notes of version 0.68.0 in the "iOS Specific" section (https://github.com/facebook/react-native/blob/main/CHANGELOG.md#ios-specific-3)

`ScrollView` source code: https://github.com/facebook/react-native/blob/457dd455524aba1bdb48ffd378fbe4fbac92fb01/Libraries/Components/ScrollView/ScrollView.js#L180

@types/react-native is missing type definition for it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.