### PR TITLE
[babel__traverse] Return correct type in get() when Array is nullable

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -350,6 +350,13 @@ const visitorWithInvalidDenylist: Visitor = {
     denylist: ['SomeRandomType'],
 };
 
+const objectTypeAnnotation: NodePath<t.ObjectTypeAnnotation> = new NodePath<t.ObjectTypeAnnotation>(
+    null as any,
+    {} as any,
+);
+
+objectTypeAnnotation.get("indexers"); // $ExpectType NodePath<ObjectTypeIndexer>[] | null | undefined
+
 // Test that NodePath can be narrowed from union to single type
 const path: NodePath<t.ExportDefaultDeclaration | t.ExportNamedDeclaration> = new NodePath<t.ExportNamedDeclaration>(
     null as any,

--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -355,7 +355,7 @@ const objectTypeAnnotation: NodePath<t.ObjectTypeAnnotation> = new NodePath<t.Ob
     {} as any,
 );
 
-objectTypeAnnotation.get("indexers"); // $ExpectType NodePath<ObjectTypeIndexer>[] | null | undefined
+objectTypeAnnotation.get('indexers'); // $ExpectType NodePath<null | undefined> | NodePath<ObjectTypeIndexer>[]
 
 // Test that NodePath can be narrowed from union to single type
 const path: NodePath<t.ExportDefaultDeclaration | t.ExportNamedDeclaration> = new NodePath<t.ExportNamedDeclaration>(

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -548,6 +548,8 @@ export class NodePath<T = Node> {
         context?: boolean | TraversalContext,
     ): T[K] extends Array<Node | null | undefined>
         ? Array<NodePath<T[K][number]>>
+        : T[K] extends Array<Node | null | undefined> | null | undefined
+        ? Array<NodePath<NonNullable<T[K]>[number]>> | null | undefined
         : T[K] extends Node | null | undefined
         ? NodePath<T[K]>
         : never;

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -549,7 +549,7 @@ export class NodePath<T = Node> {
     ): T[K] extends Array<Node | null | undefined>
         ? Array<NodePath<T[K][number]>>
         : T[K] extends Array<Node | null | undefined> | null | undefined
-        ? Array<NodePath<NonNullable<T[K]>[number]>> | null | undefined
+        ? Array<NodePath<NonNullable<T[K]>[number]>> | NodePath<null | undefined>
         : T[K] extends Node | null | undefined
         ? NodePath<T[K]>
         : never;


### PR DESCRIPTION
This is the same as #59772, not sure what happened there. I force pushed an hell broke loose
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This is a fix for the types which are currently broken.
Assuming this Node:
```ts
interface MyNode {
  property?: OtherNode[] | null;
}
```

Currently, a node like this will result in this:
```ts
let path: NodePath<MyNode>;

path.get('property'): // Type is `never`
```

This is because the return type of `get()` does not handle array properties that are nullable.

With the fix it will correctly return `OtherNode[] | null | undefined`

For the older version this does not work it seems (index type on NonNullable). It throws. So I only did it for the latest ts version 4.2+
```
ERROR: 538:26  expect  TypeScript@4.1 compile error: 
Type 'number' cannot be used to index type 'NonNullable<T[K]>'.
```