### PR TITLE
`long` types: Add missing `unsigned` final arg to `Long.fromValue`

### DIFF
--- a/types/long/index.d.ts
+++ b/types/long/index.d.ts
@@ -99,7 +99,7 @@ declare namespace Long {
         /**
          * Converts the specified value to a Long.
          */
-        fromValue( val: Long | number | string | {low: number, high: number, unsigned: boolean} ): Long;
+        fromValue( val: Long | number | string | {low: number, high: number, unsigned: boolean}, unsigned?: boolean ): Long;
     }
     interface Long
     {

--- a/types/long/long-tests.ts
+++ b/types/long/long-tests.ts
@@ -66,6 +66,11 @@ b = val.lessThanOrEqual(n);
 b = val.lessThanOrEqual(s);
 
 val = Long.fromValue(10);
+val = Long.fromValue('10');
+val = Long.fromValue(10, true);
+val = Long.fromValue('10', true);
+val = Long.fromValue({ low: 1, high: 1, unsigned: true });
+val = Long.fromValue({ low: 1, high: 1, unsigned: true }, true);
 val = val.modulo(val);
 val = val.modulo(n);
 val = val.modulo(s);


### PR DESCRIPTION
Compare the source definition in 4.0.0:
https://github.com/dcodeIO/long.js/blob/941c5c62471168b5d18153755c2a7b38d2560e58/src/long.js#L273-L280

to the type:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/eb48acf05bf3bf7197c5a3e55972530634a6d3bd/types/long/index.d.ts#L99-L102

`fromValue` can optionally accept a second `unsigned` arg.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dcodeIO/long.js/blob/941c5c62471168b5d18153755c2a7b38d2560e58/src/long.js#L273-L280
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ N/A - fixing type defs for existing v4.0.0 version. The latest 5.x version already includes correct type definitions, but the 4.0.0 version type defs are incorrect.
