### PR TITLE
[modernizr] fix 4.8 errors

### DIFF
--- a/types/modernizr/modernizr-tests.ts
+++ b/types/modernizr/modernizr-tests.ts
@@ -83,7 +83,10 @@ if (keyframes) {
   // keyframes === `false`
 }
 
-Modernizr._domPrefixes === [ "Moz", "O", "ms", "Webkit" ];
+Modernizr._domPrefixes[0] === "Moz";
+Modernizr._domPrefixes[1] === "O";
+Modernizr._domPrefixes[2] === "ms";
+Modernizr._domPrefixes[3] === "Webkit";
 
 Modernizr.hasEvent('blur'); // true;
 


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).