### PR TITLE
[hexo-util] fix 4.8 tests

### DIFF
--- a/types/hexo-util/hexo-util-tests.ts
+++ b/types/hexo-util/hexo-util-tests.ts
@@ -207,7 +207,7 @@ string = htmlTag('a', { href: 'http://zespia.tw' }, 'My blog');
 let permalink = new Permalink(':year/:month/:day/:title');
 
 permalink.rule === ':year/:month/:day/:title';
-permalink.regex === /^(.+?)\/(.+?)\/(.+?)\/(.+?)$/;
+permalink.regex; // $ExpectType RegExp
 permalink.params.should.eql(['year', 'month', 'day', 'title']);
 
 permalink = new Permalink(':year/:month/:day/:title', {
@@ -219,7 +219,7 @@ permalink = new Permalink(':year/:month/:day/:title', {
 });
 
 permalink.rule === ':year/:month/:day/:title';
-permalink.regex === /^(\d{4})\/(\d{2})\/(\d{2})\/(.+?)$/;
+permalink.regex; // $ExpectType RegExp
 permalink.params.should.eql(['year', 'month', 'day', 'title']);
 permalink.test('2014/01/31/test');
 !permalink.test('foweirojwoier');


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).
