### PR TITLE
[atlassian-connect-js] Updates from Atlassian, other improvements

### DIFF
--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -5,8 +5,19 @@ AP.resize('10px', '10px'); // $ExpectType void
 AP.sizeToParent(true); // $ExpectType void
 AP.hideFooter(true); // $ExpectType void
 AP.addRequestMarshal(); // $ExpectType void
+AP.request('http://example.com'); // $ExpectType Promise<{ body: string; xhr: XMLHttpRequest }>
 AP.request('http://example.com', {}); // $ExpectType Promise<{ body: string; xhr: XMLHttpRequest }>
+AP.request('http://example.com', { binaryAttachment: false }); // $ExpectType Promise<{ body: string; xhr: XMLHttpRequest }>
 AP.request({ url: 'http://example.com' }); // $ExpectType Promise<{ body: string; xhr: XMLHttpRequest }>
+AP.request({ url: 'http://example.com', binaryAttachment: false }); // $ExpectType Promise<{ body: string; xhr: XMLHttpRequest }>
+AP.request('http://example.com', { success: (response: string) => {} }); // $ExpectType Promise<{ body: string; xhr: XMLHttpRequest }>
+AP.request('http://example.com', { binaryAttachment: false, success: (response: string) => {} }); // $ExpectType Promise<{ body: string; xhr: XMLHttpRequest }>
+AP.request({ url: 'http://example.com', success: (response: string) => {} }); // $ExpectType Promise<{ body: string; xhr: XMLHttpRequest }>
+AP.request({ url: 'http://example.com', binaryAttachment: false, success: (response: string) => {} }); // $ExpectType Promise<{ body: string; xhr: XMLHttpRequest }>
+AP.request('http://example.com', { binaryAttachment: true }); // $ExpectType Promise<{ body: ArrayBuffer; xhr: XMLHttpRequest }>
+AP.request({ url: 'http://example.com', binaryAttachment: true }); // $ExpectType Promise<{ body: ArrayBuffer; xhr: XMLHttpRequest }>
+AP.request('http://example.com', { binaryAttachment: true, success: (response: ArrayBuffer) => {} }); // $ExpectType Promise<{ body: ArrayBuffer; xhr: XMLHttpRequest }>
+AP.request({ url: 'http://example.com', binaryAttachment: true, success: (response: ArrayBuffer) => {} }); // $ExpectType Promise<{ body: ArrayBuffer; xhr: XMLHttpRequest }>
 
 AP.confluence.saveMacro({foo: 'bar'}, "a new macro body"); // $ExpectType void
 AP.confluence.saveMacro({foo: 'bar'}); // $ExpectType void
@@ -98,8 +109,18 @@ AP.jira.isNativeApp(isNative => console.log(isNative)); // $ExpectType void
 AP.navigator.getLocation(location => console.log(location)); // $ExpectType void
 AP.navigator.go('contentview', {}); // $ExpectType void
 AP.navigator.go('issue', {}); // $ExpectType void
-AP.navigator.go('addonModule', { addonKey: 'my-addon-key', moduleKey: 'my-module-key', customData: { foo: 'bar', answer: 42, valid: true, undef: undefined, nil: null }}); // $ExpectType void
-AP.navigator.go('addonModule', { addonKey: 'my-addon-key', moduleKey: 'my-module-key', customData: { arr: ['bar', 42, false, null, undefined] }}); // $ExpectType void
+// $ExpectType void
+AP.navigator.go('addonModule', {
+    addonKey: 'my-addon-key',
+    moduleKey: 'my-module-key',
+    customData: { foo: 'bar', answer: 42, valid: true, undef: undefined, nil: null },
+});
+// $ExpectType void
+AP.navigator.go('addonModule', {
+    addonKey: 'my-addon-key',
+    moduleKey: 'my-module-key',
+    customData: { arr: ['bar', 42, false, null, undefined] },
+});
 AP.navigator.reload(); // $ExpectType void
 
 AP.user.getUser(user => console.log(user.id, user.key, user.fullName)); // $ExpectType void

