### PR TITLE
Jest 28.x Update some Types definitions

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 28.1.0
+// Type definitions for Jest 28.1
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>
@@ -90,7 +90,7 @@ type FakeableAPI =
   | 'setTimeout'
   | 'clearTimeout';
 
-type ModernFakeTimersConfig = {
+interface ModernFakeTimersConfig {
     /**
      * If set to `true` all timers will be advanced automatically by 20 milliseconds
      * every 20 milliseconds. A custom time delta may be provided by passing a number.
@@ -101,7 +101,7 @@ type ModernFakeTimersConfig = {
      * List of names of APIs that should not be faked. The default is `[]`, meaning
      * all APIs are faked.
      */
-    doNotFake?: Array<FakeableAPI>;
+    doNotFake?: FakeableAPI[];
     /** Whether fake timers should be enabled for all test files. The default is `false`. */
     enableGlobally?: boolean;
     /**
@@ -113,7 +113,7 @@ type ModernFakeTimersConfig = {
     now?: number;
     /** Maximum number of recursive timers that will be run. The default is `100_000` timers. */
     timerLimit?: number;
-};
+}
 
 declare namespace jest {
     /**

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -28,6 +28,7 @@
 //                 Regev Brody <https://github.com/regevbr>
 //                 Alexandre Germain <https://github.com/gerkindev>
 //                 Adam Jones <https://github.com/domdomegg>
+//                 Sandino Nuñez <https://github.com/sandinosaso>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.8
 
@@ -71,6 +72,48 @@ type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
         : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]> ? 10
         : 'fallback'
 ];
+
+type FakeableAPI =
+  | 'Date'
+  | 'hrtime'
+  | 'nextTick'
+  | 'performance'
+  | 'queueMicrotask'
+  | 'requestAnimationFrame'
+  | 'cancelAnimationFrame'
+  | 'requestIdleCallback'
+  | 'cancelIdleCallback'
+  | 'setImmediate'
+  | 'clearImmediate'
+  | 'setInterval'
+  | 'clearInterval'
+  | 'setTimeout'
+  | 'clearTimeout';
+
+type ModernFakeTimersConfig = {
+    /**
+     * If set to `true` all timers will be advanced automatically by 20 milliseconds
+     * every 20 milliseconds. A custom time delta may be provided by passing a number.
+     * The default is `false`.
+     */
+    advanceTimers?: boolean | number;
+    /**
+     * List of names of APIs that should not be faked. The default is `[]`, meaning
+     * all APIs are faked.
+     */
+    doNotFake?: Array<FakeableAPI>;
+    /** Whether fake timers should be enabled for all test files. The default is `false`. */
+    enableGlobally?: boolean;
+    /**
+     * Use the old fake timers implementation instead of one backed by `@sinonjs/fake-timers`.
+     * The default is `false`.
+     */
+    legacyFakeTimers?: boolean;
+    /** Sets current system time to be used by fake timers. The default is `Date.now()`. */
+    now?: number;
+    /** Maximum number of recursive timers that will be run. The default is `100_000` timers. */
+    timerLimit?: number;
+};
 
 declare namespace jest {
     /**
@@ -321,7 +364,7 @@ declare namespace jest {
     /**
      * Instructs Jest to use fake versions of the standard timer functions.
      */
-    function useFakeTimers(implementation?: 'modern' | 'legacy'): typeof jest;
+    function useFakeTimers(config: { legacyFakeTimers: boolean }): typeof jest;
     /**
      * Instructs Jest to use the real versions of the standard timer functions.
      */

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -111,7 +111,7 @@ type FakeTimersConfig = {
     now?: number | Date;
     /** Maximum number of recursive timers that will be run. The default is `100_000` timers. */
     timerLimit?: number;
-}
+};
 
 declare namespace jest {
     /**

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -90,7 +90,7 @@ type FakeableAPI =
   | 'setTimeout'
   | 'clearTimeout';
 
-type FakeTimersConfig = {
+interface FakeTimersConfig {
     /**
      * If set to `true` all timers will be advanced automatically by 20 milliseconds
      * every 20 milliseconds. A custom time delta may be provided by passing a number.
@@ -111,7 +111,7 @@ type FakeTimersConfig = {
     now?: number | Date;
     /** Maximum number of recursive timers that will be run. The default is `100_000` timers. */
     timerLimit?: number;
-};
+}
 
 declare namespace jest {
     /**

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 27.5
+// Type definitions for Jest 28.1.0
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -28,7 +28,6 @@
 //                 Regev Brody <https://github.com/regevbr>
 //                 Alexandre Germain <https://github.com/gerkindev>
 //                 Adam Jones <https://github.com/domdomegg>
-//                 Sandino Nuñez <https://github.com/sandinosaso>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.8
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -102,8 +102,6 @@ interface ModernFakeTimersConfig {
      * all APIs are faked.
      */
     doNotFake?: FakeableAPI[];
-    /** Whether fake timers should be enabled for all test files. The default is `false`. */
-    enableGlobally?: boolean;
     /**
      * Use the old fake timers implementation instead of one backed by `@sinonjs/fake-timers`.
      * The default is `false`.

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -108,7 +108,7 @@ interface ModernFakeTimersConfig {
      */
     legacyFakeTimers?: boolean;
     /** Sets current system time to be used by fake timers. The default is `Date.now()`. */
-    now?: number;
+    now?: number | Date;
     /** Maximum number of recursive timers that will be run. The default is `100_000` timers. */
     timerLimit?: number;
 }

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -90,7 +90,7 @@ type FakeableAPI =
   | 'setTimeout'
   | 'clearTimeout';
 
