### PR TITLE
fix: allow to pass node/mark attrs to prosemirror test builder methods

### DIFF
--- a/types/prosemirror-test-builder/index.d.ts
+++ b/types/prosemirror-test-builder/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { Node as ProsemirrorNode, Schema } from 'prosemirror-model';
+import { Mark, Node as ProsemirrorNode, Schema } from 'prosemirror-model';
 
 type TestNodesUnion =
     | 'p'
@@ -32,7 +32,8 @@ type TestNodesUnion =
     | 'hard_break';
 type TestMarksUnion = 'a' | 'link' | 'em' | 'strong' | 'code';
 
-type Args = Array<string | prosemirrorTestBuilder.TaggedProsemirrorNode | prosemirrorTestBuilder.TaggedFlatObject>;
+type Args = Array<string | prosemirrorTestBuilder.TaggedProsemirrorNode | prosemirrorTestBuilder.TaggedFlatObject |
+    typeof Mark['attrs'] | typeof Node['attrs']>;
 
 type NodeBuilderMethod<S extends Schema = any> = (...args: Args) => prosemirrorTestBuilder.TaggedProsemirrorNode<S>;
 

--- a/types/prosemirror-test-builder/index.d.ts
+++ b/types/prosemirror-test-builder/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { Mark, Node as ProsemirrorNode, Schema } from 'prosemirror-model';
+import { Node as ProsemirrorNode, Schema } from 'prosemirror-model';
 
 type TestNodesUnion =
     | 'p'
@@ -33,7 +33,7 @@ type TestNodesUnion =
 type TestMarksUnion = 'a' | 'link' | 'em' | 'strong' | 'code';
 
 type Args = Array<string | prosemirrorTestBuilder.TaggedProsemirrorNode | prosemirrorTestBuilder.TaggedFlatObject |
-    typeof Mark['attrs'] | typeof Node['attrs']>;
+    { [key: string]: any }>;
 
 type NodeBuilderMethod<S extends Schema = any> = (...args: Args) => prosemirrorTestBuilder.TaggedProsemirrorNode<S>;
 

--- a/types/prosemirror-test-builder/index.d.ts
+++ b/types/prosemirror-test-builder/index.d.ts
@@ -33,7 +33,7 @@ type TestNodesUnion =
 type TestMarksUnion = 'a' | 'link' | 'em' | 'strong' | 'code';
 
 type Args = Array<string | prosemirrorTestBuilder.TaggedProsemirrorNode | prosemirrorTestBuilder.TaggedFlatObject |
-    { [key: string]: any }>;
+    object>;
 
 type NodeBuilderMethod<S extends Schema = any> = (...args: Args) => prosemirrorTestBuilder.TaggedProsemirrorNode<S>;
 

--- a/types/prosemirror-test-builder/prosemirror-test-builder-tests.ts
+++ b/types/prosemirror-test-builder/prosemirror-test-builder-tests.ts
@@ -99,6 +99,9 @@ const { h1, a } = builders(schema, {
     img: { nodeType: 'image', src: 'img.png', alt: 'x' },
 });
 
+const args: Parameters<typeof h1> = [p(), { level: 1 }, { tag: { abc: 1 }, flat: [p()] }];
+const ARGS_TEST = args; // $ExpectType Args
+
 const TEST1 = h1; // $ExpectType NodeBuilderMethod<Schema<"doc" | "paragraph" | "blockquote", "em">> || NodeBuilderMethod<Schema<"blockquote" | "doc" | "paragraph", "em">>
 const TEST2 = a; // $ExpectType MarkBuilderMethod<Schema<"doc" | "paragraph" | "blockquote", "em">> || MarkBuilderMethod<Schema<"blockquote" | "doc" | "paragraph", "em">>
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-test-builder/blob/cd124a1187228db5387e353dc38c2b1b866230cb/src/build.ts#L54
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
