### PR TITLE
pg-cursor, the read method now returns the generic type passed to the constructor

### DIFF
--- a/types/pg-cursor/index.d.ts
+++ b/types/pg-cursor/index.d.ts
@@ -25,9 +25,9 @@ declare namespace Cursor {
 declare class Cursor<Row = any> extends EventEmitter {
     constructor(query: string, values?: any[], config?: Cursor.CursorQueryConfig);
     submit: (connection: Connection) => void;
-    read(maxRows: number): Promise<void>;
+    read(maxRows: number): Promise<Row>;
     read(maxRows: number, callback: Cursor.ResultCallback<Row>): undefined;
-    read(maxRows: number, callback?: Cursor.ResultCallback<Row>): Promise<void> | undefined;
+    read(maxRows: number, callback?: Cursor.ResultCallback<Row>): Promise<Row> | undefined;
     close(): Promise<void>;
     close(callback: (err: Error) => void): undefined;
     close(callback?: (err: Error) => void): Promise<void> | undefined;

--- a/types/pg-cursor/index.d.ts
+++ b/types/pg-cursor/index.d.ts
@@ -25,9 +25,9 @@ declare namespace Cursor {
 declare class Cursor<Row = any> extends EventEmitter {
     constructor(query: string, values?: any[], config?: Cursor.CursorQueryConfig);
     submit: (connection: Connection) => void;
-    read(maxRows: number): Promise<Row>;
+    read(maxRows: number): Promise<Row[]>;
     read(maxRows: number, callback: Cursor.ResultCallback<Row>): undefined;
-    read(maxRows: number, callback?: Cursor.ResultCallback<Row>): Promise<Row> | undefined;
+    read(maxRows: number, callback?: Cursor.ResultCallback<Row>): Promise<Row[]> | undefined;
     close(): Promise<void>;
     close(callback: (err: Error) => void): undefined;
     close(callback?: (err: Error) => void): Promise<void> | undefined;

--- a/types/pg-cursor/index.d.ts
+++ b/types/pg-cursor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pg-cursor 2.5
+// Type definitions for pg-cursor 2.7
 // Project: https://github.com/brianc/node-postgres#readme
 // Definitions by: Tiogshi Laj <https://github.com/Tiogshi>, Elias Fauser <https://github.com/elias-fauser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pg-cursor/pg-cursor-tests.ts
+++ b/types/pg-cursor/pg-cursor-tests.ts
@@ -47,9 +47,12 @@ const handleFn: ResultCallback<string> = (err: Error | undefined, rows: string[]
 handle.read(100, handleFn);
 
 // Returns promise when no callback
-handle.read(100).then(() => {
-    // Finished
-});
+handle
+    .read(100)
+    .then(rows => {
+        console.log(rows);
+    })
+    .catch(error => console.log(error.message));
 
 const customTypes: CustomTypesConfig = {
     getTypeParser: () => () => "aCustomTypeParser!",

--- a/types/pg-cursor/pg-cursor-tests.ts
+++ b/types/pg-cursor/pg-cursor-tests.ts
@@ -47,10 +47,13 @@ const handleFn: ResultCallback<string> = (err: Error | undefined, rows: string[]
 handle.read(100, handleFn);
 
 // Returns promise when no callback
-handle
+const promiseHandle = client.query(new Cursor<{ name: string }>('SELECT $1::text as name', ['brianc']));
+promiseHandle
     .read(100)
     .then(rows => {
-        console.log(rows);
+        const [row] = rows;
+        if (typeof row.name !== 'string') throw new Error('Generic type does not work');
+        return rows;
     })
     .catch(error => console.log(error.message));
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

