### PR TITLE
sequelize v4: allow non-array include options

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3292,7 +3292,7 @@ declare namespace sequelize {
         /**
          * Load further nested related models
          */
-        include?: Array<Model<any, any> | IncludeOptions> | undefined;
+        include?: Array<Model<any, any> | IncludeOptions> | Model<any, any> | IncludeOptions | undefined;
 
         /**
          * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will
@@ -3355,7 +3355,7 @@ declare namespace sequelize {
          * If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in
          * the as attribute when eager loading Y).
          */
-        include?: Array<Model<any, any> | IncludeOptions> | undefined;
+        include?: Array<Model<any, any> | IncludeOptions> | Model<any, any> | IncludeOptions | undefined;
 
         /**
          * Specifies an ordering. If a string is provided, it will be escaped. Using an array, you can provide
@@ -3436,7 +3436,7 @@ declare namespace sequelize {
         /**
          * Include options. See `find` for details
          */
-        include?: Array<Model<any, any> | IncludeOptions> | undefined;
+        include?: Array<Model<any, any> | IncludeOptions> | Model<any, any> | IncludeOptions | undefined;
 
         /**
          * Apply column on which COUNT() should be applied

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -944,6 +944,7 @@ User.findAll( {
 } );
 User.findAll( { paranoid : false, where : [' IS NOT NULL '], include : [{ model : User }] } );
 User.findAll( { include : [{ model : Task, paranoid: false }] } );
+User.findAll( { include : { model : Task, include: Task, paranoid: false } } );
 User.findAll( { transaction : t } );
 User.findAll( { where : { data : { name : { last : 's' }, employment : { $ne : 'a' } } }, order : [['id', 'ASC']] } );
 User.findAll( { where : { username : ['boo', 'boo2'] } } );
@@ -1113,6 +1114,7 @@ User.count( { transaction : t } );
 User.count().then( function( c ) { c.toFixed(); } );
 User.count( { where : ["username LIKE '%us%'"] } );
 User.count( { include : [{ model : User, required : false }] } );
+User.count( { include : User } );
 User.count( { distinct : true, include : [{ model : User, required : false }] } );
 User.count( { attributes : ['data'], group : ['data'] } );
 User.count( { where : { access_level : { gt : 5 } } } );


### PR DESCRIPTION
This PR adds support to non-array include options, that actually works in Sequelize v4.

Non-array `include` gets normalized in https://github.com/sequelize/sequelize/blob/v4.44.4/lib/model.js#L205 .
This normalization behavior still exists in latest v6 release so I am guessing it is a valid use.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

