### PR TITLE
[google-apps-script] Renamed Bigquery to BigQuery

### DIFF
--- a/types/google-apps-script/apis/bigquery_v2.d.ts
+++ b/types/google-apps-script/apis/bigquery_v2.d.ts
@@ -674,7 +674,7 @@ declare namespace GoogleAppsScript {
       }
     }
   }
-  interface Bigquery {
+  interface BigQuery {
     Datasets?: BigQuery.Collection.DatasetsCollection | undefined;
     Jobs?: BigQuery.Collection.JobsCollection | undefined;
     Projects?: BigQuery.Collection.ProjectsCollection | undefined;
@@ -795,4 +795,4 @@ declare namespace GoogleAppsScript {
   }
 }
 
-declare var Bigquery: GoogleAppsScript.Bigquery;
+declare var BigQuery: GoogleAppsScript.BigQuery;


### PR DESCRIPTION
Not sure if this was a change google did, or if it was broken from the start. But currently the BigQuery service is
named as `BigQuery` (See samples on [the apps script
documentation](https://developers.google.com/apps-script/advanced/bigquery)

Does this change require a major version bump?

# Template
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [apps script docs](https://developers.google.com/apps-script/advanced/bigquery)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
