### PR TITLE
Add afterSearch prop in react-bootstrap-table2-toolkit

### DIFF
--- a/types/react-bootstrap-table2-toolkit/index.d.ts
+++ b/types/react-bootstrap-table2-toolkit/index.d.ts
@@ -31,6 +31,7 @@ export interface TableSearchProps<T extends object = any> {
     placeholder?: string | undefined;
     onColumnMatch?: ((props: SearchMatchProps<T>) => void) | undefined;
     customMatchFunc?: ((props: SearchMatchProps<T>) => boolean) | undefined;
+    afterSearch?: (newResult: T[]) => void | undefined;
 }
 
 export interface CSVProps {


### PR DESCRIPTION
This prop is supported by the API, but was missing in the types.
See https://www.npmjs.com/package/react-bootstrap-table2-toolkit#aftersearch---function for the documentation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/react-bootstrap-table2-toolkit#aftersearch---function
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
  - No, existed since 1.0.41
