### PR TITLE
[google-spreadsheet] Add missing optional argument

### DIFF
--- a/types/google-spreadsheet/google-spreadsheet-tests.ts
+++ b/types/google-spreadsheet/google-spreadsheet-tests.ts
@@ -9,10 +9,13 @@ const [GOOGLE_SERVICE_ACCOUNT_EMAIL, GOOGLE_PRIVATE_KEY] = ['email', 'key'];
     const doc = new GoogleSpreadsheet('<the sheet ID from the url>');
 
     // use service account creds
-    await doc.useServiceAccountAuth({
-        client_email: GOOGLE_SERVICE_ACCOUNT_EMAIL,
-        private_key: GOOGLE_PRIVATE_KEY,
-    });
+    await doc.useServiceAccountAuth(
+        {
+            client_email: GOOGLE_SERVICE_ACCOUNT_EMAIL,
+            private_key: GOOGLE_PRIVATE_KEY,
+        },
+        'user@example.com',
+    );
     // OR use API key -- only for read-only access to public sheets
     doc.useApiKey('YOUR-API-KEY');
 

--- a/types/google-spreadsheet/index.d.ts
+++ b/types/google-spreadsheet/index.d.ts
@@ -1115,7 +1115,7 @@ export class GoogleSpreadsheet implements SpreadsheetBasicProperties {
      *
      * // doc is ready to be used
      */
-    useServiceAccountAuth(credentials: ServiceAccountCredentials, impersonateAs?: string): Promise<void>;
+    useServiceAccountAuth(credentials: ServiceAccountCredentials, impersonateAs?: string | null): Promise<void>;
 
     /**
      * @description

--- a/types/google-spreadsheet/index.d.ts
+++ b/types/google-spreadsheet/index.d.ts
@@ -1100,6 +1100,9 @@ export class GoogleSpreadsheet implements SpreadsheetBasicProperties {
      * @param credentials object of Google Service Account credentials
      * - import by requiring the JSON file Google supplies
      *
+     * @param impersonateAs an email of any user in the G Suite domain
+     * - only works if service account has domain-wide delegation enabled
+     *
      * @example
      * const credentials = require("./credentials.json");
      * const { GoogleSpreadsheet } = require("google-spreadsheet");
@@ -1112,7 +1115,7 @@ export class GoogleSpreadsheet implements SpreadsheetBasicProperties {
      *
      * // doc is ready to be used
      */
-    useServiceAccountAuth(credentials: ServiceAccountCredentials): Promise<void>;
+    useServiceAccountAuth(credentials: ServiceAccountCredentials, impersonateAs?: string): Promise<void>;
 
     /**
      * @description


### PR DESCRIPTION
Added second optional argument `impersonateAs` to `useServiceAccountAuth` method of `GoogleSpreadsheet` class.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    https://github.com/theoephraim/node-google-spreadsheet/blob/60c53dc609d837b2838f2717b5a62349932b313b/lib/GoogleSpreadsheet.js#L97-L100