### PR TITLE
[chess.js] Update board return type

### DIFF
--- a/types/chess.js/chess.js-tests.ts
+++ b/types/chess.js/chess.js-tests.ts
@@ -201,7 +201,7 @@ chess.history({ verbose: false });
 // $ExpectType Move[]
 chess.history({ verbose: true });
 
-// $ExpectType ({ type: PieceType; color: "w" | "b"; } | null)[][] || ({ type: PieceType; color: "b" | "w"; } | null)[][]
+// $ExpectType ({ type: PieceType; color: "w" | "b"; square: Square; } | null)[][] || ({ type: PieceType; color: "b" | "w"; square: Square; } | null)[][]
 chess.board();
 
 // --- comments --- \\

--- a/types/chess.js/index.d.ts
+++ b/types/chess.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for chess.js 0.11
+// Type definitions for chess.js 0.13
 // Project: https://github.com/jhlywa/chess.js
 // Definitions by: Jacob Fischer <https://github.com/JacobFischer>
 //                 Zachary Svoboda <https://github.com/zacnomore>
@@ -620,7 +620,7 @@ export interface ChessInstance {
         verbose?: boolean | undefined;
     }): string[] | Move[];
 
-    board(): Array<Array<{ type: PieceType; color: "w" | "b" } | null>>;
+    board(): Array<Array<{ type: PieceType; color: "w" | "b", square: Square } | null>>;
 
     get_comment(): string | undefined;
 


### PR DESCRIPTION
This the position was added to the return type of board

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jhlywa/chess.js/blob/master/README.md#board

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.