### PR TITLE
(Koa) Specify the response body type for Koa

### DIFF
--- a/types/koa-pino-logger/package.json
+++ b/types/koa-pino-logger/package.json
@@ -2,6 +2,7 @@
     "private": true,
     "dependencies": {
         "pino": "8.0.0",
-        "pino-http": "7.1.0"
+        "pino-http": "7.1.0",
+        "pino-pretty": "8.0.0"
     }
 }

--- a/types/koa-pino-logger/package.json
+++ b/types/koa-pino-logger/package.json
@@ -2,7 +2,6 @@
     "private": true,
     "dependencies": {
         "pino": "8.0.0",
-        "pino-http": "7.1.0",
-        "pino-pretty": "8.0.0"
+        "pino-http": "7.1.0"
     }
 }

--- a/types/koa-pino-logger/package.json
+++ b/types/koa-pino-logger/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@types/pino": "6.3"
+        "pino": "8.0.0",
+        "pino-http": "7.1.0"
     }
 }

--- a/types/koa-roles/index.d.ts
+++ b/types/koa-roles/index.d.ts
@@ -6,7 +6,11 @@
 
 import Koa = require('koa');
 
-declare class Roles<StateT extends Koa.DefaultStateExtends = Koa.DefaultState, ContextT extends Koa.DefaultContextExtends = Koa.DefaultContext, ResponseBodyT = unknown> {
+declare class Roles<
+    StateT extends Koa.DefaultStateExtends = Koa.DefaultState,
+    ContextT extends Koa.DefaultContextExtends = Koa.DefaultContext,
+    ResponseBodyT extends Koa.ResponseBody = Koa.ResponseBody
+> {
     constructor(options?: Roles.Options<StateT, ContextT, ResponseBodyT>);
 
     can(action: string): Koa.Middleware<StateT, ContextT, ResponseBodyT>;
@@ -21,11 +25,15 @@ declare namespace Roles {
     type Handler<
         StateT extends Koa.DefaultStateExtends = Koa.DefaultState,
         ContextT extends Koa.DefaultContextExtends = Koa.DefaultContext,
-        ResponseBodyT = unknown,
+        ResponseBodyT extends Koa.ResponseBody = Koa.ResponseBody,
         Action extends string = string
     > = (ctx: Koa.ParameterizedContext<StateT, ContextT, ResponseBodyT>, action: Action) => boolean | Promise<boolean>;
 
-    interface Options<StateT extends Koa.DefaultStateExtends = Koa.DefaultState, ContextT extends Koa.DefaultContextExtends = Koa.DefaultContext, ResponseBodyT = unknown> {
+    interface Options<
+        StateT extends Koa.DefaultStateExtends = Koa.DefaultState,
+        ContextT extends Koa.DefaultContextExtends = Koa.DefaultContext,
+        ResponseBodyT extends Koa.ResponseBody = Koa.ResponseBody
+    > {
         failureHandler?: (ctx: Koa.ParameterizedContext<StateT, ContextT, ResponseBodyT>, action: string) => void;
         userProperty?: string;
     }

--- a/types/koa-roles/koa-roles-tests.ts
+++ b/types/koa-roles/koa-roles-tests.ts
@@ -20,16 +20,16 @@ const handler2: Roles.Handler<TestState, TestContext, string> = any;
 const handler1or2: typeof handler1 | typeof handler2 = any;
 const handler3: Roles.Handler<TestState, TestContext, string, 'action1'> = any;
 
-// $ExpectType Roles<DefaultState, DefaultContext, unknown>
+// $ExpectType Roles<DefaultState, DefaultContext, ResponseBody>
 const roles1 = new Roles();
-// $ExpectType Roles<DefaultState, DefaultContext, unknown>
+// $ExpectType Roles<DefaultState, DefaultContext, ResponseBody>
 new Roles(options1);
 // $ExpectType Roles<TestState, TestContext, string>
 const roles2 = new Roles<TestState, TestContext, string>();
 // $ExpectType Roles<TestState, TestContext, string>
 new Roles(options2);
 
-// $ExpectType Middleware<DefaultState, DefaultContext, unknown>
+// $ExpectType Middleware<DefaultState, DefaultContext, ResponseBody>
 roles1.can('something');
 // $ExpectType Middleware<TestState, TestContext, string>
 roles2.can('something');
@@ -51,7 +51,7 @@ roles2.use(action1, handler3);
 // $ExpectError
 roles2.use(action2, handler3);
 
-// $ExpectType Middleware<DefaultState, DefaultContext, unknown>
+// $ExpectType Middleware<DefaultState, DefaultContext, ResponseBody>
 roles1.middleware();
 // $ExpectType Middleware<TestState, TestContext, string>
 roles2.middleware();

--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -511,8 +511,8 @@ declare class Application<
      *
      * Old-style middleware will be converted.
      */
-    use<NewStateT = {}, NewContextT = {}>(
-        middleware: Application.Middleware<StateT & NewStateT, ContextT & NewContextT>
+    use<NewStateT = {}, NewContextT = {}, NewResponseBody extends Application.ResponseBody = Application.ResponseBody>(
+        middleware: Application.Middleware<StateT & NewStateT, ContextT & NewContextT, NewResponseBody>
     ): Application<StateT & NewStateT, ContextT & NewContextT>;
 
     /**
@@ -557,7 +557,7 @@ declare namespace Application {
         [key: string]: any;
     }
 
-    type Middleware<StateT = DefaultState, ContextT = DefaultContext, ResponseBodyT = any> = compose.Middleware<
+    type Middleware<StateT = DefaultState, ContextT = DefaultContext, ResponseBodyT extends ResponseBody = ResponseBody> = compose.Middleware<
         ParameterizedContext<StateT, ContextT, ResponseBodyT>
     >;
 
@@ -737,7 +737,7 @@ declare namespace Application {
 
     // In accordance with the Koa documentation
     // https://github.com/koajs/koa/blob/master/docs/api/response.md#responsebody-1
-    type ResponseBody = string | Buffer | {} | Stream | ResponseBody[] | null | undefined;
+    type ResponseBody = string | Buffer | object | Stream | ResponseBody[] | null | undefined;
 
     type ParameterizedContext<StateT = DefaultState, ContextT = DefaultContext, ResponseBodyT extends ResponseBody = ResponseBody> = ExtendableContext
         & { state: StateT; }

--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -8,6 +8,7 @@
 //                 Christian Vaagland Tellnes <https://github.com/tellnes>
 //                 Piotr Kuczynski <https://github.com/pkuczynski>
 //                 vnoder <https://github.com/vnoder>
+//                 Denis Tokarev <https://github.com/devlato>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -35,6 +36,7 @@ import { Socket, ListenOptions } from 'net';
 import * as url from 'url';
 import * as contentDisposition from 'content-disposition';
 import { ParsedUrlQuery } from 'querystring';
+import { Stream } from 'stream';
 
 declare interface ContextDelegatedRequest {
     /**
@@ -318,7 +320,7 @@ declare interface ContextDelegatedResponse {
     /**
      * Get/Set response body.
      */
-    body: unknown;
+    body: Application.ResponseBody;
 
     /**
      * Return parsed response Content-Length when present.
@@ -733,7 +735,11 @@ declare namespace Application {
         respond?: boolean | undefined;
     }
 
-    type ParameterizedContext<StateT = DefaultState, ContextT = DefaultContext, ResponseBodyT = unknown> = ExtendableContext
+    // In accordance with the Koa documentation
+    // https://github.com/koajs/koa/blob/master/docs/api/response.md#responsebody-1
+    type ResponseBody = string | Buffer | {} | Stream | ResponseBody[] | null | undefined;
+
+    type ParameterizedContext<StateT = DefaultState, ContextT = DefaultContext, ResponseBodyT extends ResponseBody = ResponseBody> = ExtendableContext
         & { state: StateT; }
         & ContextT
         & { body: ResponseBodyT; response: { body: ResponseBodyT }; };

--- a/types/koa/test/body.ts
+++ b/types/koa/test/body.ts
@@ -1,0 +1,71 @@
+import Koa = require('koa');
+import { Buffer } from 'buffer';
+import stream from 'stream';
+
+const app = new Koa();
+
+app.use(ctx => {
+    ctx.body = 'Hello World';
+});
+
+app.use(ctx => {
+    ctx.body = new Buffer();
+});
+
+app.use(ctx => {
+    ctx.body = {};
+});
+
+app.use(ctx => {
+    ctx.body = new stream.Readable();
+});
+
+app.use(ctx => {
+    ctx.body = ['Hello', 'World'];
+});
+
+app.use(ctx => {
+    ctx.body = null;
+});
+
+app.use(ctx => {
+    ctx.body = undefined;
+});
+
+app.use(ctx => {
+    // $ExpectError
+    ctx.response.body = 10;
+});
+
+app.use(ctx => {
+    ctx.response.body = 'Hello World';
+});
+
+app.use(ctx => {
+    ctx.response.body = new Buffer();
+});
+
+app.use(ctx => {
+    ctx.response.body = {};
+});
+
+app.use(ctx => {
+    ctx.response.body = new stream.Readable();
+});
+
+app.use(ctx => {
+    ctx.response.body = ['Hello', 'World'];
+});
+
+app.use(ctx => {
+    ctx.response.body = null;
+});
+
+app.use(ctx => {
+    ctx.response.body = undefined;
+});
+
+app.use(ctx => {
+    // $ExpectError
+    ctx.response.body = 10;
+});

--- a/types/koa/test/body.ts
+++ b/types/koa/test/body.ts
@@ -1,6 +1,6 @@
 import Koa = require('koa');
-import { Buffer } from 'buffer';
-import stream from 'stream';
+import { Buffer } from 'node:buffer';
+import stream from 'node:stream';
 
 const app = new Koa();
 
@@ -9,7 +9,7 @@ app.use(ctx => {
 });
 
 app.use(ctx => {
-    ctx.body = new Buffer();
+    ctx.body = Buffer.from('I\'m a string!', 'utf-8');
 });
 
 app.use(ctx => {
@@ -42,7 +42,7 @@ app.use(ctx => {
 });
 
 app.use(ctx => {
-    ctx.response.body = new Buffer();
+    ctx.response.body = Buffer.from('I\'m a string!', 'utf-8');
 });
 
 app.use(ctx => {

--- a/types/koa/tsconfig.json
+++ b/types/koa/tsconfig.json
@@ -5,7 +5,8 @@
         "test/constructor.ts",
         "test/default.ts",
         "test/settings.ts",
-        "test/typed-response-body.ts"
+        "test/typed-response-body.ts",
+        "test/body.ts"
     ],
     "compilerOptions": {
         "module": "commonjs",


### PR DESCRIPTION
In this PR, we specify the type of Koa response body, in accordance with the official documentation ([more info](https://github.com/koajs/koa/blob/master/docs/api/response.md#responsebody-1)).

We also update the dependent packages:
* `koa-roles` –  updated types and tests.
* `koa-pino-logger` – updated it since the packages it imports now come with TS typings out-of-the-box and don't require `@types/*` anymore. 
  The new additions to `koa-pino-logger`'s `package.json` ([`pino`](https://www.npmjs.com/package/pino) and [`pino-http`](https://www.npmjs.com/package/pino-http)) have been allowed as external dependencies in a separate PR:
  * [Add pino and pino-http to the list of allowed dependencies #481](https://github.com/microsoft/DefinitelyTyped-tools/pull/481)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
