### PR TITLE
[autobahn] Allow type specifiers for args, kwargs and results

### DIFF
--- a/types/autobahn/autobahn-tests.ts
+++ b/types/autobahn/autobahn-tests.ts
@@ -1,4 +1,4 @@
-import autobahn = require("autobahn");
+import autobahn = require('autobahn');
 
 class MyClass {
     add2Count: number = 0;
@@ -8,19 +8,26 @@ class MyClass {
         this.session = session;
     }
 
-    add2(args: Array<number>): number {
+    add2(args: [number, number]): number {
         this.add2Count++;
         return args[0] + args[1];
     }
 
-    onEvent(args: Array<any>): void {
-        console.log("Event:", args[0]);
+    doGreeting(_args: [], kwArgs: { greeting: string; who: string }): string {
+        return `${kwArgs.greeting} ${kwArgs.who}`;
+    }
+
+    onEvent(args: [string]): void {
+        console.log('Event:', args[0]);
+    }
+
+    onEventTwo(args: [string]): void {
+        console.log('Event 2:', args[0]);
     }
 }
 
 function test_client() {
-    var options: autobahn.IConnectionOptions =
-        { url: 'ws://127.0.0.1:8080/ws', realm: 'realm1' };
+    var options: autobahn.IConnectionOptions = { url: 'ws://127.0.0.1:8080/ws', realm: 'realm1' };
 
     var connection = new autobahn.Connection(options);
 
@@ -28,35 +35,85 @@ function test_client() {
         var myInstance = new MyClass(session);
 
         // 1) subscribe to a topic
-        session.subscribe('com.myapp.hello', myInstance.onEvent);
+        const fixedHelloSubscription = session.subscribe('com.myapp.hello', myInstance.onEvent);
+        // 1a) subscribe to a topic, while ensuring that a different handler would be able to pick it up
+        const randomHelloSubscription = session.subscribe<[string]>(
+            'com.myapp.hello2',
+            Math.random() < 0.5 ? myInstance.onEvent : myInstance.onEventTwo,
+        );
 
         // 2) publish an event
         session.publish('com.myapp.hello', ['Hello, world!']);
 
+        // 2a) public an event that should be type safe for the receiver
+        session.publish<Parameters<typeof myInstance.onEvent>[0]>('com.myapp.hello', ['Hello, world!']);
+        session.publish<[string]>('com.myapp.hello2', ['Hello, world!']);
+
         // 3) register a procedure for remoting
-        session.register('com.myapp.add2', myInstance.add2, { invoke: 'roundrobin' });
+        const add2reg = session.register('com.myapp.add2', myInstance.add2, { invoke: 'roundrobin' });
+        const doGreetingReg = session.register('com.myapp.doGreeting', myInstance.doGreeting, { invoke: 'roundrobin' });
 
         // 4) call a remote procedure
-        session.call<number>('com.myapp.add2', [2, 3]).then(
-            res => {
-                console.log("Result:", res);
+        session.call<number>('com.myapp.add2', [2, 3]).then(res => {
+            console.log('Result:', res);
+        });
+        session.call<string>('com.myapp.add2', [], { greeting: 'hello', who: 'world' }).then(res => {
+            console.log('Result:', res);
+        });
+
+        // 4a) call a remote procedure that should be type safe for the receiver
+        session
+            .call<ReturnType<typeof myInstance.add2>, Parameters<typeof myInstance.add2>[0]>('com.myapp.add2', [2, 3])
+            .then(res => {
+                console.log('Result:', res);
             });
+        session
+            .call<
+                ReturnType<typeof myInstance.doGreeting>,
+                Parameters<typeof myInstance.doGreeting>[0],
+                Parameters<typeof myInstance.doGreeting>[1]
+            >('com.myapp.add2', [], { greeting: 'hello', who: 'world' })
+            .then(res => {
+                console.log('Result:', res);
+            });
+
+        // 5) unsubscribe
+        fixedHelloSubscription.then(sub => {
+            return sub.unsubscribe();
+        });
+        randomHelloSubscription.then(sub => {
+            session.unsubscribe(sub);
+        });
+
+        // 6) unregister
+        add2reg.then(reg => {
+            reg.unregister();
+        });
+        doGreetingReg.then(reg => {
+            session.unregister(reg);
+        });
     };
 
     if (!connection.isOpen && !connection.isRetrying && connection.session == null) {
         connection.open();
     }
 
-    var { isConnected, transport: { info: { protocol, type, url } }, defer } = connection;
+    var {
+        isConnected,
+        transport: {
+            info: { protocol, type, url },
+        },
+        defer,
+    } = connection;
     console.log(isConnected, protocol, type, url, defer);
 }
 
 function test_custom_transport_factory() {
-    autobahn.transports.register('custom', CustomTransportFactory)
-    
+    autobahn.transports.register('custom', CustomTransportFactory);
+
     var CustomFactoryFactory = autobahn.transports.get('');
     var customFactory = new CustomFactoryFactory({});
-    var customTransport = customFactory.create()
+    var customTransport = customFactory.create();
     console.log(customTransport.info);
 }
 
@@ -68,9 +125,9 @@ class CustomTransportFactory {
             onclose(details: autobahn.ICloseEventDetails) {},
             send(message: any[]) {},
             close(errorCode: number, reason?: string) {},
-            info: {type: 'custom'}
+            info: { type: 'custom' },
         };
     }
 
-    type: autobahn.TransportType = 'custom'
+    type: autobahn.TransportType = 'custom';
 }


### PR DESCRIPTION
With these additions, users now have the ability to declare expected types when registering/calling/subscribing/publishing. Assuming there are shared interfaces between the different clients, and that they are trusted, this would save from a lot of potential bugs.

I realize there's the danger of people using those types with the assumption the client will be protected from invalid messages (which is not the case), but even so - with these additions, unknown can be declared instead of any, with authors thereby forcing themselves to strictly check the input's shape.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/crossbario/autobahn-js/blob/master/packages/autobahn/lib/session.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.