### PR TITLE
Correct typing for input_components in manifest

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7214,8 +7214,9 @@ declare namespace chrome.runtime {
             type?: string | undefined;
             id?: string | undefined;
             description?: string | undefined;
-            language?: string | undefined;
+            language?: string[] | string | undefined;
             layouts?: string[] | undefined;
+            indicator?: string | undefined;
         }[] | undefined;
         key?: string | undefined;
         minimum_chrome_version?: string | undefined;


### PR DESCRIPTION
1) language can also be string  - see for example: https://crsrc.org/c/chrome/browser/resources/chromeos/input_method/google_xkb_manifest.json;drc=f69e007e1f095d667de85bd6a40f4816e626c5a2;l=1079
2) Add indicator field - see for example: https://crsrc.org/c/chrome/browser/resources/chromeos/input_method/google_xkb_manifest.json;drc=f69e007e1f095d667de85bd6a40f4816e626c5a2;l=54

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://crsrc.org/c/chrome/browser/resources/chromeos/input_method/google_xkb_manifest.json

