### PR TITLE
[react] Deprecate ReactChild

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -217,6 +217,9 @@ declare namespace React {
      * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
      */
     type ReactText = string | number;
+    /**
+     * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
+     */
     type ReactChild = ReactElement | string | number;
 
     /**
@@ -224,7 +227,7 @@ declare namespace React {
      */
     interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
     type ReactFragment = Iterable<ReactNode>;
-    type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;
+    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined;
 
     //
     // Top Level API


### PR DESCRIPTION
There's nothing special about this type that is relevant for inputs or outputs in React's API. So we can remove this type to improve the onboarding experience by reducing the amount of things to learn (e.g. "When do I use `React.ReactChild`?").