### PR TITLE
[asana] added property CustomField.display_value

### DIFF
--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -234,3 +234,8 @@ const typeaheadForWorkspaceQuery: asana.resources.Typeahead.TypeaheadParams = {
     opt_fields: ['name', 'completed', 'parent', 'custom_fields.gid', 'custom_fields.number_value'],
 };
 client.typeahead.typeaheadForWorkspace('workspace_gid', typeaheadForWorkspaceQuery);
+
+// Custom Fields have a string property "display_value"
+// https://developers.asana.com/docs/custom-field
+let customField: asana.resources.CustomField;
+customField.display_value;

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -2968,6 +2968,7 @@ declare namespace asana {
             enum_options: EnumValue[] | null;
             enum_value: EnumValue | null;
             number_value: number | null;
+            display_value: string | null;
         }
 
         interface CustomFieldsStatic {


### PR DESCRIPTION
Added the missing `display_value` property to `CustomField`, because according to [the documentation](https://developers.asana.com/docs/custom-field):

> _Integrations that don't require the underlying type should use this field to read values. Using this field will future-proof an app against new custom field types._

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.asana.com/docs/custom-field
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
