### PR TITLE
feat(node): allow `undefined` as argument for functions that clear timers

### DIFF
--- a/types/node/test/timers.ts
+++ b/types/node/test/timers.ts
@@ -39,11 +39,11 @@ import * as timers from 'node:timers';
     }) {
         const setTimeout = promisify(timers.setTimeout);
         let v: void = await setTimeout(100); // tslint:disable-line no-void-expression void-return
-        let s: string = await setTimeout(100, "");
+        let s: string = await setTimeout(100, '');
 
         const setImmediate = promisify(timers.setImmediate);
         v = await setImmediate();
-        s = await setImmediate("");
+        s = await setImmediate('');
 
         // $ExpectType (foo: any) => Promise<string>
         const doSomethingPromise = promisify(doSomething);
@@ -90,4 +90,13 @@ import * as timers from 'node:timers';
     queueMicrotask(() => {
         // cool
     });
+
+    function waitFor(options?: { timeout: number }) {
+        const timerId = options && setTimeout(() => {}, options.timeout);
+        clearTimeout(timerId);
+        const intervalId = options && setTimeout(() => {}, options.timeout);
+        clearInterval(intervalId);
+        const immediateId = options && setImmediate(() => {});
+        clearImmediate(immediateId);
+    }
 }

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -69,7 +69,7 @@ declare module 'timers' {
         namespace setTimeout {
             const __promisify__: typeof setTimeoutPromise;
         }
-        function clearTimeout(timeoutId: NodeJS.Timeout): void;
+        function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
         function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timer;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -77,7 +77,7 @@ declare module 'timers' {
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }
-        function clearInterval(intervalId: NodeJS.Timeout): void;
+        function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
         function setImmediate<TArgs extends any[]>(callback: (...args: TArgs) => void, ...args: TArgs): NodeJS.Immediate;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -85,7 +85,7 @@ declare module 'timers' {
         namespace setImmediate {
             const __promisify__: typeof setImmediatePromise;
         }
-        function clearImmediate(immediateId: NodeJS.Immediate): void;
+        function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
         function queueMicrotask(callback: () => void): void;
     }
 }

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -179,15 +179,15 @@ declare namespace setTimeout {
     function __promisify__(ms: number): Promise<void>;
     function __promisify__<T>(ms: number, value: T): Promise<T>;
 }
-declare function clearTimeout(timeoutId: NodeJS.Timeout): void;
+declare function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
 declare function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
-declare function clearInterval(intervalId: NodeJS.Timeout): void;
+declare function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
 declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
 declare namespace setImmediate {
     function __promisify__(): Promise<void>;
     function __promisify__<T>(value: T): Promise<T>;
 }
-declare function clearImmediate(immediateId: NodeJS.Immediate): void;
+declare function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
 
 declare function queueMicrotask(callback: () => void): void;
 

--- a/types/node/v12/timers.d.ts
+++ b/types/node/v12/timers.d.ts
@@ -4,13 +4,13 @@ declare module 'timers' {
         function __promisify__(ms: number): Promise<void>;
         function __promisify__<T>(ms: number, value: T): Promise<T>;
     }
-    function clearTimeout(timeoutId: NodeJS.Timeout): void;
+    function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
     function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
-    function clearInterval(intervalId: NodeJS.Timeout): void;
+    function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
     function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
     namespace setImmediate {
         function __promisify__(): Promise<void>;
         function __promisify__<T>(value: T): Promise<T>;
     }
-    function clearImmediate(immediateId: NodeJS.Immediate): void;
+    function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
 }

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -52,15 +52,15 @@ declare namespace setTimeout {
     function __promisify__(ms: number): Promise<void>;
     function __promisify__<T>(ms: number, value: T): Promise<T>;
 }
-declare function clearTimeout(timeoutId: NodeJS.Timeout): void;
+declare function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
 declare function setInterval(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
-declare function clearInterval(intervalId: NodeJS.Timeout): void;
+declare function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
 declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
 declare namespace setImmediate {
     function __promisify__(): Promise<void>;
     function __promisify__<T>(value: T): Promise<T>;
 }
-declare function clearImmediate(immediateId: NodeJS.Immediate): void;
+declare function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
 
 declare function queueMicrotask(callback: () => void): void;
 

--- a/types/node/v14/timers.d.ts
+++ b/types/node/v14/timers.d.ts
@@ -4,15 +4,15 @@ declare module 'timers' {
         function __promisify__(ms: number): Promise<void>;
         function __promisify__<T>(ms: number, value: T): Promise<T>;
     }
-    function clearTimeout(timeoutId: NodeJS.Timeout): void;
+    function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
     function setInterval(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
-    function clearInterval(intervalId: NodeJS.Timeout): void;
+    function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
     function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
     namespace setImmediate {
         function __promisify__(): Promise<void>;
         function __promisify__<T>(value: T): Promise<T>;
     }
-    function clearImmediate(immediateId: NodeJS.Immediate): void;
+    function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
 }
 declare module 'node:timers' {
     export * from 'timers';

--- a/types/node/v16/timers.d.ts
+++ b/types/node/v16/timers.d.ts
@@ -69,7 +69,7 @@ declare module 'timers' {
         namespace setTimeout {
             const __promisify__: typeof setTimeoutPromise;
         }
-        function clearTimeout(timeoutId: NodeJS.Timeout): void;
+        function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
         function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timer;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -77,7 +77,7 @@ declare module 'timers' {
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }
-        function clearInterval(intervalId: NodeJS.Timeout): void;
+        function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
         function setImmediate<TArgs extends any[]>(callback: (...args: TArgs) => void, ...args: TArgs): NodeJS.Immediate;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -85,7 +85,7 @@ declare module 'timers' {
         namespace setImmediate {
             const __promisify__: typeof setImmediatePromise;
         }
-        function clearImmediate(immediateId: NodeJS.Immediate): void;
+        function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
         function queueMicrotask(callback: () => void): void;
     }
 }


### PR DESCRIPTION
**Why?**

1. It's at times convenient
2. it's allowed by the implementation, see node's [source code](https://github.com/nodejs/node/blob/24adba675179ebba363d46f5dd30685d58cdb7f4/lib/timers.js#L184) (although it's not allowed by the type declared in their JSDoc)
3. node has tests that this should work, see [here](https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/test/parallel/test-timers-clear-null-does-not-throw-error.js)
4. It creates a weird mismatch with the types defined in the Lib DOM, see the definitions [here](https://github.com/microsoft/TypeScript/blob/0d9a4fe490499de6ec4b8a399ec96645b67d99a6/lib/lib.dom.d.ts#L18660-L18661) and makes it really inconvenient in projects that load both lib DOM and `@types/node` (while not super correct, it's often the case as it's quite convenient to have a single `tsconfig.json`). On such an occasion overloads are created for each of those functions, and the node variant takes precedence so the return type of the `setTimeout` & co is based on that:
<img width="613" alt="Screenshot 2022-04-15 at 14 26 25" src="https://user-images.githubusercontent.com/9800850/163570584-c9b6e65a-9404-42e9-8fb7-49bba2f4fec5.png">
but that return type can't be used with the clearing function because no overload matches it:

<img width="939" alt="Screenshot 2022-04-15 at 14 28 00" src="https://user-images.githubusercontent.com/9800850/163570661-896027ce-a86a-4092-81cc-62e4f5b7f24d.png">

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
