### PR TITLE
[react-native-auth0] - Correcting the federated parameter in WabAuth.clearSession to be optional according to the documenation.

### DIFF
--- a/types/react-native-auth0/index.d.ts
+++ b/types/react-native-auth0/index.d.ts
@@ -221,7 +221,7 @@ export interface AuthorizeOptions {
 }
 
 export interface ClearSessionParams {
-    federated: boolean;
+    federated?: boolean;
     customScheme?: string;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.github.io/react-native-auth0/WebAuth.html#.clearSession

This is a PR updating the `ClearSessionParams` interface. Property `federated` is declared as mandatory when the documentation states as optional. The tests don't need to be modified since they already treat the federated prop as optional. 