### PR TITLE
[jscodeshift] Update testUtils to allow transform as module

### DIFF
--- a/types/jscodeshift/src/testUtils.d.ts
+++ b/types/jscodeshift/src/testUtils.d.ts
@@ -5,7 +5,12 @@ export interface TestOptions {
 }
 
 export function applyTransform(
-    module: { default: Transform; parser: TestOptions['parser'] } | Transform,
+    module:
+        | {
+              default: Transform;
+              parser: TestOptions['parser'];
+          }
+        | Transform,
     options: Options | null | undefined,
     input: {
         path?: string;
@@ -31,7 +36,12 @@ export function runTest(
 ): string;
 
 export function defineInlineTest(
-    module: Transform,
+    module:
+        | {
+              default: Transform;
+              parser: TestOptions['parser'];
+          }
+        | Transform,
     options: Options,
     inputSource: string,
     expectedOutputSource: string,
@@ -39,7 +49,12 @@ export function defineInlineTest(
 ): void;
 
 export function runInlineTest(
-    module: Transform,
+    module:
+        | {
+              default: Transform;
+              parser: TestOptions['parser'];
+          }
+        | Transform,
     options: Options,
     input: {
         path?: string;
@@ -49,10 +64,25 @@ export function runInlineTest(
     testOptions?: TestOptions,
 ): string;
 
-export function defineSnapshotTest(module: Transform, options: Options, input: string, testName?: string): void;
+export function defineSnapshotTest(
+    module:
+        | {
+              default: Transform;
+              parser: TestOptions['parser'];
+          }
+        | Transform,
+    options: Options,
+    input: string,
+    testName?: string,
+): void;
 
 export function runSnapshotTest(
-    module: Transform,
+    module:
+        | {
+              default: Transform;
+              parser: TestOptions['parser'];
+          }
+        | Transform,
     options: Options,
     input: {
         path?: string;


### PR DESCRIPTION
This PR updates the definitions of `defineInlineTest`, `runInlineTest`, `defineSnapshotTest`, and `runSnapshotTest` to allow transforms to be passed as a module or a function.

Each of these functions ultimately call the `applyTransform` function, which handles the transform module/function here:
https://github.com/facebook/jscodeshift/blob/088962fd2769dd81eac445ffd2c93bd1b47f303a/src/testUtils.js#L17

==============================================================================

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes
