### PR TITLE
[plotly.js] Config.setBackground function needs parentheses (fix #60184)

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1584,7 +1584,7 @@ export interface Config {
      * function to add the background color to a different container
      * or 'opaque' to ensure there's white behind it
      */
-    setBackground: () => string | 'opaque' | 'transparent';
+    setBackground: ((gd: PlotlyHTMLElement, bgColor: string) => any) | 'opaque' | 'transparent';
 
     /** URL to topojson files used in geo charts */
     topojsonURL: string;

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1584,7 +1584,7 @@ export interface Config {
      * function to add the background color to a different container
      * or 'opaque' to ensure there's white behind it
      */
-    setBackground: ((gd: PlotlyHTMLElement, bgColor: string) => any) | 'opaque' | 'transparent';
+    setBackground: ((gd: PlotlyHTMLElement, bgColor: string) => void) | 'opaque' | 'transparent';
 
     /** URL to topojson files used in geo charts */
     topojsonURL: string;

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -281,6 +281,7 @@ const graphDiv = '#test';
             ],
             ['toImage'],
         ],
+        setBackground: 'transparent',
     };
     Plotly.newPlot('myDiv', data, layout, config);
 })();


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60184

`() => string | 'transparent' | 'opaque'` reduces to `() => string` unless parentheses are used
(note that moving `() => string` to the end of the union type leads to "TS1385: Function type notation must be parenthesized when used in a union type.")

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60184
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
