### PR TITLE
jest-when: Updated available functions and extension of `jest.MockInstance`

### DIFF
--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -4,6 +4,7 @@
 //                 Trung Dang <https://github.com/immanuel192>
 //                 Gregor Stamać <https://github.com/gstamac>
 //                 Nicholas Hehr <https://github.com/hipsterbrown>
+//                 Bogi Napoleon Wennerström <https://github.com/boginw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.8
 
@@ -13,23 +14,35 @@ export type ArgumentOrMatcher<ArgTypes extends any[]> = {
     [Index in keyof ArgTypes]: ArgTypes[Index] | WhenMock<boolean, [ArgTypes[Index]]>;
 };
 
-export interface WhenMock<T = any, Y extends any[] = any> extends jest.MockInstance<T, Y> {
-    calledWith(allArgsMatcher: AllArgsMatcher<Y>): this;
-    calledWith(...matchers: ArgumentOrMatcher<Y>): this;
-    expectCalledWith(allArgsMatcher: AllArgsMatcher<Y>): this;
-    expectCalledWith(...matchers: ArgumentOrMatcher<Y>): this;
-    mockReturnValue(value: T): this;
-    mockReturnValueOnce(value: T): this;
-    mockResolvedValue(value: jest.ResolvedValue<T>): this;
-    mockResolvedValueOnce(value: jest.ResolvedValue<T>): this;
-    mockRejectedValue(value: jest.RejectedValue<T>): this;
-    mockRejectedValueOnce(value: jest.RejectedValue<T>): this;
-    mockImplementation(fn: (...args: Y) => T): this;
-    mockImplementationOnce(fn?: (...args: Y) => T): this;
-    defaultReturnValue(value: T): this;
-    defaultResolvedValue(value: jest.ResolvedValue<T>): this;
-    defaultRejectedValue(value: jest.RejectedValue<T>): this;
-    defaultImplementation(fn: (...args: Y) => T): this;
+export interface WhenMock<T = any, Y extends any[] = any> {
+    calledWith(allArgsMatcher: AllArgsMatcher<Y>): WhenMockWithMatchers<T, Y>;
+    calledWith(...matchers: ArgumentOrMatcher<Y>): WhenMockWithMatchers<T, Y>;
+    expectCalledWith(allArgsMatcher: AllArgsMatcher<Y>): WhenMockWithMatchers<T, Y>;
+    expectCalledWith(...matchers: ArgumentOrMatcher<Y>): WhenMockWithMatchers<T, Y>;
+    mockReturnValue(value: T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockResolvedValue(value: jest.ResolvedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockRejectedValue(value: jest.RejectedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockImplementation(fn: (...args: Y) => T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    defaultReturnValue(value: T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    defaultResolvedValue(value: jest.ResolvedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    defaultRejectedValue(value: jest.RejectedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    defaultImplementation(fn: (...args: Y) => T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    resetWhenMocks(): void;
+}
+
+export interface WhenMockWithMatchers<T = any, Y extends any[] = any> {
+    mockReturnValue(value: T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockReturnValueOnce(value: T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockResolvedValue(value: jest.ResolvedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockResolvedValueOnce(value: jest.ResolvedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockRejectedValue(value: jest.RejectedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockRejectedValueOnce(value: jest.RejectedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockImplementation(fn: (...args: Y) => T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    mockImplementationOnce(fn?: (...args: Y) => T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    defaultImplementation(fn: (...args: Y) => T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    defaultReturnValue(value: T): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    defaultResolvedValue(value: jest.ResolvedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
+    defaultRejectedValue(value: jest.RejectedValue<T>): WhenMockWithMatchers<T, Y> & WhenMock<T, Y>;
 }
 
 export interface AllArgsMatcher<Y> {

--- a/types/jest-when/jest-when-tests.ts
+++ b/types/jest-when/jest-when-tests.ts
@@ -30,6 +30,18 @@ describe('mock-when test', () => {
         expect(result).toEqual('yay!');
     });
 
+    it('is not a jest MockInstance', () => {
+        const fn = jest.fn();
+
+        const mockInstance: jest.MockInstance<any, any> = when(fn); // $ExpectError
+    });
+
+    it('is not a jest MockInstance when matchers provided', () => {
+        const fn = jest.fn();
+
+        const mockInstance: jest.MockInstance<any, any> = when(fn).calledWith(); // $ExpectError
+    });
+
     it('Supports compound declarations:', () => {
         const fn = jest.fn();
         when(fn).calledWith(1).mockReturnValueOnce('no').mockReturnValue('yes');
@@ -99,6 +111,14 @@ describe('mock-when test', () => {
         expect(testPassed).toBeTruthy();
     });
 
+    it('should not support all *Once functions without matchers', () => {
+        const fn = jest.fn();
+        when(fn).mockReturnValueOnce(() => 1); // $ExpectError
+        when(fn).mockResolvedValueOnce(() => 1); // $ExpectError
+        when(fn).mockRejectedValueOnce(() => 1); // $ExpectError
+        when(fn).mockImplementationOnce(() => 1); // $ExpectError
+    });
+
     it('should support for mockImplementation', () => {
         const fn = jest.fn();
         const expectValue = { a: 1, b: 2 };
@@ -131,6 +151,12 @@ describe('mock-when test', () => {
         resetAllWhenMocks();
 
         expect(fn(1)).toEqual('initial');
+    });
+
+    it('should not support resetAllWhenMocks when matchers provided', () => {
+        const fn = jest.fn();
+
+        when(fn).calledWith().resetAllWhenMocks(); // $ExpectError
     });
 
     it('should supper verifyAllWhenMocksCalled', () => {

--- a/types/jest-when/jest-when-tests.ts
+++ b/types/jest-when/jest-when-tests.ts
@@ -42,6 +42,24 @@ describe('mock-when test', () => {
         const mockInstance: jest.MockInstance<any, any> = when(fn).calledWith(); // $ExpectError
     });
 
+    it('should support resetWhenMocks', () => {
+        const fn = jest.fn();
+
+        when(fn).resetWhenMocks();
+    });
+
+    it('should not support resetWhenMocks when matchers provided', () => {
+        const fn = jest.fn();
+
+        when(fn).calledWith().resetWhenMocks(); // $ExpectError
+    });
+
+    it('should support resetWhenMocks when implementation mocked', () => {
+        const fn = jest.fn();
+
+        when(fn).mockImplementation(() => 1).resetWhenMocks();
+    });
+
     it('Supports compound declarations:', () => {
         const fn = jest.fn();
         when(fn).calledWith(1).mockReturnValueOnce('no').mockReturnValue('yes');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [README](https://github.com/timkindberg/jest-when/blob/master/README.md?plain=1#L9)

The [README](https://github.com/timkindberg/jest-when/blob/master/README.md?plain=1#L9) of "jest-when" says that : 
> [jest-when] Feels like canonical jest syntax.

The current types, however, suggest that [jest-when] *is* canonical jest syntax. It has previously been argued over [type safety or usability](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57774#discussion_r779211197) wrt. to this package, but in my experience, this slight distinction is very frustrating. Having `WhenMock` extending `jest.MockInstance` means that useful functions from `MockInstance`, like `mockClear()`, get suggested when using "jest-when". However, these functions do not exist in "jest-when". This results in frustrating runtime errors and debugging. Other methods on `WhenMock`, such as all the ones ending in `Once`, are only present once `.calledWith` has been called. These `Once` methods have also brought a lot of frustrations when they get suggested, as they do not exist.

This PR fixes the abovementioned issues. However, even though the library `WhenMock` isn't a `jest.MockInstance`, there's bound to be someone, who relies on that being true. Therefore, this PR can be considered to introduce breaking type changes.