### PR TITLE
Add "exports" field to react package.json

### DIFF
--- a/types/react/package.json
+++ b/types/react/package.json
@@ -2,5 +2,22 @@
   "private": true,
   "dependencies": {
     "csstype": "^3.0.2"
+  },
+  "exports": {
+    ".": {
+      "types": "./index.d.ts"
+    },
+    "./jsx-runtime": {
+      "types": "./jsx-runtime.d.ts"
+    },
+    "./jsx-dev-runtime": {
+      "types": "./jsx-dev-runtime.d.ts"
+    },
+    "./next": {
+      "types": "./next.d.ts"
+    },
+    "./experimental": {
+      "types": "./experimental.d.ts"
+    }
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. _What header do you mean?_

---

Hi,

this PR adds an `"exports"` field to the react package.json. This update is necessary for this setup:
- I'm using typescript@next (4.7.0-dev.20220406 at the time of writing)
- I have set compiler option [https://www.typescriptlang.org/tsconfig#moduleResolution](moduleResolution) to `nodenext`
- I have set compiler option [https://www.typescriptlang.org/tsconfig#jsx](jsx) to `jsx-react`
- I don't include an `import React from "react"` in my script, like so:
  ```tsx
  import ReactDOM from "react-dom";
  ReactDOM.render(<div>Hello world</div>, document.querySelector("#root"));
  ```

With this setup, typescript will automatically import the `createElement()` function from `react/jsx-runtime`. Starting from [React@18.0.0](https://unpkg.com/browse/react@18.0.0/package.json), the package.json includes an "exports" field ([React@17.0.2](https://unpkg.com/browse/react@17.0.2/package.json) without "exports" for reference). Typescript can only find the types if @types/react package.json includes an "exports" field as well. Also see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/57195.

---

This is my first contribution to this repository, so please help me get this PR into an accepable state. I'm not sure if I've done these things right:
1. I have not updated the package.json files in `types/react/v17/`, v16 and v15, because older react versions didn't have an "exports" field.
2. The tests fail with error: 
   ```
   dtslint@0.0.111
   Error: /Users/pschiffmann/projects/DefinitelyTyped/types/react/index.d.ts:38:22
   ERROR: 38:22  expect  TypeScript@4.7 compile error: 
   Cannot find module 'csstype' or its corresponding type declarations.
   ```
   csstype is listed as a dependency in the react package.json, but doesn't get installed when I run `npm install`.
3. Do I need to add any test cases for the module resolution?