### PR TITLE
[react-modal-view] Add types for react-modal-view

### DIFF
--- a/types/react-modal-view/index.d.ts
+++ b/types/react-modal-view/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for react-modal-view 1.1
+// Project: https://github.com/StevenIseki/react-modal-view
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Component, ReactNode } from 'react';
+
+export interface ModalProps {
+    /** Modal contents */
+    children?: ReactNode | undefined;
+    /** Whether or not the modal should be visible */
+    visible?: boolean | undefined;
+    /** Whether or not the modal is closable */
+    closable?: boolean | undefined;
+
+    /** Called when the modal is shown */
+    onShow?: (() => void) | undefined;
+    /** Called when the modal is hidden */
+    onHide?: (() => void) | undefined;
+}
+
+export default class Modal extends Component<ModalProps> {
+    /**
+     * Doesn't seem to be used anywhere.
+     * Not actually assignable to ModalProps
+     */
+    static get defaultProps(): { type: 'notice'; message: null };
+
+    handleBeforeComponentUpdate(props: ModalProps): void;
+
+    handleComponentUpdate(prevProps: ModalProps, prevState: { visible: boolean }): void;
+
+    handleCloseBtnClick(e: MouseEvent): void;
+
+    handleOverlayClick(e: MouseEvent): void;
+
+    toggleVisibility(): void;
+
+    show(): void;
+
+    hide(): void;
+}

--- a/types/react-modal-view/react-modal-view-tests.tsx
+++ b/types/react-modal-view/react-modal-view-tests.tsx
@@ -1,0 +1,13 @@
+import Modal from 'react-modal-view';
+
+<Modal />;
+
+<Modal>
+    <p>Hello, World!</p>
+</Modal>;
+
+const emptyCallback = () => {};
+
+<Modal visible closable onShow={emptyCallback} onHide={emptyCallback}>
+    <p>Hello, World!</p>
+</Modal>;

--- a/types/react-modal-view/tsconfig.json
+++ b/types/react-modal-view/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": ["es6"],
-        "jsx": "react-jsx",
+        "jsx": "preserve",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/react-modal-view/tsconfig.json
+++ b/types/react-modal-view/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "jsx": "react-jsx",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "react-modal-view-tests.tsx"]
+}

--- a/types/react-modal-view/tslint.json
+++ b/types/react-modal-view/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Related discussion: #60254

Adds types for the npm package react-modal-view.

npm: <https://www.npmjs.com/package/react-modal-view>
GitHub: <https://github.com/StevenIseki/react-modal-view>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test react-modal-view`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
