### PR TITLE
Add missing helper to `@types/prettier`

### DIFF
--- a/types/prettier/doc.d.ts
+++ b/types/prettier/doc.d.ts
@@ -218,4 +218,5 @@ export namespace utils {
         shouldTraverseConditionalGroups?: boolean,
     ): void;
     function willBreak(doc: Doc): boolean;
+    function canBreak(doc: Doc): boolean;
 }


### PR DESCRIPTION
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/prettier/prettier/blob/a0898192234c82ec320476f30423e2ff837e7915/src/document/doc-utils.js#L430
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
