### PR TITLE
Update mongo-db/mongoose dependents

### DIFF
--- a/types/mongodb-queue/index.d.ts
+++ b/types/mongodb-queue/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: FiveOFive <https://github.com/FiveOFive>
 //                 codejockie <https://github.com/codejockie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.5
+// Minimum TypeScript Version: 4.1
 
 import { Db, MongoError } from 'mongodb';
 

--- a/types/mongodb-queue/package.json
+++ b/types/mongodb-queue/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^3.6.20"
+        "mongodb": "^4.5.0"
     }
 }

--- a/types/mongoose-aggregate-paginate-v2/index.d.ts
+++ b/types/mongoose-aggregate-paginate-v2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/webgangster/mongoose-aggregate-paginate-v2
 // Definitions by: Alexandre Croteau <https://github.com/acrilex1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 //
 // Based on type declarations for mongoose-paginate-v2 1.3.
 //

--- a/types/mongoose-aggregate-paginate-v2/mongoose-aggregate-paginate-v2-tests.ts
+++ b/types/mongoose-aggregate-paginate-v2/mongoose-aggregate-paginate-v2-tests.ts
@@ -3,7 +3,7 @@
  * Adapted to mongoose-aggregate-paginate-v2 by Alexandre Croteau <https://github.com/acrilex1>
  */
 
-import { Schema, model, AggregatePaginateModel, PaginateOptions, AggregatePaginateResult, Document } from 'mongoose';
+import { Schema, model, Aggregate, AggregatePaginateModel, PaginateOptions, AggregatePaginateResult, Document } from 'mongoose';
 import mongooseAggregatePaginate = require('mongoose-aggregate-paginate-v2');
 import { Router, Request, Response } from 'express';
 
@@ -30,6 +30,8 @@ const UserModel: UserModel<User> = model<User>('User', UserSchema) as UserModel<
 //#region Test Paginate
 const router: Router = Router();
 
