### PR TITLE
[react] Deprecate `VoidFunctionComponent` and `VFC`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -523,8 +523,14 @@ declare namespace React {
         displayName?: string | undefined;
     }
 
+    /**
+     * @deprecated - Equivalent with `React.FC`
+     */
     type VFC<P = {}> = VoidFunctionComponent<P>;
 
+    /**
+     * @deprecated - Equivalent with `React.FunctionComponent`
+     */
     interface VoidFunctionComponent<P = {}> {
         (props: P, context?: any): ReactElement<any, any> | null;
         propTypes?: WeakValidationMap<P> | undefined;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -524,12 +524,12 @@ declare namespace React {
     }
 
     /**
-     * @deprecated - Equivalent with `React.FC`
+     * @deprecated - Equivalent with `React.FC`.
      */
     type VFC<P = {}> = VoidFunctionComponent<P>;
 
     /**
-     * @deprecated - Equivalent with `React.FunctionComponent`
+     * @deprecated - Equivalent with `React.FunctionComponent`.
      */
     interface VoidFunctionComponent<P = {}> {
         (props: P, context?: any): ReactElement<any, any> | null;


### PR DESCRIPTION
`VoidFunctionComponent` is now equivalent with `FunctionComponent`.

Since the release of the React 18 types I haven't seen any use case for `FunctionComponent` with implicit `children` beyond "it breaks existing stuff".

If we need to restore implicit `children` on `FunctionComponent` we can always undeprecate `VoidFunctionComponent`.