### PR TITLE
[postcss-js] Add types for postcss-js

### DIFF
--- a/types/postcss-js/index.d.ts
+++ b/types/postcss-js/index.d.ts
@@ -1,0 +1,51 @@
+// Type definitions for postcss-js 4.0
+// Project: https://github.com/postcss/postcss-js
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { AcceptedPlugin, ProcessOptions, Root, LazyResult } from 'postcss';
+import NoWorkResult from 'postcss/lib/no-work-result';
+
+/** CSS-in-JS object */
+export type CssInJs = Record<string, any>;
+
+/**
+ * Convert a PostCSS `Root` into a CSS-in-JS object
+ * @param root The root to convert
+ * @returns CSS-in-JS object
+ */
+export function objectify(root: Root): CssInJs;
+
+/**
+ * Parse a CSS-in-JS object into a PostCSS `Root`
+ * @param obj The CSS-in-JS to parse
+ * @returns A PostCSS `Root`
+ */
+export function parse(obj: CssInJs): Root;
+
+/**
+ * Create a PostCSS processor with a simple API
+ * @param plugins Synchronous plugins to use with PostCSS
+ * @returns A processor function that accepts (idk) and returns a CSS-in-JS object
+ */
+export function sync(plugins: AcceptedPlugin[]): (input: CssInJs) => CssInJs;
+
+/**
+ * Create a PostCSS processor with a simple API, allowing asynchronous plugins
+ * @param plugins Plugins to use with PostCSS
+ * @returns A processor function that accepts (idk) and returns a CSS-in-JS object
+ */
+export function async(plugins: AcceptedPlugin[]): (input: CssInJs) => Promise<CssInJs>;
+
+// Override process method to allow passing CssInJs
+// when the parser is the postcss-js parser.
+// This lets the postcss-js parser be used
+// as long as the object passed to `process` is a CSS-in-JS object
+declare module 'postcss/lib/processor' {
+    export default interface Processor {
+        process(
+            obj: CssInJs,
+            opts: Omit<ProcessOptions, 'parser'> & { parser: typeof parse },
+        ): LazyResult | NoWorkResult;
+    }
+}

--- a/types/postcss-js/package.json
+++ b/types/postcss-js/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.3.3"
+    }
+}

--- a/types/postcss-js/postcss-js-tests.ts
+++ b/types/postcss-js/postcss-js-tests.ts
@@ -1,0 +1,37 @@
+import postcss from 'postcss';
+import * as postcssJs from 'postcss-js';
+
+const style = {
+    top: 10,
+    '&:hover': {
+        top: 5,
+    },
+};
+
+// Parse using postcss-js parser
+postcss()
+    .process(style, { parser: postcssJs.parse })
+    .then(result => {
+        result; // $ExpectType Result
+    });
+
+// Try to parse random object with postcss-js parser (errors)
+// $ExpectError
+postcss().process('.a {}', { parser: postcssJs.parse });
+
+postcssJs.parse(style);
+
+postcssJs.objectify(postcss.root());
+
+// Sync and async fail to work if no parameters are passed
+postcssJs.sync(); // $ExpectError
+postcssJs.async(); // $ExpectError
+
+postcssJs.sync([])(style); // $ExpectType CssInJs || Record<string, any>
+
+postcssJs.async([])(style); // $ExpectType Promise<CssInJs> || Promise<Record<string, any>>
+postcssJs
+    .async([])(style)
+    .then(result => {
+        result; // $ExpectType CssInJs || Record<string, any>
+    });

--- a/types/postcss-js/tsconfig.json
+++ b/types/postcss-js/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es2018"],
+        "lib": ["es6", "ES2018.Promise"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/postcss-js/tsconfig.json
+++ b/types/postcss-js/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es2018"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "postcss-js-tests.ts"]
+}

--- a/types/postcss-js/tslint.json
+++ b/types/postcss-js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Related discussion: #59115 (mistitled)

Adds types for the npm package postcss-js.

npm: <https://www.npmjs.com/package/postcss-js>
GitHub: <https://github.com/postcss/postcss-js>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test postcss-js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
