### PR TITLE
@ember/object: add get fallbacks for unknown objects

### DIFF
--- a/types/ember/test/ember-module-tests.ts
+++ b/types/ember/test/ember-module-tests.ts
@@ -36,7 +36,7 @@ Ember.deprecate("you shouldn't use this anymore", 3 === 3, {
 });
 // get
 Ember.get({ z: 23 }, 'z'); // $ExpectType number
-Ember.get({ z: 23 }, 'zz'); // $ExpectError
+Ember.get({ z: 23 }, 'zz'); // $ExpectType unknown
 // getEngineParent
 Ember.getEngineParent(new Ember.EngineInstance()); // $ExpectType EngineInstance
 // getOwner

--- a/types/ember/v3/test/ember-module-tests.ts
+++ b/types/ember/v3/test/ember-module-tests.ts
@@ -44,7 +44,7 @@ Ember.deprecate("you shouldn't use this anymore", 3 === 3, {
 });
 // get
 Ember.get({ z: 23 }, 'z'); // $ExpectType number
-Ember.get({ z: 23 }, 'zz'); // $ExpectError
+Ember.get({ z: 23 }, 'zz'); // $ExpectType unknown
 // getEngineParent
 Ember.getEngineParent(new Ember.EngineInstance()); // $ExpectType EngineInstance
 // getOwner

--- a/types/ember__object/index.d.ts
+++ b/types/ember__object/index.d.ts
@@ -68,6 +68,7 @@ export function get<T, K extends keyof T>(
     obj: T,
     key: K
 ): UnwrapComputedPropertyGetter<T[K]>;
+export function get(obj: unknown, key: string): unknown;
 
 /**
  * Sets the value of a property on an object, respecting computed properties

--- a/types/ember__object/test/get-set.ts
+++ b/types/ember__object/test/get-set.ts
@@ -1,0 +1,12 @@
+import { get, set } from '@ember/object';
+
+const basicPojo = { greeting: 'hello' };
+
+get(basicPojo, 'greeting'); // $ExpectType string
+get(basicPojo, 'salutation'); // $ExpectType unknown
+set(basicPojo, 'greeting', 'ahoy'); // $ExpectType string
+set(basicPojo, 'salutation', 'heyo'); // $ExpectError
+
+declare let whoKnows: unknown;
+get(whoKnows, 'any-string'); // $ExpectType unknown
+set(whoKnows, 'any-string', 123); // $ExpectError

--- a/types/ember__object/tsconfig.json
+++ b/types/ember__object/tsconfig.json
@@ -37,6 +37,7 @@
         "test/observable.ts",
         "test/octane.ts",
         "test/proxy.ts",
-        "test/reopen.ts"
+        "test/reopen.ts",
+        "test/get-set.ts"
     ]
 }

--- a/types/ember__object/v3/index.d.ts
+++ b/types/ember__object/v3/index.d.ts
@@ -163,6 +163,8 @@ export function get<T, K extends keyof T>(
     obj: T,
     key: K
 ): UnwrapComputedPropertyGetter<T[K]>;
+export function get(obj: unknown, key: string): unknown;
+
 /**
  * Retrieves the value of a property from an Object, or a default value in the
  * case that the property returns `undefined`.

--- a/types/ember__object/v3/test/get-set.ts
+++ b/types/ember__object/v3/test/get-set.ts
@@ -1,0 +1,12 @@
+import { get, set } from '@ember/object';
+
+const basicPojo = { greeting: 'hello' };
+
+get(basicPojo, 'greeting'); // $ExpectType string
+get(basicPojo, 'salutation'); // $ExpectType unknown
+set(basicPojo, 'greeting', 'ahoy'); // $ExpectType string
+set(basicPojo, 'salutation', 'heyo'); // $ExpectError
+
+declare let whoKnows: unknown;
+get(whoKnows, 'any-string'); // $ExpectType unknown
+set(whoKnows, 'any-string', 123); // $ExpectError

--- a/types/ember__object/v3/tsconfig.json
+++ b/types/ember__object/v3/tsconfig.json
@@ -65,6 +65,7 @@
         "test/observable.ts",
         "test/octane.ts",
         "test/proxy.ts",
-        "test/reopen.ts"
+        "test/reopen.ts",
+        "test/get-set.ts"
     ]
 }


### PR DESCRIPTION
This way, `get` works with unknown arguments, which is one of the only remaining use cases for it in modern Ember apps. Critically, it does so in a way that is safe: if you ask for a key on an unknown object, you will get back `unknown`, and if you ask for an unknown key on a known object, you will *also* get back `unknown`, which will help you catch the typo case. For exactly the type case, however, this does *not* add a corresponding update for `set`. As a bonus, this is probably the *only* thing we'll be shipping in Ember's native types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://api.emberjs.com/ember/4.2/functions/@ember%2Fobject/get>, <https://api.emberjs.com/ember/4.2/functions/@ember%2Fobject/set>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
