### PR TITLE
[angular] fix 4.8 errors

### DIFF
--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -1323,7 +1323,7 @@ namespace locationTests {
     $location.path('/foo');
     assert($location.absUrl() === 'http://example.com/foo');
 
-    assert($location.search() === {});
+    $location.search();
     $location.search({ a: 'b', c: true });
     assert($location.absUrl() === 'http://example.com/foo?a=b&c');
 
@@ -1335,7 +1335,6 @@ namespace locationTests {
     // open http://example.com/new?x=y -> redirect to http://example.com/#!/new?x=y
     // (again replacing the http://example.com/new?x=y history item)
     assert($location.path() === '/new');
-    assert($location.search() === { x: 'y' });
 
     $location.path('/foo/bar');
     assert($location.path() === '/foo/bar');


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===`  in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).