### PR TITLE
[content-disposition] Update type of `parameters`

### DIFF
--- a/types/content-disposition/content-disposition-tests.ts
+++ b/types/content-disposition/content-disposition-tests.ts
@@ -5,7 +5,7 @@ const withFilenameNoOptions = contentDisposition('EURO rates.txt');
 const withFilenameAndOptions = contentDisposition('€ rates.txt', { type: 'attachment', fallback: 'EURO rates.txt' });
 const noFilename = contentDisposition(undefined, { type: 'attachment', fallback: true });
 
-const { parse } = contentDisposition
+const { parse } = contentDisposition;
 
 const res = parse('attachment; filename="EURO rates.txt"');
 const type = res.type;
@@ -13,5 +13,5 @@ const parameters = res.parameters;
 
 if ("filename" in parameters) {
   // $ExpectType string
-  parameters["filename"]
+  parameters["filename"];
 }

--- a/types/content-disposition/content-disposition-tests.ts
+++ b/types/content-disposition/content-disposition-tests.ts
@@ -5,6 +5,13 @@ const withFilenameNoOptions = contentDisposition('EURO rates.txt');
 const withFilenameAndOptions = contentDisposition('€ rates.txt', { type: 'attachment', fallback: 'EURO rates.txt' });
 const noFilename = contentDisposition(undefined, { type: 'attachment', fallback: true });
 
-const res = contentDisposition.parse('attachment; filename="EURO rates.txt"');
+const { parse } = contentDisposition
+
+const res = parse('attachment; filename="EURO rates.txt"');
 const type = res.type;
 const parameters = res.parameters;
+
+if ("filename" in parameters) {
+  // $ExpectType string
+  parameters["filename"]
+}

--- a/types/content-disposition/index.d.ts
+++ b/types/content-disposition/index.d.ts
@@ -17,7 +17,7 @@ declare namespace contentDisposition {
          * An object of the parameters in the disposition
          * (name of parameter always lower case and extended versions replace non-extended versions)
          */
-        parameters: any;
+        parameters: {[key: string]: string};
     }
 
     interface Options {


### PR DESCRIPTION
The `parameters` field is filled from the values of a `RegExpExecArray`, and indexing into one results in a string. Thus we know reliably that all keys and values of `parameter` will be strings.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jshttp/content-disposition/blob/1037e24/index.js#L340
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
