### PR TITLE
Updates and additions to WebXR types, with Layers and Multiview Extension

### DIFF
--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -13,43 +13,43 @@
 //  https://github.com/immersive-web
 //
 
-export interface Navigator {
+interface Navigator {
     xr?: XRSystem | undefined;
 }
 
 /**
  * Available session modes
  */
-export type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
+type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
 
 /**
  * Reference space types
  */
-export type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor' | 'unbounded';
+type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor' | 'unbounded';
 
-export type XREnvironmentBlendMode = 'opaque' | 'additive' | 'alpha-blend';
+type XREnvironmentBlendMode = 'opaque' | 'additive' | 'alpha-blend';
 
-export type XRVisibilityState = 'visible' | 'visible-blurred' | 'hidden';
+type XRVisibilityState = 'visible' | 'visible-blurred' | 'hidden';
 
 /**
  * Handedness types
  */
-export type XRHandedness = 'none' | 'left' | 'right';
+type XRHandedness = 'none' | 'left' | 'right';
 
 /**
  * InputSource target ray modes
  */
-export type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
+type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
 
 /**
  * Eye types
  */
-export type XREye = 'none' | 'left' | 'right';
+type XREye = 'none' | 'left' | 'right';
 
 /**
  * Type of XR events available
  */
-export type XREventType =
+type XREventType =
     | 'devicechange'
     | 'visibilitychange'
     | 'end'
@@ -62,46 +62,46 @@ export type XREventType =
     | 'squeezeend'
     | 'reset';
 
-export type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
+type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
 
-export type XRPlaneSet = Set<XRPlane>;
-export type XRAnchorSet = Set<XRAnchor>;
+type XRPlaneSet = Set<XRPlane>;
+type XRAnchorSet = Set<XRAnchor>;
 
-export interface XREventHandler {
+interface XREventHandler {
     (event: Event): any;
 }
 
 // tslint:disable-next-line no-empty-interface
-export interface XRLayer extends EventTarget { }
+interface XRLayer extends EventTarget { }
 
-export interface XRSessionInit {
+interface XRSessionInit {
     optionalFeatures?: string[] | undefined;
     requiredFeatures?: string[] | undefined;
 }
 
-export interface XRSessionEvent extends Event {
+interface XRSessionEvent extends Event {
     readonly session: XRSession;
 }
 
-export interface XRSystemDeviceChangeEvent extends Event {
+interface XRSystemDeviceChangeEvent extends Event {
     type: "devicechange";
 }
 
-export interface XRSessionGrant {
+interface XRSessionGrant {
     mode: XRSessionMode;
 }
 
-export interface XRSystemSessionGrantedEvent extends Event {
+interface XRSystemSessionGrantedEvent extends Event {
     type: "sessiongranted";
     session: XRSessionGrant;
 }
 
-export interface XRSystemEventMap extends HTMLMediaElementEventMap {
+interface XRSystemEventMap extends HTMLMediaElementEventMap {
     "devicechange": XRSystemDeviceChangeEvent;
     "sessiongranted": XRSystemSessionGrantedEvent;
 }
 
-export interface XRSystem extends EventTarget {
+interface XRSystem extends EventTarget {
     requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
     isSessionSupported(mode: XRSessionMode): Promise<boolean>;
 
@@ -114,14 +114,14 @@ export interface XRSystem extends EventTarget {
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
-export interface XRViewport {
+interface XRViewport {
     readonly x: number;
     readonly y: number;
     readonly width: number;
     readonly height: number;
 }
 
-export interface XRWebGLLayerInit {
+interface XRWebGLLayerInit {
     antialias?: boolean | undefined;
     depth?: boolean | undefined;
     stencil?: boolean | undefined;
@@ -130,10 +130,7 @@ export interface XRWebGLLayerInit {
     framebufferScaleFactor?: number | undefined;
 }
 
-export interface XRWebGLLayer extends XRLayer {
-}
-
-export class XRWebGLLayer {
+declare class XRWebGLLayer implements XRLayer {
     static getNativeFramebufferScaleFactor(session: XRSession): number;
 
     constructor(
@@ -151,12 +148,16 @@ export class XRWebGLLayer {
     readonly framebufferHeight: number;
 
     getViewport(view: XRView): XRViewport | undefined;
+
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions): void;
+    dispatchEvent(event: Event): boolean;
 }
 
 // tslint:disable-next-line no-empty-interface
-export interface XRSpace extends EventTarget { }
+interface XRSpace extends EventTarget { }
 
-export interface XRRenderState {
+interface XRRenderState {
     readonly baseLayer?: XRWebGLLayer | undefined;
     readonly depthFar: number;
     readonly depthNear: number;
@@ -166,7 +167,7 @@ export interface XRRenderState {
     readonly layers?: XRLayer[] | undefined;
 }
 
-export interface XRRenderStateInit {
+interface XRRenderStateInit {
     baseLayer?: XRWebGLLayer;
     depthFar?: number;
     depthNear?: number;
@@ -174,16 +175,16 @@ export interface XRRenderStateInit {
     layers?: XRLayer[] | undefined;
 }
 
-export interface XRReferenceSpace extends XRSpace {
+interface XRReferenceSpace extends XRSpace {
     getOffsetReferenceSpace(originOffset: XRRigidTransform): XRReferenceSpace;
     onreset: XREventHandler;
 }
 
-export interface XRBoundedReferenceSpace extends XRReferenceSpace {
+interface XRBoundedReferenceSpace extends XRReferenceSpace {
     readonly boundsGeometry: DOMPointReadOnly[];
 }
 
-export interface XRInputSource {
+interface XRInputSource {
     readonly handedness: XRHandedness;
     readonly targetRayMode: XRTargetRayMode;
     readonly targetRaySpace: XRSpace;
@@ -193,12 +194,12 @@ export interface XRInputSource {
     readonly hand?: XRHand | undefined;
 }
 
-export interface XRPose {
+interface XRPose {
     readonly transform: XRRigidTransform;
     readonly emulatedPosition: boolean;
 }
 
-export interface XRFrame {
+interface XRFrame {
     readonly session: XRSession;
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
@@ -222,16 +223,16 @@ export interface XRFrame {
     getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose;
 }
 
-export class XRFrame {
+declare class XRFrame {
     prototype: XRFrame;
 }
 
-export interface XRInputSourceEvent extends Event {
+interface XRInputSourceEvent extends Event {
     readonly frame: XRFrame;
     readonly inputSource: XRInputSource;
 }
 
-export interface XRSessionEventMap {
+interface XRSessionEventMap {
     "end": XREventHandler;
     "inputsourceschange": XREventHandler;
     "select": XREventHandler;
@@ -244,7 +245,7 @@ export interface XRSessionEventMap {
     "frameratechange": XREventHandler;
 }
 
-export interface XRSession extends EventTarget {
+interface XRSession extends EventTarget {
     /**
      * Returns a list of this session's XRInputSources, each representing an input device
      * used to control the camera and/or scene.
@@ -283,10 +284,10 @@ export interface XRSession extends EventTarget {
     requestAnimationFrame(callback: XRFrameRequestCallback): number;
 
     /**
-     * Requests that a new XRReferenceSpace of the specified export type be created.
+     * Requests that a new XRReferenceSpace of the specified type be created.
      * Returns a promise which resolves with the XRReferenceSpace or
      * XRBoundedReferenceSpace which was requested, or throws a NotSupportedError if
-     * the requested space export type isn't supported by the device.
+     * the requested space type isn't supported by the device.
      */
     requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace | XRBoundedReferenceSpace>;
 
@@ -323,15 +324,15 @@ export interface XRSession extends EventTarget {
     updateWorldTrackingState?: (options: { planeDetectionState?: { enabled: boolean } | undefined }) => void;
 }
 
-export class XRSession {
+declare class XRSession {
     prototype: XRSession;
 }
 
-export interface XRViewerPose extends XRPose {
+interface XRViewerPose extends XRPose {
     readonly views: XRView[];
 }
 
-export class XRRigidTransform {
+declare class XRRigidTransform {
     constructor(position?: DOMPointInit, direction?: DOMPointInit);
     position: DOMPointReadOnly;
     orientation: DOMPointReadOnly;
@@ -339,7 +340,7 @@ export class XRRigidTransform {
     inverse: XRRigidTransform;
 }
 
-export interface XRView {
+interface XRView {
     readonly eye: XREye;
     readonly projectionMatrix: Float32Array;
     readonly transform: XRRigidTransform;
@@ -347,72 +348,72 @@ export interface XRView {
     requestViewportScale(scale: number): void;
 }
 
-export interface XRInputSourceChangeEvent extends XRSessionEvent {
+interface XRInputSourceChangeEvent extends XRSessionEvent {
     removed: XRInputSource[];
     added: XRInputSource[];
 }
 
 // Experimental/Draft features
-export class XRRay {
+declare class XRRay {
     constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
     readonly origin: DOMPointReadOnly;
     readonly direction: DOMPointReadOnly;
     readonly matrix: Float32Array;
 }
 
-export type XRHitTestTrackableType =
+type XRHitTestTrackableType =
     | 'point'
     | 'plane'
     | 'mesh';
 
-export interface XRHitResult {
+interface XRHitResult {
     hitMatrix: Float32Array;
 }
 
-export interface XRTransientInputHitTestResult {
+interface XRTransientInputHitTestResult {
     readonly inputSource: XRInputSource;
     readonly results: XRHitTestResult[];
 }
 
-export interface XRHitTestResult {
+interface XRHitTestResult {
     getPose(baseSpace: XRSpace): XRPose | undefined;
     // When anchor system is enabled
     createAnchor?(pose: XRRigidTransform): Promise<XRAnchor>;
 }
 
-export interface XRHitTestSource {
+interface XRHitTestSource {
     cancel(): void;
 }
 
-export interface XRTransientInputHitTestSource {
+interface XRTransientInputHitTestSource {
     cancel(): void;
 }
 
-export interface XRHitTestOptionsInit {
+interface XRHitTestOptionsInit {
     space: XRSpace;
     entityTypes?: XRHitTestTrackableType[] | undefined;
     offsetRay?: XRRay | undefined;
 }
 
-export interface XRTransientInputHitTestOptionsInit {
+interface XRTransientInputHitTestOptionsInit {
     profile: string;
     entityTypes?: XRHitTestTrackableType[] | undefined;
     offsetRay?: XRRay | undefined;
 }
 
-export interface XRAnchor {
+interface XRAnchor {
     anchorSpace: XRSpace;
     delete(): void;
 }
 
-export interface XRPlane {
+interface XRPlane {
     orientation: 'Horizontal' | 'Vertical';
     planeSpace: XRSpace;
     polygon: DOMPointReadOnly[];
     lastChangedTime: number;
 }
 
-export type XRHandJoint =
+type XRHandJoint =
     | 'wrist'
     | 'thumb-metacarpal'
     | 'thumb-phalanx-proximal'
@@ -439,15 +440,15 @@ export type XRHandJoint =
     | 'pinky-finger-phalanx-distal'
     | 'pinky-finger-tip';
 
-export interface XRJointSpace extends XRSpace {
+interface XRJointSpace extends XRSpace {
     readonly jointName: XRHandJoint;
 }
 
-export interface XRJointPose extends XRPose {
+interface XRJointPose extends XRPose {
     readonly radius: number | undefined;
 }
 
-export interface XRHand extends Iterable<XRJointSpace> {
+interface XRHand extends Iterable<XRJointSpace> {
     readonly length: number;
 
     [index: number]: XRJointSpace;
@@ -484,23 +485,21 @@ export interface XRHand extends Iterable<XRJointSpace> {
     readonly LITTLE_PHALANX_TIP: number;
 }
 
-
-
 // WebXR Layers
-export interface XRLayerEventInit extends EventInit {
+interface XRLayerEventInit extends EventInit {
     layer: XRLayer;
 }
 
-export class XRLayerEvent extends Event {
+declare class XRLayerEvent extends Event {
     constructor(type: string, eventInitDict: XRLayerEventInit);
     readonly layer: XRLayer;
 }
 
-export interface XRCompositionLayerEventMap {
+interface XRCompositionLayerEventMap {
     "redraw": XRLayerEvent;
 }
 
-export interface XRCompositionLayer extends XRLayer {
+interface XRCompositionLayer extends XRLayer {
     readonly layout: XRLayerLayout;
     blendTextureSourceAlpha: boolean;
     chromaticAberrationCorrection?: boolean;
@@ -512,29 +511,48 @@ export interface XRCompositionLayer extends XRLayer {
 
     // Events
     onredraw: (evt: XRCompositionLayerEventMap["redraw"]) => any;
-    addEventListener<K extends keyof XRCompositionLayerEventMap>(this: XRCompositionLayer, type: K, callback: (evt: XRCompositionLayerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof XRCompositionLayerEventMap>(this: XRCompositionLayer, type: K, callback: (evt: XRCompositionLayerEventMap[K]) => any): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+
+    addEventListener<K extends keyof XRCompositionLayerEventMap>(
+        this: XRCompositionLayer,
+        type: K,
+        callback: (evt: XRCompositionLayerEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+
+    removeEventListener<K extends keyof XRCompositionLayerEventMap>(
+        this: XRCompositionLayer,
+        type: K,
+        callback: (evt: XRCompositionLayerEventMap[K]) => any
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions
+    ): void;
 }
 
-export type XRTextureType = "texture" | "texture-array";
+type XRTextureType = "texture" | "texture-array";
 
-export type XRLayerLayout =
+type XRLayerLayout =
     | "default"
     | "mono"
     | "stereo"
     | "stereo-left-right"
     | "stereo-top-bottom";
 
-export interface XRProjectionLayerInit {
+interface XRProjectionLayerInit {
     scaleFactor?: number;
     textureType?: XRTextureType;
     colorFormat?: GLenum;
     depthFormat?: GLenum;
 }
 
-export interface XRProjectionLayer extends XRCompositionLayer {
+interface XRProjectionLayer extends XRCompositionLayer {
     readonly textureWidth: number;
     readonly textureHeight: number;
     readonly textureArrayLength: number;
@@ -542,7 +560,7 @@ export interface XRProjectionLayer extends XRCompositionLayer {
     fixedFoveation: number;
 }
 
-export interface XRLayerInit {
+interface XRLayerInit {
     mipLevels?: number;
     viewPixelWidth: number;
     viewPixelHeight: number;
@@ -553,13 +571,13 @@ export interface XRLayerInit {
     layout?: XRLayerLayout;
 }
 
-export interface XRMediaLayerInit {
+interface XRMediaLayerInit {
     invertStereo?: boolean;
     space: XRSpace;
     layout?: XRLayerLayout;
 }
 
-export interface XRCylinderLayerInit extends XRLayerInit {
+interface XRCylinderLayerInit extends XRLayerInit {
     textureType?: XRTextureType;
     transform: XRRigidTransform;
     radius?: number;
@@ -567,40 +585,40 @@ export interface XRCylinderLayerInit extends XRLayerInit {
     aspectRatio?: number;
 }
 
-export interface XRMediaCylinderLayerInit extends XRMediaLayerInit {
+interface XRMediaCylinderLayerInit extends XRMediaLayerInit {
     transform?: XRRigidTransform;
     radius?: number;
     centralAngle?: number;
     aspectRatio?: number;
 }
 
-export interface XRCylinderLayer extends XRCompositionLayer {
+interface XRCylinderLayer extends XRCompositionLayer {
     transform: XRRigidTransform;
     radius: number;
     centralAngle: number;
     aspectRatio: number;
 }
 
-export interface XRQuadLayerInit extends XRLayerInit {
+interface XRQuadLayerInit extends XRLayerInit {
     textureType?: XRTextureType;
     transform?: XRRigidTransform;
     width?: number;
     height?: number;
 }
 
-export interface XRMediaQuadLayerInit extends XRMediaLayerInit {
+interface XRMediaQuadLayerInit extends XRMediaLayerInit {
     transform?: XRRigidTransform;
     width?: number;
     height?: number;
 }
 
-export interface XRQuadLayer extends XRCompositionLayer {
+interface XRQuadLayer extends XRCompositionLayer {
     transform: XRRigidTransform;
     width: number;
     height: number;
 }
 
-export interface XREquirectLayerInit extends XRLayerInit {
+interface XREquirectLayerInit extends XRLayerInit {
     textureType?: XRTextureType;
     transform?: XRRigidTransform;
     radius?: number;
@@ -609,7 +627,7 @@ export interface XREquirectLayerInit extends XRLayerInit {
     lowerVerticalAngle?: number;
 }
 
-export interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
+interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
     transform?: XRRigidTransform;
     radius?: number;
     centralHorizontalAngle?: number;
@@ -617,7 +635,7 @@ export interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
     lowerVerticalAngle?: number;
 }
 
-export interface XREquirectLayer extends XRCompositionLayer {
+interface XREquirectLayer extends XRCompositionLayer {
     transform: XRRigidTransform;
     radius: number;
     centralHorizontalAngle: number;
@@ -625,19 +643,19 @@ export interface XREquirectLayer extends XRCompositionLayer {
     lowerVerticalAngle: number;
 }
 
-export interface XRCubeLayerInit extends XRLayerInit {
+interface XRCubeLayerInit extends XRLayerInit {
     orientation?: DOMPointReadOnly;
 }
 
-export interface XRCubeLayer extends XRCompositionLayer {
+interface XRCubeLayer extends XRCompositionLayer {
     orientation: DOMPointReadOnly;
 }
 
-export interface XRSubImage {
+interface XRSubImage {
     readonly viewport: XRViewport;
 }
 
-export interface XRWebGLSubImage extends XRSubImage {
+interface XRWebGLSubImage extends XRSubImage {
     readonly colorTexture: WebGLTexture;
     readonly depthStencilTexture: WebGLTexture;
     readonly imageIndex: number;
@@ -645,7 +663,7 @@ export interface XRWebGLSubImage extends XRSubImage {
     readonly textureHeight: number;
 }
 
-export class XRWebGLBinding {
+declare class XRWebGLBinding {
     constructor(session: XRSession, context: WebGLRenderingContext);
 
     readonly nativeProjectionScaleFactor: number;
@@ -660,7 +678,7 @@ export class XRWebGLBinding {
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
 }
 
-export class XRMediaBinding {
+declare class XRMediaBinding {
     constructor(sesion: XRSession);
 
     createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
@@ -669,32 +687,74 @@ export class XRMediaBinding {
 }
 
 // WebGL extensions
-export interface XRWebGLRenderingContext {
+interface WebGLRenderingContext {
     makeXRCompatible(): Promise<void>;
-}
-
-export interface WebGLRenderingContextBase {
     getExtension(extensionName: "OCULUS_multiview"): OCULUS_multiview | null;
+    getExtension(extensionName: "EXT_blend_minmax"): EXT_blend_minmax | null;
+    getExtension(extensionName: "EXT_texture_filter_anisotropic"): EXT_texture_filter_anisotropic | null;
+    getExtension(extensionName: "EXT_frag_depth"): EXT_frag_depth | null;
+    getExtension(extensionName: "EXT_shader_texture_lod"): EXT_shader_texture_lod | null;
+    getExtension(extensionName: "EXT_sRGB"): EXT_sRGB | null;
+    getExtension(extensionName: "OES_vertex_array_object"): OES_vertex_array_object | null;
+    getExtension(extensionName: "WEBGL_color_buffer_float"): WEBGL_color_buffer_float | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_astc"): WEBGL_compressed_texture_astc | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_s3tc_srgb"): WEBGL_compressed_texture_s3tc_srgb | null;
+    getExtension(extensionName: "WEBGL_debug_shaders"): WEBGL_debug_shaders | null;
+    getExtension(extensionName: "WEBGL_draw_buffers"): WEBGL_draw_buffers | null;
+    getExtension(extensionName: "WEBGL_lose_context"): WEBGL_lose_context | null;
+    getExtension(extensionName: "WEBGL_depth_texture"): WEBGL_depth_texture | null;
+    getExtension(extensionName: "WEBGL_debug_renderer_info"): WEBGL_debug_renderer_info | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_s3tc"): WEBGL_compressed_texture_s3tc | null;
+    getExtension(extensionName: "OES_texture_half_float_linear"): OES_texture_half_float_linear | null;
+    getExtension(extensionName: "OES_texture_half_float"): OES_texture_half_float | null;
+    getExtension(extensionName: "OES_texture_float_linear"): OES_texture_float_linear | null;
+    getExtension(extensionName: "OES_texture_float"): OES_texture_float | null;
+    getExtension(extensionName: "OES_standard_derivatives"): OES_standard_derivatives | null;
+    getExtension(extensionName: "OES_element_index_uint"): OES_element_index_uint | null;
+    getExtension(extensionName: "ANGLE_instanced_arrays"): ANGLE_instanced_arrays | null;
+    getExtension(extensionName: string): any;
 }
 
-export interface WebGLRenderingContext extends XRWebGLRenderingContext {
+interface WebGL2RenderingContext {
+    makeXRCompatible(): Promise<void>;
+    getExtension(extensionName: "OCULUS_multiview"): OCULUS_multiview | null;
+    getExtension(extensionName: "EXT_blend_minmax"): EXT_blend_minmax | null;
+    getExtension(extensionName: "EXT_texture_filter_anisotropic"): EXT_texture_filter_anisotropic | null;
+    getExtension(extensionName: "EXT_frag_depth"): EXT_frag_depth | null;
+    getExtension(extensionName: "EXT_shader_texture_lod"): EXT_shader_texture_lod | null;
+    getExtension(extensionName: "EXT_sRGB"): EXT_sRGB | null;
+    getExtension(extensionName: "OES_vertex_array_object"): OES_vertex_array_object | null;
+    getExtension(extensionName: "WEBGL_color_buffer_float"): WEBGL_color_buffer_float | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_astc"): WEBGL_compressed_texture_astc | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_s3tc_srgb"): WEBGL_compressed_texture_s3tc_srgb | null;
+    getExtension(extensionName: "WEBGL_debug_shaders"): WEBGL_debug_shaders | null;
+    getExtension(extensionName: "WEBGL_draw_buffers"): WEBGL_draw_buffers | null;
+    getExtension(extensionName: "WEBGL_lose_context"): WEBGL_lose_context | null;
+    getExtension(extensionName: "WEBGL_depth_texture"): WEBGL_depth_texture | null;
+    getExtension(extensionName: "WEBGL_debug_renderer_info"): WEBGL_debug_renderer_info | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_s3tc"): WEBGL_compressed_texture_s3tc | null;
+    getExtension(extensionName: "OES_texture_half_float_linear"): OES_texture_half_float_linear | null;
+    getExtension(extensionName: "OES_texture_half_float"): OES_texture_half_float | null;
+    getExtension(extensionName: "OES_texture_float_linear"): OES_texture_float_linear | null;
+    getExtension(extensionName: "OES_texture_float"): OES_texture_float | null;
+    getExtension(extensionName: "OES_standard_derivatives"): OES_standard_derivatives | null;
+    getExtension(extensionName: "OES_element_index_uint"): OES_element_index_uint | null;
+    getExtension(extensionName: "ANGLE_instanced_arrays"): ANGLE_instanced_arrays | null;
+    getExtension(extensionName: string): any;
 }
 
-export interface WebGL2RenderingContext extends XRWebGLRenderingContext {
-}
-
-export enum XOVR_multiview2 {
+declare enum XOVR_multiview2 {
     FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630,
     FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632,
     MAX_VIEWS_OVR = 0x9631,
     FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR = 0x9633
 }
 
-export interface OVR_multiview2 {
-    FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR: XOVR_multiview2;
-    FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR: XOVR_multiview2;
-    MAX_VIEWS_OVR: XOVR_multiview2;
-    FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR: XOVR_multiview2;
+interface OVR_multiview2 {
+    readonly FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR: number;
+    readonly FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR: number;
+    readonly MAX_VIEWS_OVR: number;
+    readonly FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR: number;
 
     framebufferTextureMultiviewOVR(
         target: GLenum,
@@ -706,7 +766,7 @@ export interface OVR_multiview2 {
     ): WebGLRenderbuffer;
 }
 
-export interface OCULUS_multiview extends OVR_multiview2 {
+interface OCULUS_multiview extends OVR_multiview2 {
     framebufferTextureMultisampleMultiviewOVR(
         target: GLenum,
         attachment: GLenum,

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -83,9 +83,35 @@ export interface XRSessionEvent extends Event {
     readonly session: XRSession;
 }
 
+export interface XRSystemDeviceChangeEvent extends Event {
+    type: "devicechange";
+}
+
+export interface XRSessionGrant {
+    mode: XRSessionMode;
+}
+
+export interface XRSystemSessionGrantedEvent extends Event {
+    type: "sessiongranted";
+    session: XRSessionGrant;
+}
+
+export interface XRSystemEventMap extends HTMLMediaElementEventMap {
+    "devicechange": XRSystemDeviceChangeEvent;
+    "sessiongranted": XRSystemSessionGrantedEvent;
+}
+
 export interface XRSystem extends EventTarget {
-    isSessionSupported: (sessionMode: XRSessionMode) => Promise<boolean>;
-    requestSession: (sessionMode: XRSessionMode, sessionInit?: any) => Promise<XRSession>;
+    requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
+    isSessionSupported(mode: XRSessionMode): Promise<boolean>;
+
+    ondevicechange: ((this: XRSystem, ev: XRSystemDeviceChangeEvent) => any) | null;
+    onsessiongranted: ((this: XRSystem, ev: XRSystemSessionGrantedEvent) => any) | null;
+
+    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 export interface XRViewport {

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -103,16 +103,16 @@ interface XRSystemEventMap extends HTMLMediaElementEventMap {
 }
 
 interface XRSystem extends EventTarget {
-    requestSession(mode: XRSessionMode, options?: XRSessionInit | undefined): Promise<XRSession>;
+    requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
     isSessionSupported(mode: XRSessionMode): Promise<boolean>;
 
     ondevicechange: ((this: XRSystem, ev: XRSystemDeviceChangeEvent) => any) | null;
     onsessiongranted: ((this: XRSystem, ev: XRSystemSessionGrantedEvent) => any) | null;
 
-    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions | undefined): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void;
-    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions | undefined): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void;
+    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 interface XRViewport {
@@ -137,7 +137,7 @@ declare class XRWebGLLayer implements XRLayer {
     constructor(
         session: XRSession,
         context: WebGLRenderingContext | WebGL2RenderingContext,
-        layerInit?: XRWebGLLayerInit | undefined,
+        layerInit?: XRWebGLLayerInit,
     );
 
     readonly antialias: boolean;
@@ -150,8 +150,8 @@ declare class XRWebGLLayer implements XRLayer {
 
     getViewport(view: XRView): XRViewport | undefined;
 
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions | undefined): void;
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions | undefined): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions): void;
     dispatchEvent(event: Event): boolean;
 }
 
@@ -307,10 +307,10 @@ interface XRSession extends EventTarget {
     onvisibilitychange: XREventHandler;
     onframeratechange: XREventHandler;
 
-    addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions | undefined): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void;
-    removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions | undefined): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void;
+    addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 
     // hit test
     requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource> | undefined;
@@ -334,7 +334,7 @@ interface XRViewerPose extends XRPose {
 }
 
 declare class XRRigidTransform {
-    constructor(position?: DOMPointInit | undefined, direction?: DOMPointInit | undefined);
+    constructor(position?: DOMPointInit, direction?: DOMPointInit);
     position: DOMPointReadOnly;
     orientation: DOMPointReadOnly;
     matrix: Float32Array;
@@ -356,7 +356,7 @@ interface XRInputSourceChangeEvent extends XRSessionEvent {
 
 // Experimental/Draft features
 declare class XRRay {
-    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit | undefined);
+    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
     readonly origin: DOMPointReadOnly;
     readonly direction: DOMPointReadOnly;
     readonly matrix: Float32Array;
@@ -517,12 +517,12 @@ interface XRCompositionLayer extends XRLayer {
         this: XRCompositionLayer,
         type: K,
         callback: (evt: XRCompositionLayerEventMap[K]) => any,
-        options?: boolean | AddEventListenerOptions | undefined
+        options?: boolean | AddEventListenerOptions
     ): void;
     addEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | AddEventListenerOptions | undefined
+        options?: boolean | AddEventListenerOptions
     ): void;
 
     removeEventListener<K extends keyof XRCompositionLayerEventMap>(
@@ -533,7 +533,7 @@ interface XRCompositionLayer extends XRLayer {
     removeEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | EventListenerOptions | undefined
+        options?: boolean | EventListenerOptions
     ): void;
 }
 
@@ -669,22 +669,22 @@ declare class XRWebGLBinding {
 
     readonly nativeProjectionScaleFactor: number;
 
-    createProjectionLayer(init?: XRProjectionLayerInit | undefined): XRProjectionLayer;
-    createQuadLayer(init?: XRQuadLayerInit | undefined): XRQuadLayer;
-    createCylinderLayer(init?: XRCylinderLayerInit | undefined): XRCylinderLayer;
-    createEquirectLayer(init?: XREquirectLayerInit | undefined): XREquirectLayer;
-    createCubeLayer(init?: XRCubeLayerInit | undefined): XRCubeLayer;
+    createProjectionLayer(init?: XRProjectionLayerInit): XRProjectionLayer;
+    createQuadLayer(init?: XRQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(init?: XRCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(init?: XREquirectLayerInit): XREquirectLayer;
+    createCubeLayer(init?: XRCubeLayerInit): XRCubeLayer;
 
-    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye | undefined): XRWebGLSubImage;
+    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
 }
 
 declare class XRMediaBinding {
     constructor(sesion: XRSession);
 
-    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit | undefined): XRQuadLayer;
-    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit | undefined): XRCylinderLayer;
-    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit | undefined): XREquirectLayer;
+    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
 }
 
 // WebGL extensions

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -153,6 +153,9 @@ export interface XRRenderState {
     readonly depthFar: number;
     readonly depthNear: number;
     readonly inlineVerticalFieldOfView?: number | undefined;
+
+    // https://immersive-web.github.io/layers/#xrrenderstatechanges
+    readonly layers?: XRLayer[] | undefined;
 }
 
 export interface XRRenderStateInit extends XRRenderState {
@@ -418,4 +421,188 @@ export interface XRHand extends Iterable<XRJointSpace> {
     readonly LITTLE_PHALANX_INTERMEDIATE: number;
     readonly LITTLE_PHALANX_DISTAL: number;
     readonly LITTLE_PHALANX_TIP: number;
+}
+
+
+
+// WebXR Layers
+export interface XRLayerEventInit extends EventInit {
+    layer: XRLayer;
+}
+
+export class XRLayerEvent extends Event {
+    constructor(type: string, eventInitDict: XRLayerEventInit);
+    readonly layer: XRLayer;
+}
+
+export interface XRCompositionLayerEventMap {
+    "redraw": XRLayerEvent;
+}
+
+export interface XRCompositionLayer extends XRLayer {
+    readonly layout: XRLayerLayout;
+    blendTextureSourceAlpha: boolean;
+    chromaticAberrationCorrection?: boolean;
+    readonly mipLevels: number;
+    readonly needsRedraw: boolean;
+    destroy(): void;
+
+    space: XRSpace;
+
+    // Events
+    onredraw: (evt: XRCompositionLayerEventMap["redraw"]) => any;
+    addEventListener<K extends keyof XRCompositionLayerEventMap>(this: XRCompositionLayer, type: K, callback: (evt: XRCompositionLayerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof XRCompositionLayerEventMap>(this: XRCompositionLayer, type: K, callback: (evt: XRCompositionLayerEventMap[K]) => any): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
+export type XRTextureType = "texture" | "texture-array";
+
+export type XRLayerLayout =
+    | "default"
+    | "mono"
+    | "stereo"
+    | "stereo-left-right"
+    | "stereo-top-bottom";
+
+export interface XRProjectionLayerInit {
+    scaleFactor?: number;
+    textureType?: XRTextureType;
+    colorFormat?: GLenum;
+    depthFormat?: GLenum;
+}
+
+export interface XRProjectionLayer extends XRCompositionLayer {
+    readonly textureWidth: number;
+    readonly textureHeight: number;
+    readonly textureArrayLength: number;
+    readonly ignoreDepthValues: number;
+    fixedFoveation: number;
+}
+
+export interface XRLayerInit {
+    mipLevels?: number;
+    viewPixelWidth: number;
+    viewPixelHeight: number;
+    isStatic?: boolean;
+    colorFormat?: GLenum;
+    depthFormat?: GLenum;
+    space: XRSpace;
+    layout?: XRLayerLayout;
+}
+
+export interface XRMediaLayerInit {
+    invertStereo?: boolean;
+    space: XRSpace;
+    layout?: XRLayerLayout;
+}
+
+export interface XRCylinderLayerInit extends XRLayerInit {
+    textureType?: XRTextureType;
+    transform: XRRigidTransform;
+    radius?: number;
+    centralAngle?: number;
+    aspectRatio?: number;
+}
+
+export interface XRMediaCylinderLayerInit extends XRMediaLayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralAngle?: number;
+    aspectRatio?: number;
+}
+
+export interface XRCylinderLayer extends XRCompositionLayer {
+    transform: XRRigidTransform;
+    radius: number;
+    centralAngle: number;
+    aspectRatio: number;
+}
+
+export interface XRQuadLayerInit extends XRLayerInit {
+    textureType?: XRTextureType;
+    transform?: XRRigidTransform;
+    width?: number;
+    height?: number;
+}
+
+export interface XRMediaQuadLayerInit extends XRMediaLayerInit {
+    transform?: XRRigidTransform;
+    width?: number;
+    height?: number;
+}
+
+export interface XRQuadLayer extends XRCompositionLayer {
+    transform: XRRigidTransform;
+    width: number;
+    height: number;
+}
+
+export interface XREquirectLayerInit extends XRLayerInit {
+    textureType?: XRTextureType;
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralHorizontalAngle?: number;
+    upperVerticalAngle?: number;
+    lowerVerticalAngle?: number;
+}
+
+export interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralHorizontalAngle?: number;
+    upperVerticalAngle?: number;
+    lowerVerticalAngle?: number;
+}
+
+export interface XREquirectLayer extends XRCompositionLayer {
+    transform: XRRigidTransform;
+    radius: number;
+    centralHorizontalAngle: number;
+    upperVerticalAngle: number;
+    lowerVerticalAngle: number;
+}
+
+export interface XRCubeLayerInit extends XRLayerInit {
+    orientation?: DOMPointReadOnly;
+}
+
+export interface XRCubeLayer extends XRCompositionLayer {
+    orientation: DOMPointReadOnly;
+}
+
+export interface XRSubImage {
+    readonly viewport: XRViewport;
+}
+
+export interface XRWebGLSubImage extends XRSubImage {
+    readonly colorTexture: WebGLTexture;
+    readonly depthStencilTexture: WebGLTexture;
+    readonly imageIndex: number;
+    readonly textureWidth: number;
+    readonly textureHeight: number;
+}
+
+export class XRWebGLBinding {
+    constructor(session: XRSession, context: WebGLRenderingContext);
+
+    readonly nativeProjectionScaleFactor: number;
+
+    createProjectionLayer(init?: XRProjectionLayerInit): XRProjectionLayer;
+    createQuadLayer(init?: XRQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(init?: XRCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(init?: XREquirectLayerInit): XREquirectLayer;
+    createCubeLayer(init?: XRCubeLayerInit): XRCubeLayer;
+
+    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
+    getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
+}
+
+export class XRMediaBinding {
+    constructor(sesion: XRSession);
+
+    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
 }

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -207,8 +207,9 @@ export interface XRFrame {
     worldInformation?: {
         detectedPlanes?: XRPlaneSet | undefined;
     } | undefined;
+
     // Hand tracking
-    getJointPose?(joint: XRJointSpace, baseSpace: XRSpace): XRJointPose;
+    getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose;
 }
 
 export interface XRInputSourceEvent extends Event {
@@ -379,11 +380,39 @@ export interface XRPlane {
     lastChangedTime: number;
 }
 
-// tslint:disable-next-line no-empty-interface
-export interface XRJointSpace extends XRSpace {}
+export type XRHandJoint =
+    | 'wrist'
+    | 'thumb-metacarpal'
+    | 'thumb-phalanx-proximal'
+    | 'thumb-phalanx-distal'
+    | 'thumb-tip'
+    | 'index-finger-metacarpal'
+    | 'index-finger-phalanx-proximal'
+    | 'index-finger-phalanx-intermediate'
+    | 'index-finger-phalanx-distal'
+    | 'index-finger-tip'
+    | 'middle-finger-metacarpal'
+    | 'middle-finger-phalanx-proximal'
+    | 'middle-finger-phalanx-intermediate'
+    | 'middle-finger-phalanx-distal'
+    | 'middle-finger-tip'
+    | 'ring-finger-metacarpal'
+    | 'ring-finger-phalanx-proximal'
+    | 'ring-finger-phalanx-intermediate'
+    | 'ring-finger-phalanx-distal'
+    | 'ring-finger-tip'
+    | 'pinky-finger-metacarpal'
+    | 'pinky-finger-phalanx-proximal'
+    | 'pinky-finger-phalanx-intermediate'
+    | 'pinky-finger-phalanx-distal'
+    | 'pinky-finger-tip';
+
+export interface XRJointSpace extends XRSpace {
+    readonly jointName: XRHandJoint;
+}
 
 export interface XRJointPose extends XRPose {
-    radius: number | undefined;
+    readonly radius: number | undefined;
 }
 
 export interface XRHand extends Iterable<XRJointSpace> {

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -198,8 +198,9 @@ export interface XRFrame {
     // AR
     getHitTestResults(hitTestSource: XRHitTestSource): XRHitTestResult[];
     getHitTestResultsForTransientInput(
-        hitTestSource: XRTransientInputHitTestSource,
+        hitTestSource: XRTransientInputHitTestSource
     ): XRTransientInputHitTestResult[];
+
     // Anchors
     trackedAnchors?: XRAnchorSet | undefined;
     createAnchor?(pose: XRRigidTransform, space: XRSpace): Promise<XRAnchor>;
@@ -281,13 +282,13 @@ export interface XRSession {
     onvisibilitychange: XREventHandler;
 
     // hit test
-    requestHitTestSource?(options: XRHitTestOptionsInit): Promise<XRHitTestSource>;
-    requestHitTestSourceForTransientInput?(
+    requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource>;
+    requestHitTestSourceForTransientInput?: (
         options: XRTransientInputHitTestOptionsInit,
-    ): Promise<XRTransientInputHitTestSource>;
+    ) => Promise<XRTransientInputHitTestSource>;
 
     // legacy AR hit test
-    requestHitTest?(ray: XRRay, referenceSpace: XRReferenceSpace): Promise<XRHitResult[]>;
+    requestHitTest?: (ray: XRRay, referenceSpace: XRReferenceSpace) => Promise<XRHitResult[]>;
 
     // legacy plane detection
     updateWorldTrackingState?(options: { planeDetectionState?: { enabled: boolean } | undefined }): void;
@@ -322,16 +323,15 @@ export interface XRInputSourceChangeEvent extends Event {
 // Experimental/Draft features
 export class XRRay {
     constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
-    origin: DOMPointReadOnly;
-    direction: DOMPointReadOnly;
-    matrix: Float32Array;
+    readonly origin: DOMPointReadOnly;
+    readonly direction: DOMPointReadOnly;
+    readonly matrix: Float32Array;
 }
 
-export enum XRHitTestTrackableType {
-    'point',
-    'plane',
-    'mesh',
-}
+export type XRHitTestTrackableType =
+    | 'point'
+    | 'plane'
+    | 'mesh';
 
 export interface XRHitResult {
     hitMatrix: Float32Array;

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -14,7 +14,7 @@
 //
 
 export interface Navigator {
-    xr: XRSystem;
+    xr?: XRSystem | undefined;
 }
 
 /**

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -102,16 +102,16 @@ interface XRSystemEventMap extends HTMLMediaElementEventMap {
 }
 
 interface XRSystem extends EventTarget {
-    requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
+    requestSession(mode: XRSessionMode, options?: XRSessionInit | undefined): Promise<XRSession>;
     isSessionSupported(mode: XRSessionMode): Promise<boolean>;
 
     ondevicechange: ((this: XRSystem, ev: XRSystemDeviceChangeEvent) => any) | null;
     onsessiongranted: ((this: XRSystem, ev: XRSystemSessionGrantedEvent) => any) | null;
 
-    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions | undefined): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void;
+    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions | undefined): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void;
 }
 
 interface XRViewport {
@@ -136,7 +136,7 @@ declare class XRWebGLLayer implements XRLayer {
     constructor(
         session: XRSession,
         context: WebGLRenderingContext | WebGL2RenderingContext,
-        layerInit ?: XRWebGLLayerInit,
+        layerInit?: XRWebGLLayerInit | undefined,
     );
 
     readonly antialias: boolean;
@@ -149,8 +149,8 @@ declare class XRWebGLLayer implements XRLayer {
 
     getViewport(view: XRView): XRViewport | undefined;
 
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions | undefined): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions | undefined): void;
     dispatchEvent(event: Event): boolean;
 }
 
@@ -168,9 +168,9 @@ interface XRRenderState {
 }
 
 interface XRRenderStateInit {
-    baseLayer?: XRWebGLLayer;
-    depthFar?: number;
-    depthNear?: number;
+    baseLayer?: XRWebGLLayer | undefined;
+    depthFar?: number | undefined;
+    depthNear?: number | undefined;
     inlineVerticalFieldOfView?: number | undefined;
     layers?: XRLayer[] | undefined;
 }
@@ -212,7 +212,7 @@ interface XRFrame {
 
     // Anchors
     trackedAnchors?: XRAnchorSet | undefined;
-    createAnchor?: (pose: XRRigidTransform, space: XRSpace) => Promise<XRAnchor>;
+    createAnchor?: (pose: XRRigidTransform, space: XRSpace) => Promise<XRAnchor> | undefined;
 
     // Planes
     worldInformation?: {
@@ -220,7 +220,7 @@ interface XRFrame {
     } | undefined;
 
     // Hand tracking
-    getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose;
+    getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose | undefined;
 }
 
 declare class XRFrame {
@@ -258,8 +258,8 @@ interface XRSession extends EventTarget {
     readonly renderState: XRRenderState;
     readonly environmentBlendMode: XREnvironmentBlendMode;
     readonly visibilityState: XRVisibilityState;
-    readonly frameRate?: number;
-    readonly supportedFrameRates?: Float32Array;
+    readonly frameRate?: number | undefined;
+    readonly supportedFrameRates?: Float32Array | undefined;
 
     /**
      * Removes a callback from the animation frame painting callback from
@@ -306,22 +306,22 @@ interface XRSession extends EventTarget {
     onvisibilitychange: XREventHandler;
     onframeratechange: XREventHandler;
 
-    addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions | undefined): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void;
+    removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions | undefined): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void;
 
     // hit test
-    requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource>;
+    requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource> | undefined;
     requestHitTestSourceForTransientInput?: (
         options: XRTransientInputHitTestOptionsInit,
-    ) => Promise<XRTransientInputHitTestSource>;
+    ) => Promise<XRTransientInputHitTestSource> | undefined;
 
     // legacy AR hit test
-    requestHitTest?: (ray: XRRay, referenceSpace: XRReferenceSpace) => Promise<XRHitResult[]>;
+    requestHitTest?: (ray: XRRay, referenceSpace: XRReferenceSpace) => Promise<XRHitResult[]> | undefined;
 
     // legacy plane detection
-    updateWorldTrackingState?: (options: { planeDetectionState?: { enabled: boolean } | undefined }) => void;
+    updateWorldTrackingState?: (options: { planeDetectionState?: { enabled: boolean } | undefined }) => void | undefined;
 }
 
 declare class XRSession {
@@ -333,7 +333,7 @@ interface XRViewerPose extends XRPose {
 }
 
 declare class XRRigidTransform {
-    constructor(position?: DOMPointInit, direction?: DOMPointInit);
+    constructor(position?: DOMPointInit | undefined, direction?: DOMPointInit | undefined);
     position: DOMPointReadOnly;
     orientation: DOMPointReadOnly;
     matrix: Float32Array;
@@ -355,7 +355,7 @@ interface XRInputSourceChangeEvent extends XRSessionEvent {
 
 // Experimental/Draft features
 declare class XRRay {
-    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
+    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit | undefined);
     readonly origin: DOMPointReadOnly;
     readonly direction: DOMPointReadOnly;
     readonly matrix: Float32Array;
@@ -378,7 +378,7 @@ interface XRTransientInputHitTestResult {
 interface XRHitTestResult {
     getPose(baseSpace: XRSpace): XRPose | undefined;
     // When anchor system is enabled
-    createAnchor?(pose: XRRigidTransform): Promise<XRAnchor>;
+    createAnchor?: (pose: XRRigidTransform) => Promise<XRAnchor> | undefined;
 }
 
 interface XRHitTestSource {
@@ -502,7 +502,7 @@ interface XRCompositionLayerEventMap {
 interface XRCompositionLayer extends XRLayer {
     readonly layout: XRLayerLayout;
     blendTextureSourceAlpha: boolean;
-    chromaticAberrationCorrection?: boolean;
+    chromaticAberrationCorrection?: boolean | undefined;
     readonly mipLevels: number;
     readonly needsRedraw: boolean;
     destroy(): void;
@@ -516,12 +516,12 @@ interface XRCompositionLayer extends XRLayer {
         this: XRCompositionLayer,
         type: K,
         callback: (evt: XRCompositionLayerEventMap[K]) => any,
-        options?: boolean | AddEventListenerOptions
+        options?: boolean | AddEventListenerOptions | undefined
     ): void;
     addEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | AddEventListenerOptions
+        options?: boolean | AddEventListenerOptions | undefined
     ): void;
 
     removeEventListener<K extends keyof XRCompositionLayerEventMap>(
@@ -532,7 +532,7 @@ interface XRCompositionLayer extends XRLayer {
     removeEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | EventListenerOptions
+        options?: boolean | EventListenerOptions | undefined
     ): void;
 }
 
@@ -546,10 +546,10 @@ type XRLayerLayout =
     | "stereo-top-bottom";
 
 interface XRProjectionLayerInit {
-    scaleFactor?: number;
-    textureType?: XRTextureType;
-    colorFormat?: GLenum;
-    depthFormat?: GLenum;
+    scaleFactor?: number | undefined;
+    textureType?: XRTextureType | undefined;
+    colorFormat?: GLenum | undefined;
+    depthFormat?: GLenum | undefined;
 }
 
 interface XRProjectionLayer extends XRCompositionLayer {
@@ -561,35 +561,35 @@ interface XRProjectionLayer extends XRCompositionLayer {
 }
 
 interface XRLayerInit {
-    mipLevels?: number;
+    mipLevels?: number | undefined;
     viewPixelWidth: number;
     viewPixelHeight: number;
-    isStatic?: boolean;
-    colorFormat?: GLenum;
-    depthFormat?: GLenum;
+    isStatic?: boolean | undefined;
+    colorFormat?: GLenum | undefined;
+    depthFormat?: GLenum | undefined;
     space: XRSpace;
-    layout?: XRLayerLayout;
+    layout?: XRLayerLayout | undefined;
 }
 
 interface XRMediaLayerInit {
-    invertStereo?: boolean;
+    invertStereo?: boolean | undefined;
     space: XRSpace;
-    layout?: XRLayerLayout;
+    layout?: XRLayerLayout | undefined;
 }
 
 interface XRCylinderLayerInit extends XRLayerInit {
-    textureType?: XRTextureType;
+    textureType?: XRTextureType | undefined;
     transform: XRRigidTransform;
-    radius?: number;
-    centralAngle?: number;
-    aspectRatio?: number;
+    radius?: number | undefined;
+    centralAngle?: number | undefined;
+    aspectRatio?: number | undefined;
 }
 
 interface XRMediaCylinderLayerInit extends XRMediaLayerInit {
-    transform?: XRRigidTransform;
-    radius?: number;
-    centralAngle?: number;
-    aspectRatio?: number;
+    transform?: XRRigidTransform | undefined;
+    radius?: number | undefined;
+    centralAngle?: number | undefined;
+    aspectRatio?: number | undefined;
 }
 
 interface XRCylinderLayer extends XRCompositionLayer {
@@ -600,16 +600,16 @@ interface XRCylinderLayer extends XRCompositionLayer {
 }
 
 interface XRQuadLayerInit extends XRLayerInit {
-    textureType?: XRTextureType;
-    transform?: XRRigidTransform;
-    width?: number;
-    height?: number;
+    textureType?: XRTextureType | undefined;
+    transform?: XRRigidTransform | undefined;
+    width?: number | undefined;
+    height?: number | undefined;
 }
 
 interface XRMediaQuadLayerInit extends XRMediaLayerInit {
-    transform?: XRRigidTransform;
-    width?: number;
-    height?: number;
+    transform?: XRRigidTransform | undefined;
+    width?: number | undefined;
+    height?: number | undefined;
 }
 
 interface XRQuadLayer extends XRCompositionLayer {
@@ -619,20 +619,20 @@ interface XRQuadLayer extends XRCompositionLayer {
 }
 
 interface XREquirectLayerInit extends XRLayerInit {
-    textureType?: XRTextureType;
-    transform?: XRRigidTransform;
-    radius?: number;
-    centralHorizontalAngle?: number;
-    upperVerticalAngle?: number;
-    lowerVerticalAngle?: number;
+    textureType?: XRTextureType | undefined;
+    transform?: XRRigidTransform | undefined;
+    radius?: number | undefined;
+    centralHorizontalAngle?: number | undefined;
+    upperVerticalAngle?: number | undefined;
+    lowerVerticalAngle?: number | undefined;
 }
 
 interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
-    transform?: XRRigidTransform;
-    radius?: number;
-    centralHorizontalAngle?: number;
-    upperVerticalAngle?: number;
-    lowerVerticalAngle?: number;
+    transform?: XRRigidTransform | undefined;
+    radius?: number | undefined;
+    centralHorizontalAngle?: number | undefined;
+    upperVerticalAngle?: number | undefined;
+    lowerVerticalAngle?: number | undefined;
 }
 
 interface XREquirectLayer extends XRCompositionLayer {
@@ -644,7 +644,7 @@ interface XREquirectLayer extends XRCompositionLayer {
 }
 
 interface XRCubeLayerInit extends XRLayerInit {
-    orientation?: DOMPointReadOnly;
+    orientation?: DOMPointReadOnly | undefined;
 }
 
 interface XRCubeLayer extends XRCompositionLayer {
@@ -668,22 +668,22 @@ declare class XRWebGLBinding {
 
     readonly nativeProjectionScaleFactor: number;
 
-    createProjectionLayer(init?: XRProjectionLayerInit): XRProjectionLayer;
-    createQuadLayer(init?: XRQuadLayerInit): XRQuadLayer;
-    createCylinderLayer(init?: XRCylinderLayerInit): XRCylinderLayer;
-    createEquirectLayer(init?: XREquirectLayerInit): XREquirectLayer;
-    createCubeLayer(init?: XRCubeLayerInit): XRCubeLayer;
+    createProjectionLayer(init?: XRProjectionLayerInit | undefined): XRProjectionLayer;
+    createQuadLayer(init?: XRQuadLayerInit | undefined): XRQuadLayer;
+    createCylinderLayer(init?: XRCylinderLayerInit | undefined): XRCylinderLayer;
+    createEquirectLayer(init?: XREquirectLayerInit | undefined): XREquirectLayer;
+    createCubeLayer(init?: XRCubeLayerInit | undefined): XRCubeLayer;
 
-    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
+    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye | undefined): XRWebGLSubImage;
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
 }
 
 declare class XRMediaBinding {
     constructor(sesion: XRSession);
 
-    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
-    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
-    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
+    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit | undefined): XRQuadLayer;
+    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit | undefined): XRCylinderLayer;
+    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit | undefined): XREquirectLayer;
 }
 
 // WebGL extensions

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -408,7 +408,7 @@ interface XRAnchor {
 }
 
 interface XRPlane {
-    orientation: 'Horizontal' | 'Vertical';
+    orientation: 'horizontal' | 'vertical';
     planeSpace: XRSpace;
     polygon: DOMPointReadOnly[];
     lastChangedTime: number;

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -606,3 +606,53 @@ export class XRMediaBinding {
     createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
     createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
 }
+
+// WebGL extensions
+export interface XRWebGLRenderingContext {
+    makeXRCompatible(): Promise<void>;
+}
+
+export interface WebGLRenderingContextBase {
+    getExtension(extensionName: "OCULUS_multiview"): OCULUS_multiview | null;
+}
+
+export interface WebGLRenderingContext extends XRWebGLRenderingContext {
+}
+
+export interface WebGL2RenderingContext extends XRWebGLRenderingContext {
+}
+
+export enum XOVR_multiview2 {
+    FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630,
+    FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632,
+    MAX_VIEWS_OVR = 0x9631,
+    FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR = 0x9633
+}
+
+export interface OVR_multiview2 {
+    FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR: XOVR_multiview2;
+    FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR: XOVR_multiview2;
+    MAX_VIEWS_OVR: XOVR_multiview2;
+    FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR: XOVR_multiview2;
+
+    framebufferTextureMultiviewOVR(
+        target: GLenum,
+        attachment: GLenum,
+        texture: WebGLTexture,
+        level: number,
+        baseViewIndex: number,
+        numViews: number
+    ): WebGLRenderbuffer;
+}
+
+export interface OCULUS_multiview extends OVR_multiview2 {
+    framebufferTextureMultisampleMultiviewOVR(
+        target: GLenum,
+        attachment: GLenum,
+        texture: WebGLTexture | null,
+        level: GLint,
+        samples: GLsizei,
+        baseViewIndex: GLint,
+        numViews: GLsizei
+    ): void;
+}

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for non-npm package webxr 0.2
+// Type definitions for non-npm package webxr 0.3
 // Project: https://www.w3.org/TR/webxr/
 // Definitions by: Rob Rohan <https://github.com/robrohan>
 //                 Raanan Weber <https://github.com/RaananW>
+//                 Sean T. McBeth <https://github.com/capnmidnight>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.7
 

--- a/types/webxr/webxr-tests.ts
+++ b/types/webxr/webxr-tests.ts
@@ -1,71 +1,78 @@
-import {
-    XRWebGLLayer,
-    XRSession,
-    XRSystem,
-    XRRenderStateInit,
-    XRReferenceSpace,
-    XRFrame,
-    XRViewerPose,
-    XRRigidTransform,
-    XRView,
-    XRViewport,
-    XRFrameRequestCallback,
-} from 'webxr';
-
 const canvas = document.createElement('canvas');
-const ctx: WebGLRenderingContext | null = canvas.getContext('webgl');
+const ctx: WebGLRenderingContext | null = canvas.getContext('webgl') as any as WebGLRenderingContext;
 
-const xr = (navigator as any)?.xr as XRSystem;
-if (!xr) {
-    throw Error('You do not have WebXR');
-}
-
-let space: XRReferenceSpace;
-let layer: XRWebGLLayer;
-const startRot = new DOMPoint(0, 0, 0, 1);
-const startSpot = new DOMPoint(0, 0, 0, 1);
-xr.requestSession('immersive-vr').then((session: XRSession) => {
-    if (ctx) {
-        layer = new XRWebGLLayer(session, ctx);
-        const init: XRRenderStateInit = {
-            baseLayer: layer,
-            depthFar: 800,
-            depthNear: 0.01,
-            inlineVerticalFieldOfView: 1,
-        };
-        session.updateRenderState(init);
-
-        session
-            .requestReferenceSpace('local')
-            .then(rs => {
-                space = rs as XRReferenceSpace;
-
-                const loop: XRFrameRequestCallback = (time: number, frame: XRFrame) => {};
-                const handle = session.requestAnimationFrame(loop);
-                session.cancelAnimationFrame(handle);
-            })
-            .catch(e => {
-                throw Error("Can't get reference space" + e);
-            });
+(async () => {
+    if (!navigator.xr || ctx && !ctx.makeXRCompatible) {
+        throw Error('You do not have WebXR');
     }
-});
 
-const renderFrame = (frame: XRFrame) => {
-    const tf = new XRRigidTransform(startSpot, startRot);
-    space = space.getOffsetReferenceSpace(tf);
+    const startRot = new DOMPoint(0, 0, 0, 1);
+    const startSpot = new DOMPoint(0, 0, 0, 1);
 
-    const pose = frame.getViewerPose(space);
+    await ctx.makeXRCompatible();
 
-    if (pose) {
-        let view: XRView;
-        for (view of pose.views) {
-            const viewport: XRViewport = layer.getViewport(view);
-            // draw to the device eyes
+    const session = await navigator.xr.requestSession('immersive-vr');
+
+    const ext = ctx.getExtension("OCULUS_multiview");
+    if (ext && !ext.framebufferTextureMultisampleMultiviewOVR) {
+        throw Error("Incorrect extension type");
+    }
+
+    const layer = new XRWebGLLayer(session, ctx);
+    const init: XRRenderStateInit = {
+        baseLayer: layer,
+        depthFar: 800,
+        depthNear: 0.01,
+        inlineVerticalFieldOfView: 1,
+    };
+    session.updateRenderState(init);
+
+    let space = await session.requestReferenceSpace('local');
+
+    const loop: XRFrameRequestCallback = (time: number, frame: XRFrame) => { };
+    const handle = session.requestAnimationFrame(loop);
+    session.cancelAnimationFrame(handle);
+
+    const renderFrame = (frame: XRFrame) => {
+        const tf = new XRRigidTransform(startSpot, startRot);
+        space = space.getOffsetReferenceSpace(tf);
+
+        const pose = frame.getViewerPose(space);
+
+        if (pose) {
+            let view: XRView;
+            for (view of pose.views) {
+                const viewport: XRViewport | undefined = layer.getViewport(view);
+                // draw to the device eyes
+            }
         }
-    }
-};
+    };
 
-xr.addEventListener('devicechange', (e: Event) => {
-    // Event is a simple event; there is no additional data
-    // XR device availability changed
-});
+    navigator.xr.addEventListener('devicechange', (e: Event) => {
+        // Event is a simple event; there is no additional data
+        // XR device availability changed
+    });
+
+    const video = document.createElement("video");
+    const mediaBinding = new XRMediaBinding(session);
+    const transform = new XRRigidTransform({
+        x: 0,
+        y: 0,
+        z: -2
+    }, {
+        x: 0,
+        y: 0,
+        z: 0,
+        w: 1
+    });
+    const mediaLayer = mediaBinding.createQuadLayer(video, {
+        space,
+        layout: "mono",
+        invertStereo: false,
+        transform,
+        width: 1,
+        height: video.height / video.width
+    });
+
+    mediaLayer.destroy();
+})();


### PR DESCRIPTION
This PR fixes a number of issues with the type definitions for WebXR support in modern browsers, as defined in the documentation at [Immersive Web Work Group](https://github.com/immersive-web) and in the current implementation in Chromium. The changes cover the base "Device API", as well as the extensions for "Layers", "Hit Tests" and "Hand Input",

As WebXR API includes backwards-compatible extensions to existing interfaces in lib.dom, I've changed the definitions to be ambient exports. This aids in using the types without having to coerce them to and fro from the base definitions in lib.dom.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.