### PR TITLE
oidc-provider - Add revokeGrantPolicy Configuration interface

### DIFF
--- a/types/oidc-provider/index.d.ts
+++ b/types/oidc-provider/index.d.ts
@@ -1121,7 +1121,7 @@ export interface Configuration {
     jwks?: JWKS | undefined;
 
     responseTypes?: ResponseType[] | undefined;
-    
+
     revokeGrantPolicy?: ((ctx: KoaContextWithOIDC) => boolean) | undefined;
 
     pkce?: {

--- a/types/oidc-provider/index.d.ts
+++ b/types/oidc-provider/index.d.ts
@@ -1121,6 +1121,8 @@ export interface Configuration {
     jwks?: JWKS | undefined;
 
     responseTypes?: ResponseType[] | undefined;
+    
+    revokeGrantPolicy?: ((ctx: KoaContextWithOIDC) => boolean) | undefined;
 
     pkce?: {
         methods: PKCEMethods[];


### PR DESCRIPTION
Add revokeGrantPolicy Configuration interface to oidc-provider package

Changing an existing definition:
URL to documentation or source code which provides context for the suggested changes: [url here](https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#revokegrantpolicy)
@panva 