### PR TITLE
[wordpress__blocks] Add typings for block variations registration api 

### DIFF
--- a/types/wordpress__blocks/api/registration.d.ts
+++ b/types/wordpress__blocks/api/registration.d.ts
@@ -199,6 +199,6 @@ export function registerBlockVariation(blockName: string, variation: BlockVariat
  * Unregisters one or more variations defined for the given block type.
  *
  * @param blockName - Name of the block (example: “core/columns”).
- * @param variationName - Variation name defined for the block (or array of if more than one).
+ * @param variationName - Name of variation to be unregistered (or array if unregistering multiple variations)
  */
 export function unregisterBlockVariation(blockName: string, variationName: string | string[]): void;

--- a/types/wordpress__blocks/api/registration.d.ts
+++ b/types/wordpress__blocks/api/registration.d.ts
@@ -22,7 +22,7 @@ export function getBlockSupport(nameOrType: string | Block<any>, feature: keyof 
 export function getBlockSupport<T>(
     nameOrType: string | Block<any>,
     feature: keyof BlockSupports,
-    defaultSupports: T
+    defaultSupports: T,
 ): T extends string ? string : T extends number ? number : T extends boolean ? boolean : T;
 
 /**
@@ -76,7 +76,7 @@ export function getUnregisteredTypeHandlerName(): string | undefined;
 export function hasBlockSupport(
     nameOrType: string | Block<any>,
     feature: keyof BlockSupports,
-    defaultSupports?: boolean
+    defaultSupports?: boolean,
 ): boolean;
 
 /**
@@ -108,7 +108,7 @@ export function isReusableBlock(blockOrType: Block<any> | BlockInstance): boolea
  */
 export function registerBlockCollection(
     namespace: string,
-    settings: {title: string, icon?: BlockIcon | undefined}
+    settings: { title: string; icon?: BlockIcon | undefined },
 ): void;
 
 /**
@@ -181,7 +181,7 @@ export function unregisterBlockType(name: string): Block<any> | undefined;
  * Returns an array with the variations of a given block type.
  *
  * @param blockName - Name of block (example: “core/columns”).
- * @param [scope] - Block variation scope name.
+ * @param scope - Block variation scope name.
  *
  * @returns Block variations.
  */
@@ -191,7 +191,7 @@ export function getBlockVariations(blockName: string, scope?: BlockVariationScop
  * Registers one or more new block variations for the given block type.
  *
  * @param blockName - Name of the block (example: “core/columns”).
- * @param variation - Object or array of objects describing block variations.
+ * @param variation - Variation configuration object (or array of if more than one).
  */
 export function registerBlockVariation(blockName: string, variation: BlockVariation | BlockVariation[]): void;
 
@@ -199,6 +199,6 @@ export function registerBlockVariation(blockName: string, variation: BlockVariat
  * Unregisters one or more variations defined for the given block type.
  *
  * @param blockName - Name of the block (example: “core/columns”).
- * @param variationName - Name or array of variation names defined for the block.
+ * @param variationName - Variation name defined for the block (or array of if more than one).
  */
 export function unregisterBlockVariation(blockName: string, variationName: string | string[]): void;

--- a/types/wordpress__blocks/api/registration.d.ts
+++ b/types/wordpress__blocks/api/registration.d.ts
@@ -188,17 +188,17 @@ export function unregisterBlockType(name: string): Block<any> | undefined;
 export function getBlockVariations(blockName: string, scope?: BlockVariationScope): BlockVariation[] | undefined;
 
 /**
- * Registers a new block variation for the given block type.
+ * Registers one or more new block variations for the given block type.
  *
  * @param blockName - Name of the block (example: “core/columns”).
- * @param variation - Object describing a block variation.
+ * @param variation - Object or array of objects describing block variations.
  */
-export function registerBlockVariation(blockName: string, variation: BlockVariation): void;
+export function registerBlockVariation(blockName: string, variation: BlockVariation | BlockVariation[]): void;
 
 /**
- * Unregisters a block variation defined for the given block type.
+ * Unregisters one or more variations defined for the given block type.
  *
  * @param blockName - Name of the block (example: “core/columns”).
- * @param variationName - Name of the variation defined for the block.
+ * @param variationName - Name or array of variation names defined for the block.
  */
-export function unregisterBlockVariation(blockName: string, variationName: string): void;
+export function unregisterBlockVariation(blockName: string, variationName: string | string[]): void;

--- a/types/wordpress__blocks/api/registration.d.ts
+++ b/types/wordpress__blocks/api/registration.d.ts
@@ -1,4 +1,13 @@
-import { Block, BlockConfiguration, BlockIcon, BlockInstance, BlockStyle, BlockSupports } from '../';
+import {
+    Block,
+    BlockConfiguration,
+    BlockIcon,
+    BlockInstance,
+    BlockStyle,
+    BlockSupports,
+    BlockVariation,
+    BlockVariationScope,
+} from '../';
 
 /**
  * Returns the block support value for a feature, if defined.
@@ -167,3 +176,29 @@ export function unregisterBlockStyle(blockName: string, styleVariationName: stri
  * @returns The previous block value if successfully unregistered, otherwise `undefined`.
  */
 export function unregisterBlockType(name: string): Block<any> | undefined;
+
+/**
+ * Returns an array with the variations of a given block type.
+ *
+ * @param blockName - Name of block (example: “core/columns”).
+ * @param [scope] - Block variation scope name.
+ *
+ * @returns Block variations.
+ */
+export function getBlockVariations(blockName: string, scope?: BlockVariationScope): BlockVariation[] | undefined;
+
+/**
+ * Registers a new block variation for the given block type.
+ *
+ * @param blockName - Name of the block (example: “core/columns”).
+ * @param variation - Object describing a block variation.
+ */
+export function registerBlockVariation(blockName: string, variation: BlockVariation): void;
+
+/**
+ * Unregisters a block variation defined for the given block type.
+ *
+ * @param blockName - Name of the block (example: “core/columns”).
+ * @param variationName - Name of the variation defined for the block.
+ */
+export function unregisterBlockVariation(blockName: string, variationName: string): void;

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -507,17 +507,17 @@ export type Transform<T extends Record<string, any> = Record<string, any>> =
 
 export type BlockVariationScope = 'block' | 'inserter' | 'transform';
 
-export interface BlockVariation<TAttributes extends Record<string, any> = any> {
+export interface BlockVariation<T extends Record<string, any> = any> {
     name: string;
     title: string;
     description?: string;
     category?: string;
     icon?: BlockIcon;
     isDefault?: boolean;
-    attributes?: Partial<TAttributes>;
+    attributes?: T;
     innerBlocks?: any[];
     example?: Record<string, any>;
     scope?: BlockVariationScope[];
     keywords?: string[];
-    isActive?: (blockAttributes: TAttributes, variationAttributes: Partial<TAttributes>) => boolean | string[];
+    isActive?: (blockAttributes: T, variationAttributes: T) => boolean | string[];
 }

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -5,7 +5,7 @@
 //                 Dennis Snell <https://github.com/dmsnell>
 //                 Tomasz Tunik <https://github.com/tomasztunik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.6
+// TypeScript Version: 4.0
 
 import { Dashicon } from '@wordpress/components';
 import { dispatch, select } from '@wordpress/data';
@@ -505,14 +505,12 @@ export type Transform<T extends Record<string, any> = Record<string, any>> =
     | TransformRaw<T>
     | TransformShortcode<T>;
 
-
-    
 export type BlockAttributes = Record<string, any>;
 
 export type InnerBlockTemplate = [name: string, attributes?: BlockAttributes, innerBlocks?: InnerBlockTemplate[]];
 
 export type BlockVariationScope = 'block' | 'inserter' | 'transform';
-    
+
 export interface BlockVariation<Attributes extends BlockAttributes = BlockAttributes> {
     name: string;
     title: string;
@@ -522,10 +520,12 @@ export interface BlockVariation<Attributes extends BlockAttributes = BlockAttrib
     isDefault?: boolean;
     attributes?: Attributes;
     innerBlocks?: BlockInstance | InnerBlockTemplate[];
-    example?: BlockExampleInnerBlock | {
-        attributes: Attributes;
-        innerBlocks?: InnerBlockTemplate[];
-    };
+    example?:
+        | BlockExampleInnerBlock
+        | {
+              attributes: Attributes;
+              innerBlocks?: InnerBlockTemplate[];
+          };
     scope?: BlockVariationScope[];
     keywords?: string[];
     isActive?: (blockAttributes: Attributes, variationAttributes: Attributes) => boolean | string[];

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -505,19 +505,29 @@ export type Transform<T extends Record<string, any> = Record<string, any>> =
     | TransformRaw<T>
     | TransformShortcode<T>;
 
-export type BlockVariationScope = 'block' | 'inserter' | 'transform';
 
-export interface BlockVariation<T extends Record<string, any> = any> {
+    
+export type BlockAttributes = Record<string, any>;
+
+export type InnerBlockTemplate = [name: string, attributes?: BlockAttributes, innerBlocks?: InnerBlockTemplate[]];
+
+export type BlockVariationScope = 'block' | 'inserter' | 'transform';
+    
+export interface BlockVariation<Attributes extends BlockAttributes = BlockAttributes> {
     name: string;
     title: string;
     description?: string;
     category?: string;
     icon?: BlockIcon;
     isDefault?: boolean;
-    attributes?: T;
-    innerBlocks?: any[];
-    example?: Record<string, any>;
+    attributes?: Attributes;
+    innerBlocks?: BlockInstance | InnerBlockTemplate[];
+    example?: BlockExampleInnerBlock | {
+        attributes: Attributes;
+        innerBlocks?: InnerBlockTemplate[];
+    };
     scope?: BlockVariationScope[];
     keywords?: string[];
-    isActive?: (blockAttributes: T, variationAttributes: T) => boolean | string[];
+    isActive?: (blockAttributes: Attributes, variationAttributes: Attributes) => boolean | string[];
 }
+

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -530,4 +530,3 @@ export interface BlockVariation<Attributes extends BlockAttributes = BlockAttrib
     keywords?: string[];
     isActive?: (blockAttributes: Attributes, variationAttributes: Attributes) => boolean | string[];
 }
-

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -5,7 +5,7 @@
 //                 Dennis Snell <https://github.com/dmsnell>
 //                 Tomasz Tunik <https://github.com/tomasztunik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.0
+// TypeScript Version: 3.6
 
 import { Dashicon } from '@wordpress/components';
 import { dispatch, select } from '@wordpress/data';
@@ -507,7 +507,7 @@ export type Transform<T extends Record<string, any> = Record<string, any>> =
 
 export type BlockAttributes = Record<string, any>;
 
-export type InnerBlockTemplate = [name: string, attributes?: BlockAttributes, innerBlocks?: InnerBlockTemplate[]];
+export type InnerBlockTemplate = [string, BlockAttributes | undefined, InnerBlockTemplate[] | undefined];
 
 export type BlockVariationScope = 'block' | 'inserter' | 'transform';
 

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>
 //                 Dennis Snell <https://github.com/dmsnell>
+//                 Tomasz Tunik <https://github.com/tomasztunik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
@@ -503,3 +504,20 @@ export type Transform<T extends Record<string, any> = Record<string, any>> =
     | TransformPrefix<T>
     | TransformRaw<T>
     | TransformShortcode<T>;
+
+export type BlockVariationScope = 'block' | 'inserter' | 'transform';
+
+export interface BlockVariation<TAttributes extends Record<string, any> = any> {
+    name: string;
+    title: string;
+    description?: string;
+    category?: string;
+    icon?: BlockIcon;
+    isDefault?: boolean;
+    attributes?: Partial<TAttributes>;
+    innerBlocks?: any[];
+    example?: Record<string, any>;
+    scope?: BlockVariationScope[];
+    keywords?: string[];
+    isActive?: (blockAttributes: TAttributes, variationAttributes: Partial<TAttributes>) => boolean | string[];
+}

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -507,6 +507,18 @@ blocks.unregisterBlockStyle('my/foo', 'foo__bar');
 // $ExpectType Block<any> | undefined
 blocks.unregisterBlockType('my/foo');
 
+// $ExpectType BlockVariation<any>[] | undefined
+blocks.getBlockVariations('core/columns');
+
+// $ExpectType void
+blocks.registerBlockVariation('core/columns', {
+    name: 'core/columns/variation',
+    title: 'Core Column Variation',
+});
+
+// $ExpectType void
+blocks.unregisterBlockVariation('core/columns', 'core/columns/variation');
+
 //
 // serializer
 // ----------------------------------------------------------------------------

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -507,7 +507,7 @@ blocks.unregisterBlockStyle('my/foo', 'foo__bar');
 // $ExpectType Block<any> | undefined
 blocks.unregisterBlockType('my/foo');
 
-// $ExpectType BlockVariation<BlockAttributes>[] | undefined
+// $ExpectType BlockVariation<BlockAttributes>[] | undefined || BlockVariation<Record<string, any>>[] | undefined
 blocks.getBlockVariations('core/columns');
 
 // $ExpectType void

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -507,7 +507,7 @@ blocks.unregisterBlockStyle('my/foo', 'foo__bar');
 // $ExpectType Block<any> | undefined
 blocks.unregisterBlockType('my/foo');
 
-// $ExpectType BlockVariation<any>[] | undefined
+// $ExpectType BlockVariation<BlockAttributes>[] | undefined
 blocks.getBlockVariations('core/columns');
 
 // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- https://make.wordpress.org/core/2020/02/27/introduce-block-variations-api/
- https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/
- https://github.com/WordPress/gutenberg/blob/411547efb48744c0413152cb1a477f5b393518cf/packages/blocks/src/api/registration.js#L592-L622
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

