### PR TITLE
[react-virtualized-select] Use same types as runtime peer dependencies

### DIFF
--- a/types/react-virtualized-select/tsconfig.json
+++ b/types/react-virtualized-select/tsconfig.json
@@ -5,6 +5,9 @@
             "es6",
             "dom"
         ],
+        "paths": {
+            "react": ["react/v16"]
+        },
         "jsx": "react",
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
https://github.com/bvaughn/react-virtualized-select/blob/3.1.3/package.json#L128

Current typings of `react-virtualized-select` would not be compatible with React 18 typings (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210).

However, this change reflects runtime requirements so this is good to get in anyway.
