### PR TITLE
[graphql-upload] Added a FileUploadPromise Type

### DIFF
--- a/types/graphql-upload/index.d.ts
+++ b/types/graphql-upload/index.d.ts
@@ -47,7 +47,9 @@ export interface FileUpload {
   createReadStream(): ReadStream;
 }
 
+export type FileUploadPromise = Promise<FileUpload>; 
+
 export class Upload {
-  promise: Promise<FileUpload>;
+  promise: FileUploadPromise;
   file?: FileUpload;
 }


### PR DESCRIPTION
Added this additional type for use with schema generators like Nexus etc

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: 
This type allows for easier integration with schema generators like Nexus. For example this is now possible:
```
asNexusMethod(GraphQLUpload, 'upload', {
  module: 'graphql-upload',
  export: 'FileUploadPromise',
});
```