### PR TITLE
feat(react-pdf): add support for parcel 2 and webpack 5 base on react-pdf 5.7.0

### DIFF
--- a/types/react-pdf/dist/esm/entry.parcel2.d.ts
+++ b/types/react-pdf/dist/esm/entry.parcel2.d.ts
@@ -1,0 +1,4 @@
+export { default as Document } from '../Document';
+export { default as Page } from '../Page';
+export { default as Outline } from '../Outline';
+export { default as pdfjs } from '../pdfjs-dist';

--- a/types/react-pdf/dist/esm/entry.webpack5.d.ts
+++ b/types/react-pdf/dist/esm/entry.webpack5.d.ts
@@ -1,0 +1,4 @@
+export { default as Document } from '../Document';
+export { default as Page } from '../Page';
+export { default as Outline } from '../Outline';
+export { default as pdfjs } from '../pdfjs-dist';

--- a/types/react-pdf/dist/umd/entry.parcel2.d.ts
+++ b/types/react-pdf/dist/umd/entry.parcel2.d.ts
@@ -1,0 +1,4 @@
+export { default as Document } from '../Document';
+export { default as Page } from '../Page';
+export { default as Outline } from '../Outline';
+export { default as pdfjs } from '../pdfjs-dist';

--- a/types/react-pdf/dist/umd/entry.webpack5.d.ts
+++ b/types/react-pdf/dist/umd/entry.webpack5.d.ts
@@ -1,0 +1,4 @@
+export { default as Document } from '../Document';
+export { default as Page } from '../Page';
+export { default as Outline } from '../Outline';
+export { default as pdfjs } from '../pdfjs-dist';

--- a/types/react-pdf/index.d.ts
+++ b/types/react-pdf/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-pdf 5.0
+// Type definitions for react-pdf 5.7.0
 // Project: https://github.com/wojtekmaj/react-pdf/
 // Definitions by: CodeDaraW <https://github.com/CodeDaraW>
 //                 Nathan Hardy <https://github.com/nhardy>

--- a/types/react-pdf/index.d.ts
+++ b/types/react-pdf/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-pdf 5.7.0
+// Type definitions for react-pdf 5.7
 // Project: https://github.com/wojtekmaj/react-pdf/
 // Definitions by: CodeDaraW <https://github.com/CodeDaraW>
 //                 Nathan Hardy <https://github.com/nhardy>

--- a/types/react-pdf/react-pdf-tests.tsx
+++ b/types/react-pdf/react-pdf-tests.tsx
@@ -86,7 +86,6 @@ export class MyApp extends React.Component<{}, State> {
                     <PageUmdParcel pageNumber={pageNumber} onLoadSuccess={this.onPageLoadSuccess} />
                 </DocumentUmdParcel>
 
-
                 <DocumentEsmParcel2 file="somefile.pdf" onLoadSuccess={this.onDocumentLoadSuccess}>
                     <PageEsmParcel2 pageNumber={pageNumber} onLoadSuccess={this.onPageLoadSuccess} />
                 </DocumentEsmParcel2>

--- a/types/react-pdf/react-pdf-tests.tsx
+++ b/types/react-pdf/react-pdf-tests.tsx
@@ -5,8 +5,12 @@ import { PDFDocumentProxy } from 'pdfjs-dist/types/src/display/api';
 // Test special entry points
 import { Document as DocumentEsmWebpack, Page as PageEsmWebpack } from 'react-pdf/dist/esm/entry.webpack';
 import { Document as DocumentUmdWebpack, Page as PageUmdWebpack } from 'react-pdf/dist/umd/entry.webpack';
+import { Document as DocumentEsmWebpack5, Page as PageEsmWebpack5 } from 'react-pdf/dist/esm/entry.webpack5';
+import { Document as DocumentUmdWebpack5, Page as PageUmdWebpack5 } from 'react-pdf/dist/umd/entry.webpack5';
 import { Document as DocumentEsmParcel, Page as PageEsmParcel } from 'react-pdf/dist/esm/entry.parcel';
 import { Document as DocumentUmdParcel, Page as PageUmdParcel } from 'react-pdf/dist/umd/entry.parcel';
+import { Document as DocumentEsmParcel2, Page as PageEsmParcel2 } from 'react-pdf/dist/esm/entry.parcel2';
+import { Document as DocumentUmdParcel2, Page as PageUmdParcel2 } from 'react-pdf/dist/umd/entry.parcel2';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
@@ -66,6 +70,14 @@ export class MyApp extends React.Component<{}, State> {
                     <PageUmdWebpack pageNumber={pageNumber} onLoadSuccess={this.onPageLoadSuccess} />
                 </DocumentUmdWebpack>
 
+                <DocumentEsmWebpack5 file="somefile.pdf" onLoadSuccess={this.onDocumentLoadSuccess}>
+                    <PageEsmWebpack5 pageNumber={pageNumber} onLoadSuccess={this.onPageLoadSuccess} />
+                </DocumentEsmWebpack5>
+
+                <DocumentUmdWebpack5 file="somefile.pdf" onLoadSuccess={this.onDocumentLoadSuccess}>
+                    <PageUmdWebpack5 pageNumber={pageNumber} onLoadSuccess={this.onPageLoadSuccess} />
+                </DocumentUmdWebpack5>
+
                 <DocumentEsmParcel file="somefile.pdf" onLoadSuccess={this.onDocumentLoadSuccess}>
                     <PageEsmParcel pageNumber={pageNumber} onLoadSuccess={this.onPageLoadSuccess} />
                 </DocumentEsmParcel>
@@ -73,6 +85,15 @@ export class MyApp extends React.Component<{}, State> {
                 <DocumentUmdParcel file="somefile.pdf" onLoadSuccess={this.onDocumentLoadSuccess}>
                     <PageUmdParcel pageNumber={pageNumber} onLoadSuccess={this.onPageLoadSuccess} />
                 </DocumentUmdParcel>
+
+
+                <DocumentEsmParcel2 file="somefile.pdf" onLoadSuccess={this.onDocumentLoadSuccess}>
+                    <PageEsmParcel2 pageNumber={pageNumber} onLoadSuccess={this.onPageLoadSuccess} />
+                </DocumentEsmParcel2>
+
+                <DocumentUmdParcel2 file="somefile.pdf" onLoadSuccess={this.onDocumentLoadSuccess}>
+                    <PageUmdParcel2 pageNumber={pageNumber} onLoadSuccess={this.onPageLoadSuccess} />
+                </DocumentUmdParcel2>
 
                 <p>
                     Page {pageNumber} of {numPages}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/wojtekmaj/react-pdf/releases/tag/v5.7.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