-interface ModernFakeTimersConfig {
+type FakeTimersConfig = {
     /**
      * If set to `true` all timers will be advanced automatically by 20 milliseconds
      * every 20 milliseconds. A custom time delta may be provided by passing a number.
@@ -362,7 +362,7 @@ declare namespace jest {
     /**
      * Instructs Jest to use fake versions of the standard timer functions.
      */
-    function useFakeTimers(config?: ModernFakeTimersConfig): typeof jest;
+    function useFakeTimers(config?: FakeTimersConfig): typeof jest;
     /**
      * Instructs Jest to use the real versions of the standard timer functions.
      */

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -364,7 +364,7 @@ declare namespace jest {
     /**
      * Instructs Jest to use fake versions of the standard timer functions.
      */
-    function useFakeTimers(config: { legacyFakeTimers: boolean }): typeof jest;
+    function useFakeTimers(config?: ModernFakeTimersConfig): typeof jest;
     /**
      * Instructs Jest to use the real versions of the standard timer functions.
      */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -301,8 +301,9 @@ jest.advanceTimersToNextTimer();
 jest.advanceTimersToNextTimer(2);
 
 // https://jestjs.io/docs/configuration#faketimers-object
+jest.useFakeTimers();
 jest.useFakeTimers({ legacyFakeTimers: false });
-jest.useFakeTimers({ legacyFakeTimers: false });
+jest.useFakeTimers({ timerLimit: 50 });
 // $ExpectError
 jest.useFakeTimers('legacy');
 // $ExpectError

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -300,12 +300,14 @@ jest.autoMockOff()
 jest.advanceTimersToNextTimer();
 jest.advanceTimersToNextTimer(2);
 
-// https://jestjs.io/docs/en/jest-object#jestusefaketimersimplementation-modern--legacy
+// https://jestjs.io/docs/configuration#faketimers-object
 jest.useFakeTimers({ legacyFakeTimers: false });
 jest.useFakeTimers({ legacyFakeTimers: false });
 // $ExpectError
 jest.useFakeTimers('legacy');
+// $ExpectError
 jest.useFakeTimers('modern');
+// $ExpectError
 jest.useFakeTimers('foo');
 
 // https://jestjs.io/docs/en/jest-object#jestsetsystemtimenow-number--date

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -301,9 +301,11 @@ jest.advanceTimersToNextTimer();
 jest.advanceTimersToNextTimer(2);
 
 // https://jestjs.io/docs/en/jest-object#jestusefaketimersimplementation-modern--legacy
-jest.useFakeTimers('modern');
-jest.useFakeTimers('legacy');
+jest.useFakeTimers({ legacyFakeTimers: false });
+jest.useFakeTimers({ legacyFakeTimers: false });
 // $ExpectError
+jest.useFakeTimers('legacy');
+jest.useFakeTimers('modern');
 jest.useFakeTimers('foo');
 
 // https://jestjs.io/docs/en/jest-object#jestsetsystemtimenow-number--date


### PR DESCRIPTION
Update @types/jest type definition for useFakeTimers. 

I checked all the steps below:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] The context por the suggested change is the update of FakeTimers in Jest28: [here](https://jestjs.io/docs/configuration#faketimers-object)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
