### PR TITLE
fix(ts4.7): fix TS 4.7 linting for CI

### DIFF
--- a/types/hexo-util/hexo-util-tests.ts
+++ b/types/hexo-util/hexo-util-tests.ts
@@ -207,7 +207,7 @@ string = htmlTag('a', { href: 'http://zespia.tw' }, 'My blog');
 let permalink = new Permalink(':year/:month/:day/:title');
 
 permalink.rule === ':year/:month/:day/:title';
-permalink.regex === /^(.+?)\/(.+?)\/(.+?)\/(.+?)$/;
+permalink.regex; // $ExpectType RegExp
 permalink.params.should.eql(['year', 'month', 'day', 'title']);
 
 permalink = new Permalink(':year/:month/:day/:title', {
@@ -219,7 +219,7 @@ permalink = new Permalink(':year/:month/:day/:title', {
 });
 
 permalink.rule === ':year/:month/:day/:title';
-permalink.regex === /^(\d{4})\/(\d{2})\/(\d{2})\/(.+?)$/;
+permalink.regex; // $ExpectType RegExp
 permalink.params.should.eql(['year', 'month', 'day', 'title']);
 permalink.test('2014/01/31/test');
 !permalink.test('foweirojwoier');

--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -197,8 +197,7 @@ server.on('after', restify.plugins.auditLogger({ event: 'after', log: logger }))
 server.on('after', (req: restify.Request, res: restify.Response, route: restify.Route, err: any) => {
     route.method === 'GET';
     route.name === 'routeName';
-    route.path === '/some/path';
-    route.path === /\/some\/path\/.*/;
+    route.path; // string | $ExpectType RegExp
     restify.plugins.auditLogger({ event: 'after', log: logger })(req, res, route, err);
 });
 

--- a/types/restify/v4/restify-tests.ts
+++ b/types/restify/v4/restify-tests.ts
@@ -59,7 +59,7 @@ function send(req: restify.Request, res: restify.Response, next: restify.Next) {
     req.endHandlerTimer('test');
     req.absoluteUri('test') === 'test';
 
-    req.timers.pop() === { name: 'test', time: [0, 1234] };
+    req.timers; // $ExpectType HandlerTiming[]
     req.getLogger('test');
 
     const log = req.log;
@@ -279,9 +279,8 @@ server.on('after', restify.auditLogger({
 server.on('after', (req: restify.Request, res: restify.Response, route: restify.Route, err: any) => {
     route.spec.method === 'GET';
     route.spec.name === 'routeName';
-    route.spec.path === '/some/path';
-    route.spec.path === /\/some\/path\/.*/;
-    route.spec.versions === ['v1'];
+    route.spec.path; // $ExpectType string | RegExp
+    route.spec.versions; // $ExpectType string[]
     restify.auditLogger({ log: () => { } })(req, res, route, err);
 });
 

--- a/types/restify/v5/restify-tests.ts
+++ b/types/restify/v5/restify-tests.ts
@@ -164,9 +164,8 @@ server.on('after', restify.plugins.auditLogger({ event: 'after', log: logger }))
 server.on('after', (req: restify.Request, res: restify.Response, route: restify.Route, err: any) => {
     route.spec.method === 'GET';
     route.spec.name === 'routeName';
-    route.spec.path === '/some/path';
-    route.spec.path === /\/some\/path\/.*/;
-    route.spec.versions === ['v1'];
+    route.spec.path; // $ExpectType string | RegExp
+    route.spec.versions; // $ExpectType string[]
     restify.plugins.auditLogger({ event: 'after', log: logger })(req, res, route, err);
 });
 


### PR DESCRIPTION
- 'restify'
- 'hexo-util'

Required for Node Related PRs, fixing error(s):

```txt
ERROR: 62:5   expect  TypeScript@4.7 compile error: 
This condition will always return 'false' since JavaScript compares objects by reference, not value.
```

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).