### PR TITLE
[react-router] Parse regex options for generating valid input types to `generatePath`

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -147,7 +147,7 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
 ): match<Params> | null;
 
 // Must only use abcdefghijklmnopqrstuvwxyz0123456789-_|
-type IsExtractableRegex<T extends string, L = Lowercase<T>> =
+export type IsExtractableRegex<T extends string, L = Lowercase<T>> =
     L extends `` ? true :
     L extends `a${infer R}` ? IsExtractableRegex<R> :
     L extends `b${infer R}` ? IsExtractableRegex<R> :
@@ -190,11 +190,11 @@ type IsExtractableRegex<T extends string, L = Lowercase<T>> =
     L extends `|${infer R}` ? IsExtractableRegex<R> :
     false;
 
-type ExtractRegExpOptions<T extends string, U = string | number | boolean> = IsExtractableRegex<T> extends true
+export type ExtractRegExpOptions<T extends string, U = string | number | boolean> = IsExtractableRegex<T> extends true
     ? ExtractOptions<T>
     : U;
 
-type ExtractOptions<T extends string> = T extends `${infer Left}|${infer Right}` ? Left | ExtractOptions<Right> : T;
+export type ExtractOptions<T extends string> = T extends `${infer Left}|${infer Right}` ? Left | ExtractOptions<Right> : T;
 
 export type ExtractRouteOptionalParam<T extends string, U = string | number | boolean> = T extends `${infer Param}?`
     ? { [k in Param]?: U }

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -146,13 +146,49 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
     parent?: match<Params> | null,
 ): match<Params> | null;
 
-type OnlyIncludes<Input extends string, Allowed extends string> = StringChars<Input> extends StringChars<Allowed>
-    ? true
-    : false;
-
-type StringChars<T extends string> = T extends `${infer Left}${infer Right}` ? Left | StringChars<Right> : T;
-
-type IsExtractableRegex<T extends string> = OnlyIncludes<Lowercase<T>, 'abcdefghijklmnopqrstuvwxyz0123456789-_|'>;
+// Must only use abcdefghijklmnopqrstuvwxyz0123456789-_|
+type IsExtractableRegex<T extends string, L = Lowercase<T>> =
+    L extends `` ? true :
+    L extends `a${infer R}` ? IsExtractableRegex<R> :
+    L extends `b${infer R}` ? IsExtractableRegex<R> :
+    L extends `c${infer R}` ? IsExtractableRegex<R> :
+    L extends `d${infer R}` ? IsExtractableRegex<R> :
+    L extends `e${infer R}` ? IsExtractableRegex<R> :
+    L extends `f${infer R}` ? IsExtractableRegex<R> :
+    L extends `g${infer R}` ? IsExtractableRegex<R> :
+    L extends `h${infer R}` ? IsExtractableRegex<R> :
+    L extends `i${infer R}` ? IsExtractableRegex<R> :
+    L extends `j${infer R}` ? IsExtractableRegex<R> :
+    L extends `k${infer R}` ? IsExtractableRegex<R> :
+    L extends `l${infer R}` ? IsExtractableRegex<R> :
+    L extends `m${infer R}` ? IsExtractableRegex<R> :
+    L extends `n${infer R}` ? IsExtractableRegex<R> :
+    L extends `o${infer R}` ? IsExtractableRegex<R> :
+    L extends `p${infer R}` ? IsExtractableRegex<R> :
+    L extends `q${infer R}` ? IsExtractableRegex<R> :
+    L extends `r${infer R}` ? IsExtractableRegex<R> :
+    L extends `s${infer R}` ? IsExtractableRegex<R> :
+    L extends `t${infer R}` ? IsExtractableRegex<R> :
+    L extends `u${infer R}` ? IsExtractableRegex<R> :
+    L extends `v${infer R}` ? IsExtractableRegex<R> :
+    L extends `w${infer R}` ? IsExtractableRegex<R> :
+    L extends `x${infer R}` ? IsExtractableRegex<R> :
+    L extends `y${infer R}` ? IsExtractableRegex<R> :
+    L extends `z${infer R}` ? IsExtractableRegex<R> :
+    L extends `0${infer R}` ? IsExtractableRegex<R> :
+    L extends `1${infer R}` ? IsExtractableRegex<R> :
+    L extends `2${infer R}` ? IsExtractableRegex<R> :
+    L extends `3${infer R}` ? IsExtractableRegex<R> :
+    L extends `4${infer R}` ? IsExtractableRegex<R> :
+    L extends `5${infer R}` ? IsExtractableRegex<R> :
+    L extends `6${infer R}` ? IsExtractableRegex<R> :
+    L extends `7${infer R}` ? IsExtractableRegex<R> :
+    L extends `8${infer R}` ? IsExtractableRegex<R> :
+    L extends `9${infer R}` ? IsExtractableRegex<R> :
+    L extends `-${infer R}` ? IsExtractableRegex<R> :
+    L extends `_${infer R}` ? IsExtractableRegex<R> :
+    L extends `|${infer R}` ? IsExtractableRegex<R> :
+    false;
 
 type ExtractRegExpOptions<T extends string, U = string | number | boolean> = IsExtractableRegex<T> extends true
     ? ExtractOptions<T>

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -146,7 +146,9 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
     parent?: match<Params> | null,
 ): match<Params> | null;
 
