### PR TITLE
[mock-knex] Add missing Tracker.queries interfaces

### DIFF
--- a/types/mock-knex/index.d.ts
+++ b/types/mock-knex/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/colonyamerican/mock-knex
 // Definitions by: Jesse Zhang <https://github.com/jessezhang91>
 //                 Scott Cooper <https://github.com/scttcper>
+//                 TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.4
 
@@ -49,6 +50,15 @@ export function getTracker(): Tracker;
  */
 export interface Tracker extends EventEmitter {
     /**
+     * Whether tracking is currently enabled for this tracker
+     */
+    tracking: boolean;
+    /**
+     * The queries tracked so far by this tracker
+     */
+    queries: Queries;
+
+    /**
      * Enables query tracking mock on mocked knex client
      */
     install(): void;
@@ -57,6 +67,16 @@ export interface Tracker extends EventEmitter {
      * Disables query tracking mock on mocked knex client. Also resets 'step' counter.
      */
     uninstall(): void;
+
+    /**
+     * Install the tracker, run the callback, and uninstall the tracker.
+     */
+    wrap(cb: () => void): void;
+
+    /**
+     * Calls 'this.with()'
+     */
+    withMock(): void;
 
     /**
      * Add event listener for 'query' event. It gets esecuted for each query that should end up in database.
@@ -76,6 +96,56 @@ export interface Tracker extends EventEmitter {
 }
 
 /**
+ * The object containing queries that have been tracked so far.
+ */
+export interface Queries {
+    /**
+     * The queries tracked so far
+     */
+    queries: QueryDetails[];
+    /**
+     * The parent tracker that this 'queries' property belongs to
+     */
+    tracker: Tracker;
+
+    /**
+     * Reset this query tracker, clears the 'queries' array.
+     */
+    reset(): this;
+
+    /**
+     * If tracking is enabled, adds a 'mock' property to the 'query' argument with the following properties, among others:
+     *  - response(response, options?) - calls 'resolve()' with the 'query' or the '{ response }' as a parameter depending on 'options.stream'
+     *  - resolve(result) - calls 'query.response(result)'
+     *  - reject(error) - calls back the 'reject' argument
+     * Also emits a tracker 'query' event.
+     * Else, calls 'resolve()' without arguments.
+     */
+    track<T extends object = object>(query: T, resolve: (query: T) => void, reject: (error: Error) => void): void;
+
+    /**
+     * Returns the first (oldest) tracked query, if any have been tracked.
+     */
+    first(): QueryDetails;
+
+    /**
+     * Returns the number of queries tracked so far.
+     */
+    count(): number;
+
+    /**
+     * Returns the last (most recent) tracked query, if any have been tracked.
+     */
+    last(): QueryDetails;
+
+    /**
+     * Return the tracked query at the given point in the list of queries tracked so far.
+     * NOTE: this is a 1 based number! NOT a zero based index.
+     */
+    step(stepNum: number): QueryDetails;
+}
+
+/**
  * The object containing query details that is being sent to knex database dialect on query execution.
  * Object properties signature matches with knex toSQL() output with additional method returns(values).
  */
@@ -90,6 +160,11 @@ export interface QueryDetails extends Knex.Sql {
     reject(error: Error | string): void;
 
     /**
+     * Alias for 'response()'
+     */
+    resolve(result: any): void;
+
+    /**
      * Function that needs to be called to mock database query result for knex.
      *
      * @param values An array of mock data to be returned by database. For Bookshelf this is mostly array of objects. Knex could return any type of data.
@@ -101,5 +176,5 @@ export interface QueryDetailsResponseOption {
     /**
      * Is this a stream response, defaults to false
      */
-    stream: boolean;
+    stream?: boolean;
 }

--- a/types/mock-knex/mock-knex-tests.ts
+++ b/types/mock-knex/mock-knex-tests.ts
@@ -1,4 +1,4 @@
-import * as mockDb from "mock-knex";
+import * as mockDb from 'mock-knex';
 
 interface Knex {
     client: any;
@@ -21,7 +21,7 @@ mockDb.mock(db);
 const tracker = mockDb.getTracker();
 tracker.install();
 tracker.on('query', (query, step) => {
-    if (query.method === "first" || step === 1) {
+    if (query.method === 'first' || step === 1) {
         query.response([{
             a: 1
         }, {
@@ -32,9 +32,30 @@ tracker.on('query', (query, step) => {
             stream: false
         });
     } else {
-        query.reject(new Error("bad query"));
+        query.reject(new Error('bad query'));
     }
 });
+
+const queries = tracker.queries;
+if (tracker !== queries.tracker) {
+    throw new Error('unexpected query tracker');
+}
+if (queries.count() > 0) {
+    // $ExpectType string
+    queries.first().method;
+    // $ExpectType string
+    queries.last().sql;
+
+    queries.track({ query: 'SELECT * FROM table' }, (query) => {
+        // $ExpectType { query: string; }
+        query;
+    }, (error) => {
+        // $ExpectType Error
+        error;
+    });
+    queries.reset();
+}
+
 tracker.uninstall();
 
 mockDb.unmock(db);


### PR DESCRIPTION
Update mock-knex to reflect latest patch release additions to the API and types missing from the current type definition.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [tracker.js](https://github.com/jbrumwell/mock-knex/blob/0b0b33e7b3fbe29d42f958c25cef5b90dc5e6e4a/src/tracker.js) and [queries.js](https://github.com/jbrumwell/mock-knex/blob/0b0b33e7b3fbe29d42f958c25cef5b90dc5e6e4a/src/queries.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - [mock-knex](https://github.com/jbrumwell/mock-knex/blob/master/package.json) is still version `0.4.x`, all their recent changes have been patch number releases.