### PR TITLE
yup: Support generic value type in TestFunction

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -114,7 +114,7 @@ export interface MixedSchema<T extends any = {} | null | undefined, C = object> 
     ): MixedSchema<U, C>;
     test(name: string, message: TestOptionsMessage, test: TestFunction<unknown, C>): this;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): MixedSchema<U, C>;
-    test(options: TestOptions<Record<string, any>, C>): this;
+    test(options: TestOptions<Record<string, any>, C, unknown>): this;
     default<U extends T>(value: U | (() => U)): U extends undefined ? MixedSchema<T, C> : MixedSchema<Exclude<T, undefined>, C>;
     default(): T;
 }
@@ -169,7 +169,7 @@ export interface StringSchema<T extends string | null | undefined = string | und
         test: AssertingTestFunction<U, C>,
     ): StringSchema<U, C>;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): StringSchema<U, C>;
-    test(options: TestOptions<Record<string, any>, C>): this;
+    test(options: TestOptions<Record<string, any>, C, T | null | undefined>): this;
     optional(): StringSchema<T | undefined, C>;
     default<U extends T>(value: U | (() => U)): U extends undefined ? StringSchema<T, C> : StringSchema<Exclude<T, undefined>, C>;
     default(): T;
@@ -214,7 +214,7 @@ export interface NumberSchema<T extends number | null | undefined = number | und
         test: AssertingTestFunction<U, C>,
     ): NumberSchema<U, C>;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): NumberSchema<U, C>;
-    test(options: TestOptions<Record<string, any>, C>): this;
+    test(options: TestOptions<Record<string, any>, C, T | null | undefined>): this;
     optional(): NumberSchema<T | undefined, C>;
     default<U extends T>(value: U | (() => U)): U extends undefined ? NumberSchema<T, C> : NumberSchema<Exclude<T, undefined>, C>;
     default(): T;
@@ -250,7 +250,7 @@ export interface BooleanSchema<T extends boolean | null | undefined = boolean | 
         test: AssertingTestFunction<U, C>,
     ): BooleanSchema<U, C>;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): BooleanSchema<U, C>;
-    test(options: TestOptions<Record<string, any>, C>): this;
+    test(options: TestOptions<Record<string, any>, C, T | null | undefined>): this;
     optional(): BooleanSchema<T | undefined, C>;
     default<U extends T>(value: U | (() => U)): U extends undefined ? BooleanSchema<T, C> : BooleanSchema<Exclude<T, undefined>, C>;
     default(): T;
@@ -287,7 +287,7 @@ export interface DateSchema<T extends Date | string | null | undefined = Date | 
         test: AssertingTestFunction<U, C>,
     ): DateSchema<U, C>;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): DateSchema<U, C>;
-    test(options: TestOptions<Record<string, any>, C>): this;
+    test(options: TestOptions<Record<string, any>, C, T | null | undefined>): this;
     optional(): DateSchema<T | undefined, C>;
     default<U extends T>(value: U | (() => U)): U extends undefined ? DateSchema<T, C> : DateSchema<Exclude<T, undefined>, C>;
     default(): T;
@@ -313,8 +313,8 @@ export interface BasicArraySchema<E, T extends E[] | null | undefined, C = objec
     // applies to arrays anyway.
     oneOf(arrayOfValues: ReadonlyArray<T | Ref | null>, message?: MixedLocale['oneOf']): this;
     equals(arrayOfValues: ReadonlyArray<T | Ref | null>, message?: MixedLocale['oneOf']): this;
-    test(name: string, message: TestOptionsMessage, test: TestFunction<T | undefined | null, C>): this;
-    test(options: TestOptions<Record<string, any>, C>): this;
+    test(name: string, message: TestOptionsMessage, test: TestFunction<T | undefined | null, C>): this; // TODO
+    test(options: TestOptions<Record<string, any>, C, T | null | undefined>): this;
     innerType: Schema<E, C>;
 }
 
@@ -418,7 +418,7 @@ export interface ObjectSchema<T extends object | null | undefined = object | und
         test: AssertingTestFunction<U, C>,
     ): ObjectSchema<U, C>;
     test<U extends T = T>(options: AssertingTestOptions<U, Record<string, any>, C>): ObjectSchema<U, C>;
-    test(options: TestOptions<Record<string, any>, C>): this;
+    test(options: TestOptions<Record<string, any>, C, T | null | undefined>): this;
     default<U extends T>(value: U | (() => U)): U extends undefined ? ObjectSchema<T, C> : ObjectSchema<Exclude<T, undefined>, C>;
     default(): T;
 }
