### PR TITLE
Adding missing key 'Token' to interface 'SNSMessage' on 'aws-lambda'

### DIFF
--- a/types/aws-lambda/test/sns-tests.ts
+++ b/types/aws-lambda/test/sns-tests.ts
@@ -19,6 +19,7 @@ const handler: SNSHandler = async (event, context, callback) => {
     str = message.UnsubscribeUrl;
     str = message.TopicArn;
     str = message.Subject;
+    strOrUndefined = message.Token;
 
     const attribute: SNSMessageAttribute = attributes[str];
     str = attribute.Type;

--- a/types/aws-lambda/trigger/sns.d.ts
+++ b/types/aws-lambda/trigger/sns.d.ts
@@ -24,6 +24,7 @@ export interface SNSMessage {
     UnsubscribeUrl: string;
     TopicArn: string;
     Subject: string;
+    Token?: string;
 }
 
 export interface SNSEventRecord {


### PR DESCRIPTION
As per [the AWS SNS documentation](https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.prepare.html); SNS will send a `SubscriptionConfirmation` event which uses the `SNSMessage` interface.

This PR includes adding the optional `Token` property, allowing confirmation of the subscription.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.prepare.html>