### PR TITLE
Add ESM export mappings for `react` and `react-dom`

### DIFF
--- a/types/react-dom/package.json
+++ b/types/react-dom/package.json
@@ -1,0 +1,30 @@
+{
+  "private": true,
+  "exports": {
+    ".": {
+      "types": {
+        "default": "./index.d.ts"
+      }
+    },
+    "./client": {
+      "types": {
+        "default": "./client.d.ts"
+      }
+    },
+    "./next": {
+      "types": {
+        "default": "./next.d.ts"
+      }
+    },
+    "./server": {
+      "types": {
+        "default": "./server.d.ts"
+      }
+    },
+    "./experimental": {
+      "types": {
+        "default": "./experimental.d.ts"
+      }
+    }
+  }
+}

--- a/types/react/package.json
+++ b/types/react/package.json
@@ -9,6 +9,16 @@
         "default": "./index.d.ts"
       }
     },
+    "./next": {
+      "types": {
+        "default": "./next.d.ts"
+      }
+    },
+    "./experimental": {
+      "types": {
+        "default": "./experimental.d.ts"
+      }
+    },
     "./jsx-runtime": {
       "types": {
         "default": "./jsx-runtime.d.ts"


### PR DESCRIPTION
@weswigham recently added some of the missing exports to `react`, but some of them were omitted -- specifically `react/next` and `react/experimental` -- along with exports for `react-dom`.

I added all of the above. `react-dom` also didn't have a `package.json`, so I made an empty one (I don't know what else should go in there).

`react` now exports:
  - `./next` (the react/next module)
  - `./experimental` (the react/experimental module)

as well as what DefinitelyTyped/DefinitelyTyped#59838 added:
  - `.` (the react module)
  - `./jsx-runtime` (the react/jsx-runtime module)
  - `./jsx-dev-runtime` (the react/jsx-dev-runtime module)

`react-dom` now exports:
  - `.` (the react-dom module)
  - `./server` (the react-dom/server module)
  - `./client` (the react-dom/client module)
  - `./next` (the react-dom/next module)
  - `./experimental` (the react-dom/experimental module)

PR Checklist:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

`npm test react` only works after `npm i --prefix ./types/react` whereas `npm test react-dom` needs no special treatment.
`npm run test-all` completed with no errors.

I don't think the headers need to be updated for this change, but somebody else can correct me on that--