### PR TITLE
[desmos] fix 4.8 errors

### DIFF
--- a/types/desmos/desmos-tests.ts
+++ b/types/desmos/desmos-tests.ts
@@ -238,20 +238,14 @@ Desmos.supportedLanguages; // ['es', 'fr']
 calculator.updateSettings({ language: "fr" });
 
 // All features enabled
-Desmos.enabledFeatures ===
-    {
-        GraphingCalculator: true,
-        FourFunctionCalculator: true,
-        ScientificCalculator: true,
-    };
+Desmos.enabledFeatures.GraphingCalculator &&
+    Desmos.enabledFeatures.FourFunctionCalculator &&
+    Desmos.enabledFeatures.ScientificCalculator; // $ExpectType boolean
 
 // Only graphing calculator enabled
-Desmos.enabledFeatures ===
-    {
-        GraphingCalculator: true,
-        FourFunctionCalculator: false,
-        ScientificCalculator: false,
-    };
+Desmos.enabledFeatures.GraphingCalculator &&
+    !Desmos.enabledFeatures.FourFunctionCalculator &&
+    !Desmos.enabledFeatures.ScientificCalculator; // $ExpectType boolean
 
 const elt1 = document.getElementById("four-function-calculator") as HTMLDivElement;
 const calculator1 = Desmos.FourFunctionCalculator(elt1);


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).