### PR TITLE
[remark-hint] Requires TS >=4.5

### DIFF
--- a/types/remark-hint/index.d.ts
+++ b/types/remark-hint/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/sergioramos/remark-hint
 // Definitions by: Neko <https://github.com/Cattttttttt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.0
+// Minimum TypeScript Version: 4.5
 
 import { Plugin } from 'unified';
 import { Root } from 'mdast';


### PR DESCRIPTION
I bumped the minimum TS version to 4.5 because the types [depend on unified](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/44725bd8b9db24995de7ba651541dd476e25fc2c/types/remark-hint/package.json#L5), which has a [transitive dependency on vfile ^5.0.0](https://unpkg.com/browse/unified@10.1.2/package.json#L55), which requires TS >=4.5 since version 5.3.3, which was released a couple days ago.

vfile 5.3.3 requires TS >=4.5 because that version [introduced type modifiers](https://github.com/vfile/vfile/commit/6375cbc1846e3534cdbae06476504247c402a50d#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8R51) on export names, which was [added in TS 4.5](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names):
```sh
npm test remark-hint

dtslint@0.0.115
Error: Errors in typescript@4.0 for external dependencies:
node_modules/vfile/index.d.ts(51,3): error TS2300: Duplicate identifier 'type'.
node_modules/vfile/index.d.ts(51,3): error TS2305: Module '"./lib/index.js"' has no exported member 'type'.
node_modules/vfile/index.d.ts(51,8): error TS1005: ',' expected.