### PR TITLE
Update type definition for PushNotificationScheduledLocalObject in react-native-push-notifications

### DIFF
--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -112,7 +112,7 @@ export class PushNotificationScheduledLocalObject {
     id: string;
     date: Date;
     title: string;
-    body: string;
+    message: string;
     soundName: string;
     repeatInterval: number;
     number: number;


### PR DESCRIPTION
Updating the type for `PushNotificationScheduledLocalObject` in react-native-push-notifications to include field `message` instead of `body`, as per the [docs](https://github.com/zo0r/react-native-push-notification#6-getscheduledlocalnotifications) and the [code](https://github.com/zo0r/react-native-push-notification/blob/master/index.js#L569). `body` only exists on `PushNotificationDeliveredObject`.

Does this warrant a major version?