### PR TITLE
[sharedb] Add custom event support for Backend#on

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -97,14 +97,11 @@ declare class sharedb extends EventEmitter {
         fn: (context: sharedb.middleware.ActionContextMap[A], callback: (err?: any) => void) => void,
     ): void;
 
-    on(event: 'timing', callback: (type: string, time: number, request: any) => void): this;
-    on(event: 'submitRequestEnd', callback: (error: Error, request: SubmitRequest) => void): this;
-    on(event: 'error', callback: (err: Error) => void): this;
-    on(event: 'send', callback: (agent: Agent, response: ShareDB.ServerResponseSuccess | ShareDB.ServerResponseError) => void): this;
+    on<E extends keyof sharedb.BackendEventListenerMap>(event: E, callback: sharedb.BackendEventListenerMap[E]): this;
+    on(eventName: string | symbol, listener: (...args: any[]) => void): this;
 
-    addListener(event: 'timing', callback: (type: string, time: number, request: any) => void): this;
-    addListener(event: 'submitRequestEnd', callback: (error: Error, request: SubmitRequest) => void): this;
-    addListener(event: 'error', callback: (err: Error) => void): this;
+    addListener<E extends keyof sharedb.BackendEventListenerMap>(event: E, callback: sharedb.BackendEventListenerMap[E]): this;
+    addListener(eventName: string | symbol, listener: (...args: any[]) => void): this;
 
     getOps(agent: Agent, index: string, id: string, from: number, to: number, options: GetOpsOptions, callback: (error: Error, ops: any[]) => any): void;
     getOpsBulk(agent: Agent, index: string, id: string, fromMap: Record<string, number>, toMap: Record<string, number>, options: GetOpsOptions, callback: (error: Error, ops: any[]) => any): void;
@@ -142,6 +139,13 @@ declare namespace sharedb {
 
     type DBQueryMethod = (collection: string, query: any, fields: ProjectionFields, options: any, callback: DBQueryCallback) => void;
     type DBQueryCallback = (err: Error | null, snapshots: Snapshot[], extra?: any) => void;
+
+    interface BackendEventListenerMap {
+        error: (err: Error) => void;
+        send: (agent: Agent, response: ShareDB.ServerResponseSuccess | ShareDB.ServerResponseError) => void;
+        submitRequestEnd: (error: Error, request: SubmitRequest) => void;
+        timing: (type: string, time: number, request: any) => void;
+    }
 
     abstract class PubSub {
         private static shallowCopy(obj: any): any;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -51,6 +51,7 @@ console.log(backend.db);
 backend.on('error', (error) => console.error(error));
 backend.on('send', (agent, context) => console.log(agent, context));
 backend.addListener('timing', (type, time, request) => console.log(type, new Date(time), request));
+backend.on('someCustomEvent', (arg0: string, arg1: number) => {});
 
 // getOps allows for `from` and `to` to both be `null`:
 // https://github.com/share/sharedb/blob/960f5d152f6a8051ed2dcb00a57681a3ebbd7dc2/README.md#getops


### PR DESCRIPTION
The sharedb Backend class [extends the Node EventEmitter class](https://github.com/share/sharedb/blob/7bf6781575433c190b6e04a5756eaf9b9c15d714/lib/backend.js#L62). The current type definitions specify `on` and `addListener` methods for Backend's built-in events.

End users should be able to emit and listen to their own custom events, too. However, in TS, this is currently impossible without a `(backend as EventEmitter).on(...)`, due to the way the current type definitions are written.

This PR now makes it possible to use custom events, with a couple options that an end user can choose from:

**Option 1 - Fallback method overload signature with default `EventEmitter#on` signature**

For this, I added fallback signatures for `on` and `addListener`, identical to the signatures in the Node EventEmitter.

That allows end users to listen to custom events without pre-defining the events or the listener signature:
```ts
backend.on('someCustomEvent', (arg0: string, arg1: number) => {});
```

**Option 2 - Module augmentation**

I refactored `on` and `addListener` to use a generic signature with a BackendEventListenerMap. This means that end users can use module augmentation to define custom Backend events that can be re-used across multiple files.

```ts
declare module 'sharedb' {
  interface BackendEventListenerMap {
    someCustomEvent: (arg0: string, arg1: number) => void;
  }
}
// Listener no longer needs types inline
backend.on('someCustomEvent', (arg0, arg1) => {
  console.log(arg0.toLowerCase(), -1 * arg1);
});
```

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (N/A)
