### PR TITLE
wellknown: remove null from GeoJSONGeometry to prevent null inside collections

### DIFF
--- a/types/wellknown/index.d.ts
+++ b/types/wellknown/index.d.ts
@@ -34,8 +34,9 @@ export type GeoJSONGeometry =
     | GeoJSONMultiLineString
     | GeoJSONPolygon
     | GeoJSONMultiPolygon
-    | GeoJSONGeometryCollection
-    | null;
+    | GeoJSONGeometryCollection;
 
-export function parse(input: string): GeoJSONGeometry;
+export type GeoJSONGeometryOrNull = GeoJSONGeometry | null;
+
+export function parse(input: string): GeoJSONGeometryOrNull;
 export function stringify(gj: GeoJSONGeometry): string;

--- a/types/wellknown/wellknown-tests.ts
+++ b/types/wellknown/wellknown-tests.ts
@@ -1,6 +1,6 @@
 import * as wellknown from 'wellknown';
 
-wellknown.parse("POINT(1 2)"); // $ExpectType GeoJSONGeometry
+wellknown.parse("POINT(1 2)"); // $ExpectType GeoJSONGeometryOrNull
 
 const geoJson: wellknown.GeoJSONGeometry = {
     coordinates: [1, 2],
@@ -9,7 +9,7 @@ const geoJson: wellknown.GeoJSONGeometry = {
 
 wellknown.stringify(geoJson); // $ExpectType string
 
-wellknown.parse("GEOMETRYCOLLECTION (POINT (1 2))"); // $ExpectType GeoJSONGeometry
+wellknown.parse("GEOMETRYCOLLECTION (POINT (1 2))"); // $ExpectType GeoJSONGeometryOrNull
 
 const geometryCollection: wellknown.GeoJSONGeometry = {
     type: "GeometryCollection",


### PR DESCRIPTION
`GeoJSONGeometryCollection` nests `GeoJSONGeometry`.
Including `null` as part of the `GeoJSONGeometry` union implies that `null` can be a "geometry" in a collection.
Remove `null` from the `GeoJSONGeometry` union and include it as part of the return type of `parse`.

This will fix various errors using GeoJSON libraries where `null` cannot be assigned to `Geometry` types.

I'm not pleased with the `GeoJSONGeometryOrNull` type but testing for `// $ExpectType GeoJSONGeometry | null` fails the tests for typescript@4.1:
```
ERROR: 3:1   expect  TypeScript@4.1 expected type to be:
  GeoJSONGeometry | null
got:
  GeoJSONPoint | GeoJSONMultiPoint | GeoJSONLineString | GeoJSONMultiLineString | GeoJSONPolygon | GeoJSONMultiPolygon | GeoJSONGeometryCollection | null
ERROR: 12:1  expect  TypeScript@4.1 expected type to be:
  GeoJSONGeometry | null
got:
  GeoJSONPoint | GeoJSONMultiPoint | GeoJSONLineString | GeoJSONMultiLineString | GeoJSONPolygon | GeoJSONMultiPolygon | GeoJSONGeometryCollection | null
```

Suggestions welcome :)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
