### PR TITLE
[lodash] Add type guard signatures to isEmpty

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -561,6 +561,8 @@ declare module "../index" {
         isElement(): PrimitiveChain<boolean>;
     }
 
+    type EmptyObject<T> = { [K in keyof T]?: never };
+    type EmptyObjectOf<T> = EmptyObject<T> extends T ? EmptyObject<T> : never;
     interface LoDashStatic {
         /**
          * Checks if value is empty. A value is considered empty unless it’s an arguments object, array, string, or
@@ -569,6 +571,12 @@ declare module "../index" {
          * @param value The value to inspect.
          * @return Returns true if value is empty, else false.
          */
+        isEmpty<T extends { __trapAny: any }>(value?: T): boolean;
+        isEmpty(value: string | null | undefined): value is '' | null | undefined;
+        isEmpty(value: any[] | null | undefined): boolean;
+        isEmpty(value: ReadonlyArray<any> | null | undefined): value is Readonly<[]> | null | undefined;
+        isEmpty(value: Map<any, any> | Set<any> | List<any> | null | undefined): boolean;
+        isEmpty<T extends object>(value: T | null | undefined): value is EmptyObjectOf<T> | null | undefined;
         isEmpty(value?: any): boolean;
     }
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -572,9 +572,7 @@ declare module "../index" {
          * @return Returns true if value is empty, else false.
          */
         isEmpty<T extends { __trapAny: any }>(value?: T): boolean;
-        isEmpty(value: string | null | undefined): value is '' | null | undefined;
-        isEmpty(value: any[] | null | undefined): boolean;
-        isEmpty(value: ReadonlyArray<any> | null | undefined): value is Readonly<[]> | null | undefined;
+        isEmpty(value: string): value is '';
         isEmpty(value: Map<any, any> | Set<any> | List<any> | null | undefined): boolean;
         isEmpty<T extends object>(value: T | null | undefined): value is EmptyObjectOf<T> | null | undefined;
         isEmpty(value?: any): boolean;

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -1922,7 +1922,15 @@ declare namespace _ {
     type LodashIsBuffer = (value: any) => boolean;
     type LodashIsDate = (value: any) => value is Date;
     type LodashIsElement = (value: any) => boolean;
-    type LodashIsEmpty = (value: any) => boolean;
+    interface LodashIsEmpty {
+        <T extends { __trapAny: any }>(value: T): boolean;
+        (value: string | null | undefined): value is '' | null | undefined;
+        (value: any[] | null | undefined): boolean;
+        (value: ReadonlyArray<any> | null | undefined): value is Readonly<[]> | null | undefined;
+        (value: Map<any, any> | Set<any> | lodash.List<any> | null | undefined): boolean;
+        <T extends object>(value: T | null | undefined): value is lodash.EmptyObjectOf<T> | null | undefined;
+        (value?: any): boolean;
+    }
     interface LodashIsEqualWith {
         (customizer: lodash.IsEqualCustomizer): LodashIsEqualWith1x1;
         (customizer: lodash.__, value: any): LodashIsEqualWith1x2;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4138,12 +4138,12 @@ fp.now(); // $ExpectType number
         anything; // $ExpectType any
     }
 
-    let string: string | undefined;
+    let string = 'isEmpty';
     if (Math.random()) {
         string = '';
     }
     if (_.isEmpty(string)) {
-        string; // $ExpectType '' | undefined
+        string; // $ExpectType ""
     } else {
         string; // $ExpectType string
     }

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4138,41 +4138,21 @@ fp.now(); // $ExpectType number
         anything; // $ExpectType any
     }
 
-    const string: string | undefined = '';
+    let string: string | undefined;
+    if (Math.random()) {
+        string = '';
+    }
     if (_.isEmpty(string)) {
-        const result: '' | undefined = string;
+        string; // $ExpectType '' | undefined
     } else {
         string; // $ExpectType string
     }
 
     const array: Array<{ value: boolean }> = [];
     if (_.isEmpty(array)) {
-        const result2: Array<{ value: boolean }> = array;
         array.push({ value: true });
     } else {
-        array; // $ExpectType { value: boolean; }[]
-    }
-
-    const roarray: ReadonlyArray<{ value: boolean }> = [];
-    if (_.isEmpty(roarray)) {
-        const writable: never[] = roarray; // $ExpectError
-        const result: Readonly<[]> = roarray;
-    } else {
-        roarray; // $ExpectType readonly { value: boolean; }[]
-    }
-
-    const tuple: Readonly<[{ value: boolean }?]> = [{ value: true }];
-    if (_.isEmpty(tuple)) {
-        const result: Readonly<[]> = tuple;
-    }
-    let tuple2: Readonly<[] | [number]> = [1];
-    if (Math.random()) {
-        tuple2 = [];
-    }
-    if (_.isEmpty(tuple2)) {
-        const result: Readonly<[]> = tuple2;
-    } else {
-        tuple2; // $ExpectType readonly [number]
+        array.push({ value: false });
     }
 
     const obj: { value?: boolean } = {};

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4131,6 +4131,67 @@ fp.now(); // $ExpectType number
     _({}).isEmpty(); // $ExpectType boolean
     _.chain([]).isEmpty(); // $ExpectType PrimitiveChain<boolean>
     fp.isEmpty(anything); // $ExpectType boolean
+
+    if (_.isEmpty(anything)) {
+        const result: undefined | null | '' | [] | never[] | Record<never, never> = anything;
+    } else {
+        anything; // $ExpectType any
+    }
+
+    const string: string | undefined = '';
+    if (_.isEmpty(string)) {
+        const result: '' | undefined = string;
+    } else {
+        string; // $ExpectType string
+    }
+
+    const array: Array<{ value: boolean }> = [];
+    if (_.isEmpty(array)) {
+        const result2: Array<{ value: boolean }> = array;
+        array.push({ value: true });
+    } else {
+        array; // $ExpectType { value: boolean; }[]
+    }
+
+    const roarray: ReadonlyArray<{ value: boolean }> = [];
+    if (_.isEmpty(roarray)) {
+        const writable: never[] = roarray; // $ExpectError
+        const result: Readonly<[]> = roarray;
+    } else {
+        roarray; // $ExpectType readonly { value: boolean; }[]
+    }
+
+    const tuple: Readonly<[{ value: boolean }?]> = [{ value: true }];
+    if (_.isEmpty(tuple)) {
+        const result: Readonly<[]> = tuple;
+    }
+    let tuple2: Readonly<[] | [number]> = [1];
+    if (Math.random()) {
+        tuple2 = [];
+    }
+    if (_.isEmpty(tuple2)) {
+        const result: Readonly<[]> = tuple2;
+    } else {
+        tuple2; // $ExpectType readonly [number]
+    }
+
+    const obj: { value?: boolean } = {};
+    if (_.isEmpty(obj)) {
+        const result: { value?: undefined } = obj;
+    } else {
+        obj; // $ExpectType { value?: boolean | undefined; }
+    }
+    let obj2: { value: boolean } | null | undefined = { value: true };
+    if (Math.random()) {
+        obj2 = null;
+    } else if (Math.random()) {
+        obj2 = undefined;
+    }
+    if (_.isEmpty(obj2)) {
+        const result: null | undefined = obj2;
+    } else {
+        obj2; // $ExpectType { value: boolean; }
+    }
 }
 
 // _.isEqual

