### PR TITLE
[jest-28] fix types of `jest.useFakeTimers()`

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 27.4
+// Type definitions for Jest 28.0.0-alpha
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>
@@ -71,6 +71,77 @@ type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
         : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]> ? 10
         : 'fallback'
 ];
+
+export type FakeableAPI =
+  | 'Date'
+  | 'hrtime'
+  | 'nextTick'
+  | 'performance'
+  | 'queueMicrotask'
+  | 'requestAnimationFrame'
+  | 'cancelAnimationFrame'
+  | 'requestIdleCallback'
+  | 'cancelIdleCallback'
+  | 'setImmediate'
+  | 'clearImmediate'
+  | 'setInterval'
+  | 'clearInterval'
+  | 'setTimeout'
+  | 'clearTimeout';
+
+type FakeTimersConfig = {
+  /**
+   * If set to `true` all timers will be advanced automatically
+   * by 20 milliseconds every 20 milliseconds. A custom time delta
+   * may be provided by passing a number.
+   *
+   * @defaultValue
+   * The default is `false`.
+   */
+  advanceTimers?: boolean | number;
+  /**
+   * List of names of APIs (e.g. `Date`, `nextTick()`, `setImmediate()`,
+   * `setTimeout()`) that should not be faked.
+   *
+   * @defaultValue
+   * The default is `[]`, meaning all APIs are faked.
+   * */
+  doNotFake?: Array<FakeableAPI>;
+  /**
+   * Sets current system time to be used by fake timers.
+   *
+   * @defaultValue
+   * The default is `Date.now()`.
+   */
+  now?: number | Date;
+  /**
+   * The maximum number of recursive timers that will be run when calling
+   * `jest.runAllTimers()`.
+   *
+   * @defaultValue
+   * The default is `100_000` timers.
+   */
+  timerLimit?: number;
+  /**
+   * Use the old fake timers implementation instead of one backed by
+   * [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers).
+   *
+   * @defaultValue
+   * The default is `false`.
+   */
+  legacyFakeTimers?: false;
+};
+
+type LegacyFakeTimersConfig = {
+  /**
+   * Use the old fake timers implementation instead of one backed by
+   * [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers).
+   *
+   * @defaultValue
+   * The default is `false`.
+   */
+  legacyFakeTimers?: true;
+};
 
 declare namespace jest {
     /**
@@ -319,11 +390,20 @@ declare namespace jest {
      */
     function unmock(moduleName: string): typeof jest;
     /**
-     * Instructs Jest to use fake versions of the standard timer functions.
+     * Instructs Jest to use fake versions of the global date, performance,
+     * time and timer APIs. Fake timers implementation is backed by
+     * [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers).
+     *
+     * @remarks
+     * Calling `jest.useFakeTimers()` once again in the same test file would reinstall
+     * fake timers using the provided options.
      */
-    function useFakeTimers(implementation?: 'modern' | 'legacy'): typeof jest;
+    function useFakeTimers(
+        fakeTimersConfig?: FakeTimersConfig | LegacyFakeTimersConfig,
+      ): typeof jest;
     /**
-     * Instructs Jest to use the real versions of the standard timer functions.
+     * Instructs Jest to restore the original implementations of the global date,
+     * performance, time and timer APIs.
      */
     function useRealTimers(): typeof jest;
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -300,11 +300,68 @@ jest.autoMockOff()
 jest.advanceTimersToNextTimer();
 jest.advanceTimersToNextTimer(2);
 
-// https://jestjs.io/docs/en/jest-object#jestusefaketimersimplementation-modern--legacy
-jest.useFakeTimers('modern');
+// https://jestjs.io/docs/jest-object#jestusefaketimersfaketimersconfig
+jest.useFakeTimers({ advanceTimers: true });
+jest.useFakeTimers({ advanceTimers: 10 });
+// $ExpectError
+jest.useFakeTimers({ advanceTimers: 'fast' });
+
+jest.useFakeTimers({ doNotFake: ['Date'] });
+jest.useFakeTimers({
+    doNotFake: [
+        'Date',
+        'hrtime',
+        'nextTick',
+        'performance',
+        'queueMicrotask',
+        'requestAnimationFrame',
+        'cancelAnimationFrame',
+        'requestIdleCallback',
+        'cancelIdleCallback',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout',
+    ],
+});
+// $ExpectError
+jest.useFakeTimers({ doNotFake: ['globalThis'] });
+
+jest.useFakeTimers({ legacyFakeTimers: true });
+// $ExpectError
+jest.useFakeTimers({ legacyFakeTimers: 1000 });
+// $ExpectError
+jest.useFakeTimers({ doNotFake: ['Date'], legacyFakeTimers: true });
+// $ExpectError
+jest.useFakeTimers({ enableGlobally: true, legacyFakeTimers: true });
+// $ExpectError
+jest.useFakeTimers({ legacyFakeTimers: true, now: 1483228800000 });
+// $ExpectError
+jest.useFakeTimers({ legacyFakeTimers: true, timerLimit: 1000 });
+
+jest.useFakeTimers({ now: 1483228800000 });
+jest.useFakeTimers({ now: Date.now() });
+jest.useFakeTimers({ now: new Date(1995, 11, 17) });
+// $ExpectError
+jest.useFakeTimers({ now: '1995-12-17T03:24:00' });
+
+jest.useFakeTimers({ timerLimit: 1000 });
+// $ExpectError
+jest.useFakeTimers({ timerLimit: true });
+
+// $ExpectError
+jest.useFakeTimers({ enableGlobally: true });
+// $ExpectError
 jest.useFakeTimers('legacy');
 // $ExpectError
-jest.useFakeTimers('foo');
+jest.useFakeTimers('modern');
+
+jest.useRealTimers();
+// $ExpectError
+jest.useRealTimers(true);
+
 
 // https://jestjs.io/docs/en/jest-object#jestsetsystemtimenow-number--date
 jest.setSystemTime();

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,8 +1,8 @@
 {
     "private": true,
     "dependencies": {
-        "jest-matcher-utils": "^27.0.0",
-        "pretty-format": "^27.0.0"
+        "jest-matcher-utils": "^28.0.0",
+        "pretty-format": "^28.0.0"
     },
     "exports": {
         ".": {

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,8 +1,8 @@
 {
     "private": true,
     "dependencies": {
-        "jest-matcher-utils": "^28.0.0",
-        "pretty-format": "^28.0.0"
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
     },
     "exports": {
         ".": {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [PR which introduced the change](https://github.com/facebook/jest/pull/12572)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Jest 28 just shipped with lots of new features and breaking changes. I am trying to figure it out how to reflect those here.

For instance, `jest.useFakeTimers()` takes an options bag now. I copied types and tests from Jest repo. Would be nice to avoid coping in the future, but perhaps for now this is fine.

Another question. This and few others are breaking changes. It does not sound good to bump major version with each PR. Would it work releasing alphas first?