### PR TITLE
add missing size prop to LineMarkSeriesProps in react-vis

### DIFF
--- a/types/react-vis/index.d.ts
+++ b/types/react-vis/index.d.ts
@@ -416,6 +416,7 @@ export interface ArcSeriesProps extends AbstractSeriesProps<ArcSeriesPoint> {
 export class ArcSeries extends AbstractSeries<ArcSeriesProps> {}
 
 export interface LineMarkSeriesProps extends AbstractSeriesProps<LineMarkSeriesPoint> {
+    size?: number
     curve?: string | ((x: any) => any) | undefined; // default: null
     getNull?: RVGetNull<LineMarkSeriesPoint> | undefined;
     lineStyle?: CSSProperties | undefined; // default: {}

--- a/types/react-vis/index.d.ts
+++ b/types/react-vis/index.d.ts
@@ -416,7 +416,7 @@ export interface ArcSeriesProps extends AbstractSeriesProps<ArcSeriesPoint> {
 export class ArcSeries extends AbstractSeries<ArcSeriesProps> {}
 
 export interface LineMarkSeriesProps extends AbstractSeriesProps<LineMarkSeriesPoint> {
-    size?: number
+    size?: number;
     curve?: string | ((x: any) => any) | undefined; // default: null
     getNull?: RVGetNull<LineMarkSeriesPoint> | undefined;
     lineStyle?: CSSProperties | undefined; // default: {}

--- a/types/react-vis/react-vis-tests.tsx
+++ b/types/react-vis/react-vis-tests.tsx
@@ -52,6 +52,7 @@ export function Example() {
                 }}
             />
             <LineMarkSeries
+                size={3}
                 className="linemark-series-example"
                 style={{
                     strokeWidth: '3px',


### PR DESCRIPTION
This change adds a missing property for the LineMarkSeries React props.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://uber.github.io/react-vis/documentation/series-reference/line-mark-series
