### PR TITLE
Fix several typings in ProseMirror

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -1221,15 +1221,26 @@ export interface NodeSpec {
      * and/or styling.
      */
     whitespace?: 'pre' | 'normal';
+
     /**
      * Determines whether this node is considered an important parent
      * node during replace operations (such as paste). Non-defining (the
      * default) nodes get dropped when their entire content is replaced,
      * whereas defining nodes persist and wrap the inserted content.
-     * Likewise, in _inserted_ content the defining parents of the
-     * content are preserved when possible. Typically,
-     * non-default-paragraph textblock types, and possibly list items,
-     * are marked as defining.
+     */
+    definingAsContext?: boolean | null | undefined;
+
+    /**
+     * In inserted content the defining parents of the content are
+     * preserved when possible. Typically, non-default-paragraph
+     * textblock types, and possibly list items, are marked as defining.
+     */
+    definingForContent?: boolean | null | undefined;
+
+    /**
+     * When enabled, enables both
+     * [`definingAsContext`](#model.NodeSpec.definingAsContext) and
+     * [`definingForContent`](#model.NodeSpec.definingForContent).
      */
     defining?: boolean | null | undefined;
     /**

--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -5,6 +5,7 @@
 //                 Tim Baumann <https://github.com/timjb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
 //                 Mike Morearty <https://github.com/mmorearty>
+//                 Ocavue <https://github.com/ocavue>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-state 1.2
+// Type definitions for prosemirror-state 1.3
 // Project: https://github.com/ProseMirror/prosemirror-state, https://github.com/prosemirror/prosemirror
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>

--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -456,10 +456,25 @@ export class EditorState<S extends Schema = any> {
      * Create a new state.
      */
     static create<S extends Schema = any>(config: {
+        /**
+         * The schema to use (only relevant if no `doc` is specified).
+         */
         schema?: S | null | undefined;
+        /**
+         * The starting document.
+         */
         doc?: ProsemirrorNode<S> | null | undefined;
+        /**
+         * A valid selection in the document.
+         */
         selection?: Selection<S> | null | undefined;
+        /**
+         * The initial set of [stored marks](#state.EditorState.storedMarks).
+         */
         storedMarks?: Mark[] | null | undefined;
+        /**
+         * The plugins that should be active in this state.
+         */
         plugins?: Array<Plugin<any, S>> | null | undefined;
     }): EditorState<S>;
     /**

--- a/types/prosemirror-transform/index.d.ts
+++ b/types/prosemirror-transform/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for prosemirror-transform 1.1
+// Type definitions for prosemirror-transform 1.4
 // Project: https://github.com/ProseMirror/prosemirror-transform
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>
 //                 Tim Baumann <https://github.com/timjb>
 //                 Patrick Simmelbauer <https://github.com/patsimm>
+//                 Ocavue <https://github.com/ocavue>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -264,15 +265,16 @@ export class Transform<S extends Schema = any> {
      */
     insert(pos: number, content: Fragment<S> | ProsemirrorNode<S> | Array<ProsemirrorNode<S>>): this;
     /**
+     * :: (number, number, Slice) → this
      * Replace a range of the document with a given slice, using `from`,
      * `to`, and the slice's [`openStart`](#model.Slice.openStart) property
      * as hints, rather than fixed start and end points. This method may
      * grow the replaced area or close open nodes in the slice in order to
      * get a fit that is more in line with WYSIWYG expectations, by
      * dropping fully covered parent nodes of the replaced region when
-     * they are marked [non-defining](#model.NodeSpec.defining), or
+     * they are marked [non-defining as context](#model.NodeSpec.definingAsContext), or
      * including an open parent node from the slice that _is_ marked as
-     * [defining](#model.NodeSpec.defining).
+     * [defining its content](#model.NodeSpec.definingForContent).
      *
      * This is the method, for example, to handle paste. The similar
      * [`replace`](#transform.Transform.replace) method is a more

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -11,7 +11,7 @@
 // TypeScript Version: 3.0
 
 import { DOMParser, DOMSerializer, Node as ProsemirrorNode, ResolvedPos, Slice, Schema, Mark } from 'prosemirror-model';
-import { EditorState, Selection, Transaction } from 'prosemirror-state';
+import { EditorState, Selection, Transaction, Plugin } from 'prosemirror-state';
 import { Mapping } from 'prosemirror-transform';
 
 // Exported for testing
@@ -672,7 +672,7 @@ export type HandleDOMEventsProp<ThisT = unknown, S extends Schema = any> = Parti
     [key: string]: (this: ThisT, view: EditorView<S>, event: any) => boolean;
 };
 /**
- * The props object given directly to the editor view supports two
+ * The props object given directly to the editor view supports some
  * fields that can't be used in plugins:
  */
 export interface DirectEditorProps<S extends Schema = any> extends EditorProps<unknown, S> {
@@ -680,6 +680,18 @@ export interface DirectEditorProps<S extends Schema = any> extends EditorProps<u
      * The current state of the editor.
      */
     state: EditorState<S>;
+
+    /**
+     * A set of plugins to use in the view, applying their [plugin
+     * view](#state.PluginSpec.view) and
+     * [props](#state.PluginSpec.props). Passing plugins with a state
+     * component (a [state field](#state.PluginSpec.state) field or a
+     * [transaction](#state.PluginSpec.filterTransaction) filter or
+     * appender) will result in an error, since such plugins must be
+     * present in the state to work.
+     */
+    plugins: Plugin[]
+
     /**
      * The callback over which to send transactions (state updates)
      * produced by the view. If you specify this, you probably want to

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -690,7 +690,7 @@ export interface DirectEditorProps<S extends Schema = any> extends EditorProps<u
      * appender) will result in an error, since such plugins must be
      * present in the state to work.
      */
-    plugins: Plugin[]
+    plugins: Plugin[];
 
     /**
      * The callback over which to send transactions (state updates)

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -54,6 +54,8 @@ const res4_plugin = new state.Plugin<string, typeof schema.schema>({
 const res5_view = new view.EditorView<typeof schema.schema>(undefined, {
     state: {} as any, // this is not part of the test
 
+    plugins: [],
+
     dispatchTransaction(tr) {
         // From DirectEditorProps
         // Ensure that `this` is bound to type EditorView<schema.schema>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
 
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see below)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.




- `DirectEditorProps`: https://github.com/ProseMirror/prosemirror-view/blob/1.23.12/src/index.js#L644-L668
- `EditorState.create`: https://github.com/ProseMirror/prosemirror-state/blob/1.3.4/src/state.js#L164-L182
- `NodeSpec.defining`: https://github.com/ProseMirror/prosemirror-model/blob/b8c5166e9ac5c5cf87da3f13012b0044fd8a4bd9/src/schema.js#L379-L393
- `Transform.replaceRange`: https://github.com/ProseMirror/prosemirror-transform/blob/7f6622d93ca99dad10b99ee1036a640b9b221a92/src/replace.js#L342-L358