### PR TITLE
Update webpack-config-utils for TS 4.7

### DIFF
--- a/types/webpack-config-utils/webpack-config-utils-tests.ts
+++ b/types/webpack-config-utils/webpack-config-utils-tests.ts
@@ -43,13 +43,13 @@ import { getIfUtils, removeEmpty, propIf, propIfNot } from 'webpack-config-utils
             ifProduction // $ExpectType IfUtilsFn
         } = getIfUtils('production');
 
-        // $ExpectType "value" | "alternate"
+        // $ExpectType "value" | "alternate" || "alternate" | "value"
         ifProduction('value', 'alternate'); // 'value'
     }
     {
         const { ifNotDev } = getIfUtils({ dev: false });
 
-        // $ExpectType "value" | "alternate"
+        // $ExpectType "value" | "alternate" || "alternate" | "value"
         ifNotDev('value', 'alternate'); // 'value'
     }
     {


### PR DESCRIPTION
TS 4.7 sorts unions in a different order in some cases. This PR adds both sort orders to the $ExpectType assertions.