### PR TITLE
lodash/fp update isPlainObject to be a typeguard

### DIFF
--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -1997,7 +1997,7 @@ declare namespace _ {
     type LodashIsNumber = (value: any) => value is number;
     type LodashIsObject = (value: any) => value is object;
     type LodashIsObjectLike = (value: any) => boolean;
-    type LodashIsPlainObject = (value: any) => boolean;
+    type LodashIsPlainObject = (value: any) => value is object;
     type LodashIsRegExp = (value: any) => value is RegExp;
     type LodashIsSafeInteger = (value: any) => boolean;
     type LodashIsSet = (value: any) => value is Set<any>;


### PR DESCRIPTION
Although `isObject` typeguards to `object`, `isPlainObject` doesn't typeguard at all. `isPlainObject` is supposed to be more restrictive and likely should narrow to a more specific type. Either way, not narrowing at all is incorrect and `object` is at least a superset of the narrower solution.