### PR TITLE
[express-session] add exposed sessionStore in express.Request and fix the return type of Store.createSession

### DIFF
--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -127,3 +127,15 @@ app.use(
         store: new MyStore(),
     }),
 );
+
+app.use((req, res, next) => {
+    let sess = req.session;
+    const store = req.sessionStore;
+    store.get(sess.id, (err, session) => { });
+    store.set(sess.id, { views: 0, cookie: sess.cookie }, (err) => { });
+    sess = store.createSession(req, { views: 0, cookie: sess.cookie });
+    store.destroy(sess.id, (err) => { });
+    store.generate(req);
+    store.regenerate(req, (err) => { });
+    res.end();
+});

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -15,6 +15,8 @@ import { EventEmitter } from 'events';
 
 declare global {
     namespace Express {
+        type SessionStore = session.Store & { generate: (req: Request) => void };
+
         // Inject additional properties on express.Request
         interface Request {
             /**
@@ -37,7 +39,7 @@ declare global {
              * Even though this property isn't marked as optional, it won't exist until you use the `express-session` middleware
              * The function `generate` is added by express-session
              */
-            sessionStore: session.Store & { generate: (req: express.Request) => void };
+            sessionStore: SessionStore;
         }
     }
 }

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -31,6 +31,13 @@ declare global {
              * Even though this property isn't marked as optional, it won't exist until you use the `express-session` middleware
              */
             sessionID: string;
+
+            /**
+             * The Store in use.
+             * Even though this property isn't marked as optional, it won't exist until you use the `express-session` middleware
+             * The function `generate` is added by express-session
+             */
+            sessionStore: session.Store & { generate: (req: express.Request) => void };
         }
     }
 }
@@ -312,7 +319,7 @@ declare namespace session {
     abstract class Store extends EventEmitter {
         regenerate(req: express.Request, callback: (err?: any) => any): void;
         load(sid: string, callback: (err: any, session?: SessionData) => any): void;
-        createSession(req: express.Request, session: SessionData): void;
+        createSession(req: express.Request, session: SessionData): Session & SessionData;
 
         /**
          * Gets the session from the store given a session ID and passes it to `callback`.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [sessionStore](https://github.com/expressjs/session/blob/1010fadc2f071ddf2add94235d72224cf65159c6/index.js#L214)  [createSession](https://github.com/expressjs/session/blob/1010fadc2f071ddf2add94235d72224cf65159c6/session/store.js#L101)
