### PR TITLE
[ramda] Add curried definition for uncurryN

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -5602,6 +5602,7 @@ export function unary<T, R>(fn: (a: T, ...args: any[]) => R): (a: T) => R;
  * ```
  */
 export function uncurryN<T>(len: number, fn: (a: any) => any): (...args: unknown[]) => T;
+export function uncurryN<T>(len: number): (fn: (a: any) => any) => (...args: unknown[]) => T;
 
 /**
  * Builds a list from a seed value.

--- a/types/ramda/test/uncurryN-tests.ts
+++ b/types/ramda/test/uncurryN-tests.ts
@@ -4,4 +4,6 @@ import * as R from 'ramda';
     const addFour = (a: number) => (b: number) => (c: number) => (d: number) => a + b + c + d;
     const uncurriedAddFour = R.uncurryN<number>(4, addFour);
     const res: number = uncurriedAddFour(1, 2, 3, 4); // => 10
+    const partialUncurriedAddFour = R.uncurryN<number>(4);
+    const resPartial: number = partialUncurriedAddFour(addFour)(1, 2, 3, 4); // => 10
 };


### PR DESCRIPTION
Currently after installing the types I cannot write this:
`compose(flip, uncurryN(2))`
The change should allow to use uncurryN with a single parameter.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [uncurryN](https://github.com/ramda/ramda/blob/master/source/uncurryN.js#L27)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

