### PR TITLE
cli-progress 3.11

### DIFF
--- a/types/cli-progress/cli-progress-tests.ts
+++ b/types/cli-progress/cli-progress-tests.ts
@@ -34,7 +34,6 @@ function test1() {
         barsize: 65,
         etaAsynchronousUpdate: true,
     });
-    bar.calculateETA();
     bar.updateETA();
 }
 
@@ -101,7 +100,7 @@ function test5() {
 }
 
 function test6() {
-    // SingleBar
+    // SingleBar & MultiBar
     const bar2 = new progress.SingleBar({}, progress.Presets.shades_classic);
     bar2.increment();
     bar2.increment(10);
@@ -115,6 +114,8 @@ function test6() {
     subBar1.update({ speed: '42 kbps' });
 
     subBar1.stop();
+
+    multiBar.log('testdata\n');
 
     const removed = multiBar.remove(subBar1);
 

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -268,7 +268,6 @@ export const Format: {
     TimeFormat: typeof formatTime;
 };
 
-export class Bar extends SingleBar {
-}
+export class Bar extends SingleBar {}
 
 export {};

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -84,7 +84,7 @@ export interface Options {
     hideCursor?: boolean | null | undefined;
 
     /** glue sequence (control chars) between bar elements (default: '') */
-    barGlue?: string;
+    barGlue?: string | undefined;
 
     /** number of updates with which to calculate the eta; higher numbers give a more stable eta (default: 10) */
     etaBuffer?: number | undefined;

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -83,6 +83,9 @@ export interface Options {
      */
     hideCursor?: boolean | null | undefined;
 
+    /** glue sequence (control chars) between bar elements (default: '') */
+    barGlue?: string;
+
     /** number of updates with which to calculate the eta; higher numbers give a more stable eta (default: 10) */
     etaBuffer?: number | undefined;
 
@@ -150,7 +153,7 @@ export class GenericBar extends EventEmitter {
     constructor(opt: Options, preset?: Preset);
 
     /** Internal render function */
-    render(forceRendering?:boolean): void;
+    render(forceRendering?: boolean): void;
 
     /** Starts the progress bar and set the total and initial value */
     start(total: number, startValue: number, payload?: object): void;
@@ -259,6 +262,7 @@ export const Format: {
     TimeFormat: typeof formatTime;
 };
 
-export class Bar extends SingleBar {}
+export class Bar extends SingleBar {
+}
 
 export {};

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -124,7 +124,7 @@ export interface Options {
     autopaddingChar?: string | undefined;
 
     /** stop bar on SIGINT/SIGTERM to restore cursor settings (default: true) */
-    gracefulExit?: boolean
+    gracefulExit?: boolean;
 }
 
 export interface Preset {

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -96,6 +96,9 @@ export interface Options {
      */
     etaAsynchronousUpdate?: boolean | undefined;
 
+    /** progress calculation relative to start value ? default start at 0 (default: false) */
+    progressCalculationRelative?: boolean;
+
     /** disable line wrapping (default: false) - pass null to keep terminal settings; pass true to trim the output to terminal width */
     linewrap?: boolean | null | undefined;
 
@@ -119,6 +122,9 @@ export interface Options {
 
     /** the character sequence used for autopadding (default: " ") */
     autopaddingChar?: string | undefined;
+
+    /** stop bar on SIGINT/SIGTERM to restore cursor settings (default: true) */
+    gracefulExit?: boolean
 }
 
 export interface Preset {
@@ -204,7 +210,7 @@ export class MultiBar extends EventEmitter {
     constructor(opt: Options, preset?: Preset);
 
     /** add a new bar to the stack */
-    create(total: number, startValue: number, payload?: any): SingleBar;
+    create(total: number, startValue: number, payload?: any, barOptions?: object): SingleBar;
 
     /** remove a bar from the stack */
     remove(bar: SingleBar): boolean;

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -210,7 +210,7 @@ export class MultiBar extends EventEmitter {
     constructor(opt: Options, preset?: Preset);
 
     /** add a new bar to the stack */
-    create(total: number, startValue: number, payload?: any, barOptions?: object): SingleBar;
+    create(total: number, startValue: number, payload?: any, barOptions?: Options): SingleBar;
 
     /** remove a bar from the stack */
     remove(bar: SingleBar): boolean;

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for cli-progress 3.9
+// Type definitions for cli-progress 3.11
 // Project: https://github.com/AndiDittrich/Node.CLI-Progress
 // Definitions by:  Mohamed Hegazy <https://github.com/mhegazy>
 //                  Álvaro Martínez <https://github.com/alvaromartmart>
 //                  Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                  Marko Schilde <https://github.com/mschilde>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
@@ -144,26 +145,12 @@ export interface Preset {
     format: string;
 }
 
-export class SingleBar extends EventEmitter {
+export class GenericBar extends EventEmitter {
     /** Initialize a new Progress bar. An instance can be used multiple times! it's not required to re-create it! */
     constructor(opt: Options, preset?: Preset);
 
-    calculateETA(): void;
-    /** Force eta calculation update (long running processes) without altering the progress values. */
-    updateETA(): void;
-
-    formatTime(t: any, roundToMultipleOf: any): any;
-
-    getTotal(): any;
-
-    /** Increases the current progress value by a specified amount (default +1). Update payload optionally */
-    increment(step?: number, payload?: object): void;
-    increment(payload: object): void;
-
-    render(): void;
-
-    /** Sets the total progress value while progressbar is active. Especially useful handling dynamic tasks. */
-    setTotal(total: number): void;
+    /** Internal render function */
+    render(forceRendering?:boolean): void;
 
     /** Starts the progress bar and set the total and initial value */
     start(total: number, startValue: number, payload?: object): void;
@@ -171,21 +158,61 @@ export class SingleBar extends EventEmitter {
     /** Stops the progress bar and go to next line */
     stop(): void;
 
-    stopTimer(): void;
+    /** Sets the current progress value and optionally the payload with values of custom tokens as a second parameter */
+    update(current: number, payload?: object): void;
+    update(payload: object): void;
+
+    /** Calculate the actual progress value */
+    getProgress(): number;
+
+    /** Increases the current progress value by a specified amount (default +1). Update payload optionally */
+    increment(step?: number, payload?: object): void;
+    increment(payload: object): void;
+
+    /** Get the total (limit) value */
+    getTotal(): number;
+
+    /** Sets the total progress value while progressbar is active. Especially useful handling dynamic tasks. */
+    setTotal(total: number): void;
+
+    /** Force eta calculation update (long running processes) without altering the progress values. */
+    updateETA(): void;
+}
+
+export class SingleBar extends GenericBar {
+    /** Initialize a new Progress bar. An instance can be used multiple times! it's not required to re-create it! */
+    constructor(opt: Options, preset?: Preset);
+
+    /** Internal render function */
+    render(): void;
 
     /** Sets the current progress value and optionally the payload with values of custom tokens as a second parameter */
     update(current: number, payload?: object): void;
     update(payload: object): void;
+
+    /** Starts the progress bar and set the total and initial value */
+    start(total: number, startValue: number, payload?: object): void;
+
+    /** Stops the progress bar and go to next line */
+    stop(): void;
 }
 
 export class MultiBar extends EventEmitter {
     constructor(opt: Options, preset?: Preset);
 
+    /** add a new bar to the stack */
     create(total: number, startValue: number, payload?: any): SingleBar;
 
+    /** remove a bar from the stack */
     remove(bar: SingleBar): boolean;
 
+    /** internal update routine */
+    update(): void;
+
     stop(): void;
+
+    /** log output above the progress bars; string must end with newline character! */
+    log(data: string): void;
 }
 
 export const Presets: {

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -124,7 +124,7 @@ export interface Options {
     autopaddingChar?: string | undefined;
 
     /** stop bar on SIGINT/SIGTERM to restore cursor settings (default: true) */
-    gracefulExit?: boolean;
+    gracefulExit?: boolean | undefined;
 }
 
 export interface Preset {

--- a/types/cli-progress/index.d.ts
+++ b/types/cli-progress/index.d.ts
@@ -97,7 +97,7 @@ export interface Options {
     etaAsynchronousUpdate?: boolean | undefined;
 
     /** progress calculation relative to start value ? default start at 0 (default: false) */
-    progressCalculationRelative?: boolean;
+    progressCalculationRelative?: boolean | undefined;
 
     /** disable line wrapping (default: false) - pass null to keep terminal settings; pass true to trim the output to terminal width */
     linewrap?: boolean | null | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [MultiBar](https://github.com/npkgz/cli-progress/blob/master/lib/multi-bar.js#L221)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

What changed:

- added / extended / fixed types for `cli-progress` v.3.11 (from v.3.09)

notable changes:

- `MultiBar` supports a `log` function now
- `SingleBar` is derived from GenericBar
- `SingleBar` no longer supports `calculateEta`
- `barGlue` option was missing from `Options` interface
- added options `gracefulExit`, `progressCalculationRelative` which got introduced in v.3.11

I changed the order of the methods in the `SingleBar` class to be in line with the package code. This makes reviewing a bit harder once, but maintainability easier in the long run.