### PR TITLE
Add `prorateCharges` options to subscription update

### DIFF
--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -1202,6 +1202,7 @@ declare namespace braintree {
                 description?: string | undefined;
             } | undefined;
             startImmediately?: boolean | undefined;
+            prorateCharges?: boolean | undefined;
         } | undefined;
         paymentMethodNonce?: string | undefined;
         paymentMethodToken?: string | undefined;


### PR DESCRIPTION
If changing an existing definition:
- [ ] [Source code: braintree](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/braintree/index.d.ts)

Added missing option for `Subscription.update` method to allow prorate charges for existing subscriptions.