### PR TITLE
[pacote] Add overloads for abbreviated metadata

### DIFF
--- a/types/libnpmpublish/index.d.ts
+++ b/types/libnpmpublish/index.d.ts
@@ -4,11 +4,9 @@
 //                 Guy Adler <https://github.com/Guy-Adler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="node" />
-
+import { PackageJson } from "@npm/types";
 import fetch = require("npm-registry-fetch");
 import { Response } from "node-fetch";
-import { Manifest } from "pacote";
 
 /**
  * Sends the package represented by the manifest and tarData to the configured registry.
@@ -26,7 +24,7 @@ import { Manifest } from "pacote";
  * await libpub.publish(manifest, tarData, { npmVersion: 'my-pub-script@1.0.2', token: 'my-auth-token-here' }, opts)
  * // Package has been published to the npm registry.
  */
-export function publish(manifest: Manifest, tarballData: Buffer, options?: fetch.Options): Promise<Response>;
+export function publish(manifest: PackageJson, tarballData: Buffer, options?: fetch.Options): Promise<Response>;
 
 /**
  * Unpublishes spec from the appropriate registry. The registry in question may have its own limitations on unpublishing.

--- a/types/libnpmpublish/libnpmpublish-tests.ts
+++ b/types/libnpmpublish/libnpmpublish-tests.ts
@@ -1,6 +1,6 @@
+import { PackageJson } from "@npm/types";
 import libnpmpublish = require("libnpmpublish");
 import fetch = require("npm-registry-fetch");
-import { Manifest } from "pacote";
 
 async function test() {
     // declare variables to be used
@@ -19,14 +19,11 @@ async function test() {
         fetchRetryMintimeout: 20000,
         fetchRetryMaxtimeout: 50000,
         agent: undefined,
-        body: "bodyhere"
+        body: "bodyhere",
     };
-    const manifest: Manifest = {
+    const manifest: PackageJson = {
         name: "",
         version: "",
-        dist: {
-            tarball: ""
-        }
     };
     const tarballData: Buffer = Buffer.from("thisisafillerforthebuffertowork");
     // test param requirements and return values

--- a/types/libnpmpublish/package.json
+++ b/types/libnpmpublish/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@npm/types": "*"
+  },
+  "private": true
+}

--- a/types/pacote/index.d.ts
+++ b/types/pacote/index.d.ts
@@ -66,7 +66,7 @@ export interface CommonMetadata {
     homepage?: string | undefined;
     keywords?: string[] | undefined;
     license?: string | undefined;
-    maintainers?: Person[] | undefined;
+    maintainers: Person[];
     readme?: string | undefined;
     readmeFilename?: string | undefined;
     repository?: {
@@ -110,14 +110,30 @@ export interface Manifest extends CommonMetadata {
     publishConfig?: Record<string, unknown> | undefined;
     scripts?: Record<string, string> | undefined;
 
-    _id?: string | undefined;
-    _nodeVersion?: string | undefined;
-    _npmVersion?: string | undefined;
-    _npmUser?: Person | undefined;
+    _id: string;
+    _nodeVersion: string;
+    _npmVersion: string;
+    _npmUser: Person;
 
     // Non-standard properties from package.json may also appear.
     [key: string]: unknown;
 }
+
+export type AbbreviatedManifest = Pick<
+    Manifest,
+    | 'name'
+    | 'version'
+    | 'bin'
+    | 'directories'
+    | 'dependencies'
+    | 'devDependencies'
+    | 'peerDependencies'
+    | 'bundledDependencies'
+    | 'optionalDependencies'
+    | 'engines'
+    | 'dist'
+    | 'deprecated'
+>;
 
 /**
  * A packument is the top-level package document that lists the set of manifests
@@ -143,14 +159,18 @@ export interface Packument extends CommonMetadata {
      * In the full packument, an object mapping version numbers to publication
      * times, for the `opts.before` functionality.
      */