+declare const aggregate: Aggregate<User[]>;
+
 router.get('/users.json', (req: Request, res: Response) => {
     const descending = true;
     const options: PaginateOptions = {};
@@ -47,18 +49,6 @@ router.get('/users.json', (req: Request, res: Response) => {
         nextPage: 'nextPageCustom',
         prevPage: 'prevPageCustom',
     };
-
-    const aggregate = UserModel.aggregate([
-        {
-            $project: {
-                id: 0,
-                email: 1,
-                username: 1,
-            },
-        },
-    ])
-        .collation({ locale: 'en_US', strength: 1 })
-        .cursor({ batchSize: 200 });
 
     UserModel.aggregatePaginate(aggregate, options, (err: any, value: AggregatePaginateResult<User>) => {
         if (err) {

--- a/types/mongoose-aggregate-paginate-v2/package.json
+++ b/types/mongoose-aggregate-paginate-v2/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-auto-increment/index.d.ts
+++ b/types/mongoose-auto-increment/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/codetunnel/mongoose-auto-increment
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import { Connection, Schema, Mongoose } from 'mongoose';
 

--- a/types/mongoose-auto-increment/package.json
+++ b/types/mongoose-auto-increment/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "^4.1.12"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-autopopulate/index.d.ts
+++ b/types/mongoose-autopopulate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mongodb-js/mongoose-autopopulate
 // Definitions by: Ranjit Singh <https://github.com/rann91>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import { Schema } from 'mongoose';
 

--- a/types/mongoose-autopopulate/package.json
+++ b/types/mongoose-autopopulate/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-deep-populate/index.d.ts
+++ b/types/mongoose-deep-populate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/buunguyen/mongoose-deep-populate
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import { Mongoose, Schema } from 'mongoose';
 

--- a/types/mongoose-deep-populate/mongoose-deep-populate-tests.ts
+++ b/types/mongoose-deep-populate/mongoose-deep-populate-tests.ts
@@ -2,15 +2,16 @@ import mongooseDeepPopulate from 'mongoose-deep-populate';
 import * as mongoose from 'mongoose';
 import { Schema } from 'mongoose';
 
-var connection = mongoose.connect("mongodb://localhost/myDatabase");
+async function wrapper() {
+    var connection = await mongoose.connect("mongodb://localhost/myDatabase");
+    var deepPopulate = mongooseDeepPopulate(connection);
 
-var deepPopulate = mongooseDeepPopulate(connection);
+    var bookSchema = new Schema({
+        author: { type: Schema.Types.ObjectId, ref: 'Author' },
+        title: String,
+        genre: String,
+        publishDate: Date
+    });
 
-var bookSchema = new Schema({
-    author: { type: Schema.Types.ObjectId, ref: 'Author' },
-    title: String,
-    genre: String,
-    publishDate: Date
-});
-
-bookSchema.plugin(deepPopulate, {});
+    bookSchema.plugin(deepPopulate, {});
+}

--- a/types/mongoose-deep-populate/mongoose-deep-populate-tests.ts
+++ b/types/mongoose-deep-populate/mongoose-deep-populate-tests.ts
@@ -3,10 +3,10 @@ import * as mongoose from 'mongoose';
 import { Schema } from 'mongoose';
 
 async function wrapper() {
-    var connection = await mongoose.connect("mongodb://localhost/myDatabase");
-    var deepPopulate = mongooseDeepPopulate(connection);
+    const connection = await mongoose.connect("mongodb://localhost/myDatabase");
+    const deepPopulate = mongooseDeepPopulate(connection);
 
-    var bookSchema = new Schema({
+    const bookSchema = new Schema({
         author: { type: Schema.Types.ObjectId, ref: 'Author' },
         title: String,
         genre: String,

--- a/types/mongoose-deep-populate/package.json
+++ b/types/mongoose-deep-populate/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "4.*"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-geojson-schema/index.d.ts
+++ b/types/mongoose-geojson-schema/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rideamigoscorp/mongoose-geojson-schema#readme
 // Definitions by: Bond <https://github.com/bondz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import mongoose = require('mongoose');
 

--- a/types/mongoose-geojson-schema/package.json
+++ b/types/mongoose-geojson-schema/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-id-validator/index.d.ts
+++ b/types/mongoose-id-validator/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/CampbellSoftwareSolutions/mongoose-id-validator
 // Definitions by: Kerollos Magdy <https://github.com/kerolloz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import { Schema, Connection } from 'mongoose';
 

--- a/types/mongoose-id-validator/package.json
+++ b/types/mongoose-id-validator/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-lean-virtuals/index.d.ts
+++ b/types/mongoose-lean-virtuals/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/vkarpov15/mongoose-lean-virtuals
 // Definitions by: Isaac Herrera <https://github.com/isaacdecoded>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import { Schema } from 'mongoose';
 

--- a/types/mongoose-lean-virtuals/package.json
+++ b/types/mongoose-lean-virtuals/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-mock/index.d.ts
+++ b/types/mongoose-mock/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/JohanObrink/mongoose-mock
 // Definitions by: jt000 <https://github.com/jt000>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import mongoose = require('mongoose');
 

--- a/types/mongoose-mock/package.json
+++ b/types/mongoose-mock/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-paginate/index.d.ts
+++ b/types/mongoose-paginate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/edwardhotchkiss/mongoose-paginate
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 4.1
 
 /// <reference types="mongoose" />
 

--- a/types/mongoose-paginate/package.json
+++ b/types/mongoose-paginate/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "^5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-sequence/index.d.ts
+++ b/types/mongoose-sequence/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ramiel/mongoose-sequence
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 4.1
 
 /// <reference types="mongoose" />
 

--- a/types/mongoose-sequence/package.json
+++ b/types/mongoose-sequence/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "^5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-simple-random/index.d.ts
+++ b/types/mongoose-simple-random/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/larryprice/mongoose-simple-random
 // Definitions by: TypeScript Bot <https://github.com/typescript-bot>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import mongoose = require('mongoose');
 declare function pluginFunc(schema: mongoose.Schema): void;
@@ -10,7 +10,7 @@ declare namespace pluginFunc { }
 export = pluginFunc;
 
 declare module "mongoose" {
-    interface Model<T extends Document> extends NodeJS.EventEmitter, ModelProperties {
+    interface Model<T> extends NodeJS.EventEmitter {
         findRandom(conditions: Object, projection?: Object | null, options?: Object | null, callback?: (err: any, res?: T[]) => void)
             : void;
     }

--- a/types/mongoose-simple-random/package.json
+++ b/types/mongoose-simple-random/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongoose-unique-validator/index.d.ts
+++ b/types/mongoose-unique-validator/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/blakehaswell/mongoose-unique-validator#readme
 // Definitions by: Steve Hipwell <https://github.com/stevehipwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import { Schema } from "mongoose";
 

--- a/types/mongoose-unique-validator/package.json
+++ b/types/mongoose-unique-validator/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "5.10.5"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/mongorito/index.d.ts
+++ b/types/mongorito/index.d.ts
@@ -2,9 +2,9 @@
 // Project: https://github.com/vadimdemedes/mongorito, https://github.com/vdemedes/mongorito
 // Definitions by: Pinguet62 <https://github.com/pinguet62>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
-import { Collection, CommonOptions, Db, IndexOptions, Long, MongoClientOptions, ReadPreference } from 'mongodb';
+import { Collection, CreateIndexesOptions, Db, DropIndexesOptions, Long, MongoClientOptions, ReadPreference } from 'mongodb';
 
 export { Timestamp, ObjectId, MinKey, MaxKey, DBRef, Long } from 'mongodb';
 
@@ -67,12 +67,12 @@ export class Model extends Query {
     /**
      * @see mongodb.Collection#createIndex()
      */
-    static createIndex(fieldOrSpec: any, options?: IndexOptions): Promise<string>;
+    static createIndex(fieldOrSpec: any, options?: CreateIndexesOptions): Promise<string>;
 
     /**
      * @see mongodb.Collection#dropIndex()
      */
-    static dropIndex(indexName: string, options?: CommonOptions): Promise<object>;
+    static dropIndex(indexName: string, options?: DropIndexesOptions): Promise<object>;
 
     static embeds(key: string, model: ModelClass): void;
 

--- a/types/mongorito/package.json
+++ b/types/mongorito/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^3.6.20"
+        "mongodb": "^4.5.0"
     }
 }

--- a/types/mongration/index.d.ts
+++ b/types/mongration/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/awapps/mongration#readme
 // Definitions by: Anton Lobashev <https://github.com/soulthreads>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import { Db } from 'mongodb';
 

--- a/types/mongration/mongration-tests.ts
+++ b/types/mongration/mongration-tests.ts
@@ -20,9 +20,15 @@ migration.migrate((err, response) => {
 const step: MigrationStep = {
   id: '1-step',
   up: (db, cb) => {
-    db.collection('testcolleciton').insert({ name: 'initial-setup' }, cb);
+    // $ExpectType Db
+    db;
+    // $ExpectType (err?: Error | undefined) => void
+    cb;
   },
   down: (db, cb) => {
-    db.collection('testcollection').remove({ name: 'initial-setup' }, cb);
+    // $ExpectType Db
+    db;
+    // $ExpectType (err?: Error | undefined) => void
+    cb;
   }
 };

--- a/types/mongration/package.json
+++ b/types/mongration/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^3.6.20"
+        "mongodb": "^4.5.0"
     }
 }

--- a/types/node-mongodb-fixtures/index.d.ts
+++ b/types/node-mongodb-fixtures/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/cdimascio/node-mongodb-fixtures#readme
 // Definitions by: Chuah Chee Shian (shian15810) <https://github.com/shian15810>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.1
 
 import { MongoClientOptions } from 'mongodb';
 

--- a/types/node-mongodb-fixtures/node-mongodb-fixtures-tests.ts
+++ b/types/node-mongodb-fixtures/node-mongodb-fixtures-tests.ts
@@ -1,3 +1,4 @@
+import { MongoClientOptions } from 'mongodb';
 import Fixtures = require('node-mongodb-fixtures');
 
 const uri = 'mongodb://localhost:27017/mydb';
@@ -25,13 +26,11 @@ fixtures2.connect(uri, {});
 
 // $ExpectType Fixtures
 const fixtures3 = new Fixtures(options);
+declare const mongoOptions: MongoClientOptions;
 // $ExpectType Promise<Fixtures>
 fixtures3.connect(
     uri,
-    {
-        useNewUrlParser: true,
-        useUnifiedTopology: true,
-    },
+    mongoOptions,
     'db',
 );
 // $ExpectType Promise<Fixtures>

--- a/types/node-mongodb-fixtures/package.json
+++ b/types/node-mongodb-fixtures/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongodb": "^3.6.20"
+        "mongodb": "^4.5.0"
     }
 }

--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/saintedlama/passport-local-mongoose
 // Definitions by: Linus Brolin <https://github.com/linusbrolin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
+// TypeScript Version: 4.1
 
 /// <reference types="mongoose" />
 /// <reference types="passport-local" />

--- a/types/passport-local-mongoose/package.json
+++ b/types/passport-local-mongoose/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "mongoose": "5.*"
+        "mongoose": "^6.3.0"
     }
 }

--- a/types/resourcejs/index.d.ts
+++ b/types/resourcejs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/travist/resourcejs
 // Definitions by: Shaun Luttin <https://github.com/shaunluttin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.2
+// Minimum TypeScript Version: 4.1
 
 import express = require("express");
 import mongoose = require("mongoose");

--- a/types/resourcejs/package.json
+++ b/types/resourcejs/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/mongoose": "5.10.5"
+        "mongoose": "^6.3.0"
     }
 }


### PR DESCRIPTION
Both mongodb and mongoose ship their own types now, and only the latest versions compile on TS 4.7 without errors.

This required a few changes to packages:

- A few tests were out of date. I put in declarations of mongoose/mongodb types in place of calls to out-of-date functions.
- mongoose-simple-random referred to an out-of-date interface and a no-longer-required type parameter constraint. I deleted both.
- mongorito needed to update a couple of the mongodb option types for createIndex and dropIndex

mongoose-simple-random is the biggest change overall.