### PR TITLE
Update chess.js to v0.13: Move constants to top level

### DIFF
--- a/types/chess.js/chess.js-tests.ts
+++ b/types/chess.js/chess.js-tests.ts
@@ -34,6 +34,9 @@ chessjs.QUEEN;
 // $ExpectType "k"
 chessjs.KING;
 
+// $ExpectType number
+chessjs.EMPTY;
+
 // tslint:disable-next-line:max-line-length
 // $ExpectType ["a8", "b8", "c8", "d8", "e8", "f8", "g8", "h8", "a7", "b7", "c7", "d7", "e7", "f7", "g7", "h7", "a6", "b6", "c6", "d6", "e6", "f6", "g6", "h6", "a5", "b5", "c5", "d5", "e5", "f5", "g5", "h5", "a4", "b4", "c4", "d4", "e4", "f4", "g4", "h4", "a3", "b3", "c3", "d3", "e3", "f3", "g3", "h3", "a2", "b2", "c2", "d2", "e2", "f2", "g2", "h2", "a1", "b1", "c1", "d1", "e1", "f1", "g1", "h1"]
 chessjs.SQUARES;

--- a/types/chess.js/chess.js-tests.ts
+++ b/types/chess.js/chess.js-tests.ts
@@ -11,35 +11,35 @@ chessjs.Chess(fen);
 const chess = new chessjs.Chess();
 
 // $ExpectType "w"
-chess.WHITE;
+chessjs.WHITE;
 
 // $ExpectType "b"
-chess.BLACK;
+chessjs.BLACK;
 
 // $ExpectType "p"
-chess.PAWN;
+chessjs.PAWN;
 
 // $ExpectType "n"
-chess.KNIGHT;
+chessjs.KNIGHT;
 
 // $ExpectType "b"
-chess.BISHOP;
+chessjs.BISHOP;
 
 // $ExpectType "r"
-chess.ROOK;
+chessjs.ROOK;
 
 // $ExpectType "q"
-chess.QUEEN;
+chessjs.QUEEN;
 
 // $ExpectType "k"
-chess.KING;
+chessjs.KING;
 
 // tslint:disable-next-line:max-line-length
 // $ExpectType ["a8", "b8", "c8", "d8", "e8", "f8", "g8", "h8", "a7", "b7", "c7", "d7", "e7", "f7", "g7", "h7", "a6", "b6", "c6", "d6", "e6", "f6", "g6", "h6", "a5", "b5", "c5", "d5", "e5", "f5", "g5", "h5", "a4", "b4", "c4", "d4", "e4", "f4", "g4", "h4", "a3", "b3", "c3", "d3", "e3", "f3", "g3", "h3", "a2", "b2", "c2", "d2", "e2", "f2", "g2", "h2", "a1", "b1", "c1", "d1", "e1", "f1", "g1", "h1"]
-chess.SQUARES;
+chessjs.SQUARES;
 
 // $ExpectType { NORMAL: "n"; CAPTURE: "c"; BIG_PAWN: "b"; EP_CAPTURE: "e"; PROMOTION: "p"; KSIDE_CASTLE: "k"; QSIDE_CASTLE: "q"; }
-chess.FLAGS;
+chessjs.FLAGS;
 
 // $ExpectType void
 chess.reset();

--- a/types/chess.js/index.d.ts
+++ b/types/chess.js/index.d.ts
@@ -180,6 +180,9 @@ export const QUEEN: "q";
 /** The string that represents a King */
 export const KING: "k";
 
