### PR TITLE
[@types/braintree-web] Add DataCollector missing types

### DIFF
--- a/types/braintree-web/modules/data-collector.d.ts
+++ b/types/braintree-web/modules/data-collector.d.ts
@@ -3,11 +3,17 @@ import { Client } from './client';
 
 export interface DataCollector {
     create(options: { client: Client; kount?: boolean | undefined; paypal?: boolean | undefined }): Promise<DataCollector>;
-    create(options: { client: Client; kount?: boolean | undefined; paypal?: boolean | undefined }, callback: callback): void;
+    create(options: { client: Client; kount?: boolean | undefined; paypal?: boolean | undefined }, callback: callback<DataCollector>): void;
 
     VERSION: string;
 
     deviceData: string;
 
-    teardown(callback?: callback): void;
+    rawDeviceData: object;
+
+    getDeviceData(options?: { raw: boolean }): Promise<string | object>;
+    getDeviceData(options: { raw: boolean }, callback: callback<void>): void;
+
+    teardown(): Promise<void>;
+    teardown(callback: callback): void;
 }

--- a/types/braintree-web/test/node.ts
+++ b/types/braintree-web/test/node.ts
@@ -572,6 +572,21 @@ braintree.client.create(
                 // Implementation
             });
         });
+
+        braintree.dataCollector.create({ client: clientInstance }, (error, dataCollectorInstance) => {
+            dataCollectorInstance.getDeviceData({ raw: false }, (err, deviceData) => {
+                // Implementation
+                console.log(deviceData);
+            });
+        });
+
+        braintree.dataCollector
+            .create({ client: clientInstance })
+            .then(dataCollectorInstance => dataCollectorInstance.getDeviceData())
+            .then(deviceData => {
+                // Implementation
+                console.log(deviceData);
+            });
     },
 );
 

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -834,6 +834,21 @@ braintree.client.create(
                 });
             },
         );
+
+        braintree.dataCollector.create({ client: clientInstance }, (error, dataCollectorInstance) => {
+            dataCollectorInstance.getDeviceData({ raw: false }, (err, deviceData) => {
+                // Implementation
+                console.log(deviceData);
+            });
+        });
+
+        braintree.dataCollector
+            .create({ client: clientInstance })
+            .then(dataCollectorInstance => dataCollectorInstance.getDeviceData())
+            .then(deviceData => {
+                // Implementation
+                console.log(deviceData);
+            });
     },
 );
 


### PR DESCRIPTION
### braintree-web
DataCollector `getDeviceData` method was missing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://braintree.github.io/braintree-web/current/DataCollector.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
