### PR TITLE
express-serve-static-core: make Express.Response.get return string|undefined

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -228,3 +228,8 @@ app.get<{}, any, any, {}, { foo: boolean }>('/locals', (req, res, next) => {
     res.locals.bar; // $ExpectError
     res.send({ foo: 'ok' }); // $ExpectType Response<any, { foo: boolean; }, number>
 });
+
+// res.get returns string or undefined
+app.get<{}, any, any, {}, { foo: boolean }>('/locals', (req, res, next) => {
+    res.get('content-type'); // $ExpectType string | undefined
+});

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -914,7 +914,7 @@ export interface Response<
     headersSent: boolean;
 
     /** Get value for header `field`. */
-    get(field: string): string;
+    get(field: string): string|undefined;
 
     /** Clear cookie `name`. */
     clearCookie(name: string, options?: CookieOptions): this;

--- a/types/express-serve-static-core/ts4.0/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/ts4.0/express-serve-static-core-tests.ts
@@ -175,3 +175,8 @@ app.get<{}, any, any, {}, { foo: boolean }>('/locals', (req, res, next) => {
     res.locals.bar; // $ExpectError
     res.send({ foo: 'ok' }); // $ExpectType Response<any, { foo: boolean; }, number>
 });
+
+// res.get returns string or undefined
+app.get<{}, any, any, {}, { foo: boolean }>('/locals', (req, res, next) => {
+    res.get('content-type'); // $ExpectType string | undefined
+});

--- a/types/express-serve-static-core/ts4.0/index.d.ts
+++ b/types/express-serve-static-core/ts4.0/index.d.ts
@@ -826,7 +826,7 @@ export interface Response<
     headersSent: boolean;
 
     /** Get value for header `field`. */
-    get(field: string): string;
+    get(field: string): string | undefined;
 
     /** Clear cookie `name`. */
     clearCookie(name: string, options?: CookieOptions): this;


### PR DESCRIPTION


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/api/http.html#responsegetheadername>
  - Express uses `ServerResponse.prototype.getHeader` internally. Technically, the documented return type is `any` but the behavior I have observed in practice is `string` or `undefined`.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
