### PR TITLE
[ethereum-block-by-date] update types for version 1.4.3

### DIFF
--- a/types/ethereum-block-by-date/ethereum-block-by-date-tests.ts
+++ b/types/ethereum-block-by-date/ethereum-block-by-date-tests.ts
@@ -14,6 +14,8 @@ dater.getDate(new Date());
 dater.getDate('2016-07-20T13:20:40Z');
 // $ExpectType BlockResult
 dater.getDate('2016-07-20T13:20:40Z', false);
+// $ExpectType BlockResult
+dater.getDate('2016-07-20T13:20:40Z', false, true);
 
 // $ExpectType BlockResult[]
 dater.getEvery('weeks', '2019-09-02T12:00:00Z', '2019-09-30T12:00:00Z');
@@ -21,3 +23,5 @@ dater.getEvery('weeks', '2019-09-02T12:00:00Z', '2019-09-30T12:00:00Z');
 dater.getEvery('weeks', '2019-09-02T12:00:00Z', '2019-09-30T12:00:00Z', 2);
 // $ExpectType BlockResult[]
 dater.getEvery('weeks', '2019-09-02T12:00:00Z', '2019-09-30T12:00:00Z', 3, false);
+// $ExpectType BlockResult[]
+dater.getEvery('weeks', '2019-09-02T12:00:00Z', '2019-09-30T12:00:00Z', 3, false, true);

--- a/types/ethereum-block-by-date/index.d.ts
+++ b/types/ethereum-block-by-date/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for ethereum-block-by-date 1.4
 // Project: https://github.com/monosux/ethereum-block-by-date
-// Definitions by: Alexandre ABRIOUX <https://github.com/alexandre-abrioux>
+// Definitions by: Alexandre Abrioux <https://github.com/alexandre-abrioux>
+//                 Alexeev Sergey <https://github.com/monosux>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { DurationInputObject, MomentInput } from 'moment';
@@ -19,29 +20,32 @@ declare namespace EthDater {
 }
 
 declare class EthDater {
-    constructor(provider: EthersProviders.Provider | Web3);
+    constructor(web3: EthersProviders.Provider | Web3);
 
     /**
      * Search for the closest block on the chain corresponding to the input date.
      * @param date Date, required. Any valid moment.js value: string, milliseconds, Date() object, moment() object.
-     * @param blockAfter Block after, optional. Search for the nearest block before or after the given date. By default, true.
+     * @param after Block after, optional. Search for the nearest block before or after the given date. By default, true.
+     * @param refresh Refresh boundaries, optional. Recheck the latest block before request. By default, false.
      */
-    getDate(date: MomentInput, blockAfter?: boolean): EthDater.BlockResult;
+    getDate(date: MomentInput, after?: boolean, refresh?: boolean): EthDater.BlockResult;
 
     /**
      * Returns an array of blocks corresponding to periods.
      * For example: every first block of Monday's noons of October 2019.
-     * @param period Period, required. Valid value: years, quarters, months, weeks, days, hours, minutes.
-     * @param startDate Start date, required. Any valid moment.js value: string, milliseconds, Date() object, moment() object.
-     * @param endDate End date, required. Any valid moment.js value: string, milliseconds, Date() object, moment() object.
+     * @param duration Period, required. Valid value: years, quarters, months, weeks, days, hours, minutes.
+     * @param start Start date, required. Any valid moment.js value: string, milliseconds, Date() object, moment() object.
+     * @param end End date, required. Any valid moment.js value: string, milliseconds, Date() object, moment() object.
      * @param every Duration, optional, integer. By default, 1.
-     * @param blockAfter Block after, optional. Search for the nearest block before or after the given date. By default, true.
+     * @param after Block after, optional. Search for the nearest block before or after the given date. By default, true.
+     * @param refresh Refresh boundaries, optional. Recheck the latest block before request. By default, false.
      */
     getEvery(
-        period: keyof DurationInputObject,
-        startDate: MomentInput,
-        endDate: MomentInput,
+        duration: keyof DurationInputObject,
+        start: MomentInput,
+        end: MomentInput,
         every?: number,
-        blockAfter?: boolean,
+        after?: boolean,
+        refresh?: boolean,
     ): EthDater.BlockResult[];
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/monosux/ethereum-block-by-date/blob/master/src/ethereum-block-by-date.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Introduced Changes:
- Added the `refresh` parameter as requested in https://github.com/monosux/ethereum-block-by-date/issues/25#issuecomment-1090485156
- Renamed method signatures to conform with the [source code](https://github.com/monosux/ethereum-block-by-date/blob/master/src/ethereum-block-by-date.js).
- Added `ethereum-block-by-date`'s owner (@monosux) as a Definition Owner.