### PR TITLE
[react] Support anything with `toString()` (such as `TrustedHTML`) as input for `dangerouslySetInnerHTML`.

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -38,7 +38,6 @@
 import * as CSS from 'csstype';
 import * as PropTypes from 'prop-types';
 import { Interaction as SchedulerInteraction } from 'scheduler/tracing';
-import 'trusted-types';
 
 type NativeAnimationEvent = AnimationEvent;
 type NativeClipboardEvent = ClipboardEvent;
@@ -1375,7 +1374,7 @@ declare namespace React {
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
         dangerouslySetInnerHTML?: {
-            __html: string | TrustedHTML;
+            __html: string | { toString: () => string };
         } | undefined;
 
         // Clipboard Events

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -38,6 +38,7 @@
 import * as CSS from 'csstype';
 import * as PropTypes from 'prop-types';
 import { Interaction as SchedulerInteraction } from 'scheduler/tracing';
+import 'trusted-types';
 
 type NativeAnimationEvent = AnimationEvent;
 type NativeClipboardEvent = ClipboardEvent;
@@ -1374,7 +1375,7 @@ declare namespace React {
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
         dangerouslySetInnerHTML?: {
-            __html: string;
+            __html: string | TrustedHTML;
         } | undefined;
 
         // Clipboard Events

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -9,7 +9,6 @@ import shallowCompare = require("react-addons-shallow-compare");
 import update = require("react-addons-update");
 import createReactClass = require("create-react-class");
 import * as DOM from "react-dom-factories";
-import { trustedTypes } from "trusted-types";
 
 // NOTE: forward declarations for tests
 declare function setInterval(...args: any[]): any;
@@ -528,15 +527,11 @@ DOM.svg({
     })
 );
 
-const trustedTypesPolicy = trustedTypes.createPolicy("my-policy", {
-  createHTML: (s: string) => s
-});
-const trustedHTML = trustedTypesPolicy.createHTML("<div>trusted!</div>");
 const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
     dangerouslySetInnerHTML: {
-        __html: trustedHTML
+        __html: { toString: () => "<div>hello world</div>" }
     }
-}
+};
 DOM.div(trustedTypesHTMLAttr);
 DOM.span(trustedTypesHTMLAttr);
 DOM.input(trustedTypesHTMLAttr);

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -9,6 +9,7 @@ import shallowCompare = require("react-addons-shallow-compare");
 import update = require("react-addons-update");
 import createReactClass = require("create-react-class");
 import * as DOM from "react-dom-factories";
+import { trustedTypes } from "trusted-types";
 
 // NOTE: forward declarations for tests
 declare function setInterval(...args: any[]): any;
@@ -526,6 +527,19 @@ DOM.svg({
         fillRule: "evenodd"
     })
 );
+
+const trustedTypesPolicy = trustedTypes.createPolicy("my-policy", {
+  createHTML: (s: string) => s
+});
+const trustedHTML = trustedTypesPolicy.createHTML("<div>trusted!</div>");
+const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
+    dangerouslySetInnerHTML: {
+        __html: trustedHTML
+    }
+}
+DOM.div(trustedTypesHTMLAttr);
+DOM.span(trustedTypesHTMLAttr);
+DOM.input(trustedTypesHTMLAttr);
 
 //
 // React.Children


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/TrustedHTML

This change allows passing `TrustedHTML` to `dangerouslySetInnerHTML` in React. React correctly passes this to `innerHTML` in a way that is compatible with CSP enforcement of the Trusted Types API. We are prototyping a use case for this inside the GitHub codebase.

Since this is a nested property on an interface, I couldn't find a reasonable way to augment the `react` namespace to support this inside a single project. So I thought I'd send this PR to see if we could consider marking the functionality in `@types/react` directly.