### PR TITLE
[@types/react-native] Add Android Bluetooth Permissions 

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7798,7 +7798,10 @@ export type Permission =
     | 'android.permission.RECEIVE_WAP_PUSH'
     | 'android.permission.RECEIVE_MMS'
     | 'android.permission.READ_EXTERNAL_STORAGE'
-    | 'android.permission.WRITE_EXTERNAL_STORAGE';
+    | 'android.permission.WRITE_EXTERNAL_STORAGE'
+    | 'android.permission.BLUETOOTH_CONNECT'
+    | 'android.permission.BLUETOOTH_SCAN'
+    | 'android.permission.BLUETOOTH_ADVERTISE';
 
 export type PermissionStatus = 'granted' | 'denied' | 'never_ask_again';
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1536,6 +1536,37 @@ const PermissionsAndroidTest = () => {
                 break;
         }
     });
+
+    PermissionsAndroid.requestMultiple([
+        'android.permission.BLUETOOTH_SCAN',
+        'android.permission.BLUETOOTH_CONNECT',
+        'android.permission.BLUETOOTH_ADVERTISE'
+    ]).then(results => {
+        switch (results['android.permission.BLUETOOTH_SCAN']) {
+            case 'granted':
+                break;
+            case 'denied':
+                break;
+            case 'never_ask_again':
+                break;
+        }
+        switch (results['android.permission.BLUETOOTH_CONNECT']) {
+            case 'granted':
+                break;
+            case 'denied':
+                break;
+            case 'never_ask_again':
+                break;
+        }
+        switch (results['android.permission.BLUETOOTH_ADVERTISE']) {
+            case 'granted':
+                break;
+            case 'denied':
+                break;
+            case 'never_ask_again':
+                break;
+        }
+    });
 };
 
 // Platform


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [RN PermissionsAndroid](https://reactnative.dev/docs/0.66/permissionsandroid)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

# Add Missing Android Bluetooth Permissions
 - This PR is to add missing permissions for android. Bluetooth permissions were added to RN version 0.66, and android 12 will now require explicitly asking for [bluetooth permissions](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions). 


