### PR TITLE
feat(probe-image-size): v7.2 update options & return types

### DIFF
--- a/types/probe-image-size/index.d.ts
+++ b/types/probe-image-size/index.d.ts
@@ -47,6 +47,7 @@ declare namespace probe {
 
     function sync(data: Buffer): ProbeResult | null;
 
+    // tslint:disable-next-line:no-empty-interface
     interface ParserStream extends Transform {}
 
     type Parser = () => ParserStream;

--- a/types/probe-image-size/index.d.ts
+++ b/types/probe-image-size/index.d.ts
@@ -10,10 +10,8 @@ import needle = require("needle");
 /**
  * Get image size without full download. Supported image types: JPG, GIF, PNG, WebP, BMP, TIFF, SVG, PSD.
  */
-declare function probe(source: string, opts: needle.NeedleOptions, callback: probe.ProbeCallback): void;
 declare function probe(source: string, opts?: needle.NeedleOptions): Promise<probe.ProbeResult>;
-declare function probe(source: string | NodeJS.ReadableStream, callback: probe.ProbeCallback): void;
-declare function probe(source: NodeJS.ReadableStream): Promise<probe.ProbeResult>;
+declare function probe(source: NodeJS.ReadableStream, keepOpen?: boolean): Promise<probe.ProbeResult>;
 
 declare namespace probe {
     interface ProbeResult {

--- a/types/probe-image-size/index.d.ts
+++ b/types/probe-image-size/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for probe-image-size 7.0
+// Type definitions for probe-image-size 7.2
 // Project: https://github.com/nodeca/probe-image-size#readme
 // Definitions by: Jinesh Shah <https://github.com/jineshshah36>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>

--- a/types/probe-image-size/index.d.ts
+++ b/types/probe-image-size/index.d.ts
@@ -5,11 +5,13 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
+import needle = require("needle");
+
 /**
  * Get image size without full download. Supported image types: JPG, GIF, PNG, WebP, BMP, TIFF, SVG, PSD.
  */
-declare function probe(source: string, opts: probe.ProbeOptions, callback: probe.ProbeCallback): void;
-declare function probe(source: string, opts?: probe.ProbeOptions): Promise<probe.ProbeResult>;
+declare function probe(source: string, opts: needle.NeedleOptions, callback: probe.ProbeCallback): void;
+declare function probe(source: string, opts?: needle.NeedleOptions): Promise<probe.ProbeResult>;
 declare function probe(source: string | NodeJS.ReadableStream, callback: probe.ProbeCallback): void;
 declare function probe(source: NodeJS.ReadableStream): Promise<probe.ProbeResult>;
 
@@ -32,11 +34,6 @@ declare namespace probe {
     interface Variant {
         width: number;
         height: number;
-    }
-
-    interface ProbeOptions {
-        retries?: number | undefined;
-        timeout?: number | undefined;
     }
 
     interface ProbeError extends Error {

--- a/types/probe-image-size/index.d.ts
+++ b/types/probe-image-size/index.d.ts
@@ -6,12 +6,21 @@
 /// <reference types="node" />
 
 import needle = require("needle");
+import { Transform } from "stream";
 
 /**
  * Get image size without full download. Supported image types: JPG, GIF, PNG, WebP, BMP, TIFF, SVG, PSD.
  */
 declare function probe(source: string, opts?: needle.NeedleOptions): Promise<probe.ProbeResult>;
 declare function probe(source: NodeJS.ReadableStream, keepOpen?: boolean): Promise<probe.ProbeResult>;
+
+declare class ProbeError extends Error {
+    constructor(
+        message: string,
+        code?: "ECONTENT" | undefined | null,
+        statusCode?: number | undefined,
+    )
+}
 
 declare namespace probe {
     interface ProbeResult {
@@ -34,14 +43,28 @@ declare namespace probe {
         height: number;
     }
 
-    interface ProbeError extends Error {
-        code?: "ECONTENT" | undefined;
-        status?: number | undefined;
-    }
-
-    type ProbeCallback = (err: ProbeError | null, result: ProbeResult) => void;
+    const Error: typeof ProbeError;
 
     function sync(data: Buffer): ProbeResult | null;
+
+    interface ParserStream extends Transform {}
+
+    type Parser = () => ParserStream;
+
+    type Parsers = {
+        avif: Parser,
+        bmp: Parser,
+        gif: Parser,
+        ico: Parser,
+        jpeg: Parser,
+        png: Parser,
+        psd: Parser,
+        svg: Parser,
+        tiff: Parser,
+        webp: Parser,
+    }
+
+    const parsers: Parsers;
 }
 
 export = probe;

--- a/types/probe-image-size/index.d.ts
+++ b/types/probe-image-size/index.d.ts
@@ -17,8 +17,8 @@ declare function probe(source: NodeJS.ReadableStream, keepOpen?: boolean): Promi
 declare class ProbeError extends Error {
     constructor(
         message: string,
-        code?: "ECONTENT" | undefined | null,
-        statusCode?: number | undefined,
+        code?: "ECONTENT" | null,
+        statusCode?: number,
     )
 }
 
@@ -51,17 +51,17 @@ declare namespace probe {
 
     type Parser = () => ParserStream;
 
-    type Parsers = {
-        avif: Parser,
-        bmp: Parser,
-        gif: Parser,
-        ico: Parser,
-        jpeg: Parser,
-        png: Parser,
-        psd: Parser,
-        svg: Parser,
-        tiff: Parser,
-        webp: Parser,
+    interface Parsers {
+        avif: Parser;
+        bmp: Parser;
+        gif: Parser;
+        ico: Parser;
+        jpeg: Parser;
+        png: Parser;
+        psd: Parser;
+        svg: Parser;
+        tiff: Parser;
+        webp: Parser;
     }
 
     const parsers: Parsers;

--- a/types/probe-image-size/probe-image-size-tests.ts
+++ b/types/probe-image-size/probe-image-size-tests.ts
@@ -19,6 +19,7 @@ const data = fs.readFileSync("image.jpg");
     }
     probeResult = await probe("http://example.com/image.jpg"); // $ExpectType ProbeResult
     probeResult = await probe(input); // $ExpectType ProbeResult
+    probeResult = await probe(input, true); // $ExpectType ProbeResult
     input.destroy();
     probe.sync(data); // $ExpectType ProbeResult | null
 })();

--- a/types/probe-image-size/probe-image-size-tests.ts
+++ b/types/probe-image-size/probe-image-size-tests.ts
@@ -22,4 +22,10 @@ const data = fs.readFileSync("image.jpg");
     probeResult = await probe(input, true); // $ExpectType ProbeResult
     input.destroy();
     probe.sync(data); // $ExpectType ProbeResult | null
+
+    probe.parsers.bmp(); // $ExpectType ParserStream
+
+    new probe.Error("Error"); // $ExpectType ProbeError
+    new probe.Error("Error", "ECONTENT"); // $ExpectType ProbeError
+    new probe.Error("Error", "ECONTENT", 404); // $ExpectType ProbeError
 })();

--- a/types/probe-image-size/probe-image-size-tests.ts
+++ b/types/probe-image-size/probe-image-size-tests.ts
@@ -7,7 +7,7 @@ const data = fs.readFileSync("image.jpg");
 (async () => {
     let probeResult: probe.ProbeResult;
     probeResult = await probe(""); // $ExpectType ProbeResult
-    probeResult = await probe("", { retries: 3 }); // $ExpectType ProbeResult
+    probeResult = await probe("", { follow_max: 10 }); // $ExpectType ProbeResult
 
     probeResult = await probe("http://example.com/image.jpg", { timeout: 5000 });
     const { variants, orientation } = probeResult;

--- a/types/probe-image-size/tslint.json
+++ b/types/probe-image-size/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "no-empty-interface": false
+    }
+}

--- a/types/probe-image-size/tslint.json
+++ b/types/probe-image-size/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "@definitelytyped/dtslint/dt.json",
-    "rules": {
-        "no-empty-interface": false
-    }
-}
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
This change has been introduced in `probe-image-size` 2 years ago, in v6

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/probe-image-size#probesrc--optionskeepopen---promise
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.