### PR TITLE
[@types/react-table] Include column on FooterProps

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -319,7 +319,9 @@ export type HeaderProps<D extends object> = TableInstance<D> & {
     column: ColumnInstance<D>;
 };
 
-export type FooterProps<D extends object> = TableInstance<D> & {};
+export type FooterProps<D extends object> = TableInstance<D> & {
+    column: ColumnInstance<D>;
+};
 
 export type CellProps<D extends object, V = any> = TableInstance<D> & {
     column: ColumnInstance<D>;

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -65,33 +65,43 @@ export interface ColumnGroupInterface<D extends object> {
     columns: Array<Column<D>>;
 }
 
-export type ColumnGroup<D extends object = {}> = ColumnInterface<D> &
-    ColumnGroupInterface<D> &
-    (
-        | { Header: string }
-        | ({ id: IdType<D> } & {
-              Header: Renderer<HeaderProps<D>>;
-          })
-    ) & // Not used, but needed for backwards compatibility
-    { accessor?: Accessor<D> | undefined };
+export type ColumnGroup<D extends object = {}> =
+    & ColumnInterface<D>
+    & ColumnGroupInterface<D>
+    & (
+        | { Header: string; }
+        | ({ id: IdType<D>; } & {
+            Header: Renderer<HeaderProps<D>>;
+        })
+    )
+    // Not used, but needed for backwards compatibility
+    & { accessor?: Accessor<D> | undefined; };
 
 type ValueOf<T> = T[keyof T];
 
 // The accessors like `foo.bar` are not supported, use functions instead
-export type ColumnWithStrictAccessor<D extends object = {}> = ColumnInterface<D> &
-    ValueOf<{
+export type ColumnWithStrictAccessor<D extends object = {}> =
+    & ColumnInterface<D>
+    & ValueOf<{
         [K in keyof D]: {
             accessor: K;
         } & ColumnInterfaceBasedOnValue<D, D[K]>;
     }>;
 
-export type ColumnWithLooseAccessor<D extends object = {}> = ColumnInterface<D> &
-    ColumnInterfaceBasedOnValue<D> &
-    ({ Header: string } | { id: IdType<D> } | { accessor: keyof D extends never ? IdType<D> : never }) & {
-        accessor?: (keyof D extends never ? IdType<D> | Accessor<D> : Accessor<D>) | undefined;
-    };
+export type ColumnWithLooseAccessor<D extends object = {}> =
+    & ColumnInterface<D>
+    & ColumnInterfaceBasedOnValue<D>
+    & (
+        | { Header: string }
+        | { id: IdType<D> }
+        | { accessor: keyof D extends never ? IdType<D> : never }
+    )
+    & { accessor?: (keyof D extends never ? IdType<D> | Accessor<D> : Accessor<D>) | undefined; };
 
-export type Column<D extends object = {}> = ColumnGroup<D> | ColumnWithLooseAccessor<D> | ColumnWithStrictAccessor<D>;
+export type Column<D extends object = {}> =
+    | ColumnGroup<D>
+    | ColumnWithLooseAccessor<D>
+    | ColumnWithStrictAccessor<D>;
 
 export interface ColumnInstance<D extends object = {}>
     extends Omit<ColumnInterface<D>, 'id'>,
@@ -159,12 +169,7 @@ export type UseTableOptions<D extends object> = {
     data: readonly D[];
 } & Partial<{
     initialState: Partial<TableState<D>>;
-    stateReducer: (
-        newState: TableState<D>,
-        action: ActionType,
-        previousState: TableState<D>,
-        instance?: TableInstance<D>,
-    ) => TableState<D>;
+    stateReducer: (newState: TableState<D>, action: ActionType, previousState: TableState<D>, instance?: TableInstance<D>) => TableState<D>;
     useControlledState: (state: TableState<D>, meta: Meta<D>) => TableState<D>;
     defaultColumn: Partial<Column<D>>;
     getSubRows: (originalRow: D, relativeIndex: number) => D[];
@@ -798,7 +803,7 @@ export namespace useSortBy {
 export interface TableSortByToggleProps {
     title?: string | undefined;
     style?: CSSProperties | undefined;
-    onClick?: ((e: MouseEvent) => void) | undefined;
+    onClick?: ((e: MouseEvent) => void)| undefined;
 }
 
 export type UseSortByOptions<D extends object> = Partial<{

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -65,43 +65,33 @@ export interface ColumnGroupInterface<D extends object> {
     columns: Array<Column<D>>;
 }
 
-export type ColumnGroup<D extends object = {}> =
-    & ColumnInterface<D>
-    & ColumnGroupInterface<D>
-    & (
-        | { Header: string; }
-        | ({ id: IdType<D>; } & {
-            Header: Renderer<HeaderProps<D>>;
-        })
-    )
-    // Not used, but needed for backwards compatibility
-    & { accessor?: Accessor<D> | undefined; };
+export type ColumnGroup<D extends object = {}> = ColumnInterface<D> &
+    ColumnGroupInterface<D> &
+    (
+        | { Header: string }
+        | ({ id: IdType<D> } & {
+              Header: Renderer<HeaderProps<D>>;
+          })
+    ) & // Not used, but needed for backwards compatibility
+    { accessor?: Accessor<D> | undefined };
 
 type ValueOf<T> = T[keyof T];
 
 // The accessors like `foo.bar` are not supported, use functions instead
-export type ColumnWithStrictAccessor<D extends object = {}> =
-    & ColumnInterface<D>
-    & ValueOf<{
+export type ColumnWithStrictAccessor<D extends object = {}> = ColumnInterface<D> &
+    ValueOf<{
         [K in keyof D]: {
             accessor: K;
         } & ColumnInterfaceBasedOnValue<D, D[K]>;
     }>;
 
-export type ColumnWithLooseAccessor<D extends object = {}> =
-    & ColumnInterface<D>
-    & ColumnInterfaceBasedOnValue<D>
-    & (
-        | { Header: string }
-        | { id: IdType<D> }
-        | { accessor: keyof D extends never ? IdType<D> : never }
-    )
-    & { accessor?: (keyof D extends never ? IdType<D> | Accessor<D> : Accessor<D>) | undefined; };
+export type ColumnWithLooseAccessor<D extends object = {}> = ColumnInterface<D> &
+    ColumnInterfaceBasedOnValue<D> &
+    ({ Header: string } | { id: IdType<D> } | { accessor: keyof D extends never ? IdType<D> : never }) & {
+        accessor?: (keyof D extends never ? IdType<D> | Accessor<D> : Accessor<D>) | undefined;
+    };
 
-export type Column<D extends object = {}> =
-    | ColumnGroup<D>
-    | ColumnWithLooseAccessor<D>
-    | ColumnWithStrictAccessor<D>;
+export type Column<D extends object = {}> = ColumnGroup<D> | ColumnWithLooseAccessor<D> | ColumnWithStrictAccessor<D>;
 
 export interface ColumnInstance<D extends object = {}>
     extends Omit<ColumnInterface<D>, 'id'>,
@@ -169,7 +159,12 @@ export type UseTableOptions<D extends object> = {
     data: readonly D[];
 } & Partial<{
     initialState: Partial<TableState<D>>;
-    stateReducer: (newState: TableState<D>, action: ActionType, previousState: TableState<D>, instance?: TableInstance<D>) => TableState<D>;
+    stateReducer: (
+        newState: TableState<D>,
+        action: ActionType,
+        previousState: TableState<D>,
+        instance?: TableInstance<D>,
+    ) => TableState<D>;
     useControlledState: (state: TableState<D>, meta: Meta<D>) => TableState<D>;
     defaultColumn: Partial<Column<D>>;
     getSubRows: (originalRow: D, relativeIndex: number) => D[];
@@ -803,7 +798,7 @@ export namespace useSortBy {
 export interface TableSortByToggleProps {
     title?: string | undefined;
     style?: CSSProperties | undefined;
-    onClick?: ((e: MouseEvent) => void)| undefined;
+    onClick?: ((e: MouseEvent) => void) | undefined;
 }
 
 export type UseSortByOptions<D extends object> = Partial<{

--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -64,6 +64,7 @@ import {
     UseSortByState,
     useTable,
     defaultOrderByFn,
+    FooterProps,
 } from 'react-table';
 
 // test heavily based up https://github.com/tannerlinsley/react-table/blob/master/examples/kitchen-sink-controlled/src/App.js
@@ -357,6 +358,7 @@ function Table({ columns, data, updateMyData, skipPageReset = false }: Table<Dat
         getTableProps,
         getTableBodyProps,
         headerGroups,
+        footerGroups,
         prepareRow,
         page, // Instead of using 'rows', we'll use page,
         // which has only the rows for the active page
@@ -503,6 +505,17 @@ function Table({ columns, data, updateMyData, skipPageReset = false }: Table<Dat
                         );
                     })}
                 </tbody>
+                <tfoot>
+                    {footerGroups.map((footerGroup) => (
+                        <tr {...footerGroup.getFooterGroupProps()}>
+                            {footerGroup.headers.map((column) => (
+                                <td {...column.getFooterProps()}>
+                                    {column.render('Footer')}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tfoot>
             </table>
             {/*
         Pagination can be built however you'd like.
@@ -652,6 +665,9 @@ const Component = (props: {}) => {
                         const v = value; // $ExpectType string
                         return <>{value}</>;
                     },
+                    Footer: ({column}: FooterProps<Data>) => {
+                        return <>{column.id}</>;
+                    }
                 },
                 {
                     Header: 'Last Name',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [LOC in package that demonstrates that `column` is always included in renderers](https://github.com/TanStack/react-table/blob/02a4b0d3f6813a62f9fc84f7c1947e42f585adb2/src/publicUtils.js#L208)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


As shown in the link above, the `column` is always included in renderers for Header, Footer, and Cell, but it was omitted in FooterProps previously. This fixes that issue. I have tested this in my own code that creates custom footer renderers and needs access to `column`.