### PR TITLE
fix(monday-sdk-js): update GetResponse to reflect the nested data structure

### DIFF
--- a/types/monday-sdk-js/index.d.ts
+++ b/types/monday-sdk-js/index.d.ts
@@ -34,10 +34,8 @@ interface OAuthOptions {
 }
 
 interface GetResponse {
-    data: {
-        value: any;
-        version: any;
-    };
+    value: any;
+    version: any;
 }
 
 interface SetResponse {
@@ -53,7 +51,7 @@ interface MondayClientSdk {
      * Placeholders may be used, which will be substituted by the variables object passed within the options.
      * @param options
      */
-    api(query: string, options?: APIOptions): Promise<any>;
+    api(query: string, options?: APIOptions): Promise<{ data: object }>;
 
     /**
      * Instead of passing the API token to the `api()` method on each request, you can set the API token once using:
@@ -81,7 +79,7 @@ interface MondayClientSdk {
      */
     listen(
         typeOrTypes: SubscribableEvents | ReadonlyArray<SubscribableEvents>,
-        callback: (res: any) => void,
+        callback: (res: { data: object }) => void,
         params?: object,
     ): void;
 
@@ -137,7 +135,7 @@ interface MondayClientSdk {
              */
             excludeCancelButton?: boolean | undefined;
         },
-    ): Promise<any>;
+    ): Promise<{ data: { confirm: boolean } }>;
     /**
      * Display a message at the top of the user's page. Useful for success, error & general messages.
      * @param type Which action to perform
@@ -187,7 +185,7 @@ interface MondayClientSdk {
              * Returns a stored value from the database under `key`
              * @param key
              */
-            getItem(key: string): Promise<GetResponse>;
+            getItem(key: string): Promise<{ data: GetResponse }>;
 
             /**
              * Stores `value` under `key` in the database
@@ -202,7 +200,7 @@ interface MondayClientSdk {
 interface MondayServerSdk {
     setToken(token: string): void;
 
-    api(query: string, options?: Partial<{ token: string, variables: object} >): Promise<any>;
+    api(query: string, options?: Partial<{ token: string, variables: object } >): Promise<any>;
 
     oauthToken(code: string, clientId: string, clientSecret: string): Promise<any>;
 }

--- a/types/monday-sdk-js/index.d.ts
+++ b/types/monday-sdk-js/index.d.ts
@@ -34,8 +34,10 @@ interface OAuthOptions {
 }
 
 interface GetResponse {
-    value: any;
-    version: any;
+    data: {
+        value: any;
+        version: any;
+    };
 }
 
 interface SetResponse {

--- a/types/monday-sdk-js/test/monday-sdk-js-global.test.ts
+++ b/types/monday-sdk-js/test/monday-sdk-js-global.test.ts
@@ -1,6 +1,6 @@
 const monday = mondaySdk();
 
-monday.api('test'); // $ExpectType Promise<any>
+monday.api('test'); // $ExpectType Promise<{ data: object; }>
 monday.setToken('test'); // $ExpectType void
 monday.get('context'); // $ExpectType Promise<any>
 monday.get('settings'); // $ExpectType Promise<any>
@@ -8,10 +8,10 @@ monday.get('itemIds'); // $ExpectType Promise<any>
 monday.get('sessionToken'); // $ExpectType Promise<any>
 monday.listen('context', res => res); // $ExpectType void
 monday.execute('openItemCard', { itemId: 123 }); // $ExpectType Promise<any>
-monday.execute('confirm', { message: 'Hello' }); // $ExpectType Promise<any>
+monday.execute('confirm', { message: 'Hello' }); // $ExpectType Promise<{ data: { confirm: boolean; }; }>
 monday.execute('notice', { message: 'Hello' }); // $ExpectType Promise<any>
 monday.oauth({clientId: 'clientId'});
-monday.storage.instance.getItem('test'); // $ExpectType Promise<GetResponse>
+monday.storage.instance.getItem('test'); // $ExpectType Promise<{ data: GetResponse; }>
 monday.storage.instance.setItem('test', '123'); // $ExpectType Promise<SetResponse>
 
 const mondayServer = mondaySdk({ token: '123' });

--- a/types/monday-sdk-js/test/monday-sdk-js-module.test.ts
+++ b/types/monday-sdk-js/test/monday-sdk-js-module.test.ts
@@ -1,7 +1,7 @@
 import mondaySdk from 'monday-sdk-js';
 const monday = mondaySdk();
 
-monday.api('test'); // $ExpectType Promise<any>
+monday.api('test'); // $ExpectType Promise<{ data: object; }>
 monday.setToken('test'); // $ExpectType void
 monday.get('context'); // $ExpectType Promise<any>
 monday.get('settings'); // $ExpectType Promise<any>
@@ -9,10 +9,10 @@ monday.get('itemIds'); // $ExpectType Promise<any>
 monday.get('sessionToken'); // $ExpectType Promise<any>
 monday.listen('context', res => res); // $ExpectType void
 monday.execute('openItemCard', { itemId: 123 }); // $ExpectType Promise<any>
-monday.execute('confirm', { message: 'Hello' }); // $ExpectType Promise<any>
+monday.execute('confirm', { message: 'Hello' }); // $ExpectType Promise<{ data: { confirm: boolean; }; }>
 monday.execute('notice', { message: 'Hello' }); // $ExpectType Promise<any>
 monday.oauth({clientId: 'clientId'});
-monday.storage.instance.getItem('test'); // $ExpectType Promise<GetResponse>
+monday.storage.instance.getItem('test'); // $ExpectType Promise<{ data: GetResponse; }>
 monday.storage.instance.setItem('test', '123'); // $ExpectType Promise<SetResponse>
 
 const mondayServer = mondaySdk({ token: '123' });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://apps.developer.monday.com/docs/advanced-view#saving-persistent-data-using-the-mondaycom-storage-api 
![image](https://user-images.githubusercontent.com/5416572/162034006-334e5ad0-a586-444e-addb-d9192c64514c.png)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
The implementation hasn't actually changed in a release of the library - from what I understand this is a matter of how the data is sent back from the monday.com APIs, and that's unrelated to the versioning of the SDK.
