### PR TITLE
[sequelize] Add null to some types to be able to use it with "strictNullChecks": true

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -170,7 +170,7 @@ declare namespace sequelize {
         /**
          * Apply a scope on the related model, or remove its default scope by passing false.
          */
-        scope?: string | boolean | undefined;
+        scope?: string | boolean | undefined | null;
     }
 
     /**
@@ -3176,9 +3176,9 @@ declare namespace sequelize {
      * Logic of where statement
      */
     type WhereLogic = Partial<{
-        $ne: string | number | WhereLogic;
+        $ne: string | number | WhereLogic | null;
         $in: Array<string | number> | literal;
-        $not: boolean | string | number | AnyWhereOptions;
+        $not: boolean | string | number | AnyWhereOptions | null;
         $notIn: Array<string | number> | literal;
         $gte: number | string | Date;
         $gt: number | string | Date;
@@ -3216,7 +3216,7 @@ declare namespace sequelize {
      * A hash of attributes to describe your search, accepting any field names. See `WhereOptions` for details.
      */
     interface AnyWhereOptions {
-        [field: string]: WhereOptions<any>[] | Object;
+        [field: string]: WhereOptions<any>[] | Object | null;
     }
 
     /**

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -1207,6 +1207,7 @@ User.update( { username : 'Bill', secretValue : '43' }, { where : { secretValue 
 User.update( { username : s.cast( '1', 'char' ) }, { where : { username : 'John' } } );
 User.update( { username : s.fn( 'upper', s.col( 'username' ) ) }, { where : { username : 'John' } } );
 User.update( { username : 'Bill' }, { where : { secretValue : '42' }, returning : true } );
+User.update( { deletedAt : new Date() }, { where : { username : 'dan', deleted_at: null } } );
 User.update( { secretValue : '43' }, { where : { username : 'Peter' }, limit : 1 } );
 User.update( { name : Math.random().toString() }, { where : { id : '1' } } );
 User.update( { a : { b : 10, c : 'd' } }, { where : { username : 'Jan' }, sideEffects : false } );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Here is the discussion :  https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60183
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The Sequelize DefinitelyTyped uses "strictNullChecks": false in the tsconfig.

If we use it with a `true` value, some types are wrong, because they could be null but doesn't allowed in explicitely in the Type definition.

This PR allows some types to be also null to fix the issue with strictNullChecks: true.