### PR TITLE
[bootstrap] fix: Return jQuery instance from jQuery functions

### DIFF
--- a/types/bootstrap/js/dist/alert.d.ts
+++ b/types/bootstrap/js/dist/alert.d.ts
@@ -39,7 +39,7 @@ declare namespace Alert {
         closed = 'closed.bs.alert',
     }
 
-    type jQueryInterface = (config?: 'close' | 'dispose') => void;
+    type jQueryInterface = (config?: 'close' | 'dispose') => JQuery;
 }
 
 export default Alert;

--- a/types/bootstrap/js/dist/button.d.ts
+++ b/types/bootstrap/js/dist/button.d.ts
@@ -12,7 +12,7 @@ declare class Button extends BaseComponent {
 }
 
 declare namespace Button {
-    type jQueryInterface = (config?: 'toggle' | 'dispose') => void;
+    type jQueryInterface = (config?: 'toggle' | 'dispose') => JQuery;
 }
 
 export default Button;

--- a/types/bootstrap/js/dist/carousel.d.ts
+++ b/types/bootstrap/js/dist/carousel.d.ts
@@ -155,7 +155,7 @@ declare namespace Carousel {
 
     type jQueryInterface = (
         config?: Partial<Options> | number | 'cycle' | 'pause' | 'prev' | 'next' | 'nextWhenVisible' | 'to' | 'dispose',
-    ) => void;
+    ) => JQuery;
 }
 
 export default Carousel;

--- a/types/bootstrap/js/dist/collapse.d.ts
+++ b/types/bootstrap/js/dist/collapse.d.ts
@@ -89,7 +89,7 @@ declare namespace Collapse {
         toggle: boolean;
     }
 
-    type jQueryInterface = (config?: Partial<Options> | 'show' | 'hide' | 'toggle' | 'dispose') => void;
+    type jQueryInterface = (config?: Partial<Options> | 'show' | 'hide' | 'toggle' | 'dispose') => JQuery;
 }
 
 export default Collapse;

--- a/types/bootstrap/js/dist/dropdown.d.ts
+++ b/types/bootstrap/js/dist/dropdown.d.ts
@@ -151,7 +151,7 @@ declare namespace Dropdown {
         autoClose: boolean | 'inside' | 'outside';
     }
 
-    type jQueryInterface = (config?: Partial<Options> | 'toggle' | 'show' | 'hide' | 'update' | 'dispose') => void;
+    type jQueryInterface = (config?: Partial<Options> | 'toggle' | 'show' | 'hide' | 'update' | 'dispose') => JQuery;
 }
 
 export default Dropdown;

--- a/types/bootstrap/js/dist/modal.d.ts
+++ b/types/bootstrap/js/dist/modal.d.ts
@@ -113,7 +113,7 @@ declare namespace Modal {
 
     type jQueryInterface = (
         config?: Partial<Options> | 'toggle' | 'show' | 'hide' | 'handleUpdate' | 'dispose',
-    ) => void;
+    ) => JQuery;
 }
 
 export default Modal;

--- a/types/bootstrap/js/dist/offcanvas.d.ts
+++ b/types/bootstrap/js/dist/offcanvas.d.ts
@@ -81,7 +81,7 @@ declare namespace Offcanvas {
         hidden = 'hidden.bs.offcanvas',
     }
 
-    type jQueryInterface = (config?: 'toggle' | 'show' | 'hide') => void;
+    type jQueryInterface = (config?: 'toggle' | 'show' | 'hide') => JQuery;
 }
 
 export default Offcanvas;

--- a/types/bootstrap/js/dist/popover.d.ts
+++ b/types/bootstrap/js/dist/popover.d.ts
@@ -156,7 +156,7 @@ declare namespace Popover {
             | 'toggleEnabled'
             | 'update'
             | 'dispose',
-    ) => void;
+    ) => JQuery;
 }
 
 export default Popover;

