### PR TITLE
[react] Deprecate ReactText

### DIFF
--- a/types/react-bootstrap-table-next/index.d.ts
+++ b/types/react-bootstrap-table-next/index.d.ts
@@ -58,7 +58,7 @@ declare enum FilterComparator {
  */
 export type SortOrder = 'asc' | 'desc';
 
-export type ColumnSortValue<R, C = any> = (cell: C, row: R) => boolean | React.ReactText;
+export type ColumnSortValue<R, C = any> = (cell: C, row: R) => boolean | string | number;
 
 export type ColumnSortFunc<T, E extends keyof T = any> = (
     a: T[E],

--- a/types/react-form/v2/index.d.ts
+++ b/types/react-form/v2/index.d.ts
@@ -130,7 +130,7 @@ export interface FieldApi {
 
 export interface FieldProps {
     children?: React.ReactNode;
-    field?: string | string[] | React.ReactText[] | Array<(string | React.ReactText[])> | undefined;
+    field?: string | string[] | Array<string | number> | Array<(string | Array<string | number>)> | undefined;
     showErrors?: boolean | undefined;
     errorBefore?: boolean | undefined;
     isForm?: boolean | undefined;

--- a/types/react-hyperscript/index.d.ts
+++ b/types/react-hyperscript/index.d.ts
@@ -12,12 +12,11 @@ import type {
     ReactNode,
     ReactSVG,
     ReactSVGElement,
-    ReactText,
 } from 'react';
 
 export = $;
 
-type Children = ReactNode[] | ReactText;
+type Children = ReactNode[] | number | string;
 
 declare function $(
     children?: Children,

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -27,7 +27,6 @@ import {
     ReactElement,
     ReactFragment,
     ReactNode,
-    ReactText,
 } from 'react';
 
 export {};
@@ -874,7 +873,7 @@ export type StringKey<D> = Extract<keyof D, string>;
 export type IdType<D> = StringKey<D> | string;
 export type CellValue<V = any> = V;
 
-export type Renderer<Props> = ComponentType<Props> | ReactElement | ReactText | ReactFragment;
+export type Renderer<Props> = ComponentType<Props> | ReactElement | string | number | ReactFragment;
 
 export interface PluginHook<D extends object> {
     (hooks: Hooks<D>): void;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -213,13 +213,11 @@ declare namespace React {
         (props?: ClassAttributes<SVGElement> & SVGAttributes<SVGElement> | null, ...children: ReactNode[]): ReactSVGElement;
     }
 
-    //
-    // React Nodes
-    // http://facebook.github.io/react/docs/glossary.html
-    // ----------------------------------------------------------------------
-
+    /**
+     * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
+     */
     type ReactText = string | number;
-    type ReactChild = ReactElement | ReactText;
+    type ReactChild = ReactElement | string | number;
 
     /**
      * @deprecated Use either `ReactNode[]` if you need an array or `Iterable<ReactNode>` if its passed to a host component.


### PR DESCRIPTION
To improve onboarding to React with TypeScript I'm cutting down on things to learn. 

There's no notion of "React text" that's useful for library users. It's just a helper type that creates discussions around "is this React text or just `string | number`". And since no input to React requires `ReactText`, I'd rather have people create it in their own codebase if they think it's helpful.

The existing usage in other DT packages highlights that it was probably used as a shortcut for `string | number` and nothing else.