### PR TITLE
[DT Infrastructure] Fix failing jobs since change from CJS to ESM

### DIFF
--- a/scripts/ghostbuster.js
+++ b/scripts/ghostbuster.js
@@ -1,7 +1,8 @@
 // @ts-check
 import { flatMap, mapDefined } from "@definitelytyped/utils";
 import * as os from "node:os";
-import { writeFileSync, readFileSync, readdirSync, existsSync } from "fs-extra";
+import fsExtra from 'fs-extra';
+const { writeFileSync, readFileSync, readdirSync, existsSync } = fsExtra;
 import hp from "@definitelytyped/header-parser";
 import { Octokit } from "@octokit/core";
 

--- a/scripts/update-codeowners.js
+++ b/scripts/update-codeowners.js
@@ -2,7 +2,8 @@ import * as cp from 'node:child_process';
 import * as os from 'node:os';
 import { AllPackages, getDefinitelyTyped, parseDefinitions, clean } from '@definitelytyped/definitions-parser';
 import { loggerWithErrors } from '@definitelytyped/utils';
-import { writeFile } from 'fs-extra';
+import fsExtra from 'fs-extra';
+const { writeFile } = fsExtra;
 
 async function main() {
     const options = { definitelyTypedPath: '.', progress: false, parseInParallel: true };


### PR DESCRIPTION
This adds a commit on top of #60625 to fix another failing job I noticed.

A couple of workflows have been failing since the scripts were changed from CommonJS to ES Modules in #59750

- Update Codeowners: <https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/UpdateCodeowners.yml?query=is%3Afailure>
- Remove Deleted Accounts: <https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/ghostbuster.yml?query=is%3Afailure>

The errors happen because of attempted imports from `fs-extra` as an ES module, when it's actually CommonJS. This PR fixes the problem by using a default import and destructuring, as suggested by the error messages.

<details>
<summary>Logs for CODEOWNERS job</summary>

```text
file:///home/runner/work/DefinitelyTyped/DefinitelyTyped/scripts/update-codeowners.js:5
import { writeFile } from 'fs-extra';
         ^^^^^^^^^
SyntaxError: Named export 'writeFile' not found. The requested module 'fs-extra' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'fs-extra';
const { writeFile } = pkg;
```
</details>

<details>
<summary>Logs for deleted accounts job</summary>

```text
file:///home/runner/work/DefinitelyTyped/DefinitelyTyped/scripts/ghostbuster.js:4
import { writeFileSync, readFileSync, readdirSync, existsSync } from "fs-extra";
                                                   ^^^^^^^^^^
SyntaxError: Named export 'existsSync' not found. The requested module 'fs-extra' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:
import pkg from 'fs-extra';
const { writeFileSync, readFileSync, readdirSync, existsSync } = pkg;
```
</details>

