### PR TITLE
[pacote] Deduplicate @npm/types

### DIFF
--- a/types/libnpmpublish/index.d.ts
+++ b/types/libnpmpublish/index.d.ts
@@ -4,11 +4,9 @@
 //                 Guy Adler <https://github.com/Guy-Adler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="node" />
-
+import * as npm from "@npm/types";
 import fetch = require("npm-registry-fetch");
 import { Response } from "node-fetch";
-import { Manifest } from "pacote";
 
 /**
  * Sends the package represented by the manifest and tarData to the configured registry.
@@ -26,7 +24,7 @@ import { Manifest } from "pacote";
  * await libpub.publish(manifest, tarData, { npmVersion: 'my-pub-script@1.0.2', token: 'my-auth-token-here' }, opts)
  * // Package has been published to the npm registry.
  */
-export function publish(manifest: Manifest, tarballData: Buffer, options?: fetch.Options): Promise<Response>;
+export function publish(manifest: npm.PackageJson, tarballData: Buffer, options?: fetch.Options): Promise<Response>;
 
 /**
  * Unpublishes spec from the appropriate registry. The registry in question may have its own limitations on unpublishing.

--- a/types/libnpmpublish/libnpmpublish-tests.ts
+++ b/types/libnpmpublish/libnpmpublish-tests.ts
@@ -1,6 +1,6 @@
+import * as npm from "@npm/types";
 import libnpmpublish = require("libnpmpublish");
 import fetch = require("npm-registry-fetch");
-import { Manifest } from "pacote";
 
 async function test() {
     // declare variables to be used
@@ -21,12 +21,9 @@ async function test() {
         agent: undefined,
         body: "bodyhere"
     };
-    const manifest: Manifest = {
+    const manifest: npm.PackageJson = {
         name: "",
         version: "",
-        dist: {
-            tarball: ""
-        }
     };
     const tarballData: Buffer = Buffer.from("thisisafillerforthebuffertowork");
     // test param requirements and return values

--- a/types/libnpmpublish/package.json
+++ b/types/libnpmpublish/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@npm/types": "*"
+  },
+  "private": true
+}

--- a/types/pacote/index.d.ts
+++ b/types/pacote/index.d.ts
@@ -6,171 +6,11 @@
 
 /// <reference types="node" />
 
+import * as npm from '@npm/types';
 import npmFetch = require('npm-registry-fetch');
 import { Logger } from 'npmlog';
 import { Integrity } from 'ssri';
 import { Transform } from 'stream';
-
-export interface PackageDist {
-    /**
-     * The url to the associated package artifact. (Copied by Pacote to
-     * `manifest._resolved`.)
-     */
-    tarball: string;
-    /**
-     * The integrity SRI string for the artifact. This may not be present for
-     * older packages on the npm registry. (Copied by Pacote to
-     * `manifest._integrity`.)
-     */
-    integrity?: string | undefined;
-    /**
-     * Legacy integrity value. Hexadecimal-encoded sha1 hash. (Converted to an
-     * SRI string and copied by Pacote to `manifest._integrity` when
-     * `dist.integrity` is not present.)
-     */
-    shasum?: string | undefined;
-    /**
-     * Number of files in the tarball.
-     */
-    fileCount?: number | undefined;
-    /**
-     * Size on disk of the package when unpacked.
-     */
-    unpackedSize?: number | undefined;
-    /**
-     * A signature of the package by the
-     * [`npmregistry`](https://keybase.io/npmregistry) Keybase account.
-     * (Obviously only present for packages published to
-     * https://registry.npmjs.org.)
-     */
-    'npm-signature'?: string | undefined;
-}
-
-export interface Person {
-    name: string;
-    email?: string | undefined;
-    url?: string | undefined;
-}
-
-/**
- * Properties that can appear on both packuments and manifests. These usually
- * only appear when requesting with `fullMetadata = true`.
- */
-export interface CommonMetadata {
-    author?: Person | undefined;
-    bugs?: {
-        url?: string | undefined;
-        email?: string | undefined;
-    } | undefined;
-    contributors?: Person[] | undefined;
-    homepage?: string | undefined;
-    keywords?: string[] | undefined;
-    license?: string | undefined;
-    maintainers: Person[];
-    readme?: string | undefined;
-    readmeFilename?: string | undefined;
-    repository?: {
-        type?: string | undefined;
-        url?: string | undefined;
-        directory?: string | undefined;
-    } | undefined;
-    users?: Record<string, boolean> | undefined;
-}
-
-/**
- * A `manifest` is similar to a `package.json` file. However, it has a few
- * pieces of extra metadata, and sometimes lacks metadata that is inessential to
- * package installation.
- */
-export interface Manifest extends CommonMetadata {
-    name: string;
-    version: string;
-    dist: PackageDist;
-
-    // These properties usually appear in all requests.
-    dependencies?: Record<string, string> | undefined;
-    optionalDependencies?: Record<string, string> | undefined;
-    devDependencies?: Record<string, string> | undefined;
-    peerDependencies?: Record<string, string> | undefined;
-    bundledDependencies?: false | string[] | undefined;
-
-    bin?: Record<string, string> | undefined;
-    directories?: Record<string, string> | undefined;
-    engines?: Record<string, string> | undefined;
-
-    // These properties usually only appear when fullMetadata = true.
-    browser?: string | undefined;
-    config?: Record<string, unknown> | undefined;
-    cpu?: string[] | undefined;
-    description?: string | undefined;
-    files?: string[] | undefined;
-    main?: string | undefined;
-    man?: string | string[] | undefined;
-    os?: string[] | undefined;
-    publishConfig?: Record<string, unknown> | undefined;
-    scripts?: Record<string, string> | undefined;
-
-    _id: string;
-    _nodeVersion: string;
-    _npmVersion: string;
-    _npmUser: Person;
-
-    // Non-standard properties from package.json may also appear.
-    [key: string]: unknown;
-}
-
-export type AbbreviatedManifest = Pick<
-    Manifest,
-    | 'name'
-    | 'version'
-    | 'bin'
-    | 'directories'
-    | 'dependencies'
-    | 'devDependencies'
-    | 'peerDependencies'
-    | 'bundledDependencies'
-    | 'optionalDependencies'
-    | 'engines'
-    | 'dist'
-    | 'deprecated'
->;
-
-/**
- * A packument is the top-level package document that lists the set of manifests
- * for available versions for a package.
- *
- * When a packument is fetched with `accept: application/vnd.npm.install-v1+json`
- * in the HTTP headers, only the most minimum necessary metadata is returned.
- * Additional metadata is returned when fetched with only `accept: application/json`.
- */
-export interface Packument extends CommonMetadata {
-    name: string;
-    /**
-     * An object where each key is a version, and each value is the manifest for
-     * that version.
-     */
-    versions: Record<string, Manifest>;
-    /**
-     * An object mapping dist-tags to version numbers. This is how `foo@latest`
-     * gets turned into `foo@1.2.3`.
-     */
-    'dist-tags': { latest: string; } & Record<string, string>;
-    /**
-     * In the full packument, an object mapping version numbers to publication
-     * times, for the `opts.before` functionality.
-     */
-    time: Record<string, string> & {
-        created: string;
-        modified: string;
-    };
-
-    // Non-standard properties may also appear when fullMetadata = true.
-    [key: string]: unknown;
-}
-
-export type AbbreviatedPackument = {
-    versions: Record<string, AbbreviatedManifest>;
-} & Pick<Packument, 'name' | 'dist-tags'>;
 
 export interface FetchResult {
     /**
@@ -278,7 +118,7 @@ export interface PacoteOptions {
      * the manifest, which they memoize on this.package, so it's very cheap
      * already.
      */
-    packumentCache?: Map<string, Packument> | undefined;
+    packumentCache?: Map<string, npm.Packument> | undefined;
 }
 
 export type Options = PacoteOptions & npmFetch.Options;
