### PR TITLE
[pacote] Add some result fields

### DIFF
--- a/types/pacote/index.d.ts
+++ b/types/pacote/index.d.ts
@@ -163,9 +163,6 @@ export interface Packument extends CommonMetadata {
         created: string;
         modified: string;
     };
-
-    // Non-standard properties may also appear when fullMetadata = true.
-    [key: string]: unknown;
 }
 
 export type AbbreviatedPackument = {
@@ -200,6 +197,17 @@ export interface ManifestResult {
      * The integrity value for the package artifact.
      */
     _integrity: string;
+    /**
+     * The canonical spec of this package version: name@version.
+     */
+    _id: string;
+}
+
+export interface PackumentResult {
+    /**
+     * The size of the packument.
+     */
+    _contentLength: number;
 }
 
 export interface PacoteOptions {
@@ -309,8 +317,8 @@ export function manifest(spec: string, opts?: Options): Promise<AbbreviatedManif
  * Fetch (or simulate) a package's packument (basically, the top-level package
  * document listing all the manifests that the registry returns).
  */
-export function packument(spec: string, opts: Options & { fullMetadata: true }): Promise<Packument>;
-export function packument(spec: string, opts?: Options): Promise<AbbreviatedPackument>;
+export function packument(spec: string, opts: Options & { fullMetadata: true }): Promise<Packument & PackumentResult>;
+export function packument(spec: string, opts?: Options): Promise<AbbreviatedPackument & PackumentResult>;
 
 /**
  * Get a package tarball data as a buffer in memory.

--- a/types/pacote/pacote-tests.ts
+++ b/types/pacote/pacote-tests.ts
@@ -30,9 +30,11 @@ pacote.manifest('pacote', opts); // $ExpectType Promise<AbbreviatedManifest & Ma
 pacote.manifest('pacote', { before: new Date() }); // $ExpectType Promise<Manifest & ManifestResult>
 pacote.manifest('pacote', { fullMetadata: true }); // $ExpectType Promise<Manifest & ManifestResult>
 
-pacote.packument('pacote'); // $ExpectType Promise<AbbreviatedPackument>
-pacote.packument('pacote', opts); // $ExpectType Promise<AbbreviatedPackument>
-pacote.packument('pacote', { fullMetadata: true }); // $ExpectType Promise<Packument>
+// tslint:disable-next-line:expect
+pacote.packument('pacote'); // $ExpectType Promise<AbbreviatedPackument & PackumentResult>
+// tslint:disable-next-line:expect
+pacote.packument('pacote', opts); // $ExpectType Promise<AbbreviatedPackument & PackumentResult>
+pacote.packument('pacote', { fullMetadata: true }); // $ExpectType Promise<Packument & PackumentResult>
 
 pacote.extract('pacote', './'); // $ExpectType Promise<FetchResult>
 pacote.extract('pacote', './', opts); // $ExpectType Promise<FetchResult>


### PR DESCRIPTION
Add the [`_id`](https://github.com/npm/read-package-json-fast#:~:text=set%20the%20_id%20property%20if%20name%20and%20version%20are%20set.%20(this%20is%20load-bearing%20in%20a%20few%20places%20within%20the%20npm%20cli.)) manifest result field and the [`_cached` and `_contentLength`](https://github.com/npm/pacote/blob/298df450c03af17c069b8e40834d0154e801b61e/lib/registry.js#L77-L78) packument result fields. Like the existing [manifest result fields](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e1d9e43428d461738f146901b15e0c583cc6f849/types/pacote/index.d.ts#L170), they're added by the pacote client vs. the npm registry.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).