### PR TITLE
webxr: add class declarations so `instanceof` can be used to test types

### DIFF
--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -151,7 +151,6 @@ interface XRWebGLLayerInit {
 }
 
 interface XRWebGLLayer extends XRLayer {
-
     readonly antialias: boolean;
     readonly ignoreDepthValues: boolean;
     fixedFoveation?: number | undefined;
@@ -403,7 +402,7 @@ declare class XRViewerPose {
     prototype: XRViewerPose;
 }
 
-interface XRRigidTransform { 
+interface XRRigidTransform {
     readonly position: DOMPointReadOnly;
     readonly orientation: DOMPointReadOnly;
     readonly matrix: Float32Array;
@@ -412,6 +411,7 @@ interface XRRigidTransform {
 
 declare class XRRigidTransform {
     constructor(position?: DOMPointInit, direction?: DOMPointInit);
+    prototype: XRRigidTransform;
 }
 
 interface XRView {
@@ -617,6 +617,7 @@ interface XRLayerEvent extends Event {
 
 declare class XRLayerEvent {
     constructor(type: "redraw", eventInitDict?: XRLayerEventInit);
+    prototype: XRLayerEvent;
 }
 
 interface XRCompositionLayerEventMap {

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -13,43 +13,43 @@
 //  https://github.com/immersive-web
 //
 
-export interface Navigator {
+interface Navigator {
     xr?: XRSystem | undefined;
 }
 
 /**
  * Available session modes
  */
-export type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
+type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
 
 /**
  * Reference space types
  */
-export type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor' | 'unbounded';
+type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor' | 'unbounded';
 
-export type XREnvironmentBlendMode = 'opaque' | 'additive' | 'alpha-blend';
+type XREnvironmentBlendMode = 'opaque' | 'additive' | 'alpha-blend';
 
-export type XRVisibilityState = 'visible' | 'visible-blurred' | 'hidden';
+type XRVisibilityState = 'visible' | 'visible-blurred' | 'hidden';
 
 /**
  * Handedness types
  */
-export type XRHandedness = 'none' | 'left' | 'right';
+type XRHandedness = 'none' | 'left' | 'right';
 
 /**
  * InputSource target ray modes
  */
-export type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
+type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
 
 /**
  * Eye types
  */
-export type XREye = 'none' | 'left' | 'right';
+type XREye = 'none' | 'left' | 'right';
 
 /**
  * Type of XR events available
  */
-export type XREventType =
+type XREventType =
     | 'devicechange'
     | 'visibilitychange'
     | 'end'
@@ -62,46 +62,46 @@ export type XREventType =
     | 'squeezeend'
     | 'reset';
 
-export type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
+type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
 
-export type XRPlaneSet = Set<XRPlane>;
-export type XRAnchorSet = Set<XRAnchor>;
+type XRPlaneSet = Set<XRPlane>;
+type XRAnchorSet = Set<XRAnchor>;
 
-export interface XREventHandler {
+interface XREventHandler {
     (event: Event): any;
 }
 
 // tslint:disable-next-line no-empty-interface
-export interface XRLayer extends EventTarget { }
+interface XRLayer extends EventTarget { }
 
-export interface XRSessionInit {
+interface XRSessionInit {
     optionalFeatures?: string[] | undefined;
     requiredFeatures?: string[] | undefined;
 }
 
-export interface XRSessionEvent extends Event {
+interface XRSessionEvent extends Event {
     readonly session: XRSession;
 }
 
-export interface XRSystemDeviceChangeEvent extends Event {
+interface XRSystemDeviceChangeEvent extends Event {
     type: "devicechange";
 }
 
-export interface XRSessionGrant {
+interface XRSessionGrant {
     mode: XRSessionMode;
 }
 
-export interface XRSystemSessionGrantedEvent extends Event {
+interface XRSystemSessionGrantedEvent extends Event {
     type: "sessiongranted";
     session: XRSessionGrant;
 }
 
-export interface XRSystemEventMap extends HTMLMediaElementEventMap {
+interface XRSystemEventMap extends HTMLMediaElementEventMap {
     "devicechange": XRSystemDeviceChangeEvent;
     "sessiongranted": XRSystemSessionGrantedEvent;
 }
 
-export interface XRSystem extends EventTarget {
+interface XRSystem extends EventTarget {
     requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
     isSessionSupported(mode: XRSessionMode): Promise<boolean>;
 
@@ -114,14 +114,14 @@ export interface XRSystem extends EventTarget {
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
-export interface XRViewport {
+interface XRViewport {
     readonly x: number;
     readonly y: number;
     readonly width: number;
     readonly height: number;
 }
 
-export interface XRWebGLLayerInit {
+interface XRWebGLLayerInit {
     antialias?: boolean | undefined;
     depth?: boolean | undefined;
     stencil?: boolean | undefined;
@@ -130,10 +130,7 @@ export interface XRWebGLLayerInit {
     framebufferScaleFactor?: number | undefined;
 }
 
-export interface XRWebGLLayer extends XRLayer {
-}
-
-export class XRWebGLLayer {
+declare class XRWebGLLayer implements XRLayer {
     static getNativeFramebufferScaleFactor(session: XRSession): number;
 
     constructor(
@@ -151,12 +148,16 @@ export class XRWebGLLayer {
     readonly framebufferHeight: number;
 
     getViewport(view: XRView): XRViewport | undefined;
+
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions): void;
+    dispatchEvent(event: Event): boolean;
 }
 
 // tslint:disable-next-line no-empty-interface
-export interface XRSpace extends EventTarget { }
+interface XRSpace extends EventTarget { }
 
-export interface XRRenderState {
+interface XRRenderState {
     readonly baseLayer?: XRWebGLLayer | undefined;
     readonly depthFar: number;
     readonly depthNear: number;
@@ -166,7 +167,7 @@ export interface XRRenderState {
     readonly layers?: XRLayer[] | undefined;
 }
 
-export interface XRRenderStateInit {
+interface XRRenderStateInit {
     baseLayer?: XRWebGLLayer;
     depthFar?: number;
     depthNear?: number;
@@ -174,16 +175,16 @@ export interface XRRenderStateInit {
     layers?: XRLayer[] | undefined;
 }
 
-export interface XRReferenceSpace extends XRSpace {
+interface XRReferenceSpace extends XRSpace {
     getOffsetReferenceSpace(originOffset: XRRigidTransform): XRReferenceSpace;
     onreset: XREventHandler;
 }
 
-export interface XRBoundedReferenceSpace extends XRReferenceSpace {
+interface XRBoundedReferenceSpace extends XRReferenceSpace {
     readonly boundsGeometry: DOMPointReadOnly[];
 }
 
-export interface XRInputSource {
+interface XRInputSource {
     readonly handedness: XRHandedness;
     readonly targetRayMode: XRTargetRayMode;
     readonly targetRaySpace: XRSpace;
@@ -193,12 +194,12 @@ export interface XRInputSource {
     readonly hand?: XRHand | undefined;
 }
 
-export interface XRPose {
+interface XRPose {
     readonly transform: XRRigidTransform;
     readonly emulatedPosition: boolean;
 }
 
-export interface XRFrame {
+interface XRFrame {
     readonly session: XRSession;
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
@@ -222,16 +223,16 @@ export interface XRFrame {
     getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose;
 }
 
-export class XRFrame {
+declare class XRFrame {
     prototype: XRFrame;
 }
 
-export interface XRInputSourceEvent extends Event {
+interface XRInputSourceEvent extends Event {
     readonly frame: XRFrame;
     readonly inputSource: XRInputSource;
 }
 
-export interface XRSessionEventMap {
+interface XRSessionEventMap {
     "end": XREventHandler;
     "inputsourceschange": XREventHandler;
     "select": XREventHandler;
@@ -244,7 +245,7 @@ export interface XRSessionEventMap {
     "frameratechange": XREventHandler;
 }
 
-export interface XRSession extends EventTarget {
+interface XRSession extends EventTarget {
     /**
      * Returns a list of this session's XRInputSources, each representing an input device
      * used to control the camera and/or scene.
@@ -283,10 +284,10 @@ export interface XRSession extends EventTarget {
     requestAnimationFrame(callback: XRFrameRequestCallback): number;
 
     /**
-     * Requests that a new XRReferenceSpace of the specified export type be created.
+     * Requests that a new XRReferenceSpace of the specified type be created.
      * Returns a promise which resolves with the XRReferenceSpace or
      * XRBoundedReferenceSpace which was requested, or throws a NotSupportedError if
-     * the requested space export type isn't supported by the device.
+     * the requested space type isn't supported by the device.
      */
     requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace | XRBoundedReferenceSpace>;
 
@@ -323,15 +324,15 @@ export interface XRSession extends EventTarget {
     updateWorldTrackingState?: (options: { planeDetectionState?: { enabled: boolean } | undefined }) => void;
 }
 
-export class XRSession {
+declare class XRSession {
     prototype: XRSession;
 }
 
-export interface XRViewerPose extends XRPose {
+interface XRViewerPose extends XRPose {
     readonly views: XRView[];
 }
 
-export class XRRigidTransform {
+declare class XRRigidTransform {
     constructor(position?: DOMPointInit, direction?: DOMPointInit);
     position: DOMPointReadOnly;
     orientation: DOMPointReadOnly;
@@ -339,7 +340,7 @@ export class XRRigidTransform {
     inverse: XRRigidTransform;
 }
 
-export interface XRView {
+interface XRView {
     readonly eye: XREye;
     readonly projectionMatrix: Float32Array;
     readonly transform: XRRigidTransform;
@@ -347,72 +348,72 @@ export interface XRView {
     requestViewportScale(scale: number): void;
 }
 
-export interface XRInputSourceChangeEvent extends XRSessionEvent {
+interface XRInputSourceChangeEvent extends XRSessionEvent {
     removed: XRInputSource[];
     added: XRInputSource[];
 }
 
 // Experimental/Draft features
-export class XRRay {
+declare class XRRay {
     constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
     readonly origin: DOMPointReadOnly;
     readonly direction: DOMPointReadOnly;
     readonly matrix: Float32Array;
 }
 
-export type XRHitTestTrackableType =
+type XRHitTestTrackableType =
     | 'point'
     | 'plane'
     | 'mesh';
 
-export interface XRHitResult {
+interface XRHitResult {
     hitMatrix: Float32Array;
 }
 
-export interface XRTransientInputHitTestResult {
+interface XRTransientInputHitTestResult {
     readonly inputSource: XRInputSource;
     readonly results: XRHitTestResult[];
 }
 
-export interface XRHitTestResult {
+interface XRHitTestResult {
     getPose(baseSpace: XRSpace): XRPose | undefined;
     // When anchor system is enabled
     createAnchor?(pose: XRRigidTransform): Promise<XRAnchor>;
 }
 
-export interface XRHitTestSource {
+interface XRHitTestSource {
     cancel(): void;
 }
 
-export interface XRTransientInputHitTestSource {
+interface XRTransientInputHitTestSource {
     cancel(): void;
 }
 
-export interface XRHitTestOptionsInit {
+interface XRHitTestOptionsInit {
     space: XRSpace;
     entityTypes?: XRHitTestTrackableType[] | undefined;
     offsetRay?: XRRay | undefined;
 }
 
-export interface XRTransientInputHitTestOptionsInit {
+interface XRTransientInputHitTestOptionsInit {
     profile: string;
     entityTypes?: XRHitTestTrackableType[] | undefined;
     offsetRay?: XRRay | undefined;
 }
 
-export interface XRAnchor {
+interface XRAnchor {
     anchorSpace: XRSpace;
     delete(): void;
 }
 
-export interface XRPlane {
+interface XRPlane {
     orientation: 'Horizontal' | 'Vertical';
     planeSpace: XRSpace;
     polygon: DOMPointReadOnly[];
     lastChangedTime: number;
 }
 
-export type XRHandJoint =
+type XRHandJoint =
     | 'wrist'
     | 'thumb-metacarpal'
     | 'thumb-phalanx-proximal'
@@ -439,15 +440,15 @@ export type XRHandJoint =
     | 'pinky-finger-phalanx-distal'
     | 'pinky-finger-tip';
 
-export interface XRJointSpace extends XRSpace {
+interface XRJointSpace extends XRSpace {
     readonly jointName: XRHandJoint;
 }
 
-export interface XRJointPose extends XRPose {
+interface XRJointPose extends XRPose {
     readonly radius: number | undefined;
 }
 
-export interface XRHand extends Iterable<XRJointSpace> {
+interface XRHand extends Iterable<XRJointSpace> {
     readonly length: number;
 
     [index: number]: XRJointSpace;
@@ -484,23 +485,21 @@ export interface XRHand extends Iterable<XRJointSpace> {
     readonly LITTLE_PHALANX_TIP: number;
 }
 
-
-
 // WebXR Layers
-export interface XRLayerEventInit extends EventInit {
+interface XRLayerEventInit extends EventInit {
     layer: XRLayer;
 }
 
-export class XRLayerEvent extends Event {
+declare class XRLayerEvent extends Event {
     constructor(type: string, eventInitDict: XRLayerEventInit);
     readonly layer: XRLayer;
 }
 
-export interface XRCompositionLayerEventMap {
+interface XRCompositionLayerEventMap {
     "redraw": XRLayerEvent;
 }
 
-export interface XRCompositionLayer extends XRLayer {
+interface XRCompositionLayer extends XRLayer {
     readonly layout: XRLayerLayout;
     blendTextureSourceAlpha: boolean;
     chromaticAberrationCorrection?: boolean;
@@ -512,29 +511,48 @@ export interface XRCompositionLayer extends XRLayer {
 
     // Events
     onredraw: (evt: XRCompositionLayerEventMap["redraw"]) => any;
-    addEventListener<K extends keyof XRCompositionLayerEventMap>(this: XRCompositionLayer, type: K, callback: (evt: XRCompositionLayerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof XRCompositionLayerEventMap>(this: XRCompositionLayer, type: K, callback: (evt: XRCompositionLayerEventMap[K]) => any): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+
+    addEventListener<K extends keyof XRCompositionLayerEventMap>(
+        this: XRCompositionLayer,
+        type: K,
+        callback: (evt: XRCompositionLayerEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+
+    removeEventListener<K extends keyof XRCompositionLayerEventMap>(
+        this: XRCompositionLayer,
+        type: K,
+        callback: (evt: XRCompositionLayerEventMap[K]) => any
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions
+    ): void;
 }
 
-export type XRTextureType = "texture" | "texture-array";
+type XRTextureType = "texture" | "texture-array";
 
-export type XRLayerLayout =
+type XRLayerLayout =
     | "default"
     | "mono"
     | "stereo"
     | "stereo-left-right"
     | "stereo-top-bottom";
 
-export interface XRProjectionLayerInit {
+interface XRProjectionLayerInit {
     scaleFactor?: number;
     textureType?: XRTextureType;
     colorFormat?: GLenum;
     depthFormat?: GLenum;
 }
 
-export interface XRProjectionLayer extends XRCompositionLayer {
+interface XRProjectionLayer extends XRCompositionLayer {
     readonly textureWidth: number;
     readonly textureHeight: number;
     readonly textureArrayLength: number;
@@ -542,7 +560,7 @@ export interface XRProjectionLayer extends XRCompositionLayer {
     fixedFoveation: number;
 }
 
-export interface XRLayerInit {
+interface XRLayerInit {
     mipLevels?: number;
     viewPixelWidth: number;
     viewPixelHeight: number;
@@ -553,13 +571,13 @@ export interface XRLayerInit {
     layout?: XRLayerLayout;
 }
 
-export interface XRMediaLayerInit {
+interface XRMediaLayerInit {
     invertStereo?: boolean;
     space: XRSpace;
     layout?: XRLayerLayout;
 }
 
-export interface XRCylinderLayerInit extends XRLayerInit {
+interface XRCylinderLayerInit extends XRLayerInit {
     textureType?: XRTextureType;
     transform: XRRigidTransform;
     radius?: number;
@@ -567,40 +585,40 @@ export interface XRCylinderLayerInit extends XRLayerInit {
     aspectRatio?: number;
 }
 
-export interface XRMediaCylinderLayerInit extends XRMediaLayerInit {
+interface XRMediaCylinderLayerInit extends XRMediaLayerInit {
     transform?: XRRigidTransform;
     radius?: number;
     centralAngle?: number;
     aspectRatio?: number;
 }
 
-export interface XRCylinderLayer extends XRCompositionLayer {
+interface XRCylinderLayer extends XRCompositionLayer {
     transform: XRRigidTransform;
     radius: number;
     centralAngle: number;
     aspectRatio: number;
 }
 
-export interface XRQuadLayerInit extends XRLayerInit {
+interface XRQuadLayerInit extends XRLayerInit {
     textureType?: XRTextureType;
     transform?: XRRigidTransform;
     width?: number;
     height?: number;
 }
 
-export interface XRMediaQuadLayerInit extends XRMediaLayerInit {
+interface XRMediaQuadLayerInit extends XRMediaLayerInit {
     transform?: XRRigidTransform;
     width?: number;
     height?: number;
 }
 
-export interface XRQuadLayer extends XRCompositionLayer {
+interface XRQuadLayer extends XRCompositionLayer {
     transform: XRRigidTransform;
     width: number;
     height: number;
 }
 
-export interface XREquirectLayerInit extends XRLayerInit {
+interface XREquirectLayerInit extends XRLayerInit {
     textureType?: XRTextureType;
     transform?: XRRigidTransform;
     radius?: number;
@@ -609,7 +627,7 @@ export interface XREquirectLayerInit extends XRLayerInit {
     lowerVerticalAngle?: number;
 }
 
-export interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
+interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
     transform?: XRRigidTransform;
     radius?: number;
     centralHorizontalAngle?: number;
@@ -617,7 +635,7 @@ export interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
     lowerVerticalAngle?: number;
 }
 
-export interface XREquirectLayer extends XRCompositionLayer {
+interface XREquirectLayer extends XRCompositionLayer {
     transform: XRRigidTransform;
     radius: number;
     centralHorizontalAngle: number;
@@ -625,19 +643,19 @@ export interface XREquirectLayer extends XRCompositionLayer {
     lowerVerticalAngle: number;
 }
 
-export interface XRCubeLayerInit extends XRLayerInit {
+interface XRCubeLayerInit extends XRLayerInit {
     orientation?: DOMPointReadOnly;
 }
 
-export interface XRCubeLayer extends XRCompositionLayer {
+interface XRCubeLayer extends XRCompositionLayer {
     orientation: DOMPointReadOnly;
 }
 
-export interface XRSubImage {
+interface XRSubImage {
     readonly viewport: XRViewport;
 }
 
-export interface XRWebGLSubImage extends XRSubImage {
+interface XRWebGLSubImage extends XRSubImage {
     readonly colorTexture: WebGLTexture;
     readonly depthStencilTexture: WebGLTexture;
     readonly imageIndex: number;
@@ -645,7 +663,7 @@ export interface XRWebGLSubImage extends XRSubImage {
     readonly textureHeight: number;
 }
 
-export class XRWebGLBinding {
+declare class XRWebGLBinding {
     constructor(session: XRSession, context: WebGLRenderingContext);
 
     readonly nativeProjectionScaleFactor: number;
@@ -660,7 +678,7 @@ export class XRWebGLBinding {
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
 }
 
-export class XRMediaBinding {
+declare class XRMediaBinding {
     constructor(sesion: XRSession);
 
     createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
@@ -669,32 +687,74 @@ export class XRMediaBinding {
 }
 
 // WebGL extensions
-export interface XRWebGLRenderingContext {
+interface WebGLRenderingContext {
     makeXRCompatible(): Promise<void>;
-}
-
-export interface WebGLRenderingContextBase {
     getExtension(extensionName: "OCULUS_multiview"): OCULUS_multiview | null;
+    getExtension(extensionName: "EXT_blend_minmax"): EXT_blend_minmax | null;
+    getExtension(extensionName: "EXT_texture_filter_anisotropic"): EXT_texture_filter_anisotropic | null;
+    getExtension(extensionName: "EXT_frag_depth"): EXT_frag_depth | null;
+    getExtension(extensionName: "EXT_shader_texture_lod"): EXT_shader_texture_lod | null;
+    getExtension(extensionName: "EXT_sRGB"): EXT_sRGB | null;
+    getExtension(extensionName: "OES_vertex_array_object"): OES_vertex_array_object | null;
+    getExtension(extensionName: "WEBGL_color_buffer_float"): WEBGL_color_buffer_float | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_astc"): WEBGL_compressed_texture_astc | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_s3tc_srgb"): WEBGL_compressed_texture_s3tc_srgb | null;
+    getExtension(extensionName: "WEBGL_debug_shaders"): WEBGL_debug_shaders | null;
+    getExtension(extensionName: "WEBGL_draw_buffers"): WEBGL_draw_buffers | null;
+    getExtension(extensionName: "WEBGL_lose_context"): WEBGL_lose_context | null;
+    getExtension(extensionName: "WEBGL_depth_texture"): WEBGL_depth_texture | null;
+    getExtension(extensionName: "WEBGL_debug_renderer_info"): WEBGL_debug_renderer_info | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_s3tc"): WEBGL_compressed_texture_s3tc | null;
+    getExtension(extensionName: "OES_texture_half_float_linear"): OES_texture_half_float_linear | null;
+    getExtension(extensionName: "OES_texture_half_float"): OES_texture_half_float | null;
+    getExtension(extensionName: "OES_texture_float_linear"): OES_texture_float_linear | null;
+    getExtension(extensionName: "OES_texture_float"): OES_texture_float | null;
+    getExtension(extensionName: "OES_standard_derivatives"): OES_standard_derivatives | null;
+    getExtension(extensionName: "OES_element_index_uint"): OES_element_index_uint | null;
+    getExtension(extensionName: "ANGLE_instanced_arrays"): ANGLE_instanced_arrays | null;
+    getExtension(extensionName: string): any;
 }
 
-export interface WebGLRenderingContext extends XRWebGLRenderingContext {
+interface WebGL2RenderingContext {
+    makeXRCompatible(): Promise<void>;
+    getExtension(extensionName: "OCULUS_multiview"): OCULUS_multiview | null;
+    getExtension(extensionName: "EXT_blend_minmax"): EXT_blend_minmax | null;
+    getExtension(extensionName: "EXT_texture_filter_anisotropic"): EXT_texture_filter_anisotropic | null;
+    getExtension(extensionName: "EXT_frag_depth"): EXT_frag_depth | null;
+    getExtension(extensionName: "EXT_shader_texture_lod"): EXT_shader_texture_lod | null;
+    getExtension(extensionName: "EXT_sRGB"): EXT_sRGB | null;
+    getExtension(extensionName: "OES_vertex_array_object"): OES_vertex_array_object | null;
+    getExtension(extensionName: "WEBGL_color_buffer_float"): WEBGL_color_buffer_float | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_astc"): WEBGL_compressed_texture_astc | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_s3tc_srgb"): WEBGL_compressed_texture_s3tc_srgb | null;
+    getExtension(extensionName: "WEBGL_debug_shaders"): WEBGL_debug_shaders | null;
+    getExtension(extensionName: "WEBGL_draw_buffers"): WEBGL_draw_buffers | null;
+    getExtension(extensionName: "WEBGL_lose_context"): WEBGL_lose_context | null;
+    getExtension(extensionName: "WEBGL_depth_texture"): WEBGL_depth_texture | null;
+    getExtension(extensionName: "WEBGL_debug_renderer_info"): WEBGL_debug_renderer_info | null;
+    getExtension(extensionName: "WEBGL_compressed_texture_s3tc"): WEBGL_compressed_texture_s3tc | null;
+    getExtension(extensionName: "OES_texture_half_float_linear"): OES_texture_half_float_linear | null;
+    getExtension(extensionName: "OES_texture_half_float"): OES_texture_half_float | null;
+    getExtension(extensionName: "OES_texture_float_linear"): OES_texture_float_linear | null;
+    getExtension(extensionName: "OES_texture_float"): OES_texture_float | null;
+    getExtension(extensionName: "OES_standard_derivatives"): OES_standard_derivatives | null;
+    getExtension(extensionName: "OES_element_index_uint"): OES_element_index_uint | null;
+    getExtension(extensionName: "ANGLE_instanced_arrays"): ANGLE_instanced_arrays | null;
+    getExtension(extensionName: string): any;
 }
 
-export interface WebGL2RenderingContext extends XRWebGLRenderingContext {
-}
-
-export enum XOVR_multiview2 {
+declare enum XOVR_multiview2 {
     FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630,
     FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632,
     MAX_VIEWS_OVR = 0x9631,
     FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR = 0x9633
 }
 
-export interface OVR_multiview2 {
-    FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR: XOVR_multiview2;
-    FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR: XOVR_multiview2;
-    MAX_VIEWS_OVR: XOVR_multiview2;
-    FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR: XOVR_multiview2;
+interface OVR_multiview2 {
+    readonly FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR: number;
+    readonly FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR: number;
+    readonly MAX_VIEWS_OVR: number;
+    readonly FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR: number;
 
     framebufferTextureMultiviewOVR(
         target: GLenum,
@@ -706,7 +766,7 @@ export interface OVR_multiview2 {
     ): WebGLRenderbuffer;
 }
 
-export interface OCULUS_multiview extends OVR_multiview2 {
+interface OCULUS_multiview extends OVR_multiview2 {
     framebufferTextureMultisampleMultiviewOVR(
         target: GLenum,
         attachment: GLenum,

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package webxr 0.3
+// Type definitions for non-npm package webxr 0.4
 // Project: https://www.w3.org/TR/webxr/
 // Definitions by: Rob Rohan <https://github.com/robrohan>
 //                 Raanan Weber <https://github.com/RaananW>
@@ -50,17 +50,20 @@ type XREye = 'none' | 'left' | 'right';
 /**
  * Type of XR events available
  */
+type XRInputSourceEventType =
+    | "select"
+    | "selectend"
+    | "selectstart"
+    | "squeeze"
+    | "squeezeend"
+    | "squeezestart";
+
 type XREventType =
+    | XRInputSourceEventType
     | 'devicechange'
     | 'visibilitychange'
     | 'end'
     | 'inputsourceschange'
-    | 'select'
-    | 'selectstart'
-    | 'selectend'
-    | 'squeeze'
-    | 'squeezestart'
-    | 'squeezeend'
     | 'reset';
 
 type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
@@ -75,6 +78,10 @@ interface XREventHandler {
 // tslint:disable-next-line no-empty-interface
 interface XRLayer extends EventTarget { }
 
+declare class XRLayer {
+    prototype: XRLayer;
+}
+
 interface XRSessionInit {
     optionalFeatures?: string[] | undefined;
     requiredFeatures?: string[] | undefined;
@@ -82,6 +89,10 @@ interface XRSessionInit {
 
 interface XRSessionEvent extends Event {
     readonly session: XRSession;
+}
+
+declare class XRSessionEvent {
+    prototype: XRSessionEvent;
 }
 
 interface XRSystemDeviceChangeEvent extends Event {
@@ -115,11 +126,19 @@ interface XRSystem extends EventTarget {
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
+declare class XRSystem {
+    prototype: XRSystem;
+}
+
 interface XRViewport {
     readonly x: number;
     readonly y: number;
     readonly width: number;
     readonly height: number;
+}
+
+declare class XRViewport {
+    prototype: XRViewport;
 }
 
 interface XRWebGLLayerInit {
@@ -131,14 +150,7 @@ interface XRWebGLLayerInit {
     framebufferScaleFactor?: number | undefined;
 }
 
-declare class XRWebGLLayer implements XRLayer {
-    static getNativeFramebufferScaleFactor(session: XRSession): number;
-
-    constructor(
-        session: XRSession,
-        context: WebGLRenderingContext | WebGL2RenderingContext,
-        layerInit?: XRWebGLLayerInit,
-    );
+interface XRWebGLLayer extends XRLayer {
 
     readonly antialias: boolean;
     readonly ignoreDepthValues: boolean;
@@ -155,8 +167,24 @@ declare class XRWebGLLayer implements XRLayer {
     dispatchEvent(event: Event): boolean;
 }
 
+declare class XRWebGLLayer {
+    static getNativeFramebufferScaleFactor(session: XRSession): number;
+
+    constructor(
+        session: XRSession,
+        context: WebGLRenderingContext | WebGL2RenderingContext,
+        layerInit?: XRWebGLLayerInit,
+    );
+
+    prototype: XRWebGLLayer;
+}
+
 // tslint:disable-next-line no-empty-interface
 interface XRSpace extends EventTarget { }
+
+declare class XRSpace {
+    prototype: XRSpace;
+}
 
 interface XRRenderState {
     readonly baseLayer?: XRWebGLLayer | undefined;
@@ -166,6 +194,10 @@ interface XRRenderState {
 
     // https://immersive-web.github.io/layers/#xrrenderstatechanges
     readonly layers?: XRLayer[] | undefined;
+}
+
+declare class XRRenderState {
+    prototype: XRRenderState;
 }
 
 interface XRRenderStateInit {
@@ -181,8 +213,16 @@ interface XRReferenceSpace extends XRSpace {
     onreset: XREventHandler;
 }
 
+declare class XRReferenceSpace {
+    prototype: XRReferenceSpace;
+}
+
 interface XRBoundedReferenceSpace extends XRReferenceSpace {
     readonly boundsGeometry: DOMPointReadOnly[];
+}
+
+declare class XRBoundedReferenceSpace {
+    prototype: XRBoundedReferenceSpace;
 }
 
 interface XRInputSource {
@@ -195,9 +235,24 @@ interface XRInputSource {
     readonly hand?: XRHand | undefined;
 }
 
+declare class XRInputSource {
+    prototype: XRInputSource;
+}
+
+// tslint:disable-next-line no-empty-interface
+interface XRInputSourceArray extends Array<XRInputSource> { }
+
+declare class XRInputSourceArray {
+    prototype: XRInputSourceArray;
+}
+
 interface XRPose {
     readonly transform: XRRigidTransform;
     readonly emulatedPosition: boolean;
+}
+
+declare class XRPose {
+    prototype: XRPose;
 }
 
 interface XRFrame {
@@ -229,21 +284,32 @@ declare class XRFrame {
 }
 
 interface XRInputSourceEvent extends Event {
+    readonly type: XRInputSourceEventType;
     readonly frame: XRFrame;
     readonly inputSource: XRInputSource;
+}
+
+interface XRInputSourceEventInit extends EventInit {
+    frame?: XRFrame | undefined;
+    inputSource?: XRInputSource | undefined;
+}
+
+declare class XRInputSourceEvent {
+    constructor(type: XRInputSourceEventType, eventInitDict?: XRInputSourceEventInit);
+    prototype: XRInputSourceEvent;
 }
 
 interface XRSessionEventMap {
     "end": XREventHandler;
     "inputsourceschange": XREventHandler;
-    "select": XREventHandler;
-    "selectstart": XREventHandler;
-    "selectend": XREventHandler;
-    "squeeze": XREventHandler;
-    "squeezestart": XREventHandler;
-    "squeezeend": XREventHandler;
     "visibilitychange": XREventHandler;
     "frameratechange": XREventHandler;
+    "select": XRInputSourceEvent;
+    "selectstart": XRInputSourceEvent;
+    "selectend": XRInputSourceEvent;
+    "squeeze": XRInputSourceEvent;
+    "squeezestart": XRInputSourceEvent;
+    "squeezeend": XRInputSourceEvent;
 }
 
 interface XRSession extends EventTarget {
@@ -251,7 +317,7 @@ interface XRSession extends EventTarget {
      * Returns a list of this session's XRInputSources, each representing an input device
      * used to control the camera and/or scene.
      */
-    readonly inputSources: XRInputSource[];
+    readonly inputSources: XRInputSourceArray;
     /**
      * object which contains options affecting how the imagery is rendered.
      * This includes things such as the near and far clipping planes
@@ -330,15 +396,22 @@ declare class XRSession {
 }
 
 interface XRViewerPose extends XRPose {
-    readonly views: XRView[];
+    readonly views: ReadonlyArray<XRView>;
+}
+
+declare class XRViewerPose {
+    prototype: XRViewerPose;
+}
+
+interface XRRigidTransform { 
+    readonly position: DOMPointReadOnly;
+    readonly orientation: DOMPointReadOnly;
+    readonly matrix: Float32Array;
+    readonly inverse: XRRigidTransform;
 }
 
 declare class XRRigidTransform {
     constructor(position?: DOMPointInit, direction?: DOMPointInit);
-    position: DOMPointReadOnly;
-    orientation: DOMPointReadOnly;
-    matrix: Float32Array;
-    inverse: XRRigidTransform;
 }
 
 interface XRView {
@@ -349,17 +422,36 @@ interface XRView {
     requestViewportScale(scale: number): void;
 }
 
+declare class XRView {
+    prototype: XRView;
+}
+
 interface XRInputSourceChangeEvent extends XRSessionEvent {
-    removed: XRInputSource[];
-    added: XRInputSource[];
+    readonly removed: ReadonlyArray<XRInputSource>;
+    readonly added: ReadonlyArray<XRInputSource>;
+}
+
+interface XRInputSourceChangeEventInit extends EventInit {
+    session?: XRSession;
+    added?: XRInputSource[];
+    removed?: XRInputSource[];
+}
+
+declare class XRInputSourceChangeEvent {
+    constructor(type: "inpuptsourceschange", eventInitDict?: XRInputSourceChangeEventInit);
+    prototype: XRInputSourceChangeEvent;
 }
 
 // Experimental/Draft features
-declare class XRRay {
-    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
+interface XRRay {
     readonly origin: DOMPointReadOnly;
     readonly direction: DOMPointReadOnly;
     readonly matrix: Float32Array;
+}
+
+declare class XRRay {
+    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
+    prototype: XRRay;
 }
 
 type XRHitTestTrackableType =
@@ -373,7 +465,11 @@ interface XRHitResult {
 
 interface XRTransientInputHitTestResult {
     readonly inputSource: XRInputSource;
-    readonly results: XRHitTestResult[];
+    readonly results: ReadonlyArray<XRHitTestResult>;
+}
+
+declare class XRTransientInputHitTestResult {
+    prototype: XRTransientInputHitTestResult;
 }
 
 interface XRHitTestResult {
@@ -382,12 +478,24 @@ interface XRHitTestResult {
     createAnchor?: (pose: XRRigidTransform) => Promise<XRAnchor> | undefined;
 }
 
+declare class XRHitTestResult {
+    prototype: XRHitTestResult;
+}
+
 interface XRHitTestSource {
     cancel(): void;
 }
 
+declare class XRHitTestSource {
+    prototype: XRHitTestSource;
+}
+
 interface XRTransientInputHitTestSource {
     cancel(): void;
+}
+
+declare class XRTransientInputHitTestSource {
+    prototype: XRTransientInputHitTestSource;
 }
 
 interface XRHitTestOptionsInit {
@@ -405,6 +513,10 @@ interface XRTransientInputHitTestOptionsInit {
 interface XRAnchor {
     anchorSpace: XRSpace;
     delete(): void;
+}
+
+declare class XRAnchor {
+    prototype: XRAnchor;
 }
 
 interface XRPlane {
@@ -445,15 +557,19 @@ interface XRJointSpace extends XRSpace {
     readonly jointName: XRHandJoint;
 }
 
+declare class XRJointSpace {
+    prototype: XRJointSpace;
+}
+
 interface XRJointPose extends XRPose {
     readonly radius: number | undefined;
 }
 
-interface XRHand extends Iterable<XRJointSpace> {
-    readonly length: number;
+declare class XRJointPose {
+    prototype: XRJointPose;
+}
 
-    [index: number]: XRJointSpace;
-
+interface XRHand extends Map<number, XRJointSpace> {
     readonly WRIST: number;
 
     readonly THUMB_METACARPAL: number;
@@ -486,14 +602,21 @@ interface XRHand extends Iterable<XRJointSpace> {
     readonly LITTLE_PHALANX_TIP: number;
 }
 
+declare class XRHand {
+    prototype: XRHand;
+}
+
 // WebXR Layers
 interface XRLayerEventInit extends EventInit {
     layer: XRLayer;
 }
 
-declare class XRLayerEvent extends Event {
-    constructor(type: string, eventInitDict: XRLayerEventInit);
+interface XRLayerEvent extends Event {
     readonly layer: XRLayer;
+}
+
+declare class XRLayerEvent {
+    constructor(type: "redraw", eventInitDict?: XRLayerEventInit);
 }
 
 interface XRCompositionLayerEventMap {
@@ -537,6 +660,10 @@ interface XRCompositionLayer extends XRLayer {
     ): void;
 }
 
+declare class XRCompositionLayer {
+    prototype: XRCompositionLayer;
+}
+
 type XRTextureType = "texture" | "texture-array";
 
 type XRLayerLayout =
@@ -559,6 +686,10 @@ interface XRProjectionLayer extends XRCompositionLayer {
     readonly textureArrayLength: number;
     readonly ignoreDepthValues: number;
     fixedFoveation: number;
+}
+
+declare class XRProjectionLayer {
+    prototype: XRProjectionLayer;
 }
 
 interface XRLayerInit {
@@ -600,6 +731,10 @@ interface XRCylinderLayer extends XRCompositionLayer {
     aspectRatio: number;
 }
 
+declare class XRCylinderLayer {
+    prototype: XRCylinderLayer;
+}
+
 interface XRQuadLayerInit extends XRLayerInit {
     textureType?: XRTextureType | undefined;
     transform?: XRRigidTransform | undefined;
@@ -617,6 +752,10 @@ interface XRQuadLayer extends XRCompositionLayer {
     transform: XRRigidTransform;
     width: number;
     height: number;
+}
+
+declare class XRQuadLayer {
+    prototype: XRQuadLayer;
 }
 
 interface XREquirectLayerInit extends XRLayerInit {
@@ -644,6 +783,10 @@ interface XREquirectLayer extends XRCompositionLayer {
     lowerVerticalAngle: number;
 }
 
+declare class XREquirectLayer {
+    prototype: XREquirectLayer;
+}
+
 interface XRCubeLayerInit extends XRLayerInit {
     orientation?: DOMPointReadOnly | undefined;
 }
@@ -652,8 +795,16 @@ interface XRCubeLayer extends XRCompositionLayer {
     orientation: DOMPointReadOnly;
 }
 
+declare class XRCubeLayer {
+    prototype: XRCubeLayer;
+}
+
 interface XRSubImage {
     readonly viewport: XRViewport;
+}
+
+declare class XRSubImage {
+    prototype: XRSubImage;
 }
 
 interface XRWebGLSubImage extends XRSubImage {
@@ -664,9 +815,11 @@ interface XRWebGLSubImage extends XRSubImage {
     readonly textureHeight: number;
 }
 
-declare class XRWebGLBinding {
-    constructor(session: XRSession, context: WebGLRenderingContext);
+declare class XRWebGLSubImage {
+    prototype: XRWebGLSubImage;
+}
 
+interface XRWebGLBinding {
     readonly nativeProjectionScaleFactor: number;
 
     createProjectionLayer(init?: XRProjectionLayerInit): XRProjectionLayer;
@@ -679,12 +832,20 @@ declare class XRWebGLBinding {
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
 }
 
-declare class XRMediaBinding {
-    constructor(sesion: XRSession);
+declare class XRWebGLBinding {
+    constructor(session: XRSession, context: WebGLRenderingContext);
+    prototype: XRWebGLBinding;
+}
 
+interface XRMediaBinding {
     createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
     createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
     createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
+}
+
+declare class XRMediaBinding {
+    constructor(sesion: XRSession);
+    prototype: XRMediaBinding;
 }
 
 // WebGL extensions

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -83,9 +83,35 @@ export interface XRSessionEvent extends Event {
     readonly session: XRSession;
 }
 
+export interface XRSystemDeviceChangeEvent extends Event {
+    type: "devicechange";
+}
+
+export interface XRSessionGrant {
+    mode: XRSessionMode;
+}
+
+export interface XRSystemSessionGrantedEvent extends Event {
+    type: "sessiongranted";
+    session: XRSessionGrant;
+}
+
+export interface XRSystemEventMap extends HTMLMediaElementEventMap {
+    "devicechange": XRSystemDeviceChangeEvent;
+    "sessiongranted": XRSystemSessionGrantedEvent;
+}
+
 export interface XRSystem extends EventTarget {
-    isSessionSupported: (sessionMode: XRSessionMode) => Promise<boolean>;
-    requestSession: (sessionMode: XRSessionMode, sessionInit?: any) => Promise<XRSession>;
+    requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
+    isSessionSupported(mode: XRSessionMode): Promise<boolean>;
+
+    ondevicechange: ((this: XRSystem, ev: XRSystemDeviceChangeEvent) => any) | null;
+    onsessiongranted: ((this: XRSystem, ev: XRSystemSessionGrantedEvent) => any) | null;
+
+    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 export interface XRViewport {

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -103,16 +103,16 @@ interface XRSystemEventMap extends HTMLMediaElementEventMap {
 }
 
 interface XRSystem extends EventTarget {
-    requestSession(mode: XRSessionMode, options?: XRSessionInit | undefined): Promise<XRSession>;
+    requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
     isSessionSupported(mode: XRSessionMode): Promise<boolean>;
 
     ondevicechange: ((this: XRSystem, ev: XRSystemDeviceChangeEvent) => any) | null;
     onsessiongranted: ((this: XRSystem, ev: XRSystemSessionGrantedEvent) => any) | null;
 
-    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions | undefined): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void;
-    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions | undefined): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void;
+    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 interface XRViewport {
@@ -137,7 +137,7 @@ declare class XRWebGLLayer implements XRLayer {
     constructor(
         session: XRSession,
         context: WebGLRenderingContext | WebGL2RenderingContext,
-        layerInit?: XRWebGLLayerInit | undefined,
+        layerInit?: XRWebGLLayerInit,
     );
 
     readonly antialias: boolean;
@@ -150,8 +150,8 @@ declare class XRWebGLLayer implements XRLayer {
 
     getViewport(view: XRView): XRViewport | undefined;
 
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions | undefined): void;
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions | undefined): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions): void;
     dispatchEvent(event: Event): boolean;
 }
 
@@ -307,10 +307,10 @@ interface XRSession extends EventTarget {
     onvisibilitychange: XREventHandler;
     onframeratechange: XREventHandler;
 
-    addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions | undefined): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void;
-    removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions | undefined): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void;
+    addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 
     // hit test
     requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource> | undefined;
@@ -334,7 +334,7 @@ interface XRViewerPose extends XRPose {
 }
 
 declare class XRRigidTransform {
-    constructor(position?: DOMPointInit | undefined, direction?: DOMPointInit | undefined);
+    constructor(position?: DOMPointInit, direction?: DOMPointInit);
     position: DOMPointReadOnly;
     orientation: DOMPointReadOnly;
     matrix: Float32Array;
@@ -356,7 +356,7 @@ interface XRInputSourceChangeEvent extends XRSessionEvent {
 
 // Experimental/Draft features
 declare class XRRay {
-    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit | undefined);
+    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
     readonly origin: DOMPointReadOnly;
     readonly direction: DOMPointReadOnly;
     readonly matrix: Float32Array;
@@ -517,12 +517,12 @@ interface XRCompositionLayer extends XRLayer {
         this: XRCompositionLayer,
         type: K,
         callback: (evt: XRCompositionLayerEventMap[K]) => any,
-        options?: boolean | AddEventListenerOptions | undefined
+        options?: boolean | AddEventListenerOptions
     ): void;
     addEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | AddEventListenerOptions | undefined
+        options?: boolean | AddEventListenerOptions
     ): void;
 
     removeEventListener<K extends keyof XRCompositionLayerEventMap>(
@@ -533,7 +533,7 @@ interface XRCompositionLayer extends XRLayer {
     removeEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | EventListenerOptions | undefined
+        options?: boolean | EventListenerOptions
     ): void;
 }
 
@@ -669,22 +669,22 @@ declare class XRWebGLBinding {
 
     readonly nativeProjectionScaleFactor: number;
 
-    createProjectionLayer(init?: XRProjectionLayerInit | undefined): XRProjectionLayer;
-    createQuadLayer(init?: XRQuadLayerInit | undefined): XRQuadLayer;
-    createCylinderLayer(init?: XRCylinderLayerInit | undefined): XRCylinderLayer;
-    createEquirectLayer(init?: XREquirectLayerInit | undefined): XREquirectLayer;
-    createCubeLayer(init?: XRCubeLayerInit | undefined): XRCubeLayer;
+    createProjectionLayer(init?: XRProjectionLayerInit): XRProjectionLayer;
+    createQuadLayer(init?: XRQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(init?: XRCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(init?: XREquirectLayerInit): XREquirectLayer;
+    createCubeLayer(init?: XRCubeLayerInit): XRCubeLayer;
 
-    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye | undefined): XRWebGLSubImage;
+    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
 }
 
 declare class XRMediaBinding {
     constructor(sesion: XRSession);
 
-    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit | undefined): XRQuadLayer;
-    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit | undefined): XRCylinderLayer;
-    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit | undefined): XREquirectLayer;
+    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
 }
 
 // WebGL extensions

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -153,6 +153,9 @@ export interface XRRenderState {
     readonly depthFar: number;
     readonly depthNear: number;
     readonly inlineVerticalFieldOfView?: number | undefined;
+
+    // https://immersive-web.github.io/layers/#xrrenderstatechanges
+    readonly layers?: XRLayer[] | undefined;
 }
 
 export interface XRRenderStateInit extends XRRenderState {
@@ -418,4 +421,188 @@ export interface XRHand extends Iterable<XRJointSpace> {
     readonly LITTLE_PHALANX_INTERMEDIATE: number;
     readonly LITTLE_PHALANX_DISTAL: number;
     readonly LITTLE_PHALANX_TIP: number;
+}
+
+
+
+// WebXR Layers
+export interface XRLayerEventInit extends EventInit {
+    layer: XRLayer;
+}
+
+export class XRLayerEvent extends Event {
+    constructor(type: string, eventInitDict: XRLayerEventInit);
+    readonly layer: XRLayer;
+}
+
+export interface XRCompositionLayerEventMap {
+    "redraw": XRLayerEvent;
+}
+
+export interface XRCompositionLayer extends XRLayer {
+    readonly layout: XRLayerLayout;
+    blendTextureSourceAlpha: boolean;
+    chromaticAberrationCorrection?: boolean;
+    readonly mipLevels: number;
+    readonly needsRedraw: boolean;
+    destroy(): void;
+
+    space: XRSpace;
+
+    // Events
+    onredraw: (evt: XRCompositionLayerEventMap["redraw"]) => any;
+    addEventListener<K extends keyof XRCompositionLayerEventMap>(this: XRCompositionLayer, type: K, callback: (evt: XRCompositionLayerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof XRCompositionLayerEventMap>(this: XRCompositionLayer, type: K, callback: (evt: XRCompositionLayerEventMap[K]) => any): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
+export type XRTextureType = "texture" | "texture-array";
+
+export type XRLayerLayout =
+    | "default"
+    | "mono"
+    | "stereo"
+    | "stereo-left-right"
+    | "stereo-top-bottom";
+
+export interface XRProjectionLayerInit {
+    scaleFactor?: number;
+    textureType?: XRTextureType;
+    colorFormat?: GLenum;
+    depthFormat?: GLenum;
+}
+
+export interface XRProjectionLayer extends XRCompositionLayer {
+    readonly textureWidth: number;
+    readonly textureHeight: number;
+    readonly textureArrayLength: number;
+    readonly ignoreDepthValues: number;
+    fixedFoveation: number;
+}
+
+export interface XRLayerInit {
+    mipLevels?: number;
+    viewPixelWidth: number;
+    viewPixelHeight: number;
+    isStatic?: boolean;
+    colorFormat?: GLenum;
+    depthFormat?: GLenum;
+    space: XRSpace;
+    layout?: XRLayerLayout;
+}
+
+export interface XRMediaLayerInit {
+    invertStereo?: boolean;
+    space: XRSpace;
+    layout?: XRLayerLayout;
+}
+
+export interface XRCylinderLayerInit extends XRLayerInit {
+    textureType?: XRTextureType;
+    transform: XRRigidTransform;
+    radius?: number;
+    centralAngle?: number;
+    aspectRatio?: number;
+}
+
+export interface XRMediaCylinderLayerInit extends XRMediaLayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralAngle?: number;
+    aspectRatio?: number;
+}
+
+export interface XRCylinderLayer extends XRCompositionLayer {
+    transform: XRRigidTransform;
+    radius: number;
+    centralAngle: number;
+    aspectRatio: number;
+}
+
+export interface XRQuadLayerInit extends XRLayerInit {
+    textureType?: XRTextureType;
+    transform?: XRRigidTransform;
+    width?: number;
+    height?: number;
+}
+
+export interface XRMediaQuadLayerInit extends XRMediaLayerInit {
+    transform?: XRRigidTransform;
+    width?: number;
+    height?: number;
+}
+
+export interface XRQuadLayer extends XRCompositionLayer {
+    transform: XRRigidTransform;
+    width: number;
+    height: number;
+}
+
+export interface XREquirectLayerInit extends XRLayerInit {
+    textureType?: XRTextureType;
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralHorizontalAngle?: number;
+    upperVerticalAngle?: number;
+    lowerVerticalAngle?: number;
+}
+
+export interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralHorizontalAngle?: number;
+    upperVerticalAngle?: number;
+    lowerVerticalAngle?: number;
+}
+
+export interface XREquirectLayer extends XRCompositionLayer {
+    transform: XRRigidTransform;
+    radius: number;
+    centralHorizontalAngle: number;
+    upperVerticalAngle: number;
+    lowerVerticalAngle: number;
+}
+
+export interface XRCubeLayerInit extends XRLayerInit {
+    orientation?: DOMPointReadOnly;
+}
+
+export interface XRCubeLayer extends XRCompositionLayer {
+    orientation: DOMPointReadOnly;
+}
+
+export interface XRSubImage {
+    readonly viewport: XRViewport;
+}
+
+export interface XRWebGLSubImage extends XRSubImage {
+    readonly colorTexture: WebGLTexture;
+    readonly depthStencilTexture: WebGLTexture;
+    readonly imageIndex: number;
+    readonly textureWidth: number;
+    readonly textureHeight: number;
+}
+
+export class XRWebGLBinding {
+    constructor(session: XRSession, context: WebGLRenderingContext);
+
+    readonly nativeProjectionScaleFactor: number;
+
+    createProjectionLayer(init?: XRProjectionLayerInit): XRProjectionLayer;
+    createQuadLayer(init?: XRQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(init?: XRCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(init?: XREquirectLayerInit): XREquirectLayer;
+    createCubeLayer(init?: XRCubeLayerInit): XRCubeLayer;
+
+    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
+    getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
+}
+
+export class XRMediaBinding {
+    constructor(sesion: XRSession);
+
+    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
 }

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -207,8 +207,9 @@ export interface XRFrame {
     worldInformation?: {
         detectedPlanes?: XRPlaneSet | undefined;
     } | undefined;
+
     // Hand tracking
-    getJointPose?(joint: XRJointSpace, baseSpace: XRSpace): XRJointPose;
+    getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose;
 }
 
 export interface XRInputSourceEvent extends Event {
@@ -379,11 +380,39 @@ export interface XRPlane {
     lastChangedTime: number;
 }
 
-// tslint:disable-next-line no-empty-interface
-export interface XRJointSpace extends XRSpace {}
+export type XRHandJoint =
+    | 'wrist'
+    | 'thumb-metacarpal'
+    | 'thumb-phalanx-proximal'
+    | 'thumb-phalanx-distal'
+    | 'thumb-tip'
+    | 'index-finger-metacarpal'
+    | 'index-finger-phalanx-proximal'
+    | 'index-finger-phalanx-intermediate'
+    | 'index-finger-phalanx-distal'
+    | 'index-finger-tip'
+    | 'middle-finger-metacarpal'
+    | 'middle-finger-phalanx-proximal'
+    | 'middle-finger-phalanx-intermediate'
+    | 'middle-finger-phalanx-distal'
+    | 'middle-finger-tip'
+    | 'ring-finger-metacarpal'
+    | 'ring-finger-phalanx-proximal'
+    | 'ring-finger-phalanx-intermediate'
+    | 'ring-finger-phalanx-distal'
+    | 'ring-finger-tip'
+    | 'pinky-finger-metacarpal'
+    | 'pinky-finger-phalanx-proximal'
+    | 'pinky-finger-phalanx-intermediate'
+    | 'pinky-finger-phalanx-distal'
+    | 'pinky-finger-tip';
+
+export interface XRJointSpace extends XRSpace {
+    readonly jointName: XRHandJoint;
+}
 
 export interface XRJointPose extends XRPose {
-    radius: number | undefined;
+    readonly radius: number | undefined;
 }
 
 export interface XRHand extends Iterable<XRJointSpace> {

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -198,8 +198,9 @@ export interface XRFrame {
     // AR
     getHitTestResults(hitTestSource: XRHitTestSource): XRHitTestResult[];
     getHitTestResultsForTransientInput(
-        hitTestSource: XRTransientInputHitTestSource,
+        hitTestSource: XRTransientInputHitTestSource
     ): XRTransientInputHitTestResult[];
+
     // Anchors
     trackedAnchors?: XRAnchorSet | undefined;
     createAnchor?(pose: XRRigidTransform, space: XRSpace): Promise<XRAnchor>;
@@ -281,13 +282,13 @@ export interface XRSession {
     onvisibilitychange: XREventHandler;
 
     // hit test
-    requestHitTestSource?(options: XRHitTestOptionsInit): Promise<XRHitTestSource>;
-    requestHitTestSourceForTransientInput?(
+    requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource>;
+    requestHitTestSourceForTransientInput?: (
         options: XRTransientInputHitTestOptionsInit,
-    ): Promise<XRTransientInputHitTestSource>;
+    ) => Promise<XRTransientInputHitTestSource>;
 
     // legacy AR hit test
-    requestHitTest?(ray: XRRay, referenceSpace: XRReferenceSpace): Promise<XRHitResult[]>;
+    requestHitTest?: (ray: XRRay, referenceSpace: XRReferenceSpace) => Promise<XRHitResult[]>;
 
     // legacy plane detection
     updateWorldTrackingState?(options: { planeDetectionState?: { enabled: boolean } | undefined }): void;
@@ -322,16 +323,15 @@ export interface XRInputSourceChangeEvent extends Event {
 // Experimental/Draft features
 export class XRRay {
     constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
-    origin: DOMPointReadOnly;
-    direction: DOMPointReadOnly;
-    matrix: Float32Array;
+    readonly origin: DOMPointReadOnly;
+    readonly direction: DOMPointReadOnly;
+    readonly matrix: Float32Array;
 }
 
-export enum XRHitTestTrackableType {
-    'point',
-    'plane',
-    'mesh',
-}
+export type XRHitTestTrackableType =
+    | 'point'
+    | 'plane'
+    | 'mesh';
 
 export interface XRHitResult {
     hitMatrix: Float32Array;

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -14,7 +14,7 @@
 //
 
 export interface Navigator {
-    xr: XRSystem;
+    xr?: XRSystem | undefined;
 }
 
 /**

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -102,16 +102,16 @@ interface XRSystemEventMap extends HTMLMediaElementEventMap {
 }
 
 interface XRSystem extends EventTarget {
-    requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
+    requestSession(mode: XRSessionMode, options?: XRSessionInit | undefined): Promise<XRSession>;
     isSessionSupported(mode: XRSessionMode): Promise<boolean>;
 
     ondevicechange: ((this: XRSystem, ev: XRSystemDeviceChangeEvent) => any) | null;
     onsessiongranted: ((this: XRSystem, ev: XRSystemSessionGrantedEvent) => any) | null;
 
-    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions | undefined): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void;
+    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions | undefined): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void;
 }
 
 interface XRViewport {
@@ -136,7 +136,7 @@ declare class XRWebGLLayer implements XRLayer {
     constructor(
         session: XRSession,
         context: WebGLRenderingContext | WebGL2RenderingContext,
-        layerInit ?: XRWebGLLayerInit,
+        layerInit?: XRWebGLLayerInit | undefined,
     );
 
     readonly antialias: boolean;
@@ -149,8 +149,8 @@ declare class XRWebGLLayer implements XRLayer {
 
     getViewport(view: XRView): XRViewport | undefined;
 
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions | undefined): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions | undefined): void;
     dispatchEvent(event: Event): boolean;
 }
 
@@ -168,9 +168,9 @@ interface XRRenderState {
 }
 
 interface XRRenderStateInit {
-    baseLayer?: XRWebGLLayer;
-    depthFar?: number;
-    depthNear?: number;
+    baseLayer?: XRWebGLLayer | undefined;
+    depthFar?: number | undefined;
+    depthNear?: number | undefined;
     inlineVerticalFieldOfView?: number | undefined;
     layers?: XRLayer[] | undefined;
 }
@@ -212,7 +212,7 @@ interface XRFrame {
 
     // Anchors
     trackedAnchors?: XRAnchorSet | undefined;
-    createAnchor?: (pose: XRRigidTransform, space: XRSpace) => Promise<XRAnchor>;
+    createAnchor?: (pose: XRRigidTransform, space: XRSpace) => Promise<XRAnchor> | undefined;
 
     // Planes
     worldInformation?: {
@@ -220,7 +220,7 @@ interface XRFrame {
     } | undefined;
 
     // Hand tracking
-    getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose;
+    getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose | undefined;
 }
 
 declare class XRFrame {
@@ -258,8 +258,8 @@ interface XRSession extends EventTarget {
     readonly renderState: XRRenderState;
     readonly environmentBlendMode: XREnvironmentBlendMode;
     readonly visibilityState: XRVisibilityState;
-    readonly frameRate?: number;
-    readonly supportedFrameRates?: Float32Array;
+    readonly frameRate?: number | undefined;
+    readonly supportedFrameRates?: Float32Array | undefined;
 
     /**
      * Removes a callback from the animation frame painting callback from
@@ -306,22 +306,22 @@ interface XRSession extends EventTarget {
     onvisibilitychange: XREventHandler;
     onframeratechange: XREventHandler;
 
-    addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions | undefined): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void;
+    removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions | undefined): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions | undefined): void;
 
     // hit test
-    requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource>;
+    requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource> | undefined;
     requestHitTestSourceForTransientInput?: (
         options: XRTransientInputHitTestOptionsInit,
-    ) => Promise<XRTransientInputHitTestSource>;
+    ) => Promise<XRTransientInputHitTestSource> | undefined;
 
     // legacy AR hit test
-    requestHitTest?: (ray: XRRay, referenceSpace: XRReferenceSpace) => Promise<XRHitResult[]>;
+    requestHitTest?: (ray: XRRay, referenceSpace: XRReferenceSpace) => Promise<XRHitResult[]> | undefined;
 
     // legacy plane detection
-    updateWorldTrackingState?: (options: { planeDetectionState?: { enabled: boolean } | undefined }) => void;
+    updateWorldTrackingState?: (options: { planeDetectionState?: { enabled: boolean } | undefined }) => void | undefined;
 }
 
 declare class XRSession {
@@ -333,7 +333,7 @@ interface XRViewerPose extends XRPose {
 }
 
 declare class XRRigidTransform {
-    constructor(position?: DOMPointInit, direction?: DOMPointInit);
+    constructor(position?: DOMPointInit | undefined, direction?: DOMPointInit | undefined);
     position: DOMPointReadOnly;
     orientation: DOMPointReadOnly;
     matrix: Float32Array;
@@ -355,7 +355,7 @@ interface XRInputSourceChangeEvent extends XRSessionEvent {
 
 // Experimental/Draft features
 declare class XRRay {
-    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
+    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit | undefined);
     readonly origin: DOMPointReadOnly;
     readonly direction: DOMPointReadOnly;
     readonly matrix: Float32Array;
@@ -378,7 +378,7 @@ interface XRTransientInputHitTestResult {
 interface XRHitTestResult {
     getPose(baseSpace: XRSpace): XRPose | undefined;
     // When anchor system is enabled
-    createAnchor?(pose: XRRigidTransform): Promise<XRAnchor>;
+    createAnchor?: (pose: XRRigidTransform) => Promise<XRAnchor> | undefined;
 }
 
 interface XRHitTestSource {
@@ -502,7 +502,7 @@ interface XRCompositionLayerEventMap {
 interface XRCompositionLayer extends XRLayer {
     readonly layout: XRLayerLayout;
     blendTextureSourceAlpha: boolean;
-    chromaticAberrationCorrection?: boolean;
+    chromaticAberrationCorrection?: boolean | undefined;
     readonly mipLevels: number;
     readonly needsRedraw: boolean;
     destroy(): void;
@@ -516,12 +516,12 @@ interface XRCompositionLayer extends XRLayer {
         this: XRCompositionLayer,
         type: K,
         callback: (evt: XRCompositionLayerEventMap[K]) => any,
-        options?: boolean | AddEventListenerOptions
+        options?: boolean | AddEventListenerOptions | undefined
     ): void;
     addEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | AddEventListenerOptions
+        options?: boolean | AddEventListenerOptions | undefined
     ): void;
 
     removeEventListener<K extends keyof XRCompositionLayerEventMap>(
@@ -532,7 +532,7 @@ interface XRCompositionLayer extends XRLayer {
     removeEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | EventListenerOptions
+        options?: boolean | EventListenerOptions | undefined
     ): void;
 }
 
@@ -546,10 +546,10 @@ type XRLayerLayout =
     | "stereo-top-bottom";
 
 interface XRProjectionLayerInit {
-    scaleFactor?: number;
-    textureType?: XRTextureType;
-    colorFormat?: GLenum;
-    depthFormat?: GLenum;
+    scaleFactor?: number | undefined;
+    textureType?: XRTextureType | undefined;
+    colorFormat?: GLenum | undefined;
+    depthFormat?: GLenum | undefined;
 }
 
 interface XRProjectionLayer extends XRCompositionLayer {
@@ -561,35 +561,35 @@ interface XRProjectionLayer extends XRCompositionLayer {
 }
 
 interface XRLayerInit {
-    mipLevels?: number;
+    mipLevels?: number | undefined;
     viewPixelWidth: number;
     viewPixelHeight: number;
-    isStatic?: boolean;
-    colorFormat?: GLenum;
-    depthFormat?: GLenum;
+    isStatic?: boolean | undefined;
+    colorFormat?: GLenum | undefined;
+    depthFormat?: GLenum | undefined;
     space: XRSpace;
-    layout?: XRLayerLayout;
+    layout?: XRLayerLayout | undefined;
 }
 
 interface XRMediaLayerInit {
-    invertStereo?: boolean;
+    invertStereo?: boolean | undefined;
     space: XRSpace;
-    layout?: XRLayerLayout;
+    layout?: XRLayerLayout | undefined;
 }
 
 interface XRCylinderLayerInit extends XRLayerInit {
-    textureType?: XRTextureType;
+    textureType?: XRTextureType | undefined;
     transform: XRRigidTransform;
-    radius?: number;
-    centralAngle?: number;
-    aspectRatio?: number;
+    radius?: number | undefined;
+    centralAngle?: number | undefined;
+    aspectRatio?: number | undefined;
 }
 
 interface XRMediaCylinderLayerInit extends XRMediaLayerInit {
-    transform?: XRRigidTransform;
-    radius?: number;
-    centralAngle?: number;
-    aspectRatio?: number;
+    transform?: XRRigidTransform | undefined;
+    radius?: number | undefined;
+    centralAngle?: number | undefined;
+    aspectRatio?: number | undefined;
 }
 
 interface XRCylinderLayer extends XRCompositionLayer {
@@ -600,16 +600,16 @@ interface XRCylinderLayer extends XRCompositionLayer {
 }
 
 interface XRQuadLayerInit extends XRLayerInit {
-    textureType?: XRTextureType;
-    transform?: XRRigidTransform;
-    width?: number;
-    height?: number;
+    textureType?: XRTextureType | undefined;
+    transform?: XRRigidTransform | undefined;
+    width?: number | undefined;
+    height?: number | undefined;
 }
 
 interface XRMediaQuadLayerInit extends XRMediaLayerInit {
-    transform?: XRRigidTransform;
-    width?: number;
-    height?: number;
+    transform?: XRRigidTransform | undefined;
+    width?: number | undefined;
+    height?: number | undefined;
 }
 
 interface XRQuadLayer extends XRCompositionLayer {
@@ -619,20 +619,20 @@ interface XRQuadLayer extends XRCompositionLayer {
 }
 
 interface XREquirectLayerInit extends XRLayerInit {
-    textureType?: XRTextureType;
-    transform?: XRRigidTransform;
-    radius?: number;
-    centralHorizontalAngle?: number;
-    upperVerticalAngle?: number;
-    lowerVerticalAngle?: number;
+    textureType?: XRTextureType | undefined;
+    transform?: XRRigidTransform | undefined;
+    radius?: number | undefined;
+    centralHorizontalAngle?: number | undefined;
+    upperVerticalAngle?: number | undefined;
+    lowerVerticalAngle?: number | undefined;
 }
 
 interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
-    transform?: XRRigidTransform;
-    radius?: number;
-    centralHorizontalAngle?: number;
-    upperVerticalAngle?: number;
-    lowerVerticalAngle?: number;
+    transform?: XRRigidTransform | undefined;
+    radius?: number | undefined;
+    centralHorizontalAngle?: number | undefined;
+    upperVerticalAngle?: number | undefined;
+    lowerVerticalAngle?: number | undefined;
 }
 
 interface XREquirectLayer extends XRCompositionLayer {
@@ -644,7 +644,7 @@ interface XREquirectLayer extends XRCompositionLayer {
 }
 
 interface XRCubeLayerInit extends XRLayerInit {
-    orientation?: DOMPointReadOnly;
+    orientation?: DOMPointReadOnly | undefined;
 }
 
 interface XRCubeLayer extends XRCompositionLayer {
@@ -668,22 +668,22 @@ declare class XRWebGLBinding {
 
     readonly nativeProjectionScaleFactor: number;
 
-    createProjectionLayer(init?: XRProjectionLayerInit): XRProjectionLayer;
-    createQuadLayer(init?: XRQuadLayerInit): XRQuadLayer;
-    createCylinderLayer(init?: XRCylinderLayerInit): XRCylinderLayer;
-    createEquirectLayer(init?: XREquirectLayerInit): XREquirectLayer;
-    createCubeLayer(init?: XRCubeLayerInit): XRCubeLayer;
+    createProjectionLayer(init?: XRProjectionLayerInit | undefined): XRProjectionLayer;
+    createQuadLayer(init?: XRQuadLayerInit | undefined): XRQuadLayer;
+    createCylinderLayer(init?: XRCylinderLayerInit | undefined): XRCylinderLayer;
+    createEquirectLayer(init?: XREquirectLayerInit | undefined): XREquirectLayer;
+    createCubeLayer(init?: XRCubeLayerInit | undefined): XRCubeLayer;
 
-    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
+    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye | undefined): XRWebGLSubImage;
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
 }
 
 declare class XRMediaBinding {
     constructor(sesion: XRSession);
 
-    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
-    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
-    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
+    createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit | undefined): XRQuadLayer;
+    createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit | undefined): XRCylinderLayer;
+    createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit | undefined): XREquirectLayer;
 }
 
 // WebGL extensions

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -14,8 +14,25 @@
 //  https://github.com/immersive-web
 //
 
+/**
+ * ref: https://immersive-web.github.io/webxr/#navigator-xr-attribute
+ */
 interface Navigator {
+    /**
+     * An XRSystem object is the entry point to the API, used to query for XR features
+     * available to the user agent and initiate communication with XR hardware via the
+     * creation of XRSessions.
+     */
     xr?: XRSystem | undefined;
+}
+
+/**
+ * WebGL Context Compatability
+ *
+ * ref: https://immersive-web.github.io/webxr/#contextcompatibility
+ */
+interface WebGLContextAttributes {
+    xrCompatible?: boolean | undefined;
 }
 
 interface WebGLRenderingContextBase {
@@ -24,6 +41,8 @@ interface WebGLRenderingContextBase {
 
 /**
  * Available session modes
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrsessionmode-enum
  */
 type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
 
@@ -34,6 +53,9 @@ type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor'
 
 type XREnvironmentBlendMode = 'opaque' | 'additive' | 'alpha-blend';
 
+/**
+ * ref: https://immersive-web.github.io/webxr/#xrsession-interface
+ */
 type XRVisibilityState = 'visible' | 'visible-blurred' | 'hidden';
 
 /**
@@ -53,12 +75,8 @@ type XREye = 'none' | 'left' | 'right';
 
 type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
 
-interface EventHandler {
-    (event: Event): any;
-}
-
 interface XRSystemDeviceChangeEvent extends Event {
-    type: "devicechange";
+    type: 'devicechange';
 }
 
 interface XRSystemDeviceChangeEventHandler {
@@ -66,24 +84,62 @@ interface XRSystemDeviceChangeEventHandler {
 }
 
 interface XRSystemEventMap {
-    "devicechange": XRSystemDeviceChangeEvent;
+    devicechange: XRSystemDeviceChangeEvent;
 }
 
+/**
+ * An XRSystem object is the entry point to the API, used to query for XR features available
+ * to the user agent and initiate communication with XR hardware via the creation of
+ * XRSessions.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrsystem-interface
+ */
 interface XRSystem extends EventTarget {
+    /**
+     * Attempts to initialize an XRSession for the given mode if possible, entering immersive
+     * mode if necessary.
+     * @param mode
+     * @param options
+     */
     requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
+
+    /**
+     * Queries if a given mode may be supported by the user agent and device capabilities.
+     * @param mode
+     */
     isSessionSupported(mode: XRSessionMode): Promise<boolean>;
 
     ondevicechange: XRSystemDeviceChangeEventHandler | null;
 
-    dispatchEvent(event: Event): boolean;
-    addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof XRSystemEventMap>(
+        type: K,
+        listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof XRSystemEventMap>(
+        type: K,
+        listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
-declare abstract class XRSystem implements XRSystem { }
+declare abstract class XRSystem implements XRSystem {}
 
+/**
+ * Describes a viewport, or rectangular region, of a graphics surface.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrviewport-interface
+ */
 interface XRViewport {
     readonly x: number;
     readonly y: number;
@@ -91,12 +147,20 @@ interface XRViewport {
     readonly height: number;
 }
 
-declare abstract class XRViewport implements XRViewport { }
+declare abstract class XRViewport implements XRViewport {}
 
+/**
+ * Represents a virtual coordinate system with an origin that corresponds to a physical location.
+ * Spatial data that is requested from the API or given to the API is always expressed in relation
+ * to a specific XRSpace at the time of a specific XRFrame. Numeric values such as pose positions
+ * are coordinates in that space relative to its origin. The interface is intentionally opaque.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrspace-interface
+ */
 // tslint:disable-next-line no-empty-interface
-interface XRSpace extends EventTarget { }
+interface XRSpace extends EventTarget {}
 
-declare abstract class XRSpace implements XRSpace { }
+declare abstract class XRSpace implements XRSpace {}
 
 interface XRRenderStateInit {
     baseLayer?: XRWebGLLayer | undefined;
@@ -112,21 +176,92 @@ interface XRRenderState {
     readonly inlineVerticalFieldOfView?: number | undefined;
 }
 
-declare abstract class XRRenderState implements XRRenderState { }
+declare abstract class XRRenderState implements XRRenderState {}
 
-interface XRReferenceSpace extends XRSpace {
-    getOffsetReferenceSpace(originOffset: XRRigidTransform): XRReferenceSpace;
-    onreset: EventHandler;
+interface XRReferenceSpaceEventInit extends EventInit {
+    referenceSpace?: XRReferenceSpace | undefined;
+    transform?: XRRigidTransform | undefined;
 }
 
-declare abstract class XRReferenceSpace implements XRReferenceSpace { }
+/**
+ * XRReferenceSpaceEvents are fired to indicate changes to the state of an XRReferenceSpace.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrreferencespaceevent-interface
+ */
+interface XRReferenceSpaceEvent extends Event {
+    readonly type: 'reset';
+    readonly referenceSpace: XRReferenceSpace;
+    readonly transform?: XRRigidTransform | undefined;
+}
 
+// tslint:disable-next-line no-unnecessary-class
+declare class XRReferenceSpaceEvent implements XRReferenceSpaceEvent {
+    constructor(type: 'reset', eventInitDict?: XRReferenceSpaceEventInit);
+}
+
+interface XRReferenceSpaceEventHandler {
+    (event: XRReferenceSpaceEvent): any;
+}
+
+interface XRReferenceSpaceEventMap {
+    reset: XRReferenceSpaceEvent;
+}
+
+/**
+ * One of several common XRSpaces that applications can use to establish a spatial relationship
+ * with the user's physical environment.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrreferencespace-interface
+ */
+interface XRReferenceSpace extends XRSpace {
+    getOffsetReferenceSpace(originOffset: XRRigidTransform): XRReferenceSpace;
+    onreset: XRReferenceSpaceEventHandler;
+
+    addEventListener<K extends keyof XRReferenceSpaceEventMap>(
+        type: K,
+        listener: (this: XRReferenceSpace, ev: XRReferenceSpaceEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof XRReferenceSpaceEventMap>(
+        type: K,
+        listener: (this: XRReferenceSpace, ev: XRReferenceSpaceEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
+}
+
+declare abstract class XRReferenceSpace implements XRReferenceSpace {}
+
+/**
+ * Extends XRReferenceSpace to include boundsGeometry, indicating the pre-configured boundaries
+ * of the user's space.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrboundedreferencespace-interface
+ */
 interface XRBoundedReferenceSpace extends XRReferenceSpace {
     readonly boundsGeometry: DOMPointReadOnly[];
 }
 
-declare abstract class XRBoundedReferenceSpace implements XRBoundedReferenceSpace { }
+declare abstract class XRBoundedReferenceSpace implements XRBoundedReferenceSpace {}
 
+/**
+ * Represents an XR input source, which is any input mechanism which allows the user to perform
+ * targeted actions in the same virtual space as the viewer. Example XR input sources include,
+ * but are not limited to, handheld controllers, optically tracked hands, and gaze-based input
+ * methods that operate on the viewer's pose. Input mechanisms which are not explicitly associated
+ * with the XR device, such as traditional gamepads, mice, or keyboards SHOULD NOT be considered
+ * XR input sources.
+ * ref: https://immersive-web.github.io/webxr/#xrinputsource-interface
+ */
 interface XRInputSource {
     readonly handedness: XRHandedness;
     readonly targetRayMode: XRTargetRayMode;
@@ -137,8 +272,13 @@ interface XRInputSource {
     readonly hand?: XRHand | undefined;
 }
 
-declare abstract class XRInputSource implements XRInputSource { }
+declare abstract class XRInputSource implements XRInputSource {}
 
+/**
+ * Represents a list of XRInputSources. It is used in favor of a frozen array type when the contents
+ * of the list are expected to change over time, such as with the XRSession inputSources attribute.
+ * ref: https://immersive-web.github.io/webxr/#xrinputsourcearray-interface
+ */
 interface XRInputSourceArray {
     [Symbol.iterator](): IterableIterator<XRInputSource>;
     [n: number]: XRInputSource;
@@ -152,39 +292,67 @@ interface XRInputSourceArray {
     forEach(callbackfn: (value: XRInputSource, index: number, array: XRInputSource[]) => void, thisArg?: any): void;
 }
 
-declare abstract class XRInputSourceArray implements XRInputSourceArray { }
+declare abstract class XRInputSourceArray implements XRInputSourceArray {}
 
+/**
+ * Describes a position and orientation in space relative to an XRSpace.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrpose-interface
+ */
 interface XRPose {
     readonly transform: XRRigidTransform;
     readonly emulatedPosition: boolean;
 }
 
-declare abstract class XRPose implements XRPose { }
+declare abstract class XRPose implements XRPose {}
 
+/**
+ * Represents a snapshot of the state of all of the tracked objects for an XRSession. Applications
+ * can acquire an XRFrame by calling requestAnimationFrame() on an XRSession with an
+ * XRFrameRequestCallback. When the callback is called it will be passed an XRFrame.
+ * Events which need to communicate tracking state, such as the select event, will also provide an
+ * XRFrame.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrframe-interface
+ */
 interface XRFrame {
     readonly session: XRSession;
+    readonly predictedDisplayTime: DOMHighResTimeStamp;
+
+    /**
+     * Provides the pose of space relative to baseSpace as an XRPose, at the time represented by
+     * the XRFrame.
+     *
+     * @param space
+     * @param baseSpace
+     */
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
+
+    /**
+     * Provides the pose of the viewer relative to referenceSpace as an XRViewerPose, at the
+     * XRFrame's time.
+     *
+     * @param referenceSpace
+     */
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
 }
 
-declare abstract class XRFrame implements XRFrame { }
+declare abstract class XRFrame implements XRFrame {}
 
 /**
  * Type of XR events available
  */
-type XRInputSourceEventType =
-    | "select"
-    | "selectend"
-    | "selectstart"
-    | "squeeze"
-    | "squeezeend"
-    | "squeezestart";
+type XRInputSourceEventType = 'select' | 'selectend' | 'selectstart' | 'squeeze' | 'squeezeend' | 'squeezestart';
 
 interface XRInputSourceEventInit extends EventInit {
     frame?: XRFrame | undefined;
     inputSource?: XRInputSource | undefined;
 }
 
+/**
+ * XRInputSourceEvents are fired to indicate changes to the state of an XRInputSource.
+ * ref: https://immersive-web.github.io/webxr/#xrinputsourceevent-interface
+ */
 declare class XRInputSourceEvent extends Event {
     readonly type: XRInputSourceEventType;
     readonly frame: XRFrame;
@@ -193,38 +361,58 @@ declare class XRInputSourceEvent extends Event {
     constructor(type: XRInputSourceEventType, eventInitDict?: XRInputSourceEventInit);
 }
 
-type XRSessionEventType =
-    | 'end'
-    | 'visibilitychange'
-    | 'frameratechange';
+interface XRInputSourceEventHandler {
+    (evt: XRInputSourceEvent): any;
+}
+
+type XRSessionEventType = 'end' | 'visibilitychange' | 'frameratechange';
 
 interface XRSessionEventInit extends EventInit {
     session: XRSession;
 }
 
+/**
+ * XRSessionEvents are fired to indicate changes to the state of an XRSession.
+ * ref: https://immersive-web.github.io/webxr/#xrsessionevent-interface
+ */
 declare class XRSessionEvent extends Event {
     readonly session: XRSession;
     constructor(type: XRSessionEventType, eventInitDict?: XRSessionEventInit);
 }
 
+interface XRSessionEventHandler {
+    (evt: XRSessionEvent): any;
+}
+
+/**
+ * ref: https://immersive-web.github.io/webxr/#feature-dependencies
+ */
 interface XRSessionInit {
     optionalFeatures?: string[] | undefined;
     requiredFeatures?: string[] | undefined;
 }
 
 interface XRSessionEventMap {
-    "inputsourceschange": XRInputSourceChangeEvent;
-    "end": XRSessionEvent;
-    "visibilitychange": XRSessionEvent;
-    "frameratechange": XRSessionEvent;
-    "select": XRInputSourceEvent;
-    "selectstart": XRInputSourceEvent;
-    "selectend": XRInputSourceEvent;
-    "squeeze": XRInputSourceEvent;
-    "squeezestart": XRInputSourceEvent;
-    "squeezeend": XRInputSourceEvent;
+    inputsourceschange: XRInputSourceChangeEvent;
+    end: XRSessionEvent;
+    visibilitychange: XRSessionEvent;
+    frameratechange: XRSessionEvent;
+    select: XRInputSourceEvent;
+    selectstart: XRInputSourceEvent;
+    selectend: XRInputSourceEvent;
+    squeeze: XRInputSourceEvent;
+    squeezestart: XRInputSourceEvent;
+    squeezeend: XRInputSourceEvent;
 }
 
+/**
+ * Any interaction with XR hardware is done via an XRSession object, which can only be
+ * retrieved by calling requestSession() on the XRSystem object. Once a session has been
+ * successfully acquired, it can be used to poll the viewer pose, query information about
+ * the user's environment, and present imagery to the user.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrsession-interface
+ */
 interface XRSession extends EventTarget {
     /**
      * Returns a list of this session's XRInputSources, each representing an input device
@@ -271,36 +459,68 @@ interface XRSession extends EventTarget {
      */
     requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace | XRBoundedReferenceSpace>;
 
-    updateRenderState(renderStateInit: XRRenderStateInit): Promise<void>;
+    updateRenderState(renderStateInit?: XRRenderStateInit): Promise<void>;
 
     updateTargetFrameRate(rate: number): Promise<void>;
 
-    onend: EventHandler;
-    oninputsourceschange: EventHandler;
-    onselect: EventHandler;
-    onselectstart: EventHandler;
-    onselectend: EventHandler;
-    onsqueeze: EventHandler;
-    onsqueezestart: EventHandler;
-    onsqueezeend: EventHandler;
-    onvisibilitychange: EventHandler;
-    onframeratechange: EventHandler;
+    onend: XRSessionEventHandler;
+    oninputsourceschange: XRInputSourceChangeEventHandler;
+    onselect: XRInputSourceEventHandler;
+    onselectstart: XRInputSourceEventHandler;
+    onselectend: XRInputSourceEventHandler;
+    onsqueeze: XRInputSourceEventHandler;
+    onsqueezestart: XRInputSourceEventHandler;
+    onsqueezeend: XRInputSourceEventHandler;
+    onvisibilitychange: XRSessionEventHandler;
+    onframeratechange: XRSessionEventHandler;
 
-    dispatchEvent(ev: Event): boolean;
-    addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof XRSessionEventMap>(
+        type: K,
+        listener: (this: XRSession, ev: XRSessionEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof XRSessionEventMap>(
+        type: K,
+        listener: (this: XRSession, ev: XRSessionEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
-declare abstract class XRSession implements XRSession { }
+declare abstract class XRSession implements XRSession {}
 
+/**
+ * An XRPose describing the state of a viewer of the XR scene as tracked by the XR
+ * device. A viewer may represent a tracked piece of hardware, the observed position
+ * of a user's head relative to the hardware, or some other means of computing a series
+ * of viewpoints into the XR scene. XRViewerPoses can only be queried relative to an
+ * XRReferenceSpace. It provides, in addition to the XRPose values, an array of views
+ * which include rigid transforms to indicate the viewpoint and projection matrices.
+ * These values should be used by the application when rendering a frame of an XR scene.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrviewerpose-interface
+ */
 interface XRViewerPose extends XRPose {
     readonly views: ReadonlyArray<XRView>;
 }
 
-declare abstract class XRViewerPose implements XRViewerPose { }
+declare abstract class XRViewerPose implements XRViewerPose {}
 
+/**
+ * A transform described by a position and orientation. When interpreting an
+ * XRRigidTransform the orientation is always applied prior to the position.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrrigidtransform-interface
+ */
 declare class XRRigidTransform {
     readonly position: DOMPointReadOnly;
     readonly orientation: DOMPointReadOnly;
@@ -310,6 +530,11 @@ declare class XRRigidTransform {
     constructor(position?: DOMPointInit, direction?: DOMPointInit);
 }
 
+/**
+ * Describes a single view into an XR scene for a given frame.
+ *
+ * ref: https://immersive-web.github.io/webxr/#xrview-interface
+ */
 interface XRView {
     readonly eye: XREye;
     readonly projectionMatrix: Float32Array;
@@ -318,11 +543,20 @@ interface XRView {
     requestViewportScale(scale: number): void;
 }
 
-declare abstract class XRView implements XRView { }
+declare abstract class XRView implements XRView {}
 
+/**
+ * XRInputSourcesChangeEvents are fired to indicate changes to the XRInputSources that are
+ * available to an XRSession.
+ * ref: https://immersive-web.github.io/webxr/#xrinputsourceschangeevent-interface
+ */
 interface XRInputSourceChangeEvent extends XRSessionEvent {
     readonly removed: ReadonlyArray<XRInputSource>;
     readonly added: ReadonlyArray<XRInputSource>;
+}
+
+interface XRInputSourceChangeEventHandler {
+    (evt: XRInputSourceChangeEvent): any;
 }
 
 // Experimental/Draft features
@@ -335,7 +569,7 @@ interface XRAnchor {
     delete(): void;
 }
 
-declare abstract class XRAnchor implements XRAnchor { }
+declare abstract class XRAnchor implements XRAnchor {}
 
 interface XRFrame {
     trackedAnchors?: XRAnchorSet | undefined;
@@ -351,10 +585,7 @@ declare class XRRay {
     constructor(transformOrOrigin?: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
 }
 
-type XRHitTestTrackableType =
-    | 'point'
-    | 'plane'
-    | 'mesh';
+type XRHitTestTrackableType = 'point' | 'plane' | 'mesh';
 
 interface XRTransientInputHitTestResult {
     readonly inputSource: XRInputSource;
@@ -371,19 +602,19 @@ interface XRHitTestResult {
     createAnchor?: (pose: XRRigidTransform) => Promise<XRAnchor> | undefined;
 }
 
-declare abstract class XRHitTestResult implements XRHitTestResult { }
+declare abstract class XRHitTestResult implements XRHitTestResult {}
 
 interface XRHitTestSource {
     cancel(): void;
 }
 
-declare abstract class XRHitTestSource implements XRHitTestSource { }
+declare abstract class XRHitTestSource implements XRHitTestSource {}
 
 interface XRTransientInputHitTestSource {
     cancel(): void;
 }
 
-declare abstract class XRTransientInputHitTestSource implements XRTransientInputHitTestSource { }
+declare abstract class XRTransientInputHitTestSource implements XRTransientInputHitTestSource {}
 
 interface XRHitTestOptionsInit {
     space: XRSpace;
@@ -409,9 +640,7 @@ interface XRSession {
 
 interface XRFrame {
     getHitTestResults(hitTestSource: XRHitTestSource): XRHitTestResult[];
-    getHitTestResultsForTransientInput(
-        hitTestSource: XRTransientInputHitTestSource
-    ): XRTransientInputHitTestResult[];
+    getHitTestResultsForTransientInput(hitTestSource: XRTransientInputHitTestSource): XRTransientInputHitTestResult[];
 }
 
 // Legacy
@@ -422,9 +651,7 @@ interface XRHitResult {
 // Plane detection
 type XRPlaneSet = Set<XRPlane>;
 
-type XRPlaneOrientation =
-    | 'horizontal'
-    | 'vertical';
+type XRPlaneOrientation = 'horizontal' | 'vertical';
 
 interface XRPlane {
     orientation: XRPlaneOrientation;
@@ -433,17 +660,21 @@ interface XRPlane {
     lastChangedTime: number;
 }
 
-declare abstract class XRPlane implements XRPlane { }
+declare abstract class XRPlane implements XRPlane {}
 
 interface XRSession {
     // Legacy
-    updateWorldTrackingState?: (options: { planeDetectionState?: { enabled: boolean } | undefined }) => void | undefined;
+    updateWorldTrackingState?: (options: {
+        planeDetectionState?: { enabled: boolean } | undefined;
+    }) => void | undefined;
 }
 
 interface XRFrame {
-    worldInformation?: {
-        detectedPlanes?: XRPlaneSet | undefined;
-    } | undefined;
+    worldInformation?:
+        | {
+              detectedPlanes?: XRPlaneSet | undefined;
+          }
+        | undefined;
 }
 
 // Hand Tracking
@@ -478,13 +709,13 @@ interface XRJointSpace extends XRSpace {
     readonly jointName: XRHandJoint;
 }
 
-declare abstract class XRJointSpace implements XRJointSpace { }
+declare abstract class XRJointSpace implements XRJointSpace {}
 
 interface XRJointPose extends XRPose {
     readonly radius: number | undefined;
 }
 
-declare abstract class XRJointPose implements XRJointPose { }
+declare abstract class XRJointPose implements XRJointPose {}
 
 interface XRHand extends Map<number, XRJointSpace> {
     readonly WRIST: number;
@@ -519,7 +750,7 @@ interface XRHand extends Map<number, XRJointSpace> {
     readonly LITTLE_PHALANX_TIP: number;
 }
 
-declare abstract class XRHand implements XRHand { }
+declare abstract class XRHand implements XRHand {}
 
 interface XRFrame {
     getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose | undefined;
@@ -527,10 +758,14 @@ interface XRFrame {
 
 // WebXR Layers
 
+/**
+ * The base class for XRWebGLLayer and other layer types introduced by future extensions.
+ * ref: https://immersive-web.github.io/webxr/#xrlayer-interface
+ */
 // tslint:disable-next-line no-empty-interface
-interface XRLayer extends EventTarget { }
+interface XRLayer extends EventTarget {}
 
-declare abstract class XRLayer implements XRLayer { }
+declare abstract class XRLayer implements XRLayer {}
 
 interface XRWebGLLayerInit {
     antialias?: boolean | undefined;
@@ -541,6 +776,11 @@ interface XRWebGLLayerInit {
     framebufferScaleFactor?: number | undefined;
 }
 
+/**
+ * A layer which provides a WebGL framebuffer to render into, enabling hardware accelerated
+ * rendering of 3D graphics to be presented on the XR device. *
+ * ref: https://immersive-web.github.io/webxr/#xrwebgllayer-interface
+ */
 declare class XRWebGLLayer extends XRLayer {
     static getNativeFramebufferScaleFactor(session: XRSession): number;
 
@@ -569,7 +809,7 @@ interface XRRenderState {
     readonly layers?: XRLayer[] | undefined;
 }
 
-type XRLayerEventType = "redraw";
+type XRLayerEventType = 'redraw';
 
 interface XRLayerEvent extends Event {
     readonly type: XRLayerEventType;
@@ -577,7 +817,7 @@ interface XRLayerEvent extends Event {
 }
 
 interface XRCompositionLayerEventMap {
-    "redraw": XRLayerEvent;
+    redraw: XRLayerEvent;
 }
 
 interface XRCompositionLayer extends XRLayer {
@@ -591,44 +831,37 @@ interface XRCompositionLayer extends XRLayer {
     space: XRSpace;
 
     // Events
-    onredraw: (evt: XRCompositionLayerEventMap["redraw"]) => any;
+    onredraw: (evt: XRCompositionLayerEventMap['redraw']) => any;
 
     addEventListener<K extends keyof XRCompositionLayerEventMap>(
         this: XRCompositionLayer,
         type: K,
         callback: (evt: XRCompositionLayerEventMap[K]) => any,
-        options?: boolean | AddEventListenerOptions
+        options?: boolean | AddEventListenerOptions,
     ): void;
     addEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | AddEventListenerOptions
+        options?: boolean | AddEventListenerOptions,
     ): void;
 
     removeEventListener<K extends keyof XRCompositionLayerEventMap>(
         this: XRCompositionLayer,
         type: K,
-        callback: (evt: XRCompositionLayerEventMap[K]) => any
+        callback: (evt: XRCompositionLayerEventMap[K]) => any,
     ): void;
     removeEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject,
-        options?: boolean | EventListenerOptions
+        options?: boolean | EventListenerOptions,
     ): void;
 }
 
-declare abstract class XRCompositionLayer implements XRCompositionLayer { }
+declare abstract class XRCompositionLayer implements XRCompositionLayer {}
 
-type XRTextureType =
-    | "texture"
-    | "texture-array";
+type XRTextureType = 'texture' | 'texture-array';
 
-type XRLayerLayout =
-    | "default"
-    | "mono"
-    | "stereo"
-    | "stereo-left-right"
-    | "stereo-top-bottom";
+type XRLayerLayout = 'default' | 'mono' | 'stereo' | 'stereo-left-right' | 'stereo-top-bottom';
 
 interface XRProjectionLayerInit {
     scaleFactor?: number | undefined;
@@ -645,7 +878,7 @@ interface XRProjectionLayer extends XRCompositionLayer {
     fixedFoveation: number;
 }
 
-declare abstract class XRProjectionLayer implements XRProjectionLayer { }
+declare abstract class XRProjectionLayer implements XRProjectionLayer {}
 
 interface XRLayerInit {
     mipLevels?: number | undefined;
@@ -686,7 +919,7 @@ interface XRCylinderLayer extends XRCompositionLayer {
     aspectRatio: number;
 }
 
-declare abstract class XRCylinderLayer implements XRCylinderLayer { }
+declare abstract class XRCylinderLayer implements XRCylinderLayer {}
 
 interface XRQuadLayerInit extends XRLayerInit {
     textureType?: XRTextureType | undefined;
@@ -707,7 +940,7 @@ interface XRQuadLayer extends XRCompositionLayer {
     height: number;
 }
 
-declare abstract class XRQuadLayer implements XRQuadLayer { }
+declare abstract class XRQuadLayer implements XRQuadLayer {}
 
 interface XREquirectLayerInit extends XRLayerInit {
     textureType?: XRTextureType | undefined;
@@ -734,7 +967,7 @@ interface XREquirectLayer extends XRCompositionLayer {
     lowerVerticalAngle: number;
 }
 
-declare abstract class XREquirectLayer implements XREquirectLayer { }
+declare abstract class XREquirectLayer implements XREquirectLayer {}
 
 interface XRCubeLayerInit extends XRLayerInit {
     orientation?: DOMPointReadOnly | undefined;
@@ -744,13 +977,13 @@ interface XRCubeLayer extends XRCompositionLayer {
     orientation: DOMPointReadOnly;
 }
 
-declare abstract class XRCubeLayer implements XRCubeLayer { }
+declare abstract class XRCubeLayer implements XRCubeLayer {}
 
 interface XRSubImage {
     readonly viewport: XRViewport;
 }
 
-declare abstract class XRSubImage implements XRSubImage { }
+declare abstract class XRSubImage implements XRSubImage {}
 
 interface XRWebGLSubImage extends XRSubImage {
     readonly colorTexture: WebGLTexture;
@@ -760,7 +993,7 @@ interface XRWebGLSubImage extends XRSubImage {
     readonly textureHeight: number;
 }
 
-declare abstract class XRWebGLSubImage implements XRWebGLSubImage { }
+declare abstract class XRWebGLSubImage implements XRWebGLSubImage {}
 
 declare class XRWebGLBinding {
     readonly nativeProjectionScaleFactor: number;
@@ -787,14 +1020,14 @@ declare class XRMediaBinding {
 
 // WebGL extensions
 interface WebGLRenderingContextBase {
-    getExtension(extensionName: "OCULUS_multiview"): OCULUS_multiview | null;
+    getExtension(extensionName: 'OCULUS_multiview'): OCULUS_multiview | null;
 }
 
 declare enum XOVR_multiview2 {
     FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630,
     FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632,
     MAX_VIEWS_OVR = 0x9631,
-    FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR = 0x9633
+    FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR = 0x9633,
 }
 
 interface OVR_multiview2 {
@@ -809,11 +1042,11 @@ interface OVR_multiview2 {
         texture: WebGLTexture,
         level: number,
         baseViewIndex: number,
-        numViews: number
+        numViews: number,
     ): WebGLRenderbuffer;
 }
 
-declare abstract class OVR_multiview2 implements OVR_multiview2 { }
+declare abstract class OVR_multiview2 implements OVR_multiview2 {}
 
 // Oculus extensions
 interface XRSessionGrant {
@@ -821,7 +1054,7 @@ interface XRSessionGrant {
 }
 
 interface XRSystemSessionGrantedEvent extends Event {
-    type: "sessiongranted";
+    type: 'sessiongranted';
     session: XRSessionGrant;
 }
 
@@ -831,7 +1064,7 @@ interface XRSystemSessionGrantedEventHandler {
 
 interface XRSystemEventMap {
     // Session Grant events are an Meta Oculus Browser extension
-    "sessiongranted": XRSystemSessionGrantedEvent;
+    sessiongranted: XRSystemSessionGrantedEvent;
 }
 
 interface XRSystem {
@@ -846,8 +1079,8 @@ interface OCULUS_multiview extends OVR_multiview2 {
         level: GLint,
         samples: GLsizei,
         baseViewIndex: GLint,
-        numViews: GLsizei
+        numViews: GLsizei,
     ): void;
 }
 
-declare abstract class OCULUS_multiview implements OCULUS_multiview { }
+declare abstract class OCULUS_multiview implements OCULUS_multiview {}

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -408,7 +408,7 @@ interface XRAnchor {
 }
 
 interface XRPlane {
-    orientation: 'Horizontal' | 'Vertical';
+    orientation: 'horizontal' | 'vertical';
     planeSpace: XRSpace;
     polygon: DOMPointReadOnly[];
     lastChangedTime: number;

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -606,3 +606,53 @@ export class XRMediaBinding {
     createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
     createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
 }
+
+// WebGL extensions
+export interface XRWebGLRenderingContext {
+    makeXRCompatible(): Promise<void>;
+}
+
+export interface WebGLRenderingContextBase {
+    getExtension(extensionName: "OCULUS_multiview"): OCULUS_multiview | null;
+}
+
+export interface WebGLRenderingContext extends XRWebGLRenderingContext {
+}
+
+export interface WebGL2RenderingContext extends XRWebGLRenderingContext {
+}
+
+export enum XOVR_multiview2 {
+    FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630,
+    FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632,
+    MAX_VIEWS_OVR = 0x9631,
+    FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR = 0x9633
+}
+
+export interface OVR_multiview2 {
+    FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR: XOVR_multiview2;
+    FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR: XOVR_multiview2;
+    MAX_VIEWS_OVR: XOVR_multiview2;
+    FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR: XOVR_multiview2;
+
+    framebufferTextureMultiviewOVR(
+        target: GLenum,
+        attachment: GLenum,
+        texture: WebGLTexture,
+        level: number,
+        baseViewIndex: number,
+        numViews: number
+    ): WebGLRenderbuffer;
+}
+
+export interface OCULUS_multiview extends OVR_multiview2 {
+    framebufferTextureMultisampleMultiviewOVR(
+        target: GLenum,
+        attachment: GLenum,
+        texture: WebGLTexture | null,
+        level: GLint,
+        samples: GLsizei,
+        baseViewIndex: GLint,
+        numViews: GLsizei
+    ): void;
+}

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for non-npm package webxr 0.2
+// Type definitions for non-npm package webxr 0.3
 // Project: https://www.w3.org/TR/webxr/
 // Definitions by: Rob Rohan <https://github.com/robrohan>
 //                 Raanan Weber <https://github.com/RaananW>
+//                 Sean T. McBeth <https://github.com/capnmidnight>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.7
 

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -18,6 +18,10 @@ interface Navigator {
     xr?: XRSystem | undefined;
 }
 
+interface WebGLRenderingContextBase {
+    makeXRCompatible(): Promise<void>;
+}
+
 /**
  * Available session modes
  */
@@ -47,88 +51,38 @@ type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
  */
 type XREye = 'none' | 'left' | 'right';
 
-/**
- * Type of XR events available
- */
-type XRInputSourceEventType =
-    | "select"
-    | "selectend"
-    | "selectstart"
-    | "squeeze"
-    | "squeezeend"
-    | "squeezestart";
-
-type XREventType =
-    | XRInputSourceEventType
-    | 'devicechange'
-    | 'visibilitychange'
-    | 'end'
-    | 'inputsourceschange'
-    | 'reset';
-
 type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
 
-type XRPlaneSet = Set<XRPlane>;
-type XRAnchorSet = Set<XRAnchor>;
-
-interface XREventHandler {
+interface EventHandler {
     (event: Event): any;
-}
-
-// tslint:disable-next-line no-empty-interface
-interface XRLayer extends EventTarget { }
-
-declare class XRLayer {
-    prototype: XRLayer;
-}
-
-interface XRSessionInit {
-    optionalFeatures?: string[] | undefined;
-    requiredFeatures?: string[] | undefined;
-}
-
-interface XRSessionEvent extends Event {
-    readonly session: XRSession;
-}
-
-declare class XRSessionEvent {
-    prototype: XRSessionEvent;
 }
 
 interface XRSystemDeviceChangeEvent extends Event {
     type: "devicechange";
 }
 
-interface XRSessionGrant {
-    mode: XRSessionMode;
+interface XRSystemDeviceChangeEventHandler {
+    (event: XRSystemDeviceChangeEvent): any;
 }
 
-interface XRSystemSessionGrantedEvent extends Event {
-    type: "sessiongranted";
-    session: XRSessionGrant;
-}
-
-interface XRSystemEventMap extends HTMLMediaElementEventMap {
+interface XRSystemEventMap {
     "devicechange": XRSystemDeviceChangeEvent;
-    "sessiongranted": XRSystemSessionGrantedEvent;
 }
 
 interface XRSystem extends EventTarget {
     requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
     isSessionSupported(mode: XRSessionMode): Promise<boolean>;
 
-    ondevicechange: ((this: XRSystem, ev: XRSystemDeviceChangeEvent) => any) | null;
-    onsessiongranted: ((this: XRSystem, ev: XRSystemSessionGrantedEvent) => any) | null;
+    ondevicechange: XRSystemDeviceChangeEventHandler | null;
 
+    dispatchEvent(event: Event): boolean;
     addEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof XRSystemEventMap>(type: K, listener: (this: XRSystem, ev: XRSystemEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
-declare class XRSystem {
-    prototype: XRSystem;
-}
+declare abstract class XRSystem implements XRSystem { }
 
 interface XRViewport {
     readonly x: number;
@@ -137,52 +91,18 @@ interface XRViewport {
     readonly height: number;
 }
 
-declare class XRViewport {
-    prototype: XRViewport;
-}
-
-interface XRWebGLLayerInit {
-    antialias?: boolean | undefined;
-    depth?: boolean | undefined;
-    stencil?: boolean | undefined;
-    alpha?: boolean | undefined;
-    ignoreDepthValues?: boolean | undefined;
-    framebufferScaleFactor?: number | undefined;
-}
-
-interface XRWebGLLayer extends XRLayer {
-    readonly antialias: boolean;
-    readonly ignoreDepthValues: boolean;
-    fixedFoveation?: number | undefined;
-
-    readonly framebuffer: WebGLFramebuffer;
-    readonly framebufferWidth: number;
-    readonly framebufferHeight: number;
-
-    getViewport(view: XRView): XRViewport | undefined;
-
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | EventListenerOptions): void;
-    dispatchEvent(event: Event): boolean;
-}
-
-declare class XRWebGLLayer {
-    static getNativeFramebufferScaleFactor(session: XRSession): number;
-
-    constructor(
-        session: XRSession,
-        context: WebGLRenderingContext | WebGL2RenderingContext,
-        layerInit?: XRWebGLLayerInit,
-    );
-
-    prototype: XRWebGLLayer;
-}
+declare abstract class XRViewport implements XRViewport { }
 
 // tslint:disable-next-line no-empty-interface
 interface XRSpace extends EventTarget { }
 
-declare class XRSpace {
-    prototype: XRSpace;
+declare abstract class XRSpace implements XRSpace { }
+
+interface XRRenderStateInit {
+    baseLayer?: XRWebGLLayer | undefined;
+    depthFar?: number | undefined;
+    depthNear?: number | undefined;
+    inlineVerticalFieldOfView?: number | undefined;
 }
 
 interface XRRenderState {
@@ -190,39 +110,22 @@ interface XRRenderState {
     readonly depthFar: number;
     readonly depthNear: number;
     readonly inlineVerticalFieldOfView?: number | undefined;
-
-    // https://immersive-web.github.io/layers/#xrrenderstatechanges
-    readonly layers?: XRLayer[] | undefined;
 }
 
-declare class XRRenderState {
-    prototype: XRRenderState;
-}
-
-interface XRRenderStateInit {
-    baseLayer?: XRWebGLLayer | undefined;
-    depthFar?: number | undefined;
-    depthNear?: number | undefined;
-    inlineVerticalFieldOfView?: number | undefined;
-    layers?: XRLayer[] | undefined;
-}
+declare abstract class XRRenderState implements XRRenderState { }
 
 interface XRReferenceSpace extends XRSpace {
     getOffsetReferenceSpace(originOffset: XRRigidTransform): XRReferenceSpace;
-    onreset: XREventHandler;
+    onreset: EventHandler;
 }
 
-declare class XRReferenceSpace {
-    prototype: XRReferenceSpace;
-}
+declare abstract class XRReferenceSpace implements XRReferenceSpace { }
 
 interface XRBoundedReferenceSpace extends XRReferenceSpace {
     readonly boundsGeometry: DOMPointReadOnly[];
 }
 
-declare class XRBoundedReferenceSpace {
-    prototype: XRBoundedReferenceSpace;
-}
+declare abstract class XRBoundedReferenceSpace implements XRBoundedReferenceSpace { }
 
 interface XRInputSource {
     readonly handedness: XRHandedness;
@@ -234,75 +137,86 @@ interface XRInputSource {
     readonly hand?: XRHand | undefined;
 }
 
-declare class XRInputSource {
-    prototype: XRInputSource;
+declare abstract class XRInputSource implements XRInputSource { }
+
+interface XRInputSourceArray {
+    [Symbol.iterator](): IterableIterator<XRInputSource>;
+    [n: number]: XRInputSource;
+
+    length: number;
+
+    entries(): IterableIterator<[number, XRInputSource]>;
+    keys(): IterableIterator<number>;
+    values(): IterableIterator<XRInputSource>;
+
+    forEach(callbackfn: (value: XRInputSource, index: number, array: XRInputSource[]) => void, thisArg?: any): void;
 }
 
-// tslint:disable-next-line no-empty-interface
-interface XRInputSourceArray extends Array<XRInputSource> { }
-
-declare class XRInputSourceArray {
-    prototype: XRInputSourceArray;
-}
+declare abstract class XRInputSourceArray implements XRInputSourceArray { }
 
 interface XRPose {
     readonly transform: XRRigidTransform;
     readonly emulatedPosition: boolean;
 }
 
-declare class XRPose {
-    prototype: XRPose;
-}
+declare abstract class XRPose implements XRPose { }
 
 interface XRFrame {
     readonly session: XRSession;
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
-
-    // AR
-    getHitTestResults(hitTestSource: XRHitTestSource): XRHitTestResult[];
-    getHitTestResultsForTransientInput(
-        hitTestSource: XRTransientInputHitTestSource
-    ): XRTransientInputHitTestResult[];
-
-    // Anchors
-    trackedAnchors?: XRAnchorSet | undefined;
-    createAnchor?: (pose: XRRigidTransform, space: XRSpace) => Promise<XRAnchor> | undefined;
-
-    // Planes
-    worldInformation?: {
-        detectedPlanes?: XRPlaneSet | undefined;
-    } | undefined;
-
-    // Hand tracking
-    getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose | undefined;
 }
 
-declare class XRFrame {
-    prototype: XRFrame;
-}
+declare abstract class XRFrame implements XRFrame { }
 
-interface XRInputSourceEvent extends Event {
-    readonly type: XRInputSourceEventType;
-    readonly frame: XRFrame;
-    readonly inputSource: XRInputSource;
-}
+/**
+ * Type of XR events available
+ */
+type XRInputSourceEventType =
+    | "select"
+    | "selectend"
+    | "selectstart"
+    | "squeeze"
+    | "squeezeend"
+    | "squeezestart";
 
 interface XRInputSourceEventInit extends EventInit {
     frame?: XRFrame | undefined;
     inputSource?: XRInputSource | undefined;
 }
 
-declare class XRInputSourceEvent {
+declare class XRInputSourceEvent extends Event {
+    readonly type: XRInputSourceEventType;
+    readonly frame: XRFrame;
+    readonly inputSource: XRInputSource;
+
     constructor(type: XRInputSourceEventType, eventInitDict?: XRInputSourceEventInit);
-    prototype: XRInputSourceEvent;
+}
+
+type XRSessionEventType =
+    | 'end'
+    | 'visibilitychange'
+    | 'frameratechange';
+
+interface XRSessionEventInit extends EventInit {
+    session: XRSession;
+}
+
+declare class XRSessionEvent extends Event {
+    readonly session: XRSession;
+    constructor(type: XRSessionEventType, eventInitDict?: XRSessionEventInit);
+}
+
+interface XRSessionInit {
+    optionalFeatures?: string[] | undefined;
+    requiredFeatures?: string[] | undefined;
 }
 
 interface XRSessionEventMap {
-    "end": XREventHandler;
-    "inputsourceschange": XREventHandler;
-    "visibilitychange": XREventHandler;
-    "frameratechange": XREventHandler;
+    "inputsourceschange": XRInputSourceChangeEvent;
+    "end": XRSessionEvent;
+    "visibilitychange": XRSessionEvent;
+    "frameratechange": XRSessionEvent;
     "select": XRInputSourceEvent;
     "selectstart": XRInputSourceEvent;
     "selectend": XRInputSourceEvent;
@@ -361,57 +275,39 @@ interface XRSession extends EventTarget {
 
     updateTargetFrameRate(rate: number): Promise<void>;
 
-    onend: XREventHandler;
-    oninputsourceschange: XREventHandler;
-    onselect: XREventHandler;
-    onselectstart: XREventHandler;
-    onselectend: XREventHandler;
-    onsqueeze: XREventHandler;
-    onsqueezestart: XREventHandler;
-    onsqueezeend: XREventHandler;
-    onvisibilitychange: XREventHandler;
-    onframeratechange: XREventHandler;
+    onend: EventHandler;
+    oninputsourceschange: EventHandler;
+    onselect: EventHandler;
+    onselectstart: EventHandler;
+    onselectend: EventHandler;
+    onsqueeze: EventHandler;
+    onsqueezestart: EventHandler;
+    onsqueezeend: EventHandler;
+    onvisibilitychange: EventHandler;
+    onframeratechange: EventHandler;
 
+    dispatchEvent(ev: Event): boolean;
     addEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof XRSessionEventMap>(type: K, listener: (this: XRSession, ev: XRSessionEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-
-    // hit test
-    requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource> | undefined;
-    requestHitTestSourceForTransientInput?: (
-        options: XRTransientInputHitTestOptionsInit,
-    ) => Promise<XRTransientInputHitTestSource> | undefined;
-
-    // legacy AR hit test
-    requestHitTest?: (ray: XRRay, referenceSpace: XRReferenceSpace) => Promise<XRHitResult[]> | undefined;
-
-    // legacy plane detection
-    updateWorldTrackingState?: (options: { planeDetectionState?: { enabled: boolean } | undefined }) => void | undefined;
 }
 
-declare class XRSession {
-    prototype: XRSession;
-}
+declare abstract class XRSession implements XRSession { }
 
 interface XRViewerPose extends XRPose {
     readonly views: ReadonlyArray<XRView>;
 }
 
-declare class XRViewerPose {
-    prototype: XRViewerPose;
-}
+declare abstract class XRViewerPose implements XRViewerPose { }
 
-interface XRRigidTransform {
+declare class XRRigidTransform {
     readonly position: DOMPointReadOnly;
     readonly orientation: DOMPointReadOnly;
     readonly matrix: Float32Array;
     readonly inverse: XRRigidTransform;
-}
 
-declare class XRRigidTransform {
     constructor(position?: DOMPointInit, direction?: DOMPointInit);
-    prototype: XRRigidTransform;
 }
 
 interface XRView {
@@ -422,46 +318,43 @@ interface XRView {
     requestViewportScale(scale: number): void;
 }
 
-declare class XRView {
-    prototype: XRView;
-}
+declare abstract class XRView implements XRView { }
 
 interface XRInputSourceChangeEvent extends XRSessionEvent {
     readonly removed: ReadonlyArray<XRInputSource>;
     readonly added: ReadonlyArray<XRInputSource>;
 }
 
-interface XRInputSourceChangeEventInit extends EventInit {
-    session?: XRSession;
-    added?: XRInputSource[];
-    removed?: XRInputSource[];
-}
-
-declare class XRInputSourceChangeEvent {
-    constructor(type: "inpuptsourceschange", eventInitDict?: XRInputSourceChangeEventInit);
-    prototype: XRInputSourceChangeEvent;
-}
-
 // Experimental/Draft features
-interface XRRay {
+
+// Anchors
+type XRAnchorSet = Set<XRAnchor>;
+
+interface XRAnchor {
+    anchorSpace: XRSpace;
+    delete(): void;
+}
+
+declare abstract class XRAnchor implements XRAnchor { }
+
+interface XRFrame {
+    trackedAnchors?: XRAnchorSet | undefined;
+    createAnchor?: (pose: XRRigidTransform, space: XRSpace) => Promise<XRAnchor> | undefined;
+}
+
+// AR Hit testing
+declare class XRRay {
     readonly origin: DOMPointReadOnly;
     readonly direction: DOMPointReadOnly;
     readonly matrix: Float32Array;
-}
 
-declare class XRRay {
-    constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
-    prototype: XRRay;
+    constructor(transformOrOrigin?: XRRigidTransform | DOMPointInit, direction?: DOMPointInit);
 }
 
 type XRHitTestTrackableType =
     | 'point'
     | 'plane'
     | 'mesh';
-
-interface XRHitResult {
-    hitMatrix: Float32Array;
-}
 
 interface XRTransientInputHitTestResult {
     readonly inputSource: XRInputSource;
@@ -478,25 +371,19 @@ interface XRHitTestResult {
     createAnchor?: (pose: XRRigidTransform) => Promise<XRAnchor> | undefined;
 }
 
-declare class XRHitTestResult {
-    prototype: XRHitTestResult;
-}
+declare abstract class XRHitTestResult implements XRHitTestResult { }
 
 interface XRHitTestSource {
     cancel(): void;
 }
 
-declare class XRHitTestSource {
-    prototype: XRHitTestSource;
-}
+declare abstract class XRHitTestSource implements XRHitTestSource { }
 
 interface XRTransientInputHitTestSource {
     cancel(): void;
 }
 
-declare class XRTransientInputHitTestSource {
-    prototype: XRTransientInputHitTestSource;
-}
+declare abstract class XRTransientInputHitTestSource implements XRTransientInputHitTestSource { }
 
 interface XRHitTestOptionsInit {
     space: XRSpace;
@@ -510,22 +397,56 @@ interface XRTransientInputHitTestOptionsInit {
     offsetRay?: XRRay | undefined;
 }
 
-interface XRAnchor {
-    anchorSpace: XRSpace;
-    delete(): void;
+interface XRSession {
+    requestHitTestSource?: (options: XRHitTestOptionsInit) => Promise<XRHitTestSource> | undefined;
+    requestHitTestSourceForTransientInput?: (
+        options: XRTransientInputHitTestOptionsInit,
+    ) => Promise<XRTransientInputHitTestSource> | undefined;
+
+    // Legacy
+    requestHitTest?: (ray: XRRay, referenceSpace: XRReferenceSpace) => Promise<XRHitResult[]> | undefined;
 }
 
-declare class XRAnchor {
-    prototype: XRAnchor;
+interface XRFrame {
+    getHitTestResults(hitTestSource: XRHitTestSource): XRHitTestResult[];
+    getHitTestResultsForTransientInput(
+        hitTestSource: XRTransientInputHitTestSource
+    ): XRTransientInputHitTestResult[];
 }
+
+// Legacy
+interface XRHitResult {
+    hitMatrix: Float32Array;
+}
+
+// Plane detection
+type XRPlaneSet = Set<XRPlane>;
+
+type XRPlaneOrientation =
+    | 'horizontal'
+    | 'vertical';
 
 interface XRPlane {
-    orientation: 'horizontal' | 'vertical';
+    orientation: XRPlaneOrientation;
     planeSpace: XRSpace;
     polygon: DOMPointReadOnly[];
     lastChangedTime: number;
 }
 
+declare abstract class XRPlane implements XRPlane { }
+
+interface XRSession {
+    // Legacy
+    updateWorldTrackingState?: (options: { planeDetectionState?: { enabled: boolean } | undefined }) => void | undefined;
+}
+
+interface XRFrame {
+    worldInformation?: {
+        detectedPlanes?: XRPlaneSet | undefined;
+    } | undefined;
+}
+
+// Hand Tracking
 type XRHandJoint =
     | 'wrist'
     | 'thumb-metacarpal'
@@ -557,17 +478,13 @@ interface XRJointSpace extends XRSpace {
     readonly jointName: XRHandJoint;
 }
 
-declare class XRJointSpace {
-    prototype: XRJointSpace;
-}
+declare abstract class XRJointSpace implements XRJointSpace { }
 
 interface XRJointPose extends XRPose {
     readonly radius: number | undefined;
 }
 
-declare class XRJointPose {
-    prototype: XRJointPose;
-}
+declare abstract class XRJointPose implements XRJointPose { }
 
 interface XRHand extends Map<number, XRJointSpace> {
     readonly WRIST: number;
@@ -602,22 +519,61 @@ interface XRHand extends Map<number, XRJointSpace> {
     readonly LITTLE_PHALANX_TIP: number;
 }
 
-declare class XRHand {
-    prototype: XRHand;
+declare abstract class XRHand implements XRHand { }
+
+interface XRFrame {
+    getJointPose?: (joint: XRJointSpace, baseSpace: XRSpace) => XRJointPose | undefined;
 }
 
 // WebXR Layers
-interface XRLayerEventInit extends EventInit {
-    layer: XRLayer;
+
+// tslint:disable-next-line no-empty-interface
+interface XRLayer extends EventTarget { }
+
+declare abstract class XRLayer implements XRLayer { }
+
+interface XRWebGLLayerInit {
+    antialias?: boolean | undefined;
+    depth?: boolean | undefined;
+    stencil?: boolean | undefined;
+    alpha?: boolean | undefined;
+    ignoreDepthValues?: boolean | undefined;
+    framebufferScaleFactor?: number | undefined;
 }
+
+declare class XRWebGLLayer extends XRLayer {
+    static getNativeFramebufferScaleFactor(session: XRSession): number;
+
+    constructor(
+        session: XRSession,
+        context: WebGLRenderingContext | WebGL2RenderingContext,
+        layerInit?: XRWebGLLayerInit,
+    );
+
+    readonly antialias: boolean;
+    readonly ignoreDepthValues: boolean;
+    fixedFoveation?: number | undefined;
+
+    readonly framebuffer: WebGLFramebuffer;
+    readonly framebufferWidth: number;
+    readonly framebufferHeight: number;
+
+    getViewport(view: XRView): XRViewport | undefined;
+}
+
+interface XRRenderStateInit {
+    layers?: XRLayer[] | undefined;
+}
+
+interface XRRenderState {
+    readonly layers?: XRLayer[] | undefined;
+}
+
+type XRLayerEventType = "redraw";
 
 interface XRLayerEvent extends Event {
+    readonly type: XRLayerEventType;
     readonly layer: XRLayer;
-}
-
-declare class XRLayerEvent {
-    constructor(type: "redraw", eventInitDict?: XRLayerEventInit);
-    prototype: XRLayerEvent;
 }
 
 interface XRCompositionLayerEventMap {
@@ -661,11 +617,11 @@ interface XRCompositionLayer extends XRLayer {
     ): void;
 }
 
-declare class XRCompositionLayer {
-    prototype: XRCompositionLayer;
-}
+declare abstract class XRCompositionLayer implements XRCompositionLayer { }
 
-type XRTextureType = "texture" | "texture-array";
+type XRTextureType =
+    | "texture"
+    | "texture-array";
 
 type XRLayerLayout =
     | "default"
@@ -689,9 +645,7 @@ interface XRProjectionLayer extends XRCompositionLayer {
     fixedFoveation: number;
 }
 
-declare class XRProjectionLayer {
-    prototype: XRProjectionLayer;
-}
+declare abstract class XRProjectionLayer implements XRProjectionLayer { }
 
 interface XRLayerInit {
     mipLevels?: number | undefined;
@@ -732,9 +686,7 @@ interface XRCylinderLayer extends XRCompositionLayer {
     aspectRatio: number;
 }
 
-declare class XRCylinderLayer {
-    prototype: XRCylinderLayer;
-}
+declare abstract class XRCylinderLayer implements XRCylinderLayer { }
 
 interface XRQuadLayerInit extends XRLayerInit {
     textureType?: XRTextureType | undefined;
@@ -755,9 +707,7 @@ interface XRQuadLayer extends XRCompositionLayer {
     height: number;
 }
 
-declare class XRQuadLayer {
-    prototype: XRQuadLayer;
-}
+declare abstract class XRQuadLayer implements XRQuadLayer { }
 
 interface XREquirectLayerInit extends XRLayerInit {
     textureType?: XRTextureType | undefined;
@@ -784,9 +734,7 @@ interface XREquirectLayer extends XRCompositionLayer {
     lowerVerticalAngle: number;
 }
 
-declare class XREquirectLayer {
-    prototype: XREquirectLayer;
-}
+declare abstract class XREquirectLayer implements XREquirectLayer { }
 
 interface XRCubeLayerInit extends XRLayerInit {
     orientation?: DOMPointReadOnly | undefined;
@@ -796,17 +744,13 @@ interface XRCubeLayer extends XRCompositionLayer {
     orientation: DOMPointReadOnly;
 }
 
-declare class XRCubeLayer {
-    prototype: XRCubeLayer;
-}
+declare abstract class XRCubeLayer implements XRCubeLayer { }
 
 interface XRSubImage {
     readonly viewport: XRViewport;
 }
 
-declare class XRSubImage {
-    prototype: XRSubImage;
-}
+declare abstract class XRSubImage implements XRSubImage { }
 
 interface XRWebGLSubImage extends XRSubImage {
     readonly colorTexture: WebGLTexture;
@@ -816,12 +760,12 @@ interface XRWebGLSubImage extends XRSubImage {
     readonly textureHeight: number;
 }
 
-declare class XRWebGLSubImage {
-    prototype: XRWebGLSubImage;
-}
+declare abstract class XRWebGLSubImage implements XRWebGLSubImage { }
 
-interface XRWebGLBinding {
+declare class XRWebGLBinding {
     readonly nativeProjectionScaleFactor: number;
+
+    constructor(session: XRSession, context: WebGLRenderingContext);
 
     createProjectionLayer(init?: XRProjectionLayerInit): XRProjectionLayer;
     createQuadLayer(init?: XRQuadLayerInit): XRQuadLayer;
@@ -833,77 +777,17 @@ interface XRWebGLBinding {
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
 }
 
-declare class XRWebGLBinding {
-    constructor(session: XRSession, context: WebGLRenderingContext);
-    prototype: XRWebGLBinding;
-}
+declare class XRMediaBinding {
+    constructor(sesion: XRSession);
 
-interface XRMediaBinding {
     createQuadLayer(video: HTMLVideoElement, init?: XRMediaQuadLayerInit): XRQuadLayer;
     createCylinderLayer(video: HTMLVideoElement, init?: XRMediaCylinderLayerInit): XRCylinderLayer;
     createEquirectLayer(video: HTMLVideoElement, init?: XRMediaEquirectLayerInit): XREquirectLayer;
 }
 
-declare class XRMediaBinding {
-    constructor(sesion: XRSession);
-    prototype: XRMediaBinding;
-}
-
 // WebGL extensions
-interface WebGLRenderingContext {
-    makeXRCompatible(): Promise<void>;
+interface WebGLRenderingContextBase {
     getExtension(extensionName: "OCULUS_multiview"): OCULUS_multiview | null;
-    getExtension(extensionName: "EXT_blend_minmax"): EXT_blend_minmax | null;
-    getExtension(extensionName: "EXT_texture_filter_anisotropic"): EXT_texture_filter_anisotropic | null;
-    getExtension(extensionName: "EXT_frag_depth"): EXT_frag_depth | null;
-    getExtension(extensionName: "EXT_shader_texture_lod"): EXT_shader_texture_lod | null;
-    getExtension(extensionName: "EXT_sRGB"): EXT_sRGB | null;
-    getExtension(extensionName: "OES_vertex_array_object"): OES_vertex_array_object | null;
-    getExtension(extensionName: "WEBGL_color_buffer_float"): WEBGL_color_buffer_float | null;
-    getExtension(extensionName: "WEBGL_compressed_texture_astc"): WEBGL_compressed_texture_astc | null;
-    getExtension(extensionName: "WEBGL_compressed_texture_s3tc_srgb"): WEBGL_compressed_texture_s3tc_srgb | null;
-    getExtension(extensionName: "WEBGL_debug_shaders"): WEBGL_debug_shaders | null;
-    getExtension(extensionName: "WEBGL_draw_buffers"): WEBGL_draw_buffers | null;
-    getExtension(extensionName: "WEBGL_lose_context"): WEBGL_lose_context | null;
-    getExtension(extensionName: "WEBGL_depth_texture"): WEBGL_depth_texture | null;
-    getExtension(extensionName: "WEBGL_debug_renderer_info"): WEBGL_debug_renderer_info | null;
-    getExtension(extensionName: "WEBGL_compressed_texture_s3tc"): WEBGL_compressed_texture_s3tc | null;
-    getExtension(extensionName: "OES_texture_half_float_linear"): OES_texture_half_float_linear | null;
-    getExtension(extensionName: "OES_texture_half_float"): OES_texture_half_float | null;
-    getExtension(extensionName: "OES_texture_float_linear"): OES_texture_float_linear | null;
-    getExtension(extensionName: "OES_texture_float"): OES_texture_float | null;
-    getExtension(extensionName: "OES_standard_derivatives"): OES_standard_derivatives | null;
-    getExtension(extensionName: "OES_element_index_uint"): OES_element_index_uint | null;
-    getExtension(extensionName: "ANGLE_instanced_arrays"): ANGLE_instanced_arrays | null;
-    getExtension(extensionName: string): any;
-}
-
-interface WebGL2RenderingContext {
-    makeXRCompatible(): Promise<void>;
-    getExtension(extensionName: "OCULUS_multiview"): OCULUS_multiview | null;
-    getExtension(extensionName: "EXT_blend_minmax"): EXT_blend_minmax | null;
-    getExtension(extensionName: "EXT_texture_filter_anisotropic"): EXT_texture_filter_anisotropic | null;
-    getExtension(extensionName: "EXT_frag_depth"): EXT_frag_depth | null;
-    getExtension(extensionName: "EXT_shader_texture_lod"): EXT_shader_texture_lod | null;
-    getExtension(extensionName: "EXT_sRGB"): EXT_sRGB | null;
-    getExtension(extensionName: "OES_vertex_array_object"): OES_vertex_array_object | null;
-    getExtension(extensionName: "WEBGL_color_buffer_float"): WEBGL_color_buffer_float | null;
-    getExtension(extensionName: "WEBGL_compressed_texture_astc"): WEBGL_compressed_texture_astc | null;
-    getExtension(extensionName: "WEBGL_compressed_texture_s3tc_srgb"): WEBGL_compressed_texture_s3tc_srgb | null;
-    getExtension(extensionName: "WEBGL_debug_shaders"): WEBGL_debug_shaders | null;
-    getExtension(extensionName: "WEBGL_draw_buffers"): WEBGL_draw_buffers | null;
-    getExtension(extensionName: "WEBGL_lose_context"): WEBGL_lose_context | null;
-    getExtension(extensionName: "WEBGL_depth_texture"): WEBGL_depth_texture | null;
-    getExtension(extensionName: "WEBGL_debug_renderer_info"): WEBGL_debug_renderer_info | null;
-    getExtension(extensionName: "WEBGL_compressed_texture_s3tc"): WEBGL_compressed_texture_s3tc | null;
-    getExtension(extensionName: "OES_texture_half_float_linear"): OES_texture_half_float_linear | null;
-    getExtension(extensionName: "OES_texture_half_float"): OES_texture_half_float | null;
-    getExtension(extensionName: "OES_texture_float_linear"): OES_texture_float_linear | null;
-    getExtension(extensionName: "OES_texture_float"): OES_texture_float | null;
-    getExtension(extensionName: "OES_standard_derivatives"): OES_standard_derivatives | null;
-    getExtension(extensionName: "OES_element_index_uint"): OES_element_index_uint | null;
-    getExtension(extensionName: "ANGLE_instanced_arrays"): ANGLE_instanced_arrays | null;
-    getExtension(extensionName: string): any;
 }
 
 declare enum XOVR_multiview2 {
@@ -929,6 +813,31 @@ interface OVR_multiview2 {
     ): WebGLRenderbuffer;
 }
 
+declare abstract class OVR_multiview2 implements OVR_multiview2 { }
+
+// Oculus extensions
+interface XRSessionGrant {
+    mode: XRSessionMode;
+}
+
+interface XRSystemSessionGrantedEvent extends Event {
+    type: "sessiongranted";
+    session: XRSessionGrant;
+}
+
+interface XRSystemSessionGrantedEventHandler {
+    (event: XRSystemSessionGrantedEvent): any;
+}
+
+interface XRSystemEventMap {
+    // Session Grant events are an Meta Oculus Browser extension
+    "sessiongranted": XRSystemSessionGrantedEvent;
+}
+
+interface XRSystem {
+    onsessiongranted: XRSystemSessionGrantedEventHandler | null;
+}
+
 interface OCULUS_multiview extends OVR_multiview2 {
     framebufferTextureMultisampleMultiviewOVR(
         target: GLenum,
@@ -940,3 +849,5 @@ interface OCULUS_multiview extends OVR_multiview2 {
         numViews: GLsizei
     ): void;
 }
+
+declare abstract class OCULUS_multiview implements OCULUS_multiview { }

--- a/types/webxr/webxr-tests.ts
+++ b/types/webxr/webxr-tests.ts
@@ -1,71 +1,78 @@
-import {
-    XRWebGLLayer,
-    XRSession,
-    XRSystem,
-    XRRenderStateInit,
-    XRReferenceSpace,
-    XRFrame,
-    XRViewerPose,
-    XRRigidTransform,
-    XRView,
-    XRViewport,
-    XRFrameRequestCallback,
-} from 'webxr';
-
 const canvas = document.createElement('canvas');
-const ctx: WebGLRenderingContext | null = canvas.getContext('webgl');
+const ctx: WebGLRenderingContext | null = canvas.getContext('webgl') as any as WebGLRenderingContext;
 
-const xr = (navigator as any)?.xr as XRSystem;
-if (!xr) {
-    throw Error('You do not have WebXR');
-}
-
-let space: XRReferenceSpace;
-let layer: XRWebGLLayer;
-const startRot = new DOMPoint(0, 0, 0, 1);
-const startSpot = new DOMPoint(0, 0, 0, 1);
-xr.requestSession('immersive-vr').then((session: XRSession) => {
-    if (ctx) {
-        layer = new XRWebGLLayer(session, ctx);
-        const init: XRRenderStateInit = {
-            baseLayer: layer,
-            depthFar: 800,
-            depthNear: 0.01,
-            inlineVerticalFieldOfView: 1,
-        };
-        session.updateRenderState(init);
-
-        session
-            .requestReferenceSpace('local')
-            .then(rs => {
-                space = rs as XRReferenceSpace;
-
-                const loop: XRFrameRequestCallback = (time: number, frame: XRFrame) => {};
-                const handle = session.requestAnimationFrame(loop);
-                session.cancelAnimationFrame(handle);
-            })
-            .catch(e => {
-                throw Error("Can't get reference space" + e);
-            });
+(async () => {
+    if (!navigator.xr || ctx && !ctx.makeXRCompatible) {
+        throw Error('You do not have WebXR');
     }
-});
 
-const renderFrame = (frame: XRFrame) => {
-    const tf = new XRRigidTransform(startSpot, startRot);
-    space = space.getOffsetReferenceSpace(tf);
+    const startRot = new DOMPoint(0, 0, 0, 1);
+    const startSpot = new DOMPoint(0, 0, 0, 1);
 
-    const pose = frame.getViewerPose(space);
+    await ctx.makeXRCompatible();
 
-    if (pose) {
-        let view: XRView;
-        for (view of pose.views) {
-            const viewport: XRViewport = layer.getViewport(view);
-            // draw to the device eyes
+    const session = await navigator.xr.requestSession('immersive-vr');
+
+    const ext = ctx.getExtension("OCULUS_multiview");
+    if (ext && !ext.framebufferTextureMultisampleMultiviewOVR) {
+        throw Error("Incorrect extension type");
+    }
+
+    const layer = new XRWebGLLayer(session, ctx);
+    const init: XRRenderStateInit = {
+        baseLayer: layer,
+        depthFar: 800,
+        depthNear: 0.01,
+        inlineVerticalFieldOfView: 1,
+    };
+    session.updateRenderState(init);
+
+    let space = await session.requestReferenceSpace('local');
+
+    const loop: XRFrameRequestCallback = (time: number, frame: XRFrame) => { };
+    const handle = session.requestAnimationFrame(loop);
+    session.cancelAnimationFrame(handle);
+
+    const renderFrame = (frame: XRFrame) => {
+        const tf = new XRRigidTransform(startSpot, startRot);
+        space = space.getOffsetReferenceSpace(tf);
+
+        const pose = frame.getViewerPose(space);
+
+        if (pose) {
+            let view: XRView;
+            for (view of pose.views) {
+                const viewport: XRViewport | undefined = layer.getViewport(view);
+                // draw to the device eyes
+            }
         }
-    }
-};
+    };
 
-xr.addEventListener('devicechange', (e: Event) => {
-    // Event is a simple event; there is no additional data
-    // XR device availability changed
-});
+    navigator.xr.addEventListener('devicechange', (e: Event) => {
+        // Event is a simple event; there is no additional data
+        // XR device availability changed
+    });
+
+    const video = document.createElement("video");
+    const mediaBinding = new XRMediaBinding(session);
+    const transform = new XRRigidTransform({
+        x: 0,
+        y: 0,
+        z: -2
+    }, {
+        x: 0,
+        y: 0,
+        z: 0,
+        w: 1
+    });
+    const mediaLayer = mediaBinding.createQuadLayer(video, {
+        space,
+        layout: "mono",
+        invertStereo: false,
+        transform,
+        width: 1,
+        height: video.height / video.width
+    });
+
+    mediaLayer.destroy();
+})();

--- a/types/webxr/webxr-tests.ts
+++ b/types/webxr/webxr-tests.ts
@@ -3,15 +3,14 @@
     const ctx: WebGLRenderingContext | null = canvas.getContext('webgl');
 
     if (!ctx) {
-        throw new Error("No graphics context");
+        throw new Error('No graphics context');
     }
 
     if (!navigator.xr || !ctx.makeXRCompatible) {
         throw Error('You do not have WebXR');
     }
 
-    navigator.xr.addEventListener("sessiongranted", (evt) =>
-        console.log("Session granted", evt.session));
+    navigator.xr.addEventListener('sessiongranted', evt => console.log('Session granted', evt.session));
 
     const startRot = new DOMPoint(0, 0, 0, 1);
     const startSpot = new DOMPoint(0, 0, 0, 1);
@@ -24,19 +23,16 @@
         throw new Error("Can't test instance of XRSession");
     }
 
-    session.addEventListener("end", (evt) =>
-        console.log("The session has ended.", evt.session));
+    session.addEventListener('end', evt => console.log('The session has ended.', evt.session));
 
-    const ovrExt = ctx.getExtension("OVR_multiview2");
+    const ovrExt = ctx.getExtension('OVR_multiview2');
     if (ovrExt && !ovrExt.framebufferTextureMultiviewOVR) {
-        throw Error("Incorrect extension type");
+        throw Error('Incorrect extension type');
     }
 
-    const omvExt = ctx.getExtension("OCULUS_multiview");
-    if (omvExt
-        && !omvExt.framebufferTextureMultiviewOVR
-        && !omvExt.framebufferTextureMultisampleMultiviewOVR) {
-        throw Error("Incorrect extension type");
+    const omvExt = ctx.getExtension('OCULUS_multiview');
+    if (omvExt && !omvExt.framebufferTextureMultiviewOVR && !omvExt.framebufferTextureMultisampleMultiviewOVR) {
+        throw Error('Incorrect extension type');
     }
 
     const layer = new XRWebGLLayer(session, ctx);
@@ -52,7 +48,7 @@
 
     let space = await session.requestReferenceSpace('local');
 
-    const loop: XRFrameRequestCallback = (time: number, frame: XRFrame) => { };
+    const loop: XRFrameRequestCallback = (time: number, frame: XRFrame) => {};
     const handle = session.requestAnimationFrame(loop);
     session.cancelAnimationFrame(handle);
 
@@ -76,67 +72,70 @@
         // XR device availability changed
     });
 
-    if ("XRWebGLBinding" in window) {
+    if ('XRWebGLBinding' in window) {
         const glBinding = new XRWebGLBinding(session, ctx);
         const cubeLayer = glBinding.createCubeLayer({
             space,
-            layout: "mono",
+            layout: 'mono',
             isStatic: true,
             viewPixelWidth: 2048,
-            viewPixelHeight: 2048
+            viewPixelHeight: 2048,
         });
 
         layers.push(cubeLayer);
 
         await session.updateRenderState({
-            layers
+            layers,
         });
     }
 
-    if ("XRMediaBinding" in window) {
-        const video = document.createElement("video");
+    if ('XRMediaBinding' in window) {
+        const video = document.createElement('video');
         const mediaBinding = new XRMediaBinding(session);
-        const transform = new XRRigidTransform({
-            x: 0,
-            y: 0,
-            z: -2
-        }, {
-            x: 0,
-            y: 0,
-            z: 0,
-            w: 1
-        });
+        const transform = new XRRigidTransform(
+            {
+                x: 0,
+                y: 0,
+                z: -2,
+            },
+            {
+                x: 0,
+                y: 0,
+                z: 0,
+                w: 1,
+            },
+        );
         const mediaLayer = mediaBinding.createQuadLayer(video, {
             space,
-            layout: "mono",
+            layout: 'mono',
             invertStereo: false,
             transform,
             width: 1,
-            height: video.height / video.width
+            height: video.height / video.width,
         });
 
         layers.push(mediaLayer);
 
         await session.updateRenderState({
-            layers
+            layers,
         });
     }
 
     await session.updateRenderState({
-        layers: []
+        layers: [],
     });
 
     for (const layer of layers) {
         if (layer instanceof XRQuadLayer) {
-            console.log("Layer is a quad layer");
+            console.log('Layer is a quad layer');
         } else if (layer instanceof XRCubeLayer) {
-            console.log("Layer is a cube layer");
+            console.log('Layer is a cube layer');
         } else if (layer instanceof XRCylinderLayer) {
-            console.log("Layer is a cylinder layer");
+            console.log('Layer is a cylinder layer');
         } else if (layer instanceof XREquirectLayer) {
-            console.log("Layer is an equirectangular layer");
+            console.log('Layer is an equirectangular layer');
         } else if (layer instanceof XRProjectionLayer) {
-            console.log("Layer is a projection layer");
+            console.log('Layer is a projection layer');
         }
 
         layer.destroy();

--- a/types/webxr/webxr-tests.ts
+++ b/types/webxr/webxr-tests.ts
@@ -1,20 +1,41 @@
-const canvas = document.createElement('canvas');
-const ctx: WebGLRenderingContext | null = canvas.getContext('webgl') as any as WebGLRenderingContext;
-
 (async () => {
-    if (!navigator.xr || ctx && !ctx.makeXRCompatible) {
+    const canvas = document.createElement('canvas');
+    const ctx: WebGLRenderingContext | null = canvas.getContext('webgl');
+
+    if (!ctx) {
+        throw new Error("No graphics context");
+    }
+
+    if (!navigator.xr || !ctx.makeXRCompatible) {
         throw Error('You do not have WebXR');
     }
+
+    navigator.xr.addEventListener("sessiongranted", (evt) =>
+        console.log("Session granted", evt.session));
 
     const startRot = new DOMPoint(0, 0, 0, 1);
     const startSpot = new DOMPoint(0, 0, 0, 1);
 
     await ctx.makeXRCompatible();
 
+    // const session = new XRSession(); // shouldn't be able to do this.
     const session = await navigator.xr.requestSession('immersive-vr');
+    if (!(session instanceof XRSession)) {
+        throw new Error("Can't test instance of XRSession");
+    }
 
-    const ext = ctx.getExtension("OCULUS_multiview");
-    if (ext && !ext.framebufferTextureMultisampleMultiviewOVR) {
+    session.addEventListener("end", (evt) =>
+        console.log("The session has ended.", evt.session));
+
+    const ovrExt = ctx.getExtension("OVR_multiview2");
+    if (ovrExt && !ovrExt.framebufferTextureMultiviewOVR) {
+        throw Error("Incorrect extension type");
+    }
+
+    const omvExt = ctx.getExtension("OCULUS_multiview");
+    if (omvExt
+        && !omvExt.framebufferTextureMultiviewOVR
+        && !omvExt.framebufferTextureMultisampleMultiviewOVR) {
         throw Error("Incorrect extension type");
     }
 


### PR DESCRIPTION
There are particular cases, such as managing WebXR Layers on the Oculus Quest, where it is very useful to type-inspect the layers (e.g. the layers all store in a single collection, but there can be only one XRProjectionLayer).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.