### PR TITLE
[wordpress__blocks] Add spacing and color defs to block supports

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -52,18 +52,7 @@ export interface BlockStyle {
     readonly isDefault?: boolean | undefined;
 }
 
-export interface SerializableProps {
-    /**
-     * Skip serialization of values to the HTML
-     *
-     * If set to `true`, classes and inline styles won't be applied to
-     * the wrapper, and it's up to the block author to implement their
-     * specific application.
-     */
-    __experimentalSkipSerialization?: boolean;
-}
-
-export interface ColorProps extends SerializableProps {
+export interface ColorProps {
     /**
      * This property adds UI controls which allow the user to apply
      * a solid background color to a block.
@@ -74,7 +63,7 @@ export interface ColorProps extends SerializableProps {
      *
      * @defaultValue true
      */
-    background: string;
+    background: boolean;
     /**
      * This property adds UI controls which allow the user to apply
      * a gradient background to a block.
@@ -100,21 +89,9 @@ export interface ColorProps extends SerializableProps {
      * @defaultValue true
      */
     text: string;
-    /**
-     * This property adds UI controls which allow to apply a duotone
-     * filter to a specified selector within the block.
-     *
-     * The parent block selector is automatically added.
-     *
-     * When the block declares support for `color.__experimentalDuotone`,
-     * the attributes of a block will include `style`.
-     *
-     * @defaultValue false
-     */
-    __experimentalDuotone?: string;
 }
 
-export interface SpacingProps extends SerializableProps {
+export interface SpacingProps {
     blockGap: boolean | AxialDirections[];
     /**
      * Enable margin control UI for all or specified element directions
@@ -381,7 +358,7 @@ export interface BlockSupports {
      * of `true`, so if the color property is present they’ll also
      * be considered enabled.
      */
-    readonly color?: ColorProps | undefined;
+    readonly color?: Partial<ColorProps> | undefined;
     /**
      * This property adds a field to define a custom className for the
      * block's wrapper.
@@ -431,7 +408,7 @@ export interface BlockSupports {
      * When the block declares support for a specific spacing property,
      * the attributes definition is extended to include the `style` attribute.
      */
-    readonly spacing?: SpacingProps | undefined;
+    readonly spacing?: Partial<SpacingProps> | undefined;
 }
 
 //

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -20,9 +20,9 @@ declare module '@wordpress/data' {
     function select(key: 'core/blocks'): typeof import('./store/selectors');
 }
 
-export type AxialDirections = 'horizontal' | 'vertical';
+export type AxialDirection = 'horizontal' | 'vertical';
 
-export type CSSDirections = 'top' | 'right' | 'bottom' | 'left';
+export type CSSDirection = 'top' | 'right' | 'bottom' | 'left';
 
 export type BlockAlignment = 'left' | 'center' | 'right' | 'wide' | 'full';
 
@@ -92,19 +92,19 @@ export interface ColorProps {
 }
 
 export interface SpacingProps {
-    blockGap: boolean | AxialDirections[];
+    blockGap: boolean | AxialDirection[];
     /**
      * Enable margin control UI for all or specified element directions
      *
      * @defaultValue false
      */
-    margin: boolean | CSSDirections[];
+    margin: boolean | CSSDirection[];
     /**
      * Enable padding control UI for all or specified element directions
      *
      * @defaultValue false
      */
-    padding: boolean | CSSDirections[];
+    padding: boolean | CSSDirection[];
 }
 
 /**

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -4,6 +4,7 @@
 //                 Jon Surrell <https://github.com/sirreal>
 //                 Dennis Snell <https://github.com/dmsnell>
 //                 Tomasz Tunik <https://github.com/tomasztunik>
+//                 Lucio Giannotta <https://github.com/sunyatasattva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
@@ -18,6 +19,10 @@ declare module '@wordpress/data' {
     function dispatch(key: 'core/blocks'): typeof import('./store/actions');
     function select(key: 'core/blocks'): typeof import('./store/selectors');
 }
+
+export type AxialDirections = 'horizontal' | 'vertical';
+
+export type CSSDirections = 'top' | 'right' | 'bottom' | 'left';
 
 export type BlockAlignment = 'left' | 'center' | 'right' | 'wide' | 'full';
 
@@ -45,6 +50,84 @@ export interface BlockStyle {
     readonly name: string;
     readonly label: string;
     readonly isDefault?: boolean | undefined;
+}
+
+export interface SerializableProps {
+    /**
+     * Skip serialization of values to the HTML
+     *
+     * If set to `true`, classes and inline styles won't be applied to
+     * the wrapper, and it's up to the block author to implement their
+     * specific application.
+     */
+    __experimentalSkipSerialization?: boolean;
+}
+
+export interface ColorProps extends SerializableProps {
+    /**
+     * This property adds UI controls which allow the user to apply
+     * a solid background color to a block.
+     *
+     * When the block declares support for `color.background`,
+     * the attributes of a block will include two new entries:
+     * `backgroundColor` and `style`.
+     *
+     * @defaultValue true
+     */
+    background: string;
+    /**
+     * This property adds UI controls which allow the user to apply
+     * a gradient background to a block.
+     *
+     * When the block declares support for `color.background`,
+     * the attributes of a block will include two new entries:
+     * `gradient` and `style`.
+     *
+     * @defaultValue false
+     */
+    gradients: boolean;
+    /**
+     * This property adds block controls which allow the user
+     * to set link color in a block, link color is disabled by default.
+     *
+     * @defaultValue false
+     */
+    link: boolean;
+    /**
+     * This property adds block controls which allow the user
+     * to set text color in a block.
+     *
+     * @defaultValue true
+     */
+    text: string;
+    /**
+     * This property adds UI controls which allow to apply a duotone
+     * filter to a specified selector within the block.
+     *
+     * The parent block selector is automatically added.
+     *
+     * When the block declares support for `color.__experimentalDuotone`,
+     * the attributes of a block will include `style`.
+     *
+     * @defaultValue false
+     */
+    __experimentalDuotone?: string;
+}
+
+export interface SpacingProps extends SerializableProps {
+    blockGap: boolean | AxialDirections[];
+    /**
+     * Enable margin control UI for all or specified element directions
+     *
+     * @defaultValue false
+     */
+    margin: boolean | CSSDirections[];
+    /**
+     * Enable padding control UI for all or specified element directions
+     *
+     * @defaultValue false
+     */
+    padding: boolean | CSSDirections[];
 }
 
 /**
@@ -290,6 +373,16 @@ export interface BlockSupports {
      */
     readonly anchor?: boolean | undefined;
     /**
+     * This value signals that a block supports some of the properties
+     * related to color. When it does, the block editor will show
+     * UI controls for the user to set their values.
+     *
+     * @note The `background` and `text` keys have a default value
+     * of `true`, so if the color property is present they’ll also
+     * be considered enabled.
+     */
+    readonly color?: ColorProps | undefined;
+    /**
      * This property adds a field to define a custom className for the
      * block's wrapper.
      *
@@ -331,6 +424,14 @@ export interface BlockSupports {
      * @defaultValue true
      */
     readonly reusable?: boolean | undefined;
+    /**
+     * This value signals that a block supports some of the CSS style
+     * properties related to spacing.
+     *
+     * When the block declares support for a specific spacing property,
+     * the attributes definition is extended to include the `style` attribute.
+     */
+    readonly spacing?: SpacingProps | undefined;
 }
 
 //

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -90,7 +90,7 @@ blocks.findTransform(
             },
         },
     ],
