### PR TITLE
feat(@types/react-dom): add jsdoc for hydrateRoot in client.d.ts

### DIFF
--- a/types/react-dom/client.d.ts
+++ b/types/react-dom/client.d.ts
@@ -34,16 +34,16 @@ export interface Root {
 export function createRoot(container: Element | DocumentFragment, options?: RootOptions): Root;
 
 /**
- * Same as `createRoot()`, but is used to hydrate a container whose HTML contents were rendered by ReactDOMServer. 
- * 
+ * Same as `createRoot()`, but is used to hydrate a container whose HTML contents were rendered by ReactDOMServer.
+ *
  * React will attempt to attach event listeners to the existing markup.
- * 
+ *
  * **Example Usage**
- * 
+ *
  * ```jsx
  * hydrateRoot(document.querySelector('#root'), <App />)
  * ```
- * 
+ *
  * @see https://reactjs.org/docs/react-dom-client.html#hydrateroot
  */
 export function hydrateRoot(

--- a/types/react-dom/client.d.ts
+++ b/types/react-dom/client.d.ts
@@ -33,6 +33,19 @@ export interface Root {
  */
 export function createRoot(container: Element | DocumentFragment, options?: RootOptions): Root;
 
+/**
+ * Same as `createRoot()`, but is used to hydrate a container whose HTML contents were rendered by ReactDOMServer. 
+ * 
+ * React will attempt to attach event listeners to the existing markup.
+ * 
+ * **Example Usage**
+ * 
+ * ```jsx
+ * hydrateRoot(document.querySelector('#root'), <App />)
+ * ```
+ * 
+ * @see https://reactjs.org/docs/react-dom-client.html#hydrateroot
+ */
 export function hydrateRoot(
     container: Element | Document,
     initialChildren: React.ReactNode,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests) (~The `npm install` was taking too long in my machine and I checked the tests and there weren't any tests for jsdoc so going ahead without this. Will update if I am able to run the test 🙈~ ran the tests. They didn't print anything so guessing they worked? ).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: ([hydrateRoot docs](https://reactjs.org/docs/react-dom-client.html#hydrateroot), [hydrateRoot example](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis))
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (Didn't get this. Which header and do I have to do it for this PR?)
