### PR TITLE
feat: add node's non-global webcrypto

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3299,7 +3299,11 @@ declare module 'crypto' {
      */
     function checkPrimeSync(candidate: LargeNumberLike, options?: CheckPrimeOptions): boolean;
     namespace webcrypto {
-        class CryptoKey {} // placeholder
+        export {};
+        export import CryptoKey = globalThis.CryptoKey;
+        export const subtle: globalThis.SubtleCrypto;
+        export function getRandomValues<T extends ArrayBufferView | null>(array: T): T;
+        export function randomUUID(): string;
     }
 }
 declare module 'node:crypto' {

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -1274,10 +1274,66 @@ import { promisify } from 'node:util';
 }
 
 {
-    // tslint:disable-next-line no-object-literal-type-assertion (webcrypto.CryptoKey is a placeholder)
-    crypto.KeyObject.from({} as crypto.webcrypto.CryptoKey); // $ExpectType KeyObject
+    crypto.generateKeySync('aes', { length: 128 }); // $ExpectType KeyObject
 }
 
 {
-    crypto.generateKeySync('aes', { length: 128 }); // $ExpectType KeyObject
+    const uuid: string = crypto.webcrypto.randomUUID();
+    const random: Uint8Array = crypto.webcrypto.getRandomValues(new Uint8Array(12));
+}
+
+{
+    (async () => {
+        const cryptoKey = await crypto.webcrypto.subtle.generateKey('', false, []);
+        if ('type' in cryptoKey) {
+            crypto.KeyObject.from(cryptoKey); // $ExpectType KeyObject
+        } else {
+            crypto.KeyObject.from(cryptoKey.publicKey); // $ExpectType KeyObject
+            crypto.KeyObject.from(cryptoKey.privateKey); // $ExpectType KeyObject
+        }
+    })();
+}
+
+{
+    // importKey, exportKey
+    const algorithm = { name: 'ECDSA', hash: 'SHA-256' };
+    crypto.webcrypto.subtle.importKey('spki', new Uint8Array(/* spki */), algorithm, false, ['verify']).then(async (key) => {
+        const exportedKey: ArrayBuffer = await crypto.webcrypto.subtle.exportKey('spki', key);
+    });
+    crypto.webcrypto.subtle.importKey('pkcs8', new Uint8Array(/* pkcs8 */), algorithm, false, ['sign']).then(async (key) => {
+        const exportedKey: ArrayBuffer = await crypto.webcrypto.subtle.exportKey('pkcs8', key);
+    });
+    crypto.webcrypto.subtle.importKey('raw', new Uint8Array(), algorithm, false, ['sign']).then(async (key) => {
+        const exportedKey: ArrayBuffer = await crypto.webcrypto.subtle.exportKey('raw', key);
+    });
+    crypto.webcrypto.subtle.importKey('jwk', { kty: 'EC', /* JWK */ }, algorithm, false, ['sign']).then(async (key) => {
+        const exportedKey = await crypto.webcrypto.subtle.exportKey('jwk', key); // $ExpectType JsonWebKey
+        exportedKey.alg; // $ExpectType string | undefined
+        exportedKey.crv; // $ExpectType string | undefined
+        exportedKey.d; // $ExpectType string | undefined
+        exportedKey.dp; // $ExpectType string | undefined
+        exportedKey.dq; // $ExpectType string | undefined
+        exportedKey.e; // $ExpectType string | undefined
+        exportedKey.ext; // $ExpectType boolean | undefined
+        exportedKey.k; // $ExpectType string | undefined
+        exportedKey.key_ops; // $ExpectType string[] | undefined
+        exportedKey.kty; // $ExpectType string | undefined
+        exportedKey.n; // $ExpectType string | undefined
+        exportedKey.p; // $ExpectType string | undefined
+        exportedKey.q; // $ExpectType string | undefined
+        exportedKey.qi; // $ExpectType string | undefined
+        exportedKey.use; // $ExpectType string | undefined
+        exportedKey.x; // $ExpectType string | undefined
+        exportedKey.y; // $ExpectType string | undefined
+    });
+}
+
+{
+    // sign, verify
+    const algorithm = { name: 'ECDSA', hash: 'SHA-256' };
+    const data = Buffer.from('data');
+    crypto.webcrypto.subtle.importKey('spki', new Uint8Array(/* spki */), algorithm, false, ['verify']).then(async (key) => {
+        const sig: ArrayBuffer = await crypto.webcrypto.subtle.sign(algorithm, key, data);
+        const result: boolean = await crypto.webcrypto.subtle.verify(algorithm, key, sig, data);
+    });
 }

--- a/types/node/test/util_types.ts
+++ b/types/node/test/util_types.ts
@@ -168,3 +168,18 @@ const cryptoKeyObj: webcrypto.CryptoKey | number = new webcrypto.CryptoKey();
 if (types.isCryptoKey(cryptoKeyObj)) {
     cryptoKeyObj; // $ExpectType CryptoKey
 }
+
+{
+    (async () => {
+        const cryptoKey = await webcrypto.subtle.generateKey('', false, []);
+        if (types.isCryptoKey(cryptoKey)) {
+            cryptoKey; // $ExpectType CryptoKey
+        } else {
+            for (const cryptoKeyObj of [cryptoKey.privateKey, cryptoKey.publicKey]) {
+                if (types.isCryptoKey(cryptoKeyObj)) {
+                    cryptoKeyObj; // $ExpectType CryptoKey
+                }
+            }
+        }
+    })();
+}

