### PR TITLE
[node] Improving X509Certificate typings

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3109,20 +3109,27 @@ declare module 'crypto' {
          */
         readonly fingerprint256: string;
         /**
+         * The SHA-512 fingerprint of this certificate.
+         * @since v16.14.0
+         */
+         readonly fingerprint512: string;
+        /**
          * The complete subject of this certificate.
          * @since v15.6.0
          */
         readonly subject: string;
         /**
-         * The subject alternative name specified for this certificate.
+         * The subject alternative name specified for this certificate or `undefined`
+         * if not available.
          * @since v15.6.0
          */
-        readonly subjectAltName: string;
+        readonly subjectAltName: string | undefined;
         /**
-         * The information access content of this certificate.
+         * The information access content of this certificate or `undefined` if not
+         * available.
          * @since v15.6.0
          */
-        readonly infoAccess: string;
+        readonly infoAccess: string | undefined;
         /**
          * An array detailing the key usages for this certificate.
          * @since v15.6.0
@@ -3170,7 +3177,7 @@ declare module 'crypto' {
          * @since v15.6.0
          * @return Returns `email` if the certificate matches, `undefined` if it does not.
          */
-        checkEmail(email: string, options?: X509CheckOptions): string | undefined;
+        checkEmail(email: string, options?: Pick<X509CheckOptions, 'subject'>): string | undefined;
         /**
          * Checks whether the certificate matches the given host name.
          * @since v15.6.0
@@ -3182,7 +3189,7 @@ declare module 'crypto' {
          * @since v15.6.0
          * @return Returns `ip` if the certificate matches, `undefined` if it does not.
          */
-        checkIP(ip: string, options?: X509CheckOptions): string | undefined;
+        checkIP(ip: string): string | undefined;
         /**
          * Checks whether this certificate was issued by the given `otherCert`.
          * @since v15.6.0

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -1186,7 +1186,8 @@ import { promisify } from 'node:util';
     cert.ca; // $ExpectType boolean
     cert.fingerprint; // $ExpectType string
     cert.fingerprint256; // $ExpectType string
-    cert.infoAccess; // $ExpectType string
+    cert.fingerprint512; // $ExpectType string
+    cert.infoAccess; // $ExpectType string | undefined
     cert.issuer; // $ExpectType string
     cert.issuerCertificate; // $ExpectType X509Certificate | undefined
     cert.keyUsage; // $ExpectType string[]
@@ -1194,7 +1195,7 @@ import { promisify } from 'node:util';
     cert.raw; // $ExpectType Buffer
     cert.serialNumber; // $ExpectType string
     cert.subject; // $ExpectType string
-    cert.subjectAltName; // $ExpectType string
+    cert.subjectAltName; // $ExpectType string | undefined
     cert.validFrom; // $ExpectType string
     cert.validTo; // $ExpectType string
 
@@ -1207,11 +1208,10 @@ import { promisify } from 'node:util';
     };
 
     cert.checkEmail('test@test.com'); // $ExpectType string | undefined
-    cert.checkEmail('test@test.com', checkOpts); // $ExpectType string | undefined
+    cert.checkEmail('test@test.com', { subject: checkOpts.subject }); // $ExpectType string | undefined
     cert.checkHost('test.com'); // $ExpectType string | undefined
     cert.checkHost('test.com', checkOpts); // $ExpectType string | undefined
     cert.checkIP('1.1.1.1'); // $ExpectType string | undefined
-    cert.checkIP('1.1.1.1', checkOpts); // $ExpectType string | undefined
     cert.checkIssued(new crypto.X509Certificate('dummycert')); // $ExpectType boolean
     cert.checkPrivateKey(crypto.createPrivateKey('dummy')); // $ExpectType boolean
     cert.toLegacyObject(); // $ExpectType PeerCertificate

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -1208,7 +1208,8 @@ import { promisify } from 'node:util';
     };
 
     cert.checkEmail('test@test.com'); // $ExpectType string | undefined
-    cert.checkEmail('test@test.com', { subject: checkOpts.subject }); // $ExpectType string | undefined
+    cert.checkEmail('test@test.com', checkOpts); // $ExpectType string | undefined
+    cert.checkEmail('test@test.com', { subject: 'always' }); // $ExpectType string | undefined
     cert.checkHost('test.com'); // $ExpectType string | undefined
     cert.checkHost('test.com', checkOpts); // $ExpectType string | undefined
     cert.checkIP('1.1.1.1'); // $ExpectType string | undefined

--- a/types/node/v16/crypto.d.ts
+++ b/types/node/v16/crypto.d.ts
@@ -3109,20 +3109,27 @@ declare module 'crypto' {
          */
         readonly fingerprint256: string;
         /**
+         * The SHA-512 fingerprint of this certificate.
+         * @since v16.14.0
+         */
+         readonly fingerprint512: string;
+        /**
          * The complete subject of this certificate.
          * @since v15.6.0
          */
         readonly subject: string;
         /**
-         * The subject alternative name specified for this certificate.
+         * The subject alternative name specified for this certificate or `undefined`
+         * if not available.
          * @since v15.6.0
          */
-        readonly subjectAltName: string;
+        readonly subjectAltName: string | undefined;
         /**
-         * The information access content of this certificate.
+         * The information access content of this certificate or `undefined` if not
+         * available.
          * @since v15.6.0
          */
-        readonly infoAccess: string;
+        readonly infoAccess: string | undefined;
         /**
          * An array detailing the key usages for this certificate.
          * @since v15.6.0
@@ -3170,7 +3177,7 @@ declare module 'crypto' {
          * @since v15.6.0
          * @return Returns `email` if the certificate matches, `undefined` if it does not.
          */
-        checkEmail(email: string, options?: X509CheckOptions): string | undefined;
+        checkEmail(email: string, options?: Pick<X509CheckOptions, 'subject'>): string | undefined;
         /**
          * Checks whether the certificate matches the given host name.
          * @since v15.6.0
@@ -3182,7 +3189,7 @@ declare module 'crypto' {
          * @since v15.6.0
          * @return Returns `ip` if the certificate matches, `undefined` if it does not.
          */
-        checkIP(ip: string, options?: X509CheckOptions): string | undefined;
+        checkIP(ip: string): string | undefined;
         /**
          * Checks whether this certificate was issued by the given `otherCert`.
          * @since v15.6.0

--- a/types/node/v16/test/crypto.ts
+++ b/types/node/v16/test/crypto.ts
@@ -1188,7 +1188,8 @@ import { promisify } from 'node:util';
     cert.ca; // $ExpectType boolean
     cert.fingerprint; // $ExpectType string
     cert.fingerprint256; // $ExpectType string
-    cert.infoAccess; // $ExpectType string
+    cert.fingerprint512; // $ExpectType string
+    cert.infoAccess; // $ExpectType string | undefined
     cert.issuer; // $ExpectType string
     cert.issuerCertificate; // $ExpectType X509Certificate | undefined
     cert.keyUsage; // $ExpectType string[]
@@ -1196,7 +1197,7 @@ import { promisify } from 'node:util';
     cert.raw; // $ExpectType Buffer
     cert.serialNumber; // $ExpectType string
     cert.subject; // $ExpectType string
-    cert.subjectAltName; // $ExpectType string
+    cert.subjectAltName; // $ExpectType string | undefined
     cert.validFrom; // $ExpectType string
     cert.validTo; // $ExpectType string
 
@@ -1209,11 +1210,10 @@ import { promisify } from 'node:util';
     };
 
     cert.checkEmail('test@test.com'); // $ExpectType string | undefined
-    cert.checkEmail('test@test.com', checkOpts); // $ExpectType string | undefined
+    cert.checkEmail('test@test.com', { subject: checkOpts.subject }); // $ExpectType string | undefined
     cert.checkHost('test.com'); // $ExpectType string | undefined
     cert.checkHost('test.com', checkOpts); // $ExpectType string | undefined
     cert.checkIP('1.1.1.1'); // $ExpectType string | undefined
-    cert.checkIP('1.1.1.1', checkOpts); // $ExpectType string | undefined
     cert.checkIssued(new crypto.X509Certificate('dummycert')); // $ExpectType boolean
     cert.checkPrivateKey(crypto.createPrivateKey('dummy')); // $ExpectType boolean
     cert.toLegacyObject(); // $ExpectType PeerCertificate

--- a/types/node/v16/test/crypto.ts
+++ b/types/node/v16/test/crypto.ts
@@ -1210,7 +1210,8 @@ import { promisify } from 'node:util';
     };
 
     cert.checkEmail('test@test.com'); // $ExpectType string | undefined
-    cert.checkEmail('test@test.com', { subject: checkOpts.subject }); // $ExpectType string | undefined
+    cert.checkEmail('test@test.com', checkOpts); // $ExpectType string | undefined
+    cert.checkEmail('test@test.com', { subject: 'always' }); // $ExpectType string | undefined
     cert.checkHost('test.com'); // $ExpectType string | undefined
     cert.checkHost('test.com', checkOpts); // $ExpectType string | undefined
     cert.checkIP('1.1.1.1'); // $ExpectType string | undefined


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Official Node Documentation](https://nodejs.org/dist/latest-v16.x/docs/api/crypto.html#class-x509certificate)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

------

Hi, this is my first time contributing so please let me know of any mistakes, I wasn't sure on the different `v` folders and how that all behaves.

Here is a breakdown of the changes, you can [generate certificates yourself here](https://certificatetools.com/) to test with.

- `fingerprint512` - This is a missing type, introduced in `v16.14.0`
- `subjectAltName` - This can be `undefined`
- `infoAccess` - This can be `undefined`
- `checkEmail` - This does not accept all X509 options other than `subject`
- `checkIp` - Since `v16.14.1` no longer accepts `options`. **Is this a breaking change?**