### PR TITLE
[prosemirror-transform] fixes a bug in the function signature for Transform#split

### DIFF
--- a/types/prosemirror-transform/index.d.ts
+++ b/types/prosemirror-transform/index.d.ts
@@ -333,7 +333,7 @@ export class Transform<S extends Schema = any> {
     split(
         pos: number,
         depth?: number,
-        typesAfter?: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null | undefined }>,
+        typesAfter?: Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null | undefined } | null | undefined>,
     ): this;
     /**
      * Join the blocks around the given position. If depth is 2, their


### PR DESCRIPTION
[Transform#split](https://prosemirror.net/docs/ref/#transform.Transform.split) takes a third optional argument `typesAfter`. This argument defines an ordered list of types to apply to parent elements in the split document. In the original semantics (defined with this type string: `:: (number, ?number, ?[?{type: NodeType, attrs: ?Object}]) → this`) a null value in this array designates no changes needed.

The current type of `Array<{ type: NodeType<S>; attrs?: { [key: string]: any  | null | undefined} }>` doesn't allow for this use case since the inner value is not nullable.

A more correct type would be `Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null | undefined } | null | undefined>`

Note that this matches the function signature generated by `dts-gen`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
