### PR TITLE
[google-map-react] Add `children` to the list of props

### DIFF
--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -33,7 +33,9 @@ const options: MapOptions = {
     ],
 };
 
-<GoogleMapReact center={center} heatmapLibrary={true} zoom={3} bootstrapURLKeys={client} options={options} />;
+<GoogleMapReact center={center} heatmapLibrary={true} zoom={3} bootstrapURLKeys={client} options={options}>
+    📍
+</GoogleMapReact>;
 
 const bounds: NESWBounds = {
     ne: {

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for google-map-react 2.1
 // Project: https://github.com/google-map-react/google-map-react
 // Definitions by: Honza Brecka <https://github.com/honzabrecka>
+//                 Romain Faust <https://github.com/romain-faust>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -147,6 +148,7 @@ declare namespace googleMapReact {
     }
 
     interface Props {
+        children?: React.ReactNode;
         bootstrapURLKeys?: BootstrapURLKeys | undefined;
         defaultCenter?: Coords | undefined;
         center?: Coords | undefined;


### PR DESCRIPTION
With React 18, `children` is no more a "special" prop meaning that it should be included explicitly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Removal Of Implicit Children](https://solverfox.dev/writing/no-implicit-children/)