### PR TITLE
Fix nth

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -569,13 +569,8 @@ export function binary<T extends AnyFunction>(fn: T): (...arg: _.T.Take<Paramete
  * // logs {a: 2}
  * ```
  */
-export function bind<F extends AnyFunction, T>(
-    fn: F,
-    thisObj: T,
-): (...args: Parameters<F>) => ReturnType<F>;
-export function bind<F extends AnyFunction, T>(
-    fn: F,
-): (thisObj: T) => (...args: Parameters<F>) => ReturnType<F>;
+export function bind<F extends AnyFunction, T>(fn: F, thisObj: T): (...args: Parameters<F>) => ReturnType<F>;
+export function bind<F extends AnyFunction, T>(fn: F): (thisObj: T) => (...args: Parameters<F>) => ReturnType<F>;
 
 /**
  * A function which calls the two provided functions and returns the `&&` of the
@@ -1344,9 +1339,7 @@ export function curryN<N extends number, F extends AnyFunction>(
 ): _.F.Curry<(...args: _.T.Take<Parameters<F>, _.N.NumberOf<N>>) => ReturnType<F>>;
 export function curryN<N extends number>(
     length: N,
-): <F extends AnyFunction>(
-    fn: F,
-) => _.F.Curry<(...args: _.T.Take<Parameters<F>, _.N.NumberOf<N>>) => ReturnType<F>>;
+): <F extends AnyFunction>(fn: F) => _.F.Curry<(...args: _.T.Take<Parameters<F>, _.N.NumberOf<N>>) => ReturnType<F>>;
 
 /**
  * Decrements its argument.
@@ -3108,10 +3101,7 @@ export function median(list: readonly number[]): number;
  * count; //=> 1
  * ```
  */
-export function memoizeWith<T extends AnyFunction>(
-    keyFn: (...v: Parameters<T>) => string,
-    fn: T,
-): T;
+export function memoizeWith<T extends AnyFunction>(keyFn: (...v: Parameters<T>) => string, fn: T): T;
 
 /**
  * Create a new object with the own properties of a
@@ -3601,11 +3591,16 @@ export function omit<K extends string>(names: readonly K[]): <T>(obj: T) => Omit
  */
 export function on<T, U, R>(combine: (a: U, b: U) => R, transform: (value: T) => U, a: T, b: T): R;
 export function on<T, U, R>(combine: (a: U, b: U) => R, transform: (value: T) => U, a: T): (b: T) => R;
-export function on<T, U, R>(combine: (a: U, b: U) => R, transform: (value: T) => U): {
+export function on<T, U, R>(
+    combine: (a: U, b: U) => R,
+    transform: (value: T) => U,
+): {
     (a: T, b: T): R;
     (a: T): (b: T) => R;
 };
-export function on<U, R>(combine: (a: U, b: U) => R): {
+export function on<U, R>(
+    combine: (a: U, b: U) => R,
+): {
     <T>(transform: (value: T) => U, a: T, b: T): R;
     <T>(transform: (value: T) => U, a: T): (b: T) => R;
     <T>(transform: (value: T) => U): {
@@ -3614,7 +3609,9 @@ export function on<U, R>(combine: (a: U, b: U) => R): {
     };
 };
 // For manually specifying overloads
-export function on<T, U, R>(combine: (a: U, b: U) => R): {
+export function on<T, U, R>(
+    combine: (a: U, b: U) => R,
+): {
     (transform: (value: T) => U, a: T, b: T): R;
     (transform: (value: T) => U, a: T): (b: T) => R;
     (transform: (value: T) => U): {
@@ -4298,8 +4295,13 @@ export function project<T, U>(props: readonly string[]): (objs: readonly T[]) =>
  * ```
  */
 export function promap<A, B, C, D>(pre: (value: A) => B, post: (value: C) => D, fn: (value: B) => C): (value: A) => D;
-export function promap<A, B, C, D>(pre: (value: A) => B, post: (value: C) => D): (fn: (value: B) => C) => (value: A) => D;
-export function promap<A, B>(pre: (value: A) => B): <C, D>(post: (value: C) => D, fn: (value: B) => C) => (value: A) => D;
+export function promap<A, B, C, D>(
+    pre: (value: A) => B,
+    post: (value: C) => D,
+): (fn: (value: B) => C) => (value: A) => D;
+export function promap<A, B>(
+    pre: (value: A) => B,
+): <C, D>(post: (value: C) => D, fn: (value: B) => C) => (value: A) => D;
 
 /**
  * Returns a function that when supplied an object
@@ -5265,9 +5267,7 @@ export function test(regexp: RegExp): (str: string) => boolean;
  * R.thunkify((a: number, b: number) => a + b)(25, 17)(); //=> 42
  * ```
  */
-export function thunkify<F extends AnyFunction>(
-    fn: F,
-): _.F.Curry<(...args: Parameters<F>) => () => ReturnType<F>>;
+export function thunkify<F extends AnyFunction>(fn: F): _.F.Curry<(...args: Parameters<F>) => () => ReturnType<F>>;
 
 /**
  * Calls an input function `n` times,

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3487,10 +3487,9 @@ export function not(value: any): boolean;
  */
 export function nth<T>(n: number, list: readonly T[]): T | undefined;
 export function nth(n: number, list: string): string;
-export function nth(n: number): {
-    <T>(list: readonly T[]): T | undefined;
-    (list: string): string;
-};
+export function nth(
+    n: number,
+): <T extends readonly any[] | string>(list: T) => (T extends Array<infer E> ? E : string) | undefined;
 
 /**
  * Returns a function which returns its nth argument.

--- a/types/ramda/test/aperture-tests.ts
+++ b/types/ramda/test/aperture-tests.ts
@@ -13,7 +13,7 @@ import * as R from 'ramda';
     const res1: Array<[number, number]> = R.aperture(2, [1, 2, 3, 4, 5]);
     const res2: number[][] = R.aperture(11, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
 
-    const anyArr: any[] = [1, "2"];
+    const anyArr: any[] = [1, '2'];
     // $ExpectType [] | [any, any][]
     const aperturedAny = R.aperture(2, anyArr);
 

--- a/types/ramda/test/nth-tests.ts
+++ b/types/ramda/test/nth-tests.ts
@@ -51,3 +51,11 @@ import * as R from 'ramda';
     // $ExpectError
     R.nth(1, '', 1);
 };
+
+async () => {
+    const promise = Promise.resolve([1, 2, 3]);
+
+    // $ExpectType number
+    const el = await promise.then(R.nth(0));
+    // but I am getting string above
+};

--- a/types/ramda/test/nth-tests.ts
+++ b/types/ramda/test/nth-tests.ts
@@ -3,7 +3,7 @@ import * as R from 'ramda';
 () => {
     const list = ['foo', 'bar', 'baz', 'quux'];
 
-    // $ExpectType { <T>(list: readonly T[]): T | undefined; (list: string): string; }
+    // $ExpectType <T extends string | readonly any[]>(list: T) => (T extends (infer E)[] ? E : string) | undefined
     R.nth(1); // => 'b'
 
     // $ExpectType string | undefined
@@ -34,10 +34,10 @@ import * as R from 'ramda';
     // $ExpectType string
     R.nth(99, str); // => ''
 
-    // $ExpectType string
+    // $ExpectType string | undefined
     R.nth(1)(str); // => 'b'
 
-    // $ExpectType string
+    // $ExpectType string | undefined
     R.nth(-99)(str); // => ''
 };
 
@@ -55,7 +55,6 @@ import * as R from 'ramda';
 async () => {
     const promise = Promise.resolve([1, 2, 3]);
 
-    // $ExpectType number
+    // $ExpectType number | undefined
     const el = await promise.then(R.nth(0));
-    // but I am getting string above
 };

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -162,7 +162,7 @@ type EvolveValue<V, E> = E extends (value: V) => any
  * the seventh being `document.all`. However `NaN` is not a valid literal type,
  * and `document.all` is an object so it's probably not a good idea to add it either.
  */
-export type Falsy = undefined | null | 0 | "" | false;
+export type Falsy = undefined | null | 0 | '' | false;
 
 /**
  * The type of `R.find` and `R.findLast`
@@ -286,7 +286,7 @@ type Intersection<T1, T2> = Intersectable<T1, T2> extends true
 export type mergeArrWithLeft<T1 extends ReadonlyArray<any>, T2 extends ReadonlyArray<any>> = readonly [
     ...{
         readonly [Index in keyof T1]: Index extends keyof T2 ? Intersection<T1[Index], T2[Index]> : T1[Index];
-    }
+    },
 ];
 
 /**
@@ -320,7 +320,7 @@ type MergeArrays<T1 extends ReadonlyArray<any>, T2 extends ReadonlyArray<any>> =
  */
 export type LargestArgumentsList<T extends ReadonlyArray<any>> = T extends readonly [
     (...args: infer Args) => any,
-    ...infer Rest
+    ...infer Rest,
 ]
     ? MergeArrays<LargestArgumentsList<Rest>, Args>
     : readonly [];


### PR DESCRIPTION
The current behavior of `nth` is quit strange. Here is a problem(I included it in second commit, to check):
```ts
const promise = Promise.resolve([1, 2, 3]);

// $ExpectType number
const el = await promise.then(R.nth(0));
// but I am getting string above
```
This merge request introduces fix to this problem.

Overview:
1 commit: just format code as described in message via `'npm run prettier -- --write ./types/ramda/**/*.ts'` (quite straightforward, hope you guys don't mind it is not in separate pull request)

2 commit: show problem

3 commit: fix

I made typings a bit broader adding possibility of undefined in return clause(because it better represent function, nth can return undefined if element at specified index does not exist), and this breaks backward compatibility, but I can just add +1 commit and delete undefined if needed(when list is string) which will preserve fully backward compatibility.

*What is interesting:*
I do not know why the problem above exist, seems for me like a typescript bug or incorrect `lib.es5.d.ts` typings or something else what I do not understand for now.
But this PR fixes it.