### PR TITLE
chore: add the type 'zh-CN' to IdentityCardLocale and the type 'CN' to PostalCodeLocale

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -571,7 +571,7 @@ declare namespace validator {
      */
     function isRgbColor(str: string, includePercentValues?: boolean): boolean;
 
-    type IdentityCardLocale = 'ES' | 'he-IL' | 'zh-TW';
+    type IdentityCardLocale = 'ES' | 'he-IL' | 'zh-TW' | 'zh-CN';
 
     /**
      * Check if the string is a valid identity card code.
@@ -985,6 +985,7 @@ declare namespace validator {
         | 'BR'
         | 'CA'
         | 'CH'
+        | 'CN'
         | 'CZ'
         | 'DE'
         | 'DK'


### PR DESCRIPTION
add the type 'zh-CN' to IdentityCardLocale
add the type 'CN' to PostalCodeLocale

[validator itself suports validating  Chinese identity card and postal code](https://github.com/validatorjs/validator.js/)
