### PR TITLE
refactor(ramda): improve map type inference

### DIFF
--- a/types/ramda/test/map-tests.ts
+++ b/types/ramda/test/map-tests.ts
@@ -13,6 +13,7 @@ import * as R from 'ramda';
         return x * 2;
     }
 
+    // $ExpectType number[]
     R.map(double, [1, 2, 3]); // => [2, 4, 6]
 
     // functor
@@ -22,6 +23,7 @@ import * as R from 'ramda';
             return chars.map(char => fn(char.charCodeAt(0)));
         },
     };
+    // $ExpectType Functor<number>
     R.map((x: number) => x - 1, numberFunctor); // => "Hello World"
 };
 
@@ -32,29 +34,26 @@ import * as R from 'ramda';
     }
 
     interface B {
-        a: string;
-        b: string;
-    }
-
-    interface C {
         b: number;
         c: string;
     }
 
-    R.map<A, A>(R.inc, { a: 1, b: 2 });
-    R.map<A, B>(R.toString, { a: 1, b: 2 });
+    // $ExpectType Record<"a" | "b", number>
+    R.map(R.inc, { a: 1, b: 2 });
+    // $ExpectType Record<"a" | "b", string>
+    R.map(R.toString, { a: 1, b: 2 });
 
-    R.map<A, A>(R.inc)({ a: 1, b: 2 });
-    R.map<A, B>(R.toString)({ a: 1, b: 2 });
-
-    type KeyOfUnion<T> = T extends infer U ? keyof U : never;
+    // $ExpectType Record<"a" | "b", number>
+    R.map(R.inc)({ a: 1, b: 2 });
+    // $ExpectType Record<"a" | "b", string>
+    R.map(R.toString)({ a: 1, b: 2 });
 
     /**
      * Typescript implementation of union order is not guaranteed and can
      * change. Therefor using `||` here, which is a feature of $ExpectType
      */
     // $ExpectType Record<"c" | "a" | "b", void> || Record<"a" | "b" | "c", void>
-    R.map<A | C, Record<KeyOfUnion<A | C>, void>>(
+    R.map<A | B, void>(
         // $ExpectType (value: string | number) => void
         value => {
             value;

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -162,7 +162,7 @@ type EvolveValue<V, E> = E extends (value: V) => any
  * the seventh being `document.all`. However `NaN` is not a valid literal type,
  * and `document.all` is an object so it's probably not a good idea to add it either.
  */
-export type Falsy = undefined | null | 0 | "" | false;
+export type Falsy = undefined | null | 0 | '' | false;
 
 /**
  * The type of `R.find` and `R.findLast`
@@ -286,7 +286,7 @@ type Intersection<T1, T2> = Intersectable<T1, T2> extends true
 export type mergeArrWithLeft<T1 extends ReadonlyArray<any>, T2 extends ReadonlyArray<any>> = readonly [
     ...{
         readonly [Index in keyof T1]: Index extends keyof T2 ? Intersection<T1[Index], T2[Index]> : T1[Index];
-    }
+    },
 ];
 
 /**
@@ -320,7 +320,7 @@ type MergeArrays<T1 extends ReadonlyArray<any>, T2 extends ReadonlyArray<any>> =
  */
 export type LargestArgumentsList<T extends ReadonlyArray<any>> = T extends readonly [
     (...args: infer Args) => any,
-    ...infer Rest
+    ...infer Rest,
 ]
     ? MergeArrays<LargestArgumentsList<Rest>, Args>
     : readonly [];
@@ -531,6 +531,7 @@ export type ValueOfRecord<R> = R extends Record<any, infer T> ? T : never;
  * @param T The (possible) union
  */
 export type ValueOfUnion<T> = T extends infer U ? U[keyof U] : never;
+export type KeyOfUnion<T> = T extends infer U ? keyof U : never;
 
 /**
  * Take first `N` types of an Tuple


### PR DESCRIPTION
- better type inference

Previously the type were defined so that we need to provide explicit generics for mapping over values in a record. This change allow the types to be inferred instead. 

Example:

```ts
map(v => `${v}`, { a: 1, b: 3 }) // Record<"a" | "b", string>
const mapToString = map(v => `${v}`)
mapToString({ a: 1, b: 3 }) // Record<"a" | "b", string>
mapToString([1, 3]) // string[]
```

------
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).