### PR TITLE
[offscreencanvas] Support OffscreenCanvas as WebGL textures

### DIFF
--- a/types/offscreencanvas/index.d.ts
+++ b/types/offscreencanvas/index.d.ts
@@ -81,3 +81,93 @@ declare var OffscreenCanvas: {
     prototype: OffscreenCanvas;
     new(width: number, height: number): OffscreenCanvas;
 };
+
+interface WebGL2RenderingContextBase {
+    texImage3D(
+        target: GLenum,
+        level: GLint,
+        internalformat: GLint,
+        width: GLsizei,
+        height: GLsizei,
+        depth: GLsizei,
+        border: GLint,
+        format: GLenum,
+        type: GLenum,
+        source: TexImageSource | OffscreenCanvas,
+    ): void;
+    texSubImage3D(
+        target: GLenum,
+        level: GLint,
+        xoffset: GLint,
+        yoffset: GLint,
+        zoffset: GLint,
+        width: GLsizei,
+        height: GLsizei,
+        depth: GLsizei,
+        format: GLenum,
+        type: GLenum,
+        source: TexImageSource | OffscreenCanvas,
+    ): void;
+}
+
+interface WebGL2RenderingContextOverloads {
+    texImage2D(
+        target: GLenum,
+        level: GLint,
+        internalformat: GLint,
+        format: GLenum,
+        type: GLenum,
+        source: TexImageSource | OffscreenCanvas,
+    ): void;
+    texImage2D(
+        target: GLenum,
+        level: GLint,
+        internalformat: GLint,
+        width: GLsizei,
+        height: GLsizei,
+        border: GLint,
+        format: GLenum,
+        type: GLenum,
+        source: TexImageSource | OffscreenCanvas,
+    ): void;
+    texSubImage2D(
+        target: GLenum,
+        level: GLint,
+        xoffset: GLint,
+        yoffset: GLint,
+        format: GLenum,
+        type: GLenum,
+        source: TexImageSource | OffscreenCanvas,
+    ): void;
+    texSubImage2D(
+        target: GLenum,
+        level: GLint,
+        xoffset: GLint,
+        yoffset: GLint,
+        width: GLsizei,
+        height: GLsizei,
+        format: GLenum,
+        type: GLenum,
+        source: TexImageSource | OffscreenCanvas,
+    ): void;
+}
+
+interface WebGLRenderingContextOverloads {
+    texImage2D(
+        target: GLenum,
+        level: GLint,
+        internalformat: GLint,
+        format: GLenum,
+        type: GLenum,
+        source: TexImageSource | OffscreenCanvas,
+    ): void;
+    texSubImage2D(
+        target: GLenum,
+        level: GLint,
+        xoffset: GLint,
+        yoffset: GLint,
+        format: GLenum,
+        type: GLenum,
+        source: TexImageSource | OffscreenCanvas,
+    ): void;
+}

--- a/types/offscreencanvas/index.d.ts
+++ b/types/offscreencanvas/index.d.ts
@@ -12,9 +12,22 @@ interface HTMLCanvasElement {
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#offscreencanvasrenderingcontext2d
-interface OffscreenCanvasRenderingContext2D extends CanvasState, CanvasTransform, CanvasCompositing,
-    CanvasImageSmoothing, CanvasFillStrokeStyles, CanvasShadowStyles, CanvasFilters, CanvasRect, CanvasDrawPath,
-    CanvasText, CanvasDrawImage, CanvasImageData, CanvasPathDrawingStyles, CanvasTextDrawingStyles, CanvasPath {
+interface OffscreenCanvasRenderingContext2D
+    extends CanvasState,
+        CanvasTransform,
+        CanvasCompositing,
+        CanvasImageSmoothing,
+        CanvasFillStrokeStyles,
+        CanvasShadowStyles,
+        CanvasFilters,
+        CanvasRect,
+        CanvasDrawPath,
+        CanvasText,
+        CanvasDrawImage,
+        CanvasImageData,
+        CanvasPathDrawingStyles,
+        CanvasTextDrawingStyles,
+        CanvasPath {
     readonly canvas: OffscreenCanvas;
 }
 
@@ -30,15 +43,21 @@ interface OffscreenCanvas extends EventTarget {
     width: number;
     height: number;
 
-    getContext(contextId: "2d", contextAttributes?: CanvasRenderingContext2DSettings): OffscreenCanvasRenderingContext2D | null;
+    getContext(
+        contextId: '2d',
+        contextAttributes?: CanvasRenderingContext2DSettings,
+    ): OffscreenCanvasRenderingContext2D | null;
 
-    getContext(contextId: "bitmaprenderer", contextAttributes?: WebGLContextAttributes): ImageBitmapRenderingContext | null;
+    getContext(
+        contextId: 'bitmaprenderer',
+        contextAttributes?: WebGLContextAttributes,
+    ): ImageBitmapRenderingContext | null;
 
-    getContext(contextId: "webgl", contextAttributes?: WebGLContextAttributes): WebGLRenderingContext | null;
+    getContext(contextId: 'webgl', contextAttributes?: WebGLContextAttributes): WebGLRenderingContext | null;
 
-    getContext(contextId: "webgl2", contextAttributes?: WebGLContextAttributes): WebGL2RenderingContext | null;
+    getContext(contextId: 'webgl2', contextAttributes?: WebGLContextAttributes): WebGL2RenderingContext | null;
 
-    convertToBlob(options?: { type?: string | undefined, quality?: number | undefined }): Promise<Blob>;
+    convertToBlob(options?: { type?: string | undefined; quality?: number | undefined }): Promise<Blob>;
 
     transferToImageBitmap(): ImageBitmap;
 }
@@ -49,14 +68,28 @@ interface CanvasDrawImage {
 
     drawImage(image: CanvasImageSource | OffscreenCanvas, dx: number, dy: number, dw: number, dh: number): void;
 
-    drawImage(image: CanvasImageSource | OffscreenCanvas, sx: number, sy: number, sw: number, sh: number,
-              dx: number, dy: number, dw: number, dh: number): void;
+    drawImage(
+        image: CanvasImageSource | OffscreenCanvas,
+        sx: number,
+        sy: number,
+        sw: number,
+        sh: number,
+        dx: number,
+        dy: number,
+        dw: number,
+        dh: number,
+    ): void;
 }
 
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap
 declare function createImageBitmap(image: ImageBitmapSource | OffscreenCanvas): Promise<ImageBitmap>;
-declare function createImageBitmap(image: ImageBitmapSource | OffscreenCanvas, sx: number, sy: number,
-                                   sw: number, sh: number): Promise<ImageBitmap>;
+declare function createImageBitmap(
+    image: ImageBitmapSource | OffscreenCanvas,
+    sx: number,
+    sy: number,
+    sw: number,
+    sh: number,
+): Promise<ImageBitmap>;
 
 // OffscreenCanvas should be a part of Transferable => extend all postMessage methods
 interface Worker {
@@ -75,11 +108,15 @@ interface Window {
     postMessage(message: any, targetOrigin: string, transfer?: Array<Transferable | OffscreenCanvas>): void;
 }
 
-declare function postMessage(message: any, targetOrigin: string, transfer?: Array<Transferable | OffscreenCanvas>): void;
+declare function postMessage(
+    message: any,
+    targetOrigin: string,
+    transfer?: Array<Transferable | OffscreenCanvas>,
+): void;
 
 declare var OffscreenCanvas: {
     prototype: OffscreenCanvas;
-    new(width: number, height: number): OffscreenCanvas;
+    new (width: number, height: number): OffscreenCanvas;
 };
 
 interface WebGL2RenderingContextBase {

--- a/types/offscreencanvas/index.d.ts
+++ b/types/offscreencanvas/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package offscreencanvas-browser 2019.6
+// Type definitions for non-npm package offscreencanvas-browser 2019.7
 // Project: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface
 // Definitions by: Klaus Reimer <https://github.com/kayahr>
 //                 Oleg Varaksin <https://github.com/ova2>

--- a/types/offscreencanvas/index.d.ts
+++ b/types/offscreencanvas/index.d.ts
@@ -96,6 +96,10 @@ interface Worker {
     postMessage(message: any, transfer?: Array<Transferable | OffscreenCanvas>): void;
 }
 
+interface DedicatedWorkerGlobalScope {
+    postMessage(message: any, transfer?: Array<Transferable | OffscreenCanvas>): void;
+}
+
 interface ServiceWorker {
     postMessage(message: any, transfer?: Array<Transferable | OffscreenCanvas>): void;
 }

--- a/types/offscreencanvas/index.d.ts
+++ b/types/offscreencanvas/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for non-npm package offscreencanvas-browser 2019.6
 // Project: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface
 // Definitions by: Klaus Reimer <https://github.com/kayahr>
-//                        Oleg Varaksin <https://github.com/ova2>
+//                 Oleg Varaksin <https://github.com/ova2>
+//                 Sean T.McBeth <https://github.com/capnmidnight>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.3
 

--- a/types/offscreencanvas/offscreencanvas-tests.ts
+++ b/types/offscreencanvas/offscreencanvas-tests.ts
@@ -6,24 +6,24 @@ let width: number = offscreenCanvas.width;
 let height: number = offscreenCanvas.height;
 
 // Test OffscreenCanvas methods
-const ctx2d: OffscreenCanvasRenderingContext2D | null = offscreenCanvas.getContext("2d");
-const ctxBitmaprenderer: ImageBitmapRenderingContext | null = offscreenCanvas.getContext("bitmaprenderer");
-const ctxWebgl: WebGLRenderingContext | null = offscreenCanvas.getContext("webgl");
-const ctxWebgl2: WebGL2RenderingContext | null = offscreenCanvas.getContext("webgl2");
+const ctx2d: OffscreenCanvasRenderingContext2D | null = offscreenCanvas.getContext('2d');
+const ctxBitmaprenderer: ImageBitmapRenderingContext | null = offscreenCanvas.getContext('bitmaprenderer');
+const ctxWebgl: WebGLRenderingContext | null = offscreenCanvas.getContext('webgl');
+const ctxWebgl2: WebGL2RenderingContext | null = offscreenCanvas.getContext('webgl2');
 const imageBitmap: ImageBitmap = offscreenCanvas.transferToImageBitmap();
 const blob1: Promise<Blob> = offscreenCanvas.convertToBlob();
-const blob2: Promise<Blob> = offscreenCanvas.convertToBlob({type: "image/jpeg"});
-const blob3: Promise<Blob> = offscreenCanvas.convertToBlob({type: "image/jpeg", quality: 0.92});
+const blob2: Promise<Blob> = offscreenCanvas.convertToBlob({ type: 'image/jpeg' });
+const blob3: Promise<Blob> = offscreenCanvas.convertToBlob({ type: 'image/jpeg', quality: 0.92 });
 
 // Test OffscreenCanvasRenderingContext2D properties
 const canvasRef: OffscreenCanvas = ctx2d!.canvas;
 
 // Test HTMLCanvasElement methods
-const canvas: HTMLCanvasElement = document.createElement("canvas");
+const canvas: HTMLCanvasElement = document.createElement('canvas');
 const transferredCanvas: OffscreenCanvas = canvas.transferControlToOffscreen();
 
 // Test CanvasRenderingContext2D methods
-const ctx = canvas.getContext("2d")!;
+const ctx = canvas.getContext('2d')!;
 ctx.drawImage(offscreenCanvas, 0, 0);
 ctx.drawImage(offscreenCanvas, 0, 0, 20, 10);
 ctx.drawImage(offscreenCanvas, 0, 0, 20, 10, 0, 0, 20, 10);
@@ -33,16 +33,16 @@ const imageBitmap1 = createImageBitmap(offscreenCanvas);
 const imageBitmap2 = createImageBitmap(offscreenCanvas, 1, 2, 3, 4);
 
 // Test postMessage
-const worker = new Worker("offscreencanvas.js");
-worker.postMessage({canvas: offscreenCanvas}, [offscreenCanvas]);
+const worker = new Worker('offscreencanvas.js');
+worker.postMessage({ canvas: offscreenCanvas }, [offscreenCanvas]);
 
 const serviceWorker = new ServiceWorker();
-serviceWorker.postMessage({canvas: offscreenCanvas}, [offscreenCanvas]);
+serviceWorker.postMessage({ canvas: offscreenCanvas }, [offscreenCanvas]);
 
 const channel = new MessageChannel();
-channel.port1.postMessage({canvas: offscreenCanvas}, [offscreenCanvas]);
+channel.port1.postMessage({ canvas: offscreenCanvas }, [offscreenCanvas]);
 
-window.postMessage({canvas: offscreenCanvas}, "http://example.org:8080", [offscreenCanvas]);
+window.postMessage({ canvas: offscreenCanvas }, 'http://example.org:8080', [offscreenCanvas]);
 
 // Test creating a texture
 const texWebgl: WebGLTexture | null = ctxWebgl!.createTexture();

--- a/types/offscreencanvas/offscreencanvas-tests.ts
+++ b/types/offscreencanvas/offscreencanvas-tests.ts
@@ -43,3 +43,12 @@ const channel = new MessageChannel();
 channel.port1.postMessage({canvas: offscreenCanvas}, [offscreenCanvas]);
 
 window.postMessage({canvas: offscreenCanvas}, "http://example.org:8080", [offscreenCanvas]);
+
+// Test creating a texture
+const texWebgl: WebGLTexture | null = ctxWebgl!.createTexture();
+ctxWebgl!.bindTexture(ctxWebgl!.TEXTURE, texWebgl);
+ctxWebgl!.texImage2D(ctxWebgl!.TEXTURE, 0, ctxWebgl!.RGB, ctxWebgl!.RGB, ctxWebgl!.UNSIGNED_BYTE, offscreenCanvas);
+
+const texWebgl2: WebGLTexture | null = ctxWebgl2!.createTexture();
+ctxWebgl2!.bindTexture(ctxWebgl!.TEXTURE, texWebgl2);
+ctxWebgl2!.texImage2D(ctxWebgl2!.TEXTURE, 0, ctxWebgl2!.RGB, ctxWebgl2!.RGB, ctxWebgl2!.UNSIGNED_BYTE, offscreenCanvas);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.khronos.org/registry/webgl/specs/latest/1.0/#:~:text=typedef%20(ImageBitmap%20or%0A%20%20%20%20%20%20%20%20%20ImageData%20or%0A%20%20%20%20%20%20%20%20%20HTMLImageElement%20or%0A%20%20%20%20%20%20%20%20%20HTMLCanvasElement%20or%0A%20%20%20%20%20%20%20%20%20HTMLVideoElement%20or%0A%20%20%20%20%20%20%20%20%20OffscreenCanvas%20or%0A%20%20%20%20%20%20%20%20%20VideoFrame)%20TexImageSource%3B
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
