### PR TITLE
Add row.select/deselect methods and parameterless row() to datatables.net

### DIFF
--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -982,11 +982,15 @@ dt.row(0).select();
 dt.row(0).deselect();
 
 dt.row().select();
+dt.row().deselect();
 dt.row().data();
 dt.row().select().data();
+dt.row().deselect().data();
 
+dt.rows().select();
 dt.rows().deselect();
 dt.rows().data();
+dt.rows().select().data();
 dt.rows().deselect().data();
 
 //#endregion "Methods-Row"

--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -978,6 +978,17 @@ $('#example tbody').on('click', 'td.details-control', () => {
     }
 });
 
+dt.row(0).select();
+dt.row(0).deselect();
+
+dt.row().select();
+dt.row().data();
+dt.row().select().data();
+
+dt.rows().deselect();
+dt.rows().data();
+dt.rows().deselect().data();
+
 //#endregion "Methods-Row"
 
 //#region "Methods-Static"

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -902,10 +902,10 @@ declare namespace DataTables {
         /**
          * Select a row found by a row selector
          *
-         * @param rowSelector Row selector.
+         * @param rowSelector Row selector. If undefined returns the first row in the DataTable.
          * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
          */
-        (rowSelector: any, modifier?: ObjectSelectorModifier): RowMethods;
+        (rowSelector?: any, modifier?: ObjectSelectorModifier): RowMethods;
 
         /**
          * Add a new row to the table using the given data
@@ -956,6 +956,16 @@ declare namespace DataTables {
          * Delete the selected row from the DataTable.
          */
         remove(): Node;
+
+        /**
+         * Selects this row.
+         */
+        select(): Api;
+
+        /**
+         * Deselects this row.
+         */
+        deselect(): Api;
     }
 
     interface RowsMethodsModel {
@@ -969,10 +979,10 @@ declare namespace DataTables {
         /**
          * Select rows found by a row selector
          *
-         * @param cellSelector Row selector.
+         * @param cellSelector Row selector. If undefined returns every row in the DataTable.
          * @param Option used to specify how the cells should be ordered, and if paging or filtering in the table should be taken into account.
          */
-        (rowSelector: any, modifier?: ObjectSelectorModifier): RowsMethods;
+        (rowSelector?: any, modifier?: ObjectSelectorModifier): RowsMethods;
 
         /**
          * Add new rows to the table using the data given
@@ -1020,6 +1030,16 @@ declare namespace DataTables {
          * Delete the selected rows from the DataTable.
          */
         remove(): Api;
+
+        /**
+         * Selects the given rows.
+         */
+        select(): Api;
+
+        /**
+         * Deselects the given rows.
+         */
+        deselect(): Api;
     }
     //#endregion "row-methods"
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatables.net/reference/api/row().select() and https://datatables.net/reference/type/row-selector#No-selector
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
