### PR TITLE
fix geojson position

### DIFF
--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -38,7 +38,7 @@ export type BBox = [number, number, number, number] | [number, number, number, n
  * The previous GeoJSON specification allowed more elements (e.g., which could be used to represent M values),
  * but the current specification only allows X, Y, and (optionally) Z to be defined.
  */
-export type Position = number[]; // [number, number] | [number, number, number];
+export type Position = [number, number, ...number[]]; // [number, number] | [number, number, number];
 
 /**
  * The base GeoJSON object.

--- a/types/shpjs/shpjs-tests.ts
+++ b/types/shpjs/shpjs-tests.ts
@@ -19,7 +19,7 @@ shp.getShapeFile(new Int32Array(50)).then((geojson) => {});
 const combinedGeojson = shp.combine([
     [{
         type: 'Point',
-        coordinates: []
+        coordinates: [1,2]
     }],
     [{
         test: 'test'

--- a/types/shpjs/shpjs-tests.ts
+++ b/types/shpjs/shpjs-tests.ts
@@ -19,7 +19,7 @@ shp.getShapeFile(new Int32Array(50)).then((geojson) => {});
 const combinedGeojson = shp.combine([
     [{
         type: 'Point',
-        coordinates: [1,2]
+        coordinates: [1, 2]
     }],
     [{
         test: 'test'


### PR DESCRIPTION

If changing an existing definition:
- Provide a URL to documentation or source code which provides context for the suggested changes: https://geojson.org/schema/GeoJSON.json

In the types definition, we have a coordinate being a `Position`:
```ts
export interface Point extends GeoJsonObject {
    type: "Point";
    coordinates: Position;
}
```
In the official JSON schema definition of GeoJSON (https://geojson.org/schema/GeoJSON.json), we have the coordinate that is an array of at least 2 numbers:
```json
"coordinates": {
  "type": "array",
  "minItems": 2,
  "items": {
     "type": "number"
  }
},
```

