### PR TITLE
[jest-environment-puppeteer] support for jest 28

### DIFF
--- a/types/jest-environment-puppeteer/index.d.ts
+++ b/types/jest-environment-puppeteer/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8
 
-import NodeEnvironment = require('jest-environment-node');
+import NodeEnvironment from 'jest-environment-node';
 import { Browser, Page, BrowserContext } from 'puppeteer';
 import { Context } from 'vm';
 

--- a/types/jest-environment-puppeteer/index.d.ts
+++ b/types/jest-environment-puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jest-environment-puppeteer 5.0
+// Type definitions for jest-environment-puppeteer 6.0
 // Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-environment-puppeteer
 // Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/jest-environment-puppeteer/package.json
+++ b/types/jest-environment-puppeteer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@jest/types": ">=24 <=27",
-        "jest-environment-node": ">=24 <=27"
+        "@jest/types": ">=24 <=28",
+        "jest-environment-node": ">=24 <=28"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This fixes two typing errors around `NodeEnvironment`.
```
Cannot use namespace 'NodeEnvironment' as a type.ts ts(2709)
Type 'typeof import("../DefinitelyTyped/types/jest-environment-puppeteer/node_modules/jest-environment-node/build/index")' is not a constructor function type.ts(2507)
```

<img width="526" alt="Bildschirmfoto 2022-05-02 um 12 12 16" src="https://user-images.githubusercontent.com/4380295/166218840-f84b805c-e3b9-455c-80f0-40dd319488b3.png">

