### PR TITLE
[react-tracking] useTracking generic type can be a function

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -98,7 +98,7 @@ export const ReactTrackingContext: TrackingContext;
  * @param trackingData represents the data to be tracked (or a function returning that data)
  * @param options Additional options
  */
-export function useTracking<P = {}>(trackingData?: Partial<P>, options?: Partial<Options<P>>): TrackingHook<P>;
+export function useTracking<P = {}>(trackingData?: Partial<P> | (() => Partial<P>), options?: Partial<Options<P>>): TrackingHook<P>;
 
 /**
  * This is the type of the `track` function. It’s declared as an interface so that consumers can extend the typing and

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from 'react';
 import {
     Track,
     track as _track,
@@ -8,7 +8,7 @@ import {
     TrackingContext,
     ReactTrackingContext,
     useTracking,
-} from "react-tracking";
+} from 'react-tracking';
 
 function customEventReporter(data: { page?: string | undefined }) {}
 
@@ -29,18 +29,18 @@ interface TrackingData {
 const track: Track<TrackingData, Props, State> = _track;
 
 @track(
-    { page: "ClassPage" },
+    { page: 'ClassPage' },
     {
         dispatch: customEventReporter,
-        dispatchOnMount: contextData => ({ event: "pageDataReady" }),
-        process: ownTrackingData => (ownTrackingData.page ? { event: "pageview" } : null),
+        dispatchOnMount: contextData => ({ event: 'pageDataReady' }),
+        process: ownTrackingData => (ownTrackingData.page ? { event: 'pageview' } : null),
     },
 )
 class ClassPage extends React.Component<Props, State> {
-    @track({ event: "Clicked" })
+    @track({ event: 'Clicked' })
     @track((_props, _state, [e]: [React.MouseEvent]) => {
         if (e.ctrlKey) {
-            return { event: "Click + ctrl key" };
+            return { event: 'Click + ctrl key' };
         }
     })
     handleClick() {
@@ -63,13 +63,13 @@ class ClassPage extends React.Component<Props, State> {
 
     @track((_props, _state, _args, [resp, err]) => {
         if (err || !resp) {
-            return { event: "Async Error" };
+            return { event: 'Async Error' };
         }
-        return { event: "Async Response" };
+        return { event: 'Async Response' };
     })
     async handleAsync() {
         // ... other stuff
-        return "response";
+        return 'response';
     }
 }
 
@@ -77,7 +77,7 @@ const FunctionPage: React.FC<Props> = props => {
     return (
         <div
             onClick={() => {
-                props.tracking && props.tracking.trackEvent({ action: "click" });
+                props.tracking && props.tracking.trackEvent({ action: 'click' });
             }}
         />
     );
@@ -85,7 +85,7 @@ const FunctionPage: React.FC<Props> = props => {
 
 const WrappedFunctionPage = track(
     {
-        page: "FunctionPage",
+        page: 'FunctionPage',
     },
     {
         dispatchOnMount: true,
@@ -106,7 +106,7 @@ class Test extends React.Component<any, null> {
 const TestContext = () => {
     const trackingContext = {
         tracking: {
-            data: { foo: "bar" },
+            data: { foo: 'bar' },
             dispatch: (data: {}) => data,
             process: (x: string) => x,
         },
@@ -125,11 +125,11 @@ interface Trackables {
 }
 
 const TestHook = track()((props: { foo: string }) => {
-    const { Track, trackEvent } = useTracking<Trackables>({ page: "Page" }, { dispatchOnMount: false });
+    const { Track, trackEvent } = useTracking<Trackables>({ page: 'Page' }, { dispatchOnMount: false });
 
     React.useEffect(() =>
         trackEvent({
-            action: "useEffect callback",
+            action: 'useEffect callback',
         }),
     );
     return (
@@ -137,7 +137,31 @@ const TestHook = track()((props: { foo: string }) => {
             <div
                 onClick={() => {
                     trackEvent({
-                        action: "Click",
+                        action: 'Click',
+                    });
+                }}
+            />
+        </Track>
+    );
+});
+
+const TestHookWithDataFunction = track()((props: { foo: string }) => {
+    const { Track, trackEvent } = useTracking<Trackables>(() => ({ page: 'Page' }), {
+        dispatchOnMount: false,
+        dispatch: ({ page }) => {},
+    });
+
+    React.useEffect(() =>
+        trackEvent({
+            action: 'useEffect callback',
+        }),
+    );
+    return (
+        <Track>
+            <div
+                onClick={() => {
+                    trackEvent({
+                        action: 'Click',
                     });
                 }}
             />
@@ -150,8 +174,8 @@ const TestEmptyHook = track()((props: { foo: string }) => {
 
     React.useEffect(() =>
         trackEvent({
-            page: "Home",
-            action: "useEffect callback",
+            page: 'Home',
+            action: 'useEffect callback',
         }),
     );
     return (
@@ -159,8 +183,8 @@ const TestEmptyHook = track()((props: { foo: string }) => {
             <div
                 onClick={() => {
                     trackEvent({
-                        page: "Home",
-                        action: "Click",
+                        page: 'Home',
+                        action: 'Click',
                     });
                 }}
             />


### PR DESCRIPTION
### Commit Context
When passing a function for TrackData the dependencies within TrackData, such as `options` are actually passed the result of that function call.

Previously if you had:

```ts
useTracking<P extends Function>(getData, {
  dispatch: (data) => {
  }
});
```

The type of `data` within dispatch will be a function even though it's actually the result of calling that function.

This PR isn't breaking, as `P` can still be any function. It simply fixes the typing for the case where you wish to pass a tracking data function which returns `P`.

nytimes/react-tracking#172

### Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [Here is where the function passed in is called](https://github.com/nytimes/react-tracking/blob/main/src/useTrackingImpl.js#L32)
  - [Here is an example of that being passed to `dispatch`](https://github.com/nytimes/react-tracking/blob/main/src/useTrackingImpl.js#L48)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.