### PR TITLE
[node]: Add signal to client request options

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -580,6 +580,7 @@ declare module 'http2' {
         parent?: number | undefined;
         weight?: number | undefined;
         waitForTrailers?: boolean | undefined;
+        signal?: AbortSignal | undefined;
     }
     export interface SessionState {
         effectiveLocalWindowSize?: number | undefined;

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -95,7 +95,8 @@ import { URL } from 'node:url';
         exclusive: true,
         parent: 0,
         weight: 0,
-        waitForTrailers: true
+        waitForTrailers: true,
+        signal: new AbortController().signal,
     };
     (http2Session as ClientHttp2Session).request();
     (http2Session as ClientHttp2Session).request(headers);

--- a/types/node/v14/http2.d.ts
+++ b/types/node/v14/http2.d.ts
@@ -252,6 +252,7 @@ declare module 'http2' {
         parent?: number | undefined;
         weight?: number | undefined;
         waitForTrailers?: boolean | undefined;
+        signal?: AbortSignal | undefined;
     }
 
     export interface SessionState {

--- a/types/node/v16/http2.d.ts
+++ b/types/node/v16/http2.d.ts
@@ -580,6 +580,7 @@ declare module 'http2' {
         parent?: number | undefined;
         weight?: number | undefined;
         waitForTrailers?: boolean | undefined;
+        signal?: AbortSignal | undefined;
     }
     export interface SessionState {
         effectiveLocalWindowSize?: number | undefined;


### PR DESCRIPTION
`signal` parameter is missing in `ClientSessionRequestOptions`.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[clienthttp2session.request(headers[, options])](https://nodejs.org/dist/latest-v16.x/docs/api/http2.html#clienthttp2sessionrequestheaders-options)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.