### PR TITLE
[react-vertical-timeline-component v3.5.2] Add support for '1-column-left' & '1-column-right'

### DIFF
--- a/types/react-vertical-timeline-component/index.d.ts
+++ b/types/react-vertical-timeline-component/index.d.ts
@@ -11,7 +11,7 @@ export interface VerticalTimelineProps {
     animate?: boolean | undefined;
     children?: React.ReactNode;
     className?: string | undefined;
-    layout?: '1-column' | '2-columns' | undefined;
+    layout?: '1-column' | '1-column-left' | '1-column-right' | '2-columns' | undefined;
     lineColor?: string | undefined;
 }
 


### PR DESCRIPTION
Currently (Apr 15 2022), `<VerticalTimeline layout='1-column-right'>` throws a linting error "No overload matches this call."
The VerticalTimeline.js component in the actual react-vertical-timeline-component library has, after v3.1.0: 

`layout: _propTypes.default.oneOf(['1-column-left', '1-column', '2-columns', '1-column-right'])`

but this was not updated in DefinitelyTyped.
This PR fixes the linting error.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. - tested locally with npm patch-package, unsure of what to add to the tests file
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [VerticalTimelineElement.js](https://github.com/stephane-monnot/react-vertical-timeline/blob/master/src/VerticalTimelineElement.js)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
