### PR TITLE
define properties on Panorama

### DIFF
--- a/types/navermaps/index.d.ts
+++ b/types/navermaps/index.d.ts
@@ -1079,6 +1079,8 @@ declare namespace naver.maps {
     }
     class Panorama extends KVO {
         constructor(panoramaDiv: string | HTMLElement, panoramaOptions: PanoramaOptions);
+        aroundControl: AroundControl | null;
+        controls: KVOArray[];
         getLocation(): PanoramaLocation;
         getMaxScale(): number;
         getMaxZoom(): number;

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -243,6 +243,6 @@ const panoramaOptions = {
 
 const pano = new naver.maps.Panorama('pano', panoramaOptions);
 if (pano.aroundControl) {
-    pano.aroundControl.getElement()
+    pano.aroundControl.getElement();
 }
 pano.controls[0].clear();

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -242,3 +242,7 @@ const panoramaOptions = {
 };
 
 const pano = new naver.maps.Panorama('pano', panoramaOptions);
+if (pano.aroundControl) {
+    pano.aroundControl.getElement()
+}
+pano.controls[0].clear();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Panorama Class has some properties not documented, 
![image](https://user-images.githubusercontent.com/16171447/170622792-ea88f078-c284-4477-a20a-f0cfef1bbbb3.png)

This PR define some properties below on Panorama,
`aroundControl: aroundControl | null`
`controls: KVOArray[]`

aroundControl property is needed to access AroundControl Class.