-    transform => transform.type === 'block'
+    transform => transform.type === 'block',
 );
 
 declare const RAW_TRANSFORM_ARRAY: Array<blocks.TransformRaw<any>>;
@@ -343,7 +343,7 @@ blocks.registerBlockType<{ foo: string }>('my/foo', {
 blocks.registerBlockType<{ foo: object }>('my/foo', {
     attributes: {
         foo: {
-            type: 'object'
+            type: 'object',
         },
     },
     icon: {
@@ -395,6 +395,15 @@ blocks.registerBlockType({
     usesContext: ['groupId'],
     supports: {
         align: true,
+        color: {
+            background: true,
+            gradients: false,
+            link: true,
+        },
+        spacing: {
+            blockGap: ['horizontal'],
+            margin: ['top', 'left'],
+        },
     },
     styles: [
         { name: 'default', label: 'Default', isDefault: true },
@@ -486,7 +495,7 @@ blocks.registerBlockType(
         editorStyle: 'file:./build/index.css',
         style: 'file:./build/style.css',
     },
-    { edit: () => null, save: () => null }
+    { edit: () => null, save: () => null },
 );
 
 // $ExpectType void
@@ -566,7 +575,7 @@ blocks.doBlocksMatchTemplate([BLOCK_INSTANCE]);
 // $ExpectType boolean
 blocks.doBlocksMatchTemplate(
     [BLOCK_INSTANCE, BLOCK_INSTANCE],
-    [['core/test-block'], ['core/test-block-2', {}, [['core/test-block']]], ['core/test-block-2']]
+    [['core/test-block'], ['core/test-block-2', {}, [['core/test-block']]], ['core/test-block-2']],
 );
 
 // $ExpectType BlockInstance<{ [k: string]: any; }>[]
@@ -578,11 +587,17 @@ blocks.synchronizeBlocksWithTemplate([BLOCK_INSTANCE, BLOCK_INSTANCE]);
 // $ExpectType BlockInstance<{ [k: string]: any; }>[]
 blocks.synchronizeBlocksWithTemplate(
     [BLOCK_INSTANCE, BLOCK_INSTANCE],
-    [['my/foo', { foo: 'bar' }], ['my/foo', { foo: 'bar' }]]
+    [
+        ['my/foo', { foo: 'bar' }],
+        ['my/foo', { foo: 'bar' }],
+    ],
 );
 
 // $ExpectType BlockInstance<{ [k: string]: any; }>[]
-blocks.synchronizeBlocksWithTemplate(undefined, [['my/foo', { foo: 'bar' }], ['my/foo', { foo: 'bar' }]]);
+blocks.synchronizeBlocksWithTemplate(undefined, [
+    ['my/foo', { foo: 'bar' }],
+    ['my/foo', { foo: 'bar' }],
+]);
 
 //
 // utils


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Block API: Block Supports](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/)

---

### Notes for this PR:

I have added some of the missing types to the `supports` section of a block, to be in line with what the docs currently say. However, I have two main questions about this:

1. **Should `__experimental` props be added to the types?** As of now, I have added them for two reasons: first of all, these props are actually there, so a user using them would be forced to manually edit the types or deal with frustrating errors; secondly, though **experimental**, they are not **internal**: they are actually mentioned in the official docs, that's why I believe they should be there, and we should update this package accordingly when they graduate or get dropped.
2. I am not sure which tests to add here, so I would appreciate some guidance: I have seen that the current tests do not really cover all of the possible `supports` properties, so I am not sure whether I should add tests here, and what kind of things should I test for this.