### PR TITLE
Add node-midi (just 'midi' on npm) type declarations

### DIFF
--- a/types/midi/index.d.ts
+++ b/types/midi/index.d.ts
@@ -30,8 +30,6 @@ export class Input extends EventEmitter {
    * input.ignoreTypes(true, false, true)
    */
   ignoreTypes(sysex: boolean, timing: boolean, activeSensing: boolean): void;
-  /** Check if the port is open */
-  isPortOpen(): boolean;
   /** Open the specified input port */
   openPort(port: number): void;
   /**
@@ -52,8 +50,6 @@ export class Output {
   getPortCount(): number;
   /** Get the name of a specified output port */
   getPortName(port: number): string;
-  /** Check if the port is open */
-  isPortOpen(): boolean;
   /** Open the specified output port */
   openPort(port: number): void;
   /**

--- a/types/midi/index.d.ts
+++ b/types/midi/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for midi x.x
+// Project: https://github.com/baz/foo (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
+// Definitions by: Matthew Soulanille <https://github.com/mattsoulanille>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+declare module 'midi' {
+  export class Input extends EventEmitter {
+    closePort(): void;
+    getPortCount(): number;
+    getPortName(port: number): string;
+    ignoreTypes(sysex: boolean, timing: boolean, activeSensing: boolean): void;
+    isPortOpen(): boolean;
+    openPort(port: number): void;
+    openVirtualPort(port: string): void;
+  }
+
+  export class Output {
+    closePort(): void;
+    getPortCount(): number;
+    getPortName(port: number): string;
+    isPortOpen(): boolean;
+    openPort(port: number): void;
+    openVirtualPort(port: string): void;
+    send(message: [number, ...number[]]): void;
+    sendMessage(message: [number, ...number[]]): void;
+  }
+
+  export const input: {new(): Input};
+  export const output: {new(): Output};
+
+  export function createReadStream(input?: Input): Stream;
+
+  export function createWriteStream(output?: Output): Stream;
+}

--- a/types/midi/index.d.ts
+++ b/types/midi/index.d.ts
@@ -1,35 +1,55 @@
-// Type definitions for midi x.x
-// Project: https://github.com/baz/foo (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
+// Type definitions for midi 2.0
+// Project: https://github.com/justinlatimer/node-midi (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
 // Definitions by: Matthew Soulanille <https://github.com/mattsoulanille>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-declare module 'midi' {
-  export class Input extends EventEmitter {
-    closePort(): void;
-    getPortCount(): number;
-    getPortName(port: number): string;
-    ignoreTypes(sysex: boolean, timing: boolean, activeSensing: boolean): void;
-    isPortOpen(): boolean;
-    openPort(port: number): void;
-    openVirtualPort(port: string): void;
-  }
 
-  export class Output {
-    closePort(): void;
-    getPortCount(): number;
-    getPortName(port: number): string;
-    isPortOpen(): boolean;
-    openPort(port: number): void;
-    openVirtualPort(port: string): void;
-    send(message: [number, ...number[]]): void;
-    sendMessage(message: [number, ...number[]]): void;
-  }
+import * as Stream from 'stream';
+import * as EventEmitter from 'events';
 
-  export const input: {new(): Input};
-  export const output: {new(): Output};
-
-  export function createReadStream(input?: Input): Stream;
-
-  export function createWriteStream(output?: Output): Stream;
+export class Input extends EventEmitter {
+  /** Close the midi port */
+  closePort(): void;
+  /** Count the available input ports */
+  getPortCount(): number;
+  /** Get the name of a specified input port */
+  getPortName(port: number): string;
+  /**
+   * Sysex, timing, and active sensing messages are ignored by default. To
+   * enable these message types, pass false for the appropriate type in the
+   * function below.  Order: (Sysex, Timing, Active Sensing) For example if you
+   * want to receive only MIDI Clock beats you should use
+   * input.ignoreTypes(true, false, true)
+   */
+  ignoreTypes(sysex: boolean, timing: boolean, activeSensing: boolean): void;
+  /** Check if the port is open */
+  isPortOpen(): boolean;
+  /** Open the first available input port */
+  openPort(port: number): void;
+  /**
+   * Instead of opening a connection to an existing MIDI device, on Mac OS X and
+   * Linux with ALSA you can create a virtual device that other software may
+   * connect to. This can be done simply by calling openVirtualPort(portName)
+   * instead of openPort(portNumber).
+   */
+  openVirtualPort(port: string): void;
 }