--- a/types/node/v16/crypto.d.ts
+++ b/types/node/v16/crypto.d.ts
@@ -3299,7 +3299,11 @@ declare module 'crypto' {
      */
     function checkPrimeSync(candidate: LargeNumberLike, options?: CheckPrimeOptions): boolean;
     namespace webcrypto {
-        class CryptoKey {} // placeholder
+        export {};
+        export import CryptoKey = globalThis.CryptoKey;
+        export const subtle: globalThis.SubtleCrypto;
+        export function getRandomValues<T extends ArrayBufferView | null>(array: T): T;
+        export function randomUUID(): string;
     }
 }
 declare module 'node:crypto' {

--- a/types/node/v16/test/crypto.ts
+++ b/types/node/v16/test/crypto.ts
@@ -1276,10 +1276,66 @@ import { promisify } from 'node:util';
 }
 
 {
-    // tslint:disable-next-line no-object-literal-type-assertion (webcrypto.CryptoKey is a placeholder)
-    crypto.KeyObject.from({} as crypto.webcrypto.CryptoKey); // $ExpectType KeyObject
+    crypto.generateKeySync('aes', { length: 128 }); // $ExpectType KeyObject
 }
 
 {
-    crypto.generateKeySync('aes', { length: 128 }); // $ExpectType KeyObject
+    const uuid: string = crypto.webcrypto.randomUUID();
+    const random: Uint8Array = crypto.webcrypto.getRandomValues(new Uint8Array(12));
+}
+
+{
+    (async () => {
+        const cryptoKey = await crypto.webcrypto.subtle.generateKey('', false, []);
+        if ('type' in cryptoKey) {
+            crypto.KeyObject.from(cryptoKey); // $ExpectType KeyObject
+        } else {
+            crypto.KeyObject.from(cryptoKey.publicKey); // $ExpectType KeyObject
+            crypto.KeyObject.from(cryptoKey.privateKey); // $ExpectType KeyObject
+        }
+    })();
+}
+
+{
+    // importKey, exportKey
+    const algorithm = { name: 'ECDSA', hash: 'SHA-256' };
+    crypto.webcrypto.subtle.importKey('spki', new Uint8Array(/* spki */), algorithm, false, ['verify']).then(async (key) => {
+        const exportedKey: ArrayBuffer = await crypto.webcrypto.subtle.exportKey('spki', key);
+    });
+    crypto.webcrypto.subtle.importKey('pkcs8', new Uint8Array(/* pkcs8 */), algorithm, false, ['sign']).then(async (key) => {
+        const exportedKey: ArrayBuffer = await crypto.webcrypto.subtle.exportKey('pkcs8', key);
+    });
+    crypto.webcrypto.subtle.importKey('raw', new Uint8Array(), algorithm, false, ['sign']).then(async (key) => {
+        const exportedKey: ArrayBuffer = await crypto.webcrypto.subtle.exportKey('raw', key);
+    });
+    crypto.webcrypto.subtle.importKey('jwk', { kty: 'EC', /* JWK */ }, algorithm, false, ['sign']).then(async (key) => {
+        const exportedKey = await crypto.webcrypto.subtle.exportKey('jwk', key); // $ExpectType JsonWebKey
+        exportedKey.alg; // $ExpectType string | undefined
+        exportedKey.crv; // $ExpectType string | undefined
+        exportedKey.d; // $ExpectType string | undefined
+        exportedKey.dp; // $ExpectType string | undefined
+        exportedKey.dq; // $ExpectType string | undefined
+        exportedKey.e; // $ExpectType string | undefined
+        exportedKey.ext; // $ExpectType boolean | undefined
+        exportedKey.k; // $ExpectType string | undefined
+        exportedKey.key_ops; // $ExpectType string[] | undefined
+        exportedKey.kty; // $ExpectType string | undefined
+        exportedKey.n; // $ExpectType string | undefined
+        exportedKey.p; // $ExpectType string | undefined
+        exportedKey.q; // $ExpectType string | undefined
+        exportedKey.qi; // $ExpectType string | undefined
+        exportedKey.use; // $ExpectType string | undefined
+        exportedKey.x; // $ExpectType string | undefined
+        exportedKey.y; // $ExpectType string | undefined
+    });
+}
+
+{
+    // sign, verify
+    const algorithm = { name: 'ECDSA', hash: 'SHA-256' };
+    const data = Buffer.from('data');
+    crypto.webcrypto.subtle.importKey('spki', new Uint8Array(/* spki */), algorithm, false, ['verify']).then(async (key) => {
+        const sig: ArrayBuffer = await crypto.webcrypto.subtle.sign(algorithm, key, data);
+        const result: boolean = await crypto.webcrypto.subtle.verify(algorithm, key, sig, data);
+    });
 }

--- a/types/node/v16/test/util_types.ts
+++ b/types/node/v16/test/util_types.ts
@@ -168,3 +168,18 @@ const cryptoKeyObj: webcrypto.CryptoKey | number = new webcrypto.CryptoKey();
 if (types.isCryptoKey(cryptoKeyObj)) {
     cryptoKeyObj; // $ExpectType CryptoKey
 }
+
+{
+    (async () => {
+        const cryptoKey = await webcrypto.subtle.generateKey('', false, []);
+        if (types.isCryptoKey(cryptoKey)) {
+            cryptoKey; // $ExpectType CryptoKey
+        } else {
+            for (const cryptoKeyObj of [cryptoKey.privateKey, cryptoKey.publicKey]) {
+                if (types.isCryptoKey(cryptoKeyObj)) {
+                    cryptoKeyObj; // $ExpectType CryptoKey
+                }
+            }
+        }
+    })();
+}


### PR DESCRIPTION
Adds node's experimental, non-global [webcrypto module](https://nodejs.org/docs/latest-v16.x/api/webcrypto.html). I only added a few tests since the actual SubtleCrypto interface types come from lib DOM.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://nodejs.org/docs/latest-v16.x/api/webcrypto.html)