--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -98,6 +98,8 @@ AP.jira.isNativeApp(isNative => console.log(isNative)); // $ExpectType void
 AP.navigator.getLocation(location => console.log(location)); // $ExpectType void
 AP.navigator.go('contentview', {}); // $ExpectType void
 AP.navigator.go('issue', {}); // $ExpectType void
+AP.navigator.go('addonModule', { addonKey: 'my-addon-key', moduleKey: 'my-module-key', customData: { foo: 'bar', answer: 42, valid: true, undef: undefined, nil: null }}); // $ExpectType void
+AP.navigator.go('addonModule', { addonKey: 'my-addon-key', moduleKey: 'my-module-key', customData: { arr: ['bar', 42, false, null, undefined] }}); // $ExpectType void
 AP.navigator.reload(); // $ExpectType void
 
 AP.user.getUser(user => console.log(user.id, user.key, user.fullName)); // $ExpectType void

--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -19,15 +19,18 @@ AP.request({ url: 'http://example.com', binaryAttachment: true }); // $ExpectTyp
 AP.request('http://example.com', { binaryAttachment: true, success: (response: ArrayBuffer) => {} }); // $ExpectType Promise<{ body: ArrayBuffer; xhr: XMLHttpRequest }>
 AP.request({ url: 'http://example.com', binaryAttachment: true, success: (response: ArrayBuffer) => {} }); // $ExpectType Promise<{ body: ArrayBuffer; xhr: XMLHttpRequest }>
 
-AP.confluence.saveMacro({foo: 'bar'}, "a new macro body"); // $ExpectType void
-AP.confluence.saveMacro({foo: 'bar'}); // $ExpectType void
+AP.confluence.saveMacro({ foo: 'bar' }, 'a new macro body'); // $ExpectType void
+AP.confluence.saveMacro({ foo: 'bar' }); // $ExpectType void
 AP.confluence.closeMacroEditor(); // $ExpectType void
 AP.confluence.getMacroBody(body => console.log(body)); // $ExpectType void
 AP.confluence.getMacroData(data => console.log(data)); // $ExpectType void
-AP.confluence.onMacroPropertyPanelEvent({"{event-type}.{control-key}.{macro-key}.macro.property-panel": () => null}); // $ExpectType void
+AP.confluence.onMacroPropertyPanelEvent({ '{event-type}.{control-key}.{macro-key}.macro.property-panel': () => null }); // $ExpectType void
 AP.confluence.closeMacroPropertyPanel(); // $ExpectType void
 AP.confluence.getContentProperty('propertyKey', property => console.log(property)); // $ExpectType void
