### PR TITLE
[gapi.drive] add supportsAllDrives and fields to GetParameters interface

### DIFF
--- a/types/gapi.drive/gapi.drive-tests.ts
+++ b/types/gapi.drive/gapi.drive-tests.ts
@@ -89,4 +89,23 @@
             }
         });
     }
+
+    /**
+     * Get file.
+     */
+    function getFile() {
+        gapi.client.drive.files.get({
+            fileId: '1',
+            supportsAllDrives: true,
+            fields: 'embedLink, title, mimeType, description',
+        }).then(function(response: any) {
+            appendPre('File:');
+            var file = response.result;
+            if (file) {
+                appendPre(file.title + ' (' + file.id + ')');
+            } else {
+                appendPre('No files found.');
+            }
+        });
+    }
 }

--- a/types/gapi.drive/index.d.ts
+++ b/types/gapi.drive/index.d.ts
@@ -31,6 +31,8 @@ declare namespace gapi.client {
             revisionId?: string | undefined;
             supportsTeamDrives?: boolean | undefined;
             updateViewedDate?: boolean | undefined;
+            supportsAllDrives?: boolean | undefined;
+            fields?: string | undefined;
         }
 
         interface PatchParameters {


### PR DESCRIPTION

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/drive/api/v2/reference/files/get

`fields` isn't properly documented on the official Google documentation but it works also for the Google Drive v2.