+/** The constant that represents an empty square or value */
+export const EMPTY: number;
+
 /** A list of all the squares in the game, from "a1" to "h8" */
 export const SQUARES: [
     "a8",

--- a/types/chess.js/index.d.ts
+++ b/types/chess.js/index.d.ts
@@ -653,5 +653,5 @@ export const Chess: {
      * the board configuration in Forsyth-Edwards Notation.
      * @param fen specifies the board configuration in Forsyth-Edwards Notation.
      */
-    new(fen?: string): ChessInstance;
+    new (fen?: string): ChessInstance;
 };

--- a/types/chess.js/index.d.ts
+++ b/types/chess.js/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for chess.js 0.11
+// Type definitions for chess.js 0.13
 // Project: https://github.com/jhlywa/chess.js
 // Definitions by: Jacob Fischer <https://github.com/JacobFischer>
 //                 Zachary Svoboda <https://github.com/zacnomore>
+//                 Lars Kecker <https://github.com/CapOfCave>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.3
 
@@ -155,116 +156,117 @@ export interface Comment {
     comment: string;
 }
 
+/** The string that represents the White color side */
+export const WHITE: "w";
+
+/** The string that represents the Black color side */
+export const BLACK: "b";
+
+/** The string that represents a Pawn */
+export const PAWN: "p";
+
+/** The string that represents a Knight */
+export const KNIGHT: "n";
+
+/** The string that represents a Bishop */
+export const BISHOP: "b";
+
+/** The string that represents a Rook */
+export const ROOK: "r";
+
+/** The string that represents a Queen */
+export const QUEEN: "q";
+
+/** The string that represents a King */
+export const KING: "k";
+
+/** A list of all the squares in the game, from "a1" to "h8" */
+export const SQUARES: [
+    "a8",
+    "b8",
+    "c8",
+    "d8",
+    "e8",
+    "f8",
+    "g8",
+    "h8",
+    "a7",
+    "b7",
+    "c7",
+    "d7",
+    "e7",
+    "f7",
+    "g7",
+    "h7",
+    "a6",
+    "b6",
+    "c6",
+    "d6",
+    "e6",
+    "f6",
+    "g6",
+    "h6",
+    "a5",
+    "b5",
+    "c5",
+    "d5",
+    "e5",
+    "f5",
+    "g5",
+    "h5",
+    "a4",
+    "b4",
+    "c4",
+    "d4",
+    "e4",
+    "f4",
+    "g4",
+    "h4",
+    "a3",
+    "b3",
+    "c3",
+    "d3",
+    "e3",
+    "f3",
+    "g3",
+    "h3",
+    "a2",
+    "b2",
+    "c2",
+    "d2",
+    "e2",
+    "f2",
+    "g2",
+    "h2",
+    "a1",
+    "b1",
+    "c1",
+    "d1",
+    "e1",
+    "f1",
+    "g1",
+    "h1",
+];
+
+/** Flags used to build flag strings for moves */
+export const FLAGS: {
+    /** a non-capture */
+    NORMAL: "n";
+    /** a standard capture */
+    CAPTURE: "c";
+    /** a pawn push of two squares */
+    BIG_PAWN: "b";
+    /** an en passant capture */
+    EP_CAPTURE: "e";
+    /** a promotion */
+    PROMOTION: "p";
+    /** kingside castling */
+    KSIDE_CASTLE: "k";
+    /** queenside castling */
+    QSIDE_CASTLE: "q";
+};
+
 export interface ChessInstance {
-    /** The string that represents the White color side */
-    readonly WHITE: "w";
-
-    /** The string that represents the Black color side */
-    readonly BLACK: "b";
-
-    /** The string that represents a Pawn */
-    readonly PAWN: "p";
-
-    /** The string that represents a Knight */
-    readonly KNIGHT: "n";
-    /** The string that represents a Bishop */
-    readonly BISHOP: "b";
-
-    /** The string that represents a Rook */
-    readonly ROOK: "r";
-
-    /** The string that represents a Queen */
-    readonly QUEEN: "q";
-
-    /** The string that represents a King */
-    readonly KING: "k";
-
-    /** A list of all the squares in the game, from "a1" to "h8" */
-    readonly SQUARES: [
-        "a8",
-        "b8",
-        "c8",
-        "d8",
-        "e8",
-        "f8",
-        "g8",
-        "h8",
-        "a7",
-        "b7",
-        "c7",
-        "d7",
-        "e7",
-        "f7",
-        "g7",
-        "h7",
-        "a6",
-        "b6",
-        "c6",
-        "d6",
-        "e6",
-        "f6",
-        "g6",
-        "h6",
-        "a5",
-        "b5",
-        "c5",
-        "d5",
-        "e5",
-        "f5",
-        "g5",
-        "h5",
-        "a4",
-        "b4",
-        "c4",
-        "d4",
-        "e4",
-        "f4",
-        "g4",
-        "h4",
-        "a3",
-        "b3",
-        "c3",
-        "d3",
-        "e3",
-        "f3",
-        "g3",
-        "h3",
-        "a2",
-        "b2",
-        "c2",
-        "d2",
-        "e2",
-        "f2",
-        "g2",
-        "h2",
-        "a1",
-        "b1",
-        "c1",
-        "d1",
-        "e1",
-        "f1",
-        "g1",
-        "h1",
-    ];
-
-    /** Flags used to build flag strings for moves */
-    readonly FLAGS: {
-        /** a non-capture */
-        NORMAL: "n";
-        /** a standard capture */
-        CAPTURE: "c";
-        /** a pawn push of two squares */
-        BIG_PAWN: "b";
-        /** an en passant capture */
-        EP_CAPTURE: "e";
-        /** a promotion */
-        PROMOTION: "p";
-        /** kingside castling */
-        KSIDE_CASTLE: "k";
-        /** queenside castling */
-        QSIDE_CASTLE: "q";
-    };
-
     /**
      * The board is cleared, and the FEN string is loaded.
      * Returns true if the position was successfully loaded, otherwise false
@@ -651,5 +653,5 @@ export const Chess: {
      * the board configuration in Forsyth-Edwards Notation.
      * @param fen specifies the board configuration in Forsyth-Edwards Notation.
      */
-    new (fen?: string): ChessInstance;
+    new(fen?: string): ChessInstance;
 };


### PR DESCRIPTION
chess.js received a major update in v0.13.0. All constants were moved to the top level of the module (as seen in [this commit](https://github.com/jhlywa/chess.js/commit/8249063dc52f3545e6cf89051cb3fc646969daf1)). This results in a breaking change in both the library itself and its types. Updating this types package without increasing the major version should, however, not cause any trouble since 
1) it's still considered unstable according to semver as indicated by major version zero
2) it only follows the breaking change in chess.js itself, instead of introducing a new breaking point

This pull request aims to upgrade to the newest chess.js version with minimal changes. Further refactoring could be done to better align this package with the guidelines. This is, however, out of scope for this PR.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url here](https://github.com/jhlywa/chess.js/pull/318)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
