### PR TITLE
[node-fetch] Add `Fetch` type representing just the `fetch` function

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -217,6 +217,11 @@ declare function fetch(
     init?: RequestInit
 ): Promise<Response>;
 
+// This function type represents the type of the `fetch` function alone and
+// excludes anything added to the function object (like `isRedirect` below).
+// This type should stay in sync with the type definition immediately above.
+export type Fetch = (url: RequestInfo, init?: RequestInit) => Promise<Response>;
+
 declare namespace fetch {
     function isRedirect(code: number): boolean;
 }

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -4,7 +4,8 @@ import fetch, {
     Request,
     RequestInit,
     Response,
-    FetchError
+    FetchError,
+    Fetch
 } from "node-fetch";
 import { URL } from "url";
 import { Agent } from "http";
@@ -214,4 +215,8 @@ function test_ResponseInit() {
 
 async function test_BlobText() {
     const someString = await new Blob(["Hello world"]).text(); // $ExpectType string
+}
+
+async function test_fetchIsFetchType() {
+    const fetchFn: Fetch = fetch;
 }


### PR DESCRIPTION
We want to provide a fetcher _interface_ in order to allow users to bring their own fetcher. The typings from `node-fetch` are really close to allowing that, but the `isRedirect` is problematic. This allows us to specify the function type without bringing anything extra.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
