### PR TITLE
Fix types/jsonlines data event type

### DIFF
--- a/types/jsonlines/index.d.ts
+++ b/types/jsonlines/index.d.ts
@@ -7,11 +7,6 @@
 
 import { Transform } from 'stream';
 
-export interface Line {
-    data: string;
-    type: string;
-}
-
 export interface Options {
     emitInvalidLines?: boolean | undefined;
 }
@@ -23,7 +18,7 @@ export class Parser extends Transform {
     // added 'invalid-line'
     on(event: 'error' | 'invalid-line', listener: (err: Error) => void): this;
     // changed
-    on(event: 'data', listener: (line: Line) => void): this;
+    on(event: 'data', listener: (data: any) => void): this;
     // inherited
     on(event: string | symbol, listener: (...args: any[]) => void): this;
 }
@@ -34,7 +29,7 @@ export class Stringifier extends Transform {
     on(event: 'close' | 'end' | 'pause' | 'readable' | 'resume', listener: () => void): this;
     on(event: 'error', listener: (err: Error) => void): this;
     // changed
-    on(event: 'data', listener: (line: Line) => void): this;
+    on(event: 'data', listener: (data: any) => void): this;
     // inherited
     on(event: string | symbol, listener: (...args: any[]) => void): this;
 }

--- a/types/jsonlines/jsonlines-tests.ts
+++ b/types/jsonlines/jsonlines-tests.ts
@@ -2,10 +2,7 @@ import jsonlines = require("jsonlines");
 
 const parser = jsonlines.parse(); // $ExpectType Parser
 
-parser.on("data", data => {
-    data; // $ExpectType Line
-});
-
+parser.on("data", data => {});
 parser.on("end", () => {});
 
 parser.write("{ 'test': 'This is a test!' }\n");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53304#issuecomment-1130962054
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

I made a mistake in my original PR for the `jsonlines` library. @JoshuaWise has pointed it out here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53304#issuecomment-1130962054

This PR updates the data event argument to `any`, since any JSON can be returned.