### PR TITLE
fix(serverless): :bug: added missing details about cloudwatch event types

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -528,13 +528,28 @@ declare namespace Aws {
     }
 
     interface CloudwatchEvent {
-        event: string;
+        event: CloudwatchEventInternalEvent | string;
         name?: string | undefined;
         description?: string | undefined;
         enabled?: boolean | undefined;
         input?: Input | undefined;
         inputPath?: string | undefined;
         inputTransformer?: InputTransformer | undefined;
+    }
+
+    interface CloudwatchEventInternalEvent {
+        source: string | string[];
+        "detail-type"?: string | string[];
+        detail?: object;
+        region?: string;
+        /**
+         * Supposed to be array of ARNs but needs more info
+         */
+        resources?: string[],
+        version?: string;
+        id?: string;
+        time?: string;
+        account?: string;
     }
 
     interface CloudwatchLog {

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -545,7 +545,7 @@ declare namespace Aws {
         /**
          * Supposed to be array of ARNs but needs more info
          */
-        resources?: string[],
+        resources?: string[];
         version?: string;
         id?: string;
         time?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html
https://www.serverless.com/framework/docs/providers/aws/events/cloudwatch-event

This caught my attention on stack overflow
https://stackoverflow.com/questions/71124403/incorrect-schema-for-yaml-file-using-serverless-framework-configuration-expect
