### PR TITLE
Add link to Chromium flags list

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -2185,7 +2185,7 @@ export interface ChromeArgOptions {
     headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
-     * The list of Chromium flags can be found here.
+     * The list of Chromium flags can be found here: https://peter.sh/experiments/chromium-command-line-switches
      */
     args?: string[] | undefined;
     /**

--- a/types/puppeteer/v1/index.d.ts
+++ b/types/puppeteer/v1/index.d.ts
@@ -2075,7 +2075,7 @@ export interface ChromeArgOptions {
     headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
-     * The list of Chromium flags can be found here.
+     * The list of Chromium flags can be found here: https://peter.sh/experiments/chromium-command-line-switches
      */
     args?: string[] | undefined;
     /**

--- a/types/puppeteer/v2/index.d.ts
+++ b/types/puppeteer/v2/index.d.ts
@@ -2126,7 +2126,7 @@ export interface ChromeArgOptions {
     headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
-     * The list of Chromium flags can be found here.
+     * The list of Chromium flags can be found here: https://peter.sh/experiments/chromium-command-line-switches
      */
     args?: string[] | undefined;
     /**

--- a/types/puppeteer/v3/index.d.ts
+++ b/types/puppeteer/v3/index.d.ts
@@ -2102,7 +2102,7 @@ export interface ChromeArgOptions {
     headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
-     * The list of Chromium flags can be found here.
+     * The list of Chromium flags can be found here: https://peter.sh/experiments/chromium-command-line-switches
      */
     args?: string[] | undefined;
     /**

--- a/types/puppeteer/v4/index.d.ts
+++ b/types/puppeteer/v4/index.d.ts
@@ -2051,7 +2051,7 @@ export interface ChromeArgOptions {
     headless?: boolean | undefined;
     /**
      * Additional arguments to pass to the browser instance.
-     * The list of Chromium flags can be found here.
+     * The list of Chromium flags can be found here: https://peter.sh/experiments/chromium-command-line-switches
      */
     args?: string[] | undefined;
     /**


### PR DESCRIPTION
Add missing link to chromium flags list in comment for `ChromeArgOptions` for Puppeteer
