### PR TITLE
@ckeditor/ckeditor5-utils Fix Collection interface

### DIFF
--- a/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
@@ -252,6 +252,12 @@ new Collection([{ name: '' }]).remove({ surname: '' });
 new Collection([{ name: '' }]).map(item => item.name);
 // $ExpectType number[]
 new Collection([{ name: '' }]).map((_, idx) => idx);
+new Collection().off("foo", (ev, ...args) => {
+    // $ExpectType EventInfo<Collection<Record<string, any>, "id">, "foo">
+    ev;
+    // $ExpectError any[]
+    args;
+});
 
 // collection#bindTo
 

--- a/types/ckeditor__ckeditor5-utils/src/collection.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/collection.d.ts
@@ -1,11 +1,12 @@
-import EventInfo from './eventinfo';
-import { PriorityString } from './priorities';
-import { Emitter, EmitterMixinDelegateChain } from './emittermixin';
+import { Emitter } from './emittermixin';
 
 export interface CollectionBindTo<T> {
     as: (Class: { new (item: T): any }) => void;
     using: (callbackOrProperty: keyof T | ((item: T) => any)) => void;
 }
+
+// tslint:disable-next-line:no-empty-interface
+export default interface Collection extends Emitter {}
 
 /**
  * Collections are ordered sets of objects. Items in the collection can be retrieved by their indexes
@@ -236,30 +237,4 @@ export default class Collection<T extends Record<string, any> = Record<string, a
      *
      */
     [Symbol.iterator](): Iterator<T & { [x in I]: string }>;
-
-    on<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    once<K extends string>(
-        event: K,
-        callback: (this: this, info: EventInfo<this, K>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    off<K extends string>(event: K, callback?: (this: this, info: EventInfo<this, K>, ...args: any[]) => void): void;
-    listenTo<P extends string, E extends Emitter>(
-        emitter: E,
-        event: P,
-        callback: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-        options?: { priority?: number | PriorityString | undefined },
-    ): void;
-    stopListening<E extends Emitter, P extends string>(
-        emitter?: E,
-        event?: P,
-        callback?: (this: this, info: EventInfo<E, P>, ...args: any[]) => void,
-    ): void;
-    fire(eventOrInfo: string | EventInfo, ...args: any[]): unknown;
-    delegate(...events: string[]): EmitterMixinDelegateChain;
-    stopDelegating(event?: string, emitter?: Emitter): void;
 }


### PR DESCRIPTION
`off` method does not match current Emitter interface

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ckeditor/ckeditor5/blob/v32.0.0/packages/ckeditor5-utils/src/collection.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.