### PR TITLE
[react] FunctionComponent type doesn't have "children" prop

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -508,7 +508,7 @@ declare namespace React {
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {
-        (props: P, context?: any): ReactElement<any, any> | null;
+        (props: PropsWithChildren<P>, context?: any): ReactElement<any, any> | null;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
         defaultProps?: Partial<P> | undefined;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -13,9 +13,16 @@ FunctionComponent.defaultProps = {
 };
 <FunctionComponent />;
 <slot name="slot1"></slot>;
-// `FunctionComponent` has no `children`
-// $ExpectError
 <FunctionComponent>24</FunctionComponent>;
+
+const FunctionComponent2: React.FunctionComponent<SCProps> = ({ foo, children }) => {
+    return <div>{foo}{children}</div>;
+};
+FunctionComponent2.displayName = "FunctionComponent4";
+FunctionComponent2.defaultProps = {
+    foo: 42
+};
+<FunctionComponent2>24</FunctionComponent2>;
 
 const VoidFunctionComponent: React.VoidFunctionComponent<SCProps> = ({ foo }: SCProps) => {
     return <div>{foo}</div>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

props are supposed to have a "children" prop by default but it's missing on v18. Is it intended or it's just a mistake?