### PR TITLE
[react-reconciler] Update types for react-reconciler@0.28

### DIFF
--- a/types/react-reconciler/index.d.ts
+++ b/types/react-reconciler/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://reactjs.org/
 // Definitions by: Nathan Bierema <https://github.com/Methuselah96>
 //                 Zhang Haocong <https://github.com/zhanghaocong>
+//                 Mathieu Dutour <https://github.com/mathieudutour>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -261,11 +262,6 @@ declare namespace ReactReconciler {
          * This method is called for a container that's used as a portal target. Usually you can leave it empty.
          */
         preparePortalMount(containerInfo: Container): void;
-
-        /**
-         * You can proxy this to `performance.now()` or its equivalent in your environment.
-         */
-        now(): number;
 
         /**
          * You can proxy this to `setTimeout` or its equivalent in your environment.

--- a/types/react-reconciler/index.d.ts
+++ b/types/react-reconciler/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://reactjs.org/
 // Definitions by: Nathan Bierema <https://github.com/Methuselah96>
 //                 Zhang Haocong <https://github.com/zhanghaocong>
-//                 Mathieu Dutour <https://github.com/mathieudutour>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -24,6 +23,7 @@ declare function ReactReconciler<
     NoTimeout
 >(
     config: ReactReconciler.HostConfig<
+        // tslint:disable:no-unnecessary-generics
         Type,
         Props,
         Container,
@@ -37,6 +37,7 @@ declare function ReactReconciler<
         ChildSet,
         TimeoutHandle,
         NoTimeout
+        // tslint:enable:no-unnecessary-generics
     >,
 ): ReactReconciler.Reconciler<
     Container,
@@ -286,7 +287,7 @@ declare namespace ReactReconciler {
          * Set this to `true` to indicate that your renderer supports `scheduleMicrotask`. We use microtasks as part of our discrete event implementation in React DOM. If you're not sure if your renderer should support this, you probably should. The option to not implement `scheduleMicrotask` exists so that platforms with more control over user events, like React Native, can choose to use a different mechanism.
          */
         // tslint:enable:max-line-length
-        supportsMicrotask?: boolean
+        supportsMicrotask?: boolean;
 
         /**
          * Optional. You can proxy this to `queueMicrotask` or its equivalent in your environment.
@@ -300,11 +301,12 @@ declare namespace ReactReconciler {
         // tslint:enable:max-line-length
         isPrimaryRenderer: boolean;
 
-      /**
-       * Whether the renderer shouldn't trigger missing `act()` warnings
-       */
-        warnsIfNotActing?: boolean
+        /**
+         * Whether the renderer shouldn't trigger missing `act()` warnings
+         */
+        warnsIfNotActing?: boolean;
 
+        // tslint:disable:max-line-length
         /**
          * To implement this method, you'll need some constants available on the special `react-reconciler/constants` entry point:
          *
@@ -336,19 +338,18 @@ declare namespace ReactReconciler {
          *
          * You can consult the `getCurrentEventPriority()` implementation in `ReactDOMHostConfig.js` for a reference implementation.
          */
+        // tslint:enable:max-line-length
         getCurrentEventPriority(): Lane;
 
-        getInstanceFromNode(node: Object): Fiber | null | undefined;
+        getInstanceFromNode(node: any): Fiber | null | undefined;
 
         beforeActiveInstanceBlur(): void;
 
         afterActiveInstanceBlur(): void;
 
-        preparePortalMount(portalInstance: Instance): void;
+        prepareScopeUpdate(scopeInstance: any, instance: any): void;
 
-        prepareScopeUpdate(scopeInstance: Object, inst: Object): void;
-
-        getInstanceFromScope(scopeInstance: Object): null | Instance;
+        getInstanceFromScope(scopeInstance: any): null | Instance;
 
         detachDeletedInstance(node: Instance): void;
 

--- a/types/react-reconciler/index.d.ts
+++ b/types/react-reconciler/index.d.ts
@@ -21,7 +21,7 @@ declare function ReactReconciler<
     UpdatePayload,
     ChildSet,
     TimeoutHandle,
