### PR TITLE
[resolve] Fix `packageFilter()` typings

### DIFF
--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -96,7 +96,7 @@ interface JSONArray extends Array<JSONValue> { }
 
 declare namespace resolve {
   export type PackageJSON = JSONObject;
-  
+
   interface Opts {
     /** directory to begin resolving from (defaults to __dirname) */
     basedir?: string | undefined;

--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -87,9 +87,16 @@ declare function resolveSync(id: string, opts?: resolve.SyncOpts): string;
  */
 declare function resolveIsCore(id: string): boolean | undefined;
 
-type PackageJson = Record<string, unknown>;
+// https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540
+type JSONValue = string | number | boolean | JSONObject | JSONArray;
+interface JSONObject {
+    [x: string]: JSONValue;
+}
+interface JSONArray extends Array<JSONValue> { }
 
 declare namespace resolve {
+  export type PackageJSON = JSONObject;
+  
   interface Opts {
     /** directory to begin resolving from (defaults to __dirname) */
     basedir?: string | undefined;
@@ -100,9 +107,9 @@ declare namespace resolve {
     /** array of file extensions to search in order (defaults to ['.js']) */
     extensions?: string | ReadonlyArray<string> | undefined;
     /** transform the parsed package.json contents before looking at the "main" field */
-    packageFilter?: ((pkg: PackageJson, pkgFile: string, dir: string) => PackageJson) | undefined;
+    packageFilter?: ((pkg: PackageJSON, pkgFile: string, dir: string) => PackageJSON) | undefined;
     /** transform a path within a package */
-    pathFilter?: ((pkg: PackageJson, path: string, relativePath: string) => string) | undefined;
+    pathFilter?: ((pkg: PackageJSON, path: string, relativePath: string) => string) | undefined;
     /** require.paths array to use if nothing is found on the normal node_modules recursive walk (probably don't use this) */
     paths?: string | ReadonlyArray<string> | undefined;
     /** return the list of candidate paths where the packages sources may be found (probably don't use this) */

--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -87,6 +87,8 @@ declare function resolveSync(id: string, opts?: resolve.SyncOpts): string;
  */
 declare function resolveIsCore(id: string): boolean | undefined;
 
+type PackageJson = Record<string, unknown>;
+
 declare namespace resolve {
   interface Opts {
     /** directory to begin resolving from (defaults to __dirname) */
@@ -98,9 +100,9 @@ declare namespace resolve {
     /** array of file extensions to search in order (defaults to ['.js']) */
     extensions?: string | ReadonlyArray<string> | undefined;
     /** transform the parsed package.json contents before looking at the "main" field */
-    packageFilter?: ((pkg: any, pkgfile: string) => any) | undefined;
+    packageFilter?: ((pkg: PackageJson, pkgFile: string, dir: string) => PackageJson) | undefined;
     /** transform a path within a package */
-    pathFilter?: ((pkg: any, path: string, relativePath: string) => string) | undefined;
+    pathFilter?: ((pkg: PackageJson, path: string, relativePath: string) => string) | undefined;
     /** require.paths array to use if nothing is found on the normal node_modules recursive walk (probably don't use this) */
     paths?: string | ReadonlyArray<string> | undefined;
     /** return the list of candidate paths where the packages sources may be found (probably don't use this) */

--- a/types/resolve/resolve-tests.ts
+++ b/types/resolve/resolve-tests.ts
@@ -26,7 +26,7 @@ function test_options_async() {
             basedir: process.cwd(),
             package: {},
             extensions: ['.js'],
-            packageFilter: function(pkg, pkgfile) {
+            packageFilter: function(pkg, pkgfile, dir) {
                 return pkg;
             },
             pathFilter: function(pkg, path, relativePath) {
@@ -75,7 +75,7 @@ function test_options_sync() {
         basedir: process.cwd(),
         package: {},
         extensions: ['.js'],
-        packageFilter: function(pkg, pkgfile) {
+        packageFilter: function(pkg, pkgfile, dir) {
             return pkg;
         },
         pathFilter: function(pkg, path, relativePath) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](https://github.com/browserify/resolve/blob/dc8ad1945c663ba47821a269aefb5549f6177cf7/lib/sync.js#L162-L164)

---

See the link. `packageFilter()` takes three arguments, but currently only two are included in type definitions.