### PR TITLE
feat(babel__register): Add initial type defs

### DIFF
--- a/types/babel__register/babel__register-tests.ts
+++ b/types/babel__register/babel__register-tests.ts
@@ -1,0 +1,40 @@
+import register1 = require('@babel/register');
+import * as register2 from '@babel/register';
+// tslint:disable-next-line:no-duplicate-imports
+import register3, { RegisterOptions } from '@babel/register';
+
+// $ExpectType typeof register
+register1;
+
+// $ExpectType typeof register
+register2.default;
+
+// $ExpectType typeof register
+register3;
+// $ExpectType RegisterOptions
+type Opts = RegisterOptions;
+
+// $ExpectType void
+register3();
+register3({});
+register3({ cache: false });
+// taken from https://babeljs.io/docs/en/babel-register/#specifying-options
+register3({
+    ignore: [
+        /regex/,
+        filepath => {
+            return filepath !== '/path/to/es6-file.js';
+        },
+    ],
+    only: [
+        /my_es6_folder/,
+        filepath => {
+            return filepath === '/path/to/es6-file.js';
+        },
+    ],
+    extensions: ['.es6', '.es', '.jsx', '.js', '.mjs'],
+    cache: true,
+    rootMode: 'upward',
+});
+// $ExpectError
+register3({ blah: 'blah' });

--- a/types/babel__register/index.d.ts
+++ b/types/babel__register/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for @babel/register 7.17
+// Project: https://github.com/babel/babel/tree/main/packages/babel-register, https://babeljs.io/docs/en/babel-register/
+// Definitions by: Paul Sanchez <https://github.com/basicdays>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.1
+
+import { TransformOptions } from '@babel/core';
+
+interface RegisterOptions extends TransformOptions {
+    /**
+     * Setting this will remove the currently hooked extensions of `.es6`, `.es`,
+     * `.jsx`, `.mjs` and `.js` so you'll have to add them back if you want them
+     * to be used again.
+     */
+    extensions?: string[];
+    /**
+     * Setting this to false will disable the cache.
+     */
+    cache?: boolean;
+}
+
+declare function register(opts?: RegisterOptions): void;
+declare namespace register {
+    export { register as default, RegisterOptions };
+}
+export = register;

--- a/types/babel__register/tsconfig.json
+++ b/types/babel__register/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@babel/*": [
+                "babel__*"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "babel__register-tests.ts"
+    ]
+}

--- a/types/babel__register/tslint.json
+++ b/types/babel__register/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.