### PR TITLE
Fix failing "Update CODEOWNERS" job

### DIFF
--- a/scripts/update-codeowners.js
+++ b/scripts/update-codeowners.js
@@ -2,7 +2,8 @@ import * as cp from 'node:child_process';
 import * as os from 'node:os';
 import { AllPackages, getDefinitelyTyped, parseDefinitions, clean } from '@definitelytyped/definitions-parser';
 import { loggerWithErrors } from '@definitelytyped/utils';
-import { writeFile } from 'fs-extra';
+import fsExtra from 'fs-extra';
+const { writeFile } = fsExtra;
 
 async function main() {
     const options = { definitelyTypedPath: '.', progress: false, parseInParallel: true };


### PR DESCRIPTION
The job to update the CODEOWNERS file has been failing since its change from CJS to ESM: <https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/UpdateCodeowners.yml?query=is%3Afailure>

The script tries to import `fs-extra` as an ES module, but fails:

```text
file:///home/runner/work/DefinitelyTyped/DefinitelyTyped/scripts/update-codeowners.js:5
import { writeFile } from 'fs-extra';
         ^^^^^^^^^
SyntaxError: Named export 'writeFile' not found. The requested module 'fs-extra' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'fs-extra';
const { writeFile } = pkg;
```

This PR fixes the problem by using the default export and destructuring, as the error suggests to do.