### PR TITLE
fix(prosemirror): declare EditorProps.plugins optional and format .d.ts files

### DIFF
--- a/types/prosemirror-collab/index.d.ts
+++ b/types/prosemirror-collab/index.d.ts
@@ -26,7 +26,10 @@ import { Step } from 'prosemirror-transform';
  *     This client's ID, used to distinguish its changes from those of
  *     other clients. Defaults to a random 32-bit number.
  */
-export function collab(config?: { version?: number | null | undefined; clientID?: number | string | null | undefined }): Plugin;
+export function collab(config?: {
+    version?: number | null | undefined;
+    clientID?: number | string | null | undefined;
+}): Plugin;
 
 /**
  * Create a transaction that represents a set of new steps received from

--- a/types/prosemirror-dropcursor/index.d.ts
+++ b/types/prosemirror-dropcursor/index.d.ts
@@ -19,7 +19,7 @@ import { Plugin } from 'prosemirror-state';
  * @param options.width The precise width of the cursor in pixels. Defaults to 1.
  */
 export function dropCursor(options?: {
-  class?: string | null | undefined;
-  color?: string | null | undefined;
-  width?: number | null | undefined;
+    class?: string | null | undefined;
+    color?: string | null | undefined;
+    width?: number | null | undefined;
 }): Plugin;

--- a/types/prosemirror-gapcursor/index.d.ts
+++ b/types/prosemirror-gapcursor/index.d.ts
@@ -26,7 +26,7 @@ export class GapCursor extends Selection {}
  */
 export function gapCursor(): Plugin;
 
