### PR TITLE
[react] Deprecate ReactChildren

### DIFF
--- a/types/moxy__next-router-scroll/RouterScrollProvider.d.ts
+++ b/types/moxy__next-router-scroll/RouterScrollProvider.d.ts
@@ -1,6 +1,6 @@
 import { NextScrollBehaviorContext } from './scroll-behavior';
 import { ShouldUpdateScroll } from 'scroll-behavior';
-import { ReactChildren } from 'react';
+import { ReactNode } from 'react';
 export default ScrollBehaviorProvider;
 declare function ScrollBehaviorProvider({
     disableNextLinkScroll,
@@ -20,6 +20,6 @@ declare namespace ScrollBehaviorProvider {
     namespace propTypes {
         const disableNextLinkScroll: boolean;
         const shouldUpdateScroll: any;
-        const children: ReactChildren;
+        const children: ReactNode;
     }
 }

--- a/types/react-mentions/lib/utils/readConfigFromChildren.d.ts
+++ b/types/react-mentions/lib/utils/readConfigFromChildren.d.ts
@@ -1,4 +1,4 @@
-import { ReactChildren } from 'react';
+import { ReactNode } from 'react';
 import { Config } from './applyChangeToValue';
 
-export function readConfigFromChildren(children: ReactChildren): Config[];
+export function readConfigFromChildren(children: ReactNode): Config[];

--- a/types/react-native-table-component/index.d.ts
+++ b/types/react-native-table-component/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: David Cole <https://github.com/davidcole1340>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Component, ReactChildren, ReactNode } from 'react';
+import { Component, ReactNode } from 'react';
 import { TextStyle, ViewStyle, StyleProp } from 'react-native';
 
 // cell.js
@@ -76,7 +76,7 @@ export interface TableProps {
 }
 
 export class Table extends Component<TableProps> {
-  _renderChildren(props: TableProps): ReactChildren;
+  _renderChildren(props: TableProps): ReactNode;
 }
 
 export interface TableWrapperProps {
@@ -86,5 +86,5 @@ export interface TableWrapperProps {
 }
 
 export class TableWrapper extends Component<TableWrapperProps> {
-  _renderChildren(props: TableWrapperProps): ReactChildren;
+  _renderChildren(props: TableWrapperProps): ReactNode;
 }

--- a/types/react-router-transition/index.d.ts
+++ b/types/react-router-transition/index.d.ts
@@ -72,7 +72,7 @@ interface CommonProps {
  * http://maisano.github.io/react-router-transition/animated-switch/props
  */
 export interface AnimatedSwitchProps extends CommonProps {
-    children: React.ReactNode|React.ReactNodeArray|React.ReactChildren;
+    children: React.ReactNode;
 }
 
 /**

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -377,6 +377,7 @@ declare namespace React {
 
     function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 
+    // Sync with `ReactChildren` until `ReactChildren` is removed.
     const Children: {
         map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
             C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
@@ -3009,6 +3010,7 @@ declare namespace React {
     /**
      * @deprecated - Use `typeof React.Children` instead.
      */
+    // Sync with type of `const Children`.
     interface ReactChildren {
         map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
             C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -377,7 +377,14 @@ declare namespace React {
 
     function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 
-    const Children: ReactChildren;
+    const Children: {
+        map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
+            C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
+        forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
+        count(children: any): number;
+        only<C>(children: C): C extends any[] ? never : C;
+        toArray(children: ReactNode | ReactNode[]): Array<Exclude<ReactNode, boolean | null | undefined>>;
+    };
     const Fragment: ExoticComponent<{ children?: ReactNode | undefined }>;
     const StrictMode: ExoticComponent<{ children?: ReactNode | undefined }>;
 
@@ -2999,6 +3006,9 @@ declare namespace React {
     // React.Children
     // ----------------------------------------------------------------------
 
+    /**
+     * @deprecated - Use `typeof React.Children` instead.
+     */
     interface ReactChildren {
         map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
             C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;


### PR DESCRIPTION
The type can be (and [is currently](https://twitter.com/HeikoMathes/status/1513399571753230341)) confused with something that you assign to `children`.
So instead, we just declare the type directly on `React.Children`.