### PR TITLE
[ember__routing] Fix typing for `activate` and `deactivate` in ember route

### DIFF
--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -454,13 +454,13 @@ export default class Route<Model = unknown, Params extends object = object>
      * This hook is executed when the router enters the route. It is not executed
      * when the model for the route changes.
      */
-    activate(): void;
+    activate(transition: Transition): void;
 
     /**
      * This hook is executed when the router completely exits this route. It is
      * not executed when the model for the route changes.
      */
-    deactivate(): void;
+    deactivate(transition: Transition): void;
 
     /**
      * The didTransition action is fired after a transition has successfully been

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -43,6 +43,18 @@ Route.extend({
     },
 });
 
+class ActivateRoute extends Route {
+    activate(transition: Transition) {
+        this.transitionTo('someOtherRoute');
+    }
+}
+
+class DeactivateRoute extends Route {
+    deactivate(transition: Transition) {
+        this.transitionTo('someOtherRoute');
+    }
+}
+
 class RedirectRoute extends Route {
     redirect(model: {}, a: Transition) {
         if (!model) {


### PR DESCRIPTION
These two methods actually receive a `Transition` argument.

See: https://api.emberjs.com/ember/4.3/classes/Route/methods?anchor=activate

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.emberjs.com/ember/4.3/classes/Route/methods?anchor=activate
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
