### PR TITLE
@ckeditor/ckeditor5-utils Observable set method signature

### DIFF
--- a/types/ckeditor__ckeditor5-cloud-services/ckeditor__ckeditor5-cloud-services-tests.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/ckeditor__ckeditor5-cloud-services-tests.ts
@@ -16,6 +16,13 @@ instance
     });
 instance.tokenUrl = "foo";
 instance.tokenUrl = () => "foo";
+token.set('foo', 5);
+token.on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<Token, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
 
 const core = new CloudServicesCore(new MyEditor());
 token = core.createToken("foo");

--- a/types/ckeditor__ckeditor5-cloud-services/src/token/token.d.ts
+++ b/types/ckeditor__ckeditor5-cloud-services/src/token/token.d.ts
@@ -1,7 +1,7 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Token extends Observable {}
 
 export default class Token implements Observable {
     constructor(
@@ -19,35 +19,4 @@ export default class Token implements Observable {
         tokenUrlOrRefreshToken: string | (() => Promise<Token>),
         options: { initValue?: string | undefined; autoRefresh?: boolean | undefined },
     ): Promise<Token>;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
+++ b/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
@@ -15,6 +15,9 @@ import { EditorWithUI } from '@ckeditor/ckeditor5-core/src/editor/editorwithui';
 import Selection from '@ckeditor/ckeditor5-engine/src/model/selection';
 import ParagraphCommand from '@ckeditor/ckeditor5-paragraph/src/paragraphcommand';
 import View from '@ckeditor/ckeditor5-ui/src/view';
+import { Emitter } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
 
 /**
  * Editor
@@ -82,6 +85,12 @@ class MyPlugin extends Plugin {
 }
 
 const myPlugin = new MyPlugin(editor);
+myPlugin.on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<MyPlugin, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
 const promise = myPlugin.init?.();
 promise != null && promise.then(() => {});
 myPlugin.myMethod();
@@ -117,6 +126,7 @@ class MyEmptyEditor extends Editor {
 /**
  * Command
  */
+
 class MyCommand extends Command {
     get value(): boolean {
         return this.value;
@@ -131,6 +141,13 @@ class MyCommand extends Command {
 }
 
 const command = new MyCommand(editor);
+
+command.on('execute', (ev, ...args) => {
+    // $ExpectType EventInfo<MyCommand, "execute">
+    ev;
+    // $ExpectType any[]
+    args;
+});
 
 // $ExpectType boolean
 command.value;
@@ -203,6 +220,13 @@ editor.plugins.get(MyCPlugin).myCMethod();
 context.plugins.get(MyCPlugin).myCMethod();
 (context.plugins.get('MyCPlugin') as MyCPlugin).myCMethod();
 
+editor.plugins.get(MyCPlugin).on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<MyCPlugin, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
 /**
  * DataApiMixin
  */
@@ -232,6 +256,14 @@ new EditorUI(editor).componentFactory.add('', locale => new View(locale));
 new EditorUI(editor).set('foo', true);
 // $ExpectType { top: number; right: number; bottom: number; left: number; }
 new EditorUI(editor).viewportOffset;
+new EditorUI(editor).on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<EditorUI, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+new EditorUI(editor).set('foo');
 
 /** Pending Actions */
 // $ExpectType boolean

--- a/types/ckeditor__ckeditor5-core/src/command.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/command.d.ts
@@ -1,8 +1,8 @@
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import Editor from './editor/editor';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Command extends Observable {}
 
 /**
  * The base class for CKEditor commands.
@@ -77,7 +77,7 @@ export default class Command implements Observable {
      *    enableBold();
      */
     get isEnabled(): boolean;
-    protected set isEnabled(val: boolean);
+    protected set isEnabled(value: boolean);
 
     /**
      * A flag indicating whether a command execution changes the editor data or not.
@@ -160,35 +160,4 @@ export default class Command implements Observable {
      * Destroys the command.
      */
     destroy(): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/contextplugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/contextplugin.d.ts
@@ -1,9 +1,9 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import Context from './context';
 import Editor from './editor/editor';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface ContextPlugin extends Observable {}
 
 /**
  * The base class for {@link module:core/context~Context} plugin classes.
@@ -35,37 +35,6 @@ export default abstract class ContextPlugin implements Observable {
     static readonly isContextPlugin: true;
     static readonly pluginName?: string | undefined;
     static readonly requires?: Array<typeof ContextPlugin> | undefined;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (ev: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }
 
 export interface ContextPluginInterface<T = ContextPlugin> {

--- a/types/ckeditor__ckeditor5-core/src/editor/editor.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editor.d.ts
@@ -1,16 +1,16 @@
 import { Conversion, DataController, EditingController, Model } from '@ckeditor/ckeditor5-engine';
 import Config from '@ckeditor/ckeditor5-utils/src/config';
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import Locale from '@ckeditor/ckeditor5-utils/src/locale';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import CommandCollection from '../commandcollection';
 import ContextPlugin from '../contextplugin';
 import EditingKeystrokeHandler from '../editingkeystrokehandler';
 import Plugin, { LoadedPlugins } from '../plugin';
 import PluginCollection from '../plugincollection';
 import { EditorConfig } from './editorconfig';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Editor extends Observable {}
 
 export default abstract class Editor implements Observable {
     /**
@@ -171,35 +171,4 @@ export default abstract class Editor implements Observable {
     static create(sourceElementOrData: HTMLElement | string, config?: EditorConfig): Promise<Editor>;
     static builtinPlugins: Array<typeof Plugin | typeof ContextPlugin | string>;
     static defaultConfig?: EditorConfig | undefined;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/editor/editorui.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editorui.d.ts
@@ -1,10 +1,10 @@
 import ComponentFactory from '@ckeditor/ckeditor5-ui/src/componentfactory';
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import Editor from './editor';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface EditorUI extends Observable {}
 
 /**
  * A class providing the minimal interface that is required to successfully bootstrap any editor UI.
@@ -105,36 +105,4 @@ export default class EditorUI implements Observable {
      * Returns array of names of all editor editable elements.
      */
     getEditableElementsNames(): Iterable<string>;
-
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
 }

--- a/types/ckeditor__ckeditor5-core/src/plugin.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/plugin.d.ts
@@ -1,10 +1,10 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import ContextPlugin from './contextplugin';
 import Editor from './editor/editor';
 import { EditorWithUI } from './editor/editorwithui';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Plugin extends Observable {}
 
 /**
  * The base class for CKEditor plugin classes.
@@ -138,45 +138,14 @@ export default class Plugin implements Observable {
      * **Note:** This method is optional. A plugin instance does not need to have it defined.
      */
     afterInit?(): Promise<void> | void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(bindProperties: string): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }
 
 // Beware that this defines a class constructor, not the class instance.
 export interface PluginInterface<T = Plugin> {
     new (editor: Editor): T;
-    init?(): Promise<void>|void;
-    afterInit?(): Promise<void>|void;
-    destroy?(): Promise<void>|void;
+    init?(): Promise<void> | void;
+    afterInit?(): Promise<void> | void;
+    destroy?(): Promise<void> | void;
 }
 
 export type LoadedPlugins = Array<typeof Plugin | typeof ContextPlugin>;

--- a/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
@@ -39,7 +39,7 @@ import {
     StylesProcessor,
     transformSets,
     TreeWalker,
-    ViewDocument,
+    ViewDocument
 } from '@ckeditor/ckeditor5-engine';
 import DowncastDispatcher from '@ckeditor/ckeditor5-engine/src/conversion/downcastdispatcher';
 import DowncastHelpers, {
@@ -50,14 +50,14 @@ import DowncastHelpers, {
     insertText,
     insertUIElement,
     remove,
-    wrap,
+    wrap
 } from '@ckeditor/ckeditor5-engine/src/conversion/downcasthelpers';
 import Mapper from '@ckeditor/ckeditor5-engine/src/conversion/mapper';
 import UpcastDispatcher from '@ckeditor/ckeditor5-engine/src/conversion/upcastdispatcher';
 import UpcastHelpers, {
     convertSelectionChange,
     convertText,
-    convertToModelFragment,
+    convertToModelFragment
 } from '@ckeditor/ckeditor5-engine/src/conversion/upcasthelpers';
 import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 import ModelDocument from '@ckeditor/ckeditor5-engine/src/model/document';
@@ -69,6 +69,7 @@ import Node from '@ckeditor/ckeditor5-engine/src/model/node';
 import Operation from '@ckeditor/ckeditor5-engine/src/model/operation/operation';
 import ModelPosition from '@ckeditor/ckeditor5-engine/src/model/position';
 import RootElement from '@ckeditor/ckeditor5-engine/src/model/rootelement';
+import Schema from '@ckeditor/ckeditor5-engine/src/model/schema';
 import Selection from '@ckeditor/ckeditor5-engine/src/model/selection';
 import Text from '@ckeditor/ckeditor5-engine/src/model/text';
 import TextProxy from '@ckeditor/ckeditor5-engine/src/model/textproxy';
@@ -79,7 +80,7 @@ import insertContent from '@ckeditor/ckeditor5-engine/src/model/utils/insertcont
 import modifySelection from '@ckeditor/ckeditor5-engine/src/model/utils/modifyselection';
 import {
     injectSelectionPostFixer,
-    mergeIntersectingRanges,
+    mergeIntersectingRanges
 } from '@ckeditor/ckeditor5-engine/src/model/utils/selection-post-fixer';
 import Writer from '@ckeditor/ckeditor5-engine/src/model/writer';
 import { getBoxSidesValues } from '@ckeditor/ckeditor5-engine/src/styles/utils';
@@ -204,6 +205,14 @@ let model: Model = new Model();
 model.change(writer => {
     writer.insertText('foo', model.document.selection.getFirstPosition());
 });
+new Model().on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<Model, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+new Model().set('foo');
 
 model.document.createRoot();
 model.schema.register('paragraph', { inheritAllFrom: '$block' });
@@ -255,7 +264,12 @@ bool = needsPlaceholder(viewElement, bool);
 const editingcontroller: EditingController = new EditingController(model, stylesProcessor);
 editingcontroller.destroy();
 editingcontroller.set('foo', 'bar');
-editingcontroller.once('foo', () => {});
+editingcontroller.once('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<EditingController, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
 editingcontroller.downcastDispatcher.on('insert:$element', () => {});
 
 const datacontroller: DataController = new DataController(model, stylesProcessor);
@@ -1667,3 +1681,12 @@ downcastWriter.createUIElement('span', null, function callback(domDocument) {
 
     return domElement;
 });
+
+new Schema().on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<Schema, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+new Schema().set('foo');

--- a/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/controller/editingcontroller.d.ts
@@ -1,12 +1,12 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import DowncastDispatcher from '../conversion/downcastdispatcher';
 import Mapper from '../conversion/mapper';
 import Model from '../model/model';
 import { StylesProcessor } from '../view/stylesmap';
 import View from '../view/view';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface EditingController extends Observable {}
 
 /**
  * Controller for the editing pipeline. The editing pipeline controls {@link ~EditingController#model model} rendering,
@@ -43,35 +43,4 @@ export default class EditingController implements Observable {
      * by `EditingController` that need to be destroyed.
      */
     destroy(): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/model.d.ts
@@ -1,7 +1,4 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import Batch from './batch';
 import Document from './document';
 import DocumentFragment from './documentfragment';
@@ -15,6 +12,9 @@ import Range from './range';
 import Schema from './schema';
 import Selection, { Selectable } from './selection';
 import Writer from './writer';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Model extends Observable {}
 
 export default class Model implements Observable {
     readonly document: Document;
@@ -33,10 +33,7 @@ export default class Model implements Observable {
     createRange(start: Position, end?: Position | null): Range;
     createRangeIn(element: Element): Range;
     createRangeOn(item: Item): Range;
-    createSelection(
-        selectable?: Selectable | Selectable[],
-        options?: { backward?: boolean | undefined },
-    ): Selection;
+    createSelection(selectable?: Selectable | Selectable[], options?: { backward?: boolean | undefined }): Selection;
     createSelection(
         selectable?: Selectable | Selectable[],
         placeOrOffset?: number | 'before' | 'end' | 'after' | 'on' | 'in',
@@ -74,35 +71,4 @@ export default class Model implements Observable {
             unit?: 'character' | 'codePoint' | 'word' | undefined;
         },
     ): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/model/schema.d.ts
@@ -1,7 +1,4 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import DocumentSelection from './documentselection';
 import Element from './element';
 import { Item } from './item';
@@ -10,6 +7,9 @@ import Position from './position';
 import Range from './range';
 import Selection from './selection';
 import Writer from './writer';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Schema extends Observable {}
 
 export default class Schema implements Observable {
     addAttributeCheck(callback: (context: SchemaContext, name: string) => any): void;
@@ -37,37 +37,6 @@ export default class Schema implements Observable {
     register(itemName: string, definition: SchemaItemDefinition): void;
     removeDisallowedAttributes(nodes: Iterable<Node>, writer: Writer): void;
     setAttributeProperties(attributeName: string, properties: AttributeProperties): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }
 
 export interface SchemaItemDefinition {

--- a/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/document.d.ts
@@ -76,8 +76,7 @@ export default class Document implements BubblingEmitter, Observable {
      */
     destroy(): void;
 
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
+    set(...args: [option: Record<string, unknown>] | [name: string, value: unknown] | [name: string]): void;
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;

--- a/types/ckeditor__ckeditor5-engine/src/view/view.d.ts
+++ b/types/ckeditor__ckeditor5-engine/src/view/view.d.ts
@@ -1,7 +1,4 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import Document from './document';
 import DomConverter from './domconverter';
 import DowncastWriter from './downcastwriter';
@@ -14,7 +11,7 @@ import Selection, { Selectable } from './selection';
 import { StylesProcessor } from './stylesmap';
 
 // tslint:disable-next-line:no-empty-interface
-export interface Observers {}
+export default interface View extends Observable {}
 
 export default class View implements Observable {
     readonly document: Document;
@@ -49,35 +46,4 @@ export default class View implements Observable {
     getObserver<T extends Observer>(key: new (view: View) => T): T;
 
     scrollToTheSelection(): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-find-and-replace/ckeditor__ckeditor5-find-and-replace-tests.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/ckeditor__ckeditor5-find-and-replace-tests.ts
@@ -23,11 +23,11 @@ const state = new FindAndReplaceState(new Model());
 // $ExpectType string
 state.searchText;
 // $ExpectError
-state.searchText = "foo";
+state.searchText = 'foo';
 // $ExpectType string
 state.replaceText;
 // $ExpectError
-state.replaceText = "foo";
+state.replaceText = 'foo';
 // $ExpectType boolean
 state.matchCase;
 // $ExpectError
@@ -37,6 +37,15 @@ state.clear(new Model());
 state.results;
 // $ExpectError
 state.results = state.results;
+
+state.on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<FindAndReplaceState, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+state.set('foo');
 
 const plugin = editor.plugins.get('FindAndReplaceEditing');
 if (plugin instanceof FindAndReplaceEditing) {

--- a/types/ckeditor__ckeditor5-find-and-replace/src/findandreplacestate.d.ts
+++ b/types/ckeditor__ckeditor5-find-and-replace/src/findandreplacestate.d.ts
@@ -1,10 +1,10 @@
 import { Model } from '@ckeditor/ckeditor5-engine';
 import { Marker } from '@ckeditor/ckeditor5-engine/src/model/markercollection';
 import { Collection } from '@ckeditor/ckeditor5-utils';
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface FindAndReplaceState extends Observable {}
 
 export interface Result {
     id: string;
@@ -30,35 +30,4 @@ export default class FindAndReplaceState implements Observable {
     get matchWholeWords(): boolean;
     protected set matchWholeWords(value: boolean);
     clear(model: Model): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-font/src/documentcolorcollection.d.ts
+++ b/types/ckeditor__ckeditor5-font/src/documentcolorcollection.d.ts
@@ -1,13 +1,9 @@
 import { ColorDefinition } from '@ckeditor/ckeditor5-ui/src/colorgrid/colorgridview';
 import { Collection } from '@ckeditor/ckeditor5-utils';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface DocumentColorCollection extends Observable {}
 
 export default class DocumentColorCollection extends Collection<ColorDefinition> implements Observable {
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    isEmpty: boolean;
-    hasColor(color: string): boolean;
 }

--- a/types/ckeditor__ckeditor5-link/ckeditor__ckeditor5-link-tests.ts
+++ b/types/ckeditor__ckeditor5-link/ckeditor__ckeditor5-link-tests.ts
@@ -93,6 +93,29 @@ new ManualDecorator({
     styles: { bg: 'red' },
 });
 
+new ManualDecorator({
+    id: '',
+    label: '',
+    attributes: { foo: 'bar' },
+    defaultValue: true,
+    classes: 'foo',
+    styles: { bg: 'red' },
+}).on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<ManualDecorator, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+new ManualDecorator({
+    id: '',
+    label: '',
+    attributes: { foo: 'bar' },
+    defaultValue: true,
+    classes: 'foo',
+    styles: { bg: 'red' },
+}).set('foo');
+
 // $ExpectType AutoLink
 editor.plugins.get('AutoLink');
 

--- a/types/ckeditor__ckeditor5-link/src/utils/manualdecorator.d.ts
+++ b/types/ckeditor__ckeditor5-link/src/utils/manualdecorator.d.ts
@@ -1,7 +1,7 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface ManualDecorator extends Observable {}
 
 /**
  * Helper class that stores manual decorators with observable {@link module:link/utils~ManualDecorator#value}
@@ -59,35 +59,4 @@ export default class ManualDecorator implements Observable {
      * Styles should be added in a form of styles defined in {@link module:engine/view/elementdefinition~ElementDefinition}.
      */
     readonly styles: Record<string, string> | undefined;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-revision-history/ckeditor__ckeditor5-revision-history-tests.ts
+++ b/types/ckeditor__ckeditor5-revision-history/ckeditor__ckeditor5-revision-history-tests.ts
@@ -5,6 +5,13 @@ new Revision().setAttribute('', '');
 new Revision().removeAttribute('');
 new Revision().authors.has(new Revision().creator!);
 new Revision().id.startsWith('');
+new Revision().on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<Revision, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+new Revision().set('foo');
 
 new RevisionHistory().adapter.updateRevisions([
     {

--- a/types/ckeditor__ckeditor5-revision-history/src/revision.d.ts
+++ b/types/ckeditor__ckeditor5-revision-history/src/revision.d.ts
@@ -1,8 +1,8 @@
 import { User } from '@ckeditor/ckeditor5-collaboration-core/src/users';
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Revision extends Observable {}
 
 export default class Revision implements Observable {
     get attributes(): Record<string, any>;
@@ -20,35 +20,4 @@ export default class Revision implements Observable {
     setAttribute(name: string, value: unknown): void;
     toJSON(): Record<string, string>;
     setName(name: string): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-typing/ckeditor__ckeditor5-typing-tests.ts
+++ b/types/ckeditor__ckeditor5-typing/ckeditor__ckeditor5-typing-tests.ts
@@ -11,16 +11,18 @@ import {
     TextTransformation,
     TextWatcher,
     TwoStepCaretMovement,
-    Typing
+    Typing,
 } from '@ckeditor/ckeditor5-typing';
 import DeleteCommand from '@ckeditor/ckeditor5-typing/src/deletecommand';
 import InputCommand from '@ckeditor/ckeditor5-typing/src/inputcommand';
 import {
     TextTransformationConfig,
-    TextTransformationDescription
+    TextTransformationDescription,
 } from '@ckeditor/ckeditor5-typing/src/texttransformation';
 import findAttributeRange from '@ckeditor/ckeditor5-typing/src/utils/findattributerange';
-import injectUnsafeKeystrokesHandling, { isNonTypingKeystroke } from '@ckeditor/ckeditor5-typing/src/utils/injectunsafekeystrokeshandling';
+import injectUnsafeKeystrokesHandling, {
+    isNonTypingKeystroke,
+} from '@ckeditor/ckeditor5-typing/src/utils/injectunsafekeystrokeshandling';
 
 class MyEditor extends Editor {}
 const editor = new MyEditor();
@@ -37,6 +39,15 @@ del.init();
 
 const textWatcher = new TextWatcher(new Model(), foo => foo.startsWith('bar'));
 textWatcher.hasMatch === textWatcher.testCallback('foo');
+
+textWatcher.on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<TextWatcher, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+textWatcher.set('foo');
 
 const twoStep = new TwoStepCaretMovement(editor);
 twoStep.init();
@@ -95,4 +106,4 @@ editor.commands.get('InputCommand');
 editor.commands.get('DeleteCommand');
 
 // $ExpectType boolean
-isNonTypingKeystroke(new KeyEventData(new View(new StylesProcessor()), new KeyboardEvent("foo")));
+isNonTypingKeystroke(new KeyEventData(new View(new StylesProcessor()), new KeyboardEvent('foo')));

--- a/types/ckeditor__ckeditor5-typing/src/textwatcher.d.ts
+++ b/types/ckeditor__ckeditor5-typing/src/textwatcher.d.ts
@@ -1,9 +1,9 @@
 import { Model } from '@ckeditor/ckeditor5-engine';
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import { TextTransformationDescription } from './texttransformation';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface TextWatcher extends Observable {}
 
 export default class TextWatcher implements Observable {
     constructor(
@@ -16,35 +16,4 @@ export default class TextWatcher implements Observable {
     get isEnabled(): boolean;
     protected set isEnabled(value: boolean);
     testCallback: (str: string) => boolean | { normalizedTransformation: TextTransformationDescription };
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/ckeditor__ckeditor5-ui-tests.ts
+++ b/types/ckeditor__ckeditor5-ui/ckeditor__ckeditor5-ui-tests.ts
@@ -70,6 +70,15 @@ view.isRendered === bool;
 let template: Template;
 template = view.template as Template;
 
+view.on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<View, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+view.set('foo');
+
 let htmlelement = template.render() as HTMLElement;
 
 let locale: Locale = new Locale();
@@ -139,6 +148,15 @@ viewCollection.remove(view);
 // $ExpectError
 viewCollection.remove([view]);
 viewCollection.destroy();
+
+viewCollection.on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<ViewCollection<View>, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+viewCollection.set('foo');
 
 /**
  * Template
@@ -529,7 +547,7 @@ new InputView(locale).id;
 // $ExpectType string
 new InputView(locale).placeholder;
 // $ExpectError
-new InputView(locale).placeholder = "";
+new InputView(locale).placeholder = '';
 new InputView(locale).destroy();
 new InputView(locale).focus();
 
@@ -542,7 +560,7 @@ new InputNumberView(locale).id;
 // $ExpectType string
 new InputNumberView(locale).placeholder;
 // $ExpectError
-new InputNumberView(locale).placeholder = "";
+new InputNumberView(locale).placeholder = '';
 new InputNumberView(locale).destroy();
 new InputNumberView(locale).focus();
 // $ExpectType number | undefined
@@ -551,7 +569,7 @@ new InputNumberView(locale).min;
 new InputNumberView(locale).step;
 
 // $ExpectType InputNumberView
-createLabeledInputNumber(labeledfieldview, "", "");
+createLabeledInputNumber(labeledfieldview, '', '');
 
 // $ExpectType BalloonToolbar
 editor.plugins.get('BalloonToolbar');

--- a/types/ckeditor__ckeditor5-ui/src/model.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/model.d.ts
@@ -1,40 +1,9 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Model extends Observable {}
 
 export default class Model implements Observable {
     constructor(attributes?: Record<string, unknown>, properties?: Record<string, unknown>);
     readonly [x: string]: any;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-ui/src/view.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/view.d.ts
@@ -350,8 +350,7 @@ export default class View implements DomEmitter, Observable {
     enableCssTransitions?(): void;
     disableCssTransitions?(): void;
 
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
+    set(...args: [option: Record<string, unknown>] | [name: string, value: unknown] | [name: string]): void;
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;

--- a/types/ckeditor__ckeditor5-ui/src/viewcollection.d.ts
+++ b/types/ckeditor__ckeditor5-ui/src/viewcollection.d.ts
@@ -1,16 +1,11 @@
 import { Collection } from "@ckeditor/ckeditor5-utils";
-import { Emitter } from "@ckeditor/ckeditor5-utils/src/emittermixin";
-import { BindChain, Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
+import { Observable } from "@ckeditor/ckeditor5-utils/src/observablemixin";
 import View from "./view";
 
-export default class ViewCollection<T extends View = View> extends Collection<T> implements Emitter, Observable {
+export default interface ViewCollection<T extends View = View> extends Collection<T>, Observable {}
+
+export default class ViewCollection<T extends View = View> extends Collection<T> implements Observable {
     constructor(initialItems?: Iterable<T>);
     destroy(): void;
     setParent(element: HTMLElement): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
 }

--- a/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
@@ -650,9 +650,7 @@ objectToMap({ foo: 1, bar: 2 }).get('foo');
 // utils/observablemixin ======================================================
 
 class Car implements Observable {
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    set(_name: any, _value?: any): void {
+    set(...args: [option: Record<string, unknown>] | [name: string, value: unknown] | [name: string]): void {
         throw new Error('Method not implemented.');
     }
     bind(..._bindProperties: string[]): BindChain {
@@ -739,6 +737,7 @@ bettle.set('seats', undefined);
 bettle.set({
     color: 'red',
 });
+bettle.set('color');
 
 bettle.unbind();
 bettle.unbind('color');

--- a/types/ckeditor__ckeditor5-utils/src/focustracker.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/focustracker.d.ts
@@ -49,8 +49,7 @@ export default class FocusTracker implements DomEmitter, Observable {
     get isFocused(): boolean;
     protected set isFocused(value: boolean);
 
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
+    set(...args: [option: Record<string, unknown>] | [name: string, value: unknown] | [name: string]): void;
     bind(...bindProperties: string[]): BindChain;
     unbind(...unbindProperties: string[]): void;
     decorate(methodName: string): void;

--- a/types/ckeditor__ckeditor5-utils/src/observablemixin.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/observablemixin.d.ts
@@ -1,5 +1,4 @@
 import { Emitter } from './emittermixin';
-import { Emitter as DomEmitter } from './dom/emittermixin';
 
 export interface BindChain {
     to<O1 extends Observable, K1 extends keyof O1>(
@@ -94,8 +93,7 @@ export interface Observable extends Emitter {
      * properties and methods, but means that `foo.set( 'bar', 1 )` may be slightly slower than `foo.bar = 1`.
      *
      */
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
+    set(...args: [option: Record<string, unknown>] | [name: string, value: unknown] | [name: string]): void;
     /**
      * Binds {@link #set observable properties} to other objects implementing the
      * {@link module:utils/observablemixin~Observable} interface.

--- a/types/ckeditor__ckeditor5-widget/ckeditor__ckeditor5-widget-tests.ts
+++ b/types/ckeditor__ckeditor5-widget/ckeditor__ckeditor5-widget-tests.ts
@@ -5,12 +5,8 @@ import Selection from '@ckeditor/ckeditor5-engine/src/model/selection';
 import Document from '@ckeditor/ckeditor5-engine/src/view/document';
 import ViewElement from '@ckeditor/ckeditor5-engine/src/view/element';
 import View from '@ckeditor/ckeditor5-engine/src/view/view';
-import Resizer from '@ckeditor/ckeditor5-widget/src/widgetresize/resizer';
-import SizeView from '@ckeditor/ckeditor5-widget/src/widgetresize/sizeview';
 import {
-    findOptimalInsertionRange,
-    checkSelectionOnObject,
-    getLabel,
+    checkSelectionOnObject, findOptimalInsertionRange, getLabel,
     isWidget,
     setHighlightHandling,
     setLabel,
@@ -18,9 +14,12 @@ import {
     Widget,
     WidgetResize,
     WidgetToolbarRepository,
-    WidgetTypeAround,
+    WidgetTypeAround
 } from '@ckeditor/ckeditor5-widget/';
 import HighlightStack from '@ckeditor/ckeditor5-widget/src/highlightstack';
+import Resizer from '@ckeditor/ckeditor5-widget/src/widgetresize/resizer';
+import ResizeState from '@ckeditor/ckeditor5-widget/src/widgetresize/resizerstate';
+import SizeView from '@ckeditor/ckeditor5-widget/src/widgetresize/sizeview';
 
 class MyEditor extends Editor {}
 const editor = new MyEditor();
@@ -66,6 +65,14 @@ resizer = widgetResize.attachTo({
 });
 resizer = widgetResize.getResizerByViewElement(containerElement)!;
 resizer.destroy();
+resizer.on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<Resizer, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+resizer.set('foo');
 
 const widgetTypeAround = new WidgetTypeAround(editor);
 widgetTypeAround.init();
@@ -99,6 +106,27 @@ new HighlightStack().add(
     new DowncastWriter(new Document(new StylesProcessor())),
 );
 new HighlightStack().remove('', new DowncastWriter(new Document(new StylesProcessor())));
+
+const resizeState = new ResizeState({
+    isCentered: () => true,
+    getHandleHost: () => document.body,
+    editor,
+    getResizeHost: () => document.body,
+    onCommit: () => {
+        return;
+    },
+    viewElement: containerElement,
+    modelElement: new Element('div'),
+});
+
+resizeState.on('foo', (ev, ...args) => {
+    // $ExpectType EventInfo<ResizeState, "foo">
+    ev;
+    // $ExpectType any[]
+    args;
+});
+
+resizeState.set('foo');
 
 // $ExpectType Widget
 editor.plugins.get('Widget');

--- a/types/ckeditor__ckeditor5-widget/src/widgetresize/resizer.d.ts
+++ b/types/ckeditor__ckeditor5-widget/src/widgetresize/resizer.d.ts
@@ -1,10 +1,10 @@
 import { Rect } from '@ckeditor/ckeditor5-utils';
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import { ResizerOptions } from '../widgetresize';
 import ResizerState from './resizerstate';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Resizer extends Observable {}
 
 export default class Resizer implements Observable {
     constructor(options: ResizerOptions);
@@ -16,35 +16,4 @@ export default class Resizer implements Observable {
     destroy(): void;
     redraw(handleHostRect?: Rect): void;
     updateSize(domEventData: Event): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }

--- a/types/ckeditor__ckeditor5-widget/src/widgetresize/resizerstate.d.ts
+++ b/types/ckeditor__ckeditor5-widget/src/widgetresize/resizerstate.d.ts
@@ -1,8 +1,8 @@
-import { Emitter, EmitterMixinDelegateChain } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
-import { BindChain, Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import { PriorityString } from '@ckeditor/ckeditor5-utils/src/priorities';
+import { Observable } from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import { ResizerOptions } from '../widgetresize';
+
+// tslint:disable-next-line:no-empty-interface
+export default interface ResizeState extends Observable {}
 
 export default class ResizeState implements Observable {
     constructor(options: ResizerOptions);
@@ -15,35 +15,4 @@ export default class ResizeState implements Observable {
     proposedWidthPercents: number | null;
     proposedWidthPixels: number | null;
     begin(domResizeHandle: HTMLElement, domHandleHost: HTMLElement, domResizeHost: HTMLElement): void;
-
-    set(option: Record<string, unknown>): void;
-    set(name: string, value: unknown): void;
-    bind(...bindProperties: string[]): BindChain;
-    unbind(...unbindProperties: string[]): void;
-    decorate(methodName: string): void;
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }


### PR DESCRIPTION
The `Observable` interface allows passing only one arguments to the `set` method.

https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-ui/src/button/buttonview.js#L51
https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-utils/src/observablemixin.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/blob/72f503139a8fdf40b41cf26960a94b725f409338/packages/ckeditor5-ui/src/button/buttonview.js#L51
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.