### PR TITLE
[ranjs] fix 4.8 errors

### DIFF
--- a/types/ranjs/ranjs-tests.ts
+++ b/types/ranjs/ranjs-tests.ts
@@ -34,7 +34,7 @@ ss = core.shuffle(['1', '2', '3']);
 
 let normal = new dist.Normal();
 b = normal.type() === 'continuous';
-b = normal.support() === [];
+b = normal.support().length === 0;
 normal = normal.seed(0xfffff); // though Distribution.seed mutates itself
 const distState = normal.save();
 normal = new dist.Normal().load(distState);


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).