### PR TITLE
xml2js: Add ValidationError type definition

### DIFF
--- a/types/xml2js/index.d.ts
+++ b/types/xml2js/index.d.ts
@@ -98,4 +98,8 @@ export interface convertableToString {
     toString(): string;
 }
 
+export class ValidationError extends Error {
+    constructor(message: string);
+}
+
 export { processors };

--- a/types/xml2js/xml2js-tests.ts
+++ b/types/xml2js/xml2js-tests.ts
@@ -103,3 +103,9 @@ fs.readFile(__dirname + '/foo.xml', (err, data) => {
         console.log('Done parseStringPromise');
     });
 });
+
+xml2js.parseString('<root>Hello xml2js!</root>', {
+    validator: (xpath: string, previousValue: any, newValue: any) => {
+        throw new xml2js.ValidationError('validation error');
+    }
+}, (err: Error | null, result: any) => { });


### PR DESCRIPTION
Added missing ValidationError definition which is required when using a validator. Example:
```typescript
xml2js.parseString('<root><element required_attribute="true"/></root>', {
    validator: (xpath: string, previousValue: any, newValue: any): any => {
        if (xpath == '/root/element' && !(newValue.$ && newValue.$.required_attribute)) {
            throw new xml2js.ValidationError('Missing required attribute');
        }
        return newValue
    }
}, (err: Error | null, result: any) => { });
```


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/Leonidas-from-XIV/node-xml2js/blob/0.4.0/src/xml2js.coffee#L65
https://github.com/Leonidas-from-XIV/node-xml2js/blob/0.4.22/src/xml2js.coffee#L12
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.