### PR TITLE
fix(node): `fs.open` 'flags' are optional

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -1998,12 +1998,19 @@ declare module 'fs' {
      * @param [flags='r'] See `support of file system `flags``.
      * @param [mode=0o666]
      */
-    export function open(path: PathLike, flags: OpenMode, mode: Mode | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    export function open(path: PathLike, flags: OpenMode | undefined, mode: Mode | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    /**
+     * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param [flags='r'] See `support of file system `flags``.
+     */
+    export function open(path: PathLike, flags: OpenMode | undefined, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
     /**
      * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function open(path: PathLike, flags: OpenMode, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    export function open(path: PathLike, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+
     export namespace open {
         /**
          * Asynchronous open(2) - open and possibly create a file.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -487,7 +487,20 @@ declare module 'fs/promises' {
      * @param [mode=0o666] Sets the file mode (permission and sticky bits) if the file is created.
      * @return Fulfills with a {FileHandle} object.
      */
-    function open(path: PathLike, flags: string | number, mode?: Mode): Promise<FileHandle>;
+    function open(path: PathLike, flags: string | number | undefined, mode?: Mode): Promise<FileHandle>;
+    /**
+     * Opens a `FileHandle`.
+     *
+     * Refer to the POSIX [`open(2)`](http://man7.org/linux/man-pages/man2/open.2.html) documentation for more detail.
+     *
+     * Some characters (`< > : " / \ | ? *`) are reserved under Windows as documented
+     * by [Naming Files, Paths, and Namespaces](https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file). Under NTFS, if the filename contains
+     * a colon, Node.js will open a file system stream, as described by [this MSDN page](https://docs.microsoft.com/en-us/windows/desktop/FileIO/using-streams).
+     * @since v10.0.0
+     * @param [flags='r'] See `support of file system `flags``.
+     * @return Fulfills with a {FileHandle} object.
+     */
+    function open(path: PathLike, flags?: string | number): Promise<FileHandle>;
     /**
      * Renames `oldPath` to `newPath`.
      * @since v10.0.0

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -487,20 +487,7 @@ declare module 'fs/promises' {
      * @param [mode=0o666] Sets the file mode (permission and sticky bits) if the file is created.
      * @return Fulfills with a {FileHandle} object.
      */
-    function open(path: PathLike, flags: string | number | undefined, mode?: Mode): Promise<FileHandle>;
-    /**
-     * Opens a `FileHandle`.
-     *
-     * Refer to the POSIX [`open(2)`](http://man7.org/linux/man-pages/man2/open.2.html) documentation for more detail.
-     *
-     * Some characters (`< > : " / \ | ? *`) are reserved under Windows as documented
-     * by [Naming Files, Paths, and Namespaces](https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file). Under NTFS, if the filename contains
-     * a colon, Node.js will open a file system stream, as described by [this MSDN page](https://docs.microsoft.com/en-us/windows/desktop/FileIO/using-streams).
-     * @since v10.0.0
-     * @param [flags='r'] See `support of file system `flags``.
-     * @return Fulfills with a {FileHandle} object.
-     */
-    function open(path: PathLike, flags?: string | number): Promise<FileHandle>;
+    function open(path: PathLike, flags?: string | number, mode?: Mode): Promise<FileHandle>;
     /**
      * Renames `oldPath` to `newPath`.
      * @since v10.0.0

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -378,6 +378,14 @@ async function testPromisify() {
 })();
 
 {
+    fs.open('test', (err, fd) => {});
+    fs.open('test', 'r', (err, fd) => {});
+    fs.open('test', undefined, (err, fd) => {});
+    fs.open('test', 'r', 0o666, (err, fd) => {});
+    fs.open('test', 'r', undefined, (err, fd) => {});
+}
+
+{
     fs.opendir('test', async (err, dir) => {
         const dirEnt: fs.Dirent | null = await dir.read();
     });
@@ -700,17 +708,21 @@ const anyStats: fs.Stats | fs.BigIntStats = fs.statSync('.', { bigint: Math.rand
 }
 
 {
-    fs.promises.open('/dev/input/event0', 'r').then((fd) => {
+    fs.promises.open('/dev/input/event0').then(fd => {
         // Create a stream from some character device.
         const stream = fd.createReadStream(); // $ExpectType ReadStream
         stream.close();
         stream.push(null);
         stream.read(0);
     });
-}
-
-{
-    fs.promises.open('/tmp/tmp.txt', 'w').then((fd) => {
+    fs.promises.open('/dev/input/event0', 'r').then(fd => {
+        // Create a stream from some character device.
+        const stream = fd.createReadStream(); // $ExpectType ReadStream
+        stream.close();
+        stream.push(null);
+        stream.read(0);
+    });
+    fs.promises.open('/tmp/tmp.txt', 'w', 0o666).then(fd => {
         // Create a stream from some character device.
         const stream = fd.createWriteStream(); // $ExpectType WriteStream
         stream.close();

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -2191,8 +2191,7 @@ declare module 'fs' {
          * @param [mode] A file mode. If a string is passed, it is parsed as an octal integer. If not
          * supplied, defaults to `0o666`.
          */
-        function open(path: PathLike, flags: string | number | undefined, mode?: string | number): Promise<FileHandle>;
-        function open(path: PathLike, flags?: string | number): Promise<FileHandle>;
+        function open(path: PathLike, flags?: string | number, mode?: string | number): Promise<FileHandle>;
 
         /**
          * Asynchronously reads data from the file referenced by the supplied `FileHandle`.

--- a/types/node/v12/fs.d.ts
+++ b/types/node/v12/fs.d.ts
@@ -1089,15 +1089,23 @@ declare module 'fs' {
     /**
      * Asynchronous open(2) - open and possibly create a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
+     * @param [flags='r'] See `support of file system `flags``.
+     * @param [mode] A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
      */
-    function open(path: PathLike, flags: string | number, mode: string | number | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    function open(path: PathLike, flags: string | number | undefined, mode: string | number | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+
+    /**
+     * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param [flags='r'] See `support of file system `flags``.
+     */
+    function open(path: PathLike, flags: string | number | undefined, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
 
     /**
      * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    function open(path: PathLike, flags: string | number, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    function open(path: PathLike, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     namespace open {
@@ -2179,10 +2187,12 @@ declare module 'fs' {
         /**
          * Asynchronous open(2) - open and possibly create a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-         * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not
+         * @param [flags='r'] See `support of file system `flags``.
+         * @param [mode] A file mode. If a string is passed, it is parsed as an octal integer. If not
          * supplied, defaults to `0o666`.
          */
-        function open(path: PathLike, flags: string | number, mode?: string | number): Promise<FileHandle>;
+        function open(path: PathLike, flags: string | number | undefined, mode?: string | number): Promise<FileHandle>;
+        function open(path: PathLike, flags?: string | number): Promise<FileHandle>;
 
         /**
          * Asynchronously reads data from the file referenced by the supplied `FileHandle`.

--- a/types/node/v12/test/fs.ts
+++ b/types/node/v12/test/fs.ts
@@ -319,6 +319,22 @@ async function testPromisify() {
 }
 
 {
+    fs.open('test', (err, fd) => {});
+    fs.open('test', 'r', (err, fd) => {});
+    fs.open('test', undefined, (err, fd) => {});
+    fs.open('test', 'r', 0o666, (err, fd) => {});
+    fs.open('test', 'r', undefined, (err, fd) => {});
+}
+
+async () => {
+    await fs.promises.open('test');
+    await fs.promises.open('test', 'r');
+    await fs.promises.open('test', undefined);
+    await fs.promises.open('test', 'r', 0o666);
+    await fs.promises.open('test', 'r', undefined);
+};
+
+{
     fs.opendir('test', async (err, dir) => {
         const dirEnt: fs.Dirent | null = await dir.read();
     });

--- a/types/node/v14/fs.d.ts
+++ b/types/node/v14/fs.d.ts
@@ -1264,15 +1264,23 @@ declare module 'fs' {
     /**
      * Asynchronous open(2) - open and possibly create a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
+     * @param [flags='r'] See `support of file system `flags``.
+     * @param [mode=0o666]
      */
-    export function open(path: PathLike, flags: OpenMode, mode: Mode | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    export function open(path: PathLike, flags: OpenMode | undefined, mode: Mode | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+
+    /**
+     * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param [flags='r'] See `support of file system `flags``.
+     */
+    export function open(path: PathLike, flags: OpenMode | undefined, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
 
     /**
      * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function open(path: PathLike, flags: OpenMode, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    export function open(path: PathLike, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
     export namespace open {

--- a/types/node/v14/fs/promises.d.ts
+++ b/types/node/v14/fs/promises.d.ts
@@ -184,10 +184,17 @@ declare module 'fs/promises' {
     /**
      * Asynchronous open(2) - open and possibly create a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not
+     * @param [flags='r'] See `support of file system `flags``.
+     * @param [mode] A file mode. If a string is passed, it is parsed as an octal integer. If not
      * supplied, defaults to `0o666`.
      */
-    function open(path: PathLike, flags: string | number, mode?: Mode): Promise<FileHandle>;
+    function open(path: PathLike, flags: string | number | undefined, mode?: string | number): Promise<FileHandle>;
+    /**
+     * Asynchronous open(2) - open and possibly create a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param [flags='r'] See `support of file system `flags``.
+     */
+    function open(path: PathLike, flags?: string | number): Promise<FileHandle>;
 
     /**
      * Asynchronously reads data from the file referenced by the supplied `FileHandle`.

--- a/types/node/v14/fs/promises.d.ts
+++ b/types/node/v14/fs/promises.d.ts
@@ -188,13 +188,7 @@ declare module 'fs/promises' {
      * @param [mode] A file mode. If a string is passed, it is parsed as an octal integer. If not
      * supplied, defaults to `0o666`.
      */
-    function open(path: PathLike, flags: string | number | undefined, mode?: string | number): Promise<FileHandle>;
-    /**
-     * Asynchronous open(2) - open and possibly create a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * @param [flags='r'] See `support of file system `flags``.
-     */
-    function open(path: PathLike, flags?: string | number): Promise<FileHandle>;
+    function open(path: PathLike, flags?: string | number, mode?: string | number): Promise<FileHandle>;
 
     /**
      * Asynchronously reads data from the file referenced by the supplied `FileHandle`.

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -349,6 +349,22 @@ async function testPromisify() {
 })();
 
 {
+    fs.open('test', (err, fd) => {});
+    fs.open('test', 'r', (err, fd) => {});
+    fs.open('test', undefined, (err, fd) => {});
+    fs.open('test', 'r', 0o666, (err, fd) => {});
+    fs.open('test', 'r', undefined, (err, fd) => {});
+}
+
+async () => {
+    await fs.promises.open('test');
+    await fs.promises.open('test', 'r');
+    await fs.promises.open('test', undefined);
+    await fs.promises.open('test', 'r', 0o666);
+    await fs.promises.open('test', 'r', undefined);
+};
+
+{
     fs.opendir('test', async (err, dir) => {
         const dirEnt: fs.Dirent | null = await dir.read();
     });

--- a/types/node/v16/fs.d.ts
+++ b/types/node/v16/fs.d.ts
@@ -1993,12 +1993,18 @@ declare module 'fs' {
      * @param [flags='r'] See `support of file system `flags``.
      * @param [mode=0o666]
      */
-    export function open(path: PathLike, flags: OpenMode, mode: Mode | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    export function open(path: PathLike, flags: OpenMode | undefined, mode: Mode | undefined | null, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    /**
+     * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
+     * @param [flags='r'] See `support of file system `flags``.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    export function open(path: PathLike, flags: OpenMode | undefined, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
     /**
      * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function open(path: PathLike, flags: OpenMode, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
+    export function open(path: PathLike, callback: (err: NodeJS.ErrnoException | null, fd: number) => void): void;
     export namespace open {
         /**
          * Asynchronous open(2) - open and possibly create a file.

--- a/types/node/v16/fs/promises.d.ts
+++ b/types/node/v16/fs/promises.d.ts
@@ -487,7 +487,20 @@ declare module 'fs/promises' {
      * @param [mode=0o666] Sets the file mode (permission and sticky bits) if the file is created.
      * @return Fulfills with a {FileHandle} object.
      */
-    function open(path: PathLike, flags: string | number, mode?: Mode): Promise<FileHandle>;
+    function open(path: PathLike, flags: string | number | undefined, mode?: Mode): Promise<FileHandle>;
+    /**
+     * Opens a `FileHandle`.
+     *
+     * Refer to the POSIX [`open(2)`](http://man7.org/linux/man-pages/man2/open.2.html) documentation for more detail.
+     *
+     * Some characters (`< > : " / \ | ? *`) are reserved under Windows as documented
+     * by [Naming Files, Paths, and Namespaces](https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file). Under NTFS, if the filename contains
+     * a colon, Node.js will open a file system stream, as described by [this MSDN page](https://docs.microsoft.com/en-us/windows/desktop/FileIO/using-streams).
+     * @since v10.0.0
+     * @param [flags='r'] See `support of file system `flags``.
+     * @return Fulfills with a {FileHandle} object.
+     */
+    function open(path: PathLike, flags?: string | number): Promise<FileHandle>;
     /**
      * Renames `oldPath` to `newPath`.
      * @since v10.0.0

--- a/types/node/v16/fs/promises.d.ts
+++ b/types/node/v16/fs/promises.d.ts
@@ -487,20 +487,7 @@ declare module 'fs/promises' {
      * @param [mode=0o666] Sets the file mode (permission and sticky bits) if the file is created.
      * @return Fulfills with a {FileHandle} object.
      */
-    function open(path: PathLike, flags: string | number | undefined, mode?: Mode): Promise<FileHandle>;
-    /**
-     * Opens a `FileHandle`.
-     *
-     * Refer to the POSIX [`open(2)`](http://man7.org/linux/man-pages/man2/open.2.html) documentation for more detail.
-     *
-     * Some characters (`< > : " / \ | ? *`) are reserved under Windows as documented
-     * by [Naming Files, Paths, and Namespaces](https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file). Under NTFS, if the filename contains
-     * a colon, Node.js will open a file system stream, as described by [this MSDN page](https://docs.microsoft.com/en-us/windows/desktop/FileIO/using-streams).
-     * @since v10.0.0
-     * @param [flags='r'] See `support of file system `flags``.
-     * @return Fulfills with a {FileHandle} object.
-     */
-    function open(path: PathLike, flags?: string | number): Promise<FileHandle>;
+    function open(path: PathLike, flags?: string | number, mode?: Mode): Promise<FileHandle>;
     /**
      * Renames `oldPath` to `newPath`.
      * @since v10.0.0

--- a/types/node/v16/test/fs.ts
+++ b/types/node/v16/test/fs.ts
@@ -368,6 +368,14 @@ async function testPromisify() {
 })();
 
 {
+    fs.open('test', (err, fd) => {});
+    fs.open('test', 'r', (err, fd) => {});
+    fs.open('test', undefined, (err, fd) => {});
+    fs.open('test', 'r', 0o666, (err, fd) => {});
+    fs.open('test', 'r', undefined, (err, fd) => {});
+}
+
+{
     fs.opendir('test', async (err, dir) => {
         const dirEnt: fs.Dirent | null = await dir.read();
     });
@@ -687,17 +695,21 @@ const anyStats: fs.Stats | fs.BigIntStats = fs.statSync('.', { bigint: Math.rand
 }
 
 {
-    fs.promises.open('/dev/input/event0', 'r').then((fd) => {
+    fs.promises.open('/dev/input/event0').then(fd => {
         // Create a stream from some character device.
         const stream = fd.createReadStream(); // $ExpectType ReadStream
         stream.close();
         stream.push(null);
         stream.read(0);
     });
-}
-
-{
-    fs.promises.open('/tmp/tmp.txt', 'w').then((fd) => {
+    fs.promises.open('/dev/input/event0', 'r').then(fd => {
+        // Create a stream from some character device.
+        const stream = fd.createReadStream(); // $ExpectType ReadStream
+        stream.close();
+        stream.push(null);
+        stream.read(0);
+    });
+    fs.promises.open('/tmp/tmp.txt', 'w', 0o666).then(fd => {
         // Create a stream from some character device.
         const stream = fd.createWriteStream(); // $ExpectType WriteStream
         stream.close();


### PR DESCRIPTION
https://github.com/nodejs/node/blob/v12.0.0/lib/fs.js#L417
https://github.com/nodejs/node/blob/v12.0.0/lib/internal/fs/promises.js#L199

Updates down to v12 (as per linked source)

/cc @louwers

Thanks!

Fixes #60473

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.