@@ -302,15 +142,15 @@ export function extract(spec: string, dest?: string, opts?: Options): Promise<Fe
 export function manifest(
     spec: string,
     opts: Options & ({ before: Date } | { fullMetadata: true })
-): Promise<Manifest & ManifestResult>;
-export function manifest(spec: string, opts?: Options): Promise<AbbreviatedManifest & ManifestResult>;
+): Promise<npm.Manifest & ManifestResult>;
+export function manifest(spec: string, opts?: Options): Promise<npm.AbbreviatedManifest & ManifestResult>;
 
 /**
  * Fetch (or simulate) a package's packument (basically, the top-level package
  * document listing all the manifests that the registry returns).
  */
-export function packument(spec: string, opts: Options & { fullMetadata: true }): Promise<Packument>;
-export function packument(spec: string, opts?: Options): Promise<AbbreviatedPackument>;
+export function packument(spec: string, opts: Options & { fullMetadata: true }): Promise<npm.Packument>;
+export function packument(spec: string, opts?: Options): Promise<npm.AbbreviatedPackument>;
 
 /**
  * Get a package tarball data as a buffer in memory.

--- a/types/pacote/index.d.ts
+++ b/types/pacote/index.d.ts
@@ -66,7 +66,7 @@ export interface CommonMetadata {
     homepage?: string | undefined;
     keywords?: string[] | undefined;
     license?: string | undefined;
-    maintainers?: Person[] | undefined;
+    maintainers: Person[];
     readme?: string | undefined;
     readmeFilename?: string | undefined;
     repository?: {
@@ -110,14 +110,30 @@ export interface Manifest extends CommonMetadata {
     publishConfig?: Record<string, unknown> | undefined;
     scripts?: Record<string, string> | undefined;
 
-    _id?: string | undefined;
-    _nodeVersion?: string | undefined;
-    _npmVersion?: string | undefined;
-    _npmUser?: Person | undefined;
+    _id: string;
+    _nodeVersion: string;
+    _npmVersion: string;
+    _npmUser: Person;
 
     // Non-standard properties from package.json may also appear.
     [key: string]: unknown;
 }
+
+export type AbbreviatedManifest = Pick<
+    Manifest,
+    | 'name'
+    | 'version'
+    | 'bin'
+    | 'directories'
+    | 'dependencies'
+    | 'devDependencies'
+    | 'peerDependencies'
+    | 'bundledDependencies'
+    | 'optionalDependencies'
+    | 'engines'
+    | 'dist'
+    | 'deprecated'
+>;
 
 /**
  * A packument is the top-level package document that lists the set of manifests
@@ -143,14 +159,18 @@ export interface Packument extends CommonMetadata {
      * In the full packument, an object mapping version numbers to publication
      * times, for the `opts.before` functionality.
      */
