### PR TITLE
eslint: Update LintResult to include suppressedMessages

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -1,12 +1,12 @@
-import { Comment, WhileStatement } from "estree";
-import { AST, SourceCode, Rule, Linter, ESLint, RuleTester, Scope } from "eslint";
-import { ESLintRules } from "eslint/rules";
+import { Comment, WhileStatement } from 'estree';
+import { AST, SourceCode, Rule, Linter, ESLint, RuleTester, Scope } from 'eslint';
+import { ESLintRules } from 'eslint/rules';
 
 const SOURCE = `var foo = bar;`;
 
 const AST: AST.Program = {
-    type: "Program",
-    sourceType: "module",
+    type: 'Program',
+    sourceType: 'module',
     body: [],
     comments: [],
     tokens: [],
@@ -18,8 +18,8 @@ const AST: AST.Program = {
 };
 
 const TOKEN: AST.Token = {
-    type: "Identifier",
-    value: "foo",
+    type: 'Identifier',
+    value: 'foo',
     loc: {
         start: { line: 0, column: 0 },
         end: { line: 0, column: 3 },
@@ -28,8 +28,8 @@ const TOKEN: AST.Token = {
 };
 
 const COMMENT: Comment = {
-    type: "Block",
-    value: "foo",
+    type: 'Block',
+    value: 'foo',
     loc: {
         start: { line: 0, column: 0 },
         end: { line: 0, column: 0 },
@@ -77,9 +77,9 @@ sourceCode.getTokenByRangeStart(0, { includeComments: false as boolean }); // $E
 sourceCode.getFirstToken(AST); // $ExpectType Token | null
 sourceCode.getFirstToken(AST, 0);
 sourceCode.getFirstToken(AST, { skip: 0 });
-sourceCode.getFirstToken(AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; }) | null
-sourceCode.getFirstToken(AST, { filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier" }); // $ExpectType (Token & { type: "Identifier"; }) | null
-sourceCode.getFirstToken(AST, { skip: 0, filter: t => t.type === "Identifier" });
+sourceCode.getFirstToken(AST, (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier'); // $ExpectType (Token & { type: "Identifier"; }) | null
+sourceCode.getFirstToken(AST, { filter: (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier' }); // $ExpectType (Token & { type: "Identifier"; }) | null
+sourceCode.getFirstToken(AST, { skip: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getFirstToken(AST, { includeComments: true }); // $ExpectType Comment | Token | null
 sourceCode.getFirstToken(AST, { includeComments: true, skip: 0 });
 // prettier-ignore
@@ -92,8 +92,8 @@ sourceCode.getFirstToken(AST, { // $ExpectType (Token & { type: "Identifier"; })
 sourceCode.getFirstTokens(AST); // $ExpectType Token[]
 sourceCode.getFirstTokens(AST, 0); // $ExpectType Token[]
 sourceCode.getFirstTokens(AST, { count: 0 });
-sourceCode.getFirstTokens(AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; })[]
-sourceCode.getFirstTokens(AST, { filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier" }); // $ExpectType (Token & { type: "Identifier"; })[]
+sourceCode.getFirstTokens(AST, (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier'); // $ExpectType (Token & { type: "Identifier"; })[]
+sourceCode.getFirstTokens(AST, { filter: (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier' }); // $ExpectType (Token & { type: "Identifier"; })[]
 // prettier-ignore
 sourceCode.getFirstTokens(AST, { // $ExpectType (Token & { type: "Identifier"; })[]
     count: 0,
@@ -111,82 +111,82 @@ sourceCode.getFirstTokens(AST, {// $ExpectType (Token & { type: "Identifier"; })
 sourceCode.getLastToken(AST);
 sourceCode.getLastToken(AST, 0);
 sourceCode.getLastToken(AST, { skip: 0 });
-sourceCode.getLastToken(AST, t => t.type === "Identifier");
-sourceCode.getLastToken(AST, { filter: t => t.type === "Identifier" });
-sourceCode.getLastToken(AST, { skip: 0, filter: t => t.type === "Identifier" });
+sourceCode.getLastToken(AST, t => t.type === 'Identifier');
+sourceCode.getLastToken(AST, { filter: t => t.type === 'Identifier' });
+sourceCode.getLastToken(AST, { skip: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getLastToken(AST, { includeComments: true });
 sourceCode.getLastToken(AST, { includeComments: true, skip: 0 });
-sourceCode.getLastToken(AST, { includeComments: true, skip: 0, filter: t => t.type === "Identifier" });
+sourceCode.getLastToken(AST, { includeComments: true, skip: 0, filter: t => t.type === 'Identifier' });
 
 sourceCode.getLastTokens(AST);
 sourceCode.getLastTokens(AST, 0);
 sourceCode.getLastTokens(AST, { count: 0 });
-sourceCode.getLastTokens(AST, t => t.type === "Identifier");
-sourceCode.getLastTokens(AST, { filter: t => t.type === "Identifier" });
-sourceCode.getLastTokens(AST, { count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getLastTokens(AST, t => t.type === 'Identifier');
+sourceCode.getLastTokens(AST, { filter: t => t.type === 'Identifier' });
+sourceCode.getLastTokens(AST, { count: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getLastTokens(AST, { includeComments: true });
 sourceCode.getLastTokens(AST, { includeComments: true, count: 0 });
-sourceCode.getLastTokens(AST, { includeComments: true, count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getLastTokens(AST, { includeComments: true, count: 0, filter: t => t.type === 'Identifier' });
 
 sourceCode.getTokenBefore(AST);
 sourceCode.getTokenBefore(AST, 0);
 sourceCode.getTokenBefore(AST, { skip: 0 });
-sourceCode.getTokenBefore(AST, t => t.type === "Identifier");
-sourceCode.getTokenBefore(AST, { filter: t => t.type === "Identifier" });
-sourceCode.getTokenBefore(AST, { skip: 0, filter: t => t.type === "Identifier" });
+sourceCode.getTokenBefore(AST, t => t.type === 'Identifier');
+sourceCode.getTokenBefore(AST, { filter: t => t.type === 'Identifier' });
+sourceCode.getTokenBefore(AST, { skip: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getTokenBefore(AST, { includeComments: true });
 sourceCode.getTokenBefore(AST, { includeComments: true, skip: 0 });
-sourceCode.getTokenBefore(AST, { includeComments: true, skip: 0, filter: t => t.type === "Identifier" });
+sourceCode.getTokenBefore(AST, { includeComments: true, skip: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getTokenBefore(TOKEN, 0);
 sourceCode.getTokenBefore(COMMENT, 0);
 
 sourceCode.getTokensBefore(AST);
 sourceCode.getTokensBefore(AST, 0);
 sourceCode.getTokensBefore(AST, { count: 0 });
-sourceCode.getTokensBefore(AST, t => t.type === "Identifier");
-sourceCode.getTokensBefore(AST, { filter: t => t.type === "Identifier" });
-sourceCode.getTokensBefore(AST, { count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getTokensBefore(AST, t => t.type === 'Identifier');
+sourceCode.getTokensBefore(AST, { filter: t => t.type === 'Identifier' });
+sourceCode.getTokensBefore(AST, { count: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getTokensBefore(AST, { includeComments: true });
 sourceCode.getTokensBefore(AST, { includeComments: true, count: 0 });
-sourceCode.getTokensBefore(AST, { includeComments: true, count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getTokensBefore(AST, { includeComments: true, count: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getTokensBefore(TOKEN, 0);
 sourceCode.getTokensBefore(COMMENT, 0);
 
 sourceCode.getTokenAfter(AST);
 sourceCode.getTokenAfter(AST, 0);
 sourceCode.getTokenAfter(AST, { skip: 0 });
-sourceCode.getTokenAfter(AST, t => t.type === "Identifier");
-sourceCode.getTokenAfter(AST, { filter: t => t.type === "Identifier" });
-sourceCode.getTokenAfter(AST, { skip: 0, filter: t => t.type === "Identifier" });
+sourceCode.getTokenAfter(AST, t => t.type === 'Identifier');
+sourceCode.getTokenAfter(AST, { filter: t => t.type === 'Identifier' });
+sourceCode.getTokenAfter(AST, { skip: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getTokenAfter(AST, { includeComments: true });
 sourceCode.getTokenAfter(AST, { includeComments: true, skip: 0 });
-sourceCode.getTokenAfter(AST, { includeComments: true, skip: 0, filter: t => t.type === "Identifier" });
+sourceCode.getTokenAfter(AST, { includeComments: true, skip: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getTokenAfter(TOKEN, 0);
 sourceCode.getTokenAfter(COMMENT, 0);
 
 sourceCode.getTokensAfter(AST);
 sourceCode.getTokensAfter(AST, 0);
 sourceCode.getTokensAfter(AST, { count: 0 });
-sourceCode.getTokensAfter(AST, t => t.type === "Identifier");
-sourceCode.getTokensAfter(AST, { filter: t => t.type === "Identifier" });
-sourceCode.getTokensAfter(AST, { count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getTokensAfter(AST, t => t.type === 'Identifier');
+sourceCode.getTokensAfter(AST, { filter: t => t.type === 'Identifier' });
+sourceCode.getTokensAfter(AST, { count: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getTokensAfter(AST, { includeComments: true });
 sourceCode.getTokensAfter(AST, { includeComments: true, count: 0 });
-sourceCode.getTokensAfter(AST, { includeComments: true, count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getTokensAfter(AST, { includeComments: true, count: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getTokensAfter(TOKEN, 0);
 sourceCode.getTokensAfter(COMMENT, 0);
 
 sourceCode.getFirstTokenBetween(AST, AST); // $ExpectType Token | null
 sourceCode.getFirstTokenBetween(AST, AST, 0);
 sourceCode.getFirstTokenBetween(AST, AST, { skip: 0 });
-sourceCode.getFirstTokenBetween(AST, AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; }) | null
+sourceCode.getFirstTokenBetween(AST, AST, (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier'); // $ExpectType (Token & { type: "Identifier"; }) | null
 // prettier-ignore
 sourceCode.getFirstTokenBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; }) | null
     filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
 });
 sourceCode.getFirstTokenBetween(AST, AST, {
     skip: 0,
-    filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
+    filter: (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier',
 });
 sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true }); // $ExpectType Comment | Token | null
 sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true, skip: 0 });
@@ -200,12 +200,12 @@ sourceCode.getFirstTokenBetween(AST, AST, { // $ExpectType (Token & { type: "Ide
 sourceCode.getFirstTokensBetween(AST, AST); // $ExpectType Token[]
 sourceCode.getFirstTokensBetween(AST, AST, 0);
 sourceCode.getFirstTokensBetween(AST, AST, { count: 0 });
-sourceCode.getFirstTokensBetween(AST, AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; })[]
+sourceCode.getFirstTokensBetween(AST, AST, (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier'); // $ExpectType (Token & { type: "Identifier"; })[]
 // prettier-ignore
 sourceCode.getFirstTokensBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; })[]
     filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
 });
-sourceCode.getFirstTokensBetween(AST, AST, { count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getFirstTokensBetween(AST, AST, { count: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true }); // $ExpectType (Comment | Token)[]
 sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true, count: 0 });
 // prettier-ignore
@@ -218,22 +218,22 @@ sourceCode.getFirstTokensBetween(AST, AST, { // $ExpectType (Token & { type: "Id
 sourceCode.getLastTokenBetween(AST, AST);
 sourceCode.getLastTokenBetween(AST, AST, 0);
 sourceCode.getLastTokenBetween(AST, AST, { skip: 0 });
-sourceCode.getLastTokenBetween(AST, AST, t => t.type === "Identifier");
-sourceCode.getLastTokenBetween(AST, AST, { filter: t => t.type === "Identifier" });
-sourceCode.getLastTokenBetween(AST, AST, { skip: 0, filter: t => t.type === "Identifier" });
+sourceCode.getLastTokenBetween(AST, AST, t => t.type === 'Identifier');
+sourceCode.getLastTokenBetween(AST, AST, { filter: t => t.type === 'Identifier' });
+sourceCode.getLastTokenBetween(AST, AST, { skip: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getLastTokenBetween(AST, AST, { includeComments: true });
 sourceCode.getLastTokenBetween(AST, AST, { includeComments: true, skip: 0 });
-sourceCode.getLastTokenBetween(AST, AST, { includeComments: true, skip: 0, filter: t => t.type === "Identifier" });
+sourceCode.getLastTokenBetween(AST, AST, { includeComments: true, skip: 0, filter: t => t.type === 'Identifier' });
 
 sourceCode.getLastTokensBetween(AST, AST);
 sourceCode.getLastTokensBetween(AST, AST, 0);
 sourceCode.getLastTokensBetween(AST, AST, { count: 0 });
-sourceCode.getLastTokensBetween(AST, AST, t => t.type === "Identifier");
-sourceCode.getLastTokensBetween(AST, AST, { filter: t => t.type === "Identifier" });
-sourceCode.getLastTokensBetween(AST, AST, { count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getLastTokensBetween(AST, AST, t => t.type === 'Identifier');
+sourceCode.getLastTokensBetween(AST, AST, { filter: t => t.type === 'Identifier' });
+sourceCode.getLastTokensBetween(AST, AST, { count: 0, filter: t => t.type === 'Identifier' });
 sourceCode.getLastTokensBetween(AST, AST, { includeComments: true });
 sourceCode.getLastTokensBetween(AST, AST, { includeComments: true, count: 0 });
-sourceCode.getLastTokensBetween(AST, AST, { includeComments: true, count: 0, filter: t => t.type === "Identifier" });
+sourceCode.getLastTokensBetween(AST, AST, { includeComments: true, count: 0, filter: t => t.type === 'Identifier' });
 
 sourceCode.getTokensBetween(AST, AST);
 sourceCode.getTokensBetween(AST, AST, 0);
@@ -241,8 +241,8 @@ sourceCode.getTokensBetween(AST, AST, 0);
 sourceCode.getTokens(AST); // $ExpectType Token[]
 sourceCode.getTokens(AST, 0);
 sourceCode.getTokens(AST, 0, 0);
-sourceCode.getTokens(AST, (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier"); // $ExpectType (Token & { type: "Identifier"; })[]
-sourceCode.getTokens(AST, { filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier" }); // $ExpectType (Token & { type: "Identifier"; })[]
+sourceCode.getTokens(AST, (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier'); // $ExpectType (Token & { type: "Identifier"; })[]
+sourceCode.getTokens(AST, { filter: (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier' }); // $ExpectType (Token & { type: "Identifier"; })[]
 sourceCode.getTokens(AST, { includeComments: true }); // $ExpectType (Comment | Token)[]
 // prettier-ignore
 sourceCode.getTokens(AST, { // $ExpectType (Token & { type: "Identifier"; })[]
@@ -281,11 +281,11 @@ const scope = scopeManager.scopes[0];
 
 const variable = scope.variables[0];
 
-variable.name = "foo";
+variable.name = 'foo';
 
-variable.identifiers[0].type = "Identifier";
+variable.identifiers[0].type = 'Identifier';
 
-variable.defs[0].name.type = "Identifier";
+variable.defs[0].name.type = 'Identifier';
 variable.defs[0].type;
 variable.defs[0].node;
 variable.defs[0].parent;
@@ -293,7 +293,7 @@ variable.defs[0].parent;
 const reference = scope.references[0];
 
 reference.from = scope;
-reference.identifier.type = "Identifier";
+reference.identifier.type = 'Identifier';
 reference.resolved = variable;
 reference.writeExpr = AST;
 reference.init = true;
@@ -327,10 +327,10 @@ rule = {
     },
     meta: {
         docs: {
-            description: "disallow the use of `console`",
-            category: "Possible Errors",
+            description: 'disallow the use of `console`',
+            category: 'Possible Errors',
             recommended: true,
-            url: "https://eslint.org/docs/rules/no-console",
+            url: 'https://eslint.org/docs/rules/no-console',
             suggestion: true,
         },
     },
@@ -339,19 +339,19 @@ rule = {
     create(context) {
         return {};
     },
-    meta: { fixable: "whitespace" },
+    meta: { fixable: 'whitespace' },
 };
 rule = {
     create(context) {
         return {};
     },
-    meta: { fixable: "code" },
+    meta: { fixable: 'code' },
 };
 rule = {
     create(context) {
         return {};
     },
-    meta: { schema: [{ enum: ["always", "never"] }] },
+    meta: { schema: [{ enum: ['always', 'never'] }] },
 };
 rule = {
     create(context) {
@@ -363,7 +363,7 @@ rule = {
     create(context) {
         return {};
     },
-    meta: { type: "layout" },
+    meta: { type: 'layout' },
 };
 rule = {
     create(context) {
@@ -371,10 +371,10 @@ rule = {
     },
     meta: {
         docs: {
-            description: "disallow the use of `console`",
-            category: "Possible Errors",
+            description: 'disallow the use of `console`',
+            category: 'Possible Errors',
             recommended: true,
-            url: "https://eslint.org/docs/rules/no-console",
+            url: 'https://eslint.org/docs/rules/no-console',
         },
         hasSuggestions: true,
     },
@@ -396,70 +396,70 @@ rule = {
 
         context.getScope();
 
-        context.markVariableAsUsed("foo");
+        context.markVariableAsUsed('foo');
 
-        context.report({ message: "foo", node: AST });
-        context.report({ message: "foo", loc: { line: 0, column: 0 } });
-        context.report({ message: "foo", node: AST, data: { foo: "bar" } });
-        context.report({ message: "foo", node: AST, fix: () => null });
-        context.report({ message: "foo", node: AST, fix: ruleFixer => ruleFixer.replaceText(AST, "foo") });
+        context.report({ message: 'foo', node: AST });
+        context.report({ message: 'foo', loc: { line: 0, column: 0 } });
+        context.report({ message: 'foo', node: AST, data: { foo: 'bar' } });
+        context.report({ message: 'foo', node: AST, fix: () => null });
+        context.report({ message: 'foo', node: AST, fix: ruleFixer => ruleFixer.replaceText(AST, 'foo') });
 
         context.report({
-            message: "foo",
+            message: 'foo',
             node: AST,
             fix: ruleFixer => {
-                ruleFixer.insertTextAfter(AST, "foo");
-                ruleFixer.insertTextAfter(TOKEN, "foo");
+                ruleFixer.insertTextAfter(AST, 'foo');
+                ruleFixer.insertTextAfter(TOKEN, 'foo');
 
-                ruleFixer.insertTextAfterRange([0, 0], "foo");
+                ruleFixer.insertTextAfterRange([0, 0], 'foo');
 
-                ruleFixer.insertTextBefore(AST, "foo");
-                ruleFixer.insertTextBefore(TOKEN, "foo");
+                ruleFixer.insertTextBefore(AST, 'foo');
+                ruleFixer.insertTextBefore(TOKEN, 'foo');
 
-                ruleFixer.insertTextBeforeRange([0, 0], "foo");
+                ruleFixer.insertTextBeforeRange([0, 0], 'foo');
 
                 ruleFixer.remove(AST);
                 ruleFixer.remove(TOKEN);
 
                 ruleFixer.removeRange([0, 0]);
 
-                ruleFixer.replaceText(AST, "foo");
-                ruleFixer.replaceText(TOKEN, "foo");
+                ruleFixer.replaceText(AST, 'foo');
+                ruleFixer.replaceText(TOKEN, 'foo');
 
-                ruleFixer.replaceTextRange([0, 0], "foo");
+                ruleFixer.replaceTextRange([0, 0], 'foo');
 
                 return null;
             },
         });
 
         context.report({
-            message: "foo",
+            message: 'foo',
             node: AST,
             fix: ruleFixer => {
-                return [ruleFixer.insertTextAfter(AST, "foo"), ruleFixer.insertTextAfter(TOKEN, "foo")];
+                return [ruleFixer.insertTextAfter(AST, 'foo'), ruleFixer.insertTextAfter(TOKEN, 'foo')];
             },
         });
 
         context.report({
-            message: "foo",
+            message: 'foo',
             node: AST,
             suggest: [
                 {
-                    desc: "foo",
+                    desc: 'foo',
                     fix: ruleFixer => {
-                        return [ruleFixer.insertTextAfter(AST, "foo"), ruleFixer.insertTextAfter(TOKEN, "foo")];
+                        return [ruleFixer.insertTextAfter(AST, 'foo'), ruleFixer.insertTextAfter(TOKEN, 'foo')];
                     },
                 },
                 {
-                    messageId: "foo",
+                    messageId: 'foo',
                     fix: ruleFixer => {
-                        return [ruleFixer.insertTextAfter(AST, "foo"), ruleFixer.insertTextAfter(TOKEN, "foo")];
+                        return [ruleFixer.insertTextAfter(AST, 'foo'), ruleFixer.insertTextAfter(TOKEN, 'foo')];
                     },
                 },
                 {
-                    desc: "foo",
-                    fix: ruleFixer => null
-                }
+                    desc: 'foo',
+                    fix: ruleFixer => null,
+                },
             ],
         });
 
@@ -477,7 +477,7 @@ rule = {
                 // $ExpectError
                 node.parent;
             },
-            "Program:exit"() {},
+            'Program:exit'() {},
             'MemberExpression[object.name="req"]': (node: Rule.Node) => {
                 node.parent;
             },
@@ -496,63 +496,63 @@ linter.version;
 linter.verify(SOURCE, {});
 linter.verify(new SourceCode(SOURCE, AST), {});
 
-linter.verify(SOURCE, {}, "test.js");
+linter.verify(SOURCE, {}, 'test.js');
 linter.verify(SOURCE, {}, {});
-linter.verify(SOURCE, {}, { filename: "test.js" });
+linter.verify(SOURCE, {}, { filename: 'test.js' });
 linter.verify(SOURCE, {}, { allowInlineConfig: false });
 linter.verify(SOURCE, {}, { reportUnusedDisableDirectives: true });
-linter.verify(SOURCE, {}, { preprocess: input => input.split(" ") });
+linter.verify(SOURCE, {}, { preprocess: input => input.split(' ') });
 linter.verify(SOURCE, {}, { postprocess: problemList => problemList[0] });
 
-linter.verify(SOURCE, { parserOptions: { ecmaVersion: 2021 } }, "test.js");
-linter.verify(SOURCE, { parserOptions: { ecmaVersion: 2022 } }, "test.js");
-linter.verify(SOURCE, { parserOptions: { ecmaVersion: "latest" } }, "test.js");
-linter.verify(SOURCE, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } } }, "test.js");
+linter.verify(SOURCE, { parserOptions: { ecmaVersion: 2021 } }, 'test.js');
+linter.verify(SOURCE, { parserOptions: { ecmaVersion: 2022 } }, 'test.js');
+linter.verify(SOURCE, { parserOptions: { ecmaVersion: 'latest' } }, 'test.js');
+linter.verify(SOURCE, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } } }, 'test.js');
 linter.verify(
     SOURCE,
     { parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-    "test.js",
+    'test.js',
 );
-linter.verify(SOURCE, { env: { node: true } }, "test.js");
-linter.verify(SOURCE, { globals: { foo: true } }, "test.js");
-linter.verify(SOURCE, { globals: { foo: "readonly" } }, "test.js");
-linter.verify(SOURCE, { globals: { foo: "readable" } }, "test.js");
-linter.verify(SOURCE, { globals: { foo: "writable" } }, "test.js");
-linter.verify(SOURCE, { globals: { foo: "writeable" } }, "test.js");
-linter.verify(SOURCE, { parser: "custom-parser" }, "test.js");
-linter.verify(SOURCE, { settings: { info: "foo" } }, "test.js");
-linter.verify(SOURCE, { processor: "a-plugin/a-processor" }, "test.js");
-linter.verify(SOURCE, { plugins: ["a-plugin"] }, "test.js");
-linter.verify(SOURCE, { root: true }, "test.js");
-linter.verify(SOURCE, { extends: "eslint-config-bad-guy" }, "test.js");
-linter.verify(SOURCE, { extends: ["eslint-config-bad-guy", "eslint-config-roblox"] }, "test.js");
+linter.verify(SOURCE, { env: { node: true } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: true } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: 'readonly' } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: 'readable' } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: 'writable' } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: 'writeable' } }, 'test.js');
+linter.verify(SOURCE, { parser: 'custom-parser' }, 'test.js');
+linter.verify(SOURCE, { settings: { info: 'foo' } }, 'test.js');
+linter.verify(SOURCE, { processor: 'a-plugin/a-processor' }, 'test.js');
+linter.verify(SOURCE, { plugins: ['a-plugin'] }, 'test.js');
+linter.verify(SOURCE, { root: true }, 'test.js');
+linter.verify(SOURCE, { extends: 'eslint-config-bad-guy' }, 'test.js');
+linter.verify(SOURCE, { extends: ['eslint-config-bad-guy', 'eslint-config-roblox'] }, 'test.js');
 
-linter.verify(SOURCE, { rules: {} }, "test.js");
-linter.verify(SOURCE, { rules: { quotes: 2 } }, "test.js");
-linter.verify(SOURCE, { rules: { quotes: [2, "double"] } }, "test.js");
-linter.verify(SOURCE, { rules: { "no-unused-vars": [2, { vars: "all" }] } }, "test.js");
-linter.verify(SOURCE, { rules: { "no-console": 1 } }, "test.js");
-linter.verify(SOURCE, { rules: { "no-console": 0 } }, "test.js");
-linter.verify(SOURCE, { rules: { "no-console": "error" } }, "test.js");
+linter.verify(SOURCE, { rules: {} }, 'test.js');
+linter.verify(SOURCE, { rules: { quotes: 2 } }, 'test.js');
+linter.verify(SOURCE, { rules: { quotes: [2, 'double'] } }, 'test.js');
+linter.verify(SOURCE, { rules: { 'no-unused-vars': [2, { vars: 'all' }] } }, 'test.js');
+linter.verify(SOURCE, { rules: { 'no-console': 1 } }, 'test.js');
+linter.verify(SOURCE, { rules: { 'no-console': 0 } }, 'test.js');
+linter.verify(SOURCE, { rules: { 'no-console': 'error' } }, 'test.js');
 linter.verify(
     SOURCE,
     {
-        rules: { "no-console": "error" },
+        rules: { 'no-console': 'error' },
         overrides: [
             {
-                extends: ["eslint-config-bad-guy"],
-                excludedFiles: ["*-test.js", "*.spec.js"],
-                files: ["*-test.js", "*.spec.js"],
+                extends: ['eslint-config-bad-guy'],
+                excludedFiles: ['*-test.js', '*.spec.js'],
+                files: ['*-test.js', '*.spec.js'],
                 rules: {
-                    "no-unused-expressions": "off",
+                    'no-unused-expressions': 'off',
                 },
             },
         ],
     },
-    "test.js",
+    'test.js',
 );
-linter.verify(SOURCE, { rules: { "no-console": "warn" } }, "test.js");
-linter.verify(SOURCE, { rules: { "no-console": "off" } }, "test.js");
+linter.verify(SOURCE, { rules: { 'no-console': 'warn' } }, 'test.js');
+linter.verify(SOURCE, { rules: { 'no-console': 'off' } }, 'test.js');
 
 const lintingResult = linter.verify(SOURCE, {});
 
@@ -560,12 +560,12 @@ for (const msg of lintingResult) {
     msg.severity = 1;
     msg.severity = 2;
 
-    msg.ruleId = "foo";
+    msg.ruleId = 'foo';
 
     msg.fatal = true;
 
-    msg.message = "foo";
-    msg.messageId = "foo";
+    msg.message = 'foo';
+    msg.messageId = 'foo';
 
     msg.line = 0;
     msg.endLine = 0;
@@ -575,36 +575,36 @@ for (const msg of lintingResult) {
     msg.source = SOURCE;
 
     if (msg.fix) {
-        msg.fix.text = "foo";
+        msg.fix.text = 'foo';
         msg.fix.range = [0, 0];
     }
 
     if (msg.suggestions) {
         for (const suggestion of msg.suggestions) {
-            suggestion.desc = "foo";
-            suggestion.messageId = "foo";
-            suggestion.fix.text = "foo";
+            suggestion.desc = 'foo';
+            suggestion.messageId = 'foo';
+            suggestion.fix.text = 'foo';
             suggestion.fix.range = [0, 0];
         }
     }
 }
 
 linter.verifyAndFix(SOURCE, {});
-linter.verifyAndFix(SOURCE, {}, "test.js");
+linter.verifyAndFix(SOURCE, {}, 'test.js');
 linter.verifyAndFix(SOURCE, {}, { fix: false });
 
 const fixResult = linter.verifyAndFix(SOURCE, {});
 
 fixResult.fixed = true;
-fixResult.output = "foo";
+fixResult.output = 'foo';
 
 for (const msg of fixResult.messages) {
-    msg.ruleId = "foo";
+    msg.ruleId = 'foo';
 }
 
 sourceCode = linter.getSourceCode();
 
-linter.defineRule("test", rule);
+linter.defineRule('test', rule);
 
 linter.defineRules({
     foo: rule,
@@ -613,8 +613,8 @@ linter.defineRules({
 
 linter.getRules();
 
-linter.defineParser("custom-parser", { parse: (src, opts) => AST });
-linter.defineParser("custom-parser", {
+linter.defineParser('custom-parser', { parse: (src, opts) => AST });
+linter.defineParser('custom-parser', {
     parseForESLint(src, opts) {
         return {
             ast: AST,
@@ -631,8 +631,8 @@ const _processor: Linter.Processor = {
         return [
             text,
             {
-                text: "",
-                filename: "1.js",
+                text: '',
+                filename: '1.js',
             },
         ];
     },
@@ -651,58 +651,58 @@ eslint = new ESLint();
 eslint = new ESLint({ allowInlineConfig: false });
 eslint = new ESLint({ baseConfig: {} });
 eslint = new ESLint({ overrideConfig: {} });
-eslint = new ESLint({ overrideConfigFile: "foo" });
+eslint = new ESLint({ overrideConfigFile: 'foo' });
 eslint = new ESLint({ cache: true });
-eslint = new ESLint({ cacheLocation: "foo" });
-eslint = new ESLint({ cacheStrategy: "content" });
-eslint = new ESLint({ cwd: "foo" });
+eslint = new ESLint({ cacheLocation: 'foo' });
+eslint = new ESLint({ cacheStrategy: 'content' });
+eslint = new ESLint({ cwd: 'foo' });
 eslint = new ESLint({ errorOnUnmatchedPattern: true });
-eslint = new ESLint({ extensions: ["js"] });
+eslint = new ESLint({ extensions: ['js'] });
 eslint = new ESLint({ fix: true });
 eslint = new ESLint({ fix: message => false });
-eslint = new ESLint({ fixTypes: ["problem"] });
+eslint = new ESLint({ fixTypes: ['problem'] });
 eslint = new ESLint({ globInputPaths: true });
 eslint = new ESLint({ ignore: true });
-eslint = new ESLint({ ignorePath: "foo" });
+eslint = new ESLint({ ignorePath: 'foo' });
 eslint = new ESLint({ useEslintrc: false });
 eslint = new ESLint({ plugins: { foo: {} } });
-eslint = new ESLint({ reportUnusedDisableDirectives: "error" });
-eslint = new ESLint({ resolvePluginsRelativeTo: "test" });
-eslint = new ESLint({ rulePaths: ["foo"] });
+eslint = new ESLint({ reportUnusedDisableDirectives: 'error' });
+eslint = new ESLint({ resolvePluginsRelativeTo: 'test' });
+eslint = new ESLint({ rulePaths: ['foo'] });
 
-let resultsPromise = eslint.lintFiles(["myfile.js", "lib/"]);
+let resultsPromise = eslint.lintFiles(['myfile.js', 'lib/']);
 
-resultsPromise = eslint.lintText(SOURCE, { filePath: "foo" });
+resultsPromise = eslint.lintText(SOURCE, { filePath: 'foo' });
 
-eslint.calculateConfigForFile("./config.json");
+eslint.calculateConfigForFile('./config.json');
 
-eslint.isPathIgnored("./dist/index.js");
+eslint.isPathIgnored('./dist/index.js');
 
 let formatterPromise: Promise<ESLint.Formatter>;
 
-formatterPromise = eslint.loadFormatter("codeframe");
+formatterPromise = eslint.loadFormatter('codeframe');
 formatterPromise = eslint.loadFormatter();
 
-const customFormatter1: ESLint.Formatter = { format: () => "ok" };
-const customFormatter2: ESLint.Formatter = { format: () => Promise.resolve("ok") };
+const customFormatter1: ESLint.Formatter = { format: () => 'ok' };
+const customFormatter2: ESLint.Formatter = { format: () => Promise.resolve('ok') };
 
 let data: ESLint.LintResultData;
 const meta: Rule.RuleMetaData = {
-    type: "suggestion",
+    type: 'suggestion',
     docs: {
-        description: "disallow unnecessary semicolons",
-        category: "Possible Errors",
+        description: 'disallow unnecessary semicolons',
+        category: 'Possible Errors',
         recommended: true,
-        url: "https://eslint.org/docs/rules/no-extra-semi",
+        url: 'https://eslint.org/docs/rules/no-extra-semi',
     },
-    fixable: "code",
+    fixable: 'code',
     schema: [],
     messages: {
-        unexpected: "Unnecessary semicolon.",
+        unexpected: 'Unnecessary semicolon.',
     },
 };
 
-data = { cwd: "/foo/bar", rulesMeta: { "no-extra-semi": meta } };
+data = { cwd: '/foo/bar', rulesMeta: { 'no-extra-semi': meta } };
 
 const version: string = ESLint.version;
 
@@ -725,18 +725,27 @@ const version: string = ESLint.version;
     results[0].fixableWarningCount = 0;
 
     for (const file of results) {
-        file.filePath = "foo.js";
+        file.filePath = 'foo.js';
 
         file.errorCount = 0;
         file.warningCount = 0;
         file.fixableErrorCount = 0;
         file.fixableWarningCount = 0;
 
-        file.source = "foo";
-        file.output = "foo";
+        file.source = 'foo';
+        file.output = 'foo';
 
         for (const message of file.messages) {
-            message.ruleId = "foo";
+            message.ruleId = 'foo';
+        }
+
+        for (const suppressedMessage of file.suppressedMessages) {
+            suppressedMessage.suppressions = [
+                {
+                    kind: 'foo',
+                    justification: 'just cuz',
+                },
+            ];
         }
     }
 })();
@@ -749,7 +758,7 @@ let eslintConfig: Linter.Config<ESLintRules>;
 
 eslintConfig = {
     rules: {
-        "capitalized-comments": [2, "always", { ignorePattern: "const|let" }],
+        'capitalized-comments': [2, 'always', { ignorePattern: 'const|let' }],
     },
 };
 
@@ -759,50 +768,50 @@ eslintConfig = {
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 
-ruleTester.run("my-rule", rule, {
+ruleTester.run('my-rule', rule, {
     valid: [
-        { code: "foo" },
-        { code: "foo", options: [{ allowFoo: true }] },
-        { code: "foo", filename: "test.js" },
-        { code: "foo", parserOptions: {} },
-        { code: "foo", settings: { foo: true } },
-        { code: "foo", parser: "foo" },
-        { code: "foo", globals: { foo: true } },
-        RuleTester.only("foo"),
+        { code: 'foo' },
+        { code: 'foo', options: [{ allowFoo: true }] },
+        { code: 'foo', filename: 'test.js' },
+        { code: 'foo', parserOptions: {} },
+        { code: 'foo', settings: { foo: true } },
+        { code: 'foo', parser: 'foo' },
+        { code: 'foo', globals: { foo: true } },
+        RuleTester.only('foo'),
     ],
 
     invalid: [
-        { code: "foo", errors: 1 },
-        { code: "foo", errors: 1, output: "foo" },
-        { code: "foo", errors: ["foo"] },
-        { code: "foo", errors: [{ message: "foo" }] },
-        { code: "foo", errors: [{ message: "foo", type: "foo" }] },
-        { code: "foo", errors: [{ message: "foo", data: { foo: true } }] },
-        { code: "foo", errors: [{ message: "foo", line: 0 }] },
+        { code: 'foo', errors: 1 },
+        { code: 'foo', errors: 1, output: 'foo' },
+        { code: 'foo', errors: ['foo'] },
+        { code: 'foo', errors: [{ message: 'foo' }] },
+        { code: 'foo', errors: [{ message: 'foo', type: 'foo' }] },
+        { code: 'foo', errors: [{ message: 'foo', data: { foo: true } }] },
+        { code: 'foo', errors: [{ message: 'foo', line: 0 }] },
         {
-            code: "foo",
+            code: 'foo',
             errors: [
                 {
-                    message: "foo",
+                    message: 'foo',
                     suggestions: [
                         {
-                            desc: "foo",
-                            output: "foo",
+                            desc: 'foo',
+                            output: 'foo',
                         },
                         {
-                            messageId: "foo",
-                            output: "foo",
+                            messageId: 'foo',
+                            output: 'foo',
                         },
                     ],
                 },
             ],
         },
-        { code: "foo", errors: 1, only: true },
+        { code: 'foo', errors: 1, only: true },
     ],
 });
 
-ruleTester.run("simple-valid-test", rule, {
-    valid: ["foo", "bar", { code: "foo", options: [{ allowFoo: true }] }],
+ruleTester.run('simple-valid-test', rule, {
+    valid: ['foo', 'bar', { code: 'foo', options: [{ allowFoo: true }] }],
 });
 
 //#endregion

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -763,6 +763,15 @@ export namespace Linter {
         suggestions?: LintSuggestion[] | undefined;
     }
 
+    interface LintSuppression {
+        kind: string;
+        justification: string;
+    }
+
+    interface SuppressedLintMessage extends LintMessage {
+        suppressions: LintSuppression[];
+    }
+
     interface FixOptions extends LintOptions {
         fix?: boolean | undefined;
     }
@@ -861,6 +870,7 @@ export namespace ESLint {
     interface LintResult {
         filePath: string;
         messages: Linter.LintMessage[];
+        suppressedMessages: Linter.SuppressedLintMessage[];
         errorCount: number;
         fatalErrorCount: number;
         warningCount: number;


### PR DESCRIPTION
Updates `LintResult` to include `suppressedMessages` property. Adds new `SuppressedLintMessage` type.

It's not clear to me why `suppressedMessages` is not optional, but as per the [types in the repo](https://github.com/eslint/eslint/blob/f2c2d350425268efa4b78ee6e0a2df8860e0efad/lib/shared/types.js#L182), it doesn't appear that it is.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [LintResult](https://eslint.org/docs/developer-guide/nodejs-api#-lintresult-type) and [SuppressedLintMessage](https://eslint.org/docs/developer-guide/nodejs-api#-suppressedlintmessage-type)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

