### PR TITLE
[better-curry] fix 4.8 errors

### DIFF
--- a/types/better-curry/better-curry-tests.ts
+++ b/types/better-curry/better-curry-tests.ts
@@ -1,7 +1,7 @@
 
 
 import bc = require('better-curry');
-bc.flatten([1,2,3,[1,2],['a']]) === [];
+bc.flatten([1,2,3,[1,2],['a']]).length === 0;
 bc.MAX_OPTIMIZED = 5;
 
 function fn(...args: number[]): number[] {
@@ -12,7 +12,7 @@ function fn2(arg1: string, arg2: any): number {
     return parseInt(arg1 + String(arg2)) + 1;
 }
 
-bc.predefine(fn, [1,2])() === [];
+bc.predefine(fn, [1,2])().length === 0;
 bc.predefine(fn, [1,2]).__length === 3;
 
 var f = bc.wrap(fn2, {}, 10, true);


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).