### PR TITLE
fix(@hapi/hapi): dictionary entries can be undefined

### DIFF
--- a/types/hapi__hapi/index.d.ts
+++ b/types/hapi__hapi/index.d.ts
@@ -4092,7 +4092,7 @@ export namespace Lifecycle {
 
 export namespace Util {
     interface Dictionary<T> {
-        [key: string]: T;
+        [key: string]: T | undefined;
     }
 
     type HTTP_METHODS_PARTIAL_LOWERCASE = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';


### PR DESCRIPTION
The following are *not* always defined and should not be considered to always be strings:
- `request.headers.blabla`
- `request.query.foo`
- `request.params.xxx`

Checks:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://hapi.dev/api/?v=20.2.1#-requestheaders)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
