### PR TITLE
update(html5-to-pdf): v4.0

### DIFF
--- a/types/html5-to-pdf/html5-to-pdf-tests.ts
+++ b/types/html5-to-pdf/html5-to-pdf-tests.ts
@@ -1,6 +1,6 @@
-import * as HTML5ToPDF from "html5-to-pdf";
+import HTML5ToPDF = require('html5-to-pdf');
 
-const options = { inputBody: "<html><body>Hello World</body></html>" };
+const options = { inputBody: '<html><body>Hello World</body></html>' };
 const converter = new HTML5ToPDF(options);
 converter.parseOptions(options); // $ExpectType ParsedOptions
 converter.build(); // $ExpectType Promise<Buffer>

--- a/types/html5-to-pdf/index.d.ts
+++ b/types/html5-to-pdf/index.d.ts
@@ -1,10 +1,9 @@
-// Type definitions for html5-to-pdf 3.1
+// Type definitions for html5-to-pdf 4.0
 // Project: https://github.com/peterdemartini/html5-to-pdf
 // Definitions by: Sam Alexander <https://github.com/samalexander>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
 
-import { LaunchOptions, PDFOptions, Page } from "puppeteer";
+import { LaunchOptions, PDFOptions, Page } from 'puppeteer';
 
 declare class HTML5ToPDF {
     constructor(options: HTML5ToPDF.Options);
@@ -25,7 +24,7 @@ declare namespace HTML5ToPDF {
         /**
          * File type
          */
-        type: "css" | "js";
+        type: 'css' | 'js';
         /**
          * File path
          */
@@ -47,7 +46,7 @@ declare namespace HTML5ToPDF {
          * [COMPATIBLE]\
          * Page size
          */
-        pageSize?: "A3" | "A4" | "Legal" | "Tabloid" | undefined;
+        pageSize?: 'A3' | 'A4' | 'Legal' | 'Tabloid' | undefined;
         /**
          * [COMPATIBLE]\
          * True for landscape, false for portrait.
@@ -114,5 +113,3 @@ declare namespace HTML5ToPDF {
 }
 
 export = HTML5ToPDF;
-
-export as namespace HTML5ToPDF;

--- a/types/html5-to-pdf/tsconfig.json
+++ b/types/html5-to-pdf/tsconfig.json
@@ -15,11 +15,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "puppeteer": [
-                "puppeteer/v1"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
- bump to v4
- prepare to migrate to native Puppeeter types (v7), removing outdated
  reference to v1
- remove wrong global script export

https://github.com/peterdemartini/html5-to-pdf/compare/v3.1.3...v4.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).