### PR TITLE
asana: Define opt_fields as string, not string[]

### DIFF
--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -227,10 +227,19 @@ client.customFields
 // $ExpectError
 client.typeahead.typeaheadForWorkspace('workspace_gid', {});
 
-const typeaheadForWorkspaceQuery: asana.resources.Typeahead.TypeaheadParams = {
+// opt_fields takes string, not array
+// $ExpectError
+const badTypeaheadForWorkspaceQuery: asana.resources.Typeahead.TypeaheadParams = {
     resource_type: 'task',
     query: 'my query',
     opt_pretty: true,
     opt_fields: ['name', 'completed', 'parent', 'custom_fields.gid', 'custom_fields.number_value'],
+};
+
+const typeaheadForWorkspaceQuery: asana.resources.Typeahead.TypeaheadParams = {
+    resource_type: 'task',
+    query: 'my query',
+    opt_pretty: true,
+    opt_fields: 'name,completed,parent,custom_fields.gid,custom_fields.number_value',
 };
 client.typeahead.typeaheadForWorkspace('workspace_gid', typeaheadForWorkspaceQuery);

--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -228,11 +228,11 @@ client.customFields
 client.typeahead.typeaheadForWorkspace('workspace_gid', {});
 
 // opt_fields takes string, not array
-// $ExpectError
 const badTypeaheadForWorkspaceQuery: asana.resources.Typeahead.TypeaheadParams = {
     resource_type: 'task',
     query: 'my query',
     opt_pretty: true,
+    // $ExpectError
     opt_fields: ['name', 'completed', 'parent', 'custom_fields.gid', 'custom_fields.number_value'],
 };
 

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -2985,7 +2985,7 @@ declare namespace asana {
                 query?: string | undefined;
                 count?: number | undefined;
                 opt_pretty?: boolean | undefined;
-                opt_fields?: string[] | undefined;
+                opt_fields?: string | undefined;
             }
         }
 


### PR DESCRIPTION
This fixes a key type that resulted in broken behavior on Node.js.

This parameter ("opt_fields") controls which things Asana returns when you query it.

When passed as an array as the query string into the request library, behavior differs between browser use and node.js
use.

On the browser (using the browser-request package), the array gets silently converted to a comma-separated list (which
works).

In node.js (using the request package), the array gets passed into multiple opt_fields parameters, with each argument
passed like this (with URL encoding):
`opt_fields[0]=name&opt_fields[1]=completed&opt_fields[2]=parent.name&opt_fields[3]=custom_fields.gid&opt_fields[4]=custom_fields.number_value&opt_fields[5]=memberships.project.name`

It's better to require that this be always passed as a string to avoid surprises when code gets used in a different
context later.

The docs show this as a comma-separated string: https://developers.asana.com/docs/input-output-options

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [API docs showing comma usage](https://developers.asana.com/docs/input-output-options)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - N/A, fix for existing published versions