### PR TITLE
[aws-lambda]: Add DynamoDBStreamHandler response object with `batchItemFailures` support

### DIFF
--- a/types/aws-lambda/test/dynamodb-tests.ts
+++ b/types/aws-lambda/test/dynamodb-tests.ts
@@ -1,4 +1,4 @@
-import { DynamoDBStreamEvent } from "aws-lambda";
+import { DynamoDBStreamEvent, DynamoDBStreamHandler, DynamoDBBatchResponse } from "aws-lambda";
 
 // TODO: Update test to read all event properties, and write all result
 //       properties, like the user will.
@@ -96,3 +96,28 @@ const event: DynamoDBStreamEvent = {
         },
     ],
 };
+
+const streamHandlerWithResponse: DynamoDBStreamHandler = async (event, context, callback) => {
+    // Check result type
+    let result: DynamoDBBatchResponse;
+    // check minimally assignable case
+    result = {
+        batchItemFailures: []
+    };
+    // check maximally assignable case
+    result = {
+        batchItemFailures: [
+            {
+                itemIdentifier: ''
+            }
+        ]
+    };
+
+    // check reasonable result-returning styles
+    callback(new Error());
+    callback(null, result);
+    callback(null);
+    return result;
+};
+
+const streamHandlerNoResponse: DynamoDBStreamHandler = async (event, context, callback) => {};

--- a/types/aws-lambda/trigger/dynamodb-stream.d.ts
+++ b/types/aws-lambda/trigger/dynamodb-stream.d.ts
@@ -1,6 +1,6 @@
 import { Handler } from "../handler";
 
-export type DynamoDBStreamHandler = Handler<DynamoDBStreamEvent, void>;
+export type DynamoDBStreamHandler = Handler<DynamoDBStreamEvent, DynamoDBBatchResponse | void>;
 
 // http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_AttributeValue.html
 export interface AttributeValue {
@@ -42,4 +42,13 @@ export interface DynamoDBRecord {
 // http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-ddb-update
 export interface DynamoDBStreamEvent {
     Records: DynamoDBRecord[];
+}
+
+// https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-batchfailurereporting
+export interface DynamoDBBatchResponse {
+    batchItemFailures: DynamoDBBatchItemFailure[];
+}
+
+export interface DynamoDBBatchItemFailure {
+    itemIdentifier: string;
 }

--- a/types/aws-lambda/trigger/dynamodb-stream.d.ts
+++ b/types/aws-lambda/trigger/dynamodb-stream.d.ts
@@ -1,5 +1,6 @@
 import { Handler } from "../handler";
 
+// tslint:disable-next-line:void-return
 export type DynamoDBStreamHandler = Handler<DynamoDBStreamEvent, DynamoDBBatchResponse | void>;
 
 // http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_AttributeValue.html


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-batchfailurereporting
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
