### PR TITLE
fix private RouterDSL contructor type

### DIFF
--- a/types/ember__routing/-private/router-dsl.d.ts
+++ b/types/ember__routing/-private/router-dsl.d.ts
@@ -1,5 +1,5 @@
 export default class RouterDSL {
-    constructor(name: string, options: object);
+    constructor(name: string | null, options: object);
     route(name: string, callback: (this: RouterDSL) => void): void;
     route(
         name: string,

--- a/types/ember__routing/v3/-private/router-dsl.d.ts
+++ b/types/ember__routing/v3/-private/router-dsl.d.ts
@@ -1,5 +1,5 @@
 export default class RouterDSL {
-    constructor(name: string, options: object);
+    constructor(name: string | null, options: object);
     route(name: string, callback: (this: RouterDSL) => void): void;
     route(
         name: string,


### PR DESCRIPTION
The private types for the private RouterDSL class constructor were just slightly incorrect: the constructor allows you to pass in `null` to the `name` field, and it does not need to be a string.

https://github.com/emberjs/ember.js/blob/master/packages/%40ember/-internals/routing/lib/system/dsl.ts#L57

there were no existing tests for this, presumably because it is private API? I am happy to add some but not sure what the standard is for typing private API 😄 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/blob/master/packages/%40ember/-internals/routing/lib/system/dsl.ts#L57
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

