### PR TITLE
[react-infinite-scroller] Fix tests when `ReactFragment` does not include `{}`

### DIFF
--- a/types/react-infinite-scroller/react-infinite-scroller-tests.tsx
+++ b/types/react-infinite-scroller/react-infinite-scroller-tests.tsx
@@ -58,7 +58,7 @@ class Test4 extends React.Component {
         return (
             <div ref={this.inputRef}>
                 <InfiniteScroll
-                  element={Test4Component}
+                  element={<Test4Component />}
                   loadMore={(page) => {}}
                 >
                     <span>Test 4</span>


### PR DESCRIPTION
Given the name of the `element` prop, the prop probably does not support a component but an element. @cvetanov Could you take a look and tell me if we should extend `element` to accept `ComponentType` or really only pass `ReactNode` in which case the proposed diff should fix any future issues.

We plan to remove `{}` from `ReactFragment` since it's not actually an allowed type for children of host components (e.g. `<div>{{}}</div>` would throw at runtime) (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026 for previous attempts).

This change is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210