### PR TITLE
add missing definition for pdfkit font function

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -111,6 +111,7 @@ declare namespace PDFKit.Mixins {
 
     interface PDFFont {
         font(buffer: Buffer): this;
+        font(src: string, size?: number): this;
         font(src: string, family?: string, size?: number): this;
         fontSize(size: number): this;
         currentLineHeight(includeGap?: boolean): number;

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -128,6 +128,8 @@ doc.translate(280, 0)
 
 doc.circle(100, 100, 100).clip();
 
+doc.font('Arial', 30).text('The size is 30');
+
 doc.fontSize(25)
     .fillColor('blue')
     .text('This is a link!', 20, 0);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/foliojs/pdfkit/blob/master/lib/mixins/fonts.js#L23
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
