### PR TITLE
[jest-environment-puppeteer] Fix imported GlobalType.Global not matching with Global from jest-environment-node

### DIFF
--- a/types/jest-environment-puppeteer/index.d.ts
+++ b/types/jest-environment-puppeteer/index.d.ts
@@ -6,7 +6,6 @@
 // TypeScript Version: 3.8
 
 import NodeEnvironment = require('jest-environment-node');
-import { Global as GlobalType } from '@jest/types';
 import { Browser, Page, BrowserContext } from 'puppeteer';
 import { Context } from 'vm';
 
@@ -47,7 +46,7 @@ interface JestPuppeteer {
     debug(): Promise<void>;
 }
 
-interface Global extends GlobalType.Global {
+interface Global extends NonNullable<NodeEnvironment['global']> {
     browser: Browser;
     context: Context;
     page: Page;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/facebook/jest/commit/3bd384b87a23c38f2307da4283abde3d7f8a91ab
  - https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/59668
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.