### PR TITLE
[undertaker] Add missing undefined to return type of Undertaker.task

### DIFF
--- a/types/gulp/test/index.ts
+++ b/types/gulp/test/index.ts
@@ -41,13 +41,14 @@ gulp.task(() => {
 });
 
 // someTask will be the registered task function
+// $ExpectType TaskFunctionWrapped | undefined
 const someTask = gulp.task('someTask');
 
 const someNextTask = () => {
     return gulp.src(['some/glob/**/*.ext']).pipe(someplugin());
 };
 
-gulp.task(someTask);
+gulp.task(someTask!);
 
 const someTaskWithCb = (cb: gulp.TaskFunctionCallback) => {
     cb();

--- a/types/undertaker/index.d.ts
+++ b/types/undertaker/index.d.ts
@@ -67,7 +67,7 @@ declare class Undertaker extends EventEmitter {
      * Returns the wrapped registered function.
      * @param taskName - Task name.
      */
-    task(taskName: string): Undertaker.TaskFunctionWrapped;
+    task(taskName: string): Undertaker.TaskFunctionWrapped | undefined;
 
     /**
      * Register the task by the taskName.

--- a/types/undertaker/undertaker-tests.ts
+++ b/types/undertaker/undertaker-tests.ts
@@ -30,11 +30,15 @@ task4.flags = {
     "--foo": "bar",
 };
 taker.task(task4);
+
+// $ExpectType TaskFunctionWrapped | undefined
+const wrappedTask4 = taker.task("task4");
+
 const {
     displayName,
     description,
     flags,
-} = taker.task("task4").unwrap();
+} = wrappedTask4!.unwrap();
 
 taker.task("task5", () => {
     const emitter = new EventEmitter();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gulpjs/undertaker-registry/blob/master/index.js#L15, https://github.com/gulpjs/undertaker-registry#gettaskname--function, https://github.com/gulpjs/undertaker/blob/master/lib/get-task.js#L4

I think the change is actually correct, but I just realized that this has deep implications for gulp and other tools, too, (`gulp.task("some-task")` can actually return `undefined` if the task hasn't been defined yet), so I'm not sure if I can put up the effort to go through with this.