### PR TITLE
[serverless] Make apiGateway in tracing optional

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -266,7 +266,7 @@ declare namespace Aws {
     }
 
     interface Tracing {
-        apiGateway: boolean;
+        apiGateway?: boolean;
         lambda?: 'Active' | 'PassThrough' | boolean | undefined;
     }
 

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -849,6 +849,11 @@ const awsServerless: Aws.Serverless = {
 awsServerless.provider.vpc = 'serverless reference';
 awsServerless.functions![0].vpc = 'serverless reference';
 
+// apiGateway in tracing can be undefined
+awsServerless.provider.tracing = {
+    lambda: true,
+};
+
 const bunchOfConfigs: Aws.Serverless[] = [
     {
         service: 'users',


### PR DESCRIPTION
`apiGateway` is an optional property in Serverless configuration, the type should respect that.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.serverless.com/framework/docs/deprecations
