### PR TITLE
[mssql] add ConnectionPool.parseConnectionString() static method definition

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mssql 7.1.3
+// Type definitions for mssql 8.0.0
 // Project: https://www.npmjs.com/package/mssql
 // Definitions by: COLSA Corporation <http://www.colsa.com/>
 //                 Jørgen Elgaard Larsen <https://github.com/elhaard>
@@ -219,6 +219,7 @@ export declare class ConnectionPool extends events.EventEmitter {
     public readonly pending: number;
     public readonly borrowed: number;
     public readonly pool: Pool<Connection>;
+    public static parseConnectionString(connectionString: string): config;
     public constructor(config: config, callback?: (err?: any) => void);
     public constructor(connectionString: string, callback?: (err?: any) => void);
     public query(command: string): Promise<IResult<any>>;

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -147,6 +147,10 @@ var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function (er
     }
 });
 
+function test_connection_string_parser() {
+    var parsedConfig: sql.config = sql.ConnectionPool.parseConnectionString(connectionString);
+}
+
 function test_table() {
     var table = new sql.Table('#temp_table');
 


### PR DESCRIPTION
Add the `ConnectionPool.parseConnectionString()` method that was added in v8 of the mssql lib

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tediousjs/node-mssql/pull/1342
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
