### PR TITLE
[react] Add test for contextually typed callback args in useCallback

### DIFF
--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -122,6 +122,13 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectError
     typedCallback({});
 
+    function useContextuallyTypedCallback(fn: (event: Event) => string) {}
+    useContextuallyTypedCallback(React.useCallback(event => {
+        // $ExpectType Event
+        event;
+        return String(event);
+    }, []));
+
     // test useRef and its convenience overloads
     // $ExpectType MutableRefObject<number>
     React.useRef(0);


### PR DESCRIPTION
Got a report that contextual typing wasn't working after https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210/files#diff-32cfd8cb197872bcba371f5018185d2e75fa540b52cda2dd7d8ac12dcc021299L1112-R1068.

Though it seems to still work with this minimal repro. Will keep the test for posterity and to maybe expand later if some contextual typing really was broken.