### PR TITLE
[luxon] DateTime constructor is private

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -740,7 +740,6 @@ export class DateTime {
      */
     static isDateTime(o: unknown): o is DateTime;
 
-    // Constructor is declared `@access private`
     private constructor();
 
     // INFO

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -740,6 +740,9 @@ export class DateTime {
      */
     static isDateTime(o: unknown): o is DateTime;
 
+    // Constructor is declared `@access private`
+    private constructor();
+
     // INFO
 
     /**

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -740,7 +740,7 @@ export class DateTime {
      */
     static isDateTime(o: unknown): o is DateTime;
 
-    private constructor();
+    private constructor(config: unknown);
 
     // INFO
 

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -190,7 +190,7 @@ export class Duration {
      */
     static isDuration(o: unknown): o is Duration;
 
-    private constructor();
+    private constructor(config: unknown);
 
     /**
      * Get  the locale of a Duration, such 'en-GB'

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -190,7 +190,6 @@ export class Duration {
      */
     static isDuration(o: unknown): o is Duration;
 
-    // Constructor is declared `@private`
     private constructor();
 
     /**

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -190,6 +190,9 @@ export class Duration {
      */
     static isDuration(o: unknown): o is Duration;
 
+    // Constructor is declared `@private`
+    private constructor();
+
     /**
      * Get  the locale of a Duration, such 'en-GB'
      */

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -74,7 +74,7 @@ export class Interval {
      */
     static isInterval(o: unknown): o is Interval;
 
-    private constructor();
+    private constructor(config: unknown);
 
     /**
      * Returns the start of the Interval

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -74,7 +74,6 @@ export class Interval {
      */
     static isInterval(o: unknown): o is Interval;
 
-    // Constructor is declared `@private`
     private constructor();
 
     /**

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -74,6 +74,9 @@ export class Interval {
      */
     static isInterval(o: unknown): o is Interval;
 
+    // Constructor is declared `@private`
+    private constructor();
+
     /**
      * Returns the start of the Interval
      */

--- a/types/luxon/src/zone.d.ts
+++ b/types/luxon/src/zone.d.ts
@@ -15,7 +15,7 @@ export interface ZoneOffsetOptions {
  */
 export type ZoneOffsetFormat = 'narrow' | 'short' | 'techie';
 
-export class Zone {
+export abstract class Zone {
     /**
      * The type of zone
      */

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -208,6 +208,7 @@ Duration.fromDurationLike({ hours: 1 }); // $ExpectType Duration
 Duration.fromDurationLike(1000); // $ExpectType Duration
 Duration.fromDurationLike(dur); // $ExpectType Duration
 Duration.fromDurationLike(''); // $ExpectError
+new Duration({ hour: 2, minute: 7 }); // $ExpectError
 dt.plus(dur); // $ExpectType DateTime
 dt.plus({ quarters: 2, months: 1 }); // $ExpectType DateTime
 dur.hours; // $ExpectType number
@@ -252,6 +253,7 @@ i.divideEqually(5);
 if (Interval.isInterval(anything)) {
     anything; // $ExpectType Interval
 }
+new Interval(now, later); // $ExpectError
 Interval.invalid(); // $ExpectError
 Interval.invalid('code', 'because I said so'); // $ExpectType Interval
 Interval.isInterval(0 as unknown); // $ExpectType boolean

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -29,6 +29,7 @@ DateTime.utc({ locale: 'en-US' }); // $ExpectType DateTime
 DateTime.utc(2018, 5, 31, 23, { numberingSystem: 'arabext' }); // $ExpectType DateTime
 DateTime.utc(2019, { locale: 'en-GB' }, 5); // $ExpectError
 DateTime.isDateTime(0 as unknown); // $ExpectType boolean
+new DateTime(); // $ExpectError
 
 const dt = DateTime.local(2017, 5, 15, 8, 30);
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/issues/900#issuecomment-841578143 references https://github.com/moment/luxon/blob/master/src/datetime.js#L417
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
