### PR TITLE
[robust-segment-intersect] Add types for robust-segment-intersect

### DIFF
--- a/types/robust-segment-intersect/index.d.ts
+++ b/types/robust-segment-intersect/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for robust-segment-intersect 1.0
+// Project: https://github.com/mikolalysenko/robust-segment-intersect
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace segmentsIntersect {
+    type Coord = [number, number];
+}
+
+/**
+ * Test if the closed line segment `[firstStart, firstEnd]` intersects
+ * the closed line segment `[secondStart, secondEnd]`
+ * @param firstStart An end point of the first line
+ * @param firstEnd An end point of the first line
+ * @param secondStart An end point of the second line
+ * @param secondEnd An end point of the second line
+ * @returns Whether the lines intersect
+ */
+declare function segmentsIntersect(
+    firstStart: segmentsIntersect.Coord,
+    firstEnd: segmentsIntersect.Coord,
+    secondStart: segmentsIntersect.Coord,
+    secondEnd: segmentsIntersect.Coord,
+): boolean;
+
+export = segmentsIntersect;

--- a/types/robust-segment-intersect/robust-segment-intersect-tests.ts
+++ b/types/robust-segment-intersect/robust-segment-intersect-tests.ts
@@ -1,0 +1,7 @@
+import crosses = require('robust-segment-intersect');
+
+// $ExpectType boolean
+crosses([0, 0], [5, 5], [5, 0], [0, 5]);
+
+// $ExpectError
+crosses([1], [2], [3], [4]);

--- a/types/robust-segment-intersect/tsconfig.json
+++ b/types/robust-segment-intersect/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "robust-segment-intersect-tests.ts"]
+}

--- a/types/robust-segment-intersect/tslint.json
+++ b/types/robust-segment-intersect/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Related discussion: #59814

Adds types for the npm package robust-segment-intersect. The types in this PR were tweaked from the ones provided in the discussion in order to use `export =` syntax and to add clearer parameter names.

npm: <https://www.npmjs.com/package/robust-segment-intersect>
GitHub: <https://github.com/mikolalysenko/robust-segment-intersect>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test robust-segment-intersect`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
