### PR TITLE
[eslint] Strongly-type the 'plugins' field on the ESLint.Options interface

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -666,9 +666,38 @@ eslint = new ESLint({ ignore: true });
 eslint = new ESLint({ ignorePath: 'foo' });
 eslint = new ESLint({ useEslintrc: false });
 eslint = new ESLint({ plugins: { foo: {} } });
-eslint = new ESLint({ reportUnusedDisableDirectives: 'error' });
-eslint = new ESLint({ resolvePluginsRelativeTo: 'test' });
-eslint = new ESLint({ rulePaths: ['foo'] });
+eslint = new ESLint({
+    plugins: {
+        bar: {
+            configs: {
+                myConfig: {
+                    noInlineConfig: true
+                }
+            },
+            environments: {
+                production: {
+                    parserOptions: {
+                        ecmaVersion: 6
+                    }
+                }
+            },
+            processors: {
+                myProcessor: {
+                    supportsAutofix: false
+                }
+            },
+            rules: {
+                myRule: {
+                    create(context) { return {}; },
+                    meta: {},
+                }
+            }
+        }
+    }
+});
+eslint = new ESLint({ reportUnusedDisableDirectives: "error" });
+eslint = new ESLint({ resolvePluginsRelativeTo: "test" });
+eslint = new ESLint({ rulePaths: ["foo"] });
 
 let resultsPromise = eslint.lintFiles(['myfile.js', 'lib/']);
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -10,8 +10,8 @@
 
 /// <reference path="helpers.d.ts" />
 
-import { JSONSchema4 } from "json-schema";
 import * as ESTree from "estree";
+import { JSONSchema4 } from "json-schema";
 
 export namespace AST {
     type TokenType =
@@ -837,7 +837,6 @@ export class ESLint {
 }
 
 export namespace ESLint {
-
     type ConfigData<Rules extends Linter.RulesRecord = Linter.RulesRecord> = Omit<Linter.Config<Rules>, "$schema">;
 
     interface Environment {
@@ -849,7 +848,7 @@ export namespace ESLint {
         configs?: Record<string, ConfigData> | undefined;
         environments?: Record<string, Environment> | undefined;
         processors?: Record<string, Linter.Processor> | undefined;
-        rules?: Record<string, Function | Rule.RuleModule> | undefined;
+        rules?: Record<string, ((...args: any[]) => any) | Rule.RuleModule> | undefined;
     }
 
     interface Options {

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -837,6 +837,21 @@ export class ESLint {
 }
 
 export namespace ESLint {
+
+    type ConfigData<Rules extends Linter.RulesRecord = Linter.RulesRecord> = Omit<Linter.Config<Rules>, "$schema">;
+
+    interface Environment {
+        globals?: { [name: string]: boolean; } | undefined;
+        parserOptions?: Linter.ParserOptions | undefined;
+    }
+
+    interface Plugin {
+        configs?: Record<string, ConfigData> | undefined;
+        environments?: Record<string, Environment> | undefined;
+        processors?: Record<string, Linter.Processor> | undefined;
+        rules?: Record<string, Function | Rule.RuleModule> | undefined;
+    }
+
     interface Options {
         // File enumeration
         cwd?: string | undefined;
@@ -851,7 +866,7 @@ export namespace ESLint {
         baseConfig?: Linter.Config | undefined;
         overrideConfig?: Linter.Config | undefined;
         overrideConfigFile?: string | undefined;
-        plugins?: Record<string, any> | undefined;
+        plugins?: Record<string, Plugin> | undefined;
         reportUnusedDisableDirectives?: Linter.RuleLevel | undefined;
         resolvePluginsRelativeTo?: string | undefined;
         rulePaths?: string[] | undefined;

--- a/types/xo/index.d.ts
+++ b/types/xo/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Chuah Chee Shian (shian15810) <https://github.com/shian15810>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.9
 
 import eslint = require("eslint");
 
@@ -31,8 +32,14 @@ export function lintFiles(patterns: string | string[], options?: Options): Resul
 
 export type CLIEngineOptions = Pick<
     eslint.ESLint.Options,
-    "baseConfig" | "cwd" | "extensions" | "fix" | "ignore" | "plugins"
-> & { envs?: string[] | undefined; globals?: string[] | undefined; parser?: string | undefined; rules?: {[name: string]: eslint.Linter.RuleLevel | eslint.Linter.RuleLevelAndOptions} | undefined };
+    "baseConfig" | "cwd" | "extensions" | "fix" | "ignore"
+> & {
+    envs?: string[] | undefined;
+    globals?: string[] | undefined;
+    parser?: string | undefined;
+    plugins?: string[];
+    rules?: {[name: string]: eslint.Linter.RuleLevel | eslint.Linter.RuleLevelAndOptions} | undefined
+};
 export type ESLintOptions = Pick<eslint.Linter.LintOptions, "filename">;
 export type ESLintConfig = Pick<eslint.Linter.Config, "extends" | "settings">;
 

--- a/types/xo/index.d.ts
+++ b/types/xo/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Chuah Chee Shian (shian15810) <https://github.com/shian15810>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.9
 
 import eslint = require("eslint");
 


### PR DESCRIPTION
This PR changes the definiton of the `plugins` field on the `ESLint.Options` interface from the unsafe `Record<string, any>` to `Record<string, Plugin>` according to ESLints own type definitions as per the JSDoc comments.

There is one question that needs to be resolved before the PR can be merged if it is to provide a truly safe definition: ESLint's JSDoc defines the `rules` field on the `Plugin` interface to be a union of `Rule.RuleModule` or `Function`. The latter is a forbidden type and thus cannot be used. 

Unfortunately, I failed to determine what is the expected signature for such a function would be - it would be great if someone more familiar with the source code could point out where this branching is done in the source, and I can take it from there. Alternatively, the PR can be merged as is, but will contain a union member with a very generic type signature `(...args: any[]) => any`, which I would like to avoid if possible.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/eslint/eslint/blob/ce035e5fac632ba8d4f1860f92465f22d6b44d42/lib/shared/types.js#L163>