--- a/types/bootstrap/js/dist/scrollspy.d.ts
+++ b/types/bootstrap/js/dist/scrollspy.d.ts
@@ -65,7 +65,7 @@ declare namespace ScrollSpy {
         target: string | Element | JQuery;
     }
 
-    type jQueryInterface = (config?: Partial<Options> | 'refresh' | 'dispose') => void;
+    type jQueryInterface = (config?: Partial<Options> | 'refresh' | 'dispose') => JQuery;
 }
 
 export default ScrollSpy;

--- a/types/bootstrap/js/dist/tab.d.ts
+++ b/types/bootstrap/js/dist/tab.d.ts
@@ -58,7 +58,7 @@ declare namespace Tab {
         hidden = 'hidden.bs.tab',
     }
 
-    type jQueryInterface = (config?: 'show' | 'dispose') => void;
+    type jQueryInterface = (config?: 'show' | 'dispose') => JQuery;
 }
 
 export default Tab;

--- a/types/bootstrap/js/dist/toast.d.ts
+++ b/types/bootstrap/js/dist/toast.d.ts
@@ -86,7 +86,7 @@ declare namespace Toast {
         delay: number;
     }
 
-    type jQueryInterface = (config?: Partial<Options> | 'show' | 'hide' | 'dispose') => void;
+    type jQueryInterface = (config?: Partial<Options> | 'show' | 'hide' | 'dispose') => JQuery;
 }
 
 export default Toast;

--- a/types/bootstrap/js/dist/tooltip.d.ts
+++ b/types/bootstrap/js/dist/tooltip.d.ts
@@ -329,7 +329,7 @@ declare namespace Tooltip {
             | 'toggleEnabled'
             | 'update'
             | 'dispose',
-    ) => void;
+    ) => JQuery;
 }
 
 export default Tooltip;

