### PR TITLE
(html-validator) added `string` to allowed types for BasicOptions.validator 

### DIFF
--- a/types/html-validator/index.d.ts
+++ b/types/html-validator/index.d.ts
@@ -20,7 +20,7 @@ declare function HtmlValidator(
 
 declare namespace HtmlValidator {
     interface BasicOptions {
-        validator?: object | undefined;
+        validator?: string | object | undefined;
         ignore?: string | string[] | undefined;
         isLocal?: boolean | undefined;
         isFragment?: boolean | undefined;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/html-validator
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Rationale:
The type declarations for `html-validator` have the allowed types for `BasicOptions.validator` as `object | undefined`. However, in the official usage guide for the validator, a value of type `object` is never fed into the `BasicOptions.validator` argument - only strings are used. Therefore, I have added string to the list of allowed types.

To avoid any breaking changes I've left `object` as an allowed type in case there were use cases for it that weren't documented in the official guide.

