### PR TITLE
mapbox-gl: add 'to-rgba' expression

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -141,6 +141,7 @@ declare namespace mapboxgl {
         // Color
         | 'rgb'
         | 'rgba'
+        | 'to-rgba'
         // Math
         | '-'
         | '*'


### PR DESCRIPTION
Add `to-rgba` to the `ExpressionName` list.
'to-rgba' expression defined in docs: https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#to-rgba


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#to-rgba
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

