### PR TITLE
[itemsjs] Add types for itemsjs

### DIFF
--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -29,7 +29,9 @@ declare namespace itemsjs {
 
     interface SearchOptions<I extends {}, S extends string, A extends string> {
         query?: string | undefined;
+        /** @default 1 */
         page?: number | undefined;
+        /** @default 12 */
         per_page?: number | undefined;
         /** The name of a sort defined in the configuration's sortings, or a new custom one */
         sort?: S | Sorting<I> | undefined;
@@ -38,13 +40,16 @@ declare namespace itemsjs {
         filter?: ((item: I) => boolean) | undefined;
         /** A custom function to filter values before `filter` and `filters` are considered */
         prefilter?: ((item: I) => boolean) | undefined;
+        /** @default false */
         isExactSearch?: boolean | undefined;
         removeStopWordFilter?: boolean | undefined;
     }
 
     interface AggregationOptions<A extends string> {
         name: A;
+        /** @default 1 */
         page?: number | undefined;
+        /** @default 10 */
         per_page?: number | undefined;
         query?: string | undefined;
         conjunction?: boolean | undefined;
@@ -52,8 +57,11 @@ declare namespace itemsjs {
 
     interface SimilarOptions<I extends {}> {
         field: keyof I & string;
+        /** @default 0 */
         minimum?: number | undefined;
+        /** @default 1 */
         page?: number | undefined;
+        /** @default 10 */
         per_page?: number | undefined;
     }
 
@@ -110,6 +118,7 @@ declare namespace itemsjs {
         size?: number | undefined;
         /** @default 'count' */
         sort?: 'term' | 'count' | undefined;
+        /** @default 'asc' */
         order?: Order | undefined;
         /** @default false */
         show_facet_stats?: boolean | undefined;

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -133,6 +133,8 @@ declare namespace itemsjs {
         searchableFields?: Array<keyof I> | undefined;
         /** @default false */
         isExactSearch?: boolean | undefined;
+        /** @default true */
+        native_search_enabled?: boolean | undefined;
     }
 }
 

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -42,7 +42,10 @@ declare namespace itemsjs {
         prefilter?: ((item: I) => boolean) | undefined;
         /** @default false */
         isExactSearch?: boolean | undefined;
+        /** @default false */
         removeStopWordFilter?: boolean | undefined;
+        /** @default false */
+        is_all_filtered_items?: boolean | undefined;
     }
 
     interface AggregationOptions<A extends string> {
@@ -128,6 +131,7 @@ declare namespace itemsjs {
     interface Configuration<I extends {}, S extends string, A extends string> {
         sortings?: Record<S, Sorting<I>> | undefined;
         aggregations?: Record<A, Aggregation> | undefined;
+        /** @default [] */
         searchableFields?: Array<keyof I> | undefined;
         /** @default false */
         isExactSearch?: boolean | undefined;

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -109,12 +109,12 @@ declare namespace itemsjs {
 
     interface Sorting<I extends {}> {
         field: keyof I | Array<keyof I>;
-        order: Order | Order[];
+        order?: Order | Order[] | undefined;
     }
 
     interface Aggregation {
         title: string;
-        conjunction?: boolean;
+        conjunction?: boolean | undefined;
         /** @default 10 */
         size?: number | undefined;
         /** @default 'count' */

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -111,6 +111,7 @@ declare namespace itemsjs {
         /** @default 'count' */
         sort?: 'term' | 'count' | undefined;
         order?: Order | undefined;
+        /** @default false */
         show_facet_stats?: boolean | undefined;
     }
 

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -1,0 +1,130 @@
+// Type definitions for itemsjs 2.1
+// Project: https://github.com/itemsapi/itemsjs
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace itemsjs;
+
+declare namespace itemsjs {
+    interface Bucket<I extends {}> {
+        key: keyof I & string;
+        doc_count: number;
+        selected: boolean;
+    }
+
+    interface SearchAggregation<I extends {}, A extends string> {
+        name: A;
+        title: string;
+        position: number;
+        buckets: Array<Bucket<I>>;
+    }
+
+    interface Pagination {
+        page: number;
+        per_page: number;
+        total: number;
+    }
+
+    interface itemsjs<I extends {}, S extends string, A extends string> {
+        /** Search items */
+        search(options?: {
+            query?: string | undefined;
+            page?: number | undefined;
+            per_page?: number | undefined;
+            /** The name of a sort defined in the configuration's sortings, or a new custom one */
+            sort?: S | Sorting<I> | undefined;
+            filters?: Partial<Record<A, string[]>> | undefined;
+            /** A custom function to filter values */
+            filter?: ((item: I) => boolean) | undefined;
+            /** A custom function to filter values before `filter` and `filters` are considered */
+            prefilter?: ((item: I) => boolean) | undefined;
+            isExactSearch?: boolean | undefined;
+            removeStopWordFilter?: boolean | undefined;
+        }): {
+            data: {
+                items: I[];
+                allFilteredItems: null;
+                aggregations: Record<A, SearchAggregation<I, A>>;
+            };
+            pagination: Pagination;
+            timings: {
+                facets: number;
+                search: number;
+                sorting: number;
+                total: number;
+            };
+        };
+
+        /** Get data for aggregation */
+        aggregation(options: {
+            name: A;
+            page?: number | undefined;
+            per_page?: number | undefined;
+            query?: string | undefined;
+            conjunction?: boolean | undefined;
+        }): {
+            data: { buckets: Array<Bucket<I>> };
+            pagination: Pagination;
+        };
+
+        /**
+         * Find similar items.
+         * Uses the `id` key on items to check for uniqueness
+         */
+        similar(
+            id: I extends { id: infer ID } ? ID : unknown,
+            options: {
+                field: keyof I & string;
+                minimum?: number | undefined;
+                page?: number | undefined;
+                per_page?: number | undefined;
+            },
+        ): {
+            data: { items: Array<I & { _id: number; intersection_length: number }> };
+            pagination: Pagination;
+        };
+
+        /** Reindex with an entirely new list of items */
+        reindex(data: I[]): void;
+    }
+
+    type Order = 'asc' | 'desc';
+
+    interface Sorting<I extends {}> {
+        field: keyof I | Array<keyof I>;
+        order: Order | Order[];
+    }
+
+    interface Aggregation {
+        title: string;
+        conjunction?: boolean;
+        /** @default 10 */
+        size?: number | undefined;
+        /** @default 'count' */
+        sort?: 'term' | 'count' | undefined;
+        order?: Order | undefined;
+        show_facet_stats?: boolean | undefined;
+    }
+
+    /** Configuration for itemsjs */
+    interface Configuration<I extends {}, S extends string, A extends string> {
+        sortings?: Record<S, Sorting<I>> | undefined;
+        aggregations?: Record<A, Aggregation> | undefined;
+        searchableFields?: Array<keyof I>;
+        /** @default false */
+        isExactSearch?: boolean | undefined;
+    }
+}
+
+/**
+ * Main itemsjs function
+ * @param items The items to index
+ * @param configuration itemsjs
+ * @template I The type of items being indexed
+ */
+declare function itemsjs<I extends {} = Record<any, unknown>, S extends string = string, A extends string = string>(
+    items: I[],
+    configuration?: itemsjs.Configuration<I, S, A>,
+): itemsjs.itemsjs<I, S, A>;
+
+export = itemsjs;

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -38,8 +38,6 @@ declare namespace itemsjs {
         filters?: Partial<Record<A, string[]>> | undefined;
         /** A custom function to filter values */
         filter?: ((item: I) => boolean) | undefined;
-        /** A custom function to filter values before `filter` and `filters` are considered */
-        prefilter?: ((item: I) => boolean) | undefined;
         /** @default false */
         isExactSearch?: boolean | undefined;
         /** @default false */

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -71,7 +71,7 @@ declare namespace itemsjs {
         search(options?: SearchOptions<I, S, A>): {
             data: {
                 items: I[];
-                allFilteredItems: null;
+                allFilteredItems: I[] | null;
                 aggregations: Record<A, SearchAggregation<I, A>>;
             };
             pagination: Pagination;

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -131,8 +131,6 @@ declare namespace itemsjs {
         aggregations?: Record<A, Aggregation> | undefined;
         /** @default [] */
         searchableFields?: Array<keyof I> | undefined;
-        /** @default false */
-        isExactSearch?: boolean | undefined;
         /** @default true */
         native_search_enabled?: boolean | undefined;
     }

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -66,7 +66,7 @@ declare namespace itemsjs {
         per_page?: number | undefined;
     }
 
-    interface itemsjs<I extends {}, S extends string, A extends string> {
+    interface ItemsJs<I extends {}, S extends string, A extends string> {
         /** Search items */
         search(options?: SearchOptions<I, S, A>): {
             data: {
@@ -145,6 +145,6 @@ declare namespace itemsjs {
 declare function itemsjs<I extends {} = Record<any, unknown>, S extends string = string, A extends string = string>(
     items: I[],
     configuration?: itemsjs.Configuration<I, S, A>,
-): itemsjs.itemsjs<I, S, A>;
+): itemsjs.ItemsJs<I, S, A>;
 
 export = itemsjs;

--- a/types/itemsjs/itemsjs-tests.ts
+++ b/types/itemsjs/itemsjs-tests.ts
@@ -1,0 +1,80 @@
+import itemsjs = require('itemsjs');
+
+const myitems = [
+    { name: 'foo', anumber: 123 },
+    { name: 'bar', anumber: 456 },
+    { name: 'abc', anumber: 789 },
+];
+
+// No config
+itemsjs(myitems);
+// Empty config
+itemsjs(myitems, {});
+
+// Invalid sort
+// $ExpectError
+itemsjs(myitems, { sortings: { foo: {} } });
+
+const items = itemsjs(myitems, {
+    sortings: {
+        foo: {
+            field: 'name',
+            order: 'asc',
+        },
+    },
+    aggregations: {
+        anAggregation: {
+            title: 'A Number',
+            conjunction: false,
+        },
+    },
+});
+
+items.search({ query: 'abc' });
+
+items.search({ query: 'abc', sort: 'foo' });
+
+// Sort 'bar' was never defined
+// $ExpectError
+items.search({ query: 'abc', sort: 'bar' });
+
+items.search({
+    query: 'abc',
+    sort: {
+        field: 'anumber',
+        order: 'desc',
+    },
+});
+
+items.search({
+    query: 'abc',
+    filters: {}, // No filters provided
+});
+
+// Aggregation 'bar' was never defined
+items.search({
+    query: 'abc',
+    // $ExpectError
+    filters: { bar: [] },
+});
+
+items.search({
+    query: 'abc',
+    filters: { anAggregation: ['abc'] },
+});
+
+itemsjs<typeof myitems[number]>([]).reindex(myitems);
+
+const myItemsIds = myitems.map((v, i) => ({ id: i, ...v }));
+
+const itemsIds = itemsjs(myItemsIds);
+
+// ID 'abc' is invalid
+// $ExpectError
+itemsIds.similar('abc', { field: 'name' });
+
+// Missing options & missing field key
+itemsIds.similar(0); // $ExpectError
+itemsIds.similar(0, {}); // $ExpectError
+
+itemsIds.similar(0, { field: 'name' });

--- a/types/itemsjs/itemsjs-tests.ts
+++ b/types/itemsjs/itemsjs-tests.ts
@@ -63,6 +63,12 @@ items.search({
     filters: { anAggregation: ['abc'] },
 });
 
+// Aggregation 'bar' was never defined
+// $ExpectError
+items.aggregation({ name: 'bar' });
+
+items.aggregation({ name: 'anAggregation' });
+
 itemsjs<typeof myitems[number]>([]).reindex(myitems);
 
 const myItemsIds = myitems.map((v, i) => ({ id: i, ...v }));

--- a/types/itemsjs/itemsjs-tests.ts
+++ b/types/itemsjs/itemsjs-tests.ts
@@ -21,6 +21,10 @@ const items = itemsjs(myitems, {
             field: 'name',
             order: 'asc',
         },
+        bar: {
+            field: 'anumber',
+            order: 'desc',
+        },
     },
     aggregations: {
         anAggregation: {
@@ -34,9 +38,11 @@ items.search({ query: 'abc' });
 
 items.search({ query: 'abc', sort: 'foo' });
 
-// Sort 'bar' was never defined
-// $ExpectError
 items.search({ query: 'abc', sort: 'bar' });
+
+// Sort 'baz' was never defined
+// $ExpectError
+items.search({ query: 'abc', sort: 'baz' });
 
 items.search({
     query: 'abc',

--- a/types/itemsjs/tsconfig.json
+++ b/types/itemsjs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "itemsjs-tests.ts"]
+}

--- a/types/itemsjs/tslint.json
+++ b/types/itemsjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Related discussion: #59705

Adds types for the npm package itemsjs.

npm: <https://www.npmjs.com/package/itemsjs>
GitHub: <https://github.com/itemsapi/itemsjs>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test itemsjs`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
