### PR TITLE
fix(@types/react-dom): change hydrate reference to hydrateRoot in `renderToString` jsdoc

### DIFF
--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -58,7 +58,7 @@ export function renderToPipeableStream(children: ReactNode, options?: RenderToPi
  * and send the markup down on the initial request for faster page loads and to allow search
  * engines to crawl your pages for SEO purposes.
  *
- * If you call `ReactDOM.hydrate()` on a node that already has this server-rendered markup,
+ * If you call `ReactDOM.hydrateRoot()` on a node that already has this server-rendered markup,
  * React will preserve it and only attach event handlers, allowing you
  * to have a very performant first-load experience.
  */

--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -58,7 +58,7 @@ export function renderToPipeableStream(children: ReactNode, options?: RenderToPi
  * and send the markup down on the initial request for faster page loads and to allow search
  * engines to crawl your pages for SEO purposes.
  *
- * If you call `ReactDOM.hydrateRoot()` on a node that already has this server-rendered markup,
+ * If you call `ReactDOMClient.hydrateRoot()` on a node that already has this server-rendered markup,
  * React will preserve it and only attach event handlers, allowing you
  * to have a very performant first-load experience.
  */


### PR DESCRIPTION
As per React 18, `hydrate` is deprecated and `hydrateRoot` is the new alternative. Fixed the reference in jsdoc for `renderToString`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: ([`hydrate` deprecation message](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#deprecations), [`hydrateRoot` documentation](https://reactjs.org/docs/react-dom-client.html#hydrateroot))
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (Not sure what this means. Should I do it for this PR? and which header?)
