### PR TITLE
[aws-lambda] fix 4.8 errors

### DIFF
--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -228,9 +228,8 @@ const userMigration: UserMigrationTriggerHandler = async (event, _, callback) =>
     boolOrUndefined = response.forceAliasCreation;
     response.messageAction === 'RESEND';
     response.messageAction === 'SUPPRESS';
-    response.desiredDeliveryMediums === ['EMAIL'];
-    response.desiredDeliveryMediums === ['SMS'];
-    response.desiredDeliveryMediums === ['SMS', 'EMAIL'];
+    response.desiredDeliveryMediums[0] === 'EMAIL';
+    response.desiredDeliveryMediums[0] === 'SMS';
 
     triggerSource === 'UserMigration_Authentication';
     triggerSource === 'UserMigration_ForgotPassword';


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).