### PR TITLE
fix(types/node): `clearInterval` and `clearTimeout` should accept primitive values

### DIFF
--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -1891,14 +1891,18 @@ declare global {
 
         /**
          * A timeout identifier that can be used to clear the timeout.
-         * @remarks Note that this is actualy a `number` type.
+         * @remarks Note that this is actually a `number` type, but it
+         * is not compatible with `globalThis.clearTimeout`. Provide
+         * this to iobroker's `adatper.clearTimeout` instead.
          */
         interface Timeout {
             __ioBrokerBrand: 'Timeout';
         }
         /**
          * An interval identifier that can be used to clear the interval.
-         * @remarks Note that this is actualy a `number` type.
+         * @remarks Note that this is actually a `number` type, but it
+         * is not compatible with `globalThis.clearInterval`. Provide
+         * this to iobroker's `adapter.clearInterval` instead.
          */
         interface Interval {
             __ioBrokerBrand: 'Interval';

--- a/types/iobroker/index.d.ts
+++ b/types/iobroker/index.d.ts
@@ -1889,7 +1889,19 @@ declare global {
 
         type GetSessionCallback = (session: Session) => void;
 
-        type Timeout = number & { __ioBrokerBrand: 'Timeout' };
-        type Interval = number & { __ioBrokerBrand: 'Interval' };
+        /**
+         * A timeout identifier that can be used to clear the timeout.
+         * @remarks Note that this is actualy a `number` type.
+         */
+        interface Timeout {
+            __ioBrokerBrand: 'Timeout';
+        }
+        /**
+         * An interval identifier that can be used to clear the interval.
+         * @remarks Note that this is actualy a `number` type.
+         */
+        interface Interval {
+            __ioBrokerBrand: 'Interval';
+        }
     } // end namespace ioBroker
 } // end declare global

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -677,6 +677,10 @@ enumObj.common.members && enumObj.common.members.map(() => 1);
 adapter.clearTimeout(adapter.setTimeout(() => {}, 10));
 adapter.clearInterval(adapter.setInterval(() => {}, 10));
 // $ExpectError
+clearTimeout(adapter.setTimeout(() => {}, 10));
+// $ExpectError
+clearInterval(adapter.setInterval(() => {}, 10));
+// $ExpectError
 adapter.clearTimeout(setTimeout(() => {}, 10));
 // $ExpectError
 adapter.clearInterval(setInterval(() => {}, 10));

--- a/types/iobroker/iobroker-tests.ts
+++ b/types/iobroker/iobroker-tests.ts
@@ -677,10 +677,6 @@ enumObj.common.members && enumObj.common.members.map(() => 1);
 adapter.clearTimeout(adapter.setTimeout(() => {}, 10));
 adapter.clearInterval(adapter.setInterval(() => {}, 10));
 // $ExpectError
-clearTimeout(adapter.setTimeout(() => {}, 10));
-// $ExpectError
-clearInterval(adapter.setInterval(() => {}, 10));
-// $ExpectError
 adapter.clearTimeout(setTimeout(() => {}, 10));
 // $ExpectError
 adapter.clearInterval(setInterval(() => {}, 10));

--- a/types/node/test/timers.ts
+++ b/types/node/test/timers.ts
@@ -21,6 +21,7 @@ import * as timers from 'node:timers';
             .refresh();
         const b: boolean = timeout.hasRef();
         timers.clearInterval(timeout);
+        timers.clearInterval(timeout[Symbol.toPrimitive]());
     }
     {
         const timeout = timers
@@ -32,6 +33,7 @@ import * as timers from 'node:timers';
             .refresh();
         const b: boolean = timeout.hasRef();
         timers.clearTimeout(timeout);
+        timers.clearTimeout(timeout[Symbol.toPrimitive]());
     }
     async function testPromisify(doSomething: {
         (foo: any, onSuccessCallback: (result: string) => void, onErrorCallback: (reason: any) => void): void;

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -69,7 +69,7 @@ declare module 'timers' {
         namespace setTimeout {
             const __promisify__: typeof setTimeoutPromise;
         }
-        function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
+        function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
         function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timer;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -85,7 +85,7 @@ declare module 'timers' {
         namespace setImmediate {
             const __promisify__: typeof setImmediatePromise;
         }
-        function clearImmediate(immediateId: NodeJS.Immediate | string | number | undefined): void;
+        function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
         function queueMicrotask(callback: () => void): void;
     }
 }

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -77,7 +77,7 @@ declare module 'timers' {
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }
-        function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
+        function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
         function setImmediate<TArgs extends any[]>(callback: (...args: TArgs) => void, ...args: TArgs): NodeJS.Immediate;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -85,7 +85,7 @@ declare module 'timers' {
         namespace setImmediate {
             const __promisify__: typeof setImmediatePromise;
         }
-        function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
+        function clearImmediate(immediateId: NodeJS.Immediate | string | number | undefined): void;
         function queueMicrotask(callback: () => void): void;
     }
 }

--- a/types/node/v12/globals.d.ts
+++ b/types/node/v12/globals.d.ts
@@ -179,9 +179,9 @@ declare namespace setTimeout {
     function __promisify__(ms: number): Promise<void>;
     function __promisify__<T>(ms: number, value: T): Promise<T>;
 }
-declare function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
+declare function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
 declare function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
-declare function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
+declare function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
 declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
 declare namespace setImmediate {
     function __promisify__(): Promise<void>;
@@ -1249,8 +1249,8 @@ declare namespace NodeJS {
         WeakMap: WeakMapConstructor;
         WeakSet: WeakSetConstructor;
         clearImmediate: (immediateId: Immediate) => void;
-        clearInterval: (intervalId: Timeout) => void;
-        clearTimeout: (timeoutId: Timeout) => void;
+        clearInterval: (intervalId: Timeout | string | number) => void;
+        clearTimeout: (timeoutId: Timeout | string | number) => void;
         console: typeof console;
         decodeURI: typeof decodeURI;
         decodeURIComponent: typeof decodeURIComponent;

--- a/types/node/v12/node-tests.ts
+++ b/types/node/v12/node-tests.ts
@@ -316,6 +316,7 @@ import Module = require('module');
             .refresh();
         const b: boolean = timeout.hasRef();
         timers.clearInterval(timeout);
+        timers.clearInterval(timeout[Symbol.toPrimitive]());
     }
     {
         const timeout = timers
@@ -327,6 +328,7 @@ import Module = require('module');
             .refresh();
         const b: boolean = timeout.hasRef();
         timers.clearTimeout(timeout);
+        timers.clearTimeout(timeout[Symbol.toPrimitive]());
     }
     async function testPromisify() {
         const setTimeout = util.promisify(timers.setTimeout);

--- a/types/node/v12/timers.d.ts
+++ b/types/node/v12/timers.d.ts
@@ -4,9 +4,9 @@ declare module 'timers' {
         function __promisify__(ms: number): Promise<void>;
         function __promisify__<T>(ms: number, value: T): Promise<T>;
     }
-    function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
+    function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
     function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
-    function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
+    function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
     function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
     namespace setImmediate {
         function __promisify__(): Promise<void>;

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -52,9 +52,9 @@ declare namespace setTimeout {
     function __promisify__(ms: number): Promise<void>;
     function __promisify__<T>(ms: number, value: T): Promise<T>;
 }
-declare function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
+declare function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
 declare function setInterval(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
-declare function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
+declare function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
 declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
 declare namespace setImmediate {
     function __promisify__(): Promise<void>;

--- a/types/node/v14/node-tests.ts
+++ b/types/node/v14/node-tests.ts
@@ -165,6 +165,7 @@ import * as trace_events from 'trace_events';
             .refresh();
         const b: boolean = timeout.hasRef();
         timers.clearInterval(timeout);
+        timers.clearInterval(timeout[Symbol.toPrimitive]());
     }
     {
         const timeout = timers
@@ -176,6 +177,7 @@ import * as trace_events from 'trace_events';
             .refresh();
         const b: boolean = timeout.hasRef();
         timers.clearTimeout(timeout);
+        timers.clearTimeout(timeout[Symbol.toPrimitive]());
     }
     async function testPromisify(doSomething: {
         (foo: any, onSuccessCallback: (result: string) => void, onErrorCallback: (reason: any) => void): void;

--- a/types/node/v14/timers.d.ts
+++ b/types/node/v14/timers.d.ts
@@ -4,9 +4,9 @@ declare module 'timers' {
         function __promisify__(ms: number): Promise<void>;
         function __promisify__<T>(ms: number, value: T): Promise<T>;
     }
-    function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
+    function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
     function setInterval(callback: (...args: any[]) => void, ms?: number, ...args: any[]): NodeJS.Timeout;
-    function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
+    function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
     function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
     namespace setImmediate {
         function __promisify__(): Promise<void>;

--- a/types/node/v16/test/timers.ts
+++ b/types/node/v16/test/timers.ts
@@ -21,6 +21,7 @@ import * as timers from 'node:timers';
             .refresh();
         const b: boolean = timeout.hasRef();
         timers.clearInterval(timeout);
+        timers.clearInterval(timeout[Symbol.toPrimitive]());
     }
     {
         const timeout = timers
@@ -32,6 +33,7 @@ import * as timers from 'node:timers';
             .refresh();
         const b: boolean = timeout.hasRef();
         timers.clearTimeout(timeout);
+        timers.clearTimeout(timeout[Symbol.toPrimitive]());
     }
     async function testPromisify(doSomething: {
         (foo: any, onSuccessCallback: (result: string) => void, onErrorCallback: (reason: any) => void): void;

--- a/types/node/v16/timers.d.ts
+++ b/types/node/v16/timers.d.ts
@@ -69,7 +69,7 @@ declare module 'timers' {
         namespace setTimeout {
             const __promisify__: typeof setTimeoutPromise;
         }
-        function clearTimeout(timeoutId: NodeJS.Timeout | undefined): void;
+        function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
         function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timer;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return
@@ -77,7 +77,7 @@ declare module 'timers' {
         namespace setInterval {
             const __promisify__: typeof setIntervalPromise;
         }
-        function clearInterval(intervalId: NodeJS.Timeout | undefined): void;
+        function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
         function setImmediate<TArgs extends any[]>(callback: (...args: TArgs) => void, ...args: TArgs): NodeJS.Immediate;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/timers.html#clearintervaltimeout (`Timeout | string | number` for both)
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~ N/A