### PR TITLE
[node] fix: exclude SIGKILL and SIGSTOP from functions adding listeners to process

### DIFF
--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -87,6 +87,11 @@ declare module 'process' {
                 | 'SIGBREAK'
                 | 'SIGLOST'
                 | 'SIGINFO';
+            type UnlistenableSignals = 'SIGKILL' | 'SIGSTOP';
+            type ListenableSignals = Exclude<Signals, UnlistenableSignals>;
+            type NotA<T> = T extends UnlistenableSignals ? never : T;
+            type NotB<T> = UnlistenableSignals extends T ? never : T;
+            type AllowedSignal<T> = NotA<T> & NotB<T>;
             type UncaughtExceptionOrigin = 'uncaughtException' | 'unhandledRejection';
             type MultipleResolveType = 'resolve' | 'reject';
             type BeforeExitListener = (code: number) => void;
@@ -101,7 +106,7 @@ declare module 'process' {
             type UnhandledRejectionListener = (reason: unknown, promise: Promise<unknown>) => void;
             type WarningListener = (warning: Error) => void;
             type MessageListener = (message: unknown, sendHandle: unknown) => void;
-            type SignalsListener = (signal: Signals) => void;
+            type SignalsListener = (signal: ListenableSignals) => void;
             type MultipleResolveListener = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void;
             type WorkerListener = (worker: Worker) => void;
             interface Socket extends ReadWriteStream {
@@ -1393,7 +1398,7 @@ declare module 'process' {
                 addListener(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 addListener(event: 'warning', listener: WarningListener): this;
                 addListener(event: 'message', listener: MessageListener): this;
-                addListener(event: Signals, listener: SignalsListener): this;
+                addListener(event: ListenableSignals, listener: SignalsListener): this;
                 addListener(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 addListener(event: 'worker', listener: WorkerListener): this;
                 emit(event: 'beforeExit', code: number): boolean;
@@ -1417,10 +1422,11 @@ declare module 'process' {
                 on(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 on(event: 'warning', listener: WarningListener): this;
                 on(event: 'message', listener: MessageListener): this;
-                on(event: Exclude<Signals, 'SIGKILL' | 'SIGSTOP'>, listener: SignalsListener): this;
+                on(event: ListenableSignals, listener: SignalsListener): this;
                 on(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 on(event: 'worker', listener: WorkerListener): this;
-                on(event: string | symbol, listener: (...args: any[]) => void): this;
+                on<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
+
                 once(event: 'beforeExit', listener: BeforeExitListener): this;
                 once(event: 'disconnect', listener: DisconnectListener): this;
                 once(event: 'exit', listener: ExitListener): this;
@@ -1430,10 +1436,10 @@ declare module 'process' {
                 once(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 once(event: 'warning', listener: WarningListener): this;
                 once(event: 'message', listener: MessageListener): this;
-                once(event: Signals, listener: SignalsListener): this;
+                once(event: ListenableSignals, listener: SignalsListener): this;
                 once(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 once(event: 'worker', listener: WorkerListener): this;
-                once(event: string | symbol, listener: (...args: any[]) => void): this;
+                once<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
                 prependListener(event: 'beforeExit', listener: BeforeExitListener): this;
                 prependListener(event: 'disconnect', listener: DisconnectListener): this;
                 prependListener(event: 'exit', listener: ExitListener): this;
@@ -1443,7 +1449,7 @@ declare module 'process' {
                 prependListener(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 prependListener(event: 'warning', listener: WarningListener): this;
                 prependListener(event: 'message', listener: MessageListener): this;
-                prependListener(event: Signals, listener: SignalsListener): this;
+                prependListener(event: ListenableSignals, listener: SignalsListener): this;
                 prependListener(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 prependListener(event: 'worker', listener: WorkerListener): this;
                 prependOnceListener(event: 'beforeExit', listener: BeforeExitListener): this;
@@ -1455,7 +1461,7 @@ declare module 'process' {
                 prependOnceListener(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 prependOnceListener(event: 'warning', listener: WarningListener): this;
                 prependOnceListener(event: 'message', listener: MessageListener): this;
-                prependOnceListener(event: Signals, listener: SignalsListener): this;
+                prependOnceListener(event: ListenableSignals, listener: SignalsListener): this;
                 prependOnceListener(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 prependOnceListener(event: 'worker', listener: WorkerListener): this;
                 listeners(event: 'beforeExit'): BeforeExitListener[];
@@ -1467,7 +1473,7 @@ declare module 'process' {
                 listeners(event: 'unhandledRejection'): UnhandledRejectionListener[];
                 listeners(event: 'warning'): WarningListener[];
                 listeners(event: 'message'): MessageListener[];
-                listeners(event: Signals): SignalsListener[];
+                listeners(event: ListenableSignals): SignalsListener[];
                 listeners(event: 'multipleResolves'): MultipleResolveListener[];
                 listeners(event: 'worker'): WorkerListener[];
             }

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -1417,7 +1417,7 @@ declare module 'process' {
                 on(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 on(event: 'warning', listener: WarningListener): this;
                 on(event: 'message', listener: MessageListener): this;
-                on(event: Signals, listener: SignalsListener): this;
+                on(event: Exclude<Signals, 'SIGKILL' | 'SIGSTOP'>, listener: SignalsListener): this;
                 on(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 on(event: 'worker', listener: WorkerListener): this;
                 on(event: string | symbol, listener: (...args: any[]) => void): this;

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -1425,6 +1425,7 @@ declare module 'process' {
                 on(event: ListenableSignals, listener: SignalsListener): this;
                 on(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 on(event: 'worker', listener: WorkerListener): this;
+                // tslint:disable-next-line:no-unnecessary-generics
                 on<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
 
                 once(event: 'beforeExit', listener: BeforeExitListener): this;
@@ -1439,6 +1440,8 @@ declare module 'process' {
                 once(event: ListenableSignals, listener: SignalsListener): this;
                 once(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 once(event: 'worker', listener: WorkerListener): this;
+
+                // tslint:disable-next-line:no-unnecessary-generics
                 once<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
                 prependListener(event: 'beforeExit', listener: BeforeExitListener): this;
                 prependListener(event: 'disconnect', listener: DisconnectListener): this;

--- a/types/node/test/process.ts
+++ b/types/node/test/process.ts
@@ -120,6 +120,33 @@ import EventEmitter = require('node:events');
     // This is some additional information
 }
 
+{
+  // $ExpectError
+  process.addListener("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.addListener("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.on("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.on("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.once("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.once("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.prependListener("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.prependListener("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.prependOnceListener("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.prependOnceListener("SIGSTOP", (_event) => { });
+}
+
 const hrtimeBigint: bigint = process.hrtime.bigint();
 
 process.allowedNodeEnvironmentFlags.has('asdf');

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -832,6 +832,8 @@ declare namespace NodeJS {
         "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" |
         "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO";
 
+    type UnlistenableSignals = 'SIGKILL' | 'SIGSTOP';
+    type ListenableSignals = Exclude<Signals, UnlistenableSignals>;
     type MultipleResolveType = 'resolve' | 'reject';
 
     type BeforeExitListener = (code: number) => void;
@@ -842,7 +844,7 @@ declare namespace NodeJS {
     type UnhandledRejectionListener = (reason: {} | null | undefined, promise: Promise<any>) => void;
     type WarningListener = (warning: Error) => void;
     type MessageListener = (message: any, sendHandle: any) => void;
-    type SignalsListener = (signal: Signals) => void;
+    type SignalsListener = (signal: ListenableSignals) => void;
     type NewListenerListener = (type: string | symbol, listener: (...args: any[]) => void) => void;
     type RemoveListenerListener = (type: string | symbol, listener: (...args: any[]) => void) => void;
     type MultipleResolveListener = (type: MultipleResolveType, promise: Promise<any>, value: any) => void;
@@ -1113,7 +1115,7 @@ declare namespace NodeJS {
          *   7. unhandledRejection
          *   8. warning
          *   9. message
-         *  10. <All OS Signals>
+         *  10. <All OS Signals> (except by SIGKILL and SIGSTOP)
          *  11. newListener/removeListener inherited from EventEmitter
          */
         addListener(event: "beforeExit", listener: BeforeExitListener): this;
@@ -1124,7 +1126,7 @@ declare namespace NodeJS {
         addListener(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
         addListener(event: "warning", listener: WarningListener): this;
         addListener(event: "message", listener: MessageListener): this;
-        addListener(event: Signals, listener: SignalsListener): this;
+        addListener(event: ListenableSignals, listener: SignalsListener): this;
         addListener(event: "newListener", listener: NewListenerListener): this;
         addListener(event: "removeListener", listener: RemoveListenerListener): this;
         addListener(event: "multipleResolves", listener: MultipleResolveListener): this;
@@ -1150,7 +1152,7 @@ declare namespace NodeJS {
         on(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
         on(event: "warning", listener: WarningListener): this;
         on(event: "message", listener: MessageListener): this;
-        on(event: Signals, listener: SignalsListener): this;
+        on(event: ListenableSignals, listener: SignalsListener): this;
         on(event: "newListener", listener: NewListenerListener): this;
         on(event: "removeListener", listener: RemoveListenerListener): this;
         on(event: "multipleResolves", listener: MultipleResolveListener): this;
@@ -1163,7 +1165,7 @@ declare namespace NodeJS {
         once(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
         once(event: "warning", listener: WarningListener): this;
         once(event: "message", listener: MessageListener): this;
-        once(event: Signals, listener: SignalsListener): this;
+        once(event: ListenableSignals, listener: SignalsListener): this;
         once(event: "newListener", listener: NewListenerListener): this;
         once(event: "removeListener", listener: RemoveListenerListener): this;
         once(event: "multipleResolves", listener: MultipleResolveListener): this;
@@ -1176,7 +1178,7 @@ declare namespace NodeJS {
         prependListener(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
         prependListener(event: "warning", listener: WarningListener): this;
         prependListener(event: "message", listener: MessageListener): this;
-        prependListener(event: Signals, listener: SignalsListener): this;
+        prependListener(event: ListenableSignals, listener: SignalsListener): this;
         prependListener(event: "newListener", listener: NewListenerListener): this;
         prependListener(event: "removeListener", listener: RemoveListenerListener): this;
         prependListener(event: "multipleResolves", listener: MultipleResolveListener): this;
@@ -1189,7 +1191,7 @@ declare namespace NodeJS {
         prependOnceListener(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
         prependOnceListener(event: "warning", listener: WarningListener): this;
         prependOnceListener(event: "message", listener: MessageListener): this;
-        prependOnceListener(event: Signals, listener: SignalsListener): this;
+        prependOnceListener(event: ListenableSignals, listener: SignalsListener): this;
         prependOnceListener(event: "newListener", listener: NewListenerListener): this;
         prependOnceListener(event: "removeListener", listener: RemoveListenerListener): this;
         prependOnceListener(event: "multipleResolves", listener: MultipleResolveListener): this;
@@ -1202,7 +1204,7 @@ declare namespace NodeJS {
         listeners(event: "unhandledRejection"): UnhandledRejectionListener[];
         listeners(event: "warning"): WarningListener[];
         listeners(event: "message"): MessageListener[];
-        listeners(event: Signals): SignalsListener[];
+        listeners(event: ListenableSignals): SignalsListener[];
         listeners(event: "newListener"): NewListenerListener[];
         listeners(event: "removeListener"): RemoveListenerListener[];
         listeners(event: "multipleResolves"): MultipleResolveListener[];

--- a/types/node/v12/test/process.ts
+++ b/types/node/v12/test/process.ts
@@ -76,6 +76,33 @@ import { EventEmitter } from "events";
 }
 
 {
+  // $ExpectError
+  process.addListener("SIGKILL", (event: string | symbol, listener: Function) => { });
+  // $ExpectError
+  process.addListener("SIGSTOP", (event: string | symbol, listener: Function) => { });
+
+  // $ExpectError
+  process.on("SIGKILL", (event: string | symbol, listener: Function) => { });
+  // $ExpectError
+  process.on("SIGSTOP", (event: string | symbol, listener: Function) => { });
+
+  // $ExpectError
+  process.once("SIGKILL", (event: string | symbol, listener: Function) => { });
+  // $ExpectError
+  process.once("SIGSTOP", (event: string | symbol, listener: Function) => { });
+
+  // $ExpectError
+  process.prependListener("SIGKILL", (event: string | symbol, listener: Function) => { });
+  // $ExpectError
+  process.prependListener("SIGSTOP", (event: string | symbol, listener: Function) => { });
+
+  // $ExpectError
+  process.prependOnceListener("SIGKILL", (event: string | symbol, listener: Function) => { });
+  // $ExpectError
+  process.prependOnceListener("SIGSTOP", (event: string | symbol, listener: Function) => { });
+}
+
+{
     // Emit a warning using a string.
     process.emitWarning('Something happened!');
     // Emits: (node:56338) Warning: Something happened!

--- a/types/node/v14/process.d.ts
+++ b/types/node/v14/process.d.ts
@@ -345,6 +345,8 @@ declare module 'process' {
                 on(event: "newListener", listener: NewListenerListener): this;
                 on(event: "removeListener", listener: RemoveListenerListener): this;
                 on(event: "multipleResolves", listener: MultipleResolveListener): this;
+
+                // tslint:disable-next-line:no-unnecessary-generics
                 on<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
 
                 once(event: "beforeExit", listener: BeforeExitListener): this;
@@ -360,6 +362,8 @@ declare module 'process' {
                 once(event: "newListener", listener: NewListenerListener): this;
                 once(event: "removeListener", listener: RemoveListenerListener): this;
                 once(event: "multipleResolves", listener: MultipleResolveListener): this;
+
+                // tslint:disable-next-line:no-unnecessary-generics
                 once<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
 
                 prependListener(event: "beforeExit", listener: BeforeExitListener): this;

--- a/types/node/v14/process.d.ts
+++ b/types/node/v14/process.d.ts
@@ -60,6 +60,11 @@ declare module 'process' {
                 "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" |
                 "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO";
 
+            type UnlistenableSignals = 'SIGKILL' | 'SIGSTOP';
+            type ListenableSignals = Exclude<Signals, UnlistenableSignals>;
+            type NotA<T> = T extends UnlistenableSignals ? never : T;
+            type NotB<T> = UnlistenableSignals extends T ? never : T;
+            type AllowedSignal<T> = NotA<T> & NotB<T>;
             type UncaughtExceptionOrigin = 'uncaughtException' | 'unhandledRejection';
             type MultipleResolveType = 'resolve' | 'reject';
 
@@ -71,7 +76,7 @@ declare module 'process' {
             type UnhandledRejectionListener = (reason: {} | null | undefined, promise: Promise<any>) => void;
             type WarningListener = (warning: Error) => void;
             type MessageListener = (message: any, sendHandle: any) => void;
-            type SignalsListener = (signal: Signals) => void;
+            type SignalsListener = (signal: ListenableSignals) => void;
             type NewListenerListener = (type: string | symbol, listener: (...args: any[]) => void) => void;
             type RemoveListenerListener = (type: string | symbol, listener: (...args: any[]) => void) => void;
             type MultipleResolveListener = (type: MultipleResolveType, promise: Promise<any>, value: any) => void;
@@ -308,7 +313,7 @@ declare module 'process' {
                 addListener(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
                 addListener(event: "warning", listener: WarningListener): this;
                 addListener(event: "message", listener: MessageListener): this;
-                addListener(event: Signals, listener: SignalsListener): this;
+                addListener(event: ListenableSignals, listener: SignalsListener): this;
                 addListener(event: "newListener", listener: NewListenerListener): this;
                 addListener(event: "removeListener", listener: RemoveListenerListener): this;
                 addListener(event: "multipleResolves", listener: MultipleResolveListener): this;
@@ -336,11 +341,11 @@ declare module 'process' {
                 on(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
                 on(event: "warning", listener: WarningListener): this;
                 on(event: "message", listener: MessageListener): this;
-                on(event: Signals, listener: SignalsListener): this;
+                on(event: ListenableSignals, listener: SignalsListener): this;
                 on(event: "newListener", listener: NewListenerListener): this;
                 on(event: "removeListener", listener: RemoveListenerListener): this;
                 on(event: "multipleResolves", listener: MultipleResolveListener): this;
-                on(event: string | symbol, listener: (...args: any[]) => void): this;
+                on<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
 
                 once(event: "beforeExit", listener: BeforeExitListener): this;
                 once(event: "disconnect", listener: DisconnectListener): this;
@@ -351,10 +356,11 @@ declare module 'process' {
                 once(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
                 once(event: "warning", listener: WarningListener): this;
                 once(event: "message", listener: MessageListener): this;
-                once(event: Signals, listener: SignalsListener): this;
+                once(event: ListenableSignals, listener: SignalsListener): this;
                 once(event: "newListener", listener: NewListenerListener): this;
                 once(event: "removeListener", listener: RemoveListenerListener): this;
                 once(event: "multipleResolves", listener: MultipleResolveListener): this;
+                once<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
 
                 prependListener(event: "beforeExit", listener: BeforeExitListener): this;
                 prependListener(event: "disconnect", listener: DisconnectListener): this;
@@ -365,7 +371,7 @@ declare module 'process' {
                 prependListener(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
                 prependListener(event: "warning", listener: WarningListener): this;
                 prependListener(event: "message", listener: MessageListener): this;
-                prependListener(event: Signals, listener: SignalsListener): this;
+                prependListener(event: ListenableSignals, listener: SignalsListener): this;
                 prependListener(event: "newListener", listener: NewListenerListener): this;
                 prependListener(event: "removeListener", listener: RemoveListenerListener): this;
                 prependListener(event: "multipleResolves", listener: MultipleResolveListener): this;
@@ -379,7 +385,7 @@ declare module 'process' {
                 prependOnceListener(event: "unhandledRejection", listener: UnhandledRejectionListener): this;
                 prependOnceListener(event: "warning", listener: WarningListener): this;
                 prependOnceListener(event: "message", listener: MessageListener): this;
-                prependOnceListener(event: Signals, listener: SignalsListener): this;
+                prependOnceListener(event: ListenableSignals, listener: SignalsListener): this;
                 prependOnceListener(event: "newListener", listener: NewListenerListener): this;
                 prependOnceListener(event: "removeListener", listener: RemoveListenerListener): this;
                 prependOnceListener(event: "multipleResolves", listener: MultipleResolveListener): this;
@@ -393,7 +399,7 @@ declare module 'process' {
                 listeners(event: "unhandledRejection"): UnhandledRejectionListener[];
                 listeners(event: "warning"): WarningListener[];
                 listeners(event: "message"): MessageListener[];
-                listeners(event: Signals): SignalsListener[];
+                listeners(event: ListenableSignals): SignalsListener[];
                 listeners(event: "newListener"): NewListenerListener[];
                 listeners(event: "removeListener"): RemoveListenerListener[];
                 listeners(event: "multipleResolves"): MultipleResolveListener[];

--- a/types/node/v14/test/process.ts
+++ b/types/node/v14/test/process.ts
@@ -89,6 +89,33 @@ import EventEmitter = require('node:events');
 }
 
 {
+  // $ExpectError
+  process.addListener("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.addListener("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.on("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.on("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.once("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.once("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.prependListener("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.prependListener("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.prependOnceListener("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.prependOnceListener("SIGSTOP", (_event) => { });
+}
+
+{
     function abortNeverReturns() {
         process.abort(); // $ExpectType never
     }

--- a/types/node/v16/process.d.ts
+++ b/types/node/v16/process.d.ts
@@ -1425,6 +1425,8 @@ declare module 'process' {
                 on(event: ListenableSignals, listener: SignalsListener): this;
                 on(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 on(event: 'worker', listener: WorkerListener): this;
+
+                // tslint:disable-next-line:no-unnecessary-generics
                 on<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
                 once(event: 'beforeExit', listener: BeforeExitListener): this;
                 once(event: 'disconnect', listener: DisconnectListener): this;
@@ -1438,6 +1440,8 @@ declare module 'process' {
                 once(event: ListenableSignals, listener: SignalsListener): this;
                 once(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 once(event: 'worker', listener: WorkerListener): this;
+
+                // tslint:disable-next-line:no-unnecessary-generics
                 once<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
                 prependListener(event: 'beforeExit', listener: BeforeExitListener): this;
                 prependListener(event: 'disconnect', listener: DisconnectListener): this;

--- a/types/node/v16/process.d.ts
+++ b/types/node/v16/process.d.ts
@@ -87,6 +87,11 @@ declare module 'process' {
                 | 'SIGBREAK'
                 | 'SIGLOST'
                 | 'SIGINFO';
+            type UnlistenableSignals = 'SIGKILL' | 'SIGSTOP';
+            type ListenableSignals = Exclude<Signals, UnlistenableSignals>;
+            type NotA<T> = T extends UnlistenableSignals ? never : T;
+            type NotB<T> = UnlistenableSignals extends T ? never : T;
+            type AllowedSignal<T> = NotA<T> & NotB<T>;
             type UncaughtExceptionOrigin = 'uncaughtException' | 'unhandledRejection';
             type MultipleResolveType = 'resolve' | 'reject';
             type BeforeExitListener = (code: number) => void;
@@ -101,7 +106,7 @@ declare module 'process' {
             type UnhandledRejectionListener = (reason: unknown, promise: Promise<unknown>) => void;
             type WarningListener = (warning: Error) => void;
             type MessageListener = (message: unknown, sendHandle: unknown) => void;
-            type SignalsListener = (signal: Signals) => void;
+            type SignalsListener = (signal: ListenableSignals) => void;
             type MultipleResolveListener = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void;
             type WorkerListener = (worker: Worker) => void;
             interface Socket extends ReadWriteStream {
@@ -1393,7 +1398,7 @@ declare module 'process' {
                 addListener(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 addListener(event: 'warning', listener: WarningListener): this;
                 addListener(event: 'message', listener: MessageListener): this;
-                addListener(event: Signals, listener: SignalsListener): this;
+                addListener(event: ListenableSignals, listener: SignalsListener): this;
                 addListener(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 addListener(event: 'worker', listener: WorkerListener): this;
                 emit(event: 'beforeExit', code: number): boolean;
@@ -1417,10 +1422,10 @@ declare module 'process' {
                 on(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 on(event: 'warning', listener: WarningListener): this;
                 on(event: 'message', listener: MessageListener): this;
-                on(event: Signals, listener: SignalsListener): this;
+                on(event: ListenableSignals, listener: SignalsListener): this;
                 on(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 on(event: 'worker', listener: WorkerListener): this;
-                on(event: string | symbol, listener: (...args: any[]) => void): this;
+                on<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
                 once(event: 'beforeExit', listener: BeforeExitListener): this;
                 once(event: 'disconnect', listener: DisconnectListener): this;
                 once(event: 'exit', listener: ExitListener): this;
@@ -1430,10 +1435,10 @@ declare module 'process' {
                 once(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 once(event: 'warning', listener: WarningListener): this;
                 once(event: 'message', listener: MessageListener): this;
-                once(event: Signals, listener: SignalsListener): this;
+                once(event: ListenableSignals, listener: SignalsListener): this;
                 once(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 once(event: 'worker', listener: WorkerListener): this;
-                once(event: string | symbol, listener: (...args: any[]) => void): this;
+                once<T extends string | symbol>(event: AllowedSignal<T>, listener: (...args: any[]) => void): this;
                 prependListener(event: 'beforeExit', listener: BeforeExitListener): this;
                 prependListener(event: 'disconnect', listener: DisconnectListener): this;
                 prependListener(event: 'exit', listener: ExitListener): this;
@@ -1443,7 +1448,7 @@ declare module 'process' {
                 prependListener(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 prependListener(event: 'warning', listener: WarningListener): this;
                 prependListener(event: 'message', listener: MessageListener): this;
-                prependListener(event: Signals, listener: SignalsListener): this;
+                prependListener(event: ListenableSignals, listener: SignalsListener): this;
                 prependListener(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 prependListener(event: 'worker', listener: WorkerListener): this;
                 prependOnceListener(event: 'beforeExit', listener: BeforeExitListener): this;
@@ -1455,7 +1460,7 @@ declare module 'process' {
                 prependOnceListener(event: 'unhandledRejection', listener: UnhandledRejectionListener): this;
                 prependOnceListener(event: 'warning', listener: WarningListener): this;
                 prependOnceListener(event: 'message', listener: MessageListener): this;
-                prependOnceListener(event: Signals, listener: SignalsListener): this;
+                prependOnceListener(event: ListenableSignals, listener: SignalsListener): this;
                 prependOnceListener(event: 'multipleResolves', listener: MultipleResolveListener): this;
                 prependOnceListener(event: 'worker', listener: WorkerListener): this;
                 listeners(event: 'beforeExit'): BeforeExitListener[];
@@ -1467,7 +1472,7 @@ declare module 'process' {
                 listeners(event: 'unhandledRejection'): UnhandledRejectionListener[];
                 listeners(event: 'warning'): WarningListener[];
                 listeners(event: 'message'): MessageListener[];
-                listeners(event: Signals): SignalsListener[];
+                listeners(event: ListenableSignals): SignalsListener[];
                 listeners(event: 'multipleResolves'): MultipleResolveListener[];
                 listeners(event: 'worker'): WorkerListener[];
             }

--- a/types/node/v16/test/process.ts
+++ b/types/node/v16/test/process.ts
@@ -119,6 +119,33 @@ import EventEmitter = require('node:events');
     // This is some additional information
 }
 
+{
+  // $ExpectError
+  process.addListener("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.addListener("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.on("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.on("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.once("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.once("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.prependListener("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.prependListener("SIGSTOP", (_event) => { });
+
+  // $ExpectError
+  process.prependOnceListener("SIGKILL", (_event) => { });
+  // $ExpectError
+  process.prependOnceListener("SIGSTOP", (_event) => { });
+}
+
 const hrtimeBigint: bigint = process.hrtime.bigint();
 
 process.allowedNodeEnvironmentFlags.has('asdf');

--- a/types/node/v16/test/process.ts
+++ b/types/node/v16/test/process.ts
@@ -120,6 +120,7 @@ import EventEmitter = require('node:events');
 }
 
 {
+  // tslint:disable:no-unnecessary-generics
   // $ExpectError
   process.addListener("SIGKILL", (_event) => { });
   // $ExpectError


### PR DESCRIPTION
This commit excludes SIGKILL and SIGSTOP from the Signals union type since adding a listener to these signals is not allowed and one of them actually terminates the process unconditionally.

https://nodejs.org/api/process.html#process_signal_events

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/process.html#process_signal_events
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
