### PR TITLE
Broaden emit / trigger extraParams type

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -818,3 +818,7 @@ const myExt: cytoscape.Ext = (cy) => {
     // $ExpectType unknown
     cy("core", "prop");
 };
+
+// Test CollectionEvents
+collSel.emit('myEvt', ['string', 1, {a: 1, b: true}]);
+collSel.trigger('myEvt', ['string', 1, {a: 1, b: true}]);

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -1502,8 +1502,8 @@ declare namespace cytoscape {
          * http://js.cytoscape.org/#eles.trigger
          * alias: emit
          */
-        trigger(events: EventNames, extra?: string[]): this;
-        emit(events: EventNames, extra?: string[]): this;
+        trigger(events: EventNames, extra?: unknown[]): this;
+        emit(events: EventNames, extra?: unknown[]): this;
     }
 
     /**


### PR DESCRIPTION
https://js.cytoscape.org/#eles.emit

The `emit` and `trigger` methods don't only take a string. The docs are silent on the type, but it seems made to let a developer pass whatever they want.

The `EventNames` type just maps to `string`, so this isn't enforcing a set of known events.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://js.cytoscape.org/#eles.emit
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
