### PR TITLE
sparql-http-client: resolve dom/node AbortSignal conflict

### DIFF
--- a/types/sparql-http-client/Endpoint.d.ts
+++ b/types/sparql-http-client/Endpoint.d.ts
@@ -1,3 +1,4 @@
+import { fetch, HeadersInit, Response, Headers } from './partial-dom';
 interface CommonEndpointOptions {
     fetch?: typeof fetch | undefined;
     headers?: HeadersInit | undefined;

--- a/types/sparql-http-client/RawQuery.d.ts
+++ b/types/sparql-http-client/RawQuery.d.ts
@@ -1,4 +1,5 @@
 import { QueryInit, Query } from '.';
+import { Response } from './partial-dom';
 
 declare namespace RawQuery {
     type RawQuery = Query<Response, Response, Response, Response>;

--- a/types/sparql-http-client/StreamClient.d.ts
+++ b/types/sparql-http-client/StreamClient.d.ts
@@ -4,6 +4,7 @@ import StreamQuery = require('./StreamQuery');
 import StreamStore = require('./StreamStore');
 import { Endpoint, EndpointOptions } from './Endpoint';
 import { Readable } from 'stream';
+import { HeadersInit } from './partial-dom';
 
 interface Constructor<T, Q extends BaseQuad = Quad> {
     new (options: { endpoint: Endpoint; factory: DataFactory<Q>; }): T;

--- a/types/sparql-http-client/StreamStore.d.ts
+++ b/types/sparql-http-client/StreamStore.d.ts
@@ -1,6 +1,7 @@
 import { Store } from "./";
 import { BaseQuad, Quad, DataFactory, Stream, Term } from "rdf-js";
 import Endpoint = require("./Endpoint");
+import { ReadableStream } from './minidom';
 
 declare namespace StreamStore {
     interface StreamStoreInit<Q extends BaseQuad = Quad> {

--- a/types/sparql-http-client/partial-dom.d.ts
+++ b/types/sparql-http-client/partial-dom.d.ts
@@ -1,0 +1,140 @@
+export type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";
+export interface Headers {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void;
+}
+export type HeadersInit = string[][] | Record<string, string> | Headers;
+export interface ReadableStreamDefaultReadDoneResult {
+    done: true;
+    value?: undefined;
+}
+
+export interface ReadableStreamDefaultReadValueResult<T> {
+    done: false;
+    value: T;
+}
+export type ReadableStreamDefaultReadResult<T> = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult;
+export interface ReadableStreamGenericReader {
+    readonly closed: Promise<undefined>;
+    cancel(reason?: any): Promise<void>;
+}
+export interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericReader {
+    read(): Promise<ReadableStreamDefaultReadResult<R>>;
+    releaseLock(): void;
+}
+export type RequestCache = "default" | "force-cache" | "no-cache" | "no-store" | "only-if-cached" | "reload";
+export type RequestCredentials = "include" | "omit" | "same-origin";
+export type RequestDestination = "" | "audio" | "audioworklet" | "document" | "embed" | "font" | "frame"
+    | "iframe" | "image" | "manifest" | "object" | "paintworklet" | "report" | "script" | "sharedworker" | "style" | "track" | "video" | "worker" | "xslt";
+export type RequestMode = "cors" | "navigate" | "no-cors" | "same-origin";
+export type RequestRedirect = "error" | "follow" | "manual";
+export type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade"
+    | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";
+export interface Request extends Body {
+    readonly cache: RequestCache;
+    readonly credentials: RequestCredentials;
+    readonly destination: RequestDestination;
+    readonly headers: Headers;
+    readonly integrity: string;
+    readonly keepalive: boolean;
+    readonly method: string;
+    readonly mode: RequestMode;
+    readonly redirect: RequestRedirect;
+    readonly referrer: string;
+    readonly referrerPolicy: ReferrerPolicy;
+    readonly signal: AbortSignal;
+    readonly url: string;
+    clone(): Request;
+}
+export type BufferSource = ArrayBufferView | ArrayBuffer;
+export type XMLHttpRequestBodyInit = Blob | BufferSource | FormData | URLSearchParams | string;
+export type BodyInit = ReadableStream | XMLHttpRequestBodyInit;
+export interface RequestInit {
+    body?: BodyInit | null;
+    cache?: RequestCache;
+    credentials?: RequestCredentials;
+    headers?: HeadersInit;
+    integrity?: string;
+    keepalive?: boolean;
+    method?: string;
+    mode?: RequestMode;
+    redirect?: RequestRedirect;
+    referrer?: string;
+    referrerPolicy?: ReferrerPolicy;
+    signal?: AbortSignal | null;
+    window?: null;
+}
+export type RequestInfo = Request | string;
+export function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+export interface StreamPipeOptions {
+    preventAbort?: boolean;
+    preventCancel?: boolean;
+    preventClose?: boolean;
+    // use AbortSignal from node, not dom
+    signal?: AbortSignal;
+}
+export interface WritableStreamDefaultWriter<W = any> {
+    readonly closed: Promise<undefined>;
+    readonly desiredSize: number | null;
+    readonly ready: Promise<undefined>;
+    abort(reason?: any): Promise<void>;
+    close(): Promise<void>;
+    releaseLock(): void;
+    write(chunk?: W): Promise<void>;
+}
+export interface WritableStream<W = any> {
+    readonly locked: boolean;
+    abort(reason?: any): Promise<void>;
+    close(): Promise<void>;
+    getWriter(): WritableStreamDefaultWriter<W>;
+}
+export interface ReadableWritablePair<R = any, W = any> {
+    readable: ReadableStream<R>;
+    writable: WritableStream<W>;
+}
+export interface ReadableStream<R = any> {
+    readonly locked: boolean;
+    cancel(reason?: any): Promise<void>;
+    getReader(): ReadableStreamDefaultReader<R>;
+    pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
+    pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+    tee(): [ReadableStream<R>, ReadableStream<R>];
+}
+export interface File extends Blob {
+    readonly lastModified: number;
+    readonly name: string;
+    readonly webkitRelativePath: string;
+}
+export type FormDataEntryValue = File | string;
+export interface FormData {
+    append(name: string, value: string | Blob, fileName?: string): void;
+    delete(name: string): void;
+    get(name: string): FormDataEntryValue | null;
+    getAll(name: string): FormDataEntryValue[];
+    has(name: string): boolean;
+    set(name: string, value: string | Blob, fileName?: string): void;
+    forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
+}
+export interface Body {
+    readonly body: ReadableStream<Uint8Array> | null;
+    readonly bodyUsed: boolean;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    formData(): Promise<FormData>;
+    json(): Promise<any>;
+    text(): Promise<string>;
+}
+export interface Response extends Body {
+    readonly headers: Headers;
+    readonly ok: boolean;
+    readonly redirected: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly type: ResponseType;
+    readonly url: string;
+    clone(): Response;
+}

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -6,6 +6,7 @@ import RawQuery = require('sparql-http-client/RawQuery');
 import { Client } from 'sparql-http-client';
 import { Readable } from 'stream';
 import { DataFactory, Stream, Quad, NamedNode, Term } from 'rdf-js';
+import { HeadersInit, fetch, Response } from 'sparql-http-client/partial-dom';
 
 interface TestQuad extends Quad {
     toCanonical(): string;

--- a/types/sparql-http-client/tsconfig.json
+++ b/types/sparql-http-client/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "webworker"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Do this by copying the required DOM types into sparql-http-client, *except* for AbortSignal, which now uses the node definition of the type.

I'm not sure this is the right solution but it does let the package compile with all versions of Typescript.
