### PR TITLE
Leaflet.markercluster: Add missing cluster options

### DIFF
--- a/types/leaflet.markercluster/index.d.ts
+++ b/types/leaflet.markercluster/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Leaflet.markercluster 1.6
+// Type definitions for Leaflet.markercluster 1.5
 // Project: https://github.com/Leaflet/Leaflet.markercluster
 // Definitions by: Robert Imig <https://github.com/rimig>, Nenad Filipovic <https://github.com/nenadfilipovic>, Yaroslav Kormushyn <https://github.com/YaroslavKormushyn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/leaflet.markercluster/index.d.ts
+++ b/types/leaflet.markercluster/index.d.ts
@@ -40,6 +40,37 @@ declare module 'leaflet' {
     }
 
     interface MarkerClusterGroupOptions extends LayerOptions {
+
+        /*
+        * The maximum radius that a cluster will cover from the central marker (in pixels). Default 80.
+        * Decreasing will make more, smaller clusters. You can also use a function that accepts
+        * the current map zoom and returns the maximum cluster radius in pixels
+        */
+        maxClusterRadius?: number | ((zoom: number) => number) | undefined;
+
+        /*
+        * Function used to create the cluster icon
+        */
+        iconCreateFunction?: ((cluster: MarkerCluster) => Icon | DivIcon) | undefined;
+
+        /*
+        * Map pane where the cluster icons will be added.
+        * Defaults to L.Marker's default (currently 'markerPane')
+        */
+        clusterPane?: string | undefined;
+
+        /*
+        * When you click a cluster at any zoom level we spiderfy it
+        * so you can see all of its markers.
+        */
+        spiderfyOnEveryZoom?: boolean | undefined;
+
+        /*
+        * When you click a cluster at the bottom zoom level we spiderfy it
+        * so you can see all of its markers.
+        */
+        spiderfyOnMaxZoom?: boolean | undefined;
+
         /*
         * When you mouse over a cluster it shows the bounds of its markers.
         */
@@ -51,10 +82,14 @@ declare module 'leaflet' {
         zoomToBoundsOnClick?: boolean | undefined;
 
         /*
-        * When you click a cluster at the bottom zoom level we spiderfy it
-        * so you can see all of its markers.
+        * If set to true, overrides the icon for all added markers to make them appear as a 1 size cluster.
         */
-        spiderfyOnMaxZoom?: boolean | undefined;
+        singleMarkerMode?: boolean | undefined;
+
+        /*
+        * If set, at this zoom level and below markers will not be clustered. This defaults to disabled.
+        */
+        disableClusteringAtZoom?: number | undefined;
 
         /*
         * Clusters and markers too far from the viewport are removed from the map
@@ -77,33 +112,9 @@ declare module 'leaflet' {
         animateAddingMarkers?: boolean | undefined;
 
         /*
-        * If set, at this zoom level and below markers will not be clustered. This defaults to disabled.
+        * Custom function to calculate spiderfy shape positions
         */
-        disableClusteringAtZoom?: number | undefined;
-
-        /*
-        * The maximum radius that a cluster will cover from the central marker (in pixels). Default 80.
-        * Decreasing will make more, smaller clusters. You can also use a function that accepts
-        * the current map zoom and returns the maximum cluster radius in pixels
-        */
-        maxClusterRadius?: number | ((zoom: number) => number) | undefined;
-
-        /*
-        * Options to pass when creating the L.Polygon(points, options) to show the bounds of a cluster.
-        * Defaults to empty
-        */
-        polygonOptions?: PolylineOptions | undefined;
-
-        /*
-        * If set to true, overrides the icon for all added markers to make them appear as a 1 size cluster.
-        */
-        singleMarkerMode?: boolean | undefined;
-
-        /*
-        * Allows you to specify PolylineOptions to style spider legs.
-        * By default, they are { weight: 1.5, color: '#222', opacity: 0.5 }.
-        */
-        spiderLegPolylineOptions?: PolylineOptions | undefined;
+        spiderfyShapePositions: ((count: number, centerPoint: Point) => Point[]) | undefined,
 
         /*
         * Increase from 1 to increase the distance away from the center that spiderfied markers are placed.
@@ -112,15 +123,10 @@ declare module 'leaflet' {
         spiderfyDistanceMultiplier?: number | undefined;
 
         /*
-        * Function used to create the cluster icon
+        * Allows you to specify PolylineOptions to style spider legs.
+        * By default, they are { weight: 1.5, color: '#222', opacity: 0.5 }.
         */
-        iconCreateFunction?: ((cluster: MarkerCluster) => Icon | DivIcon) | undefined;
-
-        /*
-        * Map pane where the cluster icons will be added.
-        * Defaults to L.Marker's default (currently 'markerPane')
-         */
-        clusterPane?: string | undefined;
+        spiderLegPolylineOptions?: PolylineOptions | undefined;
 
         /*
         * Boolean to split the addLayers processing in to small intervals so that the page does not freeze.
@@ -143,6 +149,12 @@ declare module 'leaflet' {
         * Typically used to implement a progress indicator. Defaults to null.
         */
         chunkProgress?: ((processedMarkers: number, totalMarkers: number, elapsedTime: number) => void) | undefined;
+
+        /*
+        * Options to pass when creating the L.Polygon(points, options) to show the bounds of a cluster.
+        * Defaults to empty
+        */
+        polygonOptions?: PolylineOptions | undefined;
     }
 
     /*

--- a/types/leaflet.markercluster/index.d.ts
+++ b/types/leaflet.markercluster/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Leaflet.markercluster 1.5.1
+// Type definitions for Leaflet.markercluster 1.6
 // Project: https://github.com/Leaflet/Leaflet.markercluster
 // Definitions by: Robert Imig <https://github.com/rimig>, Nenad Filipovic <https://github.com/nenadfilipovic>, Yaroslav Kormushyn <https://github.com/YaroslavKormushyn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -40,7 +40,6 @@ declare module 'leaflet' {
     }
 
     interface MarkerClusterGroupOptions extends LayerOptions {
-
         /*
         * The maximum radius that a cluster will cover from the central marker (in pixels). Default 80.
         * Decreasing will make more, smaller clusters. You can also use a function that accepts
@@ -114,7 +113,7 @@ declare module 'leaflet' {
         /*
         * Custom function to calculate spiderfy shape positions
         */
-        spiderfyShapePositions: ((count: number, centerPoint: Point) => Point[]) | undefined,
+        spiderfyShapePositions?: ((count: number, centerPoint: Point) => Point[]) | undefined;
 
         /*
         * Increase from 1 to increase the distance away from the center that spiderfied markers are placed.

--- a/types/leaflet.markercluster/index.d.ts
+++ b/types/leaflet.markercluster/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Leaflet.markercluster 1.5
+// Type definitions for Leaflet.markercluster 1.5.1
 // Project: https://github.com/Leaflet/Leaflet.markercluster
 // Definitions by: Robert Imig <https://github.com/rimig>, Nenad Filipovic <https://github.com/nenadfilipovic>, Yaroslav Kormushyn <https://github.com/YaroslavKormushyn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/leaflet.markercluster/leaflet.markercluster-tests.ts
+++ b/types/leaflet.markercluster/leaflet.markercluster-tests.ts
@@ -7,6 +7,7 @@ const icon: L.Icon = L.icon({ iconUrl: 'foo' });
 
 let markerClusterGroupOptions: L.MarkerClusterGroupOptions = {};
 markerClusterGroupOptions = {
+    spiderfyOnEveryZoom: true,
     showCoverageOnHover: true,
     zoomToBoundsOnClick: false,
     spiderfyOnMaxZoom: true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source](https://github.com/Leaflet/Leaflet.markercluster/blob/31360f226e1a40c03c71d68b016891beb5e63370/src/MarkerClusterGroup.js#L7)
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I cannot bump the version of the DT package with patch versions, so it stays on 1.5 as the npm package does.