### PR TITLE
[@types/node] Add missing types for Readable iterator methods

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -477,6 +477,43 @@ declare module 'stream' {
             removeListener(event: 'resume', listener: () => void): this;
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
             [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+            map<T>(
+                fn: (data: any, options?: { signal?: AbortSignal }) => T | Promise<T>,
+                options?: { signal?: AbortSignal; concurrency?: number },
+            ): Readable;
+            filter(
+                fn: (data: any, options?: { signal?: AbortSignal }) => boolean | Promise<boolean>,
+                options?: { signal?: AbortSignal; concurrency?: number },
+            ): Readable;
+            forEach(
+                fn: (data: any, options?: { signal?: AbortSignal }) => void | Promise<void>,
+                options?: { signal?: AbortSignal; concurrency?: number },
+            ): Promise<void>;
+            toArray(options?: { signal?: AbortSignal }): Promise<any[]>;
+            some(
+                fn: (data: any, options?: { signal?: AbortSignal }) => boolean | Promise<boolean>,
+                options?: { signal?: AbortSignal; concurrency?: number },
+            ): Promise<boolean>;
+            find(
+                fn: (data: any, options?: { signal?: AbortSignal }) => boolean | Promise<boolean>,
+                options?: { signal?: AbortSignal; concurrency?: number },
+            ): Promise<any>;
+            every(
+                fn: (data: any, options?: { signal?: AbortSignal }) => boolean | Promise<boolean>,
+                options?: { signal?: AbortSignal; concurrency?: number },
+            ): Promise<boolean>;
+            flatMap<T>(
+                fn: (data: any, options?: { signal?: AbortSignal }) => T | Promise<T>,
+                options?: { signal?: AbortSignal; concurrency?: number },
+            ): Readable;
+            drop(limit: number, options?: { signal?: AbortSignal }): Readable;
+            take(limit: number, options?: { signal?: AbortSignal }): Readable;
+            asIndexedPairs(options?: { signal?: AbortSignal }): Readable;
+            reduce<T>(
+                fn: (previous: any, data: any, options?: { signal?: AbortSignal }) => T | Promise<T>,
+                initial?: T,
+                options?: { signal?: AbortSignal },
+            ): Promise<T>;
         }
         interface WritableOptions extends StreamOptions<Writable> {
             decodeStrings?: boolean | undefined;

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -477,10 +477,28 @@ declare module 'stream' {
             removeListener(event: 'resume', listener: () => void): this;
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
             [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+
+            /**
+             * This method allows mapping over the stream.
+             * The fn function will be called for every chunk in the stream.
+             * If the fn function returns a promise - that promise will be awaited before being passed to the result stream.
+             * @param fn - a function to map over every chunk in the stream.
+             * @param options - options for mapping.
+             * @since v17.4.0, v16.14.0
+             */
             map<T>(
                 fn: (data: any, options?: { signal?: AbortSignal }) => T | Promise<T>,
                 options?: { signal?: AbortSignal; concurrency?: number },
             ): Readable;
+            /**
+             * This method allows filtering the stream.
+             * For each chunk in the stream the fn function will be called and if it returns a truthy value,
+             * the chunk will be passed to the result stream.
+             * If the fn function returns a promise - that promise will be awaited.
+             * @param fn - a function to filter chunks from the stream.
+             * @param options - options for filtering.
+             * @since v17.4.0, v16.14.0
+             */
             filter(
                 fn: (data: any, options?: { signal?: AbortSignal }) => boolean | Promise<boolean>,
                 options?: { signal?: AbortSignal; concurrency?: number },

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -525,6 +525,23 @@ addAbortSignal(new AbortSignal(), new Readable());
     const readableAborted: boolean = readable.readableAborted;
 }
 
+async function testReadableIteratorMethods() {
+    Readable.from([1, 2, 3]).take(2); // $ExpectType Readable
+    Readable.from([1, 2, 3]).map((item) => item + 1); // $ExpectType Readable
+    Readable.from([1, 2, 3]).filter((item) => item > 1); // $ExpectType Readable
+    await Readable.from([1, 2, 3]).forEach((item) => console.log(item)); // $ExpectType void
+    await Readable.from([1, 2, 3]).toArray(); // $ExpectType []
+    await Readable.from([1, 2, 3]).some((item) => item === 1); // $ExpectType boolean
+    await Readable.from([1, 2, 3]).every((item) => item === 1); // $ExpectType boolean
+    await Readable.from([1, 2, 3]).find((item) => item === 1);
+    Readable.from([1, 2, 3]).flatMap((item) => item + 2); // $ExpectType Readable
+    Readable.from([1, 2, 3]).take(2); // $ExpectType Readable
+    Readable.from([1, 2, 3]).drop(2); // $ExpectType Readable
+    Readable.from([1, 2, 3]).asIndexedPairs(); // $ExpectType Readable
+    await Readable.from([1, 2, 3]).reduce((item, prev) => prev + item, 0); // $ExpectType number
+    await Readable.from(['a', 'b', 'c']).reduce((item, prev) => prev + item, ''); // $ExpectType string
+}
+
 {
     isErrored(new Readable()); // $ExpectType boolean
     isErrored(new Duplex()); // $ExpectType boolean


### PR DESCRIPTION
I have added some missing types to the Readable interface for Nodejs streams. These are new methods for iterating readable streams, added in early 2022. Discussion: #60753 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [nodejs.org/api/stream.html](https://nodejs.org/api/stream.html#readablemapfn-options)
- [?] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR is still a work in progress, please give comments or feedback:
 - documentation from nodejs docs. How to document the parameters of `fn` which is itself a parameter?
 - generic typing for Readable class? (I think it should be generically typed, but this might be a big change)
 - should the `options` parameter type be an interface that they all reference (to reduce code duplication)?
 - I still need to write tests for these types (not started yet)
 - I have the common mistake of typing the return value of a function generically, but I think it is appropriate due to the possibility of generifying the Readable class