### PR TITLE
Remove my ownership from jest-environment-puppeteer

### DIFF
--- a/types/jest-environment-puppeteer/index.d.ts
+++ b/types/jest-environment-puppeteer/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for jest-environment-puppeteer 5.0
 // Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-environment-puppeteer
-// Definitions by: Josh Goldberg <https://github.com/joshuakgoldberg>
-//                 Ifiok Jr. <https://github.com/ifiokjr>
+// Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8
 


### PR DESCRIPTION
I must have missed it in my last purge of type definitions I used to work with but don't anymore. I haven't used this library in years and am not a good resource for it. 🧹
