### PR TITLE
PrivateKey.sign can take hex-string as md.

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -236,7 +236,7 @@ declare module "node-forge" {
                 dQ: jsbn.BigInteger;
                 qInv: jsbn.BigInteger;
                 decrypt(data: Bytes, scheme?: EncryptionScheme, schemeOptions?: any): Bytes;
-                sign(md: md.MessageDigest | string, scheme?: SignatureScheme): Bytes;
+                sign(md: md.MessageDigest | Bytes, scheme?: SignatureScheme): Bytes;
             }
 
             interface KeyPair {

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -236,7 +236,7 @@ declare module "node-forge" {
                 dQ: jsbn.BigInteger;
                 qInv: jsbn.BigInteger;
                 decrypt(data: Bytes, scheme?: EncryptionScheme, schemeOptions?: any): Bytes;
-                sign(md: md.MessageDigest, scheme?: SignatureScheme): Bytes;
+                sign(md: md.MessageDigest | string, scheme?: SignatureScheme): Bytes;
             }
 
             interface KeyPair {

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -661,3 +661,13 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
     isBigInteger = bn.modInverse(bn);
     isBoolean = bn.isProbablePrime(0);
 }
+
+{
+    forge.pki.rsa.generateKeyPair({ bits: 2048,}, (err, keypair) => {
+        if (err) {
+            throw err;
+        }
+        const msg = '0102030405060708090a0b0c0d0e0f00';
+        keypair.privateKey.sign(forge.util.hexToBytes(msg), 'NONE');
+    });
+}


### PR DESCRIPTION
If the message is already hashed, the raw bytes can be passed
in as using forge.utils.hexToBytes(hash) which returns a byte
string.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [This code link shows that encrypt takes a byte string](https://github.com/digitalbazaar/forge/blob/2bb97afb5058285ef09bcf1d04d6bd6b87cffd58/lib/rsa.js#L517)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
