### PR TITLE
[farbtastic] fix 4.8 errors

### DIFF
--- a/types/farbtastic/farbtastic-tests.ts
+++ b/types/farbtastic/farbtastic-tests.ts
@@ -15,13 +15,13 @@ $(document).ready(function() {
 // Create color pickers in the selected objects
 $("#colorpicker").farbtastic();
 
-// Optional callback using a callback function 
+// Optional callback using a callback function
 $("#colorpicker").farbtastic(callback);
 $("#colourpicker").farbtastic(function (color) {
     console.log(typeof color === "string");
 });
 
-// Optional callback using a DOM node 
+// Optional callback using a DOM node
 $("#colorpicker").farbtastic(domNode);
 
 // Optional callback using a jQuery object
@@ -42,7 +42,7 @@ $.farbtastic(domNode, callback);
 $.farbtastic($("#color"), callback);
 $.farbtastic("#color", callback);
 
-// Optional callback using a DOM node 
+// Optional callback using a DOM node
 $.farbtastic(domNode, domNode);
 $.farbtastic($("#color"), domNode);
 $.farbtastic("#color", domNode);
@@ -83,7 +83,9 @@ $.farbtastic("#colorpicker").setHSL([0.1, 0.2, 0.3]);
 
 // Advanced Usage: Properties
 $.farbtastic("#colorpicker").color === "#aabbcc";
-$.farbtastic("#colorpicker").hsl === [0.1, 0.2, 0.3];
+$.farbtastic("#colorpicker").hsl[0] === 0.1;
+$.farbtastic("#colorpicker").hsl[1] === 0.2;
+$.farbtastic("#colorpicker").hsl[2] === 0.3;
 $.farbtastic("#colorpicker").linked === $("#colorpicker");
 $.farbtastic("#colorpicker").linked === callback;
 
@@ -96,5 +98,5 @@ $("#colorpicker")
 $.farbtastic("#colorpicker")
     .linkTo(domNode)
     .setColor("#000000")
-    .setHSL([0, 0, 0]);            
-            
+    .setHSL([0, 0, 0]);
+


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).