### PR TITLE
[react] fix: missing target types at KeyboardEvent

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1272,6 +1272,7 @@ declare namespace React {
         shiftKey: boolean;
         /** @deprecated */
         which: number;
+        target: EventTarget & T;
     }
 
     interface MouseEvent<T = Element, E = NativeMouseEvent> extends UIEvent<T, E> {


### PR DESCRIPTION
When you try to get the target.value at the Keyboard Event, you can't reach it, unlike the other events. For me, it's only a missing target types like other events have.

Sandbox with the errors reproduced: https://codesandbox.io/s/target-onkeydown-missing-type-kr46u1
![image](https://user-images.githubusercontent.com/52859409/172267158-b321d7e4-3891-4e34-b604-8f84e1bb6a08.png)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codesandbox.io/s/target-onkeydown-missing-type-kr46u1
