### PR TITLE
Bigi - Change type of modInverse from "number" to "bigi"

### DIFF
--- a/types/bigi/index.d.ts
+++ b/types/bigi/index.d.ts
@@ -51,7 +51,7 @@ declare class bigi {
     min(a: bigi): bigi;
     mod(a: bigi): bigi;
     modInt(n: number): bigi;
-    modInverse(m: number): bigi;
+    modInverse(m: bigi): bigi;
     modPow(e: any, m: any): any;
     modPowInt(e: any, m: any): any;
     multiply(a: bigi): bigi;


### PR DESCRIPTION
As the params "m" of the function modInverse() use some bigi methods it expects a bigi type and not a number 
cf: https://github.com/cryptocoinjs/bigi/blob/master/lib/bigi.js#L1337

Select one of these and delete the others:

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
