### PR TITLE
formdiable: parse callback optional

### DIFF
--- a/types/formidable/Formidable.d.ts
+++ b/types/formidable/Formidable.d.ts
@@ -16,7 +16,7 @@ declare class IncomingForm extends EventEmitter {
      *
      * @link https://github.com/node-formidable/formidable#parserequest-callback
      */
-    parse(request: IncomingMessage, callback: (err: any, fields: Fields, files: Files) => void): void;
+    parse(request: IncomingMessage, callback?: (err: any, fields: Fields, files: Files) => void): void;
 
     once(eventName: 'end', listener: () => void): this;
     once(eventName: 'error', listener: (err: any) => void): this;

--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -190,6 +190,10 @@ http.createServer(req => {
     });
 });
 
+http.createServer(req => {
+    form.parse(req); // testing without callback
+});
+
 // $ExpectType IncomingForm
 new IncomingForm();
 


### PR DESCRIPTION
The documentation, including what's commented just above, uses the phrase "If callback is provided" suggesting it's optional. This makes it optional.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test formidable`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).  It says `tar: Option --warning=none is not supported`

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Readme](https://github.com/node-formidable/formidable/blob/master/README.md#parserequest-callback)