### PR TITLE
[restify] fix 4.8 errors

### DIFF
--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -198,7 +198,6 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
     route.method === 'GET';
     route.name === 'routeName';
     route.path === '/some/path';
-    route.path === /\/some\/path\/.*/;
     restify.plugins.auditLogger({ event: 'after', log: logger })(req, res, route, err);
 });
 

--- a/types/restify/v4/restify-tests.ts
+++ b/types/restify/v4/restify-tests.ts
@@ -59,7 +59,13 @@ function send(req: restify.Request, res: restify.Response, next: restify.Next) {
     req.endHandlerTimer('test');
     req.absoluteUri('test') === 'test';
 
-    req.timers.pop() === { name: 'test', time: [0, 1234] };
+    const popResult = req.timers.pop();
+    if (popResult) {
+        popResult.name === 'test';
+        popResult.time[0] === 0;
+        popResult.time[1] === 1234;
+    }
+
     req.getLogger('test');
 
     const log = req.log;
@@ -280,8 +286,7 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
     route.spec.method === 'GET';
     route.spec.name === 'routeName';
     route.spec.path === '/some/path';
-    route.spec.path === /\/some\/path\/.*/;
-    route.spec.versions === ['v1'];
+    route.spec.versions[0] === 'v1';
     restify.auditLogger({ log: () => { } })(req, res, route, err);
 });
 

--- a/types/restify/v5/restify-tests.ts
+++ b/types/restify/v5/restify-tests.ts
@@ -165,8 +165,7 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
     route.spec.method === 'GET';
     route.spec.name === 'routeName';
     route.spec.path === '/some/path';
-    route.spec.path === /\/some\/path\/.*/;
-    route.spec.versions === ['v1'];
+    route.spec.versions[0] === 'v1';
     restify.plugins.auditLogger({ event: 'after', log: logger })(req, res, route, err);
 });
 


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).