### PR TITLE
Fix "picture" typo in @11ty/eleventy-img

### DIFF
--- a/types/11ty__eleventy-img/11ty__eleventy-img-tests.ts
+++ b/types/11ty__eleventy-img/11ty__eleventy-img-tests.ts
@@ -1,51 +1,73 @@
 import Image = require('@11ty/eleventy-img');
+import type { ImgAttributes, PictureAttributes, SourceAttributes } from '@11ty/eleventy-img/generate-html';
 
 Image.concurrency = 4;
 
+function isImg<T>(
+    attributes: ImgAttributes<T> | PictureAttributes<T> | SourceAttributes,
+): attributes is ImgAttributes<T> {
+    return (attributes as ImgAttributes<T>).img !== undefined;
+}
+
 (async () => {
-  const url = "https://images.unsplash.com/photo-1608178398319-48f814d0750c";
-  let stats: Image.Metadata = await Image(url, {
-    widths: [300]
-  });
+    const url = 'https://images.unsplash.com/photo-1608178398319-48f814d0750c';
+    let stats: Image.Metadata = await Image(url, {
+        widths: [300],
+    });
 
-  stats = await Image(url, {
-    widths: [200, null],
-    formats: ['avif', 'webp', 'svg', null],
-    urlPath: "/img/",
-    outputDir: "./img/",
-    svgShortCircuit: true,
-    svgAllowUpscale: false,
-    cacheOptions: {
-      duration: "1d",
-      directory: ".cache",
-      removeUrlQueryParams: false,
-    },
-    filenameFormat(id, src, width, format, options) {
-      return `${id}-${width}.${format}`;
-    },
-    urlFormat({ src, width, format }) {
-      return `https://sample-image-service.11ty.dev/${encodeURIComponent(src)}/${width}/${format}/`;
-    },
-    remoteImageMetadata: {
-      width: 300,
-      height: 300,
-    },
-    hashLength: 8,
-  });
+    stats = await Image(url, {
+        widths: [200, null],
+        formats: ['avif', 'webp', 'svg', null],
+        urlPath: '/img/',
+        outputDir: './img/',
+        svgShortCircuit: true,
+        svgAllowUpscale: false,
+        cacheOptions: {
+            duration: '1d',
+            directory: '.cache',
+            removeUrlQueryParams: false,
+        },
+        filenameFormat(id, src, width, format, options) {
+            return `${id}-${width}.${format}`;
+        },
+        urlFormat({ src, width, format }) {
+            return `https://sample-image-service.11ty.dev/${encodeURIComponent(src)}/${width}/${format}/`;
+        },
+        remoteImageMetadata: {
+            width: 300,
+            height: 300,
+        },
+        hashLength: 8,
+    });
 
-  stats = Image.statsSync(url, {
-    formats: ['jpg', 'svg+xml', 'auto'],
-    sharpOptions: {
-      animated: true
+    stats = Image.statsSync(url, {
+        formats: ['jpg', 'svg+xml', 'auto'],
+        sharpOptions: {
+            animated: true,
+        },
+    });
+
+    const attributes = Image.generateObject(stats, {
+        alt: 'Sample image',
+    });
+    if (isImg(attributes)) {
+        console.log(attributes.img);
+    } else {
+        for (const source of attributes.picture) {
+            console.log(isImg(source) ? source.img : source.source);
+        }
     }
-  });
 
-  return Image.generateHTML(stats, {
-    alt: '',
-    sizes: '100vw',
-    loading: "lazy",
-    decoding: "async",
-  }, {
-    whitespaceMode: "inline"
-  });
+    return Image.generateHTML(
+        stats,
+        {
+            alt: '',
+            sizes: '100vw',
+            loading: 'lazy',
+            decoding: 'async',
+        },
+        {
+            whitespaceMode: 'inline',
+        },
+    );
 })();

--- a/types/11ty__eleventy-img/generate-html.d.ts
+++ b/types/11ty__eleventy-img/generate-html.d.ts
@@ -31,7 +31,7 @@ declare namespace generateHTML {
      * @template AddedAttributes User-provided attributes for the <img> tag.
      */
     interface PictureAttributes<AddedAttributes> {
-        children: [...SourceAttributes[], ImgAttributes<AddedAttributes>];
+        picture: [...SourceAttributes[], ImgAttributes<AddedAttributes>];
     }
 
     /**


### PR DESCRIPTION
Fixes a typo in the first version of the type definitons, and adds additional tests to cover it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/11ty/eleventy-img/blob/master/generate-html.js#L124
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
