### PR TITLE
fix(@types/node): url.parse API has been un-deprecated

### DIFF
--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -59,8 +59,12 @@ declare module 'url' {
      * lenient, non-standard algorithm for parsing URL strings, security
      * issues can be introduced. Specifically, issues with [host name spoofing](https://hackerone.com/reports/678487) and
      * incorrect handling of usernames and passwords have been identified.
+     *
+     * Deprecation of this API has been shelved for now primarily due to the the
+     * inability of the [WHATWG API to parse relative URLs](https://github.com/nodejs/node/issues/12682#issuecomment-1154492373).
+     * [Discussions are ongoing](https://github.com/whatwg/url/issues/531) for the  best way to resolve this.
+     *
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
      * @param urlString The URL string to parse.
      * @param [parseQueryString=false] If `true`, the `query` property will always be set to an object returned by the {@link querystring} module's `parse()` method. If `false`, the `query` property
      * on the returned URL object will be an unparsed, undecoded string.

--- a/types/node/v16/url.d.ts
+++ b/types/node/v16/url.d.ts
@@ -59,8 +59,12 @@ declare module 'url' {
      * lenient, non-standard algorithm for parsing URL strings, security
      * issues can be introduced. Specifically, issues with [host name spoofing](https://hackerone.com/reports/678487) and
      * incorrect handling of usernames and passwords have been identified.
+     *
+     * Deprecation of this API has been shelved for now primarily due to the the
+     * inability of the [WHATWG API to parse relative URLs](https://github.com/nodejs/node/issues/12682#issuecomment-1154492373).
+     * [Discussions are ongoing](https://github.com/whatwg/url/issues/531) for the  best way to resolve this.
+     *
      * @since v0.1.25
-     * @deprecated Legacy: Use the WHATWG URL API instead.
      * @param urlString The URL string to parse.
      * @param [parseQueryString=false] If `true`, the `query` property will always be set to an object returned by the {@link querystring} module's `parse()` method. If `false`, the `query` property
      * on the returned URL object will be an unparsed, undecoded string.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/issues/12682#issuecomment-1154492373
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.