### PR TITLE
[@wordpress/data] Fix return value of dispatched actions to be a Promise

### DIFF
--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -18,7 +18,8 @@ export { Action, combineReducers };
 //
 export type ResolveSelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => Promise<T>>;
 export type SelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => T>;
-export type DispatcherMap = Record<string, <T = void>(...args: readonly any[]) => Promise<T>>;
+type EnsurePromise<T> = T extends Promise<any> ? T : Promise<T>
+export type DispatcherMap = Record<string, <T = void>(...args: readonly any[]) => EnsurePromise<T>>;
 
 /**
  * Subscribe to any changes to the store

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -18,7 +18,7 @@ export { Action, combineReducers };
 //
 export type ResolveSelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => Promise<T>>;
 export type SelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => T>;
-export type DispatcherMap = Record<string, <T = void>(...args: readonly any[]) => T>;
+export type DispatcherMap = Record<string, <T = void>(...args: readonly any[]) => Promise<T>>;
 
 /**
  * Subscribe to any changes to the store

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -18,7 +18,7 @@ export { Action, combineReducers };
 //
 export type ResolveSelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => Promise<T>>;
 export type SelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => T>;
-type EnsurePromise<T> = T extends Promise<any> ? T : Promise<T>
+type EnsurePromise<T> = T extends Promise<any> ? T : Promise<T>;
 export type DispatcherMap = Record<string, <T = void>(...args: readonly any[]) => EnsurePromise<T>>;
 
 /**

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -19,7 +19,7 @@ export { Action, combineReducers };
 export type ResolveSelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => Promise<T>>;
 export type SelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => T>;
 type EnsurePromise<T> = T extends Promise<any> ? T : Promise<T>;
-export type DispatcherMap = Record<string, <T = void>(...args: readonly any[]) => EnsurePromise<T>>;
+export type DispatcherMap = Record<string, <T = void, DoEnsurePromise extends boolean = true>(...args: readonly any[]) => DoEnsurePromise extends true ? EnsurePromise<T> : T>;
 
 /**
  * Subscribe to any changes to the store

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -52,9 +52,6 @@ const HookComponent = () => {
 // $ExpectType DispatcherMap
 data.dispatch('foo/bar');
 
-// $ExpectType Record<string, <T = void>(...args: readonly any[]) => Promise<T>>
-data.dispatch('foo/bar');
-
 // $ExpectType Promise<void>
 data.dispatch('foo/bar').foobar();
 

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -61,6 +61,9 @@ data.dispatch('foo/bar').foobar<Promise<number>>();
 // $ExpectType Promise<number>
 data.dispatch('foo/bar').foobar<number>();
 
+// $ExpectType number
+data.dispatch('foo/bar').foobar<number, false>();
+
 // $ExpectType Record<string, <T = unknown>(...args: readonly any[]) => T> || SelectorMap
 data.select('foo/bar');
 

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -49,7 +49,7 @@ const HookComponent = () => {
 // `dispatch` overload tests
 //
 
-// $ExpectType Record<string, <T = void>(...args: readonly any[]) => Promise<T>> || DispatcherMap
+// $ExpectType Record<string, <T = void>(...args: readonly any[]) => EnsurePromise<T>> || DispatcherMap
 data.dispatch('foo/bar');
 
 // $ExpectType Promise<void>

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -49,13 +49,16 @@ const HookComponent = () => {
 // `dispatch` overload tests
 //
 
-// $ExpectType Record<string, <T = void>(...args: readonly any[]) => T> || DispatcherMap
+// $ExpectType DispatcherMap
 data.dispatch('foo/bar');
 
-// $ExpectType void
+// $ExpectType Record<string, <T = void>(...args: readonly any[]) => Promise<T>>
+data.dispatch('foo/bar');
+
+// $ExpectType Promise<void>
 data.dispatch('foo/bar').foobar();
 
-// $ExpectType number
+// $ExpectType Promise<number>
 data.dispatch('foo/bar').foobar<number>();
 
 // $ExpectType Record<string, <T = unknown>(...args: readonly any[]) => T> || SelectorMap

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -56,6 +56,9 @@ data.dispatch('foo/bar');
 data.dispatch('foo/bar').foobar();
 
 // $ExpectType Promise<number>
+data.dispatch('foo/bar').foobar<Promise<number>>();
+
+// $ExpectType Promise<number>
 data.dispatch('foo/bar').foobar<number>();
 
 // $ExpectType Record<string, <T = unknown>(...args: readonly any[]) => T> || SelectorMap

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -49,7 +49,7 @@ const HookComponent = () => {
 // `dispatch` overload tests
 //
 
-// $ExpectType DispatcherMap
+// $ExpectType Record<string, <T = void>(...args: readonly any[]) => Promise<T>> || DispatcherMap
 data.dispatch('foo/bar');
 
 // $ExpectType Promise<void>

--- a/types/wordpress__data/wordpress__data-tests.tsx
+++ b/types/wordpress__data/wordpress__data-tests.tsx
@@ -49,7 +49,7 @@ const HookComponent = () => {
 // `dispatch` overload tests
 //
 
-// $ExpectType Record<string, <T = void>(...args: readonly any[]) => EnsurePromise<T>> || DispatcherMap
+// $ExpectType Record<string, <T = void, DoEnsurePromise extends boolean = true>(...args: readonly any[]) => DoEnsurePromise extends true ? EnsurePromise<T> : T> || DispatcherMap
 data.dispatch('foo/bar');
 
 // $ExpectType Promise<void>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/6aef6e6b9b5cf2f5aeff6145cd24181edf0d43f0/packages/data/README.md#user-content-dispatch ("Note: Action creators returned by the dispatch will return a promise when they are called.")
