### PR TITLE
[postcss-css-variables] Add types for postcss-css-variables

### DIFF
--- a/types/postcss-css-variables/index.d.ts
+++ b/types/postcss-css-variables/index.d.ts
@@ -1,0 +1,62 @@
+// Type definitions for postcss-css-variables 0.18
+// Project: https://github.com/MadLittleMods/postcss-css-variables
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Declaration, PluginCreator } from 'postcss';
+
+declare namespace cssvariables {
+    type Variable = string | { value: string; isImportant?: boolean | undefined };
+
+    interface Options {
+        /**
+         * Allows you to preserve custom propertires and `var()` usage in output.
+         *
+         * Values:
+         *
+         * - `false`: Removes -`-var` declarations and replaces `var()` with their resolved/computed values.
+         * - `true`: Keeps `var()` declarations in the output and has the computed value as a fallback declaration.
+         *   Also keeps computed `--var` declarations.
+         * - `'computed'`: Keeps computed `--var` declarations in the output.
+         *   Handy to make them available to your JavaScript.
+         * - Function: Return how to preserve each given declaration.
+         *
+         * @see {@link <https://github.com/MadLittleMods/postcss-css-variables#preserve-default-false>}
+         *
+         * @default false
+         */
+        preserve?: boolean | 'computed' | ((declaration: Declaration) => boolean | 'computed') | undefined;
+        /**
+         * Define an object map of variables in JavaScript that will be declared at the `:root` scope.
+         *
+         * The object keys are automatically prefixed with `--` if not already.
+         *
+         * @see {@link <https://github.com/MadLittleMods/postcss-css-variables#variables-default->}
+         */
+        variables?: Record<string, Variable> | undefined;
+        /**
+         * Whether to preserve the custom property declarations inserted via the `variables` option in the final output.
+         *
+         * A typical use case is CSS Modules, where you would want to avoid repeating custom property definitions
+         * in every module passed through this plugin.
+         * Setting this option to `false` prevents JS-injected variables from appearing in output CSS.
+         *
+         * @see {@link <https://github.com/MadLittleMods/postcss-css-variables#preserveinjectedvariables-default-true>}
+         *
+         * @default true
+         */
+        preserveInjectedVariables?: boolean | undefined;
+        /**
+         * Keeps at-rules such as media queries in the order they were defined.
+         *
+         * @see {@link <https://github.com/MadLittleMods/postcss-css-variables#preserveatrulesorder-default-false>}
+         *
+         * @default false
+         */
+        preserveAtRulesOrder?: boolean | undefined;
+    }
+}
+
+declare var cssvariables: PluginCreator<cssvariables.Options>;
+
+export = cssvariables;

--- a/types/postcss-css-variables/package.json
+++ b/types/postcss-css-variables/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.2.6"
+    }
+}

--- a/types/postcss-css-variables/postcss-css-variables-tests.ts
+++ b/types/postcss-css-variables/postcss-css-variables-tests.ts
@@ -1,0 +1,28 @@
+import postcss from 'postcss';
+import cssvariables = require('postcss-css-variables');
+
+// Using with postcss with and without config
+postcss([cssvariables]);
+postcss([cssvariables()]);
+postcss([cssvariables({})]);
+
+// Test preserve option
+cssvariables({ preserve: true });
+cssvariables({ preserve: 'computed' });
+cssvariables({ preserve: () => true });
+cssvariables({ preserve: () => 'computed' });
+
+// Test variables option
+cssvariables({
+    variables: {
+        '--var-1': 'red',
+        '--var-2': { value: 'green' },
+        '--var-3': { value: 'blue', isImportant: true },
+    },
+});
+
+// Test other options
+cssvariables({
+    preserveInjectedVariables: true,
+    preserveAtRulesOrder: true,
+});

--- a/types/postcss-css-variables/tsconfig.json
+++ b/types/postcss-css-variables/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "ES2018.Promise"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "postcss-css-variables-tests.ts"]
+}

--- a/types/postcss-css-variables/tslint.json
+++ b/types/postcss-css-variables/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Adds types for the npm package `postcss-css-variables`.

npm: <https://www.npmjs.com/package/postcss-css-variables>
GitHub: <https://github.com/MadLittleMods/postcss-css-variables>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test postcss-css-variables`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
