### PR TITLE
bump oidc-provider

### DIFF
--- a/types/oidc-provider/index.d.ts
+++ b/types/oidc-provider/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for oidc-provider 7.8
+// Type definitions for oidc-provider 7.11
 // Project: https://github.com/panva/node-oidc-provider
 // Definitions by: Filip Skokan <https://github.com/panva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -1054,11 +1054,6 @@ export interface Configuration {
         } | undefined;
 
         jwtIntrospection?: {
-            enabled?: boolean | undefined;
-            ack?: string | undefined;
-        } | undefined;
-
-        issAuthResp?: {
             enabled?: boolean | undefined;
             ack?: string | undefined;
         } | undefined;


### PR DESCRIPTION
The API surface remains unchanged except that `issAuthResp` is now enabled by default and cannot be configured anymore.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/panva/node-oidc-provider/blob/HEAD/CHANGELOG.md?plain=1#L5-L80
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.