### PR TITLE
[notie] Update notie types for v4.3

### DIFF
--- a/types/notie/index.d.ts
+++ b/types/notie/index.d.ts
@@ -1,10 +1,175 @@
-// Type definitions for notie.js
+// Type definitions for notie 4.3
 // Project: https://github.com/jaredreich/notie.js
-// Definitions by: Mateus Demboski <https://github.com/mateusdemboski>
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+//                 Mateus Demboski <https://github.com/mateusdemboski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
- 
-declare var notie: {
-    alert: (type: number, message: string, seconds: number) => void;
-    confirm: (title: string, yes_text: string, no_text: string, yes_callback: () => void) => void;
-    input: (title: string, submit_text: string, cancel_text: string, type: string, placeholder: string, submit_callback: (value_entered: string) => void, prefilled_value_optional?: string) => void;
-};
+
+export as namespace notie;
+
+export type AlertType = 1 | 2 | 3 | 4 | 5 | 'success' | 'warning' | 'error' | 'info' | 'neutral';
+
+export type Position = 'top' | 'bottom';
+
+export function alert({ text, type, stay, time, position }: AlertOptions): void;
+
+export interface AlertOptions {
+    text: string;
+    /** @default 4 */
+    type?: AlertType | undefined;
+    /** @default false */
+    stay?: boolean | undefined;
+    /**
+     * Time to linger in seconds.
+     * Minimum: 1
+     * @default 3
+     */
+    time?: number | undefined;
+    /** @default 'top' */
+    position?: Position | undefined;
+}
+
+export function force(
+    { text, type, buttonText, position, callback }: ForceOptions,
+    optionalCallback?: () => void,
+): void;
+
+export interface ForceOptions {
+    text: string;
+    /** @default 5 */
+    type?: AlertType | undefined;
+    /** @default 'OK' */
+    buttonText?: string | undefined;
+    /** @default 'top' */
+    position?: Position | undefined;
+
+    callback?: (() => void) | undefined;
+}
+
+export function confirm(
+    { text, submitText, cancelText, position, submitCallback, cancelCallback }: ConfirmOptions,
+    optionalSubmitCallback?: () => void,
+    optionalCancelCallback?: () => void,
+): void;
+
+export interface ConfirmOptions {
+    text: string;
+    /** @default 'Yes' */
+    submitText?: string | undefined;
+    /** @default 'Cancel' */
+    cancelText?: string | undefined;
+    /** @default 'top' */
+    position?: Position | undefined;
+
+    submitCallback?: (() => void) | undefined;
+    cancelCallback?: (() => void) | undefined;
+}
+
+export function input(
+    {
+        text,
+        submitText,
+        cancelText,
+        position,
+        autocapitalize,
+        autocomplete,
+        autocorrect,
+        autofocus,
+        inputmode,
+        max,
+        maxlength,
+        min,
+        minlength,
+        placeholder,
+        spellcheck,
+        step,
+        type,
+        allowed,
+        submitCallback,
+        cancelCallback,
+    }: InputOptions,
+    optionalSubmitCallback?: (value: string) => void,
+    optionalCancelCallback?: (value: string) => void,
+): void;
+
+export interface InputOptions {
+    text: string;
+    /** @default 'Submit' */
+    submitText?: string | undefined;
+    /** @default 'Cancel' */
+    cancelText?: string | undefined;
+    /** @default 'top' */
+    position?: Position | undefined;
+    /** @default 'none' */
+    autocapitalize?: string | undefined;
+    /** @default 'off' */
+    autocomplete?: string | undefined;
+    /** @default 'off' */
+    autocorrect?: string | undefined;
+    /** @default 'true' */
+    autofocus?: string | undefined;
+    /** @default 'verbatim' */
+    inputmode?: string | undefined;
+    /** @default '' */
+    max?: string | undefined;
+    /** @default '' */
+    maxlength?: string | undefined;
+    /** @default '' */
+    min?: string | undefined;
+    /** @default '' */
+    minlength?: string | undefined;
+    /** @default '' */
+    placeholder?: string | undefined;
+    /** @default 'default' */
+    spellcheck?: string | undefined;
+    /** @default 'any' */
+    step?: string | undefined;
+    /** @default 'text' */
+    type?: string | undefined;
+    /** @default 'null' */
+    allowed?: Array<'an' | 'a' | 'n' | 's'> | RegExp | null | undefined;
+
+    submitCallback?: ((value: string) => void) | undefined;
+    cancelCallback?: ((value: string) => void) | undefined;
+}
+
+export function select(
+    { text, choices, cancelText, position, cancelCallback }: SelectOptions,
+    optionalCancelCallback?: () => void,
+): void;
+
+export interface SelectOptions {
+    text: string;
+    choices: SelectChoice[];
+    /** @default 'Cancel' */
+    cancelText?: string | undefined;
+    /** @default 'bottom' */
+    position?: Position | undefined;
+    cancelCallback?: (() => void) | undefined;
+}
+
+export interface SelectChoice {
+    text: string;
+    /** @default 1 */
+    type?: string | number | undefined;
+
+    handler(): void;
+}
+
+export function date(
+    { value, submitText, cancel, position, submitCallback, cancelCallback }: DateOptions,
+    optionalSubmitCallback?: (date: Date) => void,
+    optionalCancelCallback?: (date: Date) => void,
+): void;
+
+export interface DateOptions {
+    value: Date;
+    /** @default 'OK' */
+    submitText?: string | undefined;
+    /** @default 'Cancel' */
+    cancel?: string | undefined;
+    /** @default 'top' */
+    position?: Position | undefined;
+
+    submitCallback?: ((date: Date) => void) | undefined;
+    cancelCallback?: ((date: Date) => void) | undefined;
+}

