### PR TITLE
[postcss-nested-ancestors] Add types for postcss-nested-ancestors

### DIFF
--- a/types/postcss-nested-ancestors/index.d.ts
+++ b/types/postcss-nested-ancestors/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for postcss-nested-ancestors 3.0
+// Project: https://github.com/toomuchdesign/postcss-nested-ancestors
+// Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { PluginCreator } from 'postcss';
+
+declare namespace nestedAncestors {
+    interface Options {
+        /**
+         * Ancestor selector pattern (utility option to automatically set both `levelSymbol` and `parentSymbol`)
+         * @default '^&'
+         */
+        placeholder?: string | undefined;
+        /**
+         * Symbol to move up a level of nesting
+         * @default '^'
+         */
+        levelSymbol?: string | undefined;
+        /**
+         * Symbol to target parent
+         * @default '&'
+         */
+        parentSymbol?: string | undefined;
+        /**
+         * @experimental
+         * Whether to look through CSS for nested ancestor symbols and replace them with the relevant tag
+         * @see {@link <https://github.com/toomuchdesign/postcss-nested-ancestors#replacedeclarations-experimental>}
+         * @default false
+         */
+        replaceDeclarations?: boolean | undefined;
+    }
+}
+
+declare var nestedAncestors: PluginCreator<nestedAncestors.Options>;
+
+export = nestedAncestors;

--- a/types/postcss-nested-ancestors/package.json
+++ b/types/postcss-nested-ancestors/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.0.0"
+    }
+}

--- a/types/postcss-nested-ancestors/postcss-nested-ancestors-tests.ts
+++ b/types/postcss-nested-ancestors/postcss-nested-ancestors-tests.ts
@@ -1,0 +1,15 @@
+import postcss from 'postcss';
+import nestedAncestors = require('postcss-nested-ancestors');
+
+// Using with postcss
+postcss([nestedAncestors]);
+postcss([nestedAncestors()]);
+
+// Testing config
+nestedAncestors({});
+nestedAncestors({
+    placeholder: '^&',
+    levelSymbol: '^',
+    parentSymbol: '&',
+    replaceDeclarations: true,
+});

--- a/types/postcss-nested-ancestors/tsconfig.json
+++ b/types/postcss-nested-ancestors/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "ES2018.Promise"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "postcss-nested-ancestors-tests.ts"]
+}

--- a/types/postcss-nested-ancestors/tslint.json
+++ b/types/postcss-nested-ancestors/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Adds types for the npm package `postcss-nested-ancestors`.

npm: <https://www.npmjs.com/package/postcss-nested-ancestors>
GitHub: <https://github.com/toomuchdesign/postcss-nested-ancestors>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test postcss-nested-ancestors`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
