### PR TITLE
[jasmine-ajax] fix 4.8 errors

### DIFF
--- a/types/jasmine-ajax/jasmine-ajax-tests.ts
+++ b/types/jasmine-ajax/jasmine-ajax-tests.ts
@@ -1452,11 +1452,11 @@ describe('RequestStub', () => {
         jasmine.Ajax.stubRequest('/barbaz').andCallFunction((xhr) => {
             xhr.url === '/barbaz';
             xhr.method === 'POST';
-            xhr.params === {};
+            xhr.params;
             xhr.username === 'jane_coder';
             xhr.password === '12345';
-            xhr.requestHeaders === {Accept: 'application/json'};
-            xhr.data() === {query: 'bananas'};
+            xhr.requestHeaders.Accept === 'application/json';
+            xhr.data(); // $ExpectType string | object
             xhr.respondWith({
                 status: 200,
                 contentType: 'application/json',


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).