-// Must only use abcdefghijklmnopqrstuvwxyz0123456789-_|
+// This is a hacky way to test that the string only uses abcdefghijklmnopqrstuvwxyz0123456789-_|
+// With TS 4.5 this can be replaced:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60238#discussion_r867249457
 export type IsExtractableRegex<T extends string, L = Lowercase<T>> =
     L extends `` ? true :
     L extends `a${infer R}` ? IsExtractableRegex<R> :

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -146,21 +146,19 @@ export function matchPath<Params extends { [K in keyof Params]?: string }>(
     parent?: match<Params> | null,
 ): match<Params> | null;
 
-type OnlyIncludes<Input extends string, Allowed extends string> =
-    StringChars<Input> extends StringChars<Allowed> ? true : false
+type OnlyIncludes<Input extends string, Allowed extends string> = StringChars<Input> extends StringChars<Allowed>
+    ? true
+    : false;
 
-type StringChars<T extends string> = T extends `${infer Left}${infer Right}`
-    ? Left | StringChars<Right>
-    : T
+type StringChars<T extends string> = T extends `${infer Left}${infer Right}` ? Left | StringChars<Right> : T;
 
-type IsExtractableRegex<T extends string> = OnlyIncludes<Lowercase<T>, 'abcdefghijklmnopqrstuvwxyz0123456789-_|'>
+type IsExtractableRegex<T extends string> = OnlyIncludes<Lowercase<T>, 'abcdefghijklmnopqrstuvwxyz0123456789-_|'>;
 
-type ExtractRegExpOptions<T extends string, U = string | number | boolean> =
-    IsExtractableRegex<T> extends true ? ExtractOptions<T> : U;
+type ExtractRegExpOptions<T extends string, U = string | number | boolean> = IsExtractableRegex<T> extends true
+    ? ExtractOptions<T>
+    : U;
 
-type ExtractOptions<T extends string> = T extends `${infer Left}|${infer Right}`
-    ? Left | ExtractOptions<Right>
-    : T
+type ExtractOptions<T extends string> = T extends `${infer Left}|${infer Right}` ? Left | ExtractOptions<Right> : T;
 
 export type ExtractRouteOptionalParam<T extends string, U = string | number | boolean> = T extends `${infer Param}?`
     ? { [k in Param]?: U }
@@ -174,12 +172,12 @@ export type ExtractRouteParams<T extends string, U = string | number | boolean> 
     ? { [k in string]?: U }
     : T extends `${infer _Start}:${infer ParamWithOptionalRegExp}/${infer Rest}`
     ? ParamWithOptionalRegExp extends `${infer Param}(${infer RegExp})`
-      ? ExtractRouteOptionalParam<Param, ExtractRegExpOptions<RegExp, U>> & ExtractRouteParams<Rest, U>
-      : ExtractRouteOptionalParam<ParamWithOptionalRegExp, U> & ExtractRouteParams<Rest, U>
+        ? ExtractRouteOptionalParam<Param, ExtractRegExpOptions<RegExp, U>> & ExtractRouteParams<Rest, U>
+        : ExtractRouteOptionalParam<ParamWithOptionalRegExp, U> & ExtractRouteParams<Rest, U>
     : T extends `${infer _Start}:${infer ParamWithOptionalRegExp}`
     ? ParamWithOptionalRegExp extends `${infer Param}(${infer RegExp})`
