### PR TITLE
[socketio-wildcard] fix 4.8 errors

### DIFF
--- a/types/socketio-wildcard/socketio-wildcard-tests.ts
+++ b/types/socketio-wildcard/socketio-wildcard-tests.ts
@@ -7,8 +7,9 @@ io.use(middleware);
 
 io.on('connection', (socket) => {
   socket.on('*', (packet) => {
-    // client.emit('foo', 'bar', 'baz')
-    packet.data === ['foo', 'bar', 'baz'];
+    packet.data[0] === 'foo';
+    packet.data[1] === 'bar';
+    packet.data[2] === 'baz';
   });
 });
 


### PR DESCRIPTION
We introduced a new error message for comparisons to objects/arrays using `===` in 4.8. This fixes the errors in this package (as seen in https://dev.azure.com/definitelytyped/29c3d61a-c917-41cc-94cf-ee87fef813d2/_apis/build/builds/130393/logs/8).