### PR TITLE
[libnpmpublish] Accepts a parsed package.json

### DIFF
--- a/types/libnpmpublish/index.d.ts
+++ b/types/libnpmpublish/index.d.ts
@@ -4,11 +4,9 @@
 //                 Guy Adler <https://github.com/Guy-Adler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="node" />
-
+import { PackageJson } from "@npm/types";
 import fetch = require("npm-registry-fetch");
 import { Response } from "node-fetch";
-import { Manifest } from "pacote";
 
 /**
  * Sends the package represented by the manifest and tarData to the configured registry.
@@ -26,7 +24,7 @@ import { Manifest } from "pacote";
  * await libpub.publish(manifest, tarData, { npmVersion: 'my-pub-script@1.0.2', token: 'my-auth-token-here' }, opts)
  * // Package has been published to the npm registry.
  */
-export function publish(manifest: Manifest, tarballData: Buffer, options?: fetch.Options): Promise<Response>;
+export function publish(manifest: PackageJson, tarballData: Buffer, options?: fetch.Options): Promise<Response>;
 
 /**
  * Unpublishes spec from the appropriate registry. The registry in question may have its own limitations on unpublishing.

--- a/types/libnpmpublish/libnpmpublish-tests.ts
+++ b/types/libnpmpublish/libnpmpublish-tests.ts
@@ -1,6 +1,6 @@
+import { PackageJson } from "@npm/types";
 import libnpmpublish = require("libnpmpublish");
 import fetch = require("npm-registry-fetch");
-import { Manifest } from "pacote";
 
 async function test() {
     // declare variables to be used
@@ -19,14 +19,11 @@ async function test() {
         fetchRetryMintimeout: 20000,
         fetchRetryMaxtimeout: 50000,
         agent: undefined,
-        body: "bodyhere"
+        body: "bodyhere",
     };
-    const manifest: Manifest = {
+    const manifest: PackageJson = {
         name: "",
         version: "",
-        dist: {
-            tarball: ""
-        }
     };
     const tarballData: Buffer = Buffer.from("thisisafillerforthebuffertowork");
     // test param requirements and return values

--- a/types/libnpmpublish/package.json
+++ b/types/libnpmpublish/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@npm/types": "*"
+  },
+  "private": true
+}


### PR DESCRIPTION
One half of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60433#issuecomment-1140102155. The `Manifest` type requires a `dist` field that libnpmpublish doesn't: Its argument [can be a parsed package.json](https://github.com/npm/cli/tree/latest/workspaces/libnpmpublish#:~:text=manifest%20should%20be%20the%20parsed%20package.json%20for%20the%20package%20being%20published%20(which%20can%20also%20be%20the%20manifest%20pulled%20from%20a%20packument%2C%20a%20git%20repo%2C%20tarball%2C%20etc.)).

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60433#issuecomment-1140086080 makes additional `Manifest` fields required (the `time` field, etc.), which makes the difference between `Manifest` and `PackageJson` more noticeable.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).