### PR TITLE
fix(atlassian-connect-js): improve listener signature of onAny event methods

### DIFF
--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -61,13 +61,14 @@ AP.events.on('name', data => console.log(data)); // $ExpectType void
 AP.events.onPublic('n', () => null, filter); // $ExpectType void
 AP.events.once('name', data => console.log(data)); // $ExpectType void
 AP.events.oncePublic('name', data => console.log(data), filter); // $ExpectType void
-AP.events.onAny(data => console.log(data)); // $ExpectType void
-AP.events.onAnyPublic(data => console.log(data), filter); // $ExpectType void
+AP.events.onAny((name, data) => console.log(name, data)); // $ExpectType void
+AP.events.onAnyPublic((name, data) => console.log(name, data), filter); // $ExpectType void
 AP.events.off('name', data => console.log(data)); // $ExpectType void
 AP.events.offPublic('name', data => console.log(data)); // $ExpectType void
 AP.events.offAll('name'); // $ExpectType void
 AP.events.offAllPublic('name'); // $ExpectType void
-AP.events.offAnyPublic(data => console.log(data)); // $ExpectType void
+AP.events.offAny((name, data) => console.log(name, data)); // $ExpectType void
+AP.events.offAnyPublic((name, data) => console.log(name, data)); // $ExpectType void
 AP.events.emit('name', ['data']); // $ExpectType void
 AP.events.emitPublic('name', ['data']); // $ExpectType void
 

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -660,7 +660,7 @@ declare namespace AP {
          * Listener arguments begin with the event name, followed by any arguments passed to `events.emit`, followed by an object describing the complete event information.
          * @param listener A listener callback to subscribe for any event name
          */
-        function onAny(listener: (data: object) => void): void;
+        function onAny(listener: (name: string, data: object) => void): void;
 
         /**
          * Adds a listener for all occurrences of any event, regardless of name.
@@ -671,7 +671,7 @@ declare namespace AP {
          * @param listener A listener callback to subscribe for any event name
          * @param filter A filter function to filter the events. Callback will always be called when a matching event occurs if the filter is unspecified
          */
-        function onAnyPublic(listener: (data: object) => void, filter: (toCompare: any) => boolean): void;
+        function onAnyPublic(listener: (name: string, data: object) => void, filter: (toCompare: any) => boolean): void;
 
         /**
          * Removes a particular listener for an event.
@@ -703,13 +703,13 @@ declare namespace AP {
          * Removes an `any` event listener.
          * @param listener A listener callback to unsubscribe from any event name
          */
-        function offAny(listener: (data: object) => void): void;
+        function offAny(listener: (name: string, data: object) => void): void;
 
         /**
          * Removes an `anyPublic` event listener.
          * @param listener A listener callback to unsubscribe from any event name
          */
-        function offAnyPublic(listener: (data: object) => void): void;
+        function offAnyPublic(listener: (name: string, data: object) => void): void;
 
         /**
          * Emits an event on this bus, firing listeners by name as well as all 'any' listeners.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.atlassian.com/cloud/confluence/jsapi/events/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

> Listener arguments begin with the event name, followed by any arguments passed to events.emit, followed by an object describing the complete event information.

Based on my logging only two arguments are actually passed:

```
AP.events.onAny((...args) => {
  console.log('event!');
  console.log(...args);
});

AP.events.onAnyPublic(
  (...args) => {
    console.log('public event!');
    console.log(args);
  },
  () => true
);

AP.events.emit('customEvent', [1, 2, 3]);
AP.events.emitPublic('customPublicEvent', []);
```

![image](https://user-images.githubusercontent.com/3151613/161617877-d63af954-2fda-49ff-b160-7642cd307862.png)

But I'm not sure how stable that is, how versioning of Atlassian products works, etc so for now have left the `data` type as `object` since people can easily slot in their own type.

Likewise the docs also imply that `filter` on `onAnyPublic` is optional but I couldn't get that event emitter to actually work so have left it as.