### PR TITLE
[@ember/component/helper] Make `FunctionBasedHelper` an (abstract) constructor type

### DIFF
--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -114,6 +114,16 @@ export default class Helper<S = unknown> extends EmberObject {
 // tslint:disable-next-line:no-unnecessary-generics
 export default interface Helper<S> extends Opaque<S> {}
 
+// This type exists to provide a non-user-constructible, non-subclassable
+// type representing the conceptual "instance type" of a function helper.
+// The abstract field of type `never` presents subclassing in userspace of
+// the value returned from `helper()`. By extending `Helper<S>`, any
+// augmentations of the `Helper` type performed by tools like Glint will
+// also apply to function-based helpers as well.
+export abstract class FunctionBasedHelperInstance<S> extends Helper<S> {
+    protected abstract __concrete__: never;
+}
+
 /**
  * The type of a function-based helper.
  *
@@ -121,13 +131,11 @@ export default interface Helper<S> extends Opaque<S> {}
  *   returned by the `helper` function can be named (and indeed can be exported
  *   like `export default helper(...)` safely).
  */
-// The generic here is for a *signature: a way to hang information for tools
-// like Glint which can provide typey checking for component templates using
-// information supplied via this generic. While it may appear useless on this
-// class definition and extension, it is used by external tools and should not
-// be removed.
-// tslint:disable-next-line:no-unnecessary-generics
-export interface FunctionBasedHelper<S> extends Opaque<S> {}
+// Making `FunctionBasedHelper` a bare constructor type allows for type
+// parameters to be preserved when `helper()` is passed a generic function.
+// By making it `abstract` and impossible to subclass (see above), we prevent
+// users from attempting to instantiate a return value from `helper()`.
+export type FunctionBasedHelper<S> = abstract new () => FunctionBasedHelperInstance<S>;
 
 /**
  * In many cases, the ceremony of a full `Helper` class is not required.

--- a/types/ember__component/test/helper.ts
+++ b/types/ember__component/test/helper.ts
@@ -98,3 +98,14 @@ const badNamedArgsSig = helper<DemoSig>(([i18nizer], { name, age, potato }) => i
 
 // $ExpectError
 const badReturnSig = helper<DemoSig>(([i18nizer], { name, age }) => Boolean(i18nizer(`${name} is ${age} years old`)));
+
+const greet = helper(([name]: [string]) => `Hello, ${name}`);
+
+// $ExpectError
+new greet();
+
+// $ExpectError
+class Subgreet extends greet {}
+
+// $ExpectType abstract new <T>() => FunctionBasedHelperInstance<{ Args: { Positional: [T]; Named: EmptyObject; }; Return: [T, T]; }>
+const pair = helper(<T>([item]: [T]): [T, T] => [item, item]);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Based on conversations with @chriskrycho this afternoon, this change allows `helper()` to accept generic functions, preserving their type parameter(s) in the type of the resulting value by virtue of it being an abstract constructor type.

This type is declared to produce an abstract subtype of the class-based `Helper`, so that a single augmentation from a tool like Glint will apply to all helpers produced from `@ember/component/helper`, regardless of whether they're class- or function-based.