### PR TITLE
[react-dom] Add `renderToPipeableStream` and `renderToReadableStream`

### DIFF
--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -4,24 +4,32 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface ReadableStream {}
 
+        // tslint:disable-next-line:no-empty-interface
         interface WritableStream {}
     }
 
     /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    // tslint:disable-next-line:no-empty-interface
+    interface AbortSignal {}
+
+    /**
      * Stub for https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
      */
+    // tslint:disable-next-line:no-empty-interface
     interface ReadableStream {}
 }
 
 import { ReactElement, ReactNode } from 'react';
 
-interface RenderToPipeableStreamOptions {
+export interface RenderToPipeableStreamOptions {
     identifierPrefix?: string;
     namespaceURI?: string;
     nonce?: string;
     bootstrapScriptContent?: string;
-    bootstrapScripts?: Array<string>;
-    bootstrapModules?: Array<string>;
+    bootstrapScripts?: string[];
+    bootstrapModules?: string[];
     progressiveChunkSize?: number;
     onShellReady?: () => void;
     onShellError?: (error: unknown) => void;
@@ -29,7 +37,7 @@ interface RenderToPipeableStreamOptions {
     onError?: (error: unknown) => void;
 }
 
-interface PipeableStream {
+export interface PipeableStream {
     abort(): void;
     pipe<Writable extends NodeJS.WritableStream>(destination: Writable): Writable;
 }
@@ -80,19 +88,19 @@ export function renderToStaticMarkup(element: ReactElement): string;
  */
 export function renderToStaticNodeStream(element: ReactElement): NodeJS.ReadableStream;
 
-interface RenderToReadableStreamOptions {
+export interface RenderToReadableStreamOptions {
     identifierPrefix?: string;
     namespaceURI?: string;
     nonce?: string;
     bootstrapScriptContent?: string;
-    bootstrapScripts?: Array<string>;
-    bootstrapModules?: Array<string>;
+    bootstrapScripts?: string[];
+    bootstrapModules?: string[];
     progressiveChunkSize?: number;
     signal?: AbortSignal;
     onError?: (error: unknown) => void;
 }
 
-interface ReactDOMServerReadableStream extends ReadableStream {
+export interface ReactDOMServerReadableStream extends ReadableStream {
     allReady: Promise<void>;
 }
 

--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -3,10 +3,46 @@ declare global {
     namespace NodeJS {
         // tslint:disable-next-line:no-empty-interface
         interface ReadableStream {}
+
+        interface WritableStream {}
     }
+
+    /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+     */
+    interface ReadableStream {}
 }
 
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
+
+interface RenderToPipeableStreamOptions {
+    identifierPrefix?: string;
+    namespaceURI?: string;
+    nonce?: string;
+    bootstrapScriptContent?: string;
+    bootstrapScripts?: Array<string>;
+    bootstrapModules?: Array<string>;
+    progressiveChunkSize?: number;
+    onShellReady?: () => void;
+    onShellError?: (error: unknown) => void;
+    onAllReady?: () => void;
+    onError?: (error: unknown) => void;
+}
+
+interface PipeableStream {
+    abort(): void;
+    pipe<Writable extends NodeJS.WritableStream>(destination: Writable): Writable;
+}
+
+/**
+ * Only available in the environments with [Node.js Streams](https://nodejs.dev/learn/nodejs-streams).
+ *
+ * @see [API](https://reactjs.org/docs/react-dom-server.html#rendertopipeablestream)
+ *
+ * @param children
+ * @param options
+ */
+export function renderToPipeableStream(children: ReactNode, options?: RenderToPipeableStreamOptions): PipeableStream;
 
 /**
  * Render a React element to its initial HTML. This should only be used on the server.
@@ -24,6 +60,8 @@ export function renderToString(element: ReactElement): string;
  * Render a React element to its initial HTML. Returns a Readable stream that outputs
  * an HTML string. The HTML output by this stream is exactly equal to what
  * `ReactDOMServer.renderToString()` would return.
+ *
+ * @deprecated
  */
 export function renderToNodeStream(element: ReactElement): NodeJS.ReadableStream;
 
@@ -41,6 +79,32 @@ export function renderToStaticMarkup(element: ReactElement): string;
  * is exactly equal to what `ReactDOMServer.renderToStaticMarkup()` would return.
  */
 export function renderToStaticNodeStream(element: ReactElement): NodeJS.ReadableStream;
+
+interface RenderToReadableStreamOptions {
+    identifierPrefix?: string;
+    namespaceURI?: string;
+    nonce?: string;
+    bootstrapScriptContent?: string;
+    bootstrapScripts?: Array<string>;
+    bootstrapModules?: Array<string>;
+    progressiveChunkSize?: number;
+    signal?: AbortSignal;
+    onError?: (error: unknown) => void;
+}
+
+interface ReactDOMServerReadableStream extends ReadableStream {
+    allReady: Promise<void>;
+}
+
+/**
+ * Only available in the environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) (this includes browsers, Deno, and some modern edge runtimes).
+ *
+ * @see [API](https://reactjs.org/docs/react-dom-server.html#rendertoreadablestream)
+ */
+export function renderToReadableStream(
+    children: ReactNode,
+    options?: RenderToReadableStreamOptions,
+): Promise<ReactDOMServerReadableStream>;
 
 export const version: string;
 

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -265,7 +265,7 @@ function pipeableStreamDocumentedExample() {
     }
 
     let didError = false;
-    const res = {} as Response;
+    const res: Response = {} as any;
     const stream = ReactDOMServer.renderToPipeableStream(<App />, {
         onShellReady() {
             res.statusCode = didError ? 500 : 200;
@@ -288,10 +288,10 @@ function pipeableStreamDocumentedExample() {
  * source: https://reactjs.org/docs/react-dom-server.html#rendertoreadablestream
  */
 async function readableStreamDocumentedExample() {
-    let controller = new AbortController();
+    const controller = new AbortController();
     let didError = false;
     try {
-        let stream = await ReactDOMServer.renderToReadableStream(
+        const stream = await ReactDOMServer.renderToReadableStream(
             <html>
                 <body>Success</body>
             </html>,

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -268,14 +268,11 @@ function pipeableStreamDocumentedExample() {
     const res = {} as Response;
     const stream = ReactDOMServer.renderToPipeableStream(<App />, {
         onShellReady() {
-            // The content above all Suspense boundaries is ready.
-            // If something errored before we started streaming, we set the error code appropriately.
             res.statusCode = didError ? 500 : 200;
             res.setHeader('Content-type', 'text/html');
             stream.pipe(res);
         },
         onShellError(error) {
-            // Something errored before we could complete the shell so we emit an alternative shell.
             res.statusCode = 500;
             res.send('<!doctype html><p>Loading...</p><script src="clientrender.js"></script>');
         },
@@ -307,11 +304,7 @@ async function readableStreamDocumentedExample() {
             },
         );
 
-        // This is to wait for all Suspense boundaries to be ready. You can uncomment
-        // this line if you want to buffer the entire HTML instead of streaming it.
-        // You can use this for crawlers or static generation:
-
-        // await stream.allReady;
+        await stream.allReady;
 
         return new Response(stream, {
             status: didError ? 500 : 200,

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -7,7 +7,7 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 declare function describe(desc: string, f: () => void): void;
 declare function it(desc: string, f: () => void): void;
 
-class TestComponent extends React.Component<{x: string}> { }
+class TestComponent extends React.Component<{ x: string }> {}
 
 describe('ReactDOM', () => {
     it('render', () => {
@@ -94,15 +94,12 @@ describe('ReactDOMServer', () => {
 describe('React dom test utils', () => {
     it('Simulate', () => {
         const element = document.createElement('div');
-        const dom = ReactDOM.render(
-            React.createElement('input', { type: 'text' }),
-            element
-        ) as Element;
+        const dom = ReactDOM.render(React.createElement('input', { type: 'text' }), element) as Element;
         const node = ReactDOM.findDOMNode(dom) as HTMLInputElement;
 
         node.value = 'giraffe';
         ReactTestUtils.Simulate.change(node);
-        ReactTestUtils.Simulate.keyDown(node, { key: "Enter", keyCode: 13, which: 13 });
+        ReactTestUtils.Simulate.keyDown(node, { key: 'Enter', keyCode: 13, which: 13 });
     });
 
     it('renderIntoDocument', () => {
@@ -209,7 +206,7 @@ describe('React dom test utils', () => {
                 // tslint:disable-next-line no-void-expression
                 const result = ReactTestUtils.act(() => {});
                 // $ExpectError
-                result.then((x) => {});
+                result.then(x => {});
             });
         });
         describe('with async callback', () => {
@@ -222,7 +219,7 @@ describe('React dom test utils', () => {
             });
             it('returns a Promise-like', () => {
                 const result = ReactTestUtils.act(async () => {});
-                result.then((x) => {});
+                result.then(x => {});
             });
         });
     });
@@ -251,4 +248,79 @@ function hydrateRoot() {
         // $ExpectError
         identifierPrefix: 'react-18-app',
     });
+}
+
+/**
+ * source:
+ */
+function pipeableStreamDocumentedExample() {
+    function App() {
+        return null;
+    }
+
+    interface Response extends NodeJS.WritableStream {
+        send(content: string): void;
+        setHeader(key: string, value: unknown): void;
+        statusCode: number;
+    }
+
+    let didError = false;
+    const res = {} as Response;
+    const stream = ReactDOMServer.renderToPipeableStream(<App />, {
+        onShellReady() {
+            // The content above all Suspense boundaries is ready.
+            // If something errored before we started streaming, we set the error code appropriately.
+            res.statusCode = didError ? 500 : 200;
+            res.setHeader('Content-type', 'text/html');
+            stream.pipe(res);
+        },
+        onShellError(error) {
+            // Something errored before we could complete the shell so we emit an alternative shell.
+            res.statusCode = 500;
+            res.send('<!doctype html><p>Loading...</p><script src="clientrender.js"></script>');
+        },
+        onAllReady() {},
+        onError(err) {
+            didError = true;
+            console.error(err);
+        },
+    });
+}
+
+/**
+ * source: https://reactjs.org/docs/react-dom-server.html#rendertoreadablestream
+ */
+async function readableStreamDocumentedExample() {
+    let controller = new AbortController();
+    let didError = false;
+    try {
+        let stream = await ReactDOMServer.renderToReadableStream(
+            <html>
+                <body>Success</body>
+            </html>,
+            {
+                signal: controller.signal,
+                onError(error) {
+                    didError = true;
+                    console.error(error);
+                },
+            },
+        );
+
+        // This is to wait for all Suspense boundaries to be ready. You can uncomment
+        // this line if you want to buffer the entire HTML instead of streaming it.
+        // You can use this for crawlers or static generation:
+
+        // await stream.allReady;
+
+        return new Response(stream, {
+            status: didError ? 500 : 200,
+            headers: { 'Content-Type': 'text/html' },
+        });
+    } catch (error) {
+        return new Response('<!doctype html><p>Loading...</p><script src="clientrender.js"></script>', {
+            status: 500,
+            headers: { 'Content-Type': 'text/html' },
+        });
+    }
 }


### PR DESCRIPTION
[`renderToPipeableStream` docs](https://reactjs.org/docs/react-dom-server.html#rendertopipeablestream)
[`renderToReadableStream` docs](https://reactjs.org/docs/react-dom-server.html#rendertoreadablestream)

[`renderToPipeableStream` entrypoint](https://github.com/facebook/react/blob/main/packages/react-dom/server.node.js) points to https://github.com/facebook/react/blob/v18.0.0/packages/react-dom/src/server/ReactDOMFizzServerNode.js

[`renderToReadableStream` entrypoint](https://github.com/facebook/react/blob/v18.0.0/packages/react-dom/server.browser.js) points to 
https://github.com/facebook/react/blob/v18.0.0/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js

/cc @sebmarkbage 
