### PR TITLE
[eonasdan-bootstrap-datetimepicker] Deconstify enums

### DIFF
--- a/types/eonasdan-bootstrap-datetimepicker/eonasdan-bootstrap-datetimepicker-tests.ts
+++ b/types/eonasdan-bootstrap-datetimepicker/eonasdan-bootstrap-datetimepicker-tests.ts
@@ -1,5 +1,4 @@
 import * as moment from 'moment';
-import * as EonasdanBootstrapDatetimepicker from 'eonasdan-bootstrap-datetimepicker';
 
 // Minimum Setup
 $("#datetimepicker1").datetimepicker();
@@ -59,7 +58,7 @@ $("#datetimepicker10").datetimepicker({
 
 // Disabled Days of the Week
 $("#datetimepicker11").datetimepicker({
-    daysOfWeekDisabled: [0, 6, EonasdanBootstrapDatetimepicker.DayOfWeek.Thursday]
+    daysOfWeekDisabled: [0, 6, 4]
 });
 
 // Inline

--- a/types/eonasdan-bootstrap-datetimepicker/index.d.ts
+++ b/types/eonasdan-bootstrap-datetimepicker/index.d.ts
@@ -61,15 +61,14 @@ export interface Icons {
     close?: string | undefined;
 }
 
-export declare const enum DayOfWeek {
-    Sunday = 0,
-    Monday = 1,
-    Tuesday = 2,
-    Wednesday = 3,
-    Thursday = 4,
-    Friday = 5,
-    Saturday = 6
-}
+export type DayOfWeek =
+    | 0 /* Sunday */
+    | 1 /* Monday */
+    | 2 /* Tuesday */
+    | 3 /* Wednesday */
+    | 4 /* Thursday */
+    | 5 /* Friday */
+    | 6 /* Saturday */;
 
 export type ViewMode = "days" | "months" | "years" | "decades";
 

--- a/types/eonasdan-bootstrap-datetimepicker/tslint.json
+++ b/types/eonasdan-bootstrap-datetimepicker/tslint.json
@@ -6,7 +6,6 @@
         "interface-over-type-literal": false,
         "jsdoc-format": false,
         "max-line-length": false,
-        "no-const-enum": false,
         "no-var-keyword": false,
         "only-arrow-functions": false,
         "prefer-const": false,


### PR DESCRIPTION
These const enums [can't be used with single-file transpilation](https://www.typescriptlang.org/tsconfig#references-to-const-enum-members), i.e. `isolatedModules`:

```sh
error TS2748: Cannot access ambient const enums when the '--isolatedModules' flag is provided.
```

Can they be changed to types?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).