### PR TITLE
[react-dom] Update unstable entrypoints

### DIFF
--- a/types/react-dom/experimental.d.ts
+++ b/types/react-dom/experimental.d.ts
@@ -24,9 +24,8 @@
  * Either the import or the reference only needs to appear once, anywhere in the project.
  */
 
-// See https://github.com/facebook/react/blob/main/packages/react-dom/src/client/ReactDOM.js to see how the exports are declared,
-// and https://github.com/facebook/react/blob/main/packages/shared/ReactFeatureFlags.js to verify which APIs are
-// flagged experimental or not. Experimental APIs will be tagged with `__EXPERIMENTAL__`.
+// See https://github.com/facebook/react/blob/main/packages/react-dom/index.experimental.js to see how the exports are declared,
+// but confirm with published source code (e.g. https://unpkg.com/react-dom@experimental) that these exports end up in the published code
 
 import React = require('react');
 import ReactDOM = require('./next');

--- a/types/react-dom/experimental.d.ts
+++ b/types/react-dom/experimental.d.ts
@@ -24,8 +24,8 @@
  * Either the import or the reference only needs to appear once, anywhere in the project.
  */
 
-// See https://github.com/facebook/react/blob/master/packages/react-dom/src/client/ReactDOM.js to see how the exports are declared,
-// and https://github.com/facebook/react/blob/master/packages/shared/ReactFeatureFlags.js to verify which APIs are
+// See https://github.com/facebook/react/blob/main/packages/react-dom/src/client/ReactDOM.js to see how the exports are declared,
+// and https://github.com/facebook/react/blob/main/packages/shared/ReactFeatureFlags.js to verify which APIs are
 // flagged experimental or not. Experimental APIs will be tagged with `__EXPERIMENTAL__`.
 
 import React = require('react');
@@ -33,13 +33,4 @@ import ReactDOM = require('./next');
 
 export {};
 
-declare module '.' {
-    function unstable_flushControlled(callback: () => void): void;
-
-    // enableSelectiveHydration feature
-
-    /**
-     * @see https://github.com/facebook/react/commit/3a2b5f148d450c69aab67f055fc441d294c23518
-     */
-    function unstable_scheduleHydration(target: Element | Document | DocumentFragment | Comment): void;
-}
+declare module '.' {}

--- a/types/react-dom/next.d.ts
+++ b/types/react-dom/next.d.ts
@@ -23,7 +23,8 @@
  * Either the import or the reference only needs to appear once, anywhere in the project.
  */
 
-// See https://github.com/facebook/react/blob/main/packages/react-dom/src/client/ReactDOM.js to see how the exports are declared,
+// See https://github.com/facebook/react/blob/main/packages/react-dom/index.js to see how the exports are declared,
+// but confirm with published source code (e.g. https://unpkg.com/react-dom@next) that these exports end up in the published code
 
 import React = require('react');
 import ReactDOM = require('.');

--- a/types/react-dom/next.d.ts
+++ b/types/react-dom/next.d.ts
@@ -23,7 +23,7 @@
  * Either the import or the reference only needs to appear once, anywhere in the project.
  */
 
-// See https://github.com/facebook/react/blob/master/packages/react-dom/src/client/ReactDOM.js to see how the exports are declared,
+// See https://github.com/facebook/react/blob/main/packages/react-dom/src/client/ReactDOM.js to see how the exports are declared,
 
 import React = require('react');
 import ReactDOM = require('.');

--- a/types/react-dom/test/experimental-tests.tsx
+++ b/types/react-dom/test/experimental-tests.tsx
@@ -1,10 +1,2 @@
 import ReactDOM = require('react-dom');
 import 'react-dom/experimental';
-
-// NOTE: I don't know yet how to use this; this is just the type it expects
-// in reality it will do nothing because the root isn't hydrate: true
-ReactDOM.unstable_scheduleHydration(document);
-
-function updates() {
-    ReactDOM.unstable_flushControlled(() => {});
-}


### PR DESCRIPTION
Removes `unstable_flushControlled` and `unstable_scheduleHydration` as mentioned in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210#issuecomment-1092024809.
/cc @sebmarkbage 

[`@next` source](https://unpkg.com/react@18.1.0-next-057915477-20220407/cjs/react.development.js)
[`@experiemntal` source](https://unpkg.com/react-dom@0.0.0-experimental-057915477-20220407/index.js)