### PR TITLE
google-apps-script: add missing getForegroundColorObject() to TextStyle class in the spreadsheet.d.ts

### DIFF
--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -178,6 +178,55 @@ for (let richTextRun of richTextValue.getRuns()) {
     newValueBuilder.build().getText();
 }
 
+// TextStyle - get/setForegroundColorObject
+// Build an RGB color object
+// $ExpectType Color
+const colorObjRgb = SpreadsheetApp.newColor()
+    .setRgbColor('red')
+    .build();
+
+// Build a Theme color object
+// $ExpectType Color
+const colorObjTheme = SpreadsheetApp.newColor()
+    .setThemeColor(SpreadsheetApp.ThemeColorType.ACCENT1)
+    .build();
+
+// Build TextStyle objects for Rgb, Theme, and null
+// $ExpectType TextStyle
+const rgbTextStyle = SpreadsheetApp.newTextStyle()
+    .setForegroundColorObject(colorObjRgb)
+    .build();
+
+// $ExpectType TextStyle
+const themeTextStyle = SpreadsheetApp.newTextStyle()
+    .setForegroundColorObject(colorObjTheme)
+    .build();
+
+// $ExpectType TextStyle
+const nullTextStyle = SpreadsheetApp.newTextStyle().build();
+
+// Null Color Test
+// $ExpectType Color
+const nullColorObj = nullTextStyle.getForegroundColorObject();
+Logger.log(nullColorObj); // null
+
+// RgbColor Test
+// $ExpectType Color
+const rgbColorObj = rgbTextStyle.getForegroundColorObject();
+Logger.log(rgbColorObj); // Color
+Logger.log(rgbColorObj.getColorType()); // RGB
+Logger.log(rgbColorObj.asRgbColor().asHexString()); // #ff0000
+Logger.log(rgbColorObj.asRgbColor().getBlue()); // 0
+Logger.log(rgbColorObj.asRgbColor().getGreen()); // 0
+Logger.log(rgbColorObj.asRgbColor().getRed()); // 255
+
+// ThemeColor Test
+// $ExpectType Color
+const themeColorObj = themeTextStyle.getForegroundColorObject();
+Logger.log(themeColorObj); // Color
+Logger.log(themeColorObj.getColorType()); // THEME
+Logger.log(themeColorObj.asThemeColor().getThemeColorType()); // ACCENT1}
+
 const tableCell = DocumentApp.create("").getCursor().getElement().asTableCell();
 tableCell.getParentRow().getChildIndex(tableCell);
 

--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -225,7 +225,7 @@ Logger.log(rgbColorObj.asRgbColor().getRed()); // 255
 const themeColorObj = themeTextStyle.getForegroundColorObject();
 Logger.log(themeColorObj); // Color
 Logger.log(themeColorObj.getColorType()); // THEME
-Logger.log(themeColorObj.asThemeColor().getThemeColorType()); // ACCENT1}
+Logger.log(themeColorObj.asThemeColor().getThemeColorType()); // ACCENT1
 
 const tableCell = DocumentApp.create("").getCursor().getElement().asTableCell();
 tableCell.getParentRow().getChildIndex(tableCell);

--- a/types/google-apps-script/google-apps-script.spreadsheet.d.ts
+++ b/types/google-apps-script/google-apps-script.spreadsheet.d.ts
@@ -2056,7 +2056,7 @@ declare namespace GoogleAppsScript {
       getFontFamily(): string | null;
       getFontSize(): Integer | null;
       getForegroundColor(): string | null;
-      getForegroundColorObject(): Color;
+      getForegroundColorObject(): Color | null;
       isBold(): boolean | null;
       isItalic(): boolean | null;
       isStrikethrough(): boolean | null;
@@ -2071,6 +2071,7 @@ declare namespace GoogleAppsScript {
       setFontFamily(fontFamily: string): TextStyleBuilder;
       setFontSize(fontSize: Integer): TextStyleBuilder;
       setForegroundColor(cssString: string): TextStyleBuilder;
+      setForegroundColorObject(color: Color): TextStyleBuilder;
       setItalic(italic: boolean): TextStyleBuilder;
       setStrikethrough(strikethrough: boolean): TextStyleBuilder;
       setUnderline(underline: boolean): TextStyleBuilder;

--- a/types/google-apps-script/google-apps-script.spreadsheet.d.ts
+++ b/types/google-apps-script/google-apps-script.spreadsheet.d.ts
@@ -2056,6 +2056,7 @@ declare namespace GoogleAppsScript {
       getFontFamily(): string | null;
       getFontSize(): Integer | null;
       getForegroundColor(): string | null;
+      getForegroundColorObject(): Color;
       isBold(): boolean | null;
       isItalic(): boolean | null;
       isStrikethrough(): boolean | null;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developers.google.com/apps-script/reference/spreadsheet/text-style>
