### PR TITLE
[`@wordpress/components`][`Modal`] Update types for the `onRequestClose` callback

### DIFF
--- a/types/wordpress__components/modal/index.d.ts
+++ b/types/wordpress__components/modal/index.d.ts
@@ -1,4 +1,11 @@
-import { ComponentType, HTMLProps, ReactNode } from 'react';
+import {
+    ComponentType,
+    HTMLProps,
+    ReactNode,
+    KeyboardEventHandler,
+    MouseEventHandler,
+    FocusEventHandler
+} from 'react';
 
 declare namespace Modal {
     interface Props extends HTMLProps<HTMLDivElement> {
@@ -75,8 +82,11 @@ declare namespace Modal {
         shouldCloseOnEsc?: boolean | undefined;
         /**
          * This function is called to indicate that the modal should be closed.
+         *
+         * The originating event might be different depending on how the modal
+         * is closed.
          */
-        onRequestClose(): void;
+        onRequestClose: KeyboardEventHandler | MouseEventHandler | FocusEventHandler;
     }
 }
 declare const Modal: ComponentType<Modal.Props>;

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -1,7 +1,12 @@
 import * as C from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { Value } from '@wordpress/rich-text';
-import { createRef, MouseEvent as ReactMouseEvent } from 'react';
+import {
+    createRef,
+    KeyboardEvent as ReactKeyboardEvent,
+    MouseEvent as ReactMouseEvent,
+    FocusEvent as ReactFocusEvent
+} from 'react';
 
 //
 // primitives
@@ -518,7 +523,12 @@ const kbshortcuts = {
 //
 // modal
 //
-<C.Modal title="This is my modal" isDismissible={true} onRequestClose={() => console.log('closing modal')}>
+<C.Modal title="This is my modal"
+    isDismissible={true}
+    onRequestClose={
+        ( event: ReactKeyboardEvent | ReactMouseEvent | ReactMouseEvent ) => console.log(`The ${event.type} event told me to close myself!`)
+    }
+>
     <button onClick={() => console.log('clicked')}>My custom close button</button>
 </C.Modal>;
 

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -526,7 +526,7 @@ const kbshortcuts = {
 <C.Modal title="This is my modal"
     isDismissible={true}
     onRequestClose={
-        ( event: ReactKeyboardEvent | ReactMouseEvent | ReactMouseEvent ) => console.log(`The ${event.type} event told me to close myself!`)
+        (event: ReactKeyboardEvent | ReactMouseEvent | ReactMouseEvent) => console.log(`The ${event.type} event told me to close myself!`)
     }
 >
     <button onClick={() => console.log('clicked')}>My custom close button</button>


### PR DESCRIPTION
It receives an event object as argument, and this event might triggered by a key-press (`ESC`, for example), a blur - when the Modal loses focus (clicking outside the modal, for example) or when clicking in an element that might close it (a close button). An union of React types is provided to cover all these cases.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

