### PR TITLE
[react-calendar-timeline] add buffer property

### DIFF
--- a/types/react-calendar-timeline/index.d.ts
+++ b/types/react-calendar-timeline/index.d.ts
@@ -252,7 +252,7 @@ declare module 'react-calendar-timeline' {
         resizeDetector?: ((containerResizeDetector: any) => void) | undefined;
         verticalLineClassNamesForTime?: ((start: number, end: number) => string[] | undefined) | undefined;
         horizontalLineClassNamesForGroup?: ((group: CustomGroup) => string[]) | undefined;
-
+        buffer?: number | undefined;
         // Fields that are in propTypes but not documented
         headerRef?: React.Ref<any> | undefined;
     }


### PR DESCRIPTION
property buffer is missing according to https://github.com/namespace-ee/react-calendar-timeline#buffer

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.

Select one of these and delete the others:

If adding a new definition:
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.