### PR TITLE
Accomodate TS 4.7's new union order in levelup tests

### DIFF
--- a/types/levelup/levelup-tests.ts
+++ b/types/levelup/levelup-tests.ts
@@ -61,7 +61,7 @@ db.isOpen();
 // $ExpectType boolean
 db.isClosed();
 
-// $ExpectType "new" | "opening" | "open" | "closing" | "closed" || "open" | "new" | "opening" | "closing" | "closed"
+// $ExpectType "new" | "opening" | "open" | "closing" | "closed" || "open" | "opening" | "closed" | "new" | "closing"
 db.status;
 
 // $ExpectType boolean


### PR DESCRIPTION
Looks like TS 4.7's union order changed again? @weswigham you might want to know about this.