### PR TITLE
fix: add missing parameters on Link props

### DIFF
--- a/types/react-scroll/modules/components/Link.d.ts
+++ b/types/react-scroll/modules/components/Link.d.ts
@@ -13,8 +13,8 @@ export interface ReactScrollLinkProps {
     onClick?(): void;
     duration?: number | string | ((distance: number) => number) | undefined;
     absolute?: boolean | undefined;
-    onSetActive?(to: string): void;
-    onSetInactive?(): void;
+    onSetActive?(to: string, element: HTMLElement | null): void;
+    onSetInactive?(to: string, element: HTMLElement | null): void;
     ignoreCancelEvents?: boolean | undefined;
     saveHashHistory?: boolean | undefined;
 }

--- a/types/react-scroll/modules/components/Link.d.ts
+++ b/types/react-scroll/modules/components/Link.d.ts
@@ -13,8 +13,8 @@ export interface ReactScrollLinkProps {
     onClick?(): void;
     duration?: number | string | ((distance: number) => number) | undefined;
     absolute?: boolean | undefined;
-    onSetActive?(to: string, element: HTMLElement | null): void;
-    onSetInactive?(to: string, element: HTMLElement | null): void;
+    onSetActive?(to: string, element: HTMLElement): void;
+    onSetInactive?(to: string, element: HTMLElement): void;
     ignoreCancelEvents?: boolean | undefined;
     saveHashHistory?: boolean | undefined;
 }

--- a/types/react-scroll/test/react-scroll-tests.tsx
+++ b/types/react-scroll/test/react-scroll-tests.tsx
@@ -100,10 +100,14 @@ const linkTest5 = (
         duration={500}
         delay={1000}
         isDynamic={true}
-        onSetActive={to => {
+        onSetActive={(to, element) => {
             console.log(to);
+            console.log(element);
         }}
-        onSetInactive={() => {}}
+        onSetInactive={(to, element) => {
+            console.log(to);
+            console.log(element);
+        }}
         ignoreCancelEvents={false}
     >
         Your name


### PR DESCRIPTION
onSetActive and onSetInactive props are missing parameters

You can see this parameters for onSetActive here:
https://github.com/fisshy/react-scroll/blob/master/modules/mixins/scroll-link.js#L155

You can see this parameters for onSetInactive here:
https://github.com/fisshy/react-scroll/blob/master/modules/mixins/scroll-link.js#L143
