### PR TITLE
fixed-data-table-2: Add children to ColumnGroupProps props

### DIFF
--- a/types/fixed-data-table-2/fixed-data-table-2-tests.tsx
+++ b/types/fixed-data-table-2/fixed-data-table-2-tests.tsx
@@ -3,7 +3,7 @@
  */
 
 import * as React from "react";
-import { Table, Cell, Column, CellProps } from "fixed-data-table-2";
+import { Table, Cell, Column, ColumnGroup, CellProps } from "fixed-data-table-2";
 
 // create your Table
 class MyTable1 extends React.Component {
@@ -185,6 +185,75 @@ class MyTable5 extends React.Component {
                 onRowMouseLeave={(event: React.SyntheticEvent<Table>, rowIndex: number) => { }}
                 onColumnResizeEndCallback={(newColumnWidth: number, columnKey: string) => { }}>
             // add columns
+            </Table>
+        );
+    }
+}
+
+// Test ColumnGroup
+class MyTable6 extends React.Component<{}, MyTable4State> {
+    state = {
+        tableData: [
+            { name: "Rylan", email: "Angelita_Weimann42@gmail.com", age: "18", address: "123 Collins Street" },
+            { name: "Amelia", email: "Dexter.Trantow57@hotmail.com", age: "54", address: "Herrengasse 12" },
+            { name: "Estevan", email: "Aimee7@hotmail.com", age: "36", address: "Rue du Fosse-aux-Loups 47" },
+            { name: "Florence", email: "Jarrod.Bernier13@yahoo.com", age: "68", address: "72 Liverpool St" },
+            { name: "Tressa", email: "Yadira1@hotmail.com", age: "45", address: "Hammerichsgade 1" }
+        ]
+    };
+
+    render() {
+        return (
+            <Table
+                rowsCount={this.state.tableData.length}
+                rowHeight={50}
+                headerHeight={50}
+                width={1000}
+                height={500}>
+                    <ColumnGroup header={"Basic Info"}>
+                        <Column
+                            key={"name"}
+                            header={<Cell>{"name"}</Cell>}
+                            cell={
+                                <MyTextCell
+                                    myData={this.state.tableData}
+                                    field={"name"}
+                                />
+                            }
+                            width={200} />
+                        <Column
+                            key={"age"}
+                            header={<Cell>{"age"}</Cell>}
+                            cell={
+                                <MyTextCell
+                                    myData={this.state.tableData}
+                                    field={"age"}
+                                />
+                            }
+                            width={200} />
+                    </ColumnGroup>
+                    <ColumnGroup header={"Contact Info"}>
+                        <Column
+                            key={"email"}
+                            header={<Cell>{"email"}</Cell>}
+                            cell={
+                                <MyTextCell
+                                    myData={this.state.tableData}
+                                    field={"email"}
+                                />
+                            }
+                            width={200} />
+                        <Column
+                            key={"address"}
+                            header={<Cell>{"address"}</Cell>}
+                            cell={
+                                <MyTextCell
+                                    myData={this.state.tableData}
+                                    field={"address"}
+                                />
+                            }
+                            width={200} />
+                    </ColumnGroup>
             </Table>
         );
     }

--- a/types/fixed-data-table-2/index.d.ts
+++ b/types/fixed-data-table-2/index.d.ts
@@ -597,6 +597,8 @@ export interface ColumnGroupHeaderProps {
  * Component that defines the attributes of a table column group.
  */
 export interface ColumnGroupProps extends React.ClassAttributes<ColumnGroup> {
+    children?: React.ReactNode;
+
     /**
      * The horizontal alignment of the table cell content.
      */


### PR DESCRIPTION
Explicitly define children in ColumnGroupProps
 * Be consistent with fixed-data-table-2 TableProps
 * children is no longer defined by default in @types/react ^18.0.0 ClassAttribute

Column Group Example: https://github.com/schrodinger/fixed-data-table-2/blob/ad60599a46015280452c85851a7c20dac3cf606a/examples/ColumnGroupsExample.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
