### PR TITLE
[@ember/component/helper] Handle missing helper signatures more gracefully

### DIFF
--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -92,6 +92,10 @@ export interface ExpandSignature<T> {
     Return: 'Return' extends keyof T ? T['Return'] : unknown;
 }
 
+// The `unknown extends S` checks on both of these are here to preserve backward
+// compatibility with the existing non-`Signature` definition. When migrating
+// into Ember or otherwise making a breaking change, we can drop the "default"
+// in favor of just using `ExpandSignature`.
 type NamedArgs<S> = unknown extends S ? Record<string, unknown> : ExpandSignature<S>['Args']['Named'];
 type PositionalArgs<S> = unknown extends S ? unknown[] : ExpandSignature<S>['Args']['Positional'];
 

--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -53,6 +53,19 @@ interface LegacyArgsFor<T> {
     Positional: GetOrElse<T, 'PositionalArgs', DefaultPositional>;
 }
 
+// This type allows us to present a slightly-less-obtuse error message
+// when attempting to resolve the signature of a helper that doesn't have
+// one declared from within a tool like Glint.
+declare const BadType: unique symbol;
+interface BadType<Message> {
+    [BadType]: Message;
+}
+
+interface MissingSignatureArgs {
+    Named: BadType<'This helper is missing a signature'>;
+    Positional: unknown[];
+}
+
 /**
  * Given any allowed shorthand form of a signature, desugars it to its full
  * expanded type.
@@ -71,14 +84,16 @@ interface LegacyArgsFor<T> {
 // all `ExpandSignature` types fully general to work with *any* invokable. But
 // "future" here probably means Ember v5. :sobbing:
 export interface ExpandSignature<T> {
-    Args: keyof T extends 'Args' | 'Return' // Is this a `Signature`?
+    Args: unknown extends T // Is this the default (i.e. unspecified) signature?
+        ? MissingSignatureArgs // Then return our special "missing signature" type
+        : keyof T extends 'Args' | 'Return' // Is this a `Signature`?
         ? ArgsFor<T> // Then use `Signature` args
         : LegacyArgsFor<T>; // Otherwise fall back to classic `Args`.
     Return: 'Return' extends keyof T ? T['Return'] : unknown;
 }
 
-type NamedArgs<S> = ExpandSignature<S>['Args']['Named'];
-type PositionalArgs<S> = ExpandSignature<S>['Args']['Positional'];
+type NamedArgs<S> = unknown extends S ? Record<string, unknown> : ExpandSignature<S>['Args']['Named'];
+type PositionalArgs<S> = unknown extends S ? unknown[] : ExpandSignature<S>['Args']['Positional'];
 
 type Return<S> = GetOrElse<S, 'Return', unknown>;
 

--- a/types/ember__component/test/helper.ts
+++ b/types/ember__component/test/helper.ts
@@ -1,4 +1,4 @@
-import Helper, { helper } from '@ember/component/helper';
+import Helper, { ExpandSignature, helper } from '@ember/component/helper';
 
 class DeprecatedSignatureForm extends Helper<{
     PositionalArgs: [offset: Date];
@@ -32,7 +32,24 @@ interface DemoSig {
     Return: string;
 }
 
+function testMissingSignature({ Args, Return }: ExpandSignature<unknown>) {
+    // $ExpectType BadType<"This helper is missing a signature">
+    Args.Named;
+
+    // $ExpectType unknown[]
+    Args.Positional;
+
+    // $ExpectType unknown
+    Return;
+}
+
 class SignatureForm extends Helper<DemoSig> {
+    compute([i18nizer]: [i18nizer: (s: string) => string], { name, age }: { name: string; age: number }): string {
+        return i18nizer(`${name} is ${age} years old`);
+    }
+}
+
+class NoSignatureForm extends Helper {
     compute([i18nizer]: [i18nizer: (s: string) => string], { name, age }: { name: string; age: number }): string {
         return i18nizer(`${name} is ${age} years old`);
     }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

I'm pitching this as an alternative to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59657 after _loooong_ stretch of brainstorming possibilities this afternoon with @chriskrycho 😄 

To preserve backwards compatibility with the versions of `@types/ember__component` prior to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59541, this PR (like #59657) allows for users to subclass `Helper` without providing an explicit `Signature` type. The key difference in this approach is that the default signature is still one that will prevent users from attempting to invoke the helper, preserving safety within systems like Glint.