### PR TITLE
[jest] remove done.fail

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -376,7 +376,6 @@ declare namespace jest {
 
     interface DoneCallback {
         (...args: any[]): any;
-        fail(error?: string | { message: string }): any;
     }
 
     type ProvidesCallback = ((cb: DoneCallback) => void | undefined) | (() => Promise<unknown>);


### PR DESCRIPTION
Removing `done.fail` from the Jest types as it is no longer supported or included in their documentation.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/facebook/jest/issues/11780](https://github.com/facebook/jest/issues/11780#issuecomment-1056386158)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

