### PR TITLE
[react] Remove `timeoutMs` mentions from JSDoc

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1117,7 +1117,7 @@ declare namespace React {
     }
 
     /**
-     * Returns a deferred version of the value that may “lag behind” it for at most `timeoutMs`.
+     * Returns a deferred version of the value that may “lag behind” it.
      *
      * This is commonly used to keep the interface responsive when you have something that renders immediately
      * based on user input and something that needs to wait for a data fetch.
@@ -1141,9 +1141,7 @@ declare namespace React {
      * The first is a boolean, React’s way of informing us whether we’re waiting for the transition to finish.
      * The second is a function that takes a callback. We can use it to tell React which state we want to defer.
      *
-     * **If some state update causes a component to suspend, that state update should be wrapped in a transition.**
-     *
-     * @param config An optional object with `timeoutMs`
+     * **If some state update causes a component to suspend, that state update should be wrapped in a transition.**`
      *
      * @see https://reactjs.org/docs/concurrent-mode-reference.html#usetransition
      */


### PR DESCRIPTION
Related discussion: #60564

The `timeoutMs` parameter doesn't exist any more as of facebook/react#19703

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test react`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - <https://reactjs.org/docs/hooks-reference.html#usedeferredvalue>
  - <https://reactjs.org/docs/hooks-reference.html#usetransition>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
