### PR TITLE
Update THREE webXR hand profile names

### DIFF
--- a/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
+++ b/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
@@ -19,7 +19,7 @@ export class XRHandModelFactory {
 
     createHandModel(
         controller: Group,
-        profile?: 'spheres' | 'boxes' | 'oculus',
+        profile?: 'spheres' | 'boxes' | 'mesh',
         options?: XRHandPrimitiveModelOptions,
     ): XRHandModel;
 }


### PR DESCRIPTION
The hand profile names were changed in THREE.js r129 ([commit 571347f](https://github.com/mrdoob/three.js/commit/571347f504dec332f6905bb3d8ef43f1b405d45c)). Since this repo is supposed to correspond to revision r140, this was probably an omission and should be updated.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/commit/571347f504dec332f6905bb3d8ef43f1b405d45c
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