-    NoTimeout
+    NoTimeout,
 >(
     config: ReactReconciler.HostConfig<
         // tslint:disable:no-unnecessary-generics
@@ -40,13 +40,7 @@ declare function ReactReconciler<
         NoTimeout
         // tslint:enable:no-unnecessary-generics
     >,
-): ReactReconciler.Reconciler<
-    Container,
-    Instance,
-    TextInstance,
-    SuspenseInstance,
-    PublicInstance
->;
+): ReactReconciler.Reconciler<Container, Instance, TextInstance, SuspenseInstance, PublicInstance>;
 
 declare namespace ReactReconciler {
     interface HostConfig<
@@ -62,7 +56,7 @@ declare namespace ReactReconciler {
         UpdatePayload,
         ChildSet,
         TimeoutHandle,
-        NoTimeout
+        NoTimeout,
     > {
         // -------------------
         //        Modes
@@ -378,7 +372,11 @@ declare namespace ReactReconciler {
          * Note that React uses this method both for insertions and for reordering nodes. Similar to DOM, it is expected that you can call `insertBefore` to reposition an existing child. Do not mutate any other parts of the tree from it.
          */
         // tslint:enable:max-line-length
-        insertBefore?(parentInstance: Instance, child: Instance | TextInstance, beforeChild: Instance | TextInstance | SuspenseInstance): void;
+        insertBefore?(
+            parentInstance: Instance,
+            child: Instance | TextInstance,
+            beforeChild: Instance | TextInstance | SuspenseInstance,
+        ): void;
 
         // tslint:disable:max-line-length
         /**
@@ -436,12 +434,7 @@ declare namespace ReactReconciler {
          * If you never return `true` from `finalizeInitialChildren`, you can leave it empty.
          */
         // tslint:enable:max-line-length
-        commitMount?(
-            instance: Instance,
-            type: Type,
-            props: Props,
-            internalInstanceHandle: OpaqueHandle,
-        ): void;
+        commitMount?(instance: Instance, type: Type, props: Props, internalInstanceHandle: OpaqueHandle): void;
 
         // tslint:disable:max-line-length
         /**
@@ -494,39 +487,26 @@ declare namespace ReactReconciler {
         // -------------------
         // tslint:enable:max-line-length
         cloneInstance?(
-          instance: Instance,
-          updatePayload: UpdatePayload,
-          type: Type,
-          oldProps: Props,
-          newProps: Props,
-          internalInstanceHandle: OpaqueHandle,
-          keepChildren: boolean,
-          recyclableInstance: null | Instance,
+            instance: Instance,
+            updatePayload: UpdatePayload,
+            type: Type,
+            oldProps: Props,
+            newProps: Props,
+            internalInstanceHandle: OpaqueHandle,
+            keepChildren: boolean,
+            recyclableInstance: null | Instance,
         ): Instance;
         createContainerChildSet?(container: Container): ChildSet;
-        appendChildToContainerChildSet?(
-          childSet: ChildSet,
-          child: Instance | TextInstance,
-        ): void;
-        finalizeContainerChildren?(
-          container: Container,
-          newChildren: ChildSet,
-        ): void;
-        replaceContainerChildren?(
-          container: Container,
-          newChildren: ChildSet,
-        ): void;
+        appendChildToContainerChildSet?(childSet: ChildSet, child: Instance | TextInstance): void;
+        finalizeContainerChildren?(container: Container, newChildren: ChildSet): void;
+        replaceContainerChildren?(container: Container, newChildren: ChildSet): void;
         cloneHiddenInstance?(
-          instance: Instance,
-          type: Type,
-          props: Props,
-          internalInstanceHandle: OpaqueHandle,
+            instance: Instance,
+            type: Type,
+            props: Props,
+            internalInstanceHandle: OpaqueHandle,
         ): Instance;
-        cloneHiddenTextInstance?(
-          instance: Instance,
-          text: Type,
-          internalInstanceHandle: OpaqueHandle,
-        ): TextInstance;
+        cloneHiddenTextInstance?(instance: Instance, text: Type, internalInstanceHandle: OpaqueHandle): TextInstance;
 
         // tslint:disable:max-line-length
         // -------------------
@@ -539,37 +519,21 @@ declare namespace ReactReconciler {
         // tslint:enable:max-line-length
         supportsHydration: boolean;
 
-        canHydrateInstance?(
-            instance: HydratableInstance,
-            type: Type,
-            props: Props,
-        ): null | Instance;
+        canHydrateInstance?(instance: HydratableInstance, type: Type, props: Props): null | Instance;
 
-        canHydrateTextInstance?(
-            instance: HydratableInstance,
-            text: string,
-        ): null | TextInstance;
+        canHydrateTextInstance?(instance: HydratableInstance, text: string): null | TextInstance;
 
-        canHydrateSuspenseInstance?(
-            instance: HydratableInstance,
-        ): null | SuspenseInstance;
+        canHydrateSuspenseInstance?(instance: HydratableInstance): null | SuspenseInstance;
 
         isSuspenseInstancePending?(instance: SuspenseInstance): boolean;
 
         isSuspenseInstanceFallback?(instance: SuspenseInstance): boolean;
 
-        registerSuspenseInstanceRetry?(
-            instance: SuspenseInstance,
-            callback: () => void,
-        ): void;
+        registerSuspenseInstanceRetry?(instance: SuspenseInstance, callback: () => void): void;
 
-        getNextHydratableSibling?(
-            instance: HydratableInstance,
-        ): null | HydratableInstance;
+        getNextHydratableSibling?(instance: HydratableInstance): null | HydratableInstance;
 
-        getFirstHydratableChild?(
-            parentInstance: Container | Instance,
-        ): null | HydratableInstance;
+        getFirstHydratableChild?(parentInstance: Container | Instance): null | HydratableInstance;
 
         hydrateInstance?(
             instance: Instance,
@@ -580,33 +544,20 @@ declare namespace ReactReconciler {
             internalInstanceHandle: any,
         ): null | any[];
 
-        hydrateTextInstance?(
-            textInstance: TextInstance,
-            text: string,
-            internalInstanceHandle: any,
-        ): boolean;
+        hydrateTextInstance?(textInstance: TextInstance, text: string, internalInstanceHandle: any): boolean;
 
-        hydrateSuspenseInstance?(
-            suspenseInstance: SuspenseInstance,
-            internalInstanceHandle: any,
-        ): void;
+        hydrateSuspenseInstance?(suspenseInstance: SuspenseInstance, internalInstanceHandle: any): void;
 
-        getNextHydratableInstanceAfterSuspenseInstance?(
-            suspenseInstance: SuspenseInstance,
-        ): null | HydratableInstance;
+        getNextHydratableInstanceAfterSuspenseInstance?(suspenseInstance: SuspenseInstance): null | HydratableInstance;
 
         // Returns the SuspenseInstance if this node is a direct child of a
         // SuspenseInstance. I.e. if its previous sibling is a Comment with
         // SUSPENSE_x_START_DATA. Otherwise, null.
-        getParentSuspenseInstance?(
-            targetInstance: any,
-        ): null | SuspenseInstance;
+        getParentSuspenseInstance?(targetInstance: any): null | SuspenseInstance;
 
         commitHydratedContainer?(container: Container): void;
 
-        commitHydratedSuspenseInstance?(
-            suspenseInstance: SuspenseInstance,
-        ): void;
+        commitHydratedSuspenseInstance?(suspenseInstance: SuspenseInstance): void;
 
         didNotMatchHydratedContainerTextInstance?(
             parentContainer: Container,
@@ -622,10 +573,7 @@ declare namespace ReactReconciler {
             text: string,
         ): void;
 
-        didNotHydrateContainerInstance?(
-            parentContainer: Container,
-            instance: HydratableInstance,
-        ): void;
+        didNotHydrateContainerInstance?(parentContainer: Container, instance: HydratableInstance): void;
 
         didNotHydrateInstance?(
             parentType: Type,
@@ -634,20 +582,11 @@ declare namespace ReactReconciler {
             instance: HydratableInstance,
         ): void;
 
-        didNotFindHydratableContainerInstance?(
-            parentContainer: Container,
-            type: Type,
-            props: Props,
-        ): void;
+        didNotFindHydratableContainerInstance?(parentContainer: Container, type: Type, props: Props): void;
 
-        didNotFindHydratableContainerTextInstance?(
-            parentContainer: Container,
-            text: string,
-        ): void;
+        didNotFindHydratableContainerTextInstance?(parentContainer: Container, text: string): void;
 
-        didNotFindHydratableContainerSuspenseInstance?(
-            parentContainer: Container,
-        ): void;
+        didNotFindHydratableContainerSuspenseInstance?(parentContainer: Container): void;
 
         didNotFindHydratableInstance?(
             parentType: Type,
@@ -664,11 +603,7 @@ declare namespace ReactReconciler {
             text: string,
         ): void;
 
-        didNotFindHydratableSuspenseInstance?(
-            parentType: Type,
-            parentProps: Props,
-            parentInstance: Instance,
-        ): void;
+        didNotFindHydratableSuspenseInstance?(parentType: Type, parentProps: Props, parentInstance: Instance): void;
 
         errorHydratingContainer?(parentContainer: Container): void;
     }
@@ -707,21 +642,21 @@ declare namespace ReactReconciler {
         | 24;
 
     type HookType =
-        | "useState"
-        | "useReducer"
-        | "useContext"
-        | "useRef"
-        | "useEffect"
-        | "useLayoutEffect"
-        | "useCallback"
-        | "useMemo"
-        | "useImperativeHandle"
-        | "useDebugValue"
-        | "useDeferredValue"
-        | "useTransition"
-        | "useMutableSource"
-        | "useOpaqueIdentifier"
-        | "useCacheRefresh";
+        | 'useState'
+        | 'useReducer'
+        | 'useContext'
+        | 'useRef'
+        | 'useEffect'
+        | 'useLayoutEffect'
+        | 'useCallback'
+        | 'useMemo'
+        | 'useImperativeHandle'
+        | 'useDebugValue'
+        | 'useDeferredValue'
+        | 'useTransition'
+        | 'useMutableSource'
+        | 'useOpaqueIdentifier'
+        | 'useCacheRefresh';
 
     interface Source {
         fileName: string;
@@ -730,25 +665,7 @@ declare namespace ReactReconciler {
 
     // TODO: Ideally these types would be opaque but that doesn't work well with
     // our reconciler fork infra, since these leak into non-reconciler packages.
-    type LanePriority =
-        | 0
-        | 1
-        | 2
-        | 3
-        | 4
-        | 5
-        | 6
-        | 7
-        | 8
-        | 9
-        | 10
-        | 11
-        | 12
-        | 13
-        | 14
-        | 15
-        | 16
-        | 17;
+    type LanePriority = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17;
 
     type Lanes = number;
     type Lane = number;
@@ -977,64 +894,53 @@ declare namespace ReactReconciler {
         rendererPackageName: string;
         // Note: this actually *does* depend on Fiber internal fields.
         // Used by "inspect clicked DOM element" in React DevTools.
-        findFiberByHostInstance?: ((
-            instance: Instance | TextInstance,
-        ) => Fiber | null);
+        findFiberByHostInstance?: (instance: Instance | TextInstance) => Fiber | null;
         rendererConfig?: RendererInspectionConfig;
     }
 
     interface SuspenseHydrationCallbacks<SuspenseInstance> {
-        onHydrated?: ((suspenseInstance: SuspenseInstance) => void);
-        onDeleted?: ((suspenseInstance: SuspenseInstance) => void);
+        onHydrated?: (suspenseInstance: SuspenseInstance) => void;
+        onDeleted?: (suspenseInstance: SuspenseInstance) => void;
     }
 
     interface TransitionTracingCallbacks {
         onTransitionStart?: (transitionName: string, startTime: number) => void;
         onTransitionProgress?: (
-          transitionName: string,
-          startTime: number,
-          currentTime: number,
-          pending: Array<{name: null | string}>,
+            transitionName: string,
+            startTime: number,
+            currentTime: number,
+            pending: Array<{ name: null | string }>,
         ) => void;
         onTransitionIncomplete?: (
-          transitionName: string,
-          startTime: number,
-          deletions: Array<{
-            type: string,
-            name?: string,
-            newName?: string,
-            endTime: number,
-          }>,
+            transitionName: string,
+            startTime: number,
+            deletions: Array<{
+                type: string;
+                name?: string;
+                newName?: string;
+                endTime: number;
+            }>,
         ) => void;
-        onTransitionComplete?: (
-          transitionName: string,
-          startTime: number,
-          endTime: number,
-        ) => void;
+        onTransitionComplete?: (transitionName: string, startTime: number, endTime: number) => void;
         onMarkerProgress?: (
-          transitionName: string,
-          marker: string,
-          startTime: number,
-          currentTime: number,
-          pending: Array<{name: null | string}>,
+            transitionName: string,
+            marker: string,
+            startTime: number,
+            currentTime: number,
+            pending: Array<{ name: null | string }>,
         ) => void;
         onMarkerIncomplete?: (
-          transitionName: string,
-          marker: string,
-          startTime: number,
-          deletions: Array<{
-            type: string,
-            name?: string,
-            newName?: string,
-            endTime: number,
-          }>,
+            transitionName: string,
+            marker: string,
+            startTime: number,
+            deletions: Array<{
+                type: string;
+                name?: string;
+                newName?: string;
+                endTime: number;
+            }>,
         ) => void;
-        onMarkerComplete?: (
-          transitionName: string,
-          marker: string,
-          startTime: number,
-          endTime: number,
-        ) => void;
+        onMarkerComplete?: (transitionName: string, marker: string, startTime: number, endTime: number) => void;
     }
 
     interface ComponentSelector {
@@ -1062,12 +968,7 @@ declare namespace ReactReconciler {
         value: string;
     }
 
-    type Selector =
-        | ComponentSelector
-        | HasPseudoClassSelector
-        | RoleSelector
-        | TextSelector
-        | TestNameSelector;
+    type Selector = ComponentSelector | HasPseudoClassSelector | RoleSelector | TextSelector | TestNameSelector;
 
     // TODO can not find React$AbstractComponent def
     type React$AbstractComponent<Config, Instance = any> = any;
@@ -1081,13 +982,7 @@ declare namespace ReactReconciler {
 
     type IntersectionObserverOptions = any;
 
-    interface Reconciler<
-        Container,
-        Instance,
-        TextInstance,
-        SuspenseInstance,
-        PublicInstance
-    > {
+    interface Reconciler<Container, Instance, TextInstance, SuspenseInstance, PublicInstance> {
         createContainer(
             containerInfo: Container,
             tag: RootTag,
@@ -1106,18 +1001,11 @@ declare namespace ReactReconciler {
             key?: string | null,
         ): ReactPortal;
 
-        registerMutableSourceForHydration(
-            root: FiberRoot,
-            mutableSource: MutableSource,
-        ): void;
+        registerMutableSourceForHydration(root: FiberRoot, mutableSource: MutableSource): void;
 
-        createComponentSelector(
-            component: React$AbstractComponent<never, unknown>,
-        ): ComponentSelector;
+        createComponentSelector(component: React$AbstractComponent<never, unknown>): ComponentSelector;
 
-        createHasPseudoClassSelector(
-            selectors: Selector[],
-        ): HasPseudoClassSelector;
+        createHasPseudoClassSelector(selectors: Selector[]): HasPseudoClassSelector;
 
         createRoleSelector(role: string): RoleSelector;
 
@@ -1125,32 +1013,18 @@ declare namespace ReactReconciler {
 
         createTestNameSelector(id: string): TestNameSelector;
 
-        getFindAllNodesFailureDescription(
-            hostRoot: Instance,
-            selectors: Selector[],
-        ): string | null;
+        getFindAllNodesFailureDescription(hostRoot: Instance, selectors: Selector[]): string | null;
 
-        findAllNodes(
-            hostRoot: Instance,
-            selectors: Selector[],
-        ): Instance[];
+        findAllNodes(hostRoot: Instance, selectors: Selector[]): Instance[];
 
-        findBoundingRects(
-            hostRoot: Instance,
-            selectors: Selector[],
-        ): BoundingRect[];
+        findBoundingRects(hostRoot: Instance, selectors: Selector[]): BoundingRect[];
 
-        focusWithin(
-            hostRoot: Instance,
-            selectors: Selector[],
-        ): boolean;
+        focusWithin(hostRoot: Instance, selectors: Selector[]): boolean;
 
         observeVisibleRects(
             hostRoot: Instance,
             selectors: Selector[],
-            callback: (
-                intersections: Array<{ratio: number; rect: BoundingRect}>,
-            ) => void,
+            callback: (intersections: Array<{ ratio: number; rect: BoundingRect }>) => void,
             options?: IntersectionObserverOptions,
         ): { disconnect: () => void };
 
@@ -1178,13 +1052,7 @@ declare namespace ReactReconciler {
 
         deferredUpdates<A>(fn: () => A): A;
 
-        discreteUpdates<A, B, C, D, R>(
-              fn: (arg0: A, arg1: B, arg2: C, arg3: D) => R,
-              a: A,
-              b: B,
-              c: C,
-              d: D,
-        ): R;
+        discreteUpdates<A, B, C, D, R>(fn: (arg0: A, arg1: B, arg2: C, arg3: D) => R, a: A, b: B, c: C, d: D): R;
 
         flushControlled(fn: () => any): void;
 
@@ -1195,9 +1063,7 @@ declare namespace ReactReconciler {
 
         flushPassiveEffects(): boolean;
 
-        getPublicRootInstance(
-              container: OpaqueRoot,
-        ): Component<any, any> | PublicInstance | null;
+        getPublicRootInstance(container: OpaqueRoot): Component<any, any> | PublicInstance | null;
 
         attemptSynchronousHydration(fiber: Fiber): void;
 
@@ -1213,22 +1079,15 @@ declare namespace ReactReconciler {
 
         findHostInstance(component: any): PublicInstance | null;
 
-        findHostInstanceWithWarning(
-            component: any,
-            methodName: string,
-        ): PublicInstance | null;
+        findHostInstanceWithWarning(component: any, methodName: string): PublicInstance | null;
 
-        findHostInstanceWithNoPortals(
-            fiber: Fiber,
-        ): PublicInstance | null;
+        findHostInstanceWithNoPortals(fiber: Fiber): PublicInstance | null;
 
         shouldError(fiber: Fiber): boolean | undefined;
 
         shouldSuspend(fiber: Fiber): boolean;
 
-        injectIntoDevTools(
-            devToolsConfig: DevToolsConfig<Instance, TextInstance, any>
-        ): boolean;
+        injectIntoDevTools(devToolsConfig: DevToolsConfig<Instance, TextInstance, any>): boolean;
     }
 }
 

--- a/types/react-reconciler/test/ReactFiberHostConfigWithNoHydration.ts
+++ b/types/react-reconciler/test/ReactFiberHostConfigWithNoHydration.ts
@@ -11,11 +11,11 @@
 // can re-export everything from this module.
 
 function shim(...args: any): any {
-  throw new Error(
-    'The current renderer does not support hydration. ' +
-      'This error is likely caused by a bug in React. ' +
-      'Please file an issue.',
-  );
+    throw new Error(
+        'The current renderer does not support hydration. ' +
+            'This error is likely caused by a bug in React. ' +
+            'Please file an issue.',
+    );
 }
 
 // Hydration (when unsupported)

--- a/types/react-reconciler/test/ReactFiberHostConfigWithNoHydration.ts
+++ b/types/react-reconciler/test/ReactFiberHostConfigWithNoHydration.ts
@@ -1,7 +1,21 @@
+// This file is pretty much a copy of https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberHostConfigWithNoHydration.js
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 // Renderers that don't support hydration
 // can re-export everything from this module.
 
 function shim(...args: any): any {
+  throw new Error(
+    'The current renderer does not support hydration. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
 }
 
 // Hydration (when unsupported)
@@ -15,6 +29,8 @@ export const isSuspenseInstanceFallback = shim;
 export const registerSuspenseInstanceRetry = shim;
 export const getNextHydratableSibling = shim;
 export const getFirstHydratableChild = shim;
+export const getFirstHydratableChildWithinContainer = shim;
+export const getFirstHydratableChildWithinSuspenseInstance = shim;
 export const hydrateInstance = shim;
 export const hydrateTextInstance = shim;
 export const hydrateSuspenseInstance = shim;
@@ -23,13 +39,19 @@ export const commitHydratedContainer = shim;
 export const commitHydratedSuspenseInstance = shim;
 export const clearSuspenseBoundary = shim;
 export const clearSuspenseBoundaryFromContainer = shim;
+export const shouldDeleteUnhydratedTailInstances = shim;
 export const didNotMatchHydratedContainerTextInstance = shim;
 export const didNotMatchHydratedTextInstance = shim;
-export const didNotHydrateContainerInstance = shim;
+export const didNotHydrateInstanceWithinContainer = shim;
+export const didNotHydrateInstanceWithinSuspenseInstance = shim;
 export const didNotHydrateInstance = shim;
-export const didNotFindHydratableContainerInstance = shim;
-export const didNotFindHydratableContainerTextInstance = shim;
-export const didNotFindHydratableContainerSuspenseInstance = shim;
+export const didNotFindHydratableInstanceWithinContainer = shim;
+export const didNotFindHydratableTextInstanceWithinContainer = shim;
+export const didNotFindHydratableSuspenseInstanceWithinContainer = shim;
+export const didNotFindHydratableInstanceWithinSuspenseInstance = shim;
+export const didNotFindHydratableTextInstanceWithinSuspenseInstance = shim;
+export const didNotFindHydratableSuspenseInstanceWithinSuspenseInstance = shim;
 export const didNotFindHydratableInstance = shim;
 export const didNotFindHydratableTextInstance = shim;
 export const didNotFindHydratableSuspenseInstance = shim;
+export const errorHydratingContainer = shim;

--- a/types/react-reconciler/test/ReactFiberHostConfigWithNoMicrotasks.ts
+++ b/types/react-reconciler/test/ReactFiberHostConfigWithNoMicrotasks.ts
@@ -1,0 +1,24 @@
+// This file is pretty much a copy of https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberHostConfigWithNoMicrotasks.js
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// Renderers that don't support microtasks
+// can re-export everything from this module.
+
+function shim(...args: any): any {
+  throw new Error(
+    'The current renderer does not support microtasks. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
+}
+
+// Test selectors (when unsupported)
+export const supportsMicrotasks = false;
+export const scheduleMicrotask = shim;

--- a/types/react-reconciler/test/ReactFiberHostConfigWithNoMicrotasks.ts
+++ b/types/react-reconciler/test/ReactFiberHostConfigWithNoMicrotasks.ts
@@ -12,11 +12,11 @@
 // can re-export everything from this module.
 
 function shim(...args: any): any {
-  throw new Error(
-    'The current renderer does not support microtasks. ' +
-      'This error is likely caused by a bug in React. ' +
-      'Please file an issue.',
-  );
+    throw new Error(
+        'The current renderer does not support microtasks. ' +
+            'This error is likely caused by a bug in React. ' +
+            'Please file an issue.',
+    );
 }
 
 // Test selectors (when unsupported)

--- a/types/react-reconciler/test/ReactFiberHostConfigWithNoPersistence.ts
+++ b/types/react-reconciler/test/ReactFiberHostConfigWithNoPersistence.ts
@@ -1,13 +1,26 @@
+// This file is pretty much a copy of https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberHostConfigWithNoPersistence.js
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 // Renderers that don't support persistence
 // can re-export everything from this module.
 
 function shim(...args: any): any {
+  throw new Error(
+    'The current renderer does not support persistence. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
 }
 
 // Persistence (when unsupported)
 export const supportsPersistence = false;
 export const cloneInstance = shim;
-export const cloneFundamentalInstance = shim;
 export const createContainerChildSet = shim;
 export const appendChildToContainerChildSet = shim;
 export const finalizeContainerChildren = shim;

--- a/types/react-reconciler/test/ReactFiberHostConfigWithNoPersistence.ts
+++ b/types/react-reconciler/test/ReactFiberHostConfigWithNoPersistence.ts
@@ -11,11 +11,11 @@
 // can re-export everything from this module.
 
 function shim(...args: any): any {
-  throw new Error(
-    'The current renderer does not support persistence. ' +
-      'This error is likely caused by a bug in React. ' +
-      'Please file an issue.',
-  );
+    throw new Error(
+        'The current renderer does not support persistence. ' +
+            'This error is likely caused by a bug in React. ' +
+            'Please file an issue.',
+    );
 }
 
 // Persistence (when unsupported)

--- a/types/react-reconciler/test/ReactFiberHostConfigWithNoTestSelectors.ts
+++ b/types/react-reconciler/test/ReactFiberHostConfigWithNoTestSelectors.ts
@@ -13,11 +13,11 @@
 // can re-export everything from this module.
 
 function shim(...args: any): any {
-  throw new Error(
-    'The current renderer does not support test selectors. ' +
-      'This error is likely caused by a bug in React. ' +
-      'Please file an issue.',
-  );
+    throw new Error(
+        'The current renderer does not support test selectors. ' +
+            'This error is likely caused by a bug in React. ' +
+            'Please file an issue.',
+    );
 }
 
 // Test selectors (when unsupported)

--- a/types/react-reconciler/test/ReactFiberHostConfigWithNoTestSelectors.ts
+++ b/types/react-reconciler/test/ReactFiberHostConfigWithNoTestSelectors.ts
@@ -1,7 +1,23 @@
+// This file is pretty much a copy of https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors.js
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 // Renderers that don't support test selectors
 // can re-export everything from this module.
 
 function shim(...args: any): any {
+  throw new Error(
+    'The current renderer does not support test selectors. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
 }
 
 // Test selectors (when unsupported)

--- a/types/react-reconciler/test/ReactTestHostConfig.ts
+++ b/types/react-reconciler/test/ReactTestHostConfig.ts
@@ -16,183 +16,219 @@ export type TimeoutID = number;
 
 export type Type = string;
 export interface Props {
-  [key: string]: any;
+    [key: string]: any;
 }
 export interface Container {
-  children: Array<Instance | TextInstance>;
-  createNodeMock: (...args: any[]) => any;
-  tag: "CONTAINER";
+    children: Array<Instance | TextInstance>;
+    createNodeMock: (...args: any[]) => any;
+    tag: 'CONTAINER';
 }
 export interface Instance {
-  type: string;
-  props: {
-    [key: string]: any;
-  };
-  isHidden: boolean;
-  children: Array<Instance | TextInstance>;
-  internalInstanceHandle: {
-    [key: string]: any;
-  };
-  rootContainerInstance: Container;
-  tag: "INSTANCE";
+    type: string;
+    props: {
+        [key: string]: any;
+    };
+    isHidden: boolean;
+    children: Array<Instance | TextInstance>;
+    internalInstanceHandle: {
+        [key: string]: any;
+    };
+    rootContainerInstance: Container;
+    tag: 'INSTANCE';
 }
 export interface TextInstance {
-  text: string;
-  isHidden: boolean;
-  tag: "TEXT";
+    text: string;
+    isHidden: boolean;
+    tag: 'TEXT';
 }
 export type HydratableInstance = Instance | TextInstance;
 export type PublicInstance = (Instance | TextInstance) & { kind: 'PublicInstance' };
 export interface HostContext {
-  [key: string]: any;
+    [key: string]: any;
 }
 export interface UpdatePayload {
-  [key: string]: any;
+    [key: string]: any;
 }
 export type ChildSet = undefined; // Unused
 export type TimeoutHandle = TimeoutID;
 export type NoTimeout = -1;
 export type EventResponder = any;
-export type OpaqueIDType = string | {
-  $$typeof: number | symbol;
-  toString: () => string | void;
-  valueOf: () => string | void;
-};
+export type OpaqueIDType =
+    | string
+    | {
+          $$typeof: number | symbol;
+          toString: () => string | void;
+          valueOf: () => string | void;
+      };
 
 export type RendererInspectionConfig = Readonly<{}>;
 
-export * from "./ReactFiberHostConfigWithNoPersistence";
-export * from "./ReactFiberHostConfigWithNoHydration";
-export * from "./ReactFiberHostConfigWithNoTestSelectors";
+export * from './ReactFiberHostConfigWithNoPersistence';
+export * from './ReactFiberHostConfigWithNoMicroTasks';
+export * from './ReactFiberHostConfigWithNoHydration';
+export * from './ReactFiberHostConfigWithNoTestSelectors';
 
 const NO_CONTEXT = {};
 const UPDATE_SIGNAL = {};
 const nodeToInstanceMap = new WeakMap();
 
 export function getPublicInstance(inst: Instance | TextInstance): any {
-  switch (inst.tag) {
-    case 'INSTANCE':
-      const createNodeMock = inst.rootContainerInstance.createNodeMock;
-      const mockNode = createNodeMock({
-        type: inst.type,
-        props: inst.props
-      });
+    switch (inst.tag) {
+        case 'INSTANCE':
+            const createNodeMock = inst.rootContainerInstance.createNodeMock;
+            const mockNode = createNodeMock({
+                type: inst.type,
+                props: inst.props,
+            });
 
-      if (typeof mockNode === 'object' && mockNode !== null) {
-        nodeToInstanceMap.set(mockNode, inst);
-      }
+            if (typeof mockNode === 'object' && mockNode !== null) {
+                nodeToInstanceMap.set(mockNode, inst);
+            }
 
-      return mockNode;
-    default:
-      return inst;
-  }
+            return mockNode;
+        default:
+            return inst;
+    }
 }
 
 export function appendChild(parentInstance: Instance | Container, child: Instance | TextInstance): void {
-  const index = parentInstance.children.indexOf(child);
-  if (index !== -1) {
-    parentInstance.children.splice(index, 1);
-  }
-  parentInstance.children.push(child);
+    const index = parentInstance.children.indexOf(child);
+    if (index !== -1) {
+        parentInstance.children.splice(index, 1);
+    }
+    parentInstance.children.push(child);
 }
 
-export function insertBefore(parentInstance: Instance | Container, child: Instance | TextInstance, beforeChild: Instance | TextInstance): void {
-  const index = parentInstance.children.indexOf(child);
-  if (index !== -1) {
-    parentInstance.children.splice(index, 1);
-  }
-  const beforeIndex = parentInstance.children.indexOf(beforeChild);
-  parentInstance.children.splice(beforeIndex, 0, child);
+export function insertBefore(
+    parentInstance: Instance | Container,
+    child: Instance | TextInstance,
+    beforeChild: Instance | TextInstance,
+): void {
+    const index = parentInstance.children.indexOf(child);
+    if (index !== -1) {
+        parentInstance.children.splice(index, 1);
+    }
+    const beforeIndex = parentInstance.children.indexOf(beforeChild);
+    parentInstance.children.splice(beforeIndex, 0, child);
 }
 
 export function removeChild(parentInstance: Instance | Container, child: Instance | TextInstance): void {
-  const index = parentInstance.children.indexOf(child);
-  parentInstance.children.splice(index, 1);
+    const index = parentInstance.children.indexOf(child);
+    parentInstance.children.splice(index, 1);
 }
 
 export function clearContainer(container: Container): void {
-  container.children.splice(0);
+    container.children.splice(0);
 }
 
 export function getRootHostContext(rootContainerInstance: Container): HostContext {
-  return NO_CONTEXT;
+    return NO_CONTEXT;
 }
 
-export function getChildHostContext(parentHostContext: HostContext, type: string, rootContainerInstance: Container): HostContext {
-  return NO_CONTEXT;
+export function getChildHostContext(
+    parentHostContext: HostContext,
+    type: string,
+    rootContainerInstance: Container,
+): HostContext {
+    return NO_CONTEXT;
 }
 
 export function prepareForCommit(containerInfo: Container): null | {
-  [key: string]: any;
+    [key: string]: any;
 } {
-  // noop
-  return null;
+    // noop
+    return null;
 }
 
-export function resetAfterCommit(containerInfo: Container): void {// noop
+export function resetAfterCommit(containerInfo: Container): void {
+    // noop
 }
 
-export function createInstance(type: string, props: Props, rootContainerInstance: Container, hostContext: {
-  [key: string]: any;
-}, internalInstanceHandle: {
-  [key: string]: any;
-}): Instance {
-  return {
-    type,
-    props,
-    isHidden: false,
-    children: [],
-    internalInstanceHandle,
-    rootContainerInstance,
-    tag: 'INSTANCE'
-  };
+export function createInstance(
+    type: string,
+    props: Props,
+    rootContainerInstance: Container,
+    hostContext: {
+        [key: string]: any;
+    },
+    internalInstanceHandle: {
+        [key: string]: any;
+    },
+): Instance {
+    return {
+        type,
+        props,
+        isHidden: false,
+        children: [],
+        internalInstanceHandle,
+        rootContainerInstance,
+        tag: 'INSTANCE',
+    };
 }
 
 export function appendInitialChild(parentInstance: Instance, child: Instance | TextInstance): void {
-  const index = parentInstance.children.indexOf(child);
-  if (index !== -1) {
-    parentInstance.children.splice(index, 1);
-  }
-  parentInstance.children.push(child);
+    const index = parentInstance.children.indexOf(child);
+    if (index !== -1) {
+        parentInstance.children.splice(index, 1);
+    }
+    parentInstance.children.push(child);
 }
 
-export function finalizeInitialChildren(testElement: Instance, type: string, props: Props, rootContainerInstance: Container, hostContext: {
-  [key: string]: any;
-}): boolean {
-  return false;
+export function finalizeInitialChildren(
+    testElement: Instance,
+    type: string,
+    props: Props,
+    rootContainerInstance: Container,
+    hostContext: {
+        [key: string]: any;
+    },
+): boolean {
+    return false;
 }
 
-export function prepareUpdate(testElement: Instance, type: string, oldProps: Props, newProps: Props, rootContainerInstance: Container, hostContext: {
-  [key: string]: any;
-}): null | {} {
-  return UPDATE_SIGNAL;
+export function prepareUpdate(
+    testElement: Instance,
+    type: string,
+    oldProps: Props,
+    newProps: Props,
+    rootContainerInstance: Container,
+    hostContext: {
+        [key: string]: any;
+    },
+): null | {} {
+    return UPDATE_SIGNAL;
 }
 
 export function shouldSetTextContent(type: string, props: Props): boolean {
-  return false;
+    return false;
 }
 
-export function createTextInstance(text: string, rootContainerInstance: Container, hostContext: {
-  [key: string]: any;
-}, internalInstanceHandle: {
-  [key: string]: any;
-}): TextInstance {
-  return {
-    text,
-    isHidden: false,
-    tag: 'TEXT'
-  };
+export function createTextInstance(
+    text: string,
+    rootContainerInstance: Container,
+    hostContext: {
+        [key: string]: any;
+    },
+    internalInstanceHandle: {
+        [key: string]: any;
+    },
+): TextInstance {
+    return {
+        text,
+        isHidden: false,
+        tag: 'TEXT',
+    };
 }
 
 export function getCurrentEventPriority() {
-  return ReactReconcilerConstants.DefaultEventPriority;
+    return ReactReconcilerConstants.DefaultEventPriority;
 }
 
 export const isPrimaryRenderer = false;
 export const warnsIfNotActing = true;
 
 export const scheduleTimeout = (_fn: () => void, _timeout: number): TimeoutID => noTimeout;
-export const cancelTimeout = (_id: TimeoutID) => { };
+export const cancelTimeout = (_id: TimeoutID) => {};
 
 export const noTimeout = -1;
 
@@ -202,23 +238,37 @@ export const noTimeout = -1;
 
 export const supportsMutation = true;
 
-export function commitUpdate(instance: Instance, updatePayload: {}, type: string, oldProps: Props, newProps: Props, internalInstanceHandle: {
-  [key: string]: any;
-}): void {
-  instance.type = type;
-  instance.props = newProps;
+export function commitUpdate(
+    instance: Instance,
+    updatePayload: {},
+    type: string,
+    oldProps: Props,
+    newProps: Props,
+    internalInstanceHandle: {
+        [key: string]: any;
+    },
+): void {
+    instance.type = type;
+    instance.props = newProps;
 }
 
-export function commitMount(instance: Instance, type: string, newProps: Props, internalInstanceHandle: {
-  [key: string]: any;
-}): void {// noop
+export function commitMount(
+    instance: Instance,
+    type: string,
+    newProps: Props,
+    internalInstanceHandle: {
+        [key: string]: any;
+    },
+): void {
+    // noop
 }
 
 export function commitTextUpdate(textInstance: TextInstance, oldText: string, newText: string): void {
-  textInstance.text = newText;
+    textInstance.text = newText;
 }
 
-export function resetTextContent(testElement: Instance): void {// noop
+export function resetTextContent(testElement: Instance): void {
+    // noop
 }
 
 export const appendChildToContainer = appendChild;
@@ -226,58 +276,60 @@ export const insertInContainerBefore = insertBefore;
 export const removeChildFromContainer = removeChild;
 
 export function hideInstance(instance: Instance): void {
-  instance.isHidden = true;
+    instance.isHidden = true;
 }
 
 export function hideTextInstance(textInstance: TextInstance): void {
-  textInstance.isHidden = true;
+    textInstance.isHidden = true;
 }
 
 export function unhideInstance(instance: Instance, props?: Props): void {
-  instance.isHidden = false;
+    instance.isHidden = false;
 }
 
 export function unhideTextInstance(textInstance: TextInstance, text?: string): void {
-  textInstance.isHidden = false;
+    textInstance.isHidden = false;
 }
 
-export function getInstanceFromNode(mockNode: {
-  [key: string]: any;
-}) {
-  const instance = nodeToInstanceMap.get(mockNode);
-  if (instance !== undefined) {
-    return instance.internalInstanceHandle;
-  }
-  return null;
+export function getInstanceFromNode(mockNode: { [key: string]: any }) {
+    const instance = nodeToInstanceMap.get(mockNode);
+    if (instance !== undefined) {
+        return instance.internalInstanceHandle;
+    }
+    return null;
 }
 
-export function beforeActiveInstanceBlur() {// noop
+export function beforeActiveInstanceBlur() {
+    // noop
 }
 
-export function afterActiveInstanceBlur() {// noop
+export function afterActiveInstanceBlur() {
+    // noop
 }
 
-export function preparePortalMount(portalInstance: Container): void {// noop
+export function preparePortalMount(portalInstance: Container): void {
+    // noop
 }
 
-export function prepareScopeUpdate(scopeInstance: {
-  [key: string]: any;
-}, inst: {
-  [key: string]: any;
-}): void {
-  nodeToInstanceMap.set(scopeInstance, inst);
+export function prepareScopeUpdate(
+    scopeInstance: {
+        [key: string]: any;
+    },
+    inst: {
+        [key: string]: any;
+    },
+): void {
+    nodeToInstanceMap.set(scopeInstance, inst);
 }
 
-export function getInstanceFromScope(scopeInstance: {
-  [key: string]: any;
-}): null | Instance {
-  return nodeToInstanceMap.get(scopeInstance) || null;
+export function getInstanceFromScope(scopeInstance: { [key: string]: any }): null | Instance {
+    return nodeToInstanceMap.get(scopeInstance) || null;
 }
 
 export function detachDeletedInstance(node: Instance): void {
-  // noop
+    // noop
 }
 
 export function logRecoverableError(error: any): void {
-  // noop
+    // noop
 }

--- a/types/react-reconciler/test/ReactTestHostConfig.ts
+++ b/types/react-reconciler/test/ReactTestHostConfig.ts
@@ -1,3 +1,5 @@
+// This file is pretty much a copy of https://github.com/facebook/react/blob/main/packages/react-test-renderer/src/ReactTestHostConfig.js
+
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -6,7 +8,7 @@
  *
  */
 
-import { ReactFundamentalComponentInstance } from "./ReactTypes";
+import ReactReconcilerConstants = require('react-reconciler/constants');
 
 export const REACT_OPAQUE_ID_TYPE: number | symbol = 0xeae0;
 
@@ -182,6 +184,10 @@ export function createTextInstance(text: string, rootContainerInstance: Containe
   };
 }
 
+export function getCurrentEventPriority() {
+  return ReactReconcilerConstants.DefaultEventPriority;
+}
+
 export const isPrimaryRenderer = false;
 export const warnsIfNotActing = true;
 
@@ -235,69 +241,6 @@ export function unhideTextInstance(textInstance: TextInstance, text?: string): v
   textInstance.isHidden = false;
 }
 
-export function getFundamentalComponentInstance(fundamentalInstance: ReactFundamentalComponentInstance<any, any>): Instance {
-  const {
-    impl,
-    props,
-    state
-  } = fundamentalInstance;
-  return impl.getInstance(null, props, state);
-}
-
-export function mountFundamentalComponent(fundamentalInstance: ReactFundamentalComponentInstance<any, any>): void {
-  const {
-    impl,
-    instance,
-    props,
-    state
-  } = fundamentalInstance;
-  const onMount = impl.onMount;
-  if (onMount !== undefined) {
-    onMount(null, instance, props, state);
-  }
-}
-
-export function shouldUpdateFundamentalComponent(fundamentalInstance: ReactFundamentalComponentInstance<any, any>): boolean {
-  const {
-    impl,
-    prevProps,
-    props,
-    state
-  } = fundamentalInstance;
-  const shouldUpdate = impl.shouldUpdate;
-  if (shouldUpdate !== undefined) {
-    return shouldUpdate(null, prevProps, props, state);
-  }
-  return true;
-}
-
-export function updateFundamentalComponent(fundamentalInstance: ReactFundamentalComponentInstance<any, any>): void {
-  const {
-    impl,
-    instance,
-    prevProps,
-    props,
-    state
-  } = fundamentalInstance;
-  const onUpdate = impl.onUpdate;
-  if (onUpdate !== undefined) {
-    onUpdate(null, instance, prevProps, props, state);
-  }
-}
-
-export function unmountFundamentalComponent(fundamentalInstance: ReactFundamentalComponentInstance<any, any>): void {
-  const {
-    impl,
-    instance,
-    props,
-    state
-  } = fundamentalInstance;
-  const onUnmount = impl.onUnmount;
-  if (onUnmount !== undefined) {
-    onUnmount(null, instance, props, state);
-  }
-}
-
 export function getInstanceFromNode(mockNode: {
   [key: string]: any;
 }) {
@@ -308,26 +251,7 @@ export function getInstanceFromNode(mockNode: {
   return null;
 }
 
-let clientId = 0;
-export function makeClientId(): OpaqueIDType {
-  return 'c_' + (clientId++).toString(36);
-}
-
-export function isOpaqueHydratingObject(value: any): boolean {
-  return (value !== null && typeof value === 'object' && value.$$typeof === REACT_OPAQUE_ID_TYPE);
-}
-
-export function makeOpaqueHydratingObject(attemptToReadValue: () => void): OpaqueIDType {
-  return {
-    $$typeof: REACT_OPAQUE_ID_TYPE,
-    toString: attemptToReadValue,
-    valueOf: attemptToReadValue
-  };
-}
-
-export function beforeActiveInstanceBlur(internalInstanceHandle: {
-  [key: string]: any;
-}) {// noop
+export function beforeActiveInstanceBlur() {// noop
 }
 
 export function afterActiveInstanceBlur() {// noop
@@ -346,10 +270,14 @@ export function prepareScopeUpdate(scopeInstance: {
 
 export function getInstanceFromScope(scopeInstance: {
   [key: string]: any;
-}): null | {
-  [key: string]: any;
-} {
+}): null | Instance {
   return nodeToInstanceMap.get(scopeInstance) || null;
 }
 
-export const now = Date.now;
+export function detachDeletedInstance(node: Instance): void {
+  // noop
+}
+
+export function logRecoverableError(error: any): void {
+  // noop
+}

--- a/types/react-reconciler/test/ReactTestHostConfig.ts
+++ b/types/react-reconciler/test/ReactTestHostConfig.ts
@@ -64,7 +64,7 @@ export type OpaqueIDType =
 export type RendererInspectionConfig = Readonly<{}>;
 
 export * from './ReactFiberHostConfigWithNoPersistence';
-export * from './ReactFiberHostConfigWithNoMicroTasks';
+export * from './ReactFiberHostConfigWithNoMicrotasks';
 export * from './ReactFiberHostConfigWithNoHydration';
 export * from './ReactFiberHostConfigWithNoTestSelectors';
 

--- a/types/react-reconciler/test/ReactTypes.ts
+++ b/types/react-reconciler/test/ReactTypes.ts
@@ -1,80 +1,117 @@
 export interface ReactFundamentalComponentInstance<C, H> {
-  currentFiber: {
-    [key: string]: any;
-  };
-  instance: unknown;
-  prevProps: null | {
-    [key: string]: any;
-  };
-  props: {
-    [key: string]: any;
-  };
-  impl: ReactFundamentalImpl<C, H>;
-  state: {
-    [key: string]: any;
-  };
+    currentFiber: {
+        [key: string]: any;
+    };
+    instance: unknown;
+    prevProps: null | {
+        [key: string]: any;
+    };
+    props: {
+        [key: string]: any;
+    };
+    impl: ReactFundamentalImpl<C, H>;
+    state: {
+        [key: string]: any;
+    };
 }
 
 export interface ReactFundamentalImpl<C, H> {
-  displayName: string;
-  reconcileChildren: boolean;
-  getInitialState?: ((props: {
-    [key: string]: any;
-  }) => {
-    [key: string]: any;
-  });
-  getInstance: (context: C, props: {
-    [key: string]: any;
-  }, state: {
-    [key: string]: any;
-  }) => H;
-  getServerSideString?: ((context: C, props: {
-    [key: string]: any;
-  }) => string);
-  getServerSideStringClose?: ((context: C, props: {
-    [key: string]: any;
-  }) => string);
-  onMount: (context: C, instance: unknown, props: {
-    [key: string]: any;
-  }, state: {
-    [key: string]: any;
-  }) => void;
-  shouldUpdate?: ((context: C, prevProps: null | {
-    [key: string]: any;
-  }, nextProps: {
-    [key: string]: any;
-  }, state: {
-    [key: string]: any;
-  }) => boolean);
-  onUpdate?: ((context: C, instance: unknown, prevProps: null | {
-    [key: string]: any;
-  }, nextProps: {
-    [key: string]: any;
-  }, state: {
-    [key: string]: any;
-  }) => void);
-  onUnmount?: ((context: C, instance: unknown, props: {
-    [key: string]: any;
-  }, state: {
-    [key: string]: any;
-  }) => void);
-  onHydrate?: ((context: C, props: {
-    [key: string]: any;
-  }, state: {
-    [key: string]: any;
-  }) => boolean);
-  onFocus?: ((context: C, props: {
-    [key: string]: any;
-  }, state: {
-    [key: string]: any;
-  }) => boolean);
+    displayName: string;
+    reconcileChildren: boolean;
+    getInitialState?: (props: { [key: string]: any }) => {
+        [key: string]: any;
+    };
+    getInstance: (
+        context: C,
+        props: {
+            [key: string]: any;
+        },
+        state: {
+            [key: string]: any;
+        },
+    ) => H;
+    getServerSideString?: (
+        context: C,
+        props: {
+            [key: string]: any;
+        },
+    ) => string;
+    getServerSideStringClose?: (
+        context: C,
+        props: {
+            [key: string]: any;
+        },
+    ) => string;
+    onMount: (
+        context: C,
+        instance: unknown,
+        props: {
+            [key: string]: any;
+        },
+        state: {
+            [key: string]: any;
+        },
+    ) => void;
+    shouldUpdate?: (
+        context: C,
+        prevProps: null | {
+            [key: string]: any;
+        },
+        nextProps: {
+            [key: string]: any;
+        },
+        state: {
+            [key: string]: any;
+        },
+    ) => boolean;
+    onUpdate?: (
+        context: C,
+        instance: unknown,
+        prevProps: null | {
+            [key: string]: any;
+        },
+        nextProps: {
+            [key: string]: any;
+        },
+        state: {
+            [key: string]: any;
+        },
+    ) => void;
+    onUnmount?: (
+        context: C,
+        instance: unknown,
+        props: {
+            [key: string]: any;
+        },
+        state: {
+            [key: string]: any;
+        },
+    ) => void;
+    onHydrate?: (
+        context: C,
+        props: {
+            [key: string]: any;
+        },
+        state: {
+            [key: string]: any;
+        },
+    ) => boolean;
+    onFocus?: (
+        context: C,
+        props: {
+            [key: string]: any;
+        },
+        state: {
+            [key: string]: any;
+        },
+    ) => boolean;
 }
 
 export interface ReactFundamentalComponent<C, H> {
-  $$typeof: symbol | number;
-  impl: ReactFundamentalImpl<C, H>;
+    $$typeof: symbol | number;
+    impl: ReactFundamentalImpl<C, H>;
 }
 
 export interface ReactScope {
-  $$typeof: symbol | number;
+    $$typeof: symbol | number;
 }

--- a/types/react-reconciler/test/react-reconciler-tests.ts
+++ b/types/react-reconciler/test/react-reconciler-tests.ts
@@ -21,7 +21,7 @@ ReactReconciler<
 >(ReactTestHostConfig);
 
 function isEqual(target: number, value: number): boolean {
-  return target === value;
+    return target === value;
 }
 
 // $ExpectType boolean

--- a/types/react-reconciler/tsconfig.json
+++ b/types/react-reconciler/tsconfig.json
@@ -19,6 +19,7 @@
     "files": [
         "index.d.ts",
         "test/ReactFiberHostConfigWithNoHydration.ts",
+        "test/ReactFiberHostConfigWithNoMicrotasks.ts",
         "test/ReactFiberHostConfigWithNoPersistence.ts",
         "test/ReactFiberHostConfigWithNoTestSelectors.ts",
         "test/ReactTestHostConfig.ts",


### PR DESCRIPTION
This PR update the types of `react-reconciler` to support the new 0.28.0 version (which is used by react 18).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
