### PR TITLE
[meteor, Email] add missing hookSend & customTransport methods to Email

### DIFF
--- a/types/meteor/email.d.ts
+++ b/types/meteor/email.d.ts
@@ -19,8 +19,8 @@ declare module 'meteor/email' {
       }
 
       function send(options: EmailOptions): void;
-      function hookSend(fn: (options: EmailOptions )=> boolean): void;
-      function customTransport(fn: (options: CustomEmailOptions)=> void): void;
+      function hookSend(fn: (options: EmailOptions) => boolean): void;
+      function customTransport(fn: (options: CustomEmailOptions) => void): void;
     }
 
     interface MailComposerOptions {

--- a/types/meteor/email.d.ts
+++ b/types/meteor/email.d.ts
@@ -1,18 +1,26 @@
 declare module 'meteor/email' {
     namespace Email {
-        function send(options: {
-            from?: string | undefined;
-            to?: string | string[] | undefined;
-            cc?: string | string[] | undefined;
-            bcc?: string | string[] | undefined;
-            replyTo?: string | string[] | undefined;
-            subject?: string | undefined;
-            text?: string | undefined;
-            html?: string | undefined;
-            headers?: Object | undefined;
-            attachments?: Object[] | undefined;
-            mailComposer?: MailComposer | undefined;
-        }): void;
+      interface EmailOptions {
+        from?: string | undefined;
+        to?: string | string[] | undefined;
+        cc?: string | string[] | undefined;
+        bcc?: string | string[] | undefined;
+        replyTo?: string | string[] | undefined;
+        subject?: string | undefined;
+        text?: string | undefined;
+        html?: string | undefined;
+        headers?: Object | undefined;
+        attachments?: Object[] | undefined;
+        mailComposer?: MailComposer | undefined;
+      }
+
+      interface CustomEmailOptions extends  EmailOptions {
+        packageSettings?: unknown;
+      }
+
+      function send(options: EmailOptions): void;
+      function hookSend(fn: (options: EmailOptions )=> boolean): void;
+      function customTransport(fn: (options: CustomEmailOptions)=> void): void;
     }
 
     interface MailComposerOptions {
@@ -27,6 +35,7 @@ declare module 'meteor/email' {
     interface MailComposerStatic {
         new (options: MailComposerOptions): MailComposer;
     }
+
     interface MailComposer {
         addHeader(name: string, value: string): void;
         setMessageOption(from: string, to: string, body: string, html: string): void;

--- a/types/meteor/globals/blaze.d.ts
+++ b/types/meteor/globals/blaze.d.ts
@@ -1,3 +1,4 @@
+
 declare namespace Blaze {
     var View: ViewStatic;
 

--- a/types/meteor/globals/email.d.ts
+++ b/types/meteor/globals/email.d.ts
@@ -18,9 +18,10 @@ declare namespace Email {
   }
 
   function send(options: EmailOptions): void;
-  function hookSend(fn: (options: EmailOptions )=> boolean): void;
-  function customTransport(fn: (options: CustomEmailOptions)=> void): void;
+  function hookSend(fn: (options: EmailOptions) => boolean): void;
+  function customTransport(fn: (options: CustomEmailOptions) => void): void;
 }
+
 declare interface MailComposerOptions {
     escapeSMTP: boolean;
     encoding: string;
@@ -33,6 +34,7 @@ declare var MailComposer: MailComposerStatic;
 declare interface MailComposerStatic {
     new (options: MailComposerOptions): MailComposer;
 }
+
 declare interface MailComposer {
     addHeader(name: string, value: string): void;
     setMessageOption(from: string, to: string, body: string, html: string): void;

--- a/types/meteor/globals/email.d.ts
+++ b/types/meteor/globals/email.d.ts
@@ -1,19 +1,26 @@
 declare namespace Email {
-    function send(options: {
-        from?: string | undefined;
-        to?: string | string[] | undefined;
-        cc?: string | string[] | undefined;
-        bcc?: string | string[] | undefined;
-        replyTo?: string | string[] | undefined;
-        subject?: string | undefined;
-        text?: string | undefined;
-        html?: string | undefined;
-        headers?: Object | undefined;
-        attachments?: Object[] | undefined;
-        mailComposer?: MailComposer | undefined;
-    }): void;
-}
+  interface EmailOptions {
+    from?: string | undefined;
+    to?: string | string[] | undefined;
+    cc?: string | string[] | undefined;
+    bcc?: string | string[] | undefined;
+    replyTo?: string | string[] | undefined;
+    subject?: string | undefined;
+    text?: string | undefined;
+    html?: string | undefined;
+    headers?: Object | undefined;
+    attachments?: Object[] | undefined;
+    mailComposer?: MailComposer | undefined;
+  }
 
+  interface CustomEmailOptions extends  EmailOptions {
+    packageSettings?: unknown;
+  }
+
+  function send(options: EmailOptions): void;
+  function hookSend(fn: (options: EmailOptions )=> boolean): void;
+  function customTransport(fn: (options: CustomEmailOptions)=> void): void;
+}
 declare interface MailComposerOptions {
     escapeSMTP: boolean;
     encoding: string;

--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -459,6 +459,11 @@ declare interface Subscription {
      * Access inside the publish function. The incoming connection for this subscription.
      */
     stop(): void;
+    /**
+     * Call inside the publish function. Allows subsequent methods or subscriptions for the client of this subscription
+     * to begin running without waiting for the publishing to become ready.
+     */
+    unblock(): void;
     /** Access inside the publish function. The id of the logged-in user, or `null` if no user is logged in. */
     userId: string | null;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Email.hookSend](https://docs.meteor.com/api/email.html#Email-send), [Email.customTransport](https://docs.meteor.com/api/email.html#Email-customTransport)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
