### PR TITLE
[postcss-mixins] Add types for postcss-mixins

### DIFF
--- a/types/postcss-mixins/index.d.ts
+++ b/types/postcss-mixins/index.d.ts
@@ -36,7 +36,10 @@ declare namespace postcssMixins {
      */
     type Mixin = MixinFn | MixinObj;
     type MixinFn = (mixin: Container, ...args: string[]) => MixinObj | void;
-    type MixinObj = Record<string, Record<string, any>>;
+    // The Exclude here is meant to make sure that you can't assign invalid functions to MixinObj,
+    // which is possible with Record<string, any>
+    // tslint:disable-next-line:ban-types
+    type MixinObj = Record<string, Exclude<Object, Function>>;
 }
 
 declare var postcssMixins: PluginCreator<postcssMixins.Options>;

--- a/types/postcss-mixins/index.d.ts
+++ b/types/postcss-mixins/index.d.ts
@@ -35,7 +35,7 @@ declare namespace postcssMixins {
      * A mixin, either a function or an object
      */
     type Mixin = MixinFn | MixinObj;
-    type MixinFn = (mixin: Container, ...args: string[]) => Record<string, any> | void;
+    type MixinFn = (mixin: Container, ...args: string[]) => MixinObj | void;
     type MixinObj = Record<string, Record<string, any>>;
 }
 

--- a/types/postcss-mixins/index.d.ts
+++ b/types/postcss-mixins/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for postcss-mixins 9.0
+// Project: https://github.com/postcss/postcss-mixins
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Container, PluginCreator } from 'postcss';
+
+declare namespace postcssMixins {
+    interface Options {
+        /**
+         * Define mixins in code instead of with CSS.
+         *
+         * For functions: the first parameter is the mixin rule,
+         * and all others are parameters passed to the mixin.
+         */
+        mixins?: Record<string, Mixin> | undefined;
+        /**
+         * Autoload all mixins from one or more dirs.
+         * Mixin name will be taken from file name.
+         */
+        mixinsDir?: string | string[] | undefined;
+        /**
+         * Similar to mixinsDir, except you can provide fast-glob syntax
+         * to target or not to target specific files.
+         */
+        mixinsFiles?: string | string[] | undefined;
+        /**
+         * Remove unknown mixins instead of throwing an error.
+         * Off by default.
+         */
+        silent?: boolean | undefined;
+    }
+
+    /**
+     * A mixin, either a function or an object
+     */
+    type Mixin = MixinFn | MixinObj;
+    type MixinFn = (mixin: Container, ...args: string[]) => Record<string, any> | void;
+    type MixinObj = Record<string, Record<string, any>>;
+}
+
+declare var postcssMixins: PluginCreator<postcssMixins.Options>;
+
+export = postcssMixins;

--- a/types/postcss-mixins/package.json
+++ b/types/postcss-mixins/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.2.14"
+    }
+}

--- a/types/postcss-mixins/postcss-mixins-tests.ts
+++ b/types/postcss-mixins/postcss-mixins-tests.ts
@@ -1,0 +1,49 @@
+import postcss from 'postcss';
+import postcssMixins = require('postcss-mixins');
+
+// Using with postcss with and without config
+postcss([postcssMixins]);
+postcss([postcssMixins()]);
+postcss([postcssMixins({})]);
+
+// Defining mixins
+postcssMixins({
+    mixins: {
+        // Modfifying the mixin directly
+        mixinFn1(mixin, arg1, arg2) {
+            arg1; // $ExpectType string
+            arg2; // $ExpectType string
+
+            const rule = postcss.rule();
+            rule.append(mixin.nodes);
+            mixin.replaceWith(rule);
+        },
+
+        // Returning new nodes
+        mixinFn2(_mixin, color) {
+            return {
+                '&:hover': { color },
+            };
+        },
+
+        // $ExpectError
+        invalidFn() {
+            return 1234;
+        },
+
+        // Mixin object
+        mixinObj: {
+            '&:hover': {
+                color: 'red',
+            },
+        },
+    },
+});
+
+postcssMixins({ mixinsDir: './mixins' });
+postcssMixins({ mixinsDir: ['./mixins'] });
+
+postcssMixins({ mixinsFiles: './mixins/!(*.spec.js)' });
+postcssMixins({ mixinsFiles: ['./mixins/!(*.spec.js)'] });
+
+postcssMixins({ silent: true });

--- a/types/postcss-mixins/postcss-mixins-tests.ts
+++ b/types/postcss-mixins/postcss-mixins-tests.ts
@@ -22,6 +22,7 @@ postcssMixins({
         // Returning new nodes
         mixinFn2(_mixin, color) {
             return {
+                top: 10,
                 '&:hover': { color },
             };
         },
@@ -33,9 +34,8 @@ postcssMixins({
 
         // Mixin object
         mixinObj: {
-            '&:hover': {
-                color: 'red',
-            },
+            top: 10,
+            '&:hover': { color: 'red' },
         },
     },
 });

--- a/types/postcss-mixins/tsconfig.json
+++ b/types/postcss-mixins/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "ES2018.Promise"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "postcss-mixins-tests.ts"]
+}

--- a/types/postcss-mixins/tslint.json
+++ b/types/postcss-mixins/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Adds types for the npm package `postcss-mixins`.

npm: <https://www.npmjs.com/package/postcss-mixins>
GitHub: <https://github.com/postcss/postcss-mixins>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test postcss-mixins`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
