### PR TITLE
[react] Fix target type in KeyboardEvent

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1274,6 +1274,7 @@ declare namespace React {
         shiftKey: boolean;
         /** @deprecated */
         which: number;
+        target: EventTarget & T;
     }
 
     interface MouseEvent<T = Element, E = NativeMouseEvent> extends UIEvent<T, E> {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -703,6 +703,10 @@ DOM.input({
     onChange: event => {
         // `event.target` is guaranteed to be HTMLInputElement
         const target: HTMLInputElement = event.target;
+    },
+    onKeyUp: event => {
+        // `event.target` is guaranteed to be HTMLInputElement
+        const target: HTMLInputElement = event.target;
     }
 });
 


### PR DESCRIPTION
* KeyboardEvent.target can be an Element, not just an EventTarget. Fix it correctly

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [link](https://freshman.tech/snippets/typescript/fix-value-not-exist-eventtarget/)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
