### PR TITLE
fix(@types/ember-cli-fastboot): fix isFastBoot property

### DIFF
--- a/types/ember-cli-fastboot/services/fastboot.d.ts
+++ b/types/ember-cli-fastboot/services/fastboot.d.ts
@@ -39,7 +39,7 @@ export interface Shoebox {
 
 export default class FastBoot extends Service {
   /** Allows you to check if you are running within FastBoot. */
-  isFastboot: boolean;
+  isFastBoot: boolean;
 
   /**
    * A request object which exposes details about the current request being

--- a/types/ember-cli-fastboot/test/ember-cli-fastboot-tests.ts
+++ b/types/ember-cli-fastboot/test/ember-cli-fastboot-tests.ts
@@ -8,7 +8,7 @@ assertType<_FastBoot | undefined>(FastBoot);
 /** type assertions for fastboot service & other classes */
 const instance = FastBootService.create();
 assertType<FastbootRequest>(instance.request);
-assertType<boolean>(instance.isFastboot);
+assertType<boolean>(instance.isFastBoot);
 assertType<Shoebox>(instance.shoebox);
 instance.deferRendering(new Promise<'foo'>(() => 'foo')); // $ExpectType void
 


### PR DESCRIPTION
#58050 incorrectly introduced `isFastboot` property for the FastBoot service which actually should be `isFastBoot`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/ember-fastboot/ember-cli-fastboot/pull/814
  - https://github.com/ember-fastboot/ember-cli-fastboot/blob/v3.3.0/packages/ember-cli-fastboot/addon/services/fastboot.js#L68