### PR TITLE
[infra] Upgrade actions/checkout and actions/setup-node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
There are new versions of [actions/checkout](https://github.com/actions/checkout/releases) and [actions/setup-node](https://github.com/actions/setup-node/releases).

With this PR, [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) will open PRs to upgrade each of this repo's workflows. Those PRs will remain subject to review and approval.