### PR TITLE
[qunit] add prop-contains and not-prop-contains

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for QUnit v2.11.3
+// Type definitions for QUnit v2.19.0
 // Project: http://qunitjs.com/
 // Definitions by: James Bracy <https://github.com/waratuman>
 //                 Mike North <https://github.com/mike-north>

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -372,6 +372,18 @@ declare global {
         }[];
     }
 
+    interface GlobalHooks {
+        /**
+         * Runs after each test.
+         */
+         afterEach(fn: (assert: Assert) => void | Promise<void>): void;
+
+         /**
+         * Runs before each test.
+         */
+        beforeEach(fn: (assert: Assert) => void | Promise<void>): void;
+    }
+
     interface Hooks {
         /**
          * Runs after the last test. If additional tests are defined after the
@@ -426,7 +438,10 @@ declare global {
 
     namespace QUnit {
         interface BeginDetails {
+            /** Number of registered tests */
             totalTests: number;
+            /** List of registered modules, */
+            modules: Array<{ name: string, moduleId: string }>
         }
         interface DoneDetails {
             failed: number;
@@ -536,6 +551,21 @@ declare global {
          * @param mixin An object describing which properties should be modified
          */
         extend(target: any, mixin: any): void;
+
+        /**
+         * Register a global callback to run before or after each test.
+         *
+         * This is the equivalent of applying a QUnit.module() hook to all modules
+         * and all tests, including global tests that are not associated with any module.
+         *
+         * Similar to module hooks, global hooks support async functions or
+         * returning a Promise, which will be waited for before QUnit continues executing tests.
+         * Each global hook also has access to the same assert object and
+         * test context as the QUnit.test that the hook is running for.
+         *
+         * For more details about hooks, refer to QUnit.module § Hooks.
+         */
+        hooks: GlobalHooks
 
         /**
          * Register a callback to fire whenever an assertion completes.

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -128,6 +128,21 @@ declare global {
         notOk(state: any, message?: string): void;
 
         /**
+         * Check that an object does not contain certain properties.
+         *
+         * The `notPropContains` assertion compares the subset of properties
+         * in the expected object, and tests that these keys are either absent
+         * or hold a value that is different according to a strict equality comparison.
+         *
+         * `propContains()` can be used to test to test for the presence and equality of properties.
+         *
+         * @param actual Object or Expression being tested
+         * @param expected Known comparison value
+         * @param {string} [message] A short description of the assertion
+         */
+        notPropContains(actual: any, expected: any, message?: string): void;
+
+        /**
          * A strict comparison of an object's own properties, checking for inequality.
          *
          * The `notPropEqual` assertion uses the strict inverted comparison operator
@@ -180,6 +195,25 @@ declare global {
          * @param {string} message A short description of the assertion
          */
         ok(state: any, message?: string): void;
+
+        /**
+         * Check that an object contains certain properties.
+         *
+         * The `propContains()` assertion compares only the subset of properties
+         * in the expected object, and tests that these keys exist as own properties
+         * with strictly equal values.
+         *
+         * This method is recursive and allows partial comparison of nested objects as well.
+         *
+         * `propEqual()` can be used to compare all properties, considering extra properties as unexpected.
+         *
+         * `notPropContains()` can be used to test for the absence or inequality of certain properties.
+         *
+         * @param actual Object or Expression being tested
+         * @param expected Known comparison value
+         * @param {string} [message] A short description of the assertion
+         */
+         propContains(actual: any, expected: any, message?: string): void;
 
         /**
          * A strict type and value comparison of an object's own properties.

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -60,6 +60,14 @@ QUnit.module( "Machine Maker", {
   }
 });
 
+QUnit.hooks.beforeEach(function (assert) {
+  assert.ok(true)
+});
+
+QUnit.hooks.afterEach(function (assert) {
+  assert.ok(true)
+});
+
 QUnit.test( "makes a robot", function( assert ) {
   this.parts.push( "arduino" );
   assert.equal( this.maker.build( this.parts ), "robot" );
@@ -139,6 +147,9 @@ QUnit.test( "`ok` assertion defined in the callback parameter", function( assert
 
 QUnit.begin(function( details ) {
   console.log( "Test amount:", details.totalTests );
+  for (const {name, moduleId} of details.modules) {
+    console.log(name, moduleId)
+  }
 });
 
 QUnit.config.autostart = false;
@@ -739,6 +750,15 @@ QUnit.skip( "async skip", async function( assert ) {
   await timeout();
   assert.ok(true);
 });
+
+QUnit.hooks.beforeEach(async function () {
+  await timeout();
+});
+
+QUnit.hooks.afterEach(async function () {
+  await timeout();
+});
+
 
 QUnit.module( "async", {
   async after( assert ) {

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -475,6 +475,12 @@ QUnit.test( "notOk test", function( assert ) {
   assert.notOk( "not-empty", "not-empty string fails" );
 });
 
+QUnit.test( "notPropContains test", function( assert ) {
+    const obj = { foo: 1, bar: "baz" }
+
+    assert.notPropContains( obj, { foo: 1 }, "Subset of values are strictly compared." );
+    assert.notPropContains( obj, { bar: { length: 3 } }, "Subset of values are strictly compared." );
+});
 
 QUnit.test( "notPropEqual test", function( assert ) {
   class Foo {
@@ -499,6 +505,13 @@ QUnit.test( "notPropEqual test", function( assert ) {
 
 QUnit.test( "a test", function( assert ) {
   assert.notStrictEqual( 1, "1", "String '1' and number 1 have the same value but not the same type" );
+});
+
+QUnit.test( "propContains test", function( assert ) {
+    const obj = { foo: 1, bar: "baz" }
+
+    assert.propContains( obj, { foo: 1 }, "Subset of values are strictly compared." );
+    assert.propContains( obj, { bar: { length: 3 } }, "Subset of values are strictly compared." );
 });
 
 QUnit.test( "propEqual test", function( assert ) {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

[`Qunit.hooks`](https://api.qunitjs.com/QUnit/hooks/), [`propContains()`](https://api.qunitjs.com/assert/propContains/), and [`notPropContains()`](https://api.qunitjs.com/assert/notPropContains/) was [released in v2.18.0](https://github.com/qunitjs/qunit/releases/tag/2.18.0)

[`moduleId`](https://api.qunitjs.com/callbacks/QUnit.begin/) was [released in v2.19.0](https://github.com/qunitjs/qunit/releases/tag/2.19.0)