### PR TITLE
[leaflet] Fix overload order for events

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -367,7 +367,6 @@ export abstract class Evented extends Class {
      * (e.g. 'click dblclick').
      */
     // tslint:disable:unified-signatures
-    on(type: string, fn: LeafletEventHandlerFn, context?: any): this;
     on(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
         fn: LayersControlEventHandlerFn, context?: any): this;
     on(type: 'layeradd' | 'layerremove',
@@ -400,6 +399,7 @@ export abstract class Evented extends Class {
         fn: TileEventHandlerFn, context?: any): this;
     on(type: 'tileerror',
         fn: TileErrorEventHandlerFn, context?: any): this;
+    on(type: string, fn: LeafletEventHandlerFn, context?: any): this;
 
     /**
      * Adds a set of type/listener pairs, e.g. {click: onClick, mousemove: onMouseMove}
@@ -414,7 +414,6 @@ export abstract class Evented extends Class {
      * to off in order to remove the listener.
      */
     // tslint:disable:unified-signatures
-    off(type: string, fn?: LeafletEventHandlerFn, context?: any): this;
     off(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
         fn?: LayersControlEventHandlerFn, context?: any): this;
     off(type: 'layeradd' | 'layerremove',
@@ -447,6 +446,7 @@ export abstract class Evented extends Class {
         fn?: TileEventHandlerFn, context?: any): this;
     off(type: 'tileerror',
         fn?: TileErrorEventHandlerFn, context?: any): this;
+    off(type: string, fn?: LeafletEventHandlerFn, context?: any): this;
 
     /**
      * Removes a set of type/listener pairs.
@@ -476,7 +476,6 @@ export abstract class Evented extends Class {
      * Behaves as on(...), except the listener will only get fired once and then removed.
      */
     // tslint:disable:unified-signatures
-    once(type: string, fn: LeafletEventHandlerFn, context?: any): this;
     once(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
         fn: LayersControlEventHandlerFn, context?: any): this;
     once(type: 'layeradd' | 'layerremove',
@@ -509,6 +508,7 @@ export abstract class Evented extends Class {
         fn: TileEventHandlerFn, context?: any): this;
     once(type: 'tileerror',
         fn: TileEventHandlerFn, context?: any): this;
+    once(type: string, fn: LeafletEventHandlerFn, context?: any): this;
 
     /**
      * Behaves as on(...), except the listener will only get fired once and then removed.
@@ -535,7 +535,6 @@ export abstract class Evented extends Class {
      * (e.g. 'click dblclick').
      */
     // tslint:disable:unified-signatures
-    addEventListener(type: string, fn: LeafletEventHandlerFn, context?: any): this;
     addEventListener(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
         fn: LayersControlEventHandlerFn, context?: any): this;
     addEventListener(type: 'layeradd' | 'layerremove',
@@ -568,6 +567,7 @@ export abstract class Evented extends Class {
         fn: TileEventHandlerFn, context?: any): this;
     addEventListener(type: 'tileerror',
         fn: TileErrorEventHandlerFn, context?: any): this;
+    addEventListener(type: string, fn: LeafletEventHandlerFn, context?: any): this;
 
     /**
      * Alias for on(...)
@@ -586,7 +586,6 @@ export abstract class Evented extends Class {
      * to off in order to remove the listener.
      */
     // tslint:disable:unified-signatures
-    removeEventListener(type: string, fn?: LeafletEventHandlerFn, context?: any): this;
     removeEventListener(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
         fn?: LayersControlEventHandlerFn, context?: any): this;
     removeEventListener(type: 'layeradd' | 'layerremove',
@@ -619,6 +618,7 @@ export abstract class Evented extends Class {
         fn?: TileEventHandlerFn, context?: any): this;
     removeEventListener(type: 'tileerror',
         fn?: TileErrorEventHandlerFn, context?: any): this;
+    removeEventListener(type: string, fn?: LeafletEventHandlerFn, context?: any): this;
 
     /**
      * Alias for off(...)
@@ -641,7 +641,6 @@ export abstract class Evented extends Class {
      * Behaves as on(...), except the listener will only get fired once and then removed.
      */
     // tslint:disable:unified-signatures
-    addOneTimeEventListener(type: string, fn: LeafletEventHandlerFn, context?: any): this;
     addOneTimeEventListener(type: 'baselayerchange' | 'overlayadd' | 'overlayremove',
         fn: LayersControlEventHandlerFn, context?: any): this;
     addOneTimeEventListener(type: 'layeradd' | 'layerremove',
@@ -674,6 +673,7 @@ export abstract class Evented extends Class {
         fn: TileEventHandlerFn, context?: any): this;
     addOneTimeEventListener(type: 'tileerror',
         fn: TileErrorEventHandlerFn, context?: any): this;
+    addOneTimeEventListener(type: string, fn: LeafletEventHandlerFn, context?: any): this;
 
     /**
      * Alias for once(...)

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -200,7 +200,9 @@ map = new L.Map(htmlElement, mapOptions);
 let doesItHaveLayer: boolean;
 doesItHaveLayer = map.hasLayer(L.tileLayer(''));
 
-map.on('zoomanim', (_e: L.ZoomAnimEvent) => {});
+map.on('zoomanim', e => {
+    e; // $ExpectType ZoomAnimEvent
+});
 
 map.once({
     dragend: (_e: L.DragEndEvent) => {},
@@ -208,12 +210,20 @@ map.once({
 });
 
 map.off('moveend');
-map.off('resize', (_e: L.ResizeEvent) => {});
-map.off('baselayerchange', (_e: L.LayersControlEvent) => {}, {});
+map.off('resize', e => {
+    e; // $ExpectType ResizeEvent
+});
+map.off('baselayerchange', e => {
+    e; // $ExpectType LayersControlEvent
+}, {});
 
 map.removeEventListener('loading');
-map.removeEventListener('dblclick', (_e: L.LeafletMouseEvent) => {});
-map.removeEventListener('locationerror', (_e: L.ErrorEvent) => {}, {});
+map.removeEventListener('dblclick', e => {
+    e; // $ExpectType LeafletMouseEvent
+});
+map.removeEventListener('locationerror', (e) => {
+    e; // $ExpectType ErrorEvent
+}, {});
 
 map.panInside(latLng, { padding: [50, 50], paddingBottomRight: point, paddingTopLeft: [100, 100] });
 map.panInside(latLng, { padding: [50, 50], paddingBottomRight: point, paddingTopLeft: [100, 100], animate: true, duration: 0.5 });

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -221,7 +221,7 @@ map.removeEventListener('loading');
 map.removeEventListener('dblclick', e => {
     e; // $ExpectType LeafletMouseEvent
 });
-map.removeEventListener('locationerror', (e) => {
+map.removeEventListener('locationerror', e => {
     e; // $ExpectType ErrorEvent
 }, {});
 


### PR DESCRIPTION
Related discussion: #60721

Fixes the overload order for event-related functions so that the most generic ones come last.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test leaflet`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
  Shouldn't be needed since it only moves around existing code
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