-    time?: Record<string, string> & {
+    time: Record<string, string> & {
         created: string;
         modified: string;
-    } | undefined;
+    };
 
     // Non-standard properties may also appear when fullMetadata = true.
     [key: string]: unknown;
 }
+
+export type AbbreviatedPackument = {
+    versions: Record<string, AbbreviatedManifest>;
+} & Pick<Packument, 'name' | 'dist-tags'>;
 
 export interface FetchResult {
     /**
@@ -167,7 +187,7 @@ export interface FetchResult {
     integrity: string;
 }
 
-export interface ManifestResult extends Manifest {
+export interface ManifestResult {
     /**
      * A normalized form of the spec passed in as an argument.
      */
@@ -279,13 +299,18 @@ export function extract(spec: string, dest?: string, opts?: Options): Promise<Fe
  * Fetch (or simulate) a package's manifest (basically, the `package.json` file,
  * plus a bit of metadata).
  */
-export function manifest(spec: string, opts?: Options): Promise<ManifestResult>;
+export function manifest(
+    spec: string,
+    opts: Options & ({ before: Date } | { fullMetadata: true })
+): Promise<Manifest & ManifestResult>;
+export function manifest(spec: string, opts?: Options): Promise<AbbreviatedManifest & ManifestResult>;
 
 /**
  * Fetch (or simulate) a package's packument (basically, the top-level package
  * document listing all the manifests that the registry returns).
  */
-export function packument(spec: string, opts?: Options): Promise<Packument>;
+export function packument(spec: string, opts: Options & { fullMetadata: true }): Promise<Packument>;
+export function packument(spec: string, opts?: Options): Promise<AbbreviatedPackument>;
 
 /**
  * Get a package tarball data as a buffer in memory.

--- a/types/pacote/index.d.ts
+++ b/types/pacote/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pacote 11.1
 // Project: https://github.com/npm/pacote#readme
-// Definitions by: DefinitelyTyped <https://github.com/DefinitelyTyped>
+// Definitions by: Jack Bates <https://github.com/jablko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/pacote/pacote-tests.ts
+++ b/types/pacote/pacote-tests.ts
@@ -23,11 +23,16 @@ const opts: pacote.Options = {
 pacote.resolve('pacote'); // $ExpectType Promise<string>
 pacote.resolve('pacote', opts); // $ExpectType Promise<string>
 
-pacote.manifest('pacote'); // $ExpectType Promise<ManifestResult>
-pacote.manifest('pacote', opts); // $ExpectType Promise<ManifestResult>
+// tslint:disable-next-line:expect
+pacote.manifest('pacote'); // $ExpectType Promise<AbbreviatedManifest & ManifestResult>
+// tslint:disable-next-line:expect
+pacote.manifest('pacote', opts); // $ExpectType Promise<AbbreviatedManifest & ManifestResult>
+pacote.manifest('pacote', { before: new Date() }); // $ExpectType Promise<Manifest & ManifestResult>
+pacote.manifest('pacote', { fullMetadata: true }); // $ExpectType Promise<Manifest & ManifestResult>
 
-pacote.packument('pacote'); // $ExpectType Promise<Packument>
-pacote.packument('pacote', opts); // $ExpectType Promise<Packument>
+pacote.packument('pacote'); // $ExpectType Promise<AbbreviatedPackument>
+pacote.packument('pacote', opts); // $ExpectType Promise<AbbreviatedPackument>
+pacote.packument('pacote', { fullMetadata: true }); // $ExpectType Promise<Packument>
 
 pacote.extract('pacote', './'); // $ExpectType Promise<FetchResult>
 pacote.extract('pacote', './', opts); // $ExpectType Promise<FetchResult>


### PR DESCRIPTION
The npm registry returns [abbreviated metadata](https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-metadata-format) unless the [`fullMetadata` option](https://github.com/npm/pacote#options) is `true`. This PR specializes the `packument()` and `manifest()` return types accordingly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).