### PR TITLE
[auth0] Fix typo with type for DatabaseAuthenticator#signUp

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -1022,6 +1022,11 @@ async function signupTest(): Promise<void> {
     signupResult._id; // $ExpectType string
     signupResult.email; // $ExpectType string
     signupResult.email_verified; // $ExpectType boolean
+
+    authentication.database.signUp({ email: 'email', password: 'password' }, (err, data) => {
+        err; // $ExpectType Error
+        data; // $ExpectType User<AppMetadata, UserMetadata>
+    });
 }
 
 const decoded = idToken.decode('{YOUR_API_V2_TOKEN}'); // $ExpectType DecodedToken

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -2032,7 +2032,7 @@ export class DatabaseAuthenticator<A = AppMetadata, U = UserMetadata> {
     signIn(data: SignInOptions, cb: (err: Error, data: SignInToken) => void): void;
 
     signUp(data: SignUpUserData): Promise<User<A, U>>;
-    signIn(data: SignUpUserData, cb: (err: Error, data: User) => void): void;
+    signUp(data: SignUpUserData, cb: (err: Error, data: User) => void): void;
 }
 
 export class OAuthAuthenticator {


### PR DESCRIPTION
#### Summary

Fix a typo in the type defs for Auth0's DatabaseAuthenticator `signUp` method, which accepts a callback.

#### Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/node-auth0/blob/master/src/auth/DatabaseAuthenticator.js#L91-L121
