### PR TITLE
Fix rtlcss processEnv option that should be a boolean value instead of a string

### DIFF
--- a/types/rtlcss/index.d.ts
+++ b/types/rtlcss/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for rtlcss 3.1
+// Type definitions for rtlcss 3.5
 // Project: https://github.com/MohammadYounes/rtlcss
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -23,6 +23,11 @@ declare namespace rtlcss {
     }
 
     interface ConfigOptions {
+        /**
+         * An object map of property-name Aliases,
+         * where keys are variable names and values are property names.
+         * e.g. {"aliases": {"--small-padding": "padding"}}
+         */
         aliases?: Record<string, string> | undefined;
         /**
          * Applies to CSS rules containing no directional properties,
@@ -69,7 +74,11 @@ declare namespace rtlcss {
          * When enabled, flips background-position expressed in length units using calc.
          */
         useCalc?: boolean | undefined;
-        processEnv?: string | undefined;
+        /**
+         * When disabled, prevents flipping agent-defined environment variables
+         * safe-area-inset-left, safe-area-inset-right.
+         */
+        processEnv?: boolean | undefined;
     }
 
     interface HookOptions {

--- a/types/rtlcss/rtlcss-tests.ts
+++ b/types/rtlcss/rtlcss-tests.ts
@@ -35,6 +35,7 @@ const options = {
         },
     ],
     useCalc: false,
+    processEnv: true
 };
 
 const config = {


### PR DESCRIPTION
This pull request changes the type of the `processEnv` option of the `rtlcss` package from `string` to `boolean` following the specification.

Updating `@types/rtlcss` from `3.1.2` to `3.1.4` breaks [one of my libraries](https://github.com/elchininet/postcss-rtlcss) throwing the next type error:

<img width="735" alt="image" src="https://user-images.githubusercontent.com/3728220/169623254-e5b5e9ca-8d5e-4f3b-ade0-eb363b6f1725.png">

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://rtlcss.com/learn/usage-guide/options/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
