### PR TITLE
(fix) placeholder for ComboBox in carbon-components-react

### DIFF
--- a/types/carbon-components-react/carbon-components-react-tests.tsx
+++ b/types/carbon-components-react/carbon-components-react-tests.tsx
@@ -1256,5 +1256,17 @@ const dataTableSkeletonBasic = <DataTableSkeleton />;
 // ComboBox
 //
 {
-    <ComboBox id="cbId" items={['item 1', 'item 2', 'item 3']} />;
+    const comboBoxWithMandatoryProps = <ComboBox id="cbId" items={['item 1', 'item 2', 'item 3']} />;
+    const comboBoxWithOptionalProps = (
+        <ComboBox
+            id="someId"
+            light={false}
+            items={['item 1', 'item 2', 'item 3']}
+            selectedItem={'item 1'}
+            placeholder={'filter...'}
+            titleText={'some title'}
+            invalid={false}
+            invalidText={'Please select one of the available items.'}
+        />
+    );
 }

--- a/types/carbon-components-react/lib/components/ComboBox/ComboBox.d.ts
+++ b/types/carbon-components-react/lib/components/ComboBox/ComboBox.d.ts
@@ -11,7 +11,7 @@ import { ListBoxMenuIconTranslationKey } from '../ListBox/ListBoxMenuIcon';
 import { ListBoxSelectionTranslationKey } from '../ListBox/ListBoxSelection';
 import { ListBoxSize } from '../ListBox/ListBoxPropTypes';
 
-type ExcludedAttributes = 'id' | 'onChange' | 'placeholder' | 'ref' | 'size';
+type ExcludedAttributes = 'id' | 'onChange' | 'ref' | 'size';
 
 export interface ComboBoxProps<ItemType = string, CustomElementProps = Extract<ItemType, object>>
     extends Omit<ReactInputAttr, ExcludedAttributes>,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Summary:
This PR is to fix placeholder removed by [this commit](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/79885d464eb6ac40d7819c689ef0def6b9d6533a) and put the placeholder back as optional attributed to align with the [carbon react component library changes](https://github.com/carbon-design-system/carbon/commit/df28984b51589873eda02d209544371306b3da23)
