### PR TITLE
Set plugins as optional in DirectEditorProps

### DIFF
--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -690,7 +690,7 @@ export interface DirectEditorProps<S extends Schema = any> extends EditorProps<u
      * appender) will result in an error, since such plugins must be
      * present in the state to work.
      */
-    plugins: Plugin[];
+    plugins?: Plugin[];
 
     /**
      * The callback over which to send transactions (state updates)


### PR DESCRIPTION
In the last update the `plugin` property was added to `DirectEditorProps` which is very nice, but it is actually not required.
See the code [here](https://github.com/ProseMirror/prosemirror-view/blob/master/src/index.js#L33).
