### PR TITLE
[mssql] recordsets can be arrays of various types

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -8,7 +8,7 @@
 //                 Rifa Achrinza <https://github.com/achrinza>
 //                 Daniel Hensby <https://github.com/dhensby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.6
+// TypeScript Version: 4.0
 
 /// <reference types="node" />
 
@@ -134,8 +134,8 @@ export interface IColumnMetadata {
     }
 }
 export interface IResult<T> {
-    recordsets: IRecordSet<T>[];
-    recordset: IRecordSet<T>;
+    recordsets: T extends Array<any> ? { [P in keyof T]: IRecordSet<T[P]> } : IRecordSet<T>[];
+    recordset: IRecordSet<T extends Array<any> ? T[0] : T>;
     rowsAffected: number[],
     output: { [key: string]: any };
 }

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -5,6 +5,10 @@ interface Entity {
     value: number;
 }
 
+interface AnotherEntity {
+    property: string;
+}
+
 var config: sql.config = {
     user: 'user',
     password: 'password',
@@ -95,6 +99,17 @@ var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function (er
             }
             else {
                 console.info(returnValue);
+            }
+        });
+
+        requestStoredProcedure.execute<[Entity, AnotherEntity]>('StoredProcedureName', function (err, recordsets, returnValue) {
+            if (err != null) {
+                console.error(`Error happened calling Query: ${err.name} ${err.message}`);
+            }
+            else {
+                console.info(returnValue);
+                recordsets.recordsets[0] // $ExpectType IRecordSet<Entity>
+                recordsets.recordsets[1] // $ExpectType IRecordSet<AnotherEntity>
             }
         });
 


### PR DESCRIPTION
`recordsets` that are returned by the library can be an array of many types.

For example, running `pool.request().query('SELECT * FROM [table1]; SELECT * FROM [table2]'),then(({ recordsets }) => recordsets);` will return an array with two elements, each representing the results from the executed queries. These can be of different types (especially as they are likely to come from differing table structures).

This change allows the existing usage:

```ts
pool.request().query<MyType>('SELECT * FROM [table]');
```

As well as new usage:

```ts
pool.request().query<[MyType, MyOtherType, EvenMoreTypes]>('SELECT * FROM [table]; SELECT * FROM [table2]; SELECT * FROM [table3]');
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tediousjs/node-mssql#query-command-callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.