### PR TITLE
Allow MDX JSX functions to return null

### DIFF
--- a/types/mdx/mdx-tests.tsx
+++ b/types/mdx/mdx-tests.tsx
@@ -1,4 +1,4 @@
-import { MDXContent, MDXModule } from 'mdx/types';
+import { MDXComponents, MDXContent, MDXModule } from 'mdx/types';
 import MyMDXComponent from './MyComponent.mdx';
 import MyMDComponent from './MyComponent.md';
 import MyMarkdownComponent from './MyComponent.markdown';
@@ -14,6 +14,10 @@ interface TestElementType {
     type: string;
     props: unknown;
     children: TestElementType[];
+}
+
+interface AnchorProps {
+    className?: string;
 }
 
 interface DivProps {
@@ -46,6 +50,7 @@ declare global {
         type Element = TestElementType;
 
         interface IntrinsicElements {
+            a: AnchorProps;
             div: DivProps;
             img: ImgProps;
             h1: H1Props;
@@ -72,8 +77,8 @@ class CustomImageComponent {
 // Tests — The `mdx` imports.
 
 function MyMDXPage(props: MDXModule) {
-    // dts type validation is inconsistent here.
-    const Content: MDXContent = props.default;
+    // $ExpectType MDXContent
+    const Content = props.default;
 
     // $ExpectType unknown
     props.title;
@@ -89,6 +94,11 @@ function MyMDXPage(props: MDXModule) {
 const MyComponentAlias: MDXContent = MyMDXComponent;
 const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
 
+// Ensure custom components are valid JSX components.
+declare const customComponents: MDXComponents;
+const Div = customComponents.div!;
+<Div />;
+
 // Tests — All mdx file exports.
 
 // $ExpectType TestElementType
@@ -101,6 +111,11 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
     universe={() => 'and'}
     everything={42}
     components={{
+        a(props) {
+            // $ExpectType AnchorProps
+            props;
+            return null;
+        },
         div(props) {
             // $ExpectType DivProps
             props;
@@ -160,6 +175,11 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
     universe={() => 'and'}
     everything={42}
     components={{
+        a(props) {
+            // $ExpectType AnchorProps
+            props;
+            return null;
+        },
         div(props) {
             // $ExpectType DivProps
             props;
@@ -219,6 +239,11 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
     universe={() => 'and'}
     everything={42}
     components={{
+        a(props) {
+            // $ExpectType AnchorProps
+            props;
+            return null;
+        },
         div(props) {
             // $ExpectType DivProps
             props;
@@ -278,6 +303,11 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
     universe={() => 'and'}
     everything={42}
     components={{
+        a(props) {
+            // $ExpectType AnchorProps
+            props;
+            return null;
+        },
         div(props) {
             // $ExpectType DivProps
             props;
@@ -337,6 +367,11 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
     universe={() => 'and'}
     everything={42}
     components={{
+        a(props) {
+            // $ExpectType AnchorProps
+            props;
+            return null;
+        },
         div(props) {
             // $ExpectType DivProps
             props;
@@ -396,6 +431,11 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
     universe={() => 'and'}
     everything={42}
     components={{
+        a(props) {
+            // $ExpectType AnchorProps
+            props;
+            return null;
+        },
         div(props) {
             // $ExpectType DivProps
             props;
@@ -455,6 +495,11 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
     universe={() => 'and'}
     everything={42}
     components={{
+        a(props) {
+            // $ExpectType AnchorProps
+            props;
+            return null;
+        },
         div(props) {
             // $ExpectType DivProps
             props;
@@ -514,6 +559,11 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
     universe={() => 'and'}
     everything={42}
     components={{
+        a(props) {
+            // $ExpectType AnchorProps
+            props;
+            return null;
+        },
         div(props) {
             // $ExpectType DivProps
             props;

--- a/types/mdx/mdx-tests.tsx
+++ b/types/mdx/mdx-tests.tsx
@@ -115,32 +115,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -174,32 +174,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -233,32 +233,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -292,32 +292,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -351,32 +351,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -410,32 +410,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -469,32 +469,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError
@@ -528,32 +528,32 @@ const MyComponentAliasAlias: typeof MyMDXComponent = MyComponentAlias;
             return <div />;
         },
         nested: {
-            components: (props) => {
+            components: props => {
                 // $ExpectType any
                 props;
                 return <div />;
             },
             very: {
-                deeply: (props) => {
+                deeply: props => {
                     // $ExpectType any
                     props;
                     return <div />;
                 },
                 to: {
-                    infinity: (props) => {
+                    infinity: props => {
                         // $ExpectType any
                         props;
                         return <div />;
                     },
                     and: {
-                        beyond: (props) => {
+                        beyond: props => {
                             // $ExpectType any
                             props;
                             return <div />;
                         },
                         span: 'div',
-                    }
-                }
+                    },
+                },
             },
         },
         // $ExpectError

--- a/types/mdx/types.d.ts
+++ b/types/mdx/types.d.ts
@@ -1,7 +1,7 @@
 // Internal helper types
 
 // tslint:disable-next-line: strict-export-declare-modifiers
-type FunctionComponent<Props> = (props: Props) => JSX.Element;
+type FunctionComponent<Props> = (props: Props) => JSX.Element | null;
 // tslint:disable-next-line: strict-export-declare-modifiers
 type ClassComponent<Props> = new (props: Props) => JSX.ElementClass;
 // tslint:disable-next-line: strict-export-declare-modifiers
@@ -46,7 +46,7 @@ export interface MDXProps {
 /**
  * The type of the default export of an MDX module.
  */
-export type MDXContent = FunctionComponent<MDXProps>;
+export type MDXContent = (props: MDXProps) => JSX.Element;
 
 /**
  * A generic MDX module type.

--- a/types/mdx/types.d.ts
+++ b/types/mdx/types.d.ts
@@ -18,15 +18,14 @@ interface NestedMDXComponents {
  *
  * The key is the name of the element to override. The value is the component to render instead.
  */
-export type MDXComponents = NestedMDXComponents &
-    {
-        [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]> | keyof JSX.IntrinsicElements;
-    } & {
-        /**
-         * If a wrapper component is defined, the MDX content will be wrapped inside of it.
-         */
-        wrapper?: Component<any>;
-    };
+export type MDXComponents = NestedMDXComponents & {
+    [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]> | keyof JSX.IntrinsicElements;
+} & {
+    /**
+     * If a wrapper component is defined, the MDX content will be wrapped inside of it.
+     */
+    wrapper?: Component<any>;
+};
 
 /**
  * The props that may be passed to an MDX component.


### PR DESCRIPTION
This adds compatibility with `FunctionComponent` in `@types/react`. Only `null | JSX.Element` is allowed. For any other types, TypeScript will complain.

This PR consists of two commits. The first reformats the code to adhere to DefinitelyTyped’s updated Prettier configuration. The second contains the actual changes. Please try to ignore the first. :)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L520
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.