@@ -491,7 +491,7 @@ export interface TestMessageParams {
     label: string;
 }
 
-interface BaseTestOptions<P extends Record<string, any>, C = object> {
+interface BaseTestOptions<P extends Record<string, any>, C = object, T extends any = {} | null | undefined> {
     /**
      * Unique name identifying the test. Required for exclusive tests.
      */
@@ -500,7 +500,7 @@ interface BaseTestOptions<P extends Record<string, any>, C = object> {
     /**
      * Test function, determines schema validity
      */
-    test: TestFunction<unknown, C>;
+    test: TestFunction<T | null | undefined, C>;
 
     /**
      * The validation error message
@@ -518,26 +518,26 @@ interface BaseTestOptions<P extends Record<string, any>, C = object> {
     exclusive?: boolean | undefined;
 }
 
-interface NonExclusiveTestOptions<P extends Record<string, any>, C> extends BaseTestOptions<P, C> {
+interface NonExclusiveTestOptions<P extends Record<string, any>, C, T> extends BaseTestOptions<P, C, T> {
     exclusive?: false | undefined;
 }
 
-interface ExclusiveTestOptions<P extends Record<string, any>, C> extends BaseTestOptions<P, C> {
+interface ExclusiveTestOptions<P extends Record<string, any>, C, T> extends BaseTestOptions<P, C, T> {
     exclusive: true;
     name: string;
 }
 
-interface NonExclusiveAssertingTestOptions<U, P extends Record<string, any>, C> extends NonExclusiveTestOptions<P, C> {
+interface NonExclusiveAssertingTestOptions<U, P extends Record<string, any>, C> extends NonExclusiveTestOptions<P, C, any> {
     test: AssertingTestFunction<U, C>;
 }
 
-interface ExclusiveAssertingTestOptions<U, P extends Record<string, any>, C> extends ExclusiveTestOptions<P, C> {
+interface ExclusiveAssertingTestOptions<U, P extends Record<string, any>, C> extends ExclusiveTestOptions<P, C, any> {
     test: AssertingTestFunction<U, C>;
 }
 
-export type TestOptions<P extends Record<string, any> = {}, C = object> =
-    | NonExclusiveTestOptions<P, C>
-    | ExclusiveTestOptions<P, C>;
+export type TestOptions<P extends Record<string, any> = {}, C = object, T extends any = {} | null | undefined> =
+    | NonExclusiveTestOptions<P, C, T>
+    | ExclusiveTestOptions<P, C, T>;
 
 export type AssertingTestOptions<U, P extends Record<string, any> = {}, C = object> =
     | NonExclusiveAssertingTestOptions<U, P, C>

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -1152,6 +1152,26 @@ yup.object({
         }
         return true;
     }),
+    alias: yup
+        .string()
+        .defined()
+        .test({
+            name: 'test1',
+            test: (value: string | null | undefined) => true,
+            message: 'validation error message',
+            exclusive: true,
+        })
+        .test({
+            name: 'test2',
+            // $ExpectError
+            test: (value: string) => true,
+            message: 'validation error message',
+            exclusive: true,
+        }),
+    dateOfBirthIsUnknown: yup.boolean().test({
+        test: (value: boolean | null | undefined) => true,
+        message: 'validation error message',
+    }),
     dateOfBirth: yup.date().required().test('', '', (value) => {
         // $ExpectError
         const x = Number.parseFloat(value);
@@ -1189,7 +1209,35 @@ yup.object({
             const test3 = value.name * 1;
             return false;
         });
-    })
+    }),
+    data: typedSchema
+        .test('', '', value => {
+            // $ExpectType MyInterface | null | undefined
+            const v = value;
+            return true;
+        })
+        .test({
+            name: 'name',
+            test: (value: any): value is MyInterface => true,
+            exclusive: true,
+        })
+        .test({
+            name: 'nonExclusiveTest',
+            test: (value: any): value is MyInterface => true,
+        })
+        .test({
+            test: (value: any) => new Promise<boolean>(() => true),
+        })
+        .test({
+            test: (value: MyInterface | null | undefined) => true,
+        })
+        .test({
+            test: (value: MyInterface | null | undefined) => new Promise<boolean>(() => true),
+        })
+        .test({
+            // $ExpectError
+            test: (value: MyInterface) => new Promise<boolean>(() => true),
+        }),
 });
 
 interface MyContext {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - see description below
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
    - I'm not confident about bumping the supported version from 0.29 to 0.32 because I didn't check whether the breaking changes in https://github.com/jquense/yup/blob/master/CHANGELOG.md need any type updates

The `test` method has 4 signatures:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ed0884630358b60a792be52421991fdd48483032/types/yup/index.d.ts#L161-L172

Signatures 2 and 3 involve `AssertingTestFunction` - these are out of scope.
Signatures 1 and 4 involve `TestFunction`.
Signature 1 types the `test` function as `TestFunction<T | undefined | null, C>`.
Signature 4 types the `test` function as `TestFunction<unknown, C>` from `BaseTestOptions`. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ed0884630358b60a792be52421991fdd48483032/types/yup/index.d.ts#L503

From https://github.com/jquense/yup#schematestoptions-object-schema signature 4 is an alternative to signature 1 and should behave the same. This PR is an attempt to fix this mismatch by changing `unknown` to `T | undefined | null`.

The new tests cover usages of signature 4 with the type-specific schemas like StringSchema, BooleanSchema, and ObjectSchema (not MixedSchema). Some of the tests fail with the old type definitions, with the errors pasted below. This errors are similar what I was experiencing with these versions:

* yup 0.26.3 with @types/yup 0.29.9
* yup 0.32.11 (latest version before 1.0.0-beta) with @types/yup 0.29.13 (latest)

```
ERROR: 1160:13  expect  TypeScript@4.7 compile error:
No overload matches this call.
  Overload 1 of 4, '(options: AssertingTestOptions<string, Record<string, any>, object>): StringSchema<string, object>', gave the following error.
    Type '(value: string | null | undefined) => true' is not assignable to type 'AssertingTestFunction<string, object>'.
      Signature '(value: string | null | undefined): true' must be a type predicate.
  Overload 2 of 4, '(options: TestOptions<Record<string, any>, object>): StringSchema<string, object>', gave the following error.
    Type '(value: string | null | undefined) => true' is not assignable to type 'TestFunction<unknown, object>'.
      Types of parameters 'value' and 'value' are incompatible.
        Type 'unknown' is not assignable to type 'string | null | undefined'.
ERROR: 1172:9   expect  TypeScript@4.7 compile error:
No overload matches this call.
  Overload 1 of 4, '(options: AssertingTestOptions<any, Record<string, any>, object>): BooleanSchema<any, object>', gave the following error.
    Type '(value: boolean | null | undefined) => true' is not assignable to type 'AssertingTestFunction<any, object>'.
      Signature '(value: boolean | null | undefined): true' must be a type predicate.
  Overload 2 of 4, '(options: TestOptions<Record<string, any>, object>): BooleanSchema<boolean | undefined, object>', gave the following error.
    Type '(value: boolean | null | undefined) => true' is not assignable to type 'TestFunction<unknown, object>'.
      Types of parameters 'value' and 'value' are incompatible.
        Type 'unknown' is not assignable to type 'boolean | null | undefined'.
ERROR: 1232:13  expect  TypeScript@4.7 compile error:
No overload matches this call.
  Overload 1 of 4, '(options: AssertingTestOptions<MyInterface, Record<string, any>, object>): ObjectSchema<MyInterface, object>', gave the following error.
    Type '(value: MyInterface | null | undefined) => true' is not assignable to type 'AssertingTestFunction<MyInterface, object>'.
      Signature '(value: MyInterface | null | undefined): true' must be a type predicate.
  Overload 2 of 4, '(options: TestOptions<Record<string, any>, object>): ObjectSchema<MyInterface, object>', gave the following error.
    Type '(value: MyInterface | null | undefined) => true' is not assignable to type 'TestFunction<unknown, object>'.
      Types of parameters 'value' and 'value' are incompatible.
        Type 'unknown' is not assignable to type 'MyInterface | null | undefined'.
ERROR: 1235:13  expect  TypeScript@4.7 compile error:
No overload matches this call.
  Overload 1 of 4, '(options: AssertingTestOptions<MyInterface, Record<string, any>, object>): ObjectSchema<MyInterface, object>', gave the following error.
    Type '(value: MyInterface | null | undefined) => Promise<boolean>' is not assignable to type 'AssertingTestFunction<MyInterface, object>'.
      Signature '(value: MyInterface | null | undefined): Promise<boolean>' must be a type predicate.
  Overload 2 of 4, '(options: TestOptions<Record<string, any>, object>): ObjectSchema<MyInterface, object>', gave the following error.
    Type '(value: MyInterface | null | undefined) => Promise<boolean>' is not assignable to type 'TestFunction<unknown, object>'.
      Types of parameters 'value' and 'value' are incompatible.
        Type 'unknown' is not assignable to type 'MyInterface | null | undefined'.
```