### PR TITLE
[wordpress__media-utils] Updated typings for v3

### DIFF
--- a/types/wordpress__media-utils/index.d.ts
+++ b/types/wordpress__media-utils/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/media-utils 2.0
+// Type definitions for @wordpress/media-utils 3.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/media-utils/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__media-utils/package.json
+++ b/types/wordpress__media-utils/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^3.0.0"
+        "@wordpress/element": "^4.0.0"
     }
 }


### PR DESCRIPTION
This change updates the @wordpress/element dependency to fix a clash between react types for v16 and v17.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/trunk/packages/media-utils/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
