### PR TITLE
[React Slick] Add typing for InnerSlider

### DIFF
--- a/types/react-slick/index.d.ts
+++ b/types/react-slick/index.d.ts
@@ -25,6 +25,10 @@ export interface ResponsiveObject {
     settings: "unslick" | Settings;
 }
 
+export interface InnerSlider {
+    list?: HTMLDivElement;
+}
+
 export type SwipeDirection = "left" | "down" | "right" | "up" | string;
 
 export type LazyLoadTypes = "ondemand" | "progressive";
@@ -87,6 +91,7 @@ export interface Settings {
 }
 
 declare class Slider extends React.Component<Settings, never> {
+    innerSlider?: InnerSlider | undefined;
     slickNext(): void;
     slickPause(): void;
     slickPlay(): void;

--- a/types/react-slick/react-slick-tests.tsx
+++ b/types/react-slick/react-slick-tests.tsx
@@ -68,6 +68,15 @@ const defaultSettings: Settings = {
 
 class SliderTest extends React.Component {
   private slider: Slider | null = null;
+
+  componentDidMount() {
+    const slides = this.slider?.innerSlider?.list?.querySelectorAll(".slick-slide");
+    slides?.forEach((slide, index) => {
+      const dataIndex = slide.getAttribute("data-test") || index.toString();
+      slide.setAttribute("data-test", dataIndex);
+    });
+  }
+
   render() {
     return <div>
       <Slider


### PR DESCRIPTION
I added an interface for the innerSlider so there are no type errors when trying to access all slides to set/modify a data attribute or do another type of DOM manipulation. There is a test of adding a data attribute to each slide that shows there are no type errors.
There is not a public URL that provides the exact context that I can find, but for the company I work for, this would allow us to not have to manually modify the types for react-slick.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kenwheeler/slick/issues/3485
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

