### PR TITLE
[hapi] fix 4.8 errors

### DIFF
--- a/types/hapi/v16/test/server/settings.ts
+++ b/types/hapi/v16/test/server/settings.ts
@@ -8,4 +8,4 @@ const server = new Hapi.Server({
     }
 });
 
-server.settings.app === { key: 'value' };
+server.settings.app.key === 'value';


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).