### PR TITLE
React Native: Added `unstable_pressDelay` prop to `Pressable` (follow-up)

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -538,6 +538,11 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'chi
      * the component is currently pressed and returns view styles.
      */
     style?: StyleProp<ViewStyle> | ((state: PressableStateCallbackType) => StyleProp<ViewStyle>) | undefined;
+
+    /**
+     * Duration (in milliseconds) to wait after press down before calling onPressIn.
+     */
+    unstable_pressDelay?: number
 }
 
 // TODO use React.AbstractComponent when available

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -444,7 +444,7 @@ export class PressableTest extends React.Component<{}> {
     render() {
         return (
             <>
-                <Pressable ref={this.myRef} onPress={this.onPressButton} style={{ backgroundColor: 'blue' }}>
+                <Pressable ref={this.myRef} onPress={this.onPressButton} style={{ backgroundColor: 'blue' }} unstable_pressDelay={100}>
                     <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
                         <Text style={{ margin: 30 }}>Button</Text>
                     </View>


### PR DESCRIPTION
https://reactnative.dev/docs/pressable#unstable_pressdelay

Exists according to the docs since `0.64.0`: https://reactnative.dev/docs/0.64/pressable#unstable_pressdelay

Belongs to this PR #59691, with the difference that it has only been adapted for the current version, and not the versioned types.
Hopefully the CI pipeline will run this way, as `react-native-styled-components` is based on the types of `0.65`.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.