-      ? ExtractRouteOptionalParam<Param, ExtractRegExpOptions<RegExp, U>>
-      : ExtractRouteOptionalParam<ParamWithOptionalRegExp, U>
+        ? ExtractRouteOptionalParam<Param, ExtractRegExpOptions<RegExp, U>>
+        : ExtractRouteOptionalParam<ParamWithOptionalRegExp, U>
     : {};
 
 export function generatePath<S extends string>(path: S, params?: ExtractRouteParams<S>): string;

--- a/types/react-router/test/generatePath.ts
+++ b/types/react-router/test/generatePath.ts
@@ -8,7 +8,7 @@ generatePath('/posts/:postId/comments/:commentId', { postId: '1' }); // $ExpectE
 generatePath('/posts/:postId', { userId: '1', postId: '1' }); // $ExpectError
 generatePath('/posts/:postId/:commentId+', { postId: '1' }); // $ExpectError
 generatePath(unknownPath, { nullParam: null }); // $ExpectError
-generatePath('/posts/:postId/:page(comments|latest_activity|latest-posts)', { postId: '1', page: 'show' }); // $ExpectError
+generatePath('/page/:page(comments|latest_activity|latest-posts)', { page: 'show' }); // $ExpectError
 
 // correct
 generatePath('/posts/:postId', { postId: '1' });
@@ -26,4 +26,6 @@ generatePath('/posts/:postId(\d+)/comments/:commentId(\d+)', { postId: 1, commen
 generatePath('/posts/:postId/comments/:commentId?', { postId: '1', commentId: '1' });
 generatePath(unknownPath, { stringParam: '', numParam: 3, boolParam: true, undefinedParam: undefined });
 generatePath('/posts/:postId/:page(comments|latest_activity)', { postId: '1', page: 'latest_activity' });
-generatePath('/posts/:postId/:page(comments|latest_activity|latest-posts)', { postId: '1', page: 'comments' });
+generatePath('/posts/:postId/:page?(comments|latest_activity|latest-posts)', { postId: '1', page: 'comments' });
+generatePath('/page/:page?(home)', {page: undefined});
+generatePath('/page/:page(home|comments\d+)', { page: 'comments1'});

--- a/types/react-router/test/generatePath.ts
+++ b/types/react-router/test/generatePath.ts
@@ -8,6 +8,7 @@ generatePath('/posts/:postId/comments/:commentId', { postId: '1' }); // $ExpectE
 generatePath('/posts/:postId', { userId: '1', postId: '1' }); // $ExpectError
 generatePath('/posts/:postId/:commentId+', { postId: '1' }); // $ExpectError
 generatePath(unknownPath, { nullParam: null }); // $ExpectError
+generatePath('/posts/:postId/:page(comments|latest_activity|latest-posts)', { postId: '1', page: 'show' }); // $ExpectError
 
 // correct
 generatePath('/posts/:postId', { postId: '1' });
@@ -24,3 +25,5 @@ generatePath('/posts/:postId/comments/:commentId?', { postId: '1' });
 generatePath('/posts/:postId(\d+)/comments/:commentId(\d+)', { postId: 1, commentId: 1 });
 generatePath('/posts/:postId/comments/:commentId?', { postId: '1', commentId: '1' });
 generatePath(unknownPath, { stringParam: '', numParam: 3, boolParam: true, undefinedParam: undefined });
+generatePath('/posts/:postId/:page(comments|latest_activity)', { postId: '1', page: 'latest_activity' });
+generatePath('/posts/:postId/:page(comments|latest_activity|latest-posts)', { postId: '1', page: 'comments' });


### PR DESCRIPTION
This PR adds better typing for paths like `/dashboard/:page(home|activity)` which will now have the param type `{ page: "home" | "activity" }` instead of `{ page: string }`. If the path contains regex symbols like `:page(\d+|activity)` then it will not try to parse the types. Someday we can add a full regex parser 😄 

Unfortunately the cleaner implementation to check alphanumeric only worked in TypeScript 4.5 so I tried updating the minimum TS version. That was a disaster due to dependent packages being lower version so I went with a much more verbose solution which I understand if you don't want to maintain.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://v5.reactrouter.com/web/api/generatePath
