### PR TITLE
[Chart.js]: change borderDash from any to number

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -233,7 +233,14 @@ const chartConfig: Chart.ChartConfiguration = {
             },
         ],
     },
-    options: radarChartOptions,
+    options: {
+        ...radarChartOptions,
+        elements: {
+            line: {
+                borderDash: [1, 2, 3, 4]
+            }
+        }
+    },
 };
 const radialChart: Chart = new Chart(new CanvasRenderingContext2D(), chartConfig);
 radialChart.update();

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -531,7 +531,7 @@ declare namespace Chart {
         borderWidth?: number | Scriptable<number> | undefined;
         borderColor?: ChartColor | Scriptable<ChartColor> | undefined;
         borderCapStyle?: string | Scriptable<string> | undefined;
-        borderDash?: any[] | Scriptable<any[]> | undefined;
+        borderDash?: number[] | Scriptable<number[]> | undefined;
         borderDashOffset?: number | Scriptable<number> | undefined;
         borderJoinStyle?: string | Scriptable<string> | undefined;
         capBezierPoints?: boolean | Scriptable<boolean> | undefined;


### PR DESCRIPTION
Updates the type of `borderDash` from `any[]` to
`number[]` in accordance with documentation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chartjs.org/docs/2.9.4/charts/line.html?h=borderdash
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.