### PR TITLE
[react-bootstrap] Add explicit children types for Collapse and Overlay

### DIFF
--- a/types/react-bootstrap/lib/Collapse.d.ts
+++ b/types/react-bootstrap/lib/Collapse.d.ts
@@ -3,6 +3,7 @@ import { TransitionCallbacks } from 'react-bootstrap';
 
 declare namespace Collapse {
     export interface CollapseProps extends TransitionCallbacks, React.ClassAttributes<Collapse> {
+        children?: React.ReactNode;
         dimension?: 'height' | 'width' | { ( ):string } | undefined;
         getDimensionValue?: (( dimension:number, element:React.ReactElement ) => number) | undefined;
         in?: boolean | undefined;

--- a/types/react-bootstrap/lib/Overlay.d.ts
+++ b/types/react-bootstrap/lib/Overlay.d.ts
@@ -3,6 +3,7 @@ import { TransitionCallbacks } from 'react-bootstrap';
 
 declare namespace Overlay {
     export interface OverlayProps extends TransitionCallbacks {
+        children?: React.ReactNode;
         // Optional
         animation?: any; // TODO: Add more specific type
         container?: any; // TODO: Add more specific type

--- a/types/react-bootstrap/test/react-bootstrap-tests.tsx
+++ b/types/react-bootstrap/test/react-bootstrap-tests.tsx
@@ -14,6 +14,7 @@ import {
     ListGroupItem,
     Accordion,
     Tooltip,
+    Overlay,
     OverlayTrigger,
     Popover,
     ProgressBar,
@@ -51,7 +52,8 @@ import {
     Media,
     InputGroup,
     ToggleButtonGroup,
-    ToggleButton
+    ToggleButton,
+    Collapse
 } from 'react-bootstrap';
 
 export class ReactBootstrapTest extends Component {
@@ -581,6 +583,10 @@ export class ReactBootstrapTest extends Component {
                       Tooltip bottom
                     </Tooltip>
                   </div>
+                </div>
+
+                <div style={style}>
+                    <Overlay>Overlay</Overlay>
                 </div>
 
                 <div style={style}>
@@ -1506,6 +1512,10 @@ export class ReactBootstrapTest extends Component {
                     </ToggleButton>
                   </ToggleButtonGroup>
                 </ButtonToolbar>
+              </div>
+
+              <div style={style}>
+                <Collapse>Collapse</Collapse>
               </div>
             </div>
         );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Same context as #56344; adds missing children types to `<Collapse>` and `<Overlay>` to support `@types/react@^18.0.0`.
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~