### PR TITLE
feat(vue3-openlayers): implement types

### DIFF
--- a/types/vue3-openlayers/index.d.ts
+++ b/types/vue3-openlayers/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for vue3-openlayers 0.1
+// Project: https://github.com/MelihAltintas/vue3-openlayers
+// Definitions by: Pavel Z <https://github.com/R3VoLuT1OneR>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.6
+
+import { App } from 'vue';
+import feature from 'ol/Feature';
+import * as geom from 'ol/geom';
+import * as format from 'ol/format';
+import * as loadingstrategy from 'ol/loadingstrategy';
+import * as selectconditions from 'ol/events/condition';
+import * as extent from 'ol/extent';
+import * as animations from 'ol/easing';
+
+declare module '@vue/runtime-core' {
+    function inject(key: 'ol-feature'): typeof feature;
+    function inject(key: 'ol-geom'): typeof geom;
+    function inject(key: 'ol-animations'): typeof animations;
+    function inject(key: 'ol-format'): typeof format;
+    function inject(key: 'ol-loadingstrategy'): typeof loadingstrategy;
+    function inject(key: 'ol-selectconditions'): typeof selectconditions;
+    function inject(key: 'ol-extent'): typeof extent;
+}
+
+declare function install(app: App): void;
+
+export default install;
+export {
+    install
+};

--- a/types/vue3-openlayers/package.json
+++ b/types/vue3-openlayers/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "vue": "3.2.*",
+        "@babel/types": "*"
+    }
+}

--- a/types/vue3-openlayers/tsconfig.json
+++ b/types/vue3-openlayers/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "vue3-openlayers-tests.ts"
+    ]
+}

--- a/types/vue3-openlayers/tslint.json
+++ b/types/vue3-openlayers/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/vue3-openlayers/vue3-openlayers-tests.ts
+++ b/types/vue3-openlayers/vue3-openlayers-tests.ts
@@ -1,0 +1,13 @@
+import { createApp, inject } from 'vue';
+import vue3lo from 'vue3-openlayers';
+
+const app = createApp({});
+app.use(vue3lo);
+
+inject('ol-feature').length;
+inject('ol-geom').Circle;
+inject('ol-animations').easeIn;
+inject('ol-format').WFS;
+inject('ol-loadingstrategy').all;
+inject('ol-selectconditions').all;
+inject('ol-extent').buffer;


### PR DESCRIPTION
Created type declaration for the [vue3-openlayers](https://www.npmjs.com/package/vue3-openlayers) library.

But tests fail on the external dependencies for Typescript 3.9.
Not sure how do I fix it.
This package 100% on Vue3 so which kind of typescript version it is depends, I need same for this package.

- [ ] [Run `npm test vue3-openlayers`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
