### PR TITLE
[lost] Add types for lost

### DIFF
--- a/types/lost/index.d.ts
+++ b/types/lost/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for lost 8.3
+// Project: https://github.com/peterramsing/lost
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Container, PluginCreator, Result } from 'postcss';
+
+declare namespace lost {
+    interface Settings {
+        /** @default '30px' */
+        gutter?: string | undefined;
+        /** @default 'no-flex' */
+        flexbox?: string | undefined;
+        /** @default 'auto' */
+        cycle?: string | undefined;
+        /** @default 'both' */
+        clearing?: string | undefined;
+        /** @default 99.9 */
+        rounder?: number | undefined;
+        /** @default '%' */
+        gridUnit?: string | undefined;
+        /** @default 'ltr' */
+        direction?: 'ltr' | 'rtl' | undefined;
+    }
+
+    // These are used in the files under `lib/`
+    // They all include the parameters for settings and result even when they're not used,
+    // since the library's main file passes all 3 parameters to all of them
+
+    /** Lib function that requires css and settings params */
+    type LostLib<R = void> = (css: Container, settings: Settings, _result?: Result) => R;
+    /** Lib function that only requires css param */
+    type LostLibNoSettings<R = void> = (css: Container, _settings?: Settings, _result?: Result) => R;
+    /** Lib function that requires css, settings, and result params */
+    type LostLibResult<R = void> = (css: Container, settings: Settings, result: Result) => R;
+}
+
+declare var lost: PluginCreator<lost.Settings>;
+
+export = lost;

--- a/types/lost/lib/lg-gutter.d.ts
+++ b/types/lost/lib/lg-gutter.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lgGutter: LostLib;
+export = lgGutter;

--- a/types/lost/lib/lost-align.d.ts
+++ b/types/lost/lib/lost-align.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostAlign: LostLib;
+export = lostAlign;

--- a/types/lost/lib/lost-at-rule.d.ts
+++ b/types/lost/lib/lost-at-rule.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostAtRule: LostLib;
+export = lostAtRule;

--- a/types/lost/lib/lost-center.d.ts
+++ b/types/lost/lib/lost-center.d.ts
@@ -1,0 +1,3 @@
+import { LostLibResult } from '../';
+declare var lostCenter: LostLibResult<boolean>;
+export = lostCenter;

--- a/types/lost/lib/lost-column.d.ts
+++ b/types/lost/lib/lost-column.d.ts
@@ -1,0 +1,3 @@
+import { LostLibResult } from '../';
+declare var lostColumn: LostLibResult;
+export = lostColumn;

--- a/types/lost/lib/lost-flex-container.d.ts
+++ b/types/lost/lib/lost-flex-container.d.ts
@@ -1,0 +1,3 @@
+import { LostLibNoSettings } from '../';
+declare var lostFlexContainer: LostLibNoSettings;
+export = lostFlexContainer;

--- a/types/lost/lib/lost-gutter.d.ts
+++ b/types/lost/lib/lost-gutter.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostGutter: LostLib;
+export = lostGutter;

--- a/types/lost/lib/lost-gutter.d.ts
+++ b/types/lost/lib/lost-gutter.d.ts
@@ -1,3 +1,0 @@
-import { LostLib } from '../';
-declare var lostGutter: LostLib;
-export = lostGutter;

--- a/types/lost/lib/lost-masonry-column.d.ts
+++ b/types/lost/lib/lost-masonry-column.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostMasonryColumn: LostLib;
+export = lostMasonryColumn;

--- a/types/lost/lib/lost-masonry-wrap.d.ts
+++ b/types/lost/lib/lost-masonry-wrap.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostMasonryWrap: LostLib;
+export = lostMasonryWrap;

--- a/types/lost/lib/lost-move.d.ts
+++ b/types/lost/lib/lost-move.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostMove: LostLib;
+export = lostMove;

--- a/types/lost/lib/lost-offset.d.ts
+++ b/types/lost/lib/lost-offset.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostOffset: LostLib;
+export = lostOffset;

--- a/types/lost/lib/lost-row.d.ts
+++ b/types/lost/lib/lost-row.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostRow: LostLib;
+export = lostRow;

--- a/types/lost/lib/lost-utility.d.ts
+++ b/types/lost/lib/lost-utility.d.ts
@@ -1,0 +1,3 @@
+import { LostLibNoSettings } from '../';
+declare var lostUtility: LostLibNoSettings;
+export = lostUtility;

--- a/types/lost/lib/lost-vars-gutter-local.d.ts
+++ b/types/lost/lib/lost-vars-gutter-local.d.ts
@@ -1,0 +1,3 @@
+import { LostLib, Settings } from '../';
+declare var lostVarsGutterLocal: LostLib<Settings['gutter']>;
+export = lostVarsGutterLocal;