-    time?: Record<string, string> & {
+    time: Record<string, string> & {
         created: string;
         modified: string;
-    } | undefined;
+    };
 
     // Non-standard properties may also appear when fullMetadata = true.
     [key: string]: unknown;
 }
+
+export type AbbreviatedPackument = {
+    versions: Record<string, AbbreviatedManifest>;
+} & Pick<Packument, 'name' | 'dist-tags'>;
 
 export interface FetchResult {
     /**
@@ -167,7 +187,7 @@ export interface FetchResult {
     integrity: string;
 }
 
-export interface ManifestResult extends Manifest {
+export interface ManifestResult {
     /**
      * A normalized form of the spec passed in as an argument.
      */
@@ -279,13 +299,18 @@ export function extract(spec: string, dest?: string, opts?: Options): Promise<Fe
  * Fetch (or simulate) a package's manifest (basically, the `package.json` file,
  * plus a bit of metadata).
  */
-export function manifest(spec: string, opts?: Options): Promise<ManifestResult>;
+export function manifest(
+    spec: string,
+    opts: Options & ({ before: Date } | { fullMetadata: true })
+): Promise<Manifest & ManifestResult>;
+export function manifest(spec: string, opts?: Options): Promise<AbbreviatedManifest & ManifestResult>;
 
 /**
  * Fetch (or simulate) a package's packument (basically, the top-level package
  * document listing all the manifests that the registry returns).
  */
