### PR TITLE
[react-dom] Roots accept ReactNode as initialChildren

### DIFF
--- a/types/react-dom/client.d.ts
+++ b/types/react-dom/client.d.ts
@@ -22,7 +22,7 @@ export interface RootOptions {
 }
 
 export interface Root {
-    render(children: React.ReactChild | Iterable<React.ReactNode>): void;
+    render(children: React.ReactNode): void;
     unmount(): void;
 }
 
@@ -35,6 +35,6 @@ export function createRoot(container: Element | DocumentFragment, options?: Root
 
 export function hydrateRoot(
     container: Element | Document,
-    initialChildren: React.ReactChild | Iterable<React.ReactNode>,
+    initialChildren: React.ReactNode,
     options?: HydrationOptions,
 ): Root;

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -229,6 +229,7 @@ function createRoot() {
     const root = ReactDOMClient.createRoot(document.documentElement);
 
     root.render(<div>initial render</div>);
+    root.render(false);
 
     // only makes sense for `hydrateRoot`
     // $ExpectError
@@ -248,6 +249,8 @@ function hydrateRoot() {
         // $ExpectError
         identifierPrefix: 'react-18-app',
     });
+
+    ReactDOMClient.hydrateRoot(document.getElementById('root')!, false);
 }
 
 /**


### PR DESCRIPTION
Not sure why I thought it's just `ReactChild`. 