### PR TITLE
fix(uglify-js): add `webkit` in minify options

### DIFF
--- a/types/uglify-js/index.d.ts
+++ b/types/uglify-js/index.d.ts
@@ -447,6 +447,12 @@ export interface MinifyOptions {
      * @default false
      */
     keep_fnames?: boolean | undefined;
+    /**
+     * Support non-standard Safari/Webkit.
+     * Equivalent to setting `webkit: true` in `minify()` for `compress`, `mangle` and `output` options.
+     * @default false
+     */
+    webkit?: boolean | undefined;
 }
 
 export interface MinifyOutput {


### PR DESCRIPTION
toplevel `webkit` option is preferred according to uglify-js maintainer UglifyJS/pull#5480

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
