### PR TITLE
[tap] fix: make resolveMatch's 2nd arg type 'any'

### DIFF
--- a/types/tap/index.d.ts
+++ b/types/tap/index.d.ts
@@ -725,7 +725,7 @@ declare global {
              */
             resolveMatch(
                 promiseOrFn: Promise<any> | ((...args: any[]) => Promise<any>),
-                wanted: string | RegExp | { [key: string]: RegExp },
+                wanted: any,
                 message?: string,
                 extra?: Options.Assert,
             ): Promise<void>;

--- a/types/tap/tap-tests.ts
+++ b/types/tap/tap-tests.ts
@@ -176,8 +176,8 @@ tap.test("all-assertions", t => {
 });
 
 tap.test("async test", async t => {
-    const wanted: any = 1;
-    const expectedError: any = "foo";
+    const wanted = 1;
+    const expectedError = "foo";
 
     const message = "message";
     const extra = {


### PR DESCRIPTION
Anything in node-tap that uses t.match() takes anything as a second
argument. The current implementation expects a string or an object of
anything, which is a problem because it disallows things like 'null' -
despite that being perfectly supported by t.match()!

This patch changes the 2nd argument to 'any', which allows consumers to
use all of the features of t.match().

*****

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://node-tap.org/docs/api/asserts/#tresolvematchpromise--fn-wanted-message-extra>>