### PR TITLE
fix(node): add ocb modes to crypto, fix ccm and gcm iv

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -646,6 +646,7 @@ declare module 'crypto' {
     }
     type CipherCCMTypes = 'aes-128-ccm' | 'aes-192-ccm' | 'aes-256-ccm' | 'chacha20-poly1305';
     type CipherGCMTypes = 'aes-128-gcm' | 'aes-192-gcm' | 'aes-256-gcm';
+    type CipherOCBTypes = 'aes-128-ocb' | 'aes-192-ocb' | 'aes-256-ocb';
     type BinaryLike = string | NodeJS.ArrayBufferView;
     type CipherKey = BinaryLike | KeyObject;
     interface CipherCCMOptions extends stream.TransformOptions {
@@ -653,6 +654,9 @@ declare module 'crypto' {
     }
     interface CipherGCMOptions extends stream.TransformOptions {
         authTagLength?: number | undefined;
+    }
+    interface CipherOCBOptions extends stream.TransformOptions {
+        authTagLength: number;
     }
     /**
      * Creates and returns a `Cipher` object that uses the given `algorithm` and`password`.
@@ -720,8 +724,9 @@ declare module 'crypto' {
      * @since v0.1.94
      * @param options `stream.transform` options
      */
-    function createCipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike | null, options: CipherCCMOptions): CipherCCM;
-    function createCipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike | null, options?: CipherGCMOptions): CipherGCM;
+    function createCipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike, options: CipherCCMOptions): CipherCCM;
+    function createCipheriv(algorithm: CipherOCBTypes, key: CipherKey, iv: BinaryLike, options: CipherOCBOptions): CipherOCB;
+    function createCipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike, options?: CipherGCMOptions): CipherGCM;
     function createCipheriv(algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions): Cipher;
     /**
      * Instances of the `Cipher` class are used to encrypt data. The class can be
@@ -907,6 +912,15 @@ declare module 'crypto' {
         ): this;
         getAuthTag(): Buffer;
     }
+    interface CipherOCB extends Cipher {
+        setAAD(
+            buffer: NodeJS.ArrayBufferView,
+            options?: {
+                plaintextLength: number;
+            }
+        ): this;
+        getAuthTag(): Buffer;
+    }
     /**
      * Creates and returns a `Decipher` object that uses the given `algorithm` and`password` (key).
      *
@@ -961,8 +975,9 @@ declare module 'crypto' {
      * @since v0.1.94
      * @param options `stream.transform` options
      */
