### PR TITLE
allow `mark` to be `null` for prosemirror-transform `removeMark`

### DIFF
--- a/types/prosemirror-transform/index.d.ts
+++ b/types/prosemirror-transform/index.d.ts
@@ -238,7 +238,7 @@ export class Transform<S extends Schema = any> {
      * remove all marks of that type. When it is null, remove all marks of
      * any type.
      */
-    removeMark(from: number, to: number, mark?: Mark<S> | MarkType<S>): this;
+    removeMark(from: number, to: number, mark?: Mark<S> | MarkType<S> | null): this;
     /**
      * Removes all marks and nodes from the content of the node at `pos`
      * that don't match the given new parent node type. Accepts an


### PR DESCRIPTION
As mentioned in the [ProseMirror ref](https://prosemirror.net/docs/ref/#transform.Transform.removeMark) (and the code comment in this very repo) the `mark` parameter may be set to `null` to remove all marks.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
