### PR TITLE
akamai-edgeworkers: Added respondWith support in onClientResponse

### DIFF
--- a/types/akamai-edgeworkers/index.d.ts
+++ b/types/akamai-edgeworkers/index.d.ts
@@ -234,7 +234,7 @@ declare namespace EW {
     }
 
     // onClientResponse
-    interface EgressClientRequest extends ReadsHeaders, ReadsVariables, Request, MutatesVariables {
+    interface EgressClientRequest extends ReadsHeaders, ReadsVariables, Request, HasRespondWith, MutatesVariables {
     }
     interface EgressClientResponse extends MutatesHeaders, ReadsHeaders, HasStatus {
     }

--- a/types/akamai-edgeworkers/test/akamai-edgeworkers-global.test.ts
+++ b/types/akamai-edgeworkers/test/akamai-edgeworkers-global.test.ts
@@ -88,6 +88,11 @@ export function onClientResponse(request: EW.EgressClientRequest, response: EW.E
         return;
     }
 
+    if (response.getHeader("should-respondWith")) {
+        request.respondWith(444, {}, "wanted a respond with");
+        return;
+    }
+
     // Req - getHeader
     let h = request.getHeader("onClientResponse-req-getHeader") || [];
     response.setHeader("header-from-req", h);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://techdocs.akamai.com/edgeworkers/docs/request-object#respondwith
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
