### PR TITLE
[jest] fix package.json not defined by exports - react-native

### DIFF
--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -7,6 +7,7 @@
     "exports": {
         ".": {
             "types": "./index.d.ts"
-        }
+        },
+        "./package.json": "./package.json"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. - N/A
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/react-native-community/cli/issues/1168)>> react-native-cli has an open bug. This pr is to fix the warning of `Package subpath './package.json' is not defined by "exports"` for types/jest package
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - N/A