+
+export class Output {
+  closePort(): void;
+  getPortCount(): number;
+  getPortName(port: number): string;
+  isPortOpen(): boolean;
+  openPort(port: number): void;
+  openVirtualPort(port: string): void;
+  send(message: [number, ...number[]]): void;
+  sendMessage(message: [number, ...number[]]): void;
+}
+
+export const input: {new(): Input};
+export const output: {new(): Output};
+
+export function createReadStream(input?: Input): Stream;
+
+export function createWriteStream(output?: Output): Stream;

--- a/types/midi/index.d.ts
+++ b/types/midi/index.d.ts
@@ -66,9 +66,9 @@ export class Output {
 }
 
 /** @deprecated */
-export const input: { new (): Input };
+export const input: typeof Input;
 /** @deprecated */
-export const output: { new (): Output };
+export const output: typeof Output;
 
 export function createReadStream(input?: Input): Stream;
 

--- a/types/midi/index.d.ts
+++ b/types/midi/index.d.ts
@@ -8,6 +8,13 @@
 import * as Stream from 'stream';
 import * as EventEmitter from 'events';
 
+/**
+ * An array of numbers corresponding to the MIDI bytes: [status, data1, data2].
+ * See https://www.cs.cf.ac.uk/Dave/Multimedia/node158.html for more info.
+ */
+export type MidiMessage = [number, number, number];
+export type MidiCallback = (deltaTime: number, message: MidiMessage) => void;
+
 export class Input extends EventEmitter {
   /** Close the midi port */
   closePort(): void;
@@ -25,7 +32,7 @@ export class Input extends EventEmitter {
   ignoreTypes(sysex: boolean, timing: boolean, activeSensing: boolean): void;
   /** Check if the port is open */
   isPortOpen(): boolean;
-  /** Open the first available input port */
+  /** Open the specified input port */
   openPort(port: number): void;
   /**
    * Instead of opening a connection to an existing MIDI device, on Mac OS X and
@@ -34,20 +41,37 @@ export class Input extends EventEmitter {
    * instead of openPort(portNumber).
    */
   openVirtualPort(port: string): void;
+
+  on(event: 'message', callback: MidiCallback): this;
 }
 
 export class Output {
+  /** Close the midi port */
   closePort(): void;
+  /** Count the available output ports */
   getPortCount(): number;
+  /** Get the name of a specified output port */
   getPortName(port: number): string;
+  /** Check if the port is open */
   isPortOpen(): boolean;
+  /** Open the specified output port */
   openPort(port: number): void;
+  /**
+   * Instead of opening a connection to an existing MIDI device, on Mac OS X and
+   * Linux with ALSA you can create a virtual device that other software may
+   * connect to. This can be done simply by calling openVirtualPort(portName)
+   * instead of openPort(portNumber).
+   */
   openVirtualPort(port: string): void;
-  send(message: number[]): void;
-  sendMessage(message: number[]): void;
+  /** Send a MIDI message */
+  send(message: MidiMessage): void;
+  /** Send a MIDI message */
+  sendMessage(message: MidiMessage): void;
 }
 
+/** @deprecated */
 export const input: {new(): Input};
+/** @deprecated */
 export const output: {new(): Output};
 
 export function createReadStream(input?: Input): Stream;

--- a/types/midi/index.d.ts
+++ b/types/midi/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for midi 2.0
-// Project: https://github.com/justinlatimer/node-midi (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
+// Project: https://github.com/justinlatimer/node-midi
 // Definitions by: Matthew Soulanille <https://github.com/mattsoulanille>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/midi/index.d.ts
+++ b/types/midi/index.d.ts
@@ -43,8 +43,8 @@ export class Output {
   isPortOpen(): boolean;
   openPort(port: number): void;
   openVirtualPort(port: string): void;
-  send(message: [number, ...number[]]): void;
-  sendMessage(message: [number, ...number[]]): void;
+  send(message: number[]): void;
+  sendMessage(message: number[]): void;
 }
 
 export const input: {new(): Input};

--- a/types/midi/index.d.ts
+++ b/types/midi/index.d.ts
@@ -16,59 +16,59 @@ export type MidiMessage = [number, number, number];
 export type MidiCallback = (deltaTime: number, message: MidiMessage) => void;
 
 export class Input extends EventEmitter {
-  /** Close the midi port */
-  closePort(): void;
-  /** Count the available input ports */
-  getPortCount(): number;
-  /** Get the name of a specified input port */
-  getPortName(port: number): string;
-  /**
-   * Sysex, timing, and active sensing messages are ignored by default. To
-   * enable these message types, pass false for the appropriate type in the
-   * function below.  Order: (Sysex, Timing, Active Sensing) For example if you
-   * want to receive only MIDI Clock beats you should use
-   * input.ignoreTypes(true, false, true)
-   */
-  ignoreTypes(sysex: boolean, timing: boolean, activeSensing: boolean): void;
-  /** Open the specified input port */
-  openPort(port: number): void;
-  /**
-   * Instead of opening a connection to an existing MIDI device, on Mac OS X and
-   * Linux with ALSA you can create a virtual device that other software may
-   * connect to. This can be done simply by calling openVirtualPort(portName)
-   * instead of openPort(portNumber).
-   */
-  openVirtualPort(port: string): void;
+    /** Close the midi port */
+    closePort(): void;
+    /** Count the available input ports */
+    getPortCount(): number;
+    /** Get the name of a specified input port */
+    getPortName(port: number): string;
+    /**
+     * Sysex, timing, and active sensing messages are ignored by default. To
+     * enable these message types, pass false for the appropriate type in the
+     * function below.  Order: (Sysex, Timing, Active Sensing) For example if
+     * you want to receive only MIDI Clock beats you should use
+     * input.ignoreTypes(true, false, true)
+     */
+    ignoreTypes(sysex: boolean, timing: boolean, activeSensing: boolean): void;
+    /** Open the specified input port */
+    openPort(port: number): void;
+    /**
+     * Instead of opening a connection to an existing MIDI device, on Mac OS X
+     * and Linux with ALSA you can create a virtual device that other software
+     * may connect to. This can be done simply by calling
+     * openVirtualPort(portName) instead of openPort(portNumber).
+     */
+    openVirtualPort(port: string): void;
 
-  on(event: 'message', callback: MidiCallback): this;
+    on(event: 'message', callback: MidiCallback): this;
 }
 
 export class Output {
-  /** Close the midi port */
-  closePort(): void;
-  /** Count the available output ports */
-  getPortCount(): number;
-  /** Get the name of a specified output port */
-  getPortName(port: number): string;
-  /** Open the specified output port */
-  openPort(port: number): void;
-  /**
-   * Instead of opening a connection to an existing MIDI device, on Mac OS X and
-   * Linux with ALSA you can create a virtual device that other software may
-   * connect to. This can be done simply by calling openVirtualPort(portName)
-   * instead of openPort(portNumber).
-   */
-  openVirtualPort(port: string): void;
-  /** Send a MIDI message */
-  send(message: MidiMessage): void;
-  /** Send a MIDI message */
-  sendMessage(message: MidiMessage): void;
+    /** Close the midi port */
+    closePort(): void;
+    /** Count the available output ports */
+    getPortCount(): number;
+    /** Get the name of a specified output port */
+    getPortName(port: number): string;
+    /** Open the specified output port */
+    openPort(port: number): void;
+    /**
+     * Instead of opening a connection to an existing MIDI device, on Mac OS X
+     * and Linux with ALSA you can create a virtual device that other software
+     * may connect to. This can be done simply by calling
+     * openVirtualPort(portName) instead of openPort(portNumber).
+     */
+    openVirtualPort(port: string): void;
+    /** Send a MIDI message */
+    send(message: MidiMessage): void;
+    /** Send a MIDI message */
+    sendMessage(message: MidiMessage): void;
 }
 
 /** @deprecated */
-export const input: {new(): Input};
+export const input: { new (): Input };
 /** @deprecated */
-export const output: {new(): Output};
+export const output: { new (): Output };
 
 export function createReadStream(input?: Input): Stream;
 

--- a/types/midi/midi-tests.ts
+++ b/types/midi/midi-tests.ts
@@ -20,11 +20,11 @@ input.openVirtualPort('hello'); // $ExpectType void
 input.emit('test');
 
 input.on('message', (deltaTime, message) => {
-  const [a, b, c] = message;
-  a; // $ExpectType number
-  b; // $ExpectType number
-  c; // $ExpectType number
-  deltaTime; // $ExpectType number
+    const [a, b, c] = message;
+    a; // $ExpectType number
+    b; // $ExpectType number
+    c; // $ExpectType number
+    deltaTime; // $ExpectType number
 });
 
 // create a readable stream

--- a/types/midi/midi-tests.ts
+++ b/types/midi/midi-tests.ts
@@ -13,7 +13,6 @@ input.closePort(); // $ExpectType void
 input.getPortCount(); // $ExpectType number
 input.getPortName(123); // $ExpectType string
 input.ignoreTypes(true, false, true); // $ExpectType void
-input.isPortOpen(); // $ExpectType boolean
 input.openPort(321); // $ExpectType void
 input.openVirtualPort('hello'); // $ExpectType void
 
@@ -38,7 +37,6 @@ const output = new midi.Output();
 output.closePort(); // $ExpectType void
 output.getPortCount(); // $ExpectType number
 output.getPortName(123); // $ExpectType string
-output.isPortOpen(); // $ExpectType boolean
 output.openPort(321); // $ExpectType void
 output.openVirtualPort('hello'); // $ExpectType void
 output.send([1]); // $ExpectError

--- a/types/midi/midi-tests.ts
+++ b/types/midi/midi-tests.ts
@@ -1,0 +1,47 @@
+import * as midi from 'midi';
+import * as fs from 'fs';
+
+new midi.Input(); // $ExpectType Input
+new midi.Output(); // $ExpectType Output
+
+// Legacy constructors
+new midi.input(); // $ExpectType Input
+new midi.output(); // $ExpectType Output
+
+const input = new midi.Input();
+input.closePort(); // $ExpectType void
+input.getPortCount(); // $ExpectType number
+input.getPortName(123); // $ExpectType string
+input.ignoreTypes(true, false, true); // $ExpectType void
+input.isPortOpen(); // $ExpectType boolean
+input.openPort(321); // $ExpectType void
+input.openVirtualPort('hello'); // $ExpectType void
+
+// Input extends node's EventEmitter
+input.emit('test');
+
+input.on('message', (deltaTime, message) => {
+  const [a, b, c] = message;
+  a; // $ExpectType number
+  b; // $ExpectType number
+  c; // $ExpectType number
+  deltaTime; // $ExpectType number
+});
+
+// create a readable stream
+midi.createReadStream(); // $ExpectType internal
+// createReadStream also accepts an optional `input` param
+const readStream = midi.createReadStream(input); // $ExpectType internal
+readStream.pipe(fs.createWriteStream('something.bin'));
+
+const output = new midi.Output();
+output.closePort(); // $ExpectType void
+output.getPortCount(); // $ExpectType number
+output.getPortName(123); // $ExpectType string
+output.isPortOpen(); // $ExpectType boolean
+output.openPort(321); // $ExpectType void
+output.openVirtualPort('hello'); // $ExpectType void
+output.send([1]); // $ExpectError
+output.send([1, 2, 3]); // $ExpectType void
+output.sendMessage([]); // $ExpectError
+output.sendMessage([3, 2, 1]); // $ExpectType void

--- a/types/midi/tsconfig.json
+++ b/types/midi/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "midi-tests.ts"
+    ]
+}

--- a/types/midi/tslint.json
+++ b/types/midi/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/midi/tslint.json
+++ b/types/midi/tslint.json
@@ -1,1 +1,1 @@
-{ "extends": "dtslint/dt.json" }
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Add type declarations for [node-midi](https://github.com/justinlatimer/node-midi), which is published to npm as [midi](https://www.npmjs.com/package/midi).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.