### PR TITLE
fix(toastify-js): missing method

### DIFF
--- a/types/toastify-js/index.d.ts
+++ b/types/toastify-js/index.d.ts
@@ -4,9 +4,8 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace Toastify {
+declare namespace StartToastifyInstance {
     function reposition(): void;
-
     interface Offset {
         x: number | string;
         y: number | string;
@@ -55,12 +54,27 @@ declare namespace Toastify {
         oldestFirst?: boolean | undefined;
     }
 }
-declare function Toastify(
-    options?: Toastify.Options,
-): {
+
+declare class Toastify {
+    /**
+     * The configuration object to configure Toastify
+     */
+    readonly options: StartToastifyInstance.Options;
+    /**
+     * The element that is the Toast
+     */
+    readonly toastElement: Element | null;
+    /**
+     * Display the toast
+     */
     showToast(): void;
-};
+    /**
+     * Hide the toast
+     */
+    hideToast(): void;
+}
+declare function StartToastifyInstance(options?: Toastify.Options): Toastify;
 
 export as namespace Toastify;
 
-export = Toastify;
+export = StartToastifyInstance;

--- a/types/toastify-js/toastify-js-tests.ts
+++ b/types/toastify-js/toastify-js-tests.ts
@@ -49,3 +49,16 @@ const options: Options = {
 };
 
 Toastify(options);
+
+// #60413
+const toast = Toastify({
+    text: 'Update is pending',
+    duration: 3000,
+    close: false,
+    stopOnFocus: true,
+    onClick: () => {
+        toast.hideToast(); // see this line
+    },
+});
+toast.options; // $ExpectType Options
+toast.toastElement; // $ExpectType Element | null


### PR DESCRIPTION
- missing 'hideToast' method
- missing properties (marked with @public), set to be 'readonly'

https://github.com/apvarun/toastify-js/blob/master/src/toastify-es.js

Thanks!

/cc @pavlexander

Fixes #60413

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).