### PR TITLE
[node] Improve consistency of JSDoc since tags

### DIFF
--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -258,7 +258,7 @@ declare module 'async_hooks' {
          * @param type The type of async event.
          * @param triggerAsyncId The ID of the execution context that created
          *   this async event (default: `executionAsyncId()`), or an
-         *   AsyncResourceOptions object (since 9.3)
+         *   AsyncResourceOptions object (since v9.3.0)
          */
         constructor(type: string, triggerAsyncId?: number | AsyncResourceOptions);
         /**

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -262,11 +262,11 @@ declare namespace NodeJS {
         id: string;
         filename: string;
         loaded: boolean;
-        /** @deprecated since 14.6.0 Please use `require.main` and `module.children` instead. */
+        /** @deprecated since v14.6.0 Please use `require.main` and `module.children` instead. */
         parent: Module | null | undefined;
         children: Module[];
         /**
-         * @since 11.14.0
+         * @since v11.14.0
          *
          * The directory name of the module. This is usually the same as the path.dirname() of the module.id.
          */

--- a/types/node/v12/async_hooks.d.ts
+++ b/types/node/v12/async_hooks.d.ts
@@ -111,7 +111,7 @@ declare module 'async_hooks' {
          * @param type The type of async event.
          * @param triggerAsyncId The ID of the execution context that created
          *   this async event (default: `executionAsyncId()`), or an
-         *   AsyncResourceOptions object (since 9.3)
+         *   AsyncResourceOptions object (since v9.3.0)
          */
         constructor(type: string, triggerAsyncId?: number|AsyncResourceOptions);
 

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -230,11 +230,11 @@ interface NodeModule {
     id: string;
     filename: string;
     loaded: boolean;
-    /** @deprecated since 12.19.0 Please use `require.main` and `module.children` instead. */
+    /** @deprecated since v12.19.0 Please use `require.main` and `module.children` instead. */
     parent: NodeModule | null | undefined;
     children: NodeModule[];
     /**
-     * @since 11.14.0
+     * @since v11.14.0
      *
      * The directory name of the module. This is usually the same as the path.dirname() of the module.id.
      */
@@ -1317,11 +1317,11 @@ declare namespace NodeJS {
         id: string;
         filename: string;
         loaded: boolean;
-        /** @deprecated since 12.19.0 Please use `require.main` and `module.children` instead. */
+        /** @deprecated since v12.19.0 Please use `require.main` and `module.children` instead. */
         parent: Module | null | undefined;
         children: Module[];
         /**
-         * @since 11.14.0
+         * @since v11.14.0
          *
          * The directory name of the module. This is usually the same as the path.dirname() of the module.id.
          */

--- a/types/node/v12/index.d.ts
+++ b/types/node/v12/index.d.ts
@@ -39,7 +39,7 @@
 
 // NOTE: These definitions support NodeJS and TypeScript 3.7.
 // This isn't strictly needed since 3.7 has the assert module, but this way we're consistent.
-// Typically type modificatons should be made in base.d.ts instead of here
+// Typically type modifications should be made in base.d.ts instead of here
 
 // Reference required types from the default lib:
 /// <reference lib="es2018" />

--- a/types/node/v12/inspector.d.ts
+++ b/types/node/v12/inspector.d.ts
@@ -1917,7 +1917,7 @@ declare module 'inspector' {
          * Connects a session to the main thread inspector back-end.
          * An exception will be thrown if this API was not called on a Worker
          * thread.
-         * @since 12.11.0
+         * @since v12.11.0
          */
         connectToMainThread(): void;
 

--- a/types/node/v14/async_hooks.d.ts
+++ b/types/node/v14/async_hooks.d.ts
@@ -111,7 +111,7 @@ declare module 'async_hooks' {
          * @param type The type of async event.
          * @param triggerAsyncId The ID of the execution context that created
          *   this async event (default: `executionAsyncId()`), or an
-         *   AsyncResourceOptions object (since 9.3)
+         *   AsyncResourceOptions object (since v9.3.0)
          */
         constructor(type: string, triggerAsyncId?: number|AsyncResourceOptions);
 

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -724,11 +724,11 @@ declare namespace NodeJS {
         id: string;
         filename: string;
         loaded: boolean;
-        /** @deprecated since 14.6.0 Please use `require.main` and `module.children` instead. */
+        /** @deprecated since v14.6.0 Please use `require.main` and `module.children` instead. */
         parent: Module | null | undefined;
         children: Module[];
         /**
-         * @since 11.14.0
+         * @since v11.14.0
          *
          * The directory name of the module. This is usually the same as the path.dirname() of the module.id.
          */

--- a/types/node/v14/inspector.d.ts
+++ b/types/node/v14/inspector.d.ts
@@ -1917,7 +1917,7 @@ declare module 'inspector' {
          * Connects a session to the main thread inspector back-end.
          * An exception will be thrown if this API was not called on a Worker
          * thread.
-         * @since 12.11.0
+         * @since v12.11.0
          */
         connectToMainThread(): void;
 

--- a/types/node/v16/async_hooks.d.ts
+++ b/types/node/v16/async_hooks.d.ts
@@ -258,7 +258,7 @@ declare module 'async_hooks' {
          * @param type The type of async event.
          * @param triggerAsyncId The ID of the execution context that created
          *   this async event (default: `executionAsyncId()`), or an
-         *   AsyncResourceOptions object (since 9.3)
+         *   AsyncResourceOptions object (since v9.3.0)
          */
         constructor(type: string, triggerAsyncId?: number | AsyncResourceOptions);
         /**

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -262,11 +262,11 @@ declare namespace NodeJS {
         id: string;
         filename: string;
         loaded: boolean;
-        /** @deprecated since 14.6.0 Please use `require.main` and `module.children` instead. */
+        /** @deprecated since v14.6.0 Please use `require.main` and `module.children` instead. */
         parent: Module | null | undefined;
         children: Module[];
         /**
-         * @since 11.14.0
+         * @since v11.14.0
          *
          * The directory name of the module. This is usually the same as the path.dirname() of the module.id.
          */

--- a/types/node/v16/inspector.d.ts
+++ b/types/node/v16/inspector.d.ts
@@ -1782,7 +1782,7 @@ declare module 'inspector' {
          * Connects a session to the main thread inspector back-end.
          * An exception will be thrown if this API was not called on a Worker
          * thread.
-         * @since 12.11.0
+         * @since v12.11.0
          */
         connectToMainThread(): void;
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59434#discussion_r858114731>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

@amcasey [noticed a `@since` tag that wasn't consistent](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59434#discussion_r858114731) with the other JSDoc tags - this PR updates other incorrect tags too.