### PR TITLE
graphql-resolve-batch: add info param & remove dependency on graphql@14

### DIFF
--- a/types/graphql-resolve-batch/graphql-resolve-batch-tests.ts
+++ b/types/graphql-resolve-batch/graphql-resolve-batch-tests.ts
@@ -79,7 +79,9 @@ const withSourceAndArgsAndResultTyped = createBatchResolver<
     SomeTestSource,
     SomeTestResult,
     SomeTestArgs
->(async (sources, args, _) => {
+>(async (sources, args, _, info) => {
+    // $ExpectType GraphQLResolveInfo
+    const verifyInfo = info;
     // $ExpectType ReadonlyArray<SomeTestSource>
     const verifySources = sources;
     // $ExpectType string

--- a/types/graphql-resolve-batch/index.d.ts
+++ b/types/graphql-resolve-batch/index.d.ts
@@ -38,7 +38,8 @@ export function createBatchResolver<
 export type ResolverFunction<TSource, TArgs, TContext, TReturn> = (
     source: TSource,
     args: TArgs,
-    context: TContext
+    context: TContext,
+    info: GraphQLResolveInfo
 ) => Promise<TReturn>;
 
 /**

--- a/types/graphql-resolve-batch/index.d.ts
+++ b/types/graphql-resolve-batch/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/calebmer/graphql-resolve-batch#readme
 // Definitions by: Rutger Hendrickx <https://github.com/nayni>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 4.1
 
 import { GraphQLResolveInfo } from 'graphql';
 

--- a/types/graphql-resolve-batch/package.json
+++ b/types/graphql-resolve-batch/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "devDependencies": {
-    "graphql": "16"
+  "dependencies": {
+    "graphql": ">=14"
   }
 }

--- a/types/graphql-resolve-batch/package.json
+++ b/types/graphql-resolve-batch/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "dependencies": {
-    "graphql": "^14.5.3"
+  "devDependencies": {
+    "graphql": "16"
   }
 }

--- a/types/graphql-resolve-batch/tsconfig.json
+++ b/types/graphql-resolve-batch/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6", "esnext.asynciterable", "es2018.asyncgenerator"],
+        "lib": ["es2018"],
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/graphql-resolve-batch/tsconfig.json
+++ b/types/graphql-resolve-batch/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6", "esnext.asynciterable", "es2018.asynciterable"],
+        "lib": ["es6", "esnext.asynciterable", "es2018.asyncgenerator"],
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/graphql-resolve-batch/tsconfig.json
+++ b/types/graphql-resolve-batch/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6", "esnext.asynciterable"],
+        "lib": ["es6", "esnext.asynciterable", "es2018.asynciterable"],
         "strictFunctionTypes": true,
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
- Loosens dependency on graphql v14, which can cause incorrect types when installed with other versions
- Adds `info` field which is passed as 4th arg for a standard resolver fn

-----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/calebmer/graphql-resolve-batch/blob/c834a063b016e09b3efa21560c2213cd5af9b647/src/batch.js#L102-L106
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
