### PR TITLE
[@types/express-serve-static-core] Fix type signature for 4-argument IRouter.use function.

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -214,6 +214,14 @@ app.engine('ntl', (_filePath, _options, callback) => {
     callback(new Error('not found.'));
 });
 
+// Error handlers
+app.use((err, req, res, next) => {
+    err; // $ExpectType any
+    req; // $ExpectType Request<any, any, any, any, Record<string, any>>
+    res; // $ExpectType Response<any, Record<string, any>, number>
+    next; // $ExpectType NextFunction
+});
+
 // Status test
 {
     type E = express.Response<unknown, any, 'abc'>; // $ExpectError

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -175,8 +175,8 @@ export interface IRouterMatcher<
 }
 
 export interface IRouterHandler<T, Route extends string = string> {
-    (...handlers: Array<RequestHandler<RouteParameters<Route>>>): T;
     (...handlers: Array<RequestHandlerParams<RouteParameters<Route>>>): T;
+    (...handlers: Array<RequestHandler<RouteParameters<Route>>>): T;
     <
         P = RouteParameters<Route>,
         ResBody = any,


### PR DESCRIPTION
Fixes #60353.

The problem is that the signature using `RequestHandler` has a higher precedence over the one using `RequestHandlerParams`. The problem was introduced by #10025.

#### Template
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a [URL to documentation](https://expressjs.com/en/guide/using-middleware.html#middleware.error-handling) or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