--- a/types/lost/lib/lost-vars-gutter.d.ts
+++ b/types/lost/lib/lost-vars-gutter.d.ts
@@ -1,0 +1,3 @@
+import { LostLib, Settings } from '../';
+declare var lostVarsGutter: LostLib<Settings['gutter']>;
+export = lostVarsGutter;

--- a/types/lost/lib/lost-vars.d.ts
+++ b/types/lost/lib/lost-vars.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostVars: LostLib;
+export = lostVars;

--- a/types/lost/lib/lost-waffle.d.ts
+++ b/types/lost/lib/lost-waffle.d.ts
@@ -1,0 +1,3 @@
+import { LostLib } from '../';
+declare var lostWaffle: LostLib;
+export = lostWaffle;

--- a/types/lost/lib/new-block.d.ts
+++ b/types/lost/lib/new-block.d.ts
@@ -1,0 +1,3 @@
+import { Container } from 'postcss';
+declare function newBlock(decl: Container, selector: string, props: string[], values: string[]): void;
+export = newBlock;

--- a/types/lost/lost-tests.ts
+++ b/types/lost/lost-tests.ts
@@ -1,0 +1,53 @@
+import postcss, { Result } from 'postcss';
+import lostgrid = require('lost');
+
+const css = 'div { lost-column: 1/3 }';
+postcss([lostgrid]).process(css);
+
+// Make sure that all lib functions exist
+import lostAlign = require('lost/lib/lost-align');
+import lostAtRule = require('lost/lib/lost-at-rule');
+import lostCenter = require('lost/lib/lost-center');
+import lostColumn = require('lost/lib/lost-column');
+import lostFlexContainer = require('lost/lib/lost-flex-container');
+import lostGutter = require('lost/lib/lost-gutter');
+import lostMasonryColumn = require('lost/lib/lost-masonry-column');
+import lostMasonryWrap = require('lost/lib/lost-masonry-wrap');
+import lostMove = require('lost/lib/lost-move');
+import lostOffset = require('lost/lib/lost-offset');
+import lostRow = require('lost/lib/lost-row');
+import lostUtility = require('lost/lib/lost-utility');
+import lostVarsGutterLocal = require('lost/lib/lost-vars-gutter-local');
+import lostVarsGutter = require('lost/lib/lost-vars-gutter');
+import lostVars = require('lost/lib/lost-vars');
+import lostWaffle = require('lost/lib/lost-waffle');
+import newBlock = require('lost/lib/new-block');
+
+const libs = [
+    lostAlign,
+    lostAtRule,
+    lostCenter,
+    lostColumn,
+    lostFlexContainer,
+    lostGutter,
+    lostMasonryColumn,
+    lostMasonryWrap,
+    lostMove,
+    lostOffset,
+    lostRow,
+    lostUtility,
+    lostVarsGutterLocal,
+    lostVarsGutter,
+    lostVars,
+    lostWaffle,
+];
+
+const root = postcss.root();
+declare const result: Result;
+
+newBlock(root, '*', ['a', 'b', 'c'], ['d', 'e', 'f']);
+
+// Test that libs can be passed all 3 arguments
+for (const lib of libs) {
+    lib(root, {}, result);
+}

--- a/types/lost/lost-tests.ts
+++ b/types/lost/lost-tests.ts
@@ -4,13 +4,13 @@ import lostgrid = require('lost');
 const css = 'div { lost-column: 1/3 }';
 postcss([lostgrid]).process(css);
 
-// Make sure that all lib functions exist
+// Import all lib functions
 import lostAlign = require('lost/lib/lost-align');
 import lostAtRule = require('lost/lib/lost-at-rule');
 import lostCenter = require('lost/lib/lost-center');
 import lostColumn = require('lost/lib/lost-column');
 import lostFlexContainer = require('lost/lib/lost-flex-container');
-import lostGutter = require('lost/lib/lost-gutter');
+import lgGutter = require('lost/lib/lg-gutter');
 import lostMasonryColumn = require('lost/lib/lost-masonry-column');
 import lostMasonryWrap = require('lost/lib/lost-masonry-wrap');
 import lostMove = require('lost/lib/lost-move');
@@ -29,7 +29,7 @@ const libs = [
     lostCenter,
     lostColumn,
     lostFlexContainer,
-    lostGutter,
+    lgGutter,
     lostMasonryColumn,
     lostMasonryWrap,
     lostMove,

--- a/types/lost/package.json
+++ b/types/lost/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.1.4"
+    }
+}

--- a/types/lost/tsconfig.json
+++ b/types/lost/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "ES2018.Promise"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "lost-tests.ts"]
+}

--- a/types/lost/tslint.json
+++ b/types/lost/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Adds types for the npm package `lost`, a PostCSS plugin.

npm: <https://www.npmjs.com/package/lost>
GitHub: <https://github.com/peterramsing/lost/tree/v8.3.1>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test lost`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