--- a/types/bootstrap/test/alert-tests.ts
+++ b/types/bootstrap/test/alert-tests.ts
@@ -29,8 +29,8 @@ element.addEventListener(Alert.Events.closed, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').alert();
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').alert('close');

--- a/types/bootstrap/test/button-tests.ts
+++ b/types/bootstrap/test/button-tests.ts
@@ -11,8 +11,8 @@ Button.getInstance(element);
 // $ExpectType Button
 Button.getOrCreateInstance(element);
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').button();
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').button('toggle');

--- a/types/bootstrap/test/carousel-tests.ts
+++ b/types/bootstrap/test/carousel-tests.ts
@@ -49,19 +49,19 @@ element.addEventListener(Carousel.Events.slide, event => {
     event.to; // $ExpectType number
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').carousel();
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').carousel({ interval: 1000 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').carousel(0);
 
-$('.alert').carousel('cycle'); // $ExpectType void
-$('.alert').carousel('pause'); // $ExpectType void
-$('.alert').carousel('prev'); // $ExpectType void
-$('.alert').carousel('next'); // $ExpectType void
-$('.alert').carousel('nextWhenVisible'); // $ExpectType void
-$('.alert').carousel('to'); // $ExpectType void
-$('.alert').carousel('dispose'); // $ExpectType void
+$('.alert').carousel('cycle'); // $ExpectType JQuery<HTMLElement>
+$('.alert').carousel('pause'); // $ExpectType JQuery<HTMLElement>
+$('.alert').carousel('prev'); // $ExpectType JQuery<HTMLElement>
+$('.alert').carousel('next'); // $ExpectType JQuery<HTMLElement>
+$('.alert').carousel('nextWhenVisible'); // $ExpectType JQuery<HTMLElement>
+$('.alert').carousel('to'); // $ExpectType JQuery<HTMLElement>
+$('.alert').carousel('dispose'); // $ExpectType JQuery<HTMLElement>

--- a/types/bootstrap/test/collapse-tests.ts
+++ b/types/bootstrap/test/collapse-tests.ts
@@ -33,12 +33,12 @@ element.addEventListener(Collapse.Events.hidden, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').collapse();
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').collapse({ parent: '.parent' });
 
-$('.alert').collapse('show'); // $ExpectType void
-$('.alert').collapse('hide'); // $ExpectType void
-$('.alert').collapse('toggle'); // $ExpectType void
+$('.alert').collapse('show'); // $ExpectType JQuery<HTMLElement>
+$('.alert').collapse('hide'); // $ExpectType JQuery<HTMLElement>
+$('.alert').collapse('toggle'); // $ExpectType JQuery<HTMLElement>

--- a/types/bootstrap/test/dropdown-tests.ts
+++ b/types/bootstrap/test/dropdown-tests.ts
@@ -48,13 +48,13 @@ element.addEventListener(Dropdown.Events.hidden, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').dropdown();
 
 $('.alert').dropdown({ flip: true }); // $ExpectError
-$('.alert').dropdown({ offset: [0, 2], autoClose: true }); // $ExpectType void
+$('.alert').dropdown({ offset: [0, 2], autoClose: true }); // $ExpectType JQuery<HTMLElement>
 
-$('.alert').dropdown('show'); // $ExpectType void
-$('.alert').dropdown('hide'); // $ExpectType void
-$('.alert').dropdown('toggle'); // $ExpectType void
-$('.alert').dropdown('update'); // $ExpectType void
+$('.alert').dropdown('show'); // $ExpectType JQuery<HTMLElement>
+$('.alert').dropdown('hide'); // $ExpectType JQuery<HTMLElement>
+$('.alert').dropdown('toggle'); // $ExpectType JQuery<HTMLElement>
+$('.alert').dropdown('update'); // $ExpectType JQuery<HTMLElement>

--- a/types/bootstrap/test/modal-tests.ts
+++ b/types/bootstrap/test/modal-tests.ts
@@ -37,13 +37,13 @@ element.addEventListener(Modal.Events.hidePrevented, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').modal();
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').modal({ backdrop: 'static' });
 
-$('.alert').modal('show'); // $ExpectType void
-$('.alert').modal('hide'); // $ExpectType void
-$('.alert').modal('toggle'); // $ExpectType void
-$('.alert').modal('handleUpdate'); // $ExpectType void
+$('.alert').modal('show'); // $ExpectType JQuery<HTMLElement>
+$('.alert').modal('hide'); // $ExpectType JQuery<HTMLElement>
+$('.alert').modal('toggle'); // $ExpectType JQuery<HTMLElement>
+$('.alert').modal('handleUpdate'); // $ExpectType JQuery<HTMLElement>

--- a/types/bootstrap/test/offcanvas-tests.ts
+++ b/types/bootstrap/test/offcanvas-tests.ts
@@ -43,9 +43,9 @@ element.addEventListener(Offcanvas.Events.shown, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').offcanvas();
 
-$('.alert').offcanvas('toggle'); // $ExpectType void
-$('.alert').offcanvas('show'); // $ExpectType void
-$('.alert').offcanvas('hide'); // $ExpectType void
+$('.alert').offcanvas('toggle'); // $ExpectType JQuery<HTMLElement>
+$('.alert').offcanvas('show'); // $ExpectType JQuery<HTMLElement>
+$('.alert').offcanvas('hide'); // $ExpectType JQuery<HTMLElement>

--- a/types/bootstrap/test/popover-tests.ts
+++ b/types/bootstrap/test/popover-tests.ts
@@ -70,16 +70,16 @@ element.addEventListener(Popover.Events.inserted, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').popover();
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').popover({ delay: 0.5, animation: true });
 
-$('.alert').popover('show'); // $ExpectType void
-$('.alert').popover('hide'); // $ExpectType void
-$('.alert').popover('toggle'); // $ExpectType void
-$('.alert').popover('enable'); // $ExpectType void
-$('.alert').popover('disable'); // $ExpectType void
-$('.alert').popover('toggleEnabled'); // $ExpectType void
-$('.alert').popover('update'); // $ExpectType void
+$('.alert').popover('show'); // $ExpectType JQuery<HTMLElement>
+$('.alert').popover('hide'); // $ExpectType JQuery<HTMLElement>
+$('.alert').popover('toggle'); // $ExpectType JQuery<HTMLElement>
+$('.alert').popover('enable'); // $ExpectType JQuery<HTMLElement>
+$('.alert').popover('disable'); // $ExpectType JQuery<HTMLElement>
+$('.alert').popover('toggleEnabled'); // $ExpectType JQuery<HTMLElement>
+$('.alert').popover('update'); // $ExpectType JQuery<HTMLElement>

--- a/types/bootstrap/test/scrollspy-tests.ts
+++ b/types/bootstrap/test/scrollspy-tests.ts
@@ -21,10 +21,10 @@ element.addEventListener(ScrollSpy.Events.activate, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').scrollspy();
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').scrollspy({ offset: 10 });
 
-$('.alert').scrollspy('refresh'); // $ExpectType void
+$('.alert').scrollspy('refresh'); // $ExpectType JQuery<HTMLElement>

--- a/types/bootstrap/test/tab-tests.ts
+++ b/types/bootstrap/test/tab-tests.ts
@@ -27,7 +27,7 @@ element.addEventListener(Tab.Events.shown, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').tab();
 
-$('.alert').tab('show'); // $ExpectType void
+$('.alert').tab('show'); // $ExpectType JQuery<HTMLElement>

--- a/types/bootstrap/test/toast-tests.ts
+++ b/types/bootstrap/test/toast-tests.ts
@@ -33,11 +33,11 @@ element.addEventListener(Toast.Events.shown, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').toast();
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').toast({ animation: false });
 
-$('.alert').toast('hide'); // $ExpectType void
-$('.alert').toast('show'); // $ExpectType void
+$('.alert').toast('hide'); // $ExpectType JQuery<HTMLElement>
+$('.alert').toast('show'); // $ExpectType JQuery<HTMLElement>

--- a/types/bootstrap/test/tooltip-tests.ts
+++ b/types/bootstrap/test/tooltip-tests.ts
@@ -64,16 +64,16 @@ element.addEventListener(Tooltip.Events.shown, event => {
     // do something…
 });
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').tooltip();
 
-// $ExpectType void
+// $ExpectType JQuery<HTMLElement>
 $('.alert').tooltip({ delay: 0.5, title: () => 'foo', customClass: () => 'custom-class' });
 
-$('.alert').tooltip('hide'); // $ExpectType void
-$('.alert').tooltip('show'); // $ExpectType void
-$('.alert').tooltip('toggle'); // $ExpectType void
-$('.alert').tooltip('enable'); // $ExpectType void
-$('.alert').tooltip('disable'); // $ExpectType void
-$('.alert').tooltip('toggleEnabled'); // $ExpectType void
-$('.alert').tooltip('update'); // $ExpectType void
+$('.alert').tooltip('hide'); // $ExpectType JQuery<HTMLElement>
+$('.alert').tooltip('show'); // $ExpectType JQuery<HTMLElement>
+$('.alert').tooltip('toggle'); // $ExpectType JQuery<HTMLElement>
+$('.alert').tooltip('enable'); // $ExpectType JQuery<HTMLElement>
+$('.alert').tooltip('disable'); // $ExpectType JQuery<HTMLElement>
+$('.alert').tooltip('toggleEnabled'); // $ExpectType JQuery<HTMLElement>
+$('.alert').tooltip('update'); // $ExpectType JQuery<HTMLElement>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The jQuery "interface" functions for Bootstrap return the result of [`$.each()`](https://api.jquery.com/each/), which itself returns the jQuery object. You can see the [Bootstrap popover source code](https://github.com/twbs/bootstrap/blob/51535cd95ac8eb5746e19c057aeabdbcafef3a8b/js/src/popover.js#L75) for an example of this; the other components are implemented the same way.