-export function packument(spec: string, opts?: Options): Promise<Packument>;
+export function packument(spec: string, opts: Options & { fullMetadata: true }): Promise<Packument>;
+export function packument(spec: string, opts?: Options): Promise<AbbreviatedPackument>;
 
 /**
  * Get a package tarball data as a buffer in memory.

--- a/types/pacote/package.json
+++ b/types/pacote/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@npm/types": "*"
+  },
+  "private": true
+}

--- a/types/pacote/pacote-tests.ts
+++ b/types/pacote/pacote-tests.ts
@@ -23,11 +23,16 @@ const opts: pacote.Options = {
 pacote.resolve('pacote'); // $ExpectType Promise<string>
 pacote.resolve('pacote', opts); // $ExpectType Promise<string>
 
-pacote.manifest('pacote'); // $ExpectType Promise<ManifestResult>
-pacote.manifest('pacote', opts); // $ExpectType Promise<ManifestResult>
+// tslint:disable-next-line:expect
+pacote.manifest('pacote'); // $ExpectType Promise<AbbreviatedManifest & ManifestResult>
+// tslint:disable-next-line:expect
+pacote.manifest('pacote', opts); // $ExpectType Promise<AbbreviatedManifest & ManifestResult>
+pacote.manifest('pacote', { before: new Date() }); // $ExpectType Promise<Manifest & ManifestResult>
+pacote.manifest('pacote', { fullMetadata: true }); // $ExpectType Promise<Manifest & ManifestResult>
 
-pacote.packument('pacote'); // $ExpectType Promise<Packument>
-pacote.packument('pacote', opts); // $ExpectType Promise<Packument>
+pacote.packument('pacote'); // $ExpectType Promise<AbbreviatedPackument>
+pacote.packument('pacote', opts); // $ExpectType Promise<AbbreviatedPackument>
+pacote.packument('pacote', { fullMetadata: true }); // $ExpectType Promise<Packument>
 
 pacote.extract('pacote', './'); // $ExpectType Promise<FetchResult>
 pacote.extract('pacote', './', opts); // $ExpectType Promise<FetchResult>

--- a/types/pacote/pacote-tests.ts
+++ b/types/pacote/pacote-tests.ts
@@ -1,6 +1,6 @@
+import * as npm from '@npm/types';
 import logger = require('npmlog');
 import pacote = require('pacote');
-import type { Packument } from 'pacote';
 import { Integrity } from 'ssri';
 
 const opts: pacote.Options = {
@@ -17,22 +17,22 @@ const opts: pacote.Options = {
     defaultTag: 'latest',
     registry: 'https://registry.npmjs.org',
     fullMetadata: false,
-    packumentCache: new Map<string, Packument>(),
+    packumentCache: new Map<string, npm.Packument>(),
 };
 
 pacote.resolve('pacote'); // $ExpectType Promise<string>
 pacote.resolve('pacote', opts); // $ExpectType Promise<string>
 
 // tslint:disable-next-line:expect
-pacote.manifest('pacote'); // $ExpectType Promise<AbbreviatedManifest & ManifestResult>
+pacote.manifest('pacote'); // $ExpectType Promise<npm.AbbreviatedManifest & ManifestResult>
 // tslint:disable-next-line:expect
-pacote.manifest('pacote', opts); // $ExpectType Promise<AbbreviatedManifest & ManifestResult>
-pacote.manifest('pacote', { before: new Date() }); // $ExpectType Promise<Manifest & ManifestResult>
-pacote.manifest('pacote', { fullMetadata: true }); // $ExpectType Promise<Manifest & ManifestResult>
+pacote.manifest('pacote', opts); // $ExpectType Promise<npm.AbbreviatedManifest & ManifestResult>
+pacote.manifest('pacote', { before: new Date() }); // $ExpectType Promise<npm.Manifest & ManifestResult>
+pacote.manifest('pacote', { fullMetadata: true }); // $ExpectType Promise<npm.Manifest & ManifestResult>
 
-pacote.packument('pacote'); // $ExpectType Promise<AbbreviatedPackument>
-pacote.packument('pacote', opts); // $ExpectType Promise<AbbreviatedPackument>
-pacote.packument('pacote', { fullMetadata: true }); // $ExpectType Promise<Packument>
+pacote.packument('pacote'); // $ExpectType Promise<npm.AbbreviatedPackument>
+pacote.packument('pacote', opts); // $ExpectType Promise<npm.AbbreviatedPackument>
+pacote.packument('pacote', { fullMetadata: true }); // $ExpectType Promise<npm.Packument>
 
 pacote.extract('pacote', './'); // $ExpectType Promise<FetchResult>
 pacote.extract('pacote', './', opts); // $ExpectType Promise<FetchResult>


### PR DESCRIPTION
The `Manifest` and `Packument` types from [`@npm/types`](https://www.npmjs.com/package/@npm/types) are almost identical to those in `@types/pacote`, so retire our copies and use theirs instead.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).