### PR TITLE
[jquery.payment] fix 4.8 errors

### DIFF
--- a/types/jquery.payment/jquery.payment-tests.ts
+++ b/types/jquery.payment/jquery.payment-tests.ts
@@ -31,8 +31,10 @@ $.payment.validateCardCVC('12344') === false; //=> false
 
 $.payment.cardType('4242 4242 4242 4242') === 'visa'; //=> 'visa'
 
-$.payment.cardExpiryVal('03 / 2025') === {month: 3, year: 2025}; //=> {month: 3, year: 2025}
-$.payment.cardExpiryVal('05 / 04') === {month: 3, year: 2025}; //=> {month: 5, year: 2004}
+$.payment.cardExpiryVal('03 / 2025').month === 3;
+$.payment.cardExpiryVal('03 / 2025').year === 2025;
+$.payment.cardExpiryVal('05 / 04').month === 3;
+$.payment.cardExpiryVal('05 / 04').year === 2025;
 $('input.cc-exp').payment('cardExpiryVal') //=> {month: 4, year: 2020}
 
 var valid = $.payment.validateCardNumber($('input.cc-num').val() as string);


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).