-    function createDecipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike | null, options: CipherCCMOptions): DecipherCCM;
-    function createDecipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike | null, options?: CipherGCMOptions): DecipherGCM;
+    function createDecipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike, options: CipherCCMOptions): DecipherCCM;
+    function createDecipheriv(algorithm: CipherOCBTypes, key: CipherKey, iv: BinaryLike, options: CipherOCBOptions): DecipherOCB;
+    function createDecipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike, options?: CipherGCMOptions): DecipherGCM;
     function createDecipheriv(algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions): Decipher;
     /**
      * Instances of the `Decipher` class are used to decrypt data. The class can be
@@ -1125,6 +1140,15 @@ declare module 'crypto' {
         ): this;
     }
     interface DecipherGCM extends Decipher {
+        setAuthTag(buffer: NodeJS.ArrayBufferView): this;
+        setAAD(
+            buffer: NodeJS.ArrayBufferView,
+            options?: {
+                plaintextLength: number;
+            }
+        ): this;
+    }
+    interface DecipherOCB extends Decipher {
         setAuthTag(buffer: NodeJS.ArrayBufferView): this;
         setAAD(
             buffer: NodeJS.ArrayBufferView,

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -190,6 +190,34 @@ import { promisify } from 'node:util';
 }
 
 {
+    // crypto_cipheriv_decipheriv_aad_ocb_test
+    const key = 'keykeykeykeykeykeykeykey';
+    const iv = crypto.randomBytes(12);
+    const aad = Buffer.from('0123456789', 'hex');
+
+    const cipher = crypto.createCipheriv('aes-192-ocb', key, iv, { authTagLength: 16 });
+    const plaintext = 'Hello world';
+    cipher.setAAD(aad, {
+        plaintextLength: Buffer.byteLength(plaintext),
+    });
+    const ciphertext = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+
+    const decipher = crypto.createDecipheriv('aes-192-ocb', key, iv, { authTagLength: 16 });
+    decipher.setAuthTag(tag);
+    decipher.setAAD(aad, {
+        plaintextLength: ciphertext.length,
+    });
+    const receivedPlaintext: Buffer = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+    ]);
+}
+
+{
     // crypto_cipheriv_decipheriv_cbc_string_encoding_test
     const key: string | null = 'keykeykeykeykeykeykeykey';
     const nonce = crypto.randomBytes(12);

--- a/types/node/v12/crypto.d.ts
+++ b/types/node/v12/crypto.d.ts
@@ -167,6 +167,7 @@ declare module 'crypto' {
 
     type CipherCCMTypes = 'aes-128-ccm' | 'aes-192-ccm' | 'aes-256-ccm';
     type CipherGCMTypes = 'aes-128-gcm' | 'aes-192-gcm' | 'aes-256-gcm';
+    type CipherOCBTypes = 'aes-128-ocb' | 'aes-192-ocb' | 'aes-256-ocb';
 
     type BinaryLike = string | NodeJS.ArrayBufferView;
 
@@ -178,6 +179,9 @@ declare module 'crypto' {
     interface CipherGCMOptions extends stream.TransformOptions {
         authTagLength?: number | undefined;
     }
+    interface CipherOCBOptions extends stream.TransformOptions {
+        authTagLength: number;
+    }
     /** @deprecated since v10.0.0 use createCipheriv() */
     function createCipher(algorithm: CipherCCMTypes, password: BinaryLike, options: CipherCCMOptions): CipherCCM;
     /** @deprecated since v10.0.0 use createCipheriv() */
