### PR TITLE
[Relay-compiler] Remove IR's accidental import of TypeScript

### DIFF
--- a/types/relay-compiler/lib/core/IR.d.ts
+++ b/types/relay-compiler/lib/core/IR.d.ts
@@ -6,7 +6,6 @@ import {
     TypeID,
 } from './Schema';
 import { Source } from 'graphql';
-import { TypeReferenceNode } from 'typescript';
 
 export type Metadata = { [key: string]: unknown } | undefined;
 

--- a/types/relay-compiler/relay-compiler-tests.ts
+++ b/types/relay-compiler/relay-compiler-tests.ts
@@ -69,4 +69,5 @@ getLanguagePlugin(() => ({
         },
     },
 }));
+
 getLanguagePlugin('typescript').outputExtension;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

( CI will do it )

Funny story for this one.

I was finding that in all of my codebases I was getting TypeScript's API in my auto-complete recommendations, so after a few months I figured I'd offer an idea to the compiler about removing them - https://github.com/microsoft/TypeScript/issues/49418#issuecomment-1149489436

Turns out that this unused import was what told the TypeScript compiler that there is active use of the TypeScript API within the boundaries of my app, dropping this should remove the side-effect of including the TS compiler API in any app's recommendations