### PR TITLE
[sharedb] Loosen creation types

### DIFF
--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -126,8 +126,8 @@ export class Doc<T = any> extends TypedEmitter<DocEventMap<T>> {
     ingestSnapshot(snapshot: Pick<Snapshot<T>, 'v' | 'type' | 'data'>, callback?: Callback): void;
     destroy(callback?: Callback): void;
     create(data: any, callback?: Callback): void;
-    create(data: any, type?: OTType, callback?: Callback): void;
-    create(data: any, type?: OTType, options?: ShareDBSourceOptions, callback?: Callback): void;
+    create(data: any, type?: string, callback?: Callback): void;
+    create(data: any, type?: string, options?: ShareDBSourceOptions, callback?: Callback): void;
     submitOp(data: any, options?: ShareDBSourceOptions, callback?: Callback): void;
     del(options: ShareDBSourceOptions, callback?: (err: Error) => void): void;
     whenNothingPending(callback: () => void): void;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -233,6 +233,8 @@ doc.fetch((err) => {
     }
 });
 
+doc.create({foo: true}, 'http://sharejs.org/types/JSONv0');
+
 function startServer() {
     const server = http.createServer();
 


### PR DESCRIPTION
`doc.create()` accepts an optional [type argument][1]. This type
`string` is used as a key to the object of [registered types][2], which
has both [type names][3] *and* [type URIs][4] as keys.

At the moment, the type definitions demand a type name, when a URI is
just as valid (if not actively *more* valid due to the higher degree of
specificity in a URI).

We could add the URIs on top of the existing literal type, but actually
registering arbitrary (custom, forked, etc.) types is a valid thing to
do, so this change completely loosens the type to `string`.

Note that we keep the (now unused) `OTType` definition in case any
consumers are importing it and to avoid breaking them.

[1]: https://github.com/share/sharedb/blob/92479d24e13f715fe380803d81812aa37a6e23b2/lib/client/doc.js#L882
[2]: https://github.com/share/sharedb/blob/92479d24e13f715fe380803d81812aa37a6e23b2/lib/types.js#L4
[3]: https://github.com/share/sharedb/blob/92479d24e13f715fe380803d81812aa37a6e23b2/lib/types.js#L7
[4]: https://github.com/share/sharedb/blob/92479d24e13f715fe380803d81812aa37a6e23b2/lib/types.js#L8

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