@@ -188,13 +192,19 @@ declare module 'crypto' {
     function createCipheriv(
         algorithm: CipherCCMTypes,
         key: CipherKey,
-        iv: BinaryLike | null,
+        iv: BinaryLike,
         options: CipherCCMOptions,
     ): CipherCCM;
     function createCipheriv(
+        algorithm: CipherOCBTypes,
+        key: CipherKey,
+        iv: BinaryLike,
+        options: CipherOCBOptions,
+    ): CipherOCB;
+    function createCipheriv(
         algorithm: CipherGCMTypes,
         key: CipherKey,
-        iv: BinaryLike | null,
+        iv: BinaryLike,
         options?: CipherGCMOptions,
     ): CipherGCM;
     function createCipheriv(
@@ -232,6 +242,10 @@ declare module 'crypto' {
         setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
+    interface CipherOCB extends Cipher {
+        setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
+        getAuthTag(): Buffer;
+    }
     /** @deprecated since v10.0.0 use createDecipheriv() */
     function createDecipher(algorithm: CipherCCMTypes, password: BinaryLike, options: CipherCCMOptions): DecipherCCM;
     /** @deprecated since v10.0.0 use createDecipheriv() */
@@ -242,13 +256,19 @@ declare module 'crypto' {
     function createDecipheriv(
         algorithm: CipherCCMTypes,
         key: BinaryLike,
-        iv: BinaryLike | null,
+        iv: BinaryLike,
         options: CipherCCMOptions,
     ): DecipherCCM;
     function createDecipheriv(
+        algorithm: CipherOCBTypes,
+        key: BinaryLike,
+        iv: BinaryLike,
+        options: CipherOCBOptions,
+    ): DecipherOCB;
+    function createDecipheriv(
         algorithm: CipherGCMTypes,
         key: BinaryLike,
-        iv: BinaryLike | null,
+        iv: BinaryLike,
         options?: CipherGCMOptions,
     ): DecipherGCM;
     function createDecipheriv(
@@ -283,6 +303,10 @@ declare module 'crypto' {
         setAAD(buffer: NodeJS.ArrayBufferView, options: { plaintextLength: number }): this;
     }
     interface DecipherGCM extends Decipher {
+        setAuthTag(buffer: NodeJS.ArrayBufferView): this;
+        setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
+    }
+    interface DecipherOCB extends Decipher {
         setAuthTag(buffer: NodeJS.ArrayBufferView): this;
         setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
     }

--- a/types/node/v12/test/crypto.ts
+++ b/types/node/v12/test/crypto.ts
@@ -170,6 +170,33 @@ import { promisify } from 'util';
 }
 
 {
+    const key = 'keykeykeykeykeykeykeykey';
+    const iv = crypto.randomBytes(12);
+    const aad = Buffer.from('0123456789', 'hex');
+
+    const cipher = crypto.createCipheriv('aes-192-ocb', key, iv, { authTagLength: 16 });
+    const plaintext = 'Hello world';
+    cipher.setAAD(aad, {
+        plaintextLength: Buffer.byteLength(plaintext),
+    });
+    const ciphertext = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+
+    const decipher = crypto.createDecipheriv('aes-192-ocb', key, iv, { authTagLength: 16 });
+    decipher.setAuthTag(tag);
+    decipher.setAAD(aad, {
+        plaintextLength: ciphertext.length,
+    });
+    const receivedPlaintext: Buffer = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+    ]);
+}
+
+{
     const key: string | null = 'keykeykeykeykeykeykeykey';
     const nonce = crypto.randomBytes(12);
     const aad = Buffer.from('0123456789', 'hex');

--- a/types/node/v14/crypto.d.ts
+++ b/types/node/v14/crypto.d.ts
@@ -189,6 +189,7 @@ declare module 'crypto' {
 
     type CipherCCMTypes = 'aes-128-ccm' | 'aes-192-ccm' | 'aes-256-ccm' | 'chacha20-poly1305';
     type CipherGCMTypes = 'aes-128-gcm' | 'aes-192-gcm' | 'aes-256-gcm';
+    type CipherOCBTypes = 'aes-128-ocb' | 'aes-192-ocb' | 'aes-256-ocb';
 
     type BinaryLike = string | NodeJS.ArrayBufferView;
 
@@ -200,6 +201,9 @@ declare module 'crypto' {
     interface CipherGCMOptions extends stream.TransformOptions {
         authTagLength?: number | undefined;
     }
+    interface CipherOCBOptions extends stream.TransformOptions {
+        authTagLength: number;
+    }
     /** @deprecated since v10.0.0 use `createCipheriv()` */
     function createCipher(algorithm: CipherCCMTypes, password: BinaryLike, options: CipherCCMOptions): CipherCCM;
     /** @deprecated since v10.0.0 use `createCipheriv()` */
@@ -210,13 +214,19 @@ declare module 'crypto' {
     function createCipheriv(
         algorithm: CipherCCMTypes,
         key: CipherKey,
-        iv: BinaryLike | null,
+        iv: BinaryLike,
         options: CipherCCMOptions,
     ): CipherCCM;
     function createCipheriv(
+        algorithm: CipherOCBTypes,
+        key: CipherKey,
+        iv: BinaryLike,
+        options: CipherOCBOptions,
+    ): CipherOCB;
+    function createCipheriv(
         algorithm: CipherGCMTypes,
         key: CipherKey,
-        iv: BinaryLike | null,
+        iv: BinaryLike,
         options?: CipherGCMOptions,
     ): CipherGCM;
     function createCipheriv(
@@ -246,6 +256,10 @@ declare module 'crypto' {
         setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
+    interface CipherOCB extends Cipher {
+        setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
+        getAuthTag(): Buffer;
+    }
     /** @deprecated since v10.0.0 use `createDecipheriv()` */
     function createDecipher(algorithm: CipherCCMTypes, password: BinaryLike, options: CipherCCMOptions): DecipherCCM;
     /** @deprecated since v10.0.0 use `createDecipheriv()` */
@@ -256,13 +270,19 @@ declare module 'crypto' {
     function createDecipheriv(
         algorithm: CipherCCMTypes,
         key: CipherKey,
-        iv: BinaryLike | null,
+        iv: BinaryLike,
         options: CipherCCMOptions,
     ): DecipherCCM;
     function createDecipheriv(
+        algorithm: CipherOCBTypes,
+        key: CipherKey,
+        iv: BinaryLike,
+        options: CipherOCBOptions,
+    ): DecipherOCB;
+    function createDecipheriv(
         algorithm: CipherGCMTypes,
         key: CipherKey,
-        iv: BinaryLike | null,
+        iv: BinaryLike,
         options?: CipherGCMOptions,
     ): DecipherGCM;
     function createDecipheriv(
@@ -289,6 +309,10 @@ declare module 'crypto' {
         setAAD(buffer: NodeJS.ArrayBufferView, options: { plaintextLength: number }): this;
     }
     interface DecipherGCM extends Decipher {
+        setAuthTag(buffer: NodeJS.ArrayBufferView): this;
+        setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
+    }
+    interface DecipherOCB extends Decipher {
         setAuthTag(buffer: NodeJS.ArrayBufferView): this;
         setAAD(buffer: NodeJS.ArrayBufferView, options?: { plaintextLength: number }): this;
     }

--- a/types/node/v14/test/crypto.ts
+++ b/types/node/v14/test/crypto.ts
@@ -188,6 +188,34 @@ import { promisify } from 'node:util';
 }
 
 {
+    // crypto_cipheriv_decipheriv_aad_ocb_test
+    const key = 'keykeykeykeykeykeykeykey';
+    const iv = crypto.randomBytes(12);
+    const aad = Buffer.from('0123456789', 'hex');
+
+    const cipher = crypto.createCipheriv('aes-192-ocb', key, iv, { authTagLength: 16 });
+    const plaintext = 'Hello world';
+    cipher.setAAD(aad, {
+        plaintextLength: Buffer.byteLength(plaintext),
+    });
+    const ciphertext = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+
+    const decipher = crypto.createDecipheriv('aes-192-ocb', key, iv, { authTagLength: 16 });
+    decipher.setAuthTag(tag);
+    decipher.setAAD(aad, {
+        plaintextLength: ciphertext.length,
+    });
+    const receivedPlaintext: Buffer = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+    ]);
+}
+
+{
     // crypto_cipheriv_decipheriv_cbc_string_encoding_test
     const key: string | null = 'keykeykeykeykeykeykeykey';
     const nonce = crypto.randomBytes(12);

--- a/types/node/v16/crypto.d.ts
+++ b/types/node/v16/crypto.d.ts
@@ -646,6 +646,7 @@ declare module 'crypto' {
     }
     type CipherCCMTypes = 'aes-128-ccm' | 'aes-192-ccm' | 'aes-256-ccm' | 'chacha20-poly1305';
     type CipherGCMTypes = 'aes-128-gcm' | 'aes-192-gcm' | 'aes-256-gcm';
+    type CipherOCBTypes = 'aes-128-ocb' | 'aes-192-ocb' | 'aes-256-ocb';
     type BinaryLike = string | NodeJS.ArrayBufferView;
     type CipherKey = BinaryLike | KeyObject;
     interface CipherCCMOptions extends stream.TransformOptions {
@@ -653,6 +654,9 @@ declare module 'crypto' {
     }
     interface CipherGCMOptions extends stream.TransformOptions {
         authTagLength?: number | undefined;
+    }
+    interface CipherOCBOptions extends stream.TransformOptions {
+        authTagLength: number;
     }
     /**
      * Creates and returns a `Cipher` object that uses the given `algorithm` and`password`.
@@ -720,8 +724,9 @@ declare module 'crypto' {
      * @since v0.1.94
      * @param options `stream.transform` options
      */
-    function createCipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike | null, options: CipherCCMOptions): CipherCCM;
-    function createCipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike | null, options?: CipherGCMOptions): CipherGCM;
+    function createCipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike, options: CipherCCMOptions): CipherCCM;
+    function createCipheriv(algorithm: CipherOCBTypes, key: CipherKey, iv: BinaryLike, options: CipherOCBOptions): CipherOCB;
+    function createCipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike, options?: CipherGCMOptions): CipherGCM;
     function createCipheriv(algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions): Cipher;
     /**
      * Instances of the `Cipher` class are used to encrypt data. The class can be
@@ -907,6 +912,15 @@ declare module 'crypto' {
         ): this;
         getAuthTag(): Buffer;
     }
+    interface CipherOCB extends Cipher {
+        setAAD(
+            buffer: NodeJS.ArrayBufferView,
+            options?: {
+                plaintextLength: number;
+            }
+        ): this;
+        getAuthTag(): Buffer;
+    }
     /**
      * Creates and returns a `Decipher` object that uses the given `algorithm` and`password` (key).
      *
@@ -961,8 +975,9 @@ declare module 'crypto' {
      * @since v0.1.94
      * @param options `stream.transform` options
      */
-    function createDecipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike | null, options: CipherCCMOptions): DecipherCCM;
-    function createDecipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike | null, options?: CipherGCMOptions): DecipherGCM;
+    function createDecipheriv(algorithm: CipherCCMTypes, key: CipherKey, iv: BinaryLike, options: CipherCCMOptions): DecipherCCM;
+    function createDecipheriv(algorithm: CipherOCBTypes, key: CipherKey, iv: BinaryLike, options: CipherOCBOptions): DecipherOCB;
+    function createDecipheriv(algorithm: CipherGCMTypes, key: CipherKey, iv: BinaryLike, options?: CipherGCMOptions): DecipherGCM;
     function createDecipheriv(algorithm: string, key: CipherKey, iv: BinaryLike | null, options?: stream.TransformOptions): Decipher;
     /**
      * Instances of the `Decipher` class are used to decrypt data. The class can be
@@ -1125,6 +1140,15 @@ declare module 'crypto' {
         ): this;
     }
     interface DecipherGCM extends Decipher {
+        setAuthTag(buffer: NodeJS.ArrayBufferView): this;
+        setAAD(
+            buffer: NodeJS.ArrayBufferView,
+            options?: {
+                plaintextLength: number;
+            }
+        ): this;
+    }
+    interface DecipherOCB extends Decipher {
         setAuthTag(buffer: NodeJS.ArrayBufferView): this;
         setAAD(
             buffer: NodeJS.ArrayBufferView,

--- a/types/node/v16/test/crypto.ts
+++ b/types/node/v16/test/crypto.ts
@@ -190,6 +190,34 @@ import { promisify } from 'node:util';
 }
 
 {
+    // crypto_cipheriv_decipheriv_aad_ocb_test
+    const key = 'keykeykeykeykeykeykeykey';
+    const iv = crypto.randomBytes(12);
+    const aad = Buffer.from('0123456789', 'hex');
+
+    const cipher = crypto.createCipheriv('aes-192-ocb', key, iv, { authTagLength: 16 });
+    const plaintext = 'Hello world';
+    cipher.setAAD(aad, {
+        plaintextLength: Buffer.byteLength(plaintext),
+    });
+    const ciphertext = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+
+    const decipher = crypto.createDecipheriv('aes-192-ocb', key, iv, { authTagLength: 16 });
+    decipher.setAuthTag(tag);
+    decipher.setAAD(aad, {
+        plaintextLength: ciphertext.length,
+    });
+    const receivedPlaintext: Buffer = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+    ]);
+}
+
+{
     // crypto_cipheriv_decipheriv_cbc_string_encoding_test
     const key: string | null = 'keykeykeykeykeykeykeykey';
     const nonce = crypto.randomBytes(12);


### PR DESCRIPTION
AES OCB modes were added in [v10.10.0](https://github.com/nodejs/node/pull/22716). This adds the respective type definitions for OCB ciphers in `crypto.createCipheriv` and `crypto.createDecipheriv`.

Also fixes the `iv` being mandatory (not null) for the GCM and CCM overloads.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/pull/21447

IV required for the CCM and GCM overloads
```
> 'ivLength' in crypto.getCipherInfo('aes-128-ccm')
true
> 'ivLength' in crypto.getCipherInfo('aes-128-gcm')
true
> 'ivLength' in crypto.getCipherInfo('aes-128-ocb')
true
```