### PR TITLE
feat: add AbortSignal.timeout(number)

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -69,11 +69,21 @@ declare var AbortController: {
     new(): AbortController;
 };
 
-declare var AbortSignal: {
+interface AbortSignalConstructor {
     prototype: AbortSignal;
     new(): AbortSignal;
+    /**
+     * Returns an AbortSignal that will automatically abort after a specified time.
+     *
+     * @param time The "active" time in milliseconds before the returned AbortSignal will abort.
+     *
+     * @since v17.3.0, v16.14.0
+     */
+    timeout(time: number): AbortSignal;
     // TODO: Add abort() static
-};
+}
+
+declare var AbortSignal: AbortSignalConstructor;
 //#endregion borrowed
 
 //#region ArrayLike.at()

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -72,14 +72,6 @@ declare var AbortController: {
 interface AbortSignalConstructor {
     prototype: AbortSignal;
     new(): AbortSignal;
-    /**
-     * Returns an AbortSignal that will automatically abort after a specified time.
-     *
-     * @param time The "active" time in milliseconds before the returned AbortSignal will abort.
-     *
-     * @since v17.3.0, v16.14.0
-     */
-    timeout(time: number): AbortSignal;
     // TODO: Add abort() static
 }
 

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -72,6 +72,14 @@ declare var AbortController: {
 interface AbortSignalConstructor {
     prototype: AbortSignal;
     new(): AbortSignal;
+    /**
+     * Returns an AbortSignal that will automatically abort after a specified time.
+     *
+     * @param time The "active" time in milliseconds before the returned AbortSignal will abort.
+     *
+     * @since v17.3.0, v16.14.0
+     */
+    timeout(time: number): AbortSignal;
     // TODO: Add abort() static
 }
 

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -111,11 +111,21 @@ declare var AbortController: {
     new(): AbortController;
 };
 
-declare var AbortSignal: {
+interface AbortSignalConstructor {
     prototype: AbortSignal;
     new(): AbortSignal;
+    /**
+     * Returns an AbortSignal that will automatically abort after a specified time.
+     *
+     * @param time The "active" time in milliseconds before the returned AbortSignal will abort.
+     *
+     * @since v17.3.0, v16.14.0
+     */
+    timeout(time: number): AbortSignal;
     // TODO: Add abort() static
-};
+}
+
+declare var AbortSignal: AbortSignalConstructor;
 //#endregion borrowed
 
 /**

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -114,14 +114,6 @@ declare var AbortController: {
 interface AbortSignalConstructor {
     prototype: AbortSignal;
     new(): AbortSignal;
-    /**
-     * Returns an AbortSignal that will automatically abort after a specified time.
-     *
-     * @param time The "active" time in milliseconds before the returned AbortSignal will abort.
-     *
-     * @since v17.3.0, v16.14.0
-     */
-    timeout(time: number): AbortSignal;
     // TODO: Add abort() static
 }
 

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -1,3 +1,5 @@
+/// <reference no-default-lib="true"/>
+
 // Declare "static" methods in Error
 interface ErrorConstructor {
     /** Create .stack property on a target object */

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -69,11 +69,21 @@ declare var AbortController: {
     new(): AbortController;
 };
 
-declare var AbortSignal: {
+interface AbortSignalConstructor {
     prototype: AbortSignal;
     new(): AbortSignal;
+    /**
+     * Returns an AbortSignal that will automatically abort after a specified time.
+     *
+     * @param time The "active" time in milliseconds before the returned AbortSignal will abort.
+     *
+     * @since v17.3.0, v16.14.0
+     */
+    timeout(time: number): AbortSignal;
     // TODO: Add abort() static
-};
+}
+
+declare var AbortSignal: AbortSignalConstructor;
 //#endregion borrowed
 
 //#region ArrayLike.at()

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -1,5 +1,3 @@
-/// <reference no-default-lib="true"/>
-
 // Declare "static" methods in Error
 interface ErrorConstructor {
     /** Create .stack property on a target object */

--- a/types/node/v16/test/globals.ts
+++ b/types/node/v16/test/globals.ts
@@ -26,3 +26,7 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
         gc();
     }
 }
+
+{
+    global.AbortSignal.timeout(1); // $ExpectType AbortSignal
+}


### PR DESCRIPTION
Add `AbortSignal.timeout(number)` definition to `@types/node`, available since Nodejs v17.3.0, v16.14.0.

See https://nodejs.org/api/globals.html#static-method-abortsignaltimeoutdelay for more details.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/globals.html#static-method-abortsignaltimeoutdelay
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

