### PR TITLE
[ember__component] better default signature for `Helper` class

### DIFF
--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -82,11 +82,19 @@ type PositionalArgs<S> = ExpandSignature<S>['Args']['Positional'];
 
 type Return<S> = GetOrElse<S, 'Return', unknown>;
 
+interface DefaultSignature {
+    Args: {
+        Named: Record<string, unknown>;
+        Positional: unknown[];
+    };
+    Return: unknown;
+}
+
 /**
  * Ember Helpers are functions that can compute values, and are used in templates.
  * For example, this code calls a helper named `format-currency`:
  */
-export default class Helper<S = unknown> extends EmberObject {
+export default class Helper<S = DefaultSignature> extends EmberObject {
     /**
      * In many cases, the ceremony of a full `Ember.Helper` class is not required.
      * The `helper` method create pure-function helpers without instances. For

--- a/types/ember__component/test/helper.ts
+++ b/types/ember__component/test/helper.ts
@@ -65,6 +65,12 @@ class BadReturnForm extends Helper<DemoSig> {
     }
 }
 
+class NoSignature extends Helper {
+    compute([i18nizer]: [i18nizer: (s: string) => string], { name, age }: { name: string; age: number }): string {
+        return i18nizer(`${name} is ${age} years old`);
+    }
+}
+
 // $ExpectType FunctionBasedHelper<{ Args: { Positional: [number, number]; Named: EmptyObject; }; Return: number; }>
 const inferenceOnPositional = helper(function add([a, b]: [number, number]) {
     return a + b;

--- a/types/ember__component/test/helper.ts
+++ b/types/ember__component/test/helper.ts
@@ -71,6 +71,20 @@ class NoSignature extends Helper {
     }
 }
 
+class NoSignatureBadPositional extends Helper {
+    // $ExpectError
+    compute(i18nizer: (s: string) => string, { name, age }: { name: string; age: number }): string {
+        return i18nizer(`${name} is ${age} years old`);
+    }
+}
+
+class NoSignatureBadNamed extends Helper {
+    // $ExpectError
+    compute([i18nizer]: [i18nizer: (s: string) => string], [name, age]: [string, number]): string {
+        return i18nizer(`${name} is ${age} years old`);
+    }
+}
+
 // $ExpectType FunctionBasedHelper<{ Args: { Positional: [number, number]; Named: EmptyObject; }; Return: number; }>
 const inferenceOnPositional = helper(function add([a, b]: [number, number]) {
     return a + b;


### PR DESCRIPTION
This allows class-based helpers to continue to type-check without providing a signature. This default signature also allows some basic type-checking of `compute()` (it's args must extend `unknown[]` and  `Record<string, unknown>` respectively), which is what we had when no signature was provided prior to #59541.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/typed-ember/ember-cli-typescript/discussions/1498
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~