### PR TITLE
[signalfx] Added sendEvent to the interfaces, and fixed the return type of send to be Promise<void>.

### DIFF
--- a/types/signalfx/index.d.ts
+++ b/types/signalfx/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for signalfx 7.0
+// Type definitions for signalfx 7.4
 // Project: https://github.com/signalfx/signalfx-nodejs
 // Definitions by: Vladimir Grenaderov <https://github.com/VladimirGrenaderov>
 //                 Max Boguslavskiy <https://github.com/maxbogus>
@@ -28,18 +28,31 @@ export interface SignalReport {
     counters?: SignalMetric[] | undefined;
 }
 
+export type EventCategory = 'USER_DEFINED' | 'ALERT' | 'AUDIT' | 'JOB' | 'COLLECTD' | 'SERVICE_DISCOVERY' | 'EXCEPTION';
+
+export interface SignalEvent {
+    eventType: string;
+    category?: EventCategory | undefined;
+    dimensions?: object | undefined;
+    properties?: object | undefined;
+    timestamp?: number | undefined;
+}
+
 export interface SignalClient {
-    send(report: SignalReport): void;
+    send(report: SignalReport): Promise<void>;
+    sendEvent(event: SignalEvent): Promise<void>;
 }
 
-export class Ingest {
+export class Ingest implements SignalClient {
     constructor(token: string, options?: IngestOptions);
-    send(report: SignalReport): void;
+    send(report: SignalReport): Promise<void>;
+    sendEvent(event: SignalEvent): Promise<void>;
 }
 
-export class IngestJson {
+export class IngestJson implements SignalClient {
     constructor(token: string, options?: IngestOptions);
-    send(report: SignalReport): void;
+    sendEvent(event: SignalEvent): Promise<void>;
+    send(report: SignalReport): Promise<void>;
 }
 
 export const CONSTANTS: {
@@ -51,4 +64,112 @@ export const CONSTANTS: {
     };
 };
 
-export function SignalFlow(apiToken: any, options: any): any;
+export interface SignalFlowOptions {
+    signalflowEndpoint?: string | undefined;
+    apiEndpoint?: string | undefined;
+    webSocketErrorCallback?: (err: any) => void | undefined;
+}
+
+export interface RequestOptions {
+    /** required for execute */
+    program?: string | undefined;
+    /** required for explain */
+    incidentId?: string | undefined;
+    start?: string | number | undefined;
+    end?: string | number | undefined;
+    range?: number | undefined;
+    stop?: string | number | undefined;
+    compress?: boolean | undefined;
+    throttleOptions?: { rate: number };
+    resolution?: number;
+    maxDelay?: number;
+    bigNumber?: boolean;
+    immediate?: boolean;
+}
+
+export interface ExecuteOptions extends RequestOptions {
+    program: string | undefined;
+}
+
+export interface ExplainOptions extends RequestOptions {
+    incidentId: string | undefined;
+}
+
+export interface MetadataMessage {
+    type: 'metadata';
+    channel: string;
+    tsId: string;
+    properties: {
+        jobId: string;
+        sf_organizationID: string;
+        sf_key: string[];
+        sf_metric: string;
+        sf_resolutionMs: number;
+        sf_type: string;
+        sf_isPreQuantized: boolean;
+    };
+}
+
+export interface DataMessage {
+    type: 'data';
+    channel: string;
+    data: [{ tsId: string; value: number }];
+    logicalTimestampMs: number;
+}
+
+export interface ControlMessage {
+    type: 'control-message';
+    channel?: string;
+    logicalTimestampMs: number;
+    // TODO: this is really a fixed set with different values
+    event: string;
+    progress?: number;
+    handle?: string;
+    abortInfo?: {
+        sf_job_abortReason: string;
+        sf_job_abortState: string;
+    };
+}
+
+export interface EventMessage {
+    type: 'event';
+    logicalTimestampMs: number;
+    channel: string;
+    tsId: string;
+    properties: {
+        incidentId: string;
+        inputValues: string;
+        is: 'ok' | 'anomalous';
+        was: 'ok' | 'anomalous';
+    };
+}
+
+export type StreamMessage = MetadataMessage | EventMessage | ControlMessage | DataMessage;
+
+export type StreamCallback = (err?: { error: any }, data?: StreamMessage) => void;
+
+export interface SignalfxHandle {
+    close(): boolean;
+    get_known_tsids(): string[];
+    get_metadata(): object | undefined;
+    stream(callback: StreamCallback): boolean;
+}
+
+export interface LiveTailOpts {
+    query: { matcher: { params: { op: string; args: object } } };
+    throttleOptions: { rate: number };
+}
+
+export interface LiveTail {
+    close(): boolean;
+    stream(callback: StreamCallback): boolean;
+}
+
+export class SignalFlow {
+    constructor(apiToken: string, options?: SignalFlowOptions);
+    disconnect(): void;
+    execute(opts: ExecuteOptions): SignalfxHandle;
+    explain(opts: ExplainOptions): SignalfxHandle;
+    preflight(opts: RequestOptions): SignalfxHandle;
+    livetail(opts: LiveTailOpts): LiveTail;
+}

--- a/types/signalfx/signalfx-tests.ts
+++ b/types/signalfx/signalfx-tests.ts
@@ -2,9 +2,15 @@ import * as signalfx from 'signalfx';
 
 const sgnlfx = new signalfx.Ingest('1');
 sgnlfx.send({
-  gauges: [{
-    metric: "metric",
-    value: 1,
-    dimensions: {}
-  }]
+    gauges: [
+        {
+            metric: 'metric',
+            value: 1,
+            dimensions: {},
+        },
+    ],
+});
+
+sgnlfx.sendEvent({
+    eventType: 'my-custom-event',
 });


### PR DESCRIPTION
Added sendEvent to the interfaces, and fixed the return type of send to be Promise<void>.

Also added definition around the Signalflow types.  I've not actually used them though; the definitions were sourced
from the signalfx library and the signalfx docs.

Any formatting changes are due to running prettier prior to commit as suggested in the best practices.

## Testing

```
❯ npm test signalfx

> definitely-typed@0.0.3 test /Users/jobarksdale/workspace/DefinitelyTyped
> dtslint types "signalfx"

dtslint@0.0.115
```

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [GIt repo](https://github.com/signalfx/signalfx-nodejs/tree/main), [signalflow docs](https://dev.splunk.com/observability/docs/signalflow/messages/stream_messages_specification/#Expired-tsId-message-in-WebSocket-format)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
