### PR TITLE
[styled-components-react-native] Update types to support react native v0.68

### DIFF
--- a/types/styled-components-react-native/index.d.ts
+++ b/types/styled-components-react-native/index.d.ts
@@ -70,8 +70,6 @@ declare module "styled-components/native" {
         ListView: ReactNativeThemedStyledFunction<typeof ReactNative.ListView, T>;
         Modal: ReactNativeThemedStyledFunction<typeof ReactNative.Modal, T>;
         NavigatorIOS: ReactNativeThemedStyledFunction<typeof ReactNative.NavigatorIOS, T>;
-        Picker: ReactNativeThemedStyledFunction<typeof ReactNative.Picker, T>;
-        PickerIOS: ReactNativeThemedStyledFunction<typeof ReactNative.PickerIOS, T>;
         Pressable: ReactNativeThemedStyledFunction<typeof ReactNative.Pressable, T>;
         ProgressBarAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressBarAndroid, T>;
         ProgressViewIOS: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressViewIOS, T>;

--- a/types/styled-components-react-native/tsconfig.json
+++ b/types/styled-components-react-native/tsconfig.json
@@ -13,11 +13,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "react-native": [
-                "react-native/v0.65"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Follow-up to this PR #59547 with fixes.

`Picker` and `PickerIOS` has been removed from React Native: https://github.com/facebook/react-native/blob/0.68-stable/index.js#L688-L718

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
