### PR TITLE
Fix vite-plugin-react-svg for dependencies

### DIFF
--- a/types/vite-plugin-react-svg/index.d.ts
+++ b/types/vite-plugin-react-svg/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/visualfanatic/vite-svg
 // Definitions by: Priyanshu Rav <https://github.com/priyanshurav>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.8
+// Minimum TypeScript Version: 4.0
 
 import { Plugin } from 'vite';
 import { OptimizeOptions } from 'svgo';

--- a/types/vite-plugin-react-svg/tsconfig.json
+++ b/types/vite-plugin-react-svg/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6", "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
vite-plugin-react-svg's dependencies require

1. 'lib' to include 'dom'
2. The minimum typescript version to be 4.0.
