### PR TITLE
[google.accounts] Make prompt() callback optional

### DIFF
--- a/types/google.accounts/google.accounts-tests.ts
+++ b/types/google.accounts/google.accounts-tests.ts
@@ -100,6 +100,8 @@ google.accounts.id.initialize({
     itp_support: true,
 });
 
+google.accounts.id.prompt();
+
 google.accounts.id.prompt(notification => {
     // $ExpectType boolean
     notification.isNotDisplayed();

--- a/types/google.accounts/index.d.ts
+++ b/types/google.accounts/index.d.ts
@@ -304,7 +304,7 @@ declare namespace google.accounts {
          * Displays the One Tap prompt or the browser native credential manager
          * after the initialize() method is invoked.
          */
-        function prompt(momentListener: (promptMomentNotification: PromptMomentNotification) => void): void;
+        function prompt(momentListener?: (promptMomentNotification: PromptMomentNotification) => void): void;
 
         /**
          * Renders a Sign In With Google button in your web pages.


### PR DESCRIPTION
The `momentListener` callback is optional. Example of working code (from https://developers.google.com/identity/gsi/web/reference/js-reference#google.accounts.id.initialize):
```html
<script>
  window.onload = function () {
    google.accounts.id.initialize({
      client_id: 'YOUR_GOOGLE_CLIENT_ID',
      callback: handleCredentialResponse
    });
    google.accounts.id.prompt();
  };
</script>
```
-------

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/identity/gsi/web/reference/js-reference#google.accounts.id.prompt
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
