### PR TITLE
fix(awsome-notifications): typo for `confirmOk`

### DIFF
--- a/types/awesome-notifications/awesome-notifications-tests.ts
+++ b/types/awesome-notifications/awesome-notifications-tests.ts
@@ -5,12 +5,6 @@ const awn = new AWN();
 const confirmed = () => console.log("Confirmed");
 const cancelled = () => console.log("Cancelled");
 
-awn.confirm(`Tests current confirmOK property name`, confirmed, cancelled, {
-  labels: {
-    confirmOK: "Current property name does not work"
-  }
-});
-
 awn.confirm(`Tests new confirmOk property name`, confirmed, cancelled, {
   labels: {
     confirmOk: "New property name works"

--- a/types/awesome-notifications/awesome-notifications-tests.ts
+++ b/types/awesome-notifications/awesome-notifications-tests.ts
@@ -1,4 +1,18 @@
-import AWN from 'awesome-notifications';
+import AWN from "awesome-notifications";
 
 const awn = new AWN();
-awn.alert('Hello world');
+
+const confirmed = () => console.log("Confirmed");
+const cancelled = () => console.log("Cancelled");
+
+awn.confirm(`Tests current confirmOK property name`, confirmed, cancelled, {
+  labels: {
+    confirmOK: "Current property name does not work"
+  }
+});
+
+awn.confirm(`Tests new confirmOk property name`, confirmed, cancelled, {
+  labels: {
+    confirmOk: "New property name works"
+  }
+});

--- a/types/awesome-notifications/awesome-notifications-tests.ts
+++ b/types/awesome-notifications/awesome-notifications-tests.ts
@@ -1,12 +1,12 @@
-import AWN from "awesome-notifications";
+import AWN from 'awesome-notifications';
 
 const awn = new AWN();
 
-const confirmed = () => console.log("Confirmed");
-const cancelled = () => console.log("Cancelled");
+const confirmed = () => console.log('Confirmed');
+const cancelled = () => console.log('Cancelled');
 
 awn.confirm(`Tests new confirmOk property name`, confirmed, cancelled, {
   labels: {
-    confirmOk: "New property name works"
+    confirmOk: 'New property name works'
   }
 });

--- a/types/awesome-notifications/index.d.ts
+++ b/types/awesome-notifications/index.d.ts
@@ -23,7 +23,7 @@ export interface AwnLabels {
     alert?: string;
     async?: string;
     confirm?: string;
-    confirmOK?: string;
+    confirmOk?: string;
     confirmCancel?: string;
 }
 


### PR DESCRIPTION
The current interface for `AwnLabels` contains a minor typo `confirmOK` which should have been `confirmOk` (see [official docs](https://github.com/f3oall/awesome-notifications/blob/8a1d3104c509964ebd7ff91202b41c936df37f48/docs/docs/customization/labels.md#confirmok)).
Demo: https://codesandbox.io/s/busy-keller-xzkv8f?file=/src/index.js:0-491

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://github.com/f3oall/awesome-notifications/blob/8a1d3104c509964ebd7ff91202b41c936df37f48/docs/docs/customization/labels.md#confirmok