### PR TITLE
[React Slick] Update Types to handle LazyLoad

### DIFF
--- a/types/react-slick/index.d.ts
+++ b/types/react-slick/index.d.ts
@@ -27,7 +27,7 @@ export interface ResponsiveObject {
 
 export type SwipeDirection = "left" | "down" | "right" | "up" | string;
 
-export type LazyLoadTypes = "ondemand" | "progressive";
+export type LazyLoadTypes = "ondemand" | "progressive" | "anticipated";
 
 export interface Settings {
     accessibility?: boolean | undefined;


### PR DESCRIPTION
Hello, I updated LazyTypes to handle changes made in 1.7.1

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kenwheeler/slick/releases/tag/1.7.1 
`Added lazyLoad support for secret/sizes attributes and option ‘anticipated’ to preload n images`
