### PR TITLE
Added missing definition for layers in [@types/serverless].service.provider

### DIFF
--- a/types/serverless/classes/Service.d.ts
+++ b/types/serverless/classes/Service.d.ts
@@ -26,7 +26,7 @@ declare class Service {
         runtime?: string | undefined;
         timeout?: number | undefined;
         versionFunctions: boolean;
-        layers: [string | unknown];
+        layers?: Array<string | Record<string, string>> | undefined;
     };
     serverless: Serverless;
     service: string | null;

--- a/types/serverless/classes/Service.d.ts
+++ b/types/serverless/classes/Service.d.ts
@@ -26,6 +26,7 @@ declare class Service {
         runtime?: string | undefined;
         timeout?: number | undefined;
         versionFunctions: boolean;
+        layers: [string | unknown];
     };
     serverless: Serverless;
     service: string | null;

--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -81,6 +81,7 @@ declare namespace Aws {
         logs?: Logs | undefined;
         kmsKeyArn?: string | undefined;
         eventBridge?: EventBridge | undefined;
+        layers?: Array<string | Record<string, string>> | undefined;
     }
 
     interface EventBridge {

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -368,7 +368,8 @@ const awsServerless: Aws.Serverless = {
         },
         eventBridge: {
             useCloudFormation: true
-        }
+        },
+        layers: ['arn:aws:lambda:us-east-2:451483290750:layer:NewRelicNodeJS14X:45']
     },
     package: {
         include: ['testinclude'],


### PR DESCRIPTION
* `string` for ARNs i.e. `arn:aws:lambda:us-east-2:451483290750:layer:NewRelicNodeJS14X:45`
* `Record<string, string>>` for refs i.e. `{ Ref: 'SharedLambdaLayer' }`

This PR fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60207
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.serverless.com/framework/docs/providers/aws/guide/layers
