### PR TITLE
[Serverless] Add lambda function urls field

### DIFF
--- a/types/serverless/index.d.ts
+++ b/types/serverless/index.d.ts
@@ -13,7 +13,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import Service = require('./classes/Service');
-import Plugin = require('./classes/Plugin');
 import PluginManager = require('./classes/PluginManager');
 import Utils = require('./classes/Utils');
 import YamlParser = require('./classes/YamlParser');

--- a/types/serverless/index.d.ts
+++ b/types/serverless/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for serverless 3.0
+// Type definitions for serverless 3.12
 // Project: https://github.com/serverless/serverless#readme
 // Definitions by: Hassan Khan <https://github.com/hassankhan>
 //                 Jonathan M. Wilbur <https://github.com/JonathanWilbur>
@@ -9,6 +9,7 @@
 //                 Gareth Jones <https://github.com/G-Rath>
 //                 Abdullah Ali <https://github.com/AbdullahAli>
 //                 François Farge <https://github.com/fargito>
+//                 Bruno Bodian <https://github.com/bacarybruno>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import Service = require('./classes/Service');

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -644,6 +644,7 @@ declare namespace Aws {
         destinations?: Destinations | undefined;
         events?: Event[] | undefined;
         disableLogs?: boolean | undefined;
+        url?: boolean;
     }
 
     interface AwsFunctionHandler extends AwsFunction {

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -621,10 +621,10 @@ declare namespace Aws {
 
     interface FunctionUrlConfigCors {
         allowCredentials?: boolean | undefined;
-        allowedHeaders?: boolean | string[];
-        allowedMethods?: boolean | string[];
-        allowedOrigins?: boolean | string[];
-        exposedResponseHeaders?: boolean | string[];
+        allowedHeaders?: boolean | string[] | undefined;
+        allowedMethods?: boolean | string[] | undefined;
+        allowedOrigins?: boolean | string[] | undefined;
+        exposedResponseHeaders?: boolean | string[] | undefined;
         maxAge?: number | undefined;
     }
 

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -619,6 +619,20 @@ declare namespace Aws {
         localMountPath: string;
     }
 
+    interface FunctionUrlConfigCors {
+        allowCredentials?: boolean | undefined;
+        allowedHeaders?: boolean | string[];
+        allowedMethods?: boolean | string[];
+        allowedOrigins?: boolean | string[];
+        exposedResponseHeaders?: boolean | string[];
+        maxAge?: number | undefined;
+    }
+
+    interface FunctionUrlConfig {
+        authorizer?: 'aws_iam' | undefined;
+        cors?: boolean | FunctionUrlConfigCors | undefined;
+    }
+
     interface AwsFunction {
         name?: string | undefined;
         description?: string | undefined;
@@ -644,7 +658,7 @@ declare namespace Aws {
         destinations?: Destinations | undefined;
         events?: Event[] | undefined;
         disableLogs?: boolean | undefined;
-        url?: boolean | undefined;
+        url?: boolean | FunctionUrlConfig | undefined;
     }
 
     interface AwsFunctionHandler extends AwsFunction {

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -644,7 +644,7 @@ declare namespace Aws {
         destinations?: Destinations | undefined;
         events?: Event[] | undefined;
         disableLogs?: boolean | undefined;
-        url?: boolean;
+        url?: boolean | undefined;
     }
 
     interface AwsFunctionHandler extends AwsFunction {

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -725,7 +725,8 @@ const awsServerless: Aws.Serverless = {
                         }
                     }
                 }
-            ]
+            ],
+            url: true,
         }
     },
     layers: {

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -726,8 +726,18 @@ const awsServerless: Aws.Serverless = {
                     }
                 }
             ],
-            url: true,
-        }
+            url: {
+                cors: {
+                    allowedOrigins: ['https://url1.com', 'https://url2.com'],
+                    allowedHeaders: ['Content-Type', 'Authorization'],
+                    allowedMethods: ['GET'],
+                    allowCredentials: true,
+                    exposedResponseHeaders: ['Special-Response-Header'],
+                    maxAge: 6000,
+                },
+                authorizer: 'aws_iam',
+            },
+        },
     },
     layers: {
         testLayer: {
@@ -893,6 +903,18 @@ const bunchOfConfigs: Aws.Serverless[] = [
             },
         },
         functions: {},
+    },
+    {
+        service: 'users',
+        provider: {
+            name: 'aws',
+        },
+        functions: {
+            basicLambdaFnUrl: {
+                handler: 'main.js',
+                url: true,
+            },
+        },
     },
 ];
 


### PR DESCRIPTION
Update serverless/aws types to support the newly announced [AWS Lambda Function URLs](https://aws.amazon.com/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/).

The change has already been made in the `serverless` yaml definition but was missing in this packages for people who use `serverless.ts` template file.

See https://github.com/serverless/serverless/pull/10936, https://www.serverless.com/blog/aws-lambda-function-urls-with-serverless-framework