### PR TITLE
fix(pica): correct `resizeBuffer` types

### DIFF
--- a/types/pica/index.d.ts
+++ b/types/pica/index.d.ts
@@ -92,7 +92,7 @@ declare namespace pica {
 
     interface PicaResizeBufferOptions {
         /** Uint8Array with source data. */
-        src: number[];
+        src: Uint8Array;
         /** src image width. */
         width: number;
         /** src image height. */
@@ -100,7 +100,7 @@ declare namespace pica {
         /** output width, >=0, in pixels. */
         toWidth: number;
         /** output height, >=0, in pixels. */
-        toHeigh: number;
+        toHeight: number;
         /**
          * deprecated use `.filter` instead.
          *
@@ -142,7 +142,7 @@ declare namespace pica {
         /**
          * Optional. Output buffer to write data, if you don't wish pica to create new one.
          */
-        dest?: string | undefined;
+        dest?: Uint8Array | undefined;
     }
 
     interface Pica {
@@ -169,7 +169,7 @@ declare namespace pica {
          * Resize Uint8Array with raw RGBA bitmap (don't confuse with jpeg / png / ... binaries).
          * It does not use tiles & webworkers. Left for special cases when you really need to process raw binary data (for example, if you decode jpeg files "manually").
          */
-        resizeBuffer(options: PicaResizeBufferOptions): Promise<number[]>;
+        resizeBuffer(options: PicaResizeBufferOptions): Promise<Uint8Array>;
     }
 
     interface PicaStatic {

--- a/types/pica/test/pica-tests.cjs.ts
+++ b/types/pica/test/pica-tests.cjs.ts
@@ -56,13 +56,13 @@ resizer.toBlob(canvas, 'image/png', 9);
 resizerWithOptions.toBlob(canvas, 'image/png', 9);
 
 // Resize buffer
-const resizeBufferSrc: number[] = [21, 31];
+const resizeBufferSrc = Uint8Array.of(21, 31);
 const resizeBufferOptions: pica.PicaResizeBufferOptions = {
     src: resizeBufferSrc,
     width: 100,
     height: 100,
     toWidth: 50,
-    toHeigh: 50,
+    toHeight: 50,
 };
 resizer.resizeBuffer(resizeBufferOptions);
 resizerWithOptions.resizeBuffer(resizeBufferOptions);

--- a/types/pica/test/pica-tests.global.ts
+++ b/types/pica/test/pica-tests.global.ts
@@ -54,13 +54,13 @@ resizer.toBlob(canvas, 'image/png', 9);
 resizerWithOptions.toBlob(canvas, 'image/png', 9);
 
 // Resize buffer
-const resizeBufferSrc: number[] = [21, 31];
+const resizeBufferSrc = Uint8Array.of(21, 31);
 const resizeBufferOptions: pica.PicaResizeBufferOptions = {
     src: resizeBufferSrc,
     width: 100,
     height: 100,
     toWidth: 50,
-    toHeigh: 50,
+    toHeight: 50,
 };
 resizer.resizeBuffer(resizeBufferOptions);
 resizerWithOptions.resizeBuffer(resizeBufferOptions);


### PR DESCRIPTION
The function works with `Uint8Array` values, not `number[]` or `string`. Also, `toHeight` was typo'd as `toHeigh`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`resize`](https://github.com/nodeca/pica/blob/e4e661623a14160a824087c6a66059e3b6dba5a0/lib/mm_resize/resize.js#L23)
