### PR TITLE
[react-dom] createPortal container can be a DocumentFragment

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -25,7 +25,7 @@ import {
 export function findDOMNode(instance: ReactInstance | null | undefined): Element | null | Text;
 export function unmountComponentAtNode(container: Element | DocumentFragment): boolean;
 
-export function createPortal(children: ReactNode, container: Element, key?: null | string): ReactPortal;
+export function createPortal(children: ReactNode, container: Element | DocumentFragment, key?: null | string): ReactPortal;
 
 export const version: string;
 export const render: Renderer;

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -61,6 +61,7 @@ describe('ReactDOM', () => {
         ReactDOM.createPortal(React.createElement('div'), document.createElement('div'));
         ReactDOM.createPortal(React.createElement('div'), document.createElement('div'), null);
         ReactDOM.createPortal(React.createElement('div'), document.createElement('div'), 'key');
+        ReactDOM.createPortal(React.createElement('div'), document.createDocumentFragment());
 
         ReactDOM.render(<ClassComponent />, rootElement);
     });

--- a/types/react-dom/v16/index.d.ts
+++ b/types/react-dom/v16/index.d.ts
@@ -25,7 +25,7 @@ import {
 export function findDOMNode(instance: ReactInstance | null | undefined): Element | null | Text;
 export function unmountComponentAtNode(container: Element | DocumentFragment): boolean;
 
-export function createPortal(children: ReactNode, container: Element, key?: null | string): ReactPortal;
+export function createPortal(children: ReactNode, container: Element | DocumentFragment, key?: null | string): ReactPortal;
 
 export const version: string;
 export const render: Renderer;

--- a/types/react-dom/v16/test/react-dom-tests.tsx
+++ b/types/react-dom/v16/test/react-dom-tests.tsx
@@ -60,6 +60,7 @@ describe('ReactDOM', () => {
         ReactDOM.createPortal(React.createElement('div'), document.createElement('div'));
         ReactDOM.createPortal(React.createElement('div'), document.createElement('div'), null);
         ReactDOM.createPortal(React.createElement('div'), document.createElement('div'), 'key');
+        ReactDOM.createPortal(React.createElement('div'), document.createDocumentFragment());
 
         ReactDOM.render(<ClassComponent />, rootElement);
     });

--- a/types/react-dom/v17/index.d.ts
+++ b/types/react-dom/v17/index.d.ts
@@ -21,7 +21,7 @@ import {
 export function findDOMNode(instance: ReactInstance | null | undefined): Element | null | Text;
 export function unmountComponentAtNode(container: Element | DocumentFragment): boolean;
 
-export function createPortal(children: ReactNode, container: Element, key?: null | string): ReactPortal;
+export function createPortal(children: ReactNode, container: Element | DocumentFragment, key?: null | string): ReactPortal;
 
 export const version: string;
 export const render: Renderer;

--- a/types/react-dom/v17/test/react-dom-tests.tsx
+++ b/types/react-dom/v17/test/react-dom-tests.tsx
@@ -60,6 +60,7 @@ describe('ReactDOM', () => {
         ReactDOM.createPortal(React.createElement('div'), document.createElement('div'));
         ReactDOM.createPortal(React.createElement('div'), document.createElement('div'), null);
         ReactDOM.createPortal(React.createElement('div'), document.createElement('div'), 'key');
+        ReactDOM.createPortal(React.createElement('div'), document.createDocumentFragment());
 
         ReactDOM.render(<ClassComponent />, rootElement);
     });


### PR DESCRIPTION
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/53619

See https://github.com/facebook/react/pull/24496/files#diff-548f9a0cc68e5f1c9b55f52b766b37bf04084718fc59c7d783639b6d569de309R110

@sebmarkbage Do you remember if `DocumentFragment` support was later added or do all versions of `createPortal` support it?