### PR TITLE
@types/google-one-tap: Add revoke method and update literal unions

### DIFF
--- a/types/google-one-tap/index.d.ts
+++ b/types/google-one-tap/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for google-one-tap 1.1
+// Type definitions for google-one-tap 1.2
 // Project: https://developers.google.com/identity/one-tap/web
 // Definitions by: voidpumpkin <https://github.com/voidpumpkin>
 //                 kostasmanionis <https://github.com/kostasmanionis>
@@ -15,7 +15,7 @@ export interface accounts {
         disableAutoSelect: () => void;
         storeCredential: (credential?: string, callback?: () => void) => void;
         cancel: () => void;
-        onGoogleLibraryLoad: () => void;
+        revoke: (hint: string, callback?: (response: RevocationResponse) => void) => void;
         prompt: (momentListener?: (promptMomentNotification: PromptMomentNotification) => void) => void;
         renderButton: (parent: HTMLElement, options: GsiButtonConfiguration, clickHandler?: () => void) => void;
     };
@@ -25,34 +25,41 @@ export interface GsiButtonConfiguration {
     type?: 'standard' | 'icon';
     theme?: 'outline' | 'filled_blue' | 'filled_black';
     size?: 'large' | 'medium' | 'small';
-    text?: 'signin_with' | 'signup_with' | 'continue_with' | 'signup_with';
+    text?: 'signin_with' | 'signup_with' | 'continue_with' | 'signin';
     shape?: 'rectangular' | 'pill' | 'circle' | 'square';
     logo_alignment?: 'left' | 'center';
     width?: number;
     locale?: string;
-  }
+}
 
 export interface CredentialResponse {
     credential: string;
-    select_by: string;
-    client_id: string;
+    select_by:
+        | 'auto'
+        | 'user'
+        | 'user_1tap'
+        | 'user_2tap'
+        | 'btn'
+        | 'btn_confirm'
+        | 'btn_add_session'
+        | 'btn_confirm_add_session';
 }
 
 /// https://developers.google.com/identity/gsi/web/reference/js-reference
 export interface IdConfiguration {
-    client_id?: string | undefined;
-    auto_select?: boolean | undefined;
-    callback?: ((credentialResponse: CredentialResponse) => void) | undefined;
+    client_id: string;
+    auto_select?: boolean;
+    callback?: ((credentialResponse: CredentialResponse) => void);
     login_uri?: string;
-    native_callback?: (() => void) | undefined;
-    cancel_on_tap_outside?: boolean | undefined;
-    prompt_parent_id?: string | undefined;
-    nonce?: string | undefined;
-    context?: string | undefined;
-    state_cookie_domain?: string | undefined;
+    native_callback?: (() => void);
+    cancel_on_tap_outside?: boolean;
+    prompt_parent_id?: string;
+    nonce?: string;
+    context?: 'signin' | 'signup' | 'use';
+    state_cookie_domain?: string;
     ux_mode?: 'popup' | 'redirect';
-    allowed_parent_origin?: string | string[] | undefined;
-    intermediate_iframe_close_callback?: (() => void) | undefined;
+    allowed_parent_origin?: string | string[];
+    intermediate_iframe_close_callback?: (() => void);
 }
 
 export interface PromptMomentNotification {
@@ -73,4 +80,9 @@ export interface PromptMomentNotification {
     isDismissedMoment: () => boolean;
     getDismissedReason: () => 'credential_returned' | 'cancel_called' | 'flow_restarted';
     getMomentType: () => 'display' | 'skipped' | 'dismissed';
+}
+
+export interface RevocationResponse {
+    successful: boolean;
+    error?: string;
 }

--- a/types/google-one-tap/test/google-one-tap-global.test.ts
+++ b/types/google-one-tap/test/google-one-tap-global.test.ts
@@ -9,7 +9,7 @@ const idConfiguration: google.IdConfiguration = {
     cancel_on_tap_outside: false,
     prompt_parent_id: '',
     nonce: '',
-    context: '',
+    context: 'signin',
     state_cookie_domain: '',
     allowed_parent_origin: ['test1', 'test2'],
     intermediate_iframe_close_callback: () => {},
@@ -21,8 +21,7 @@ google.accounts.id.initialize(idConfiguration);
 google.accounts.id.disableAutoSelect();
 google.accounts.id.storeCredential('', () => {});
 google.accounts.id.cancel();
-
-google.accounts.id.onGoogleLibraryLoad = () => {};
+google.accounts.id.revoke('', (_: google.RevocationResponse) => {});
 
 google.accounts.id.prompt(promptMomentNotification => {
     const isDisplayMoment: boolean = promptMomentNotification.isDisplayMoment();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [GSI JS Reference](https://developers.google.com/identity/gsi/web/reference/js-reference)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Changes summary:
* Added `revoke()` method
* Replaced some string types with literal unions
* Removed invalid `onGoogleLibraryLoad` callback
* Removed invalid `client_id` property in `CredentialResponse` (also mentioned [here](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/59378))