### PR TITLE
[`object-hash`] Add `type` reference for node types

### DIFF
--- a/types/object-hash/index.d.ts
+++ b/types/object-hash/index.d.ts
@@ -5,6 +5,8 @@
 //                 Martin Badin <https://github.com/martin-badin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
 declare namespace objectHash {
     /**
      * @see https://github.com/puleos/object-hash#hashsha1value


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    Fixes the following:
    ```
    Error: node_modules/@types/object-hash/index.d.ts:109:88 - error TS2591: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.

    109 declare function objectHash(object: {} | null, options?: objectHash.WithBufferOption): Buffer;
    ```
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