--- a/types/lodash/v3/index.d.ts
+++ b/types/lodash/v3/index.d.ts
@@ -11127,6 +11127,8 @@ declare namespace _ {
     }
 
     //_.isEmpty
+    type EmptyObject<T> = { [K in keyof T]?: never };
+    type EmptyObjectOf<T> = EmptyObject<T> extends T ? EmptyObject<T> : never;
     interface LoDashStatic {
         /**
          * Checks if value is empty. A value is considered empty unless it’s an arguments object, array, string, or
@@ -11135,6 +11137,10 @@ declare namespace _ {
          * @param value The value to inspect.
          * @return Returns true if value is empty, else false.
          */
+        isEmpty<T extends { __trapAny: any }>(value?: T): boolean;
+        isEmpty(value: string): value is '';
+        isEmpty(value: Map<any, any> | Set<any> | List<any> | null | undefined): boolean;
+        isEmpty<T extends object>(value: T | null | undefined): value is EmptyObjectOf<T> | null | undefined;
         isEmpty(value?: any): boolean;
     }
 

--- a/types/lodash/v3/lodash-tests.ts
+++ b/types/lodash/v3/lodash-tests.ts
@@ -7015,12 +7015,12 @@ namespace TestIsEmpty {
             anything; // $ExpectType any
         }
 
-        let string: string | undefined;
+        let string = 'isEmpty';
         if (Math.random()) {
             string = '';
         }
         if (_.isEmpty(string)) {
-            string; // $ExpectType '' | undefined
+            string; // $ExpectType ""
         } else {
             string; // $ExpectType string
         }
@@ -7036,7 +7036,7 @@ namespace TestIsEmpty {
         if (_.isEmpty(obj)) {
             const result: { value?: undefined } = obj;
         } else {
-            obj; // $ExpectType { value?: boolean | undefined; }
+            obj; // $ExpectType { value?: boolean; }
         }
         let obj2: { value: boolean } | null | undefined = { value: true };
         if (Math.random()) {

--- a/types/lodash/v3/lodash-tests.ts
+++ b/types/lodash/v3/lodash-tests.ts
@@ -7006,6 +7006,50 @@ namespace TestIsEmpty {
         result = _<any>([]).chain().isEmpty();
         result = _({}).chain().isEmpty();
     }
+
+    {
+        let anything: any;
+        if (_.isEmpty(anything)) {
+            const result: undefined | null | '' | [] | never[] | Record<never, never> = anything;
+        } else {
+            anything; // $ExpectType any
+        }
+
+        let string: string | undefined;
+        if (Math.random()) {
+            string = '';
+        }
+        if (_.isEmpty(string)) {
+            string; // $ExpectType '' | undefined
+        } else {
+            string; // $ExpectType string
+        }
+
+        const array: Array<{ value: boolean }> = [];
+        if (_.isEmpty(array)) {
+            array.push({ value: true });
+        } else {
+            array.push({ value: false });
+        }
+
+        const obj: { value?: boolean } = {};
+        if (_.isEmpty(obj)) {
+            const result: { value?: undefined } = obj;
+        } else {
+            obj; // $ExpectType { value?: boolean | undefined; }
+        }
+        let obj2: { value: boolean } | null | undefined = { value: true };
+        if (Math.random()) {
+            obj2 = null;
+        } else if (Math.random()) {
+            obj2 = undefined;
+        }
+        if (_.isEmpty(obj2)) {
+            const result: null | undefined = obj2;
+        } else {
+            obj2; // $ExpectType { value: boolean; }
+        }
+    }
 }
 
 // _.isEqual


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #18423 https://lodash.com/docs/4.17.15#isEmpty
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

There was a previous attempt at this here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/18423 , but this change handles the issues that the old PR didn't, and properly models the behaviour of isEmpty. I tried to be as sensible as possible, let me know if there's other improvements to make!