### PR TITLE
[react] Allow `TrustedHTML` in `dangerouslySetInnerHTML`

### DIFF
--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -153,3 +153,5 @@ interface Text { }
 interface TouchList { }
 interface WebGLRenderingContext { }
 interface WebGL2RenderingContext { }
+
+interface TrustedHTML { }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1372,7 +1372,9 @@ declare namespace React {
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
         dangerouslySetInnerHTML?: {
-            __html: string;
+            // Should be InnerHTML['innerHTML'].
+            // But unfortunately we're mixing renderer-specific type declarations.
+            __html: string | TrustedHTML;
         } | undefined;
 
         // Clipboard Events

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -527,6 +527,16 @@ DOM.svg({
     })
 );
 
+declare const trustedHtml: TrustedHTML;
+
+const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
+    dangerouslySetInnerHTML: {
+        __html: trustedHtml
+    }
+};
+DOM.div(trustedTypesHTMLAttr);
+DOM.span(trustedTypesHTMLAttr);
+
 //
 // React.Children
 // --------------------------------------------------------------------------

--- a/types/react/v16/global.d.ts
+++ b/types/react/v16/global.d.ts
@@ -149,3 +149,5 @@ interface Text { }
 interface TouchList { }
 interface WebGLRenderingContext { }
 interface WebGL2RenderingContext { }
+
+interface TrustedHTML { }

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1340,7 +1340,9 @@ declare namespace React {
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
         dangerouslySetInnerHTML?: {
-            __html: string;
+            // Should be InnerHTML['innerHTML'].
+            // But unfortunately we're mixing renderer-specific type declarations.
+            __html: string | TrustedHTML;
         } | undefined;
 
         // Clipboard Events

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -526,6 +526,16 @@ DOM.div(htmlAttr);
 DOM.span(htmlAttr);
 DOM.input(htmlAttr);
 
+declare const trustedHtml: TrustedHTML;
+
+const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
+    dangerouslySetInnerHTML: {
+        __html: trustedHtml
+    }
+};
+DOM.div(trustedTypesHTMLAttr);
+DOM.span(trustedTypesHTMLAttr);
+
 DOM.svg({
     viewBox: "0 0 48 48",
     xmlns: "http://www.w3.org/2000/svg"

--- a/types/react/v17/global.d.ts
+++ b/types/react/v17/global.d.ts
@@ -153,3 +153,5 @@ interface Text { }
 interface TouchList { }
 interface WebGLRenderingContext { }
 interface WebGL2RenderingContext { }
+
+interface TrustedHTML { }

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1339,7 +1339,9 @@ declare namespace React {
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
         dangerouslySetInnerHTML?: {
-            __html: string;
+            // Should be InnerHTML['innerHTML'].
+            // But unfortunately we're mixing renderer-specific type declarations.
+            __html: string | TrustedHTML;
         } | undefined;
 
         // Clipboard Events

--- a/types/react/v17/test/index.ts
+++ b/types/react/v17/test/index.ts
@@ -525,6 +525,16 @@ DOM.div(htmlAttr);
 DOM.span(htmlAttr);
 DOM.input(htmlAttr);
 
+declare const trustedHtml: TrustedHTML;
+
+const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
+    dangerouslySetInnerHTML: {
+        __html: trustedHtml
+    }
+};
+DOM.div(trustedTypesHTMLAttr);
+DOM.span(trustedTypesHTMLAttr);
+
 DOM.svg({
     viewBox: "0 0 48 48",
     xmlns: "http://www.w3.org/2000/svg"


### PR DESCRIPTION
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60417

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://developer.mozilla.org/en-US/docs/Web/API/TrustedHTML
   - https://codesandbox.io/s/trustedhtml-kfxbhz
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

/cc @lgarron