### PR TITLE
Update watchpack types to 2.4

### DIFF
--- a/types/watchpack/DirectoryWatcher.d.ts
+++ b/types/watchpack/DirectoryWatcher.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-/// <reference types="chokidar" />
+
 import { EventEmitter } from 'events';
 import fs = require('graceful-fs');
 import Watcher = require('./Watcher');

--- a/types/watchpack/index.d.ts
+++ b/types/watchpack/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for watchpack 1.1
+// Type definitions for watchpack 2.4
 // Project: https://github.com/webpack/watchpack
 // Definitions by: e-cloud <https://github.com/e-cloud>
+//                 Adam Jones <https://github.com/domdomegg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.9
 
@@ -9,11 +10,21 @@
 import { EventEmitter } from 'events';
 import Watcher = require('./Watcher');
 
+interface Entry {
+    /** A point in time at which is it safe to say all changes happened before that */
+    safeTime: number;
+    /** Only for file entries: the last modified timestamp of the file */
+    timestamp: number;
+}
+
 declare class Watchpack extends EventEmitter {
-    aggregatedChanges: string[];
+    aggregatedChanges: Set<string>;
+    aggregatedRemovals: Set<string>;
+
     aggregateTimeout: NodeJS.Timer;
     dirWatchers: Watcher[];
     fileWatchers: Watcher[];
+    /** Last modified times for files by path */
     mtimes: {
         [path: string]: number;
     };
@@ -23,12 +34,105 @@ declare class Watchpack extends EventEmitter {
 
     constructor(options: Watchpack.WatchOptions);
 
-    watch(files: string[], directories: string[], startTime?: number): void;
+    /**
+     * Starts watching these files and directories
+     * Calling this again will override the files and directories
+     */
+    watch(options: {
+        /**
+         * Can be files or directories
+         * For files: content and existence changes are tracked
+         * For directories: only existence and timestamp changes are tracked
+         */
+        files?: Iterable<string>;
+        /**
+         * Can only be directories
+         * Directory content (and content of children, ...) and existence changes are tracked.
+         * For files: content and existence changes are tracked
+         * Assumed to exist, when directory is not found without further information a remove event is emitted
+         */
+        directories?: Iterable<string>;
+        /**
+         * Can be files or directories
+         * Only existence changes are tracked
+         * Assued to not exist, no remove event is emitted when not found initially
+         */
+        missing?: Iterable<string>;
+        startTime?: number;
+    }): void;
 
-    close(): void;
+    on(
+        eventName: 'change',
+        listener: (
+            /** The changed file or directory */
+            filePath: string,
+            /** The last modified time of the changed file */
+            modifiedTime: number,
+            /** Textual information how this change was detected */
+            explanation: string,
+        ) => void,
+    ): this;
 
+    on(
+        eventName: 'remove',
+        listener: (
+            /** The removed file or directory */
+            filePath: string,
+            /** Textual information how this change was detected */
+            explanation: string,
+        ) => void,
+    ): this;
+
+    on(
+        eventName: 'aggregated',
+        listener: (
+            /** Set of all changed files */
+            changes: Set<string>,
+            /** Set of all removed files */
+            removals: Set<string>,
+        ) => void,
+    ): this;
+
+    /**
+     * Stops emitting events, but keeps watchers open
+     * The next "watch" call can reuse the watchers
+     * The watcher will keep aggregating events which can be received with `getAggregated()`
+     */
     pause(): void;
 
+    /**
+     * Stops emitting events and closes all watchers
+     */
+    close(): void;
+
+    /**
+     * Returns the current aggregated info and removes that from the watcher
+     * The next aggregated event won't include that info and will only emitted when futher changes happen
+     * Can be used when paused
+     */
+    getAggregated(): {
+        changes: Set<string>;
+        removals: Set<string>;
+    };
+
+    /**
+     * Collects time info objects for all known files and directories
+     * This includes info from files not directly watched
+     */
+    collectTimeInfoEntries(fileInfoEntries: Map<string, Entry>, directoryInfoEntries: Map<string, Entry>): void;
+
+    /**
+     * Returns a `Map` with all known time info objects for files and directories
+     * Similar to `collectTimeInfoEntries()` but returns a single map with all entries
+     */
+    getTimeInfoEntries(): Map<string, Entry>;
+
+    /**
+     * Returns an object with all known change times for files
+     * This include timestamps from files not directly watched
+     * Key: absolute path, value: timestamp as number
+     * @deprecated
+     */
     getTimes(): {
         [path: string]: number;
     };
@@ -46,6 +150,7 @@ declare namespace Watchpack {
     interface WatcherOptions {
         ignored?: string[] | string | RegExp | ((path: string) => boolean) | undefined;
         poll?: boolean | number | undefined;
+        followSymlinks?: boolean;
     }
     interface WatchOptions extends WatcherOptions {
         aggregateTimeout?: number | undefined;

--- a/types/watchpack/package.json
+++ b/types/watchpack/package.json
@@ -1,6 +1,3 @@
 {
-  "private": true,
-  "dependencies": {
-    "chokidar": "^2.1.2"
-  }
+  "private": true
 }

--- a/types/watchpack/watchpack-tests.ts
+++ b/types/watchpack/watchpack-tests.ts
@@ -1,8 +1,48 @@
 import Watchpack = require('watchpack');
-const watch = new Watchpack({});
 
-watch.watch(['test.js'], ['lib/'], 1000);
-watch.watch(['test.js'], ['lib/']);
+const watch = new Watchpack({
+    ignored: '**/.git',
+});
+
+watch.watch({
+    files: ['test.js'],
+    directories: ['lib/'],
+    missing: ['dist/'],
+    startTime: 1000,
+});
+watch.watch({
+    files: ['test.js'],
+    directories: ['lib/'],
+});
+watch.watch({
+    files: ['test.js'],
+});
+watch.watch({
+    directories: ['lib/'],
+});
 
 let time: number;
 time = watch.getTimes()['test.js'];
+
+watch.on('change', (filePath, modifiedTime, explanation) => {
+    console.log(`${filePath} got changed at ${new Date(modifiedTime)}, noticed by ${explanation}`);
+});
+
+watch.on('remove', (filePath, explanation) => {
+    console.log(`${filePath} got removed, noticed by ${explanation}`);
+});
+
+watch.on('aggregated', (changes, removals) => {
+    console.log(`watchpack: aggregated ${changes.size} changes and ${removals.size} removals`);
+});
+
+setTimeout(() => {
+    watch.pause();
+}, 1000);
+
+// $ExpectType { changes: Set<string>; removals: Set<string>; }
+watch.getAggregated();
+
+setTimeout(() => {
+    watch.close();
+}, 2000);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/watchpack
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I've also added myself as a maintainer, given it currently only has one owner and I'd be happy to help support types for this package. I'm already an owner on some other packages, such as `@types/jest`, `@types/log`, `@types/gatsbyjs__reach-router` among others so understand and accept the commitment :)