### PR TITLE
Update webrtc for TS 4.7

### DIFF
--- a/types/w3c-image-capture/index.d.ts
+++ b/types/w3c-image-capture/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.w3.org/TR/image-capture/
 // Definitions by: Cosium <https://github.com/cosium>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.4
+// TypeScript Version: 4.7
 
 /// <reference types="webrtc" />
 

--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -11,16 +11,6 @@
 
 /// <reference path='MediaStream.d.ts' />
 
-// https://www.w3.org/TR/webrtc/#idl-def-rtcerrordetailtype
-type RTCErrorDetailType =
-    | 'data-channel-failure'
-    | 'dtls-failure'
-    | 'fingerprint-failure'
-    | 'hardware-encoder-error'
-    | 'hardware-encoder-not-available'
-    | 'sctp-failure'
-    | 'sdp-syntax-error';
-
 // https://www.w3.org/TR/webrtc/#idl-def-rtcerror
 interface RTCError extends DOMException {
     readonly errorDetail: RTCErrorDetailType;
@@ -127,7 +117,7 @@ interface RTCIceTransport extends EventTarget {
 }
 
 interface RTCDtlsTransportEventMap {
-    "error": RTCErrorEvent;
+    "error": Event;
     "statechange": Event;
 }
 
@@ -137,7 +127,7 @@ interface RTCDtlsTransport extends EventTarget {
     readonly iceTransport: RTCIceTransport;
     readonly state: RTCDtlsTransportState;
     getRemoteCertificates(): ArrayBuffer[];
-    onerror: DtlsTransportEventHandler<RTCErrorEvent>;
+    onerror: DtlsTransportEventHandler<Event>;
     onstatechange: DtlsTransportEventHandler<Event>;
     addEventListener<K extends keyof RTCDtlsTransportEventMap>(type: K, listener: (this: RTCDtlsTransport, ev: RTCDtlsTransportEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/types/webrtc/index.d.ts
+++ b/types/webrtc/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://webrtc.org/
 // Definitions by: Toshiya Nakakura <https://github.com/nakakura>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.4
+// TypeScript Version: 4.7
 
 /// <reference path="RTCPeerConnection.d.ts" />
 /// <reference path="MediaStream.d.ts" />

--- a/types/webrtc/test/RTCPeerConnection.ts
+++ b/types/webrtc/test/RTCPeerConnection.ts
@@ -105,9 +105,9 @@ const error = new RTCError({
 
 // RPCDtlsTransport
 const dtlsTransport = pc.sctp!.transport;
-dtlsTransport.onerror = ev => console.log(ev.error.errorDetail);
+dtlsTransport.onerror = (ev: RTCErrorEvent) => console.log(ev.error.errorDetail);
 dtlsTransport.onstatechange = ev => console.log(ev.type);
-dtlsTransport.addEventListener('error', ev => console.log(ev.error.errorDetail));
+dtlsTransport.addEventListener('error', (ev: RTCErrorEvent) => console.log(ev.error.errorDetail));
 dtlsTransport.addEventListener('statechange', ev => console.log(ev.type));
 console.log(dtlsTransport.state);
 


### PR DESCRIPTION
1. error event doesn't use RTCErrorEvent in the standard lib.
2. type RTCErrorDetailType is removed so it doesn't clash with the one in the standard lib.
3. The second change means that this change only works with TS 4.7 and above.
