### PR TITLE
Add export map for react

### DIFF
--- a/types/react/package.json
+++ b/types/react/package.json
@@ -2,5 +2,22 @@
   "private": true,
   "dependencies": {
     "csstype": "^3.0.2"
+  },
+  "exports": {
+    ".": {
+      "types": {
+        "default": "./index.d.ts"
+      }
+    },
+    "./jsx-runtime": {
+      "types": {
+        "default": "./jsx-runtime.d.ts"
+      }
+    },
+    "./jsx-dev-runtime": {
+      "types": {
+        "default": "./jsx-dev-runtime.d.ts"
+      }
+    }
   }
 }


### PR DESCRIPTION
React 18 ships a export map, so the DT types should, too. AFAIK, react18 doesn't have a node-lookup-able esm-format entrypoint, so the export map is just to allow omitting the extensions on the `jsx-runtime` imports (which are, ofc, omitted by the implicit imports added by the latest versions of the jsx transform).