### PR TITLE
Add "importUserJobs" to auth0 types   

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -559,7 +559,24 @@ management
     })
     .then(results => console.log(results));
 
+management
+    .importUsersJob({
+        users: 'some file data',
+        connection_id: 'con_id',
+        upsert: true,
+    })
+    .then(results => console.log(results));
+
 management.importUsers(
+    {
+        users: 'some file data',
+        connection_id: 'con_id',
+        upsert: true,
+    },
+    (err, data) => console.log(data),
+);
+
+management.importUsersJob(
     {
         users: 'some file data',
         connection_id: 'con_id',

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1937,11 +1937,11 @@ export class ManagementClient<A = AppMetadata, U = UserMetadata> {
     getJob(params: ObjectWithId, cb?: (err: Error, data: Job) => void): void;
 
     /**
-     * @deprecated use @see importUsersJob instead 
+     * @deprecated use @see importUsersJob instead
      */
     importUsers(data: ImportUsersOptions): Promise<ImportUsersJob>;
     importUsers(data: ImportUsersOptions, cb?: (err: Error, data: ImportUsersJob) => void): void;
-    
+
     importUsersJob(data: ImportUsersOptions): Promise<ImportUsersJob>;
     importUsersJob(data: ImportUsersOptions, cb?: (err: Error, data: ImportUsersJob) => void): void;
 

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1936,8 +1936,14 @@ export class ManagementClient<A = AppMetadata, U = UserMetadata> {
     getJob(params: ObjectWithId): Promise<Job>;
     getJob(params: ObjectWithId, cb?: (err: Error, data: Job) => void): void;
 
+    /**
+     * @deprecated use @see importUsersJob instead 
+     */
     importUsers(data: ImportUsersOptions): Promise<ImportUsersJob>;
     importUsers(data: ImportUsersOptions, cb?: (err: Error, data: ImportUsersJob) => void): void;
+    
+    importUsersJob(data: ImportUsersOptions): Promise<ImportUsersJob>;
+    importUsersJob(data: ImportUsersOptions, cb?: (err: Error, data: ImportUsersJob) => void): void;
 
     exportUsers(data: ExportUsersOptions): Promise<ExportUsersJob>;
     exportUsers(data: ExportUsersOptions, cb?: (err: Error, data: ExportUsersJob) => void): void;

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for auth0 2.34
+// Type definitions for auth0 2.35
 // Project: https://github.com/auth0/node-auth0
 // Definitions by: Ian Howe <https://github.com/ianhowe76>
 //                 Dan Rumney <https://github.com/dancrumb>


### PR DESCRIPTION
Please fill in this template.


- Add `importUserJobs`  : https://github.com/auth0/node-auth0/blob/6eac9d39e47283e090f4444eb2475f9a6e870820/src/management/JobsManager.js#L220
- Deprecate `importUser`, as you can see :  https://github.com/auth0/node-auth0/blob/6eac9d39e47283e090f4444eb2475f9a6e870820/src/management/JobsManager.js#L190