### PR TITLE
[pubnub] Add `subscribeRequestTimeout` to `PubnubConfig`

### DIFF
--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -534,6 +534,7 @@ declare namespace Pubnub {
             maxSockets?: number | undefined;
             maxFreeSockets?: number | undefined;
         } | undefined;
+        subscribeRequestTimeout?: number | undefined;
         suppressLeaveEvents?: boolean | undefined;
         secretKey?: string | undefined;
         requestMessageCountThreshold?: number | undefined;

--- a/types/pubnub/pubnub-tests.ts
+++ b/types/pubnub/pubnub-tests.ts
@@ -12,6 +12,7 @@ const config: Pubnub.PubnubConfig = {
     ssl: true,
     authKey: '',
     useRandomIVs: false,
+    subscribeRequestTimeout: 60,
     uuid: 'myUUID'
 };
 


### PR DESCRIPTION
This variable is described in the PubNub Go SDK here -
https://www.pubnub.com/docs/sdks/go/api-reference/configuration#:~:text=is%20in%20seconds.-,SubscribeRequestTimeout,-int

However it is not in the PubNub JS Documentation, but is accepted and used by the JS SDK API.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
