### PR TITLE
[@types/chrome] make `declarativeNetRequest.Rule.priority` optional

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11514,7 +11514,7 @@ declare namespace chrome.declarativeNetRequest {
          * Defaults to 1.
          * When specified, should be >= 1.
          */
-        priority: number;
+        priority?: number | undefined;
     }
 
     export interface RuleAction {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -855,7 +855,7 @@ async function testDeclarativeNetRequest() {
         rule.action; // $ExpectType RuleAction
         rule.condition; // $ExpectType RuleCondition
         rule.id; // $ExpectType number
-        rule.priority; // $ExpectType number
+        rule.priority; // $ExpectType number | undefined
     })
 
     chrome.declarativeNetRequest.getAvailableStaticRuleCount(count => {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#type-Rule

> Rule priority. Defaults to 1. When specified, should be >= 1.