### PR TITLE
Make estree extensible using augmentation

### DIFF
--- a/types/estree-jsx/index.d.ts
+++ b/types/estree-jsx/index.d.ts
@@ -6,21 +6,32 @@
 // Based on https://github.com/facebook/jsx/blob/master/AST.md.
 // Extends existing types for ESTree AST from `@types/estree`.
 
-import {
-    BaseExpression,
-    BaseNode,
-    Expression,
-    Literal,
-    Node as ESTreeNode
-} from 'estree';
+import { BaseExpression, BaseNode, Expression, Literal } from 'estree';
 
 export * from 'estree';
 
-export type Node =
-    ESTreeNode | JSXIdentifier | JSXNamespacedName | JSXMemberExpression |
-    JSXEmptyExpression | JSXExpressionContainer | JSXSpreadAttribute |
-    JSXAttribute | JSXOpeningElement | JSXOpeningFragment | JSXClosingElement |
-    JSXClosingFragment | JSXElement | JSXFragment | JSXText;
+declare module 'estree' {
+    interface ExpressionMap {
+        JSXElement: JSXElement;
+    }
+
+    interface NodeMap {
+        JSXIdentifier: JSXIdentifier;
+        JSXNamespacedName: JSXNamespacedName;
+        JSXMemberExpression: JSXMemberExpression;
+        JSXEmptyExpression: JSXEmptyExpression;
+        JSXExpressionContainer: JSXExpressionContainer;
+        JSXSpreadAttribute: JSXSpreadAttribute;
+        JSXAttribute: JSXAttribute;
+        JSXOpeningElement: JSXOpeningElement;
+        JSXOpeningFragment: JSXOpeningFragment;
+        JSXClosingElement: JSXClosingElement;
+        JSXClosingFragment: JSXClosingFragment;
+        JSXElement: JSXElement;
+        JSXFragment: JSXFragment;
+        JSXText: JSXText;
+    }
+}
 
 export interface JSXIdentifier extends BaseNode {
     type: 'JSXIdentifier';

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -255,9 +255,9 @@ export interface ExpressionMap {
   ClassExpression: ClassExpression;
   ConditionalExpression: ConditionalExpression;
   FunctionExpression: FunctionExpression;
-  Identifier: Identifier ;
+  Identifier: Identifier;
   ImportExpression: ImportExpression;
-  Literal: Literal ;
+  Literal: Literal;
   LogicalExpression: LogicalExpression;
   MemberExpression: MemberExpression;
   MetaProperty: MetaProperty;
@@ -265,9 +265,9 @@ export interface ExpressionMap {
   ObjectExpression: ObjectExpression;
   SequenceExpression: SequenceExpression;
   TaggedTemplateExpression: TaggedTemplateExpression;
-  TemplateLiteral: TemplateLiteral ;
+  TemplateLiteral: TemplateLiteral;
   ThisExpression: ThisExpression;
-  UnaryExpression: UnaryExpression ;
+  UnaryExpression: UnaryExpression;
   UpdateExpression: UpdateExpression;
   YieldExpression: YieldExpression;
 }

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -35,11 +35,32 @@ interface BaseNode extends BaseNodeWithoutComments {
   trailingComments?: Array<Comment> | undefined;
 }
 
-export type Node =
-    Identifier | Literal | Program | Function | SwitchCase | CatchClause |
-    VariableDeclarator | Statement | Expression | PrivateIdentifier | Property | PropertyDefinition |
-    AssignmentProperty | Super | TemplateElement | SpreadElement | Pattern |
-    ClassBody | Class | MethodDefinition | ModuleDeclaration | ModuleSpecifier;
+interface NodeMap {
+  AssignmentProperty: AssignmentProperty;
+  CatchClause: CatchClause;
+  Class: Class;
+  ClassBody: ClassBody;
+  Expression: Expression;
+  Function: Function;
+  Identifier: Identifier;
+  Literal: Literal;
+  MethodDefinition: MethodDefinition;
+  ModuleDeclaration: ModuleDeclaration;
+  ModuleSpecifier: ModuleSpecifier;
+  Pattern: Pattern;
+  PrivateIdentifier: PrivateIdentifier;
+  Program: Program;
+  Property: Property;
+  PropertyDefinition: PropertyDefinition;
+  SpreadElement: SpreadElement;
+  Statement: Statement;
+  Super: Super;
+  SwitchCase: SwitchCase;
+  TemplateElement: TemplateElement;
+  VariableDeclarator: VariableDeclarator;
+}
+
+export type Node = NodeMap[keyof NodeMap]
 
 export interface Comment extends BaseNodeWithoutComments {
   type: "Line" | "Block";
@@ -223,14 +244,35 @@ export interface VariableDeclarator extends BaseNode {
   init?: Expression | null | undefined;
 }
 
-type Expression =
-    ThisExpression | ArrayExpression | ObjectExpression | FunctionExpression |
-    ArrowFunctionExpression | YieldExpression | Literal | UnaryExpression |
-    UpdateExpression | BinaryExpression | AssignmentExpression |
-    LogicalExpression | MemberExpression | ConditionalExpression |
-    CallExpression | NewExpression | SequenceExpression | TemplateLiteral |
-    TaggedTemplateExpression | ClassExpression | MetaProperty | Identifier |
-    AwaitExpression | ImportExpression | ChainExpression;
+export interface ExpressionMap {
+  ArrayExpression: ArrayExpression;
+  ArrowFunctionExpression: ArrowFunctionExpression;
+  AssignmentExpression: AssignmentExpression;
+  AwaitExpression: AwaitExpression;
+  BinaryExpression: BinaryExpression;
+  CallExpression: CallExpression;
+  ChainExpression: ChainExpression;
+  ClassExpression: ClassExpression;
+  ConditionalExpression: ConditionalExpression;
+  FunctionExpression: FunctionExpression;
+  Identifier: Identifier ;
+  ImportExpression: ImportExpression;
+  Literal: Literal ;
+  LogicalExpression: LogicalExpression;
+  MemberExpression: MemberExpression;
+  MetaProperty: MetaProperty;
+  NewExpression: NewExpression;
+  ObjectExpression: ObjectExpression;
+  SequenceExpression: SequenceExpression;
+  TaggedTemplateExpression: TaggedTemplateExpression;
+  TemplateLiteral: TemplateLiteral ;
+  ThisExpression: ThisExpression;
+  UnaryExpression: UnaryExpression ;
+  UpdateExpression: UpdateExpression;
+  YieldExpression: YieldExpression;
+}
+
+type Expression = ExpressionMap[keyof ExpressionMap]
 
 export interface BaseExpression extends BaseNode { }
 


### PR DESCRIPTION
This uses the same concept as mdast. `estree-jsx` now uses this to extend estree, so the two are fully compatible.

If more extensions are needed, they can be added later.

`estree` also contains `flow.d.ts`. If this is accepted, I’d also like to update those types, and resolve some linting / formatting issues.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://twitter.com/remcohaszing/status/1531674555495993344
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
