### PR TITLE
[@types/parse] adds subscribe()'s sessionToken parameter

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -785,7 +785,7 @@ declare global {
             skip(n: number): Query<T>;
             sortByTextScore(): this;
             startsWith<K extends keyof T['attributes'] | keyof BaseAttributes>(key: K, prefix: string): this;
-            subscribe(): Promise<LiveQuerySubscription>;
+            subscribe(sessionToken?: string): Promise<LiveQuerySubscription>;
             toJSON(): any;
             withJSON(json: any): this;
             withCount(includeCount?: boolean): this;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -865,7 +865,13 @@ async function test_query_subscribe() {
     const query = new Parse.Query(Game);
 
     // create subscription to Game object
-    const subscription = await query.subscribe();
+    // Without a token
+    // $ExpectType LiveQuerySubscription
+    let subscription = await query.subscribe();
+
+    // With a session token
+    // $ExpectType LiveQuerySubscription
+    subscription = await query.subscribe(new Parse.User().getSessionToken());
 
     // listen for new Game objects created on Parse server
     subscription.on('create', (game: any) => {


### PR DESCRIPTION
sessionToken parameter on ParseQuery.subscribe()

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Parse JS API Reference](https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Query.html#subscribe)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -> According to the header, it is currently typed for 2.18, while the current JS library is v3.4.2. I use this package a lot and can say this is one of the only times I've met a missing parameter in a definition but I cannot say for sure it is up to date across the whole project so I prefer not to change the version in the header.
