### PR TITLE
Add types for `@hapi/content`, `@hapi/subtext` and update types for `@hapi/call`

### DIFF
--- a/types/hapi__call/hapi__call-tests.ts
+++ b/types/hapi__call/hapi__call-tests.ts
@@ -1,10 +1,10 @@
 import { Route, Router } from '@hapi/call';
 
-const router = new Router({ isCaseSensitive: false });
+const router = new Router<{ id: string }>({ isCaseSensitive: false });
 
 router.add({ method: 'get', path: '/user/{userId}'}, { id: 'get_user'});
 
-const route: Route<{ userId: string }, {id: string }> = router.route('get', '/');
+const route = router.route('get', '/');
 
 if (!(route instanceof Error)) {
     console.log(route.route.id);
@@ -13,3 +13,6 @@ if (!(route instanceof Error)) {
 } else {
   throw route;
 }
+
+// @ts-expect-error
+const route2 = router.route('foobar', '/');

--- a/types/hapi__call/hapi__call-tests.ts
+++ b/types/hapi__call/hapi__call-tests.ts
@@ -13,6 +13,3 @@ if (!(route instanceof Error)) {
 } else {
   throw route;
 }
-
-// @ts-expect-error
-const route2 = router.route('foobar', '/');

--- a/types/hapi__call/index.d.ts
+++ b/types/hapi__call/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @hapi/call 9.0.0
+// Type definitions for @hapi/call 9.0
 // Project: https://github.com/hapijs/call#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Sebastian Malton <https://github.com/nokel81>

--- a/types/hapi__call/index.d.ts
+++ b/types/hapi__call/index.d.ts
@@ -1,12 +1,15 @@
-// Type definitions for @hapi/call 8.0
+// Type definitions for @hapi/call 9.0.0
 // Project: https://github.com/hapijs/call#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
+//                 Sebastian Malton <https://github.com/nokel81>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
+export type RouteMethod = "get" | "head" | "post" | "put" | "delete" | "connect" | "options" | "trace" | "patch";
+
 export interface RouteDefinition {
-    method: string;
+    method: RouteMethod | "*";
     path: string;
 }
 
@@ -14,16 +17,16 @@ export interface RouterOptions {
     isCaseSensitive: boolean;
 }
 
-export interface Match<P = any, D = any> {
-    params: P;
+export interface Match<Handler> {
+    params: Partial<Record<string, string>>;
     paramsArray: string[];
-    route: D;
+    route: Handler;
 }
 
-export type Route<P = any, D = any> = Match<P, D> | Error;
+export type Route<Handler> = Match<Handler> | Error;
 
-export class Router {
+export class Router<Handler> {
     constructor(routerOptions?: RouterOptions)
-    add(definition: RouteDefinition, data?: any): void;
-    route(method: string, path: string): Route;
+    add(definition: RouteDefinition, route?: Handler): void;
+    route(method: RouteMethod, path: string): Route<Handler>;
 }

--- a/types/hapi__call/index.d.ts
+++ b/types/hapi__call/index.d.ts
@@ -6,10 +6,22 @@
 
 /// <reference types="node" />
 
-export type RouteMethod = "get" | "head" | "post" | "put" | "delete" | "connect" | "options" | "trace" | "patch";
-
 export interface RouteDefinition {
-    method: RouteMethod | "*";
+    /**
+     * Generally this is an HTTP method or "*" to mean any.
+     * This field is case insensitive.
+     *
+     * - "get"
+     * - "head"
+     * - "post"
+     * - "put"
+     * - "delete"
+     * - "connect"
+     * - "options"
+     * - "trace"
+     * - "patch"
+     */
+    method: string;
     path: string;
 }
 
@@ -28,5 +40,5 @@ export type Route<Handler> = Match<Handler> | Error;
 export class Router<Handler> {
     constructor(routerOptions?: RouterOptions)
     add(definition: RouteDefinition, route?: Handler): void;
-    route(method: RouteMethod, path: string): Route<Handler>;
+    route(method: string, path: string): Route<Handler>;
 }

--- a/types/hapi__content/hapi__content-tests.ts
+++ b/types/hapi__content/hapi__content-tests.ts
@@ -6,6 +6,6 @@ console.log(parsedContentType.mime);
 console.log(parsedContentType.charset);
 console.log(parsedContentType.boundary);
 
-const parsedContentDisposition = Content.disposition('form-data; name="file"; filename=file.jpg')
+const parsedContentDisposition = Content.disposition('form-data; name="file"; filename=file.jpg');
 console.log(parsedContentDisposition.filename);
 console.log(parsedContentDisposition.name);

--- a/types/hapi__content/hapi__content-tests.ts
+++ b/types/hapi__content/hapi__content-tests.ts
@@ -7,5 +7,5 @@ console.log(parsedContentType.charset);
 console.log(parsedContentType.boundary);
 
 const parsedContentDisposition = Content.disposition('form-data; name="file"; filename=file.jpg')
-console.log(parsedContentDisposition.filename)
-console.log(parsedContentDisposition.name)
+console.log(parsedContentDisposition.filename);
+console.log(parsedContentDisposition.name);

--- a/types/hapi__content/hapi__content-tests.ts
+++ b/types/hapi__content/hapi__content-tests.ts
@@ -1,0 +1,11 @@
+import Content from '@hapi/content';
+
+const parsedContentType = Content.type("application/json; charset=utf-8");
+
+console.log(parsedContentType.mime);
+console.log(parsedContentType.charset);
+console.log(parsedContentType.boundary);
+
+const parsedContentDisposition = Content.disposition('form-data; name="file"; filename=file.jpg')
+console.log(parsedContentDisposition.filename)
+console.log(parsedContentDisposition.name)

--- a/types/hapi__content/index.d.ts
+++ b/types/hapi__content/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for @hapi/content 6.0.0
+// Project: https://github.com/hapijs/subtext#readme
+// Definitions by: Sebastian Malton <https://github.com/nokel81>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export interface ContentType {
+  mime: string;
+  charset?: string;
+  boundary?: string;
+}
+
+export function type(header: string | undefined): ContentType;
+
+export interface ContentDisposition {
+  name: string;
+  filename: string;
+}
+
+export function disposition(header: string | undefined): ContentDisposition;

--- a/types/hapi__content/index.d.ts
+++ b/types/hapi__content/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @hapi/content 6.0.0
+// Type definitions for @hapi/content 6.0
 // Project: https://github.com/hapijs/subtext#readme
 // Definitions by: Sebastian Malton <https://github.com/nokel81>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/hapi__content/tsconfig.json
+++ b/types/hapi__content/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@hapi/*": [
+                "hapi__*"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "hapi__content-tests.ts"
+    ]
+}

--- a/types/hapi__content/tslint.json
+++ b/types/hapi__content/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/hapi__subtext/hapi__subtext-tests.ts
+++ b/types/hapi__subtext/hapi__subtext-tests.ts
@@ -1,0 +1,16 @@
+import { parse } from '@hapi/subtext';
+import { IncomingMessage } from 'http';
+import { Socket } from 'net';
+
+const socket = new Socket();
+const req = new IncomingMessage(socket);
+
+parse(req, null, {
+  output: "data",
+  parse: true,
+})
+  .then(result => {
+    console.log(result.payload)
+    console.log(result.mime)
+  });
+

--- a/types/hapi__subtext/hapi__subtext-tests.ts
+++ b/types/hapi__subtext/hapi__subtext-tests.ts
@@ -10,7 +10,6 @@ parse(req, null, {
   parse: true,
 })
   .then(result => {
-    console.log(result.payload)
-    console.log(result.mime)
+    console.log(result.payload);
+    console.log(result.mime);
   });
-

--- a/types/hapi__subtext/index.d.ts
+++ b/types/hapi__subtext/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for @hapi/subtext 7.0.3
+// Project: https://github.com/hapijs/subtext#readme
+// Definitions by: Sebastian Malton <https://github.com/nokel81>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { IncomingMessage } from 'http';
+import stream from 'stream';
+import { BrotliOptions, ZlibOptions } from 'zlib';
+
+export interface MultipartOptions {
+  output: "data" | "stream" | "file";
+}
+
+
+export interface DecompressionOptions {
+  gzip?: ZlibOptions;
+  deflate?: ZlibOptions;
+  br?: BrotliOptions;
+  compress?: BrotliOptions;
+}
+
+export interface ContentDecoders {
+  gzip?: (options: ZlibOptions | null) => stream.Transform;
+  deflate?: (options: ZlibOptions | null) => stream.Transform;
+  br?: (options: BrotliOptions | null) => stream.Transform;
+  compress?: (options: BrotliOptions | null) => stream.Transform;
+}
+
+export interface Options {
+  parse: boolean;
+  output: "data" | "stream" | "file";
+  maxBytes?: number;
+  override?: string;
+  defaultContentType?: string;
+  allow?: string[];
+  timeout?: number;
+  querystring?: (str: string) => Partial<Record<string, string | string[]>>;
+  uploads?: string;
+  multipart?: boolean | MultipartOptions;
+  decoders?: ContentDecoders;
+  compression?: DecompressionOptions;
+}
+
+export interface Result {
+  /**
+   * Will be `null` if no payload was present on request
+   */
+  payload: unknown;
+  mime: string;
+}
+
+export function parse(req: IncomingMessage, tap: null | NodeJS.WritableStream, options: Options): Promise<Result>;

--- a/types/hapi__subtext/index.d.ts
+++ b/types/hapi__subtext/index.d.ts
@@ -13,7 +13,6 @@ export interface MultipartOptions {
   output: "data" | "stream" | "file";
 }
 
-
 export interface DecompressionOptions {
   gzip?: ZlibOptions;
   deflate?: ZlibOptions;

--- a/types/hapi__subtext/index.d.ts
+++ b/types/hapi__subtext/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @hapi/subtext 7.0.3
+// Type definitions for @hapi/subtext 7.0
 // Project: https://github.com/hapijs/subtext#readme
 // Definitions by: Sebastian Malton <https://github.com/nokel81>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,7 +6,7 @@
 /// <reference types="node" />
 
 import { IncomingMessage } from 'http';
-import stream from 'stream';
+import stream = require('stream');
 import { BrotliOptions, ZlibOptions } from 'zlib';
 
 export interface MultipartOptions {

--- a/types/hapi__subtext/tsconfig.json
+++ b/types/hapi__subtext/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@hapi/*": [
+                "hapi__*"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "hapi__subtext-tests.ts"
+    ]
+}

--- a/types/hapi__subtext/tslint.json
+++ b/types/hapi__subtext/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/call/blob/v9.0.0/lib/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