-AP.confluence.setContentProperty({ key: 'propertyKey', value: 'propertyValue', version: { number: 2 }}, result => console.log(result)); // $ExpectType void
+// $ExpectType void
+AP.confluence.setContentProperty({ key: 'propertyKey', value: 'propertyValue', version: { number: 2 } }, result =>
+    console.log(result),
+);
 AP.confluence.syncPropertyFromServer('propertyKey', property => console.log(property)); // $ExpectType void
 
 AP.context.getToken(token => console.log(token)); // $ExpectType void

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -5,47 +5,65 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace AP {
-    interface RequestOptions {
+    type RequestOptions = {
         /**
          * The HTTP method name.
          */
-        type: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'PATCH';
+        type?: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'PATCH';
 
         /**
          * If the request should be cached.
          */
-        cache: boolean;
+        cache?: boolean;
 
         /**
          * The body of the request; required if type is 'POST' or 'PUT'. Optionally, for 'GET' this will append the object as key=value pairs to the end of the URL query string.
          */
-        data: string | object;
+        data?: string | object;
 
         /**
          * The content-type string value of the entity body, above; required when data is supplied.
          */
-        contentType: string;
+        contentType?: string;
 
         /**
          * An object containing headers to set; supported headers are: 'Accept', 'If-Match' and 'If-None-Match'.
          */
-        headers: { Accept: string; 'If-Match': string; 'If-None-Match': string };
-
-        /**
-         * An optional callback function executed on a 200 success status code.
-         */
-        success: (response: string) => void;
+        headers?: { Accept: string; 'If-Match': string; 'If-None-Match': string };
 
         /**
          * An optional callback function executed when a HTTP status error code is returned.
          */
-        error: (xhr: XMLHttpRequest, statusText: string, errorThrown: any) => void;
+        error?: (xhr: XMLHttpRequest, statusText: string, errorThrown: any) => void;
 
         /**
          * If this is set to true, the developer acknowledges that the API endpoint which is being called may be in beta state, and thus may also have a shorter deprecation cycle than stable APIs.
          */
-        experimental: boolean;
-    }
+        experimental?: boolean;
+    } & (
+        | {
+              /**
+               * An optional callback function executed on a 200 success status code.
+               */
+              success?: (response: string) => void;
+
+              /**
+               * If this is set to true, the developer is specifying a request for an attachment consisting of binary data (e.g. an image) and the format of the response will be set to "arraybuffer".
+               */
+              binaryAttachment?: false;
+          }
+        | {
+              /**
+               * An optional callback function executed on a 200 success status code.
+               */
+              success?: (response: ArrayBuffer) => void;
+
+              /**
+               * If this is set to true, the developer is specifying a request for an attachment consisting of binary data (e.g. an image) and the format of the response will be set to "arraybuffer".
+               */
+              binaryAttachment: true;
+          }
+    );
 
     function defineGlobal(module: object): void;
     function defineModule(name: string, module: object): void;
@@ -92,15 +110,50 @@ declare namespace AP {
      * @param url Either the URI to request or an options object (as below) containing at least a 'url' property; This value should be relative to the context path of the host application.
      * @param options The options of the request.
      */
-    function request(url: string, options?: Partial<RequestOptions>): Promise<{ body: string; xhr: XMLHttpRequest }>;
+    function request(
+        url: string,
+        options?: {
+            /**
+             * If this is set to true, the developer is specifying a request for an attachment consisting of binary data (e.g. an image) and the format of the response will be set to "arraybuffer".
+             */
+            binaryAttachment?: false;
+        } & RequestOptions,
+    ): Promise<{ body: string; xhr: XMLHttpRequest }>;
     function request(
         options: {
             /**
              * The url to request from the host application, relative to the host's context path
              */
             url: string;
-        } & Partial<RequestOptions>,
+
+            /**
+             * If this is set to true, the developer is specifying a request for an attachment consisting of binary data (e.g. an image) and the format of the response will be set to "arraybuffer".
+             */
+            binaryAttachment?: false;
+        } & RequestOptions,
     ): Promise<{ body: string; xhr: XMLHttpRequest }>;
+    function request(
+        url: string,
+        options: {
+            /**
+             * If this is set to true, the developer is specifying a request for an attachment consisting of binary data (e.g. an image) and the format of the response will be set to "arraybuffer".
+             */
+            binaryAttachment: true;
+        } & RequestOptions,
+    ): Promise<{ body: ArrayBuffer; xhr: XMLHttpRequest }>;
+    function request(
+        options: {
+            /**
+             * The url to request from the host application, relative to the host's context path
+             */
+            url: string;
+
+            /**
+             * If this is set to true, the developer is specifying a request for an attachment consisting of binary data (e.g. an image) and the format of the response will be set to "arraybuffer".
+             */
+            binaryAttachment: true;
+        } & RequestOptions,
+    ): Promise<{ body: ArrayBuffer; xhr: XMLHttpRequest }>;
 
     /**
      * A Confluence specific JavaScript module which provides functions to interact with the macro editor.

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -825,6 +825,8 @@ declare namespace AP {
         /**
          * Gets the selected text on the page.
          * @param callback method to be executed with the selected text.
+         * @deprecated This method has been deprecated by Atlassian for security reasons and will always return an empty string as of 2022-07-11.
+         * @see {@link https://community.developer.atlassian.com/t/deprecation-of-connect-js-getselectedtext-api-for-security-reasons/54968}
          */
         function getSelectedText(callback: (selection: string) => void): void;
     }

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -1078,6 +1078,9 @@ declare namespace AP {
              */
             | 'site';
 
+        type CustomDataBasicValue = string | number | boolean | null | undefined;
+        type CustomDataValue = CustomDataBasicValue | CustomDataBasicValue[];
+
         interface NavigatorContext {
             /**
              * Identifies a piece of content. Required for the `contentView` target.
@@ -1142,8 +1145,10 @@ declare namespace AP {
             /**
              * Contains parameters that will be added as query parameters to the product url with "ac." prepended.
              * Used only in `addonModule` target. See Add-on specific context parameters for more info.
+             * @example Passing { foo: 'bar' } here causes your iframe to be called with "...?ac.foo=bar"
+             * @see {@link https://developer.atlassian.com/cloud/confluence/context-parameters#apps}
              */
-            customData: string;
+            customData: Record<string, CustomDataValue>;
 
             /**
              * Identifies a version of a piece of content in Confluence. This parameter is optional, and only applies to the `contentView` target, allowing navigation to a specific version.

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -272,7 +272,10 @@ declare namespace AP {
          *    alert(result.error);    // if unsuccessful, the reason for the failure
          * });
          */
-        function setContentProperty(contentProperty: ContentProperty, callback: (result: {property: ContentProperty} | {error: string}) => void): void;
+        function setContentProperty(
+            contentProperty: ContentProperty,
+            callback: (result: { property: ContentProperty } | { error: string }) => void,
+        ): void;
 
         /**
          * Raise contentProperty.update event for the Content Property with the given key on the current Content. It also provide content property to the callback like getContentProperty does.
@@ -1055,37 +1058,37 @@ declare namespace AP {
             /**
              * A specific dashboard in Jira. Takes a `dashboardId` to identify the dashboard.
              */
-            'dashboard' |
+            | 'dashboard'
 
             /**
              * A specific Issue in Jira. Takes an `issueKey` to identify the issue.
              */
-            'issue' |
+            | 'issue'
 
             /**
              * The module page within a specific add-on. Takes an `addonKey` and a `moduleKey` to identify the correct module.
              */
-            'addonModule' |
+            | 'addonModule'
 
             /**
              * The profile page for a Jira User. Takes a `username` or `userAccountId` to identify the user.
              */
-            'userProfile' |
+            | 'userProfile'
 
             /**
              * The admin details of a specific Jira Project. Takes a `projectKey` to identify the project. Only accessible to administrators.
              */
-            'projectAdminSummary' |
+            | 'projectAdminSummary'
 
             /**
              * The admin panel definted by a connect addon. Takes an `addonKey`, `adminPageKey`, `projectKey` and `projectId`. Only accessible to administrators.
              */
-            'projectAdminTabPanel' |
+            | 'projectAdminTabPanel'
 
             /**
              * A specific location contained within the site. Takes either a `relativeUrl` or `absoluteUrl` to identify the path.
              */
-            'site';
+            | 'site';
 
         type NavigatorTargetConfluence =
             /**


### PR DESCRIPTION
This PR contains the following improvements:

- Add deprecation hint to Confluence's `AP.host.getSelectedText()` as per https://community.developer.atlassian.com/t/deprecation-of-connect-js-getselectedtext-api-for-security-reasons/54968
-  Add parameter `binaryAttachment` to `AP.request()`, including the implications on the response type as per https://jira.atlassian.com/browse/CONFCLOUD-72542 . Unfortunately, this lead to even more signatures of the function and to implications on the related Options type, but I don't see a shorter way of accurately expressing the change.
- Fix type of `NavigatorContext["customData"]` from `string` to a `Record` type. This is not well documented by Atlassian, but the docs at https://developer.atlassian.com/cloud/confluence/jsapi/classes/context/ hint at this. It was experimentally verified by me.
- I had apparently previously forgotten to run `prettier` on my earlier PRs, so this fixes that.

Each change is in its own commit, which is easier to read. I can also split this PR if that's preferred.
Let me know if something is amiss or needs clarification.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. NOT APPLICABLE
