### PR TITLE
[node] Change TLSSocket `encrypted` type to `true`

### DIFF
--- a/types/node/test/tls.ts
+++ b/types/node/test/tls.ts
@@ -56,6 +56,8 @@ import * as stream from 'node:stream';
     tlsSocket.disableRenegotiation();
     tlsSocket.enableTrace();
 
+    tlsSocket.encrypted; // $ExpectType true
+
     const ciphers: string[] = getCiphers();
     const curve: string = DEFAULT_ECDH_CURVE;
     const maxVersion: string = DEFAULT_MAX_VERSION;

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -158,7 +158,7 @@ declare module 'tls' {
          * Always returns `true`. This may be used to distinguish TLS sockets from regular`net.Socket` instances.
          * @since v0.11.4
          */
-        encrypted: boolean;
+        encrypted: true;
         /**
          * String containing the selected ALPN protocol.
          * Before a handshake has completed, this value is always null.

--- a/types/node/v12/tls.d.ts
+++ b/types/node/v12/tls.d.ts
@@ -142,7 +142,7 @@ declare module 'tls' {
          * Static boolean value, always true.
          * May be used to distinguish TLS sockets from regular ones.
          */
-        encrypted: boolean;
+        encrypted: true;
 
         /**
          * String containing the selected ALPN protocol.

--- a/types/node/v14/tls.d.ts
+++ b/types/node/v14/tls.d.ts
@@ -147,7 +147,7 @@ declare module 'tls' {
          * Static boolean value, always true.
          * May be used to distinguish TLS sockets from regular ones.
          */
-        encrypted: boolean;
+        encrypted: true;
 
         /**
          * String containing the selected ALPN protocol.

--- a/types/node/v16/tls.d.ts
+++ b/types/node/v16/tls.d.ts
@@ -157,7 +157,7 @@ declare module 'tls' {
          * Always returns `true`. This may be used to distinguish TLS sockets from regular`net.Socket` instances.
          * @since v0.11.4
          */
-        encrypted: boolean;
+        encrypted: true;
         /**
          * String containing the selected ALPN protocol.
          * Before a handshake has completed, this value is always null.


### PR DESCRIPTION
Related discussion: #60700

Changes the type of the `encrypted` property on TLSSocket to `true` instead of `boolean`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test node`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/api/tls.html#tlssocketencrypted>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
