### PR TITLE
Bugfix/60271 - Fix UIkitSwiterOptions name

### DIFF
--- a/types/uikit/index.d.ts
+++ b/types/uikit/index.d.ts
@@ -292,7 +292,7 @@ export namespace UIkit {
         svg: Promise<any>;
     };
 
-    interface UIkitSwiterOptions {
+    interface UIkitSwitcherOptions {
         connect?: string | undefined;
         toggle?: string | undefined;
         active?: number | undefined;
@@ -301,11 +301,17 @@ export namespace UIkit {
         swiping?: boolean | undefined;
     }
 
+    /**
+     * An alias for `UIkitSwitcherOptions` to support backward compatibility.
+     * @deprecated
+     */
+    type UIkitSwiterOptions = UIkitSwitcherOptions;
+
     interface UIkitSwitcherElement {
         show(index: string | number | UIkitNode): void;
     }
 
-    type Switcher = (element: UIkitElement, options?: UIkitSwiterOptions) => UIkitSwitcherElement;
+    type Switcher = (element: UIkitElement, options?: UIkitSwitcherOptions | UIkitSwiterOptions) => UIkitSwitcherElement;
 
     interface UIkitTabOptions {
         connect?: string | undefined;

--- a/types/uikit/index.d.ts
+++ b/types/uikit/index.d.ts
@@ -295,7 +295,6 @@ export namespace UIkit {
     interface UIkitSwitcherOptions {
         connect?: string | undefined;
         toggle?: string | undefined;
-        itemNav?: boolean | undefined;
         active?: number | undefined;
         animation?: string | undefined;
         duration?: number | undefined;

--- a/types/uikit/index.d.ts
+++ b/types/uikit/index.d.ts
@@ -295,6 +295,7 @@ export namespace UIkit {
     interface UIkitSwitcherOptions {
         connect?: string | undefined;
         toggle?: string | undefined;
+        itemNav?: boolean | undefined;
         active?: number | undefined;
         animation?: string | undefined;
         duration?: number | undefined;


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://getuikit.com/docs/switcher](https://getuikit.com/docs/switcher)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This fixes #60271 by:

- Renaming `UIkitSwiterOptions` to `UIkitSwitcherOptions`
- Add type alias `UIkitSwiterOptions` -> `UIkitSwitcherOptions` to maintain backwards compatibility
- Add deprecated jsdoc tag to `UIkitSwiterOptions`
- ~Add `itemNav` property to `UIkitSwitcherOptions`~

The `test-all` script is returning an error though, and I have no idea how to fix it as I don't understand what the cause is.