### PR TITLE
MatchSelector (xpath) object support for expect-puppeteer

### DIFF
--- a/types/expect-puppeteer/expect-puppeteer-tests.ts
+++ b/types/expect-puppeteer/expect-puppeteer-tests.ts
@@ -2,6 +2,8 @@ import { ElementHandle, Page } from "puppeteer";
 import { getDefaultOptions, setDefaultOptions } from 'expect-puppeteer';
 
 const testGlobal = async (instance: ElementHandle | Page) => {
+    await expect(instance).toClick({ type: 'css', value: 'selector' });
+    await expect(instance).toClick({ type: 'xpath', value: 'selector' });
     await expect(instance).toClick("selector");
     await expect(instance).toClick("selector", { text: "text" });
     await expect(instance).toClick("selector", { button: "left" });
@@ -13,9 +15,13 @@ const testGlobal = async (instance: ElementHandle | Page) => {
     const dialog = await expect(instance).toDisplayDialog(async () => {});
     console.log(dialog.message());
 
+    await expect(instance).toFill({ type: 'css', value: 'selector' }, 'value');
+    await expect(instance).toFill({ type: 'xpath', value: 'selector' }, 'value');
     await expect(instance).toFill("selector", "value");
     await expect(instance).toFill("selector", "value", { delay: 777 });
 
+    await expect(instance).toFillForm({ type: 'css', value: 'selector' }, { foo: 'bar', baz: 123 });
+    await expect(instance).toFillForm({ type: 'xpath', value: 'selector' }, { foo: 'bar', baz: 123 });
     await expect(instance).toFillForm("selector", { foo: 'bar', baz: 123 });
     await expect(instance).toFillForm("selector", { foo: 'bar', baz: 123 }, { delay: 777 });
 
@@ -28,13 +34,19 @@ const testGlobal = async (instance: ElementHandle | Page) => {
     await expect(instance).toMatch(/some_regexp/, { polling: "raf", timeout: 777 });
     await expect(instance).toMatch(/some_regexp/, { polling: "mutation", timeout: 777 });
 
+    await expect(instance).toMatchElement({ type: 'css', value: 'selector' });
+    await expect(instance).toMatchElement({ type: 'xpath', value: 'selector' });
     await expect(instance).toMatchElement("selector");
     await expect(instance).toMatchElement("selector", { polling: "raf", timeout: 777 });
     await expect(instance).toMatchElement("selector", { polling: "mutation", text: "text" });
     await expect(instance).toMatchElement("selector", { polling: "raf", visible: true });
 
+    await expect(instance).toSelect({ type: 'css', value: 'selector' }, 'valueOrText');
+    await expect(instance).toSelect({ type: 'xpath', value: 'selector' }, 'valueOrText');
     await expect(instance).toSelect("selector", "valueOrText");
 
+    await expect(instance).toUploadFile({ type: 'css', value: 'selector' }, 'filePath');
+    await expect(instance).toUploadFile({ type: 'xpath', value: 'selector' }, 'filePath');
     await expect(instance).toUploadFile("selector", "filePath");
     await expect(instance).toUploadFile("selector", "filePath", { timeout: 777 });
 

--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for expect-puppeteer 4.4
+// Type definitions for expect-puppeteer 5.0
 // Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Jason Mong <https://github.com/jfm710>
@@ -13,6 +13,18 @@ import { ElementHandle, Page, Dialog } from "puppeteer";
  * Interval at which pageFunctions may be executed.
  */
 type ExpectPolling = number | "mutation" | "raf";
+
+interface MatchSelector {
+    /**
+     * A selector type
+     */
+    type: 'css' | 'xpath';
+
+    /**
+     * The selector string
+     */
+    value: string;
+}
 
 /**
  * Default options that apply to all expectations and can be set globally
@@ -69,13 +81,13 @@ interface ExpectToClickOptions extends ExpectTimingActions {
 interface ExpectPuppeteer {
     // These must all match the ExpectPuppeteer interface above.
     // We can't extend from it directly because some method names conflict in type-incompatible ways.
-    toClick(selector: string, options?: ExpectToClickOptions): Promise<void>;
+    toClick(selector: string | MatchSelector, options?: ExpectToClickOptions): Promise<void>;
     toDisplayDialog(block: () => Promise<void>): Promise<Dialog>;
-    toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
-    toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
-    toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<void>;
-    toSelect(selector: string, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
-    toUploadFile(selector: string, filePath: string, options?: ExpectTimingActions): Promise<void>;
+    toFill(selector: string | MatchSelector, value: string, options?: ExpectTimingActions): Promise<void>;
+    toMatch(selector: string | MatchSelector, options?: ExpectTimingActions): Promise<void>;
+    toMatchElement(selector: string | MatchSelector, options?: ExpectToClickOptions): Promise<void>;
+    toSelect(selector: string | MatchSelector, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
+    toUploadFile(selector: string | MatchSelector, filePath: string, options?: ExpectTimingActions): Promise<void>;
 }
 
 declare global {
@@ -83,14 +95,14 @@ declare global {
         interface Matchers<R, T> {
             // These must all match the ExpectPuppeteer interface above.
             // We can't extend from it directly because some method names conflict in type-incompatible ways.
-            toClick(selector: string, options?: ExpectToClickOptions): Promise<void>;
+            toClick(selector: string | MatchSelector, options?: ExpectToClickOptions): Promise<void>;
             toDisplayDialog(block: () => Promise<void>): Promise<Dialog>;
-            toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
-            toFillForm(selector: string, value: { [key: string]: any}, options?: ExpectTimingActions): Promise<void>;
+            toFill(selector: string | MatchSelector, value: string, options?: ExpectTimingActions): Promise<void>;
+            toFillForm(selector: string | MatchSelector, value: { [key: string]: any}, options?: ExpectTimingActions): Promise<void>;
             toMatch(matcher: string | RegExp, options?: ExpectTimingActions): Promise<void>;
-            toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<ElementHandle>;
-            toSelect(selector: string, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
-            toUploadFile(selector: string, filePath: string, options?: ExpectTimingActions): Promise<void>;
+            toMatchElement(selector: string | MatchSelector, options?: ExpectToClickOptions): Promise<ElementHandle>;
+            toSelect(selector: string | MatchSelector, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
+            toUploadFile(selector: string | MatchSelector, filePath: string, options?: ExpectTimingActions): Promise<void>;
         }
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/smooth-code/jest-puppeteer/pull/321/files>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
