### PR TITLE
Misc fixes for TS 4.7

### DIFF
--- a/types/pkijs/index.d.ts
+++ b/types/pkijs/index.d.ts
@@ -633,7 +633,7 @@ declare module "pkijs/src/CryptoEngine" {
          */
         constructor(parameters?: any);
 
-        importKey(format: "jwk", keyData: JsonWebKey, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams, extractable: boolean, keyUsages: string[]): Promise<CryptoKey>;
+        importKey(format: "jwk", keyData: JsonWebKey, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams, extractable: boolean, keyUsages: readonly string[]): Promise<CryptoKey>;
         importKey(format: "raw" | "pkcs8" | "spki", keyData: BufferSource, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams, extractable: boolean, keyUsages: string[]): Promise<CryptoKey>;
         importKey(format: string, keyData: JsonWebKey | BufferSource, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams, extractable: boolean, keyUsages: string[]): Promise<CryptoKey>;
         exportKey(format: "jwk", key: CryptoKey): Promise<JsonWebKey>;
@@ -652,9 +652,9 @@ declare module "pkijs/src/CryptoEngine" {
          */
         convert(inputFormat: string, outputFormat: string, keyData: BufferSource | JsonWebKey, algorithm: Algorithm, extractable: boolean, keyUsages: string[]): PromiseLike<BufferSource | JsonWebKey>;
 
-        generateKey(algorithm: string, extractable: boolean, keyUsages: string[]): Promise<CryptoKeyPair | CryptoKey>;
-        generateKey(algorithm: RsaHashedKeyGenParams | EcKeyGenParams, extractable: boolean, keyUsages: string[]): Promise<CryptoKeyPair>;
-        generateKey(algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: string[]): Promise<CryptoKey>;
+        generateKey(algorithm: string, extractable: boolean, keyUsages: readonly string[]): Promise<CryptoKeyPair | CryptoKey>;
+        generateKey(algorithm: RsaHashedKeyGenParams | EcKeyGenParams, extractable: boolean, keyUsages: readonly string[]): Promise<CryptoKeyPair>;
+        generateKey(algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: readonly string[]): Promise<CryptoKey>;
         importKey(format: "jwk", keyData: JsonWebKey, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKey>;
         importKey(format: "raw" | "pkcs8" | "spki", keyData: BufferSource, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKey>;
         importKey(format: string, keyData: JsonWebKey | BufferSource, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKey>;

--- a/types/pouch-redux-middleware/index.d.ts
+++ b/types/pouch-redux-middleware/index.d.ts
@@ -9,7 +9,7 @@ import * as PouchDB from 'pouchdb';
 
 export type Document<T = {[field: string]: any}> = PouchDB.Core.IdMeta & T;
 
-export interface Path<T = {[field: string]: any}> {
+export interface Path<T extends {} = {[field: string]: any}> {
     path: string;
     db: PouchDB.Database<T>;
     scheduleRemove?(doc: Document<T>): void;
@@ -30,4 +30,4 @@ export interface Path<T = {[field: string]: any}> {
     };
 }
 
-export default function PouchMiddlewareFactory<T = {[field: string]: any}>(paths?: Array<Path<T>> | Path<T>): Middleware;
+export default function PouchMiddlewareFactory<T extends {} = {[field: string]: any}>(paths?: Array<Path<T>> | Path<T>): Middleware;

--- a/types/raphael/index.d.ts
+++ b/types/raphael/index.d.ts
@@ -452,7 +452,7 @@ export type RaphaelPotentialFailure<T extends {}> = T & {
  */
 export type RaphaelPaperPluginRegistry<
     TTechnology extends RaphaelTechnology = "SVG" | "VML",
-    T extends {} = RaphaelPaper<TTechnology>> = {
+    T = RaphaelPaper<TTechnology>> = {
         /**
          * Either the paper plugin method or a new namespace with methods.
          */

--- a/types/remark-prism/index.d.ts
+++ b/types/remark-prism/index.d.ts
@@ -16,17 +16,6 @@ type SupportedPlugins =
     | 'show-invisibles'
     | 'treeview';
 
-type SupportedPlugins =
-    | 'autolinker'
-    | 'command-line'
-    | 'data-uri-highlight'
-    | 'diff-highlight'
-    | 'inline-color'
-    | 'keep-markup'
-    | 'line-numbers'
-    | 'show-invisibles'
-    | 'treeview';
-
 declare namespace remarkPrism {
     /**
      * Plugin to use prism with remark.


### PR DESCRIPTION
1. pkijs: add readonly to some arrays to match the DOM.
2. pouch-redux-middleware, raphael: remove some unneeded type parameter constraints:
3. remark-prism: remove duplicated type alias.