### PR TITLE
Serverless - Add new variable resolver (ConfigurationVariableSources) according to version 3

### DIFF
--- a/types/serverless/classes/Plugin.d.ts
+++ b/types/serverless/classes/Plugin.d.ts
@@ -30,6 +30,16 @@ declare namespace Plugin {
         };
     }
 
+    type ConfigurationVariablesSource = (variableSource: any) => Promise<any>;
+
+    interface ConfigurationVariablesSources {
+        [variablePrefix: string]: ConfigurationVariablesSource | {
+                    resolve: ConfigurationVariablesSource,
+                    isDisabledAtPrepopulation?: boolean | undefined,
+                    serviceName?: string | undefined
+            };
+    }
+
     interface Logging {
         log: {
           error: (text: string) => void;
@@ -52,6 +62,7 @@ interface Plugin {
     hooks: Plugin.Hooks;
     commands?: Plugin.Commands | undefined;
     variableResolvers?: Plugin.VariableResolvers | undefined;
+    configurationVariablesSources?: Plugin.ConfigurationVariablesSources | undefined;
 }
 
 export = Plugin;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

> Serverless Framework introduced so much changes with V3 version and it has so much breaking changes between V2 and V3.
> Variable resolution is one of them. `VariableResolvers` replaced with `ConfigurationVariablesSources`.
> This PR contains type of new variable resolver which is `ConfigurationVariablesSources`.
> See: https://www.serverless.com/framework/docs/guides/plugins/custom-variables
> See: https://www.serverless.com/framework/docs/deprecations#new-variables-resolver

