### PR TITLE
[spotify-api] Add null as a possible type to PlaylistTrackObject.track

### DIFF
--- a/types/spotify-api/index.d.ts
+++ b/types/spotify-api/index.d.ts
@@ -1196,7 +1196,7 @@ declare namespace SpotifyApi {
         added_at: string;
         added_by: UserObjectPublic;
         is_local: boolean;
-        track: TrackObjectFull;
+        track: TrackObjectFull | null;
     }
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Spotify's API for playlist tracks can return `null` for a track object.
As you can see, there is no track being omitted compared to the normal Spotify App GUI, it's just an extraneous entry with a `null` track value. This is possibly a deleted track, see my additional comment further down in this thread for more.
![image](https://user-images.githubusercontent.com/34871211/163730070-8b343d9a-4030-46ba-8d98-bdcc4c117c52.png)