-declare module "prosemirror-model" {
+declare module 'prosemirror-model' {
     interface NodeSpec {
         /**
          * By default, gap cursor are only allowed in places where the

--- a/types/prosemirror-gapcursor/prosemirror-gapcursor-tests.ts
+++ b/types/prosemirror-gapcursor/prosemirror-gapcursor-tests.ts
@@ -9,7 +9,7 @@ export const nodeSpec: NodeSpec = {
 };
 
 export const nodeSpecErr: NodeSpec = {
-    allowGapCursor: "not a boolean value", // $ExpectError
+    allowGapCursor: 'not a boolean value', // $ExpectError
 };
 
 // We want to make sure the type of spec.allowGapCursor is defined, i.e., not any

--- a/types/prosemirror-history/index.d.ts
+++ b/types/prosemirror-history/index.d.ts
@@ -25,7 +25,10 @@ export function closeHistory<S extends Schema = any>(tr: Transaction<S>): Transa
  * property](#state.Transaction.setMeta) of `false` on a transaction
  * to prevent it from being rolled back by undo.
  */
-export function history(config?: { depth?: number | null | undefined; newGroupDelay?: number | null | undefined }): Plugin;
+export function history(config?: {
+    depth?: number | null | undefined;
+    newGroupDelay?: number | null | undefined;
+}): Plugin;
 /**
  * A command function that undoes the last change, if any.
  */

--- a/types/prosemirror-schema-list/index.d.ts
+++ b/types/prosemirror-schema-list/index.d.ts
@@ -44,7 +44,7 @@ export function addListNodes<N extends string = any>(
     nodes: { [name in N]: NodeSpec } | OrderedMap<NodeSpec>,
     itemContent: string,
     listGroup?: string,
-): { [name in (N | "ordered_list" | "bullet_list" | "list_item")]: NodeSpec } | OrderedMap<NodeSpec>;
+): { [name in N | 'ordered_list' | 'bullet_list' | 'list_item']: NodeSpec } | OrderedMap<NodeSpec>;
 /**
  * Returns a command function that wraps the selection in a list with
  * the given type an attributes. If `dispatch` is null, only return a

--- a/types/prosemirror-schema-list/prosemirror-schema-list-tests.ts
+++ b/types/prosemirror-schema-list/prosemirror-schema-list-tests.ts
@@ -11,4 +11,4 @@ import {
 } from 'prosemirror-schema-list';
 
 // Add the listNodes to the schema from prosemirror-schema-basic
-const listNodes = addListNodes(schema.spec.nodes, "paragraph block*", "block");
+const listNodes = addListNodes(schema.spec.nodes, 'paragraph block*', 'block');

--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -43,13 +43,12 @@ export interface PluginSpec<T = any, S extends Schema = any> {
      * editor view.
      */
     view?:
-        | ((
-              p: EditorView<S>,
-          ) => {
+        | ((p: EditorView<S>) => {
               update?: ((view: EditorView<S>, prevState: EditorState<S>) => void) | null | undefined;
               destroy?: (() => void) | null | undefined;
           })
-        | null | undefined;
+        | null
+        | undefined;
     /**
      * When present, this will be called before a transaction is
      * applied by the state, allowing the plugin to cancel it (by
@@ -70,7 +69,8 @@ export interface PluginSpec<T = any, S extends Schema = any> {
               oldState: EditorState<S>,
               newState: EditorState<S>,
           ) => Transaction<S> | null | undefined | void)
-        | null | undefined;
+        | null
+        | undefined;
 }
 /**
  * Plugins bundle functionality that can be added to an editor.
@@ -125,7 +125,10 @@ export interface StateField<T = any, S extends Schema = Schema> {
      * Deserialize the JSON representation of this field. Note that the
      * `state` argument is again a half-initialized state.
      */
-    fromJSON?: ((this: Plugin<T, S>, config: { [key: string]: any }, value: any, state: EditorState<S>) => T) | null | undefined;
+    fromJSON?:
+        | ((this: Plugin<T, S>, config: { [key: string]: any }, value: any, state: EditorState<S>) => T)
+        | null
+        | undefined;
 }
 /**
  * A key is used to [tag](#state.PluginSpec.key)
@@ -446,7 +449,10 @@ export class EditorState<S extends Schema = any> {
      * [`init`](#state.StateField.init) method, passing in the new
      * configuration object..
      */
-    reconfigure(config: { schema?: S | null | undefined; plugins?: Array<Plugin<any, S>> | null | undefined }): EditorState<S>;
+    reconfigure(config: {
+        schema?: S | null | undefined;
+        plugins?: Array<Plugin<any, S>> | null | undefined;
+    }): EditorState<S>;
     /**
      * Serialize this state to JSON. If you want to serialize the state
      * of plugins, pass an object mapping property names to use in the

--- a/types/prosemirror-test-builder/index.d.ts
+++ b/types/prosemirror-test-builder/index.d.ts
@@ -66,13 +66,12 @@ declare namespace prosemirrorTestBuilder {
             NodeTypeAttributes | MarkTypeAttributes
         >,
         N extends string = string,
-        M extends string = string
+        M extends string = string,
     >(
         testSchema: Schema<N, M>,
         names: Obj,
     ) => Record<N, NodeBuilderMethod<Schema<N, M>>> &
-        Record<M, MarkBuilderMethod<Schema<N, M>>> &
-        {
+        Record<M, MarkBuilderMethod<Schema<N, M>>> & {
             [P in keyof Obj]: Obj[P] extends NodeTypeAttributes
                 ? NodeBuilderMethod<Schema<N, M>>
                 : MarkBuilderMethod<Schema<N, M>>;

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -595,18 +595,20 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
      */
     nodeViews?:
         | {
-              [name: string]: ((
-                  node: ProsemirrorNode<S>,
-                  view: EditorView<S>,
-                  /** get the node's current position */
-                  getPos: () => number,
-                  decorations: Decoration[],
-              ) => NodeView<S>) | ((
-                  mark: Mark<S>,
-                  view: EditorView<S>,
-                  /** indicates whether the mark's content is inline */
-                  inline: boolean,
-              ) => Pick<NodeView<S>, 'dom' | 'contentDOM'>);
+              [name: string]:
+                  | ((
+                        node: ProsemirrorNode<S>,
+                        view: EditorView<S>,
+                        /** get the node's current position */
+                        getPos: () => number,
+                        decorations: Decoration[],
+                    ) => NodeView<S>)
+                  | ((
+                        mark: Mark<S>,
+                        view: EditorView<S>,
+                        /** indicates whether the mark's content is inline */
+                        inline: boolean,
+                    ) => Pick<NodeView<S>, 'dom' | 'contentDOM'>);
           }
         | null
         | undefined;
@@ -664,11 +666,9 @@ export interface EditorProps<ThisT = unknown, S extends Schema = any> {
 /**
  * A mapping of dom events.
  */
-export type HandleDOMEventsProp<ThisT = unknown, S extends Schema = any> = Partial<
-    {
-        [K in keyof DocumentEventMap]: (this: ThisT, view: EditorView<S>, event: DocumentEventMap[K]) => boolean;
-    }
-> & {
+export type HandleDOMEventsProp<ThisT = unknown, S extends Schema = any> = Partial<{
+    [K in keyof DocumentEventMap]: (this: ThisT, view: EditorView<S>, event: DocumentEventMap[K]) => boolean;
+}> & {
     [key: string]: (this: ThisT, view: EditorView<S>, event: any) => boolean;
 };
 /**
@@ -690,7 +690,7 @@ export interface DirectEditorProps<S extends Schema = any> extends EditorProps<u
      * appender) will result in an error, since such plugins must be
      * present in the state to work.
      */
-    plugins: Plugin[];
+    plugins?: Plugin[];
 
     /**
      * The callback over which to send transactions (state updates)

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -78,6 +78,16 @@ const res6_plugin = new state.Plugin({
     },
 });
 
+const res7_view = new view.EditorView<typeof schema.schema>(undefined, {
+    state: {} as any, // this is not part of the test
+
+    dispatchTransaction(tr) {
+        // From DirectEditorProps
+        // Ensure that `this` is bound to type EditorView<schema.schema>
+        const v: view.EditorView<typeof schema.schema> = this;
+    },
+});
+
 const view1 = new state.Plugin({
     props: {
         handleDOMEvents: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-view/commit/427d278aaaacde422ed1f2b8c84bb53337162775
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
 

I also run `npm run prettier -- --write ./types/prosemirror-*/**.ts` to format all the ProseMirror related files in this pull request, as advice from the DefinitelyTyped README. 