### PR TITLE
[three] Allow AnimationMixer clipAction, existingAction and uncacheAction to have clip name as first parameter.

### DIFF
--- a/types/three/src/animation/AnimationMixer.d.ts
+++ b/types/three/src/animation/AnimationMixer.d.ts
@@ -19,16 +19,16 @@ export class AnimationMixer extends EventDispatcher {
     timeScale: number;
 
     clipAction(
-        clip: AnimationClip,
+        clip: AnimationClip | string,
         root?: Object3D | AnimationObjectGroup,
         blendMode?: AnimationBlendMode,
     ): AnimationAction;
-    existingAction(clip: AnimationClip, root?: Object3D | AnimationObjectGroup): AnimationAction | null;
+    existingAction(clip: AnimationClip | string, root?: Object3D | AnimationObjectGroup): AnimationAction | null;
     stopAllAction(): AnimationMixer;
     update(deltaTime: number): AnimationMixer;
     setTime(timeInSeconds: number): AnimationMixer;
     getRoot(): Object3D | AnimationObjectGroup;
     uncacheClip(clip: AnimationClip): void;
     uncacheRoot(root: Object3D | AnimationObjectGroup): void;
-    uncacheAction(clip: AnimationClip, root?: Object3D | AnimationObjectGroup): void;
+    uncacheAction(clip: AnimationClip | string, root?: Object3D | AnimationObjectGroup): void;
 }


### PR DESCRIPTION
From AnimationMixer documentation: "The first parameter can be either an AnimationClip object or the name of an AnimationClip."
I also verified from the source, that strings are indeed handled.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://threejs.org/docs/#api/en/animation/AnimationMixer.clipAction](url)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
