### PR TITLE
d3-delaunay: Fix Point and Bounds to use tuples not arrays

### DIFF
--- a/types/d3-delaunay/d3-delaunay-tests.ts
+++ b/types/d3-delaunay/d3-delaunay-tests.ts
@@ -13,10 +13,10 @@ import * as d3 from 'd3-delaunay';
 const constructedDelaunay = new d3.Delaunay([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 const defaultDelaunayFromArray: d3.Delaunay<[number, number]> = d3.Delaunay.from([[0, 0], [1, 0], [0, 1], [1, 1]]);
 const defaultDelaunayFromIterator = d3.Delaunay.from((function*() {
-    yield [0, 0];
-    yield [1, 0];
-    yield [0, 1];
-    yield [1, 1];
+    yield [0, 0] as [number, number];
+    yield [1, 0] as [number, number];
+    yield [0, 1] as [number, number];
+    yield [1, 1] as [number, number];
 })());
 const customDelaunayFromArray = d3.Delaunay.from({length: 4}, (d, i) => i & 1, (d, i) => (i >> 1) & 1);
 const customDelaunayFromIterator = d3.Delaunay.from((function*() {

--- a/types/d3-delaunay/index.d.ts
+++ b/types/d3-delaunay/index.d.ts
@@ -149,7 +149,7 @@ export namespace Delaunay {
     /**
      * A point represented as an array tuple [x, y].
      */
-    type Point = number[];
+    type Point = [number, number];
 
     /**
      * A closed polygon [[x0, y0], [x1, y1], [x2, y2], [x0, y0]] representing a triangle.
@@ -164,7 +164,7 @@ export namespace Delaunay {
     /**
      * A rectangular area [x, y, width, height].
      */
-    type Bounds = number[];
+    type Bounds = [number, number, number, number];
 
     /**
      * A function to extract a x- or y-coordinate from the specified point.


### PR DESCRIPTION
Right now they are defined as `number[]` (even though they are specific tuples) which causes errors downstream if you pass them into functions that expect `[number, number]` because of the potential for mismatched lengths.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-delaunay
