### PR TITLE
feat(aws-lambda): explicitly support both handler types

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -81,7 +81,9 @@ untypedCallback(null, { bar: 123 });
 // $ExpectError
 untypedCallback(null, anyObj, anyObj);
 
-interface TestResult { foo: number; }
+interface TestResult {
+    foo: number;
+}
 declare const typedCallback: AWSLambda.Callback<TestResult>;
 typedCallback();
 typedCallback(undefined);
@@ -142,12 +144,12 @@ const untypedNonAsyncHandler: AWSLambda.NonAsyncHandler = (event, context, cb) =
 };
 
 // The Handler type is the union of the two sub-types
-const nonAsyncIsHandler: AWSLambda.Handler = untypedNonAsyncHandler
-const asyncIsHandler: AWSLambda.Handler = untypedAsyncHandler
+const nonAsyncIsHandler: AWSLambda.Handler = untypedNonAsyncHandler;
+const asyncIsHandler: AWSLambda.Handler = untypedAsyncHandler;
 
 /* In node8.10 runtime, handlers may return a promise for the result value, so existing async
  * handlers that return Promise<void> before calling the callback will now have a `null` result.
- * Be safe and make that badly typed with a major verson bump to 8.10 so users expect the breaking change,
+ * Be safe and make that badly typed with a major version bump to 8.10 so users expect the breaking change,
  * since the upgrade effort should be pretty low in most cases, and it points them at a nicer solution.
  */
 

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -117,15 +117,11 @@ type CustomHandler = AWSLambda.Handler<CustomEvent, CustomResult>;
 type CustomCallback = AWSLambda.Callback<CustomResult>;
 
 // Untyped handlers should work
-const untypedAsyncHandler: AWSLambda.Handler = async (event, context, cb) => {
+const untypedAsyncHandler: AWSLambda.AsyncHandler = async (event, context) => {
     // $ExpectType any
     event;
     // $ExpectType Context
     context;
-    // $ExpectType Callback<any>
-    cb;
-    // Can still use callback
-    cb(null, { resultString: str });
     if (bool) {
         // Uncaught error
         return { resultString: bool };
@@ -133,7 +129,7 @@ const untypedAsyncHandler: AWSLambda.Handler = async (event, context, cb) => {
     return { resultString: str };
 };
 
-const untypedCallbackHandler: AWSLambda.Handler = (event, context, cb) => {
+const untypedNonAsyncHandler: AWSLambda.NonAsyncHandler = (event, context, cb) => {
     // $ExpectType any
     event;
     // $ExpectType Context
@@ -144,6 +140,10 @@ const untypedCallbackHandler: AWSLambda.Handler = (event, context, cb) => {
     // Uncaught error
     cb(null, { resultString: bool });
 };
+
+// The Handler type is the union of the two sub-types
+const nonAsyncIsHandler: AWSLambda.Handler = untypedNonAsyncHandler
+const asyncIsHandler: AWSLambda.Handler = untypedAsyncHandler
 
 /* In node8.10 runtime, handlers may return a promise for the result value, so existing async
  * handlers that return Promise<void> before calling the callback will now have a `null` result.

--- a/types/aws-lambda/handler.d.ts
+++ b/types/aws-lambda/handler.d.ts
@@ -105,7 +105,10 @@ export type AsyncHandler<TEvent = any, TResult = any> = (event: TEvent, context:
  * }
  *
  */
-export type Handler<TEvent = any, TResult = any> = AsyncHandler<TEvent, TResult> | NonAsyncHandler<TEvent, TResult>;
+export type Handler<TEvent = any, TResult = any> =
+    | AsyncHandler<TEvent, TResult>
+    | NonAsyncHandler<TEvent, TResult>
+    | ((event: TEvent, context: Context, callback: Callback<TResult>) => void | Promise<TResult>);
 
 /**
  * {@link Handler} context parameter.


### PR DESCRIPTION
Updates the definition of the Handler type to be the union of the two invocation paths in AWS Lambda: Async and Non-Async

This change will prevent users of this library from having to provide an unusued `callback` parameter and handle `void` returns in Async handlers.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

