### PR TITLE
feat: combination controlsList

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -52,6 +52,23 @@ type NativeTransitionEvent = TransitionEvent;
 type NativeUIEvent = UIEvent;
 type NativeWheelEvent = WheelEvent;
 type Booleanish = boolean | 'true' | 'false';
+// ========== Some Array util types =============
+type ArrayJoin<
+  T extends any[],
+  U extends string | number,
+> =
+  T extends [infer F, ...infer L]? L['length'] extends 0? F : `${F&string}${U}${ArrayJoin<L, U>}` : ''
+type ArrayToUnion<T extends any[]> = T extends [infer F, ...infer L]?
+  L['length'] extends 0 ? F : F | ArrayToUnion<L>
+  : never
+type C1<T extends any[], K extends string> = T extends [infer F, ...infer L] ?
+  L['length'] extends 0 ? `${F&string} ${K}` : `${F&string} ${K}` | C1<L, K>
+  :never
+type ArrayCombination<T extends any[]> = T extends [infer F, ...infer L]?
+  L['length'] extends 0 ? never : C1<L, F & string> | ArrayCombination<L>
+  : never
+type Combination<T extends string[]> = ArrayToUnion<T> | ArrayJoin<T, ' '> | ArrayCombination<T>
+// ========== Some Array util types =============
 
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 // Destructors are only allowed to return void.
@@ -2297,7 +2314,7 @@ declare namespace React {
     interface MediaHTMLAttributes<T> extends HTMLAttributes<T> {
         autoPlay?: boolean | undefined;
         controls?: boolean | undefined;
-        controlsList?: string | undefined;
+        controlsList?: Combination<['nodownload', 'nofullscreen', 'noremoteplayback']>;
         crossOrigin?: string | undefined;
         loop?: boolean | undefined;
         mediaGroup?: string | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

[controlsList mdn](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList)

the adding type's output is:

![image](https://user-images.githubusercontent.com/49113249/163669635-b6a1b4cc-1099-42be-83b9-0e569ec6a3ef.png)


you can check the [playground](https://www.typescriptlang.org/play?#code/PQKgUABBAcDsBssIFoIAUCmAnAtgVwBcBDAgSwHsA7CAMggGFycAjUykiyyFZXv75gE8IACSaCMGCAGk2AcwgAKAAJicEjLMpyAlBADEODABNSeHAaJYsRYfqIAHBwBtSAYw5UDAZwJZ53Nz6wRAAingYvpyBUADipABuGNREKda2EOQAZhC+-treADQQxuTo2PjEZF50jCxsnpQAdNwAkgQA5N4QRM7eZXjeGFl4zhBZ5FgQBAAWUg5Y5A7Tgg6REK4A1lIJpMYYZQDablR+5H0AMqS+ALqKMwQEDt4AXMDA+0nOS9hNOOQAL1IzmcRCakzkwGSyAAqgBlD7kNzeYAAdQwzGAAEE0K1gCIACoAWQuRJMpCIAFFnBgjJQCMATvTFpdrgQdDEIAADHkEbzcd4QDAADzWbgIJmmZWYUi5ACIJuQ5RAAD4QOXMKzKtUaogA7XqxUQTVTTX61Xqk3jchKi26gHW206q1mg3241arncAirKTSDCCboAXnKuEIjTqrHY1UoAB5Dh1FR1ih0TcmIKm9R0bgA+bg8r1Qbg5iAANVIGAA7plqPECCI8MwXhAHk9Xu8+W4Zk0AFbecFYSFwRBgEDAMAT0AQAD6s7n87nEAAmuQ8FNGPtRNgpAvd7OIGOJz61hAselBAApchsWPcAlC4USyjGbqpQSHG6Fbgwh9Pl+5Px5AtShzBlLAvxLIM71-ZJ-0ONgsmwCAADFiiadCEKQi4bgAfggC4ExpbRZmzGDn26AAGPDkIgZsuQAEgAb2Qmg8nkABfJiYU4xizxsS9rzjC5ihhHN2K5WiMw6I9fVPc8CXIGFKE4WN7xFP9X0od9cwgEM1MfWDungyhEKmVCIHQppMKmbCcO4AiOiIuQSJuMj-woiBqMkmi1T42wFKUlSLjzKBm0oDAkiwGST3oABGVS3M07TimkRKAPyORIIgfSNIgYzTJQtCMJMrDXLsqAHKcly0o8vCGOY1jAO0diICY6RxMk+qWLY5rWsY9qJLVOLY2EmQQto8LIuiqQ-MESMGhjBL1MMnotI-LKcpW-KkPMyzrPw3D7MI5JnJmUjlvIiBaogSakObYbRpougesyi1Zvm6MgvGsKIuwaaGCYKNGiWgzLpe9bdLk-iAuUqhVJLXzzyvG8CRTDMEah2wPuBgk8zAY8pAJe8Q2xxaE0ochSkrShviIYx0w6CmRhBbw3CwSRKAZin2f+CUXFsTU3E2bM8ynPdd2yyICAYIghm6cWFwPcdSBwBxJmlgmIEYiBKQARzwXpikpUUMHFCAWqyRYLA6ZQCeQLteicyJgEIYFvGk-HZI8OXIcObhjbFAhYz1g3nFjUmVITJMUzTGOs1zL8oAVG03RNVO9TdI0XQzu0rUVdOHXz3O9Q9LA5RzHMvxuCdJxAGcFcXZC11mJC4T5+WG-3Q9QGLCA4RmKwpEEVcpn6ZxXaoV4W0eZ43mATtuz7AchwQWBgFSbxKz+qAS3LKtcnOCfKCn1tZ47VnF-7CFgGHNex6P-kd4gIlJikegB5BE7ImbU-23ni-exX0HKOccYAgA)