### PR TITLE
[snowflake-sdk] Fix types for Connection.execute

### DIFF
--- a/types/snowflake-sdk/index.d.ts
+++ b/types/snowflake-sdk/index.d.ts
@@ -547,8 +547,8 @@ export type Connection = NodeJS.EventEmitter & {
          * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#fetching-data-types-as-strings Fetching Data Types As Strings}
          */
         fetchAsString?: Array<'String' | 'Boolean' | 'Number' | 'Date' | 'JSON'> | undefined;
-        complete: (err: SnowflakeError | undefined, stmt: Statement, rows: any[] | undefined) => void;
-    }): void;
+        complete?: (err: SnowflakeError | undefined, stmt: Statement, rows: any[] | undefined) => void;
+    }): Statement;
 
     /**
      * Fetches the result of a previously issued statement.

--- a/types/snowflake-sdk/snowflake-sdk-tests.ts
+++ b/types/snowflake-sdk/snowflake-sdk-tests.ts
@@ -74,6 +74,22 @@ const connectCallback = (err: snowflake.SnowflakeError | undefined, conn: snowfl
             //
         },
     });
+
+    const stmt = conn.execute({
+        sqlText: '',
+        streamResult: true,
+    });
+    stmt; // $ExpectType Statement
+    const stream = stmt.streamRows(); // $ExpectType ReadableStream
+
+    const stmt2 = conn.execute({
+        sqlText: '',
+        streamResult: true,
+        complete(err, stmt, rows) {
+            const stream2 = stmt.streamRows(); // $ExpectType ReadableStream
+        },
+    });
+    stmt2; // $ExpectType Statement
 };
 connection.connect(connectCallback);
 connection.connectAsync(connectCallback);
@@ -112,4 +128,28 @@ snowflake.createConnection({
 const pool = snowflake.createPool({
     account: '',
     username: '',
+});
+
+pool.use<snowflake.Statement>(conn => {
+    return conn.execute({
+        sqlText: '',
+        binds: [],
+        streamResult: true,
+    });
+}).then(statement => statement.streamRows());
+
+pool.use<snowflake.Statement>(conn => {
+    return conn.execute({
+        sqlText: '',
+        binds: [],
+        streamResult: true,
+        complete: (_err, _stmt, _rows) => {},
+    });
+}).then(statement => statement.streamRows());
+
+pool.use<snowflake.Statement>(conn => {
+    return conn.execute({
+        sqlText: '',
+        complete: (_err, _stmt, _rows) => {},
+    });
 });


### PR DESCRIPTION
This PR amends the type declarations in the 'execute' function as follows:
- the 'complete' callback is set as optional, as results can be consumed as a stream of rows 
- the return type of the 'execute' function is set to 'Statement' because  the code returns a 'statement' object that can be used to fetch the results.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Snowflake docs](https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#streaming-results
); [github](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/7d87e70a2116f9691c265f2eb554868e4edc38fe/lib/connection/statement.js#L68)
