### PR TITLE
fix(UpdateCodeowners): move to ts and fix import

### DIFF
--- a/.github/workflows/UpdateCodeowners.yml
+++ b/.github/workflows/UpdateCodeowners.yml
@@ -26,6 +26,7 @@ jobs:
       - run: git config --global user.name "TS Bot"
 
       - run: npm install
+      - run: npm run compile-scripts
       - run: npm run update-codeowners
         env:
             GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Since #59750 the update codeowners script hasn't worked so I've gone ahead and fixed it and also updated the file to .ts and moved the type definitions to actual TS type definitions and removed the JSDocs. Also if you wish I can push the commit that updates the codeowners file in this PR, otherwise, please run it once this is merged

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

