### PR TITLE
Added type definitions for Earcut.js in three/src/extras in three r139

### DIFF
--- a/types/three/src/extras/Earcut.d.ts
+++ b/types/three/src/extras/Earcut.d.ts
@@ -1,0 +1,4 @@
+import { Triangle } from 'three';
+export namespace Earcut {
+    function triangulate( data: number[], holeIndices: number[], dim: number): Triangle[];
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://threejs.org/docs/#api/en/extras/Earcut
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
