### PR TITLE
[@types/chrome] Deprecate and add replacements for domains and excludedDomains

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11545,6 +11545,8 @@ declare namespace chrome.declarativeNetRequest {
         domainType?: DomainType | undefined;
 
         /**
+         * @deprecated since Chrome 101. Use initiatorDomains instead.
+
          * The rule will only match network requests originating from the list of domains.
          * If the list is omitted, the rule is applied to requests from all domains.
          * An empty list is not allowed.
@@ -11558,6 +11560,8 @@ declare namespace chrome.declarativeNetRequest {
         domains?: string[] | undefined;
 
         /**
+         * @deprecated since Chrome 101. Use excludedInitiatorDomains instead
+         *
          * The rule will not match network requests originating from the list of excludedDomains.
          * If the list is empty or omitted, no domains are excluded.
          * This takes precedence over domains.
@@ -11569,6 +11573,56 @@ declare namespace chrome.declarativeNetRequest {
          * This matches against the request initiator and not the request url.
          */
         excludedDomains?: string[] | undefined;
+
+        /**
+         * The rule will only match network requests originating from the list of initiatorDomains.
+         * If the list is omitted, the rule is applied to requests from all domains.
+         * An empty list is not allowed.
+         *
+         * Notes:
+         * Sub-domains like "a.example.com" are also allowed.
+         * The entries must consist of only ascii characters.
+         * Use punycode encoding for internationalized domains.
+         * This matches against the request initiator and not the request url.
+         */
+        initiatorDomains?: string[] | undefined;
+
+        /**
+         * The rule will not match network requests originating from the list of excludedInitiatorDomains.
+         * If the list is empty or omitted, no domains are excluded.
+         * This takes precedence over initiatorDomains.
+         *
+         * Notes:
+         * Sub-domains like "a.example.com" are also allowed.
+         * The entries must consist of only ascii characters.
+         * Use punycode encoding for internationalized domains.
+         * This matches against the request initiator and not the request url.
+         */
+        excludedInitiatorDomains?: string[] | undefined;
+
+        /**
+         * The rule will only match network requests when the domain matches one from the list of requestDomains.
+         * If the list is omitted, the rule is applied to requests from all domains.
+         * An empty list is not allowed.
+         *
+         * Notes:
+         * Sub-domains like "a.example.com" are also allowed.
+         * The entries must consist of only ascii characters.
+         * Use punycode encoding for internationalized domains.
+         */
+        requestDomains?: string[] | undefined;
+
+        /**
+         * The rule will not match network requests when the domains matches one from the list of excludedRequestDomains.
+         * If the list is empty or omitted, no domains are excluded.
+         * This takes precedence over requestDomains.
+         *
+         * Notes:
+         * Sub-domains like "a.example.com" are also allowed.
+         * The entries must consist of only ascii characters.
+         * Use punycode encoding for internationalized domains.
+         */
+        excludedRequestDomains?: string[] | undefined;
 
         /**
          * List of request methods which the rule won't match.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1103,7 +1103,7 @@ async function testDynamicRules() {
           type: chrome.declarativeNetRequest.RuleActionType.ALLOW,
         },
         condition: {
-            domains: ["www.example.com"],
+            initiatorDomains: ["www.example.com"],
             tabIds: [2, 3, 76],
         },
         id: 2,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
 
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#type-RuleCondition

`domains` and `excludedDomains` have been deprecated, replacements are `initiatorDomains`, `excludedInitiatorDomains`, `requestDomains` and `excludedRequestDomains`.