--- a/types/notie/index.d.ts
+++ b/types/notie/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for notie 4.3
-// Project: https://github.com/jaredreich/notie.js
+// Project: https://github.com/jaredreich/notie
 // Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
 //                 Mateus Demboski <https://github.com/mateusdemboski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -214,8 +214,10 @@ export interface AllOptions {
     positions?: Partial<Record<'alert' | 'force' | 'confirm' | 'input' | 'select' | 'date', Position>> | undefined;
 }
 
+export function hideAlerts(callback?: () => void): void;
+
 declare namespace _default {
-    export { alert, force, confirm, input, select, date, setOptions };
+    export { alert, force, confirm, input, select, date, setOptions, hideAlerts };
 }
 
 export default _default;

--- a/types/notie/index.d.ts
+++ b/types/notie/index.d.ts
@@ -173,3 +173,9 @@ export interface DateOptions {
     submitCallback?: ((date: Date) => void) | undefined;
     cancelCallback?: ((date: Date) => void) | undefined;
 }
+
+declare namespace _default {
+    export { alert, force, confirm, input, select, date };
+}
+
+export default _default;

--- a/types/notie/index.d.ts
+++ b/types/notie/index.d.ts
@@ -10,7 +10,7 @@ export type AlertType = 1 | 2 | 3 | 4 | 5 | 'success' | 'warning' | 'error' | 'i
 
 export type Position = 'top' | 'bottom';
 
-export function alert({ text, type, stay, time, position }: AlertOptions): void;
+export function alert(options: AlertOptions): void;
 
 export interface AlertOptions {
     text: string;
@@ -28,10 +28,7 @@ export interface AlertOptions {
     position?: Position | undefined;
 }
 
-export function force(
-    { text, type, buttonText, position, callback }: ForceOptions,
-    optionalCallback?: () => void,
-): void;
+export function force(options: ForceOptions, callback?: () => void): void;
 
 export interface ForceOptions {
     text: string;
@@ -45,11 +42,7 @@ export interface ForceOptions {
     callback?: (() => void) | undefined;
 }
 
-export function confirm(
-    { text, submitText, cancelText, position, submitCallback, cancelCallback }: ConfirmOptions,
-    optionalSubmitCallback?: () => void,
-    optionalCancelCallback?: () => void,
-): void;
+export function confirm(options: ConfirmOptions, submitCallback?: () => void, cancelCallback?: () => void): void;
 
 export interface ConfirmOptions {
     text: string;
@@ -65,30 +58,9 @@ export interface ConfirmOptions {
 }
 
 export function input(
-    {
-        text,
-        submitText,
-        cancelText,
-        position,
-        autocapitalize,
-        autocomplete,
-        autocorrect,
-        autofocus,
-        inputmode,
-        max,
-        maxlength,
-        min,
-        minlength,
-        placeholder,
-        spellcheck,
-        step,
-        type,
-        allowed,
-        submitCallback,
-        cancelCallback,
-    }: InputOptions,
-    optionalSubmitCallback?: (value: string) => void,
-    optionalCancelCallback?: (value: string) => void,
+    options: InputOptions,
+    submitCallback?: (value: string) => void,
+    cancelCallback?: (value: string) => void,
 ): void;
 
 export interface InputOptions {
@@ -132,10 +104,7 @@ export interface InputOptions {
     cancelCallback?: ((value: string) => void) | undefined;
 }
 
-export function select(
-    { text, choices, cancelText, position, cancelCallback }: SelectOptions,
-    optionalCancelCallback?: () => void,
-): void;
+export function select(options: SelectOptions, cancelCallback?: () => void): void;
 
 export interface SelectOptions {
     text: string;
@@ -156,9 +125,9 @@ export interface SelectChoice {
 }
 
 export function date(
-    { value, submitText, cancel, position, submitCallback, cancelCallback }: DateOptions,
-    optionalSubmitCallback?: (date: Date) => void,
-    optionalCancelCallback?: (date: Date) => void,
+    options: DateOptions,
+    submitCallback?: (date: Date) => void,
+    cancelCallback?: (date: Date) => void,
 ): void;
 
 export interface DateOptions {

--- a/types/notie/index.d.ts
+++ b/types/notie/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for notie 4.3
 // Project: https://github.com/jaredreich/notie
-// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
-//                 Mateus Demboski <https://github.com/mateusdemboski>
+// Definitions by: Mateus Demboski <https://github.com/mateusdemboski>
+//                 Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace notie;

--- a/types/notie/index.d.ts
+++ b/types/notie/index.d.ts
@@ -174,8 +174,48 @@ export interface DateOptions {
     cancelCallback?: ((date: Date) => void) | undefined;
 }
 
+export function setOptions(options: AllOptions): void;
+
+export interface AllOptions {
+    alertTime?: number | undefined;
+    dateMonths?: string[] | undefined;
+    overlayClickDismiss?: boolean | undefined;
+    overlayOpacity?: number | undefined;
+    transitionCurve?: string | undefined;
+    transitionDuration?: number | undefined;
+    transitionSelector?: string | undefined;
+    classes?:
+        | Partial<
+              Record<
+                  | 'container'
+                  | 'textbox'
+                  | 'textboxInner'
+                  | 'button'
+                  | 'element'
+                  | 'elementHalf'
+                  | 'elementThird'
+                  | 'overlay'
+                  | 'backgroundSuccess'
+                  | 'backgroundWarning'
+                  | 'backgroundError'
+                  | 'backgroundInfo'
+                  | 'backgroundNeutral'
+                  | 'backgroundOverlay'
+                  | 'alert'
+                  | 'inputField'
+                  | 'selectChoiceRepeated'
+                  | 'dateSelectorInner'
+                  | 'dateSelectorUp',
+                  string
+              >
+          >
+        | undefined;
+    ids?: { overlay?: string | undefined } | undefined;
+    positions?: Partial<Record<'alert' | 'force' | 'confirm' | 'input' | 'select' | 'date', Position>> | undefined;
+}
+
 declare namespace _default {
-    export { alert, force, confirm, input, select, date };
+    export { alert, force, confirm, input, select, date, setOptions };
 }
 
 export default _default;

--- a/types/notie/notie-tests.ts
+++ b/types/notie/notie-tests.ts
@@ -1,4 +1,4 @@
-import { alert, force, confirm, input, select, date, setOptions } from 'notie';
+import { alert, force, confirm, input, select, date, setOptions, hideAlerts } from 'notie';
 
 // $ExpectError
 alert({});
@@ -110,3 +110,6 @@ setOptions({ dateMonths: [] });
 setOptions({ classes: {} });
 setOptions({ ids: {} });
 setOptions({ positions: {} });
+
+hideAlerts();
+hideAlerts(() => alert({ text: 'Alerts hidden' }));

--- a/types/notie/notie-tests.ts
+++ b/types/notie/notie-tests.ts
@@ -1,22 +1,106 @@
-notie.alert(1, 'Success!', 1.5);
-notie.alert(2, 'Warning<br><b>with</b><br><i>HTML</i><br><u>included.</u>', 2);
-notie.alert(3, 'Error.', 2.5);
-notie.alert(4, 'Information.', 2);
+import { alert, force, confirm, input, select, date } from 'notie';
 
-notie.confirm('Are you sure you want to do that?', 'Yes', 'Cancel', function() {
-    notie.alert(1, 'Good choice!', 2);
-});
-notie.confirm('Are you sure?', 'Yes', 'Cancel', function() {
-    notie.confirm('Are you <b>really</b> sure?', 'Yes', 'Cancel', function() {
-        notie.confirm('Are you really <b>really</b> sure?', 'Yes', 'Cancel', function() {
-            notie.alert(1, 'Okay, jeez...', 2);
-        });
-    });
-});
+// $ExpectError
+alert({});
+alert({ text: 'Hello, World!', position: 'bottom' });
+alert({ text: 'Hello, World!', type: 4 });
+alert({ text: 'Hello, World!', type: 'info' });
 
-notie.input('Please enter your email address:', 'Submit', 'Cancel', 'email', 'name@example.com', function(value_entered) {
-    notie.alert(1, 'You entered: ' + value_entered, 2);
+// $ExpectError
+force({});
+force({
+    text: 'Alert',
+    callback() {
+        alert({ text: 'callback' });
+    },
 });
-notie.input('What city do you live in?', 'Submit', 'Cancel', 'text', 'Enter your city:', function(value_entered) {
-    notie.alert(1, 'You entered: ' + value_entered, 2);
-}, 'New York');
+force({ text: 'Alert' }, () => alert({ text: 'callback' }));
+
+// $ExpectError
+confirm({});
+confirm({ text: 'Are you sure?' });
+confirm({
+    text: 'Are you sure?',
+    submitCallback() {
+        alert({ text: 'Confirmed' });
+    },
+    cancelCallback() {
+        alert({ text: 'Cancelled' });
+    },
+});
+confirm({ text: 'Are you sure?' }, () => alert({ text: 'Confirmed' }));
+confirm(
+    { text: 'Are you sure?' },
+    () => alert({ text: 'Confirmed' }),
+    () => alert({ text: 'Cancelled' }),
+);
+
+// $ExpectError
+input({});
+input({
+    text: 'Input',
+    submitCallback() {
+        alert({ text: 'Confirmed' });
+    },
+    cancelCallback() {
+        alert({ text: 'Cancelled' });
+    },
+});
+input({ text: 'Input' }, () => alert({ text: 'Confirmed' }));
+input(
+    { text: 'Input' },
+    () => alert({ text: 'Confirmed' }),
+    () => alert({ text: 'Cancelled' }),
+);
+
+// $ExpectError
+select({});
+// $ExpectError
+select({ text: 'Select' });
+select({
+    text: 'Select',
+    choices: [
+        {
+            type: 'abc',
+            text: 'Option 1',
+            handler: () => {},
+        },
+        {
+            text: 'Option 2',
+            handler: () => {},
+        },
+    ],
+});
+select({
+    text: 'Select',
+    choices: [{ text: 'foo', handler: () => {} }],
+    cancelCallback() {
+        alert({ text: 'Cancelled' });
+    },
+});
+select(
+    {
+        text: 'Select',
+        choices: [{ text: 'foo', handler: () => {} }],
+    },
+    () => alert({ text: 'Cancelled' }),
+);
+
+// $ExpectError
+date({});
+date({ value: new Date() });
+date({
+    value: new Date(),
+    submitCallback() {
+        alert({ text: 'Confirmed' });
+    },
+    cancelCallback() {
+        alert({ text: 'Cancelled' });
+    },
+});
+date({ value: new Date() }, () => alert({ text: 'Confirmed' }));
+date(
+    { value: new Date() },
+    () => alert({ text: 'Confirmed' }),
+    () => alert({ text: 'Cancelled' }),
+);

--- a/types/notie/notie-tests.ts
+++ b/types/notie/notie-tests.ts
@@ -1,4 +1,4 @@
-import { alert, force, confirm, input, select, date } from 'notie';
+import { alert, force, confirm, input, select, date, setOptions } from 'notie';
 
 // $ExpectError
 alert({});
@@ -104,3 +104,9 @@ date(
     () => alert({ text: 'Confirmed' }),
     () => alert({ text: 'Cancelled' }),
 );
+
+setOptions({});
+setOptions({ dateMonths: [] });
+setOptions({ classes: {} });
+setOptions({ ids: {} });
+setOptions({ positions: {} });

--- a/types/notie/tslint.json
+++ b/types/notie/tslint.json
@@ -1,8 +1,1 @@
-{
-    "extends": "@definitelytyped/dtslint/dt.json",
-    "rules": {
-        "dt-header": false,
-        "no-trailing-whitespace": false,
-        "only-arrow-functions": false
-    }
-}
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Related discussion: #59932

Types for the `notie` package were very out of date (types were for 0.0 and current version is 4.3), so these types were written from scratch.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test notie`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: All methods are documented in the README
  - <https://github.com/jaredreich/notie#available-methods>
  - <https://github.com/jaredreich/notie#options--methods>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
