### PR TITLE
vexflow: add missing definitions for stave.setNumLines etc

### DIFF
--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -814,6 +814,14 @@ declare namespace Vex {
             setXShift(x: number): void; //inconsistent type: void -> Modifier
             draw(): void;
             alignSubNotesWithNote(subNotes: Note[], note: Note): void;
+            // (Modifier extends Element in vexflow, but not in these definitions, probably because of some typing problem)
+            getStyle(): { shadowColor?: string | undefined; shadowBlur?: string | undefined; fillStyle?: string | undefined; strokeStyle?: string | undefined };
+            setStyle(style: {
+                shadowColor?: string | undefined;
+                shadowBlur?: string | undefined;
+                fillStyle?: string | undefined;
+                strokeStyle?: string | undefined;
+            }): Modifier;
         }
 
         namespace Modifier {
@@ -1378,6 +1386,15 @@ declare namespace Vex {
             getPosition(): number;
             getWidth(): number;
             getPadding(index: number): number;
+
+            //  (StaveModifier extends Element in vexflow, but not in these definitions, probably because of a typing problem)
+            setStyle(style: {
+                shadowColor?: string | undefined;
+                shadowBlur?: string | undefined;
+                fillStyle?: string | undefined;
+                strokeStyle?: string | undefined;
+            }): StaveModifier;
+            getStyle(): { shadowColor?: string | undefined; shadowBlur?: string | undefined; fillStyle?: string | undefined; strokeStyle?: string | undefined };
         }
 
         namespace StaveModifier {
@@ -2004,16 +2021,8 @@ declare namespace Vex {
 
         class TimeSignature extends StaveModifier {
             //TODO remove the following lines once TypeScript allows subclass overrides with type changes
-            //  (TimeSignature extends Element in vexflow, but not in these definitions, probably because of above problem)
             addModifier(): void;
             addEndModifier(): void;
-            setStyle(style: {
-                shadowColor?: string | undefined;
-                shadowBlur?: string | undefined;
-                fillStyle?: string | undefined;
-                strokeStyle?: string | undefined;
-            }): TimeSignature;
-            getStyle(): { shadowColor?: string | undefined; shadowBlur?: string | undefined; fillStyle?: string | undefined; strokeStyle?: string | undefined };
 
             constructor(timeSpec: string, customPadding?: number);
             parseTimeSpec(timeSpec: string): { num: number; glyph: Glyph };

--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -629,6 +629,8 @@ declare namespace Vex {
             static GCD(a: number, b: number): number;
             static LCM(a: number, b: number): number;
             static LCMM(a: number, b: number): number;
+            denominator: number;
+            numerator: number;
             set(numerator: number, denominator: number): Fraction;
             value(): number;
             simplify(): Fraction;

--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -1185,12 +1185,14 @@ declare namespace Vex {
                 num_lines?: number | undefined;
                 fill_style?: string | undefined;
                 left_bar?: boolean | undefined;
+                line_config?: {visible: boolean}[];
                 right_bar?: boolean | undefined;
                 spacing_between_lines_px?: number | undefined;
                 space_above_staff_ln?: number | undefined;
                 space_below_staff_ln?: number | undefined;
                 top_text_position?: number | undefined;
             };
+            endClef: Clef;
             resetLines(): void;
             setNoteStartX(x: number): Stave;
             getNoteStartX(): number;
@@ -1201,6 +1203,7 @@ declare namespace Vex {
             getContext(): IRenderContext;
             getX(): number;
             getNumLines(): number;
+            setNumLines(lines: number): void;
             setX(x: number): Stave;
             setY(y: number): Stave;
             setWidth(width: number): Stave;
@@ -1680,6 +1683,7 @@ declare namespace Vex {
                 state: { left_shift: number; right_shift: number; text_line: number },
             ): boolean;
             string_number: number | string;
+            radius: number;
             getNote(): Note;
             setNote(note: StemmableNote): StringNumber;
             getIndex(): number;
@@ -2000,8 +2004,16 @@ declare namespace Vex {
 
         class TimeSignature extends StaveModifier {
             //TODO remove the following lines once TypeScript allows subclass overrides with type changes
+            //  (TimeSignature extends Element in vexflow, but not in these definitions, probably because of above problem)
             addModifier(): void;
             addEndModifier(): void;
+            setStyle(style: {
+                shadowColor?: string | undefined;
+                shadowBlur?: string | undefined;
+                fillStyle?: string | undefined;
+                strokeStyle?: string | undefined;
+            }): TimeSignature;
+            getStyle(): { shadowColor?: string | undefined; shadowBlur?: string | undefined; fillStyle?: string | undefined; strokeStyle?: string | undefined };
 
             constructor(timeSpec: string, customPadding?: number);
             parseTimeSpec(timeSpec: string): { num: number; glyph: Glyph };

--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -1387,7 +1387,7 @@ declare namespace Vex {
             getWidth(): number;
             getPadding(index: number): number;
 
-            //  (StaveModifier extends Element in vexflow, but not in these definitions, probably because of a typing problem)
+            // (StaveModifier extends Element in vexflow, but not in these definitions, probably because of a typing problem)
             setStyle(style: {
                 shadowColor?: string | undefined;
                 shadowBlur?: string | undefined;

--- a/types/vexflow/vexflow-tests.ts
+++ b/types/vexflow/vexflow-tests.ts
@@ -5,6 +5,24 @@ var ctx = renderer.getContext();
 // Add a treble clef and time signature
 var stave = new Vex.Flow.Stave(10, 0, 550);
 stave.setContext(ctx).addClef('treble').addKeySignature('A').addTimeSignature('4/4');
+stave.setNumLines(5);
+stave.options.line_config = [
+    { visible: true },
+    { visible: true },
+    { visible: true },
+    { visible: true },
+    { visible: true },
+];
+// TODO add test where only some lines visible
+
+// this isn't pretty, but so isn't vexflow 1's modifier typing ;)
+const timesignature: Vex.Flow.TimeSignature = stave.getModifiers(Vex.Flow.Modifier.Position.LEFT, 'timesignatures')[0] as Vex.Flow.TimeSignature;
+timesignature.setStyle({fillStyle: "#FF0000"});
+timesignature.getStyle().strokeStyle = "#FF0000";
+if (stave.endClef) {
+    stave.endClef.setPadding(5);
+}
+// TODO add test where endClef is added with addEndClef
 
 // Dotted eighth E##, sixteenth Eb, half D, quarter Cm#5
 var notes1 = [
@@ -17,6 +35,10 @@ var notes1 = [
         .addAccidental(1, new Vex.Flow.Accidental('b'))
         .addAccidental(2, new Vex.Flow.Accidental('#')),
 ];
+
+const stringnumber: Vex.Flow.StringNumber = new Vex.Flow.StringNumber(0);
+stringnumber.radius = 0; // remove the circle around the number
+notes1[1].addModifier(0, stringnumber);
 
 // Create a beam for the first two notes
 var beam = new Vex.Flow.Beam(notes1.slice(0, 2));

--- a/types/vexflow/vexflow-tests.ts
+++ b/types/vexflow/vexflow-tests.ts
@@ -65,6 +65,11 @@ var voice1 = new Vex.Flow.Voice({
     resolution: Vex.Flow.RESOLUTION,
 }).addTickables(tickable1);
 
+var fraction = new Vex.Flow.Fraction(3, 4);
+if (fraction.numerator === 3 && fraction.denominator === 4) {
+    fraction.numerator = 4;
+}
+
 // Create a second voice with just one whole note
 var voice2 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).addTickables([
     new Vex.Flow.StaveNote({ keys: ['c/4'], duration: 'w' }),

--- a/types/vexflow/vexflow-tests.ts
+++ b/types/vexflow/vexflow-tests.ts
@@ -16,9 +16,11 @@ stave.options.line_config = [
 // TODO add test where only some lines visible
 
 // this isn't pretty, but so isn't vexflow 1's modifier typing ;)
-const timesignature: Vex.Flow.TimeSignature = stave.getModifiers(Vex.Flow.Modifier.Position.LEFT, 'timesignatures')[0] as Vex.Flow.TimeSignature;
+const timesignature: Vex.Flow.StaveModifier = stave.getModifiers(Vex.Flow.Modifier.Position.LEFT, 'timesignatures')[0];
+//  could also type as TimeSignature instead of StaveModifier
 timesignature.setStyle({fillStyle: "#FF0000"});
 timesignature.getStyle().strokeStyle = "#FF0000";
+
 if (stave.endClef) {
     stave.endClef.setPadding(5);
 }
@@ -39,6 +41,8 @@ var notes1 = [
 const stringnumber: Vex.Flow.StringNumber = new Vex.Flow.StringNumber(0);
 stringnumber.radius = 0; // remove the circle around the number
 notes1[1].addModifier(0, stringnumber);
+stringnumber.setStyle({strokeStyle: "#00FF00"});
+stringnumber.getStyle().fillStyle = "#00FF00";
 
 // Create a beam for the first two notes
 var beam = new Vex.Flow.Beam(notes1.slice(0, 2));


### PR DESCRIPTION
(no changes to existing definitions, just added some missing definitions)

Tests run fine.
Builds with OSMD with vexflow 1.2.93 and a lot of `any`s removed, exactly the desired refactors.

(of course, these definitions are still for vexflow 1.2.93 / 3.0.9, as vexflow 4 is now fully typescript and doesn't need definitions)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/0xfe/vexflow/releases/tag/3.0.9
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (it doesn't)