### PR TITLE
Prettier's ArrayElement<T> should include optional array fields

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -33,7 +33,7 @@ export type Doc = doc.builders.Doc;
 type ArrayElement<T> = T extends Array<infer E> ? E : never;
 
 // A union of the properties of the given object that are arrays.
-type ArrayProperties<T> = { [K in keyof T]: T[K] extends any[] ? K : never }[keyof T];
+type ArrayProperties<T> = { [K in keyof T]: NonNullable<T[K]> extends any[] ? K : never }[keyof T];
 
 // A union of the properties of the given array T that can be used to index it.
 // If the array is a tuple, then that's going to be the explicit indices of the

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -266,6 +266,7 @@ interface Nested1 {
     kind: '1';
     item2: Nested2;
     list2: Nested2[];
+    list4?: Nested2[];
 }
 interface Nested2 {
     kind: '2';
@@ -345,6 +346,10 @@ function print(
         child; // $ExpectType AstPath<Nested2>
     }, 'list2');
 
+    path.each(child => {
+        child; // $ExpectType AstPath<Nested2>
+    }, 'list4');
+
     path.each(
         child => {
             child; // $ExpectType AstPath<Nested3>
@@ -369,6 +374,10 @@ function print(
         child; // $ExpectType AstPath<Nested2>
     }, 'list2');
 
+    path.map(child => {
+        child; // $ExpectType AstPath<Nested2>
+    }, 'list4');
+
     path.map(
         child => {
             child; // $ExpectType AstPath<Nested3>
@@ -390,6 +399,7 @@ function print(
     );
 
     path.call(print, 'list2'); // $ExpectError
+    path.call(print, 'list4'); // $ExpectError
     path.call(print, 'item2', 'list3'); // $ExpectError
 
     path.each(print, 'item2'); // $ExpectError


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Prettier doesn't seem to have any tests
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Here it is](https://github.com/markw65/prettier-plugin-monkeyc/blob/4704023b0f84402482b4f595b8c424e39b3d5965/src/printer.ts#L209-L210)

Summary of the issue being fixed:

I have a node (in an ast similar to estree)

```
export interface TypeSpecPart extends BaseNode {
  type: "TypeSpecPart";
  name: Identifier | MemberExpression;
  body?: BlockStatement;
  callspec?: MethodDefinition;
  generics?: Array<TypeSpecList>;
}
```

Its the only node that has a "generics" field, but since generics
is optional, its not included in ArrayElement<Node>, so that

```
if (node.generics) {
  path.map(print, "generics");
}
```
generates an error, saying that "generics" isn't a valid value.

This fixes the definition of ArrayElement<T> to remove null and unknown
before checking that the element is an array.
