### PR TITLE
[aws-regions] fix 4.8 errors

### DIFF
--- a/types/aws-regions/aws-regions-tests.ts
+++ b/types/aws-regions/aws-regions-tests.ts
@@ -4,19 +4,19 @@ const listHead = awsRegions.list()[0];
 listHead.name === 'N. Virginia';
 listHead.full_name === 'US East (N. Virginia)';
 listHead.code === 'us-east-1';
-listHead.public === true;
+listHead.public; // $ExpectType boolean
 listHead.zones[0] === 'us-east-1a';
 
 const lookupResult1 = awsRegions.lookup({ code: 'us-east-1' });
 lookupResult1.name === 'N. Virginia';
 lookupResult1.full_name === 'US East (N. Virginia)';
 lookupResult1.code === 'us-east-1';
-lookupResult1.public === true;
+lookupResult1.public; // $ExpectType boolean
 lookupResult1.zones[0] === 'us-east-1a';
 
 const lookupResult2 = awsRegions.lookup({ name: 'N. Virginia' });
 lookupResult2.name === 'N. Virginia';
 lookupResult2.full_name === 'US East (N. Virginia)';
 lookupResult2.code === 'us-east-1';
-lookupResult2.public === true;
+lookupResult2.public; // $ExpectType boolean
 lookupResult2.zones[0] === 'us-east-1a';

--- a/types/aws-regions/aws-regions-tests.ts
+++ b/types/aws-regions/aws-regions-tests.ts
@@ -1,30 +1,22 @@
 import awsRegions from 'aws-regions';
 
-awsRegions.list() ===
-    [
-        {
-            name: 'N. Virginia',
-            full_name: 'US East (N. Virginia)',
-            code: 'us-east-1',
-            public: true,
-            zones: ['us-east-1a'],
-        },
-    ];
+const listHead = awsRegions.list()[0];
+listHead.name === 'N. Virginia';
+listHead.full_name === 'US East (N. Virginia)';
+listHead.code === 'us-east-1';
+listHead.public === true;
+listHead.zones[0] === 'us-east-1a';
 
-awsRegions.lookup({ code: 'us-east-1' }) ===
-    {
-        name: 'N. Virginia',
-        full_name: 'US East (N. Virginia)',
-        code: 'us-east-1',
-        public: true,
-        zones: ['us-east-1a'],
-    };
+const lookupResult1 = awsRegions.lookup({ code: 'us-east-1' });
+lookupResult1.name === 'N. Virginia';
+lookupResult1.full_name === 'US East (N. Virginia)';
+lookupResult1.code === 'us-east-1';
+lookupResult1.public === true;
+lookupResult1.zones[0] === 'us-east-1a';
 
-awsRegions.lookup({ name: 'N. Virginia' }) ===
-    {
-        name: 'N. Virginia',
-        full_name: 'US East (N. Virginia)',
-        code: 'us-east-1',
-        public: true,
-        zones: ['us-east-1a'],
-    };
+const lookupResult2 = awsRegions.lookup({ name: 'N. Virginia' });
+lookupResult2.name === 'N. Virginia';
+lookupResult2.full_name === 'US East (N. Virginia)';
+lookupResult2.code === 'us-east-1';
+lookupResult2.public === true;
+lookupResult2.zones[0] === 'us-east-1a';


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).