### PR TITLE
Fix type "react-type-animation"

### DIFF
--- a/types/react-type-animation/index.d.ts
+++ b/types/react-type-animation/index.d.ts
@@ -6,13 +6,13 @@
 import { FunctionComponent } from 'react';
 
 export interface TypeAnimationProps {
-    sequence: (string | number)[];
+    sequence: Array<string | number>;
     wrapper?: string;
     repeat?: number;
     cursor?: boolean;
     className?: string;
 }
 
-declare const TypeAnimation: FunctionComponent<TypeAnimationProps>
+declare const TypeAnimation: FunctionComponent<TypeAnimationProps>;
 
 export default TypeAnimation;

--- a/types/react-type-animation/index.d.ts
+++ b/types/react-type-animation/index.d.ts
@@ -3,50 +3,16 @@
 // Definitions by: Seungbin Oh <https://github.com/sboh1214>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ReactNode, FunctionComponent } from 'react';
+import { FunctionComponent } from 'react';
 
-interface TypingProps {
-    element?: string;
-    children: ReactNode;
+export interface TypeAnimationProps {
+    sequence: (string | number)[];
+    wrapper?: string;
+    repeat?: number;
+    cursor?: boolean;
     className?: string;
-    cursorClassName?: string;
-    cursorElement?: string;
-    cursor?: ReactNode;
-    hideCursor?: boolean;
-    speed?: number;
-    startDelay?: number;
-    loop?: boolean;
-    onStartedTyping?: () => void;
-    onBeforeType?: () => void;
-    onAfterType?: () => void;
-    onFinishedTyping?: () => void;
 }
 
-interface BackspaceProps {
-    count?: number;
-    delay?: number;
-    speed?: number;
-}
+declare const TypeAnimation: FunctionComponent<TypeAnimationProps>
 
-interface DelayProps {
-    ms: number;
-}
-
-interface SpeedProps {
-    ms: number;
-}
-
-interface ResetProps {
-    count?: number;
-    delay?: number;
-    speed?: number;
-}
-
-declare const Typing: FunctionComponent<TypingProps> & {
-    Backspace: FunctionComponent<BackspaceProps>;
-    Delay: FunctionComponent<DelayProps>;
-    Speed: FunctionComponent<SpeedProps>;
-    Reset: FunctionComponent<ResetProps>;
-};
-
-export default Typing;
+export default TypeAnimation;

--- a/types/react-type-animation/react-type-animation-tests.tsx
+++ b/types/react-type-animation/react-type-animation-tests.tsx
@@ -1,41 +1,16 @@
 import * as React from 'react';
-import Typing from 'react-type-animation';
+import TypeAnimation from 'react-type-animation';
 
-const basic = () => (
-    <Typing>
-        <span>This span will get typed.</span>
-    </Typing>
+const example = () => (
+    <TypeAnimation cursor={false} sequence={['React typing animation based on typical', 1000, '']} wrapper="h2" />
 );
 
-const backspace = () => (
-    <Typing>
-        <span>This span will get typed, then erased.</span>
-        <Typing.Backspace count={20} />
-    </Typing>
-);
-
-const delay = () => (
-    <Typing>
-        <div>
-            There will be a 1000ms delay here,
-            <Typing.Delay ms={1000} />
-            then this will be typed.
-        </div>
-    </Typing>
-);
-
-const speed = () => (
-    <Typing speed={50}>
-        This line will be typed at 50ms/character,
-        <Typing.Speed ms={200} />
-        then this will be typed at 200ms/character.
-    </Typing>
-);
-
-const reset = () => (
-    <Typing>
-        <span>This line will stay.</span>
-        <span>This line will get instantly removed after a 500 ms delay</span>
-        <Typing.Reset count={1} delay={500} />
-    </Typing>
+const exampleWithRepeat = () => (
+    <TypeAnimation
+        cursor={false}
+        sequence={['얘야, 큰 힘에는 큰 책임이 따른단다', 6000, 'I am Ironman', 6500, '거 죽기 딱 좋은 날씨네', 6400]}
+        wrapper="p"
+        className="mainTyping"
+        repeat={Infinity}
+    />
 );

--- a/types/react-type-animation/react-type-animation-tests.tsx
+++ b/types/react-type-animation/react-type-animation-tests.tsx
@@ -8,9 +8,28 @@ const example = () => (
 const exampleWithRepeat = () => (
     <TypeAnimation
         cursor={false}
-        sequence={['얘야, 큰 힘에는 큰 책임이 따른단다', 6000, 'I am Ironman', 6500, '거 죽기 딱 좋은 날씨네', 6400]}
-        wrapper="p"
-        className="mainTyping"
+        sequence={['This text will be repeated infinitely.', 1000, '']}
+        wrapper="h2"
         repeat={Infinity}
     />
+);
+
+const repeatWithThreeTimes = () => (
+    <TypeAnimation
+        cursor={true}
+        sequence={['This animation', 2000, 'Will write', 2000, 'A sequence three times.']}
+        wrapper="a"
+        repeat={3}
+    />
+);
+
+const predefinedWidth = () => (
+    <div style={{ width: '20em' }}>
+        <TypeAnimation
+            cursor={true}
+            sequence={['Pre-define width of wrapper', 2000, 'to prevent layout-shift.', 2000]}
+            wrapper="h2"
+            repeat={Infinity}
+        />
+    </div>
 );


### PR DESCRIPTION
I confused two packages and I wrote types about `react-typing-animation`, not `react-type-animation`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/maxeth/react-type-animation#readme](https://github.com/maxeth/react-type-animation#readme)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
