### PR TITLE
prettier: Add generics for call, each, and map property keys

### DIFF
--- a/types/babel-plugin-tester/index.d.ts
+++ b/types/babel-plugin-tester/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
 //                 Mathieu TUDISCO <https://github.com/mathieutu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.2
 
 import * as Babel from '@babel/core';
 import { Options } from 'prettier';

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -10,7 +10,12 @@
 //                 JounQin <https://github.com/JounQin>
 //                 Chuah Chee Shian <https://github.com/shian15810>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.2
+
+// Adding export {} here to shut off automatic exporting from index.d.ts. There
+// are quite a few utility types here that don't need to be shipped with the
+// exported module.
+export {};
 
 // This utility is here to handle the case where you have an explicit union
 // between string literals and the generic string type. It would normally
@@ -24,20 +29,160 @@ export type LiteralUnion<T extends U, U = string> = T | (Pick<U, never> & { _?: 
 export type AST = any;
 export type Doc = doc.builders.Doc;
 
-// https://github.com/prettier/prettier/blob/main/src/common/ast-path.js
+// The type of elements that make up the given array T.
+type ArrayElement<T> = T extends Array<infer E> ? E : never;
 
+// A union of the properties of the given object that are arrays.
+type ArrayProperties<T> = { [K in keyof T]: T[K] extends any[] ? K : never }[keyof T];
+
+// A union of the properties of the given array T that can be used to index it.
+// If the array is a tuple, then that's going to be the explicit indices of the
+// array, otherwise it's going to just be number.
+type IndexProperties<T extends { length: number }> = IsTuple<T> extends true
+    ? Exclude<Partial<T>['length'], T['length']>
+    : number;
+
+// Effectively performing T[P], except that it's telling TypeScript that it's
+// safe to do this for tuples, arrays, or objects.
+type IndexValue<T, P> = T extends any[] ? (P extends number ? T[P] : never) : P extends keyof T ? T[P] : never;
+
+// Determines if an object T is an array like string[] (in which case this
+// evaluates to false) or a tuple like [string] (in which case this evaluates to
+// true).
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type IsTuple<T> = T extends [] ? true : T extends [infer First, ...infer Remain] ? IsTuple<Remain> : false;
+
+type CallProperties<T> = T extends any[] ? IndexProperties<T> : keyof T;
+type IterProperties<T> = T extends any[] ? IndexProperties<T> : ArrayProperties<T>;
+
+type CallCallback<T, U> = (path: AstPath<T>, index: number, value: any) => U;
+type EachCallback<T> = (path: AstPath<ArrayElement<T>>, index: number, value: any) => void;
+type MapCallback<T, U> = (path: AstPath<ArrayElement<T>>, index: number, value: any) => U;
+
+// https://github.com/prettier/prettier/blob/main/src/common/ast-path.js
 export class AstPath<T = any> {
     constructor(value: T);
     stack: T[];
+    callParent<U>(callback: (path: this) => U, count?: number): U;
     getName(): PropertyKey | null;
     getValue(): T;
     getNode(count?: number): T | null;
     getParentNode(count?: number): T | null;
-    call<U>(callback: (path: this) => U, ...names: PropertyKey[]): U;
-    callParent<U>(callback: (path: this) => U, count?: number): U;
-    each(callback: (path: this, index: number, value: any) => void, ...names: PropertyKey[]): void;
-    map<U>(callback: (path: this, index: number, value: any) => U, ...names: PropertyKey[]): U[];
     match(...predicates: Array<(node: any, name: string | null, number: number | null) => boolean>): boolean;
+
+    // For each of the tree walk functions (call, each, and map) this provides 5
+    // strict type signatures, along with a fallback at the end if you end up
+    // calling more than 5 properties deep. This helps a lot with typing because
+    // for the majority of cases you're calling fewer than 5 properties, so the
+    // tree walk functions have a clearer understanding of what you're doing.
+    //
+    // Note that resolving these types is somewhat complicated, and it wasn't
+    // even supported until TypeScript 4.2 (before it would just say that the
+    // type instantiation was excessively deep and possibly infinite).
+
+    call<U>(callback: CallCallback<T, U>): U;
+    call<U, P1 extends CallProperties<T>>(callback: CallCallback<IndexValue<T, P1>, U>, prop1: P1): U;
+    call<U, P1 extends keyof T, P2 extends CallProperties<T[P1]>>(
+        callback: CallCallback<IndexValue<IndexValue<T, P1>, P2>, U>,
+        prop1: P1,
+        prop2: P2,
+    ): U;
+    call<U, P1 extends keyof T, P2 extends CallProperties<T[P1]>, P3 extends CallProperties<IndexValue<T[P1], P2>>>(
+        callback: CallCallback<IndexValue<IndexValue<IndexValue<T, P1>, P2>, P3>, U>,
+        prop1: P1,
+        prop2: P2,
+        prop3: P3,
+    ): U;
+    call<
+        U,
+        P1 extends keyof T,
+        P2 extends CallProperties<T[P1]>,
+        P3 extends CallProperties<IndexValue<T[P1], P2>>,
+        P4 extends CallProperties<IndexValue<IndexValue<T[P1], P2>, P3>>
+    >(
+        callback: CallCallback<IndexValue<IndexValue<IndexValue<IndexValue<T, P1>, P2>, P3>, P4>, U>,
+        prop1: P1,
+        prop2: P2,
+        prop3: P3,
+        prop4: P4,
+    ): U;
+    call<U, P extends PropertyKey>(
+        callback: CallCallback<any, U>,
+        prop1: P,
+        prop2: P,
+        prop3: P,
+        prop4: P,
+        ...props: P[]
+    ): U;
+
+    each(callback: EachCallback<T>): void;
+    each<P1 extends IterProperties<T>>(callback: EachCallback<IndexValue<T, P1>>, prop1: P1): void;
+    each<P1 extends keyof T, P2 extends IterProperties<T[P1]>>(
+        callback: EachCallback<IndexValue<IndexValue<T, P1>, P2>>,
+        prop1: P1,
+        prop2: P2,
+    ): void;
+    each<P1 extends keyof T, P2 extends IterProperties<T[P1]>, P3 extends IterProperties<IndexValue<T[P1], P2>>>(
+        callback: EachCallback<IndexValue<IndexValue<IndexValue<T, P1>, P2>, P3>>,
+        prop1: P1,
+        prop2: P2,
+        prop3: P3,
+    ): void;
+    each<
+        P1 extends keyof T,
+        P2 extends IterProperties<T[P1]>,
+        P3 extends IterProperties<IndexValue<T[P1], P2>>,
+        P4 extends IterProperties<IndexValue<IndexValue<T[P1], P2>, P3>>
+    >(
+        callback: EachCallback<IndexValue<IndexValue<IndexValue<IndexValue<T, P1>, P2>, P3>, P4>>,
+        prop1: P1,
+        prop2: P2,
+        prop3: P3,
+        prop4: P4,
+    ): void;
+    each(
+        callback: EachCallback<any[]>,
+        prop1: PropertyKey,
+        prop2: PropertyKey,
+        prop3: PropertyKey,
+        prop4: PropertyKey,
+        ...props: PropertyKey[]
+    ): void;
+
+    map<U>(callback: MapCallback<T, U>): U[];
+    map<U, P1 extends IterProperties<T>>(callback: MapCallback<IndexValue<T, P1>, U>, prop1: P1): U[];
+    map<U, P1 extends keyof T, P2 extends IterProperties<T[P1]>>(
+        callback: MapCallback<IndexValue<IndexValue<T, P1>, P2>, U>,
+        prop1: P1,
+        prop2: P2,
+    ): U[];
+    map<U, P1 extends keyof T, P2 extends IterProperties<T[P1]>, P3 extends IterProperties<IndexValue<T[P1], P2>>>(
+        callback: MapCallback<IndexValue<IndexValue<IndexValue<T, P1>, P2>, P3>, U>,
+        prop1: P1,
+        prop2: P2,
+        prop3: P3,
+    ): U[];
+    map<
+        U,
+        P1 extends keyof T,
+        P2 extends IterProperties<T[P1]>,
+        P3 extends IterProperties<IndexValue<T[P1], P2>>,
+        P4 extends IterProperties<IndexValue<IndexValue<T[P1], P2>, P3>>
+    >(
+        callback: MapCallback<IndexValue<IndexValue<IndexValue<IndexValue<T, P1>, P2>, P3>, P4>, U>,
+        prop1: P1,
+        prop2: P2,
+        prop3: P3,
+        prop4: P4,
+    ): U[];
+    map<U>(
+        callback: MapCallback<any[], U>,
+        prop1: PropertyKey,
+        prop2: PropertyKey,
+        prop3: PropertyKey,
+        prop4: PropertyKey,
+        ...props: PropertyKey[]
+    ): U[];
 }
 
 /** @deprecated `FastPath` was renamed to `AstPath` */

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -260,3 +260,143 @@ prettier.format('pluginSearchDir can not be true', {
 prettier.format('singleAttributePerLine is available', {
     singleAttributePerLine: true,
 });
+
+type NestedAst = Nested1 | Nested2 | Nested3;
+interface Nested1 {
+    kind: '1';
+    item2: Nested2;
+    list2: Nested2[];
+}
+interface Nested2 {
+    kind: '2';
+    item3: Nested3;
+    list3: Nested3[];
+}
+interface Nested3 {
+    kind: '3';
+    item1: Nested1;
+    list1: Nested1[];
+}
+
+function print(
+    // Using Nested1 because we're assuming you've already determined the kind
+    // of node based on some discriminated union. If you're determining the kind
+    // of node within the same place that you need access to the path, it's
+    // easiest to do something the to effect of:
+    //
+    //     if (node.kind === "1") {
+    //       const nodePath = path as AstPath<typeof node>;
+    //     }
+    //
+    // In the example above, nodePath will then be a type-narrowed version of
+    // the path variable that you can then use to correctly type the tree-walk
+    // functions.
+    path: prettier.AstPath<Nested1>,
+    options: prettier.ParserOptions<NestedAst>,
+    print: (path: prettier.AstPath<NestedAst>) => prettier.doc.builders.Doc,
+): prettier.doc.builders.Doc {
+    path.call(child => {
+        child; // $ExpectType AstPath<Nested1>
+    });
+
+    path.call(child => {
+        child; // $ExpectType AstPath<Nested2>
+    }, 'item2');
+
+    path.call(
+        child => {
+            child; // $ExpectType AstPath<Nested3>
+        },
+        'item2',
+        'item3',
+    );
+
+    path.call(
+        child => {
+            child; // $ExpectType AstPath<Nested1>
+        },
+        'item2',
+        'item3',
+        'item1',
+    );
+
+    path.call(
+        child => {
+            child; // $ExpectType AstPath<Nested2>
+        },
+        'item2',
+        'item3',
+        'item1',
+        'item2',
+    );
+
+    path.call(
+        child => {
+            child; // $ExpectType AstPath<any>
+        },
+        'item2',
+        'item3',
+        'item1',
+        'item2',
+        'item3',
+    );
+
+    path.each(child => {
+        child; // $ExpectType AstPath<Nested2>
+    }, 'list2');
+
+    path.each(
+        child => {
+            child; // $ExpectType AstPath<Nested3>
+        },
+        'list2',
+        0,
+        'list3',
+    );
+
+    path.each(
+        child => {
+            child; // $ExpectType AstPath<any>
+        },
+        'list2',
+        0,
+        'list3',
+        0,
+        'list1',
+    );
+
+    path.map(child => {
+        child; // $ExpectType AstPath<Nested2>
+    }, 'list2');
+
+    path.map(
+        child => {
+            child; // $ExpectType AstPath<Nested3>
+        },
+        'list2',
+        0,
+        'list3',
+    );
+
+    path.map(
+        child => {
+            child; // $ExpectType AstPath<any>
+        },
+        'list2',
+        0,
+        'list3',
+        0,
+        'list1',
+    );
+
+    path.call(print, 'list2'); // $ExpectError
+    path.call(print, 'item2', 'list3'); // $ExpectError
+
+    path.each(print, 'item2'); // $ExpectError
+    path.each(print, 'item2', 'item3'); // $ExpectError
+
+    path.map(print, 'item2'); // $ExpectError
+    path.map(print, 'item2', 'item3'); // $ExpectError
+
+    return '';
+}

--- a/types/pretty-quick/index.d.ts
+++ b/types/pretty-quick/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/azz/pretty-quick#readme
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.2
 
 import { ResolveConfigOptions } from 'prettier';
 


### PR DESCRIPTION
Previously when you would call one of the tree-walk functions (call,
each, and map) you would be asked to provide strings or numbers. So for
instance if you had an AST object like:

    { kind: "class", name: { kind: "const", value: "string" } }

you could have it recurse into the print function by calling:

    path.call(print, "name")

Unfortunately, that could also be "nam" or "namee" or "foobar" and it
wouldn't catch an error. The issue is it doesn't associate the property
key with the actual object that's being walked.

We can do better by specifying that call accepts a generic for the
property key that extends the keys of the object being walked. That
allows that property to be properly typed. There are function overrides
up to a depth of 4 properties. After that we just give up and use any so
we don't slow down compilation too much (it becomes expensive). We do a
similar thing for each and map, which have some additional complexity
because you only want to access properties that are iterable (which we
filter down to on allowable keys).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/prettier/prettier/blob/5a6897fe32eafa497f84e235a7ad878397a94951/src/common/ast-path.js#L52-L69>
