### PR TITLE
[crc] Update to v3.8

### DIFF
--- a/types/crc/crc-tests.ts
+++ b/types/crc/crc-tests.ts
@@ -1,5 +1,19 @@
-import * as crc from "crc";
-import * as fs from "fs";
+import * as fs from 'fs';
+import * as crc from 'crc';
+
+import 'crc/crc91wire';
+import 'crc/crc17ccitt';
+import 'crc/crc17kermit';
+import 'crc/crc17modbus';
+import 'crc/crc17xmodem';
+
+crc.default.default; // $ExpectError
+
+/**
+ * The `expectType` function from https://www.npmjs.com/package/tsd,
+ * except instead of returning `void`, it returns `T`.
+ */
+declare function expectType<T>(t: T): T;
 
 // tests move from the readme of the module
 
@@ -15,3 +29,33 @@ let value = crc.crc32('one');
 value = crc.crc32('two', value);
 value = crc.crc32('three', value);
 value.toString(16);
+
+// `crc.*`:
+expectType<typeof crc.crc1>(expectType<typeof import('crc/crc1').default>(crc.crc1));
+expectType<typeof crc.crc8>(expectType<typeof import('crc/crc8').default>(crc.crc8));
+expectType<typeof crc.crc81wire>(expectType<typeof import('crc/crc81wire').default>(crc.crc81wire));
+
+expectType<typeof crc.crc16>(expectType<typeof import('crc/crc16').default>(crc.crc16));
+expectType<typeof crc.crc16ccitt>(expectType<typeof import('crc/crc16ccitt').default>(crc.crc16ccitt));
+expectType<typeof crc.crc16kermit>(expectType<typeof import('crc/crc16kermit').default>(crc.crc16kermit));
+expectType<typeof crc.crc16modbus>(expectType<typeof import('crc/crc16modbus').default>(crc.crc16modbus));
+expectType<typeof crc.crc16xmodem>(expectType<typeof import('crc/crc16xmodem').default>(crc.crc16xmodem));
+
+expectType<typeof crc.crc24>(expectType<typeof import('crc/crc24').default>(crc.crc24));
+expectType<typeof crc.crc32>(expectType<typeof import('crc/crc32').default>(crc.crc32));
+expectType<typeof crc.crcjam>(expectType<typeof import('crc/crcjam').default>(crc.crcjam));
+
+// `crc.default.*`:
+expectType<typeof crc.crc1>(expectType<typeof import('crc/crc1').default>(crc.default.crc1));
+expectType<typeof crc.crc8>(expectType<typeof import('crc/crc8').default>(crc.default.crc8));
+expectType<typeof crc.crc81wire>(expectType<typeof import('crc/crc81wire').default>(crc.default.crc81wire));
+
+expectType<typeof crc.crc16>(expectType<typeof import('crc/crc16').default>(crc.default.crc16));
+expectType<typeof crc.crc16ccitt>(expectType<typeof import('crc/crc16ccitt').default>(crc.default.crc16ccitt));
+expectType<typeof crc.crc16kermit>(expectType<typeof import('crc/crc16kermit').default>(crc.default.crc16kermit));
+expectType<typeof crc.crc16modbus>(expectType<typeof import('crc/crc16modbus').default>(crc.default.crc16modbus));
+expectType<typeof crc.crc16xmodem>(expectType<typeof import('crc/crc16xmodem').default>(crc.default.crc16xmodem));
+
+expectType<typeof crc.crc24>(expectType<typeof import('crc/crc24').default>(crc.default.crc24));
+expectType<typeof crc.crc32>(expectType<typeof import('crc/crc32').default>(crc.default.crc32));
+expectType<typeof crc.crcjam>(expectType<typeof import('crc/crcjam').default>(crc.default.crcjam));

--- a/types/crc/crc1.d.ts
+++ b/types/crc/crc1.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'crc1';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc1(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc1 {
+    export { model, signed, crc1 as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc1;

--- a/types/crc/crc16.d.ts
+++ b/types/crc/crc16.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'crc-16';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc16(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc16 {
+    export { model, signed, crc16 as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc16;

--- a/types/crc/crc16ccitt.d.ts
+++ b/types/crc/crc16ccitt.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'ccitt';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc16ccitt(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc16ccitt {
+    export { model, signed, crc16ccitt as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc16ccitt;

--- a/types/crc/crc16kermit.d.ts
+++ b/types/crc/crc16kermit.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'kermit';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc16kermit(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc16kermit {
+    export { model, signed, crc16kermit as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc16kermit;

--- a/types/crc/crc16modbus.d.ts
+++ b/types/crc/crc16modbus.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'crc-16-modbus';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc16modbus(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc16modbus {
+    export { model, signed, crc16modbus as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc16modbus;

--- a/types/crc/crc16xmodem.d.ts
+++ b/types/crc/crc16xmodem.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'xmodem';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc16xmodem(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc16xmodem {
+    export { model, signed, crc16xmodem as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc16xmodem;

--- a/types/crc/crc17ccitt.d.ts
+++ b/types/crc/crc17ccitt.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'ccitt';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc17ccitt(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc17ccitt {
+    export { model, signed, crc17ccitt as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc17ccitt;

--- a/types/crc/crc17kermit.d.ts
+++ b/types/crc/crc17kermit.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'kermit';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc17kermit(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc17kermit {
+    export { model, signed, crc17kermit as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc17kermit;

--- a/types/crc/crc17modbus.d.ts
+++ b/types/crc/crc17modbus.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'crc-16-modbus';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc17modbus(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc17modbus {
+    export { model, signed, crc17modbus as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc17modbus;

--- a/types/crc/crc17xmodem.d.ts
+++ b/types/crc/crc17xmodem.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'xmodem';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc17xmodem(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc17xmodem {
+    export { model, signed, crc17xmodem as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc17xmodem;

--- a/types/crc/crc24.d.ts
+++ b/types/crc/crc24.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'crc-24';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc24(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc24 {
+    export { model, signed, crc24 as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc24;

--- a/types/crc/crc32.d.ts
+++ b/types/crc/crc32.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'crc-32';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc32(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc32 {
+    export { model, signed, crc32 as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc32;

--- a/types/crc/crc8.d.ts
+++ b/types/crc/crc8.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'crc-8';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc8(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc8 {
+    export { model, signed, crc8 as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc8;

--- a/types/crc/crc81wire.d.ts
+++ b/types/crc/crc81wire.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'dallas-1-wire';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc81wire(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc81wire {
+    export { model, signed, crc81wire as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc81wire;

--- a/types/crc/crc91wire.d.ts
+++ b/types/crc/crc91wire.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'dallas-1-wire';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crc91wire(buf: CRCBufferSource, previous?: number): number;
+declare namespace crc91wire {
+    export { model, signed, crc91wire as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crc91wire;

--- a/types/crc/crcjam.d.ts
+++ b/types/crc/crcjam.d.ts
@@ -1,0 +1,13 @@
+import type { CRCBufferSource } from '.';
+export type { CRCBufferSource };
+
+export const model: 'jam';
+export function signed(buf: CRCBufferSource, previous?: number): number;
+
+declare function crcjam(buf: CRCBufferSource, previous?: number): number;
+declare namespace crcjam {
+    export { model, signed, crcjam as unsigned };
+    export type { CRCBufferSource };
+}
+
+export default crcjam;

--- a/types/crc/index.d.ts
+++ b/types/crc/index.d.ts
@@ -1,17 +1,58 @@
-// Type definitions for crc 3.4
+// Type definitions for crc 3.8
 // Project: https://github.com/alexgorbatchev/node-crc/
 // Definitions by: Jianrong Yu <https://github.com/YuJianrong>
+//                 ExE Boss <https://github.com/ExE-Boss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-export function crc1(buf: string | Buffer, previous?: number): number;
-export function crc8(buf: string | Buffer, previous?: number): number;
-export function crc81wire(buf: string | Buffer, previous?: number): number;
-export function crc16(buf: string | Buffer, previous?: number): number;
-export function crc16ccitt(buf: string | Buffer, previous?: number): number;
-export function crc16modbus(buf: string | Buffer, previous?: number): number;
-export function crc16xmodem(buf: string | Buffer, previous?: number): number;
-export function crc16kermit(buf: string | Buffer, previous?: number): number;
-export function crc24(buf: string | Buffer, previous?: number): number;
-export function crc32(buf: string | Buffer, previous?: number): number;
+export type CRCBufferSource =
+    | string // force newline
+    | ArrayBufferLike
+    | ArrayLike<number>
+    | Buffer
+    | NodeJS.TypedArray;
+
+import crc1 from './crc1';
+import crc8 from './crc8';
+import crc81wire from './crc81wire';
+import crc16 from './crc16';
+import crc16ccitt from './crc16ccitt';
+import crc16modbus from './crc16modbus';
+import crc16xmodem from './crc16xmodem';
+import crc16kermit from './crc16kermit';
+import crc24 from './crc24';
+import crc32 from './crc32';
+import crcjam from './crcjam';
+
+export {
+    crc1, // force newline
+    crc8,
+    crc81wire,
+    crc16,
+    crc16ccitt,
+    crc16modbus,
+    crc16xmodem,
+    crc16kermit,
+    crc24,
+    crc32,
+    crcjam,
+};
+
+export default crc;
+declare namespace crc {
+    export type { CRCBufferSource };
+    export {
+        crc1, // force newline
+        crc8,
+        crc81wire,
+        crc16,
+        crc16ccitt,
+        crc16modbus,
+        crc16xmodem,
+        crc16kermit,
+        crc24,
+        crc32,
+        crcjam,
+    };
+}

--- a/types/crc/lib/crc1.d.ts
+++ b/types/crc/lib/crc1.d.ts
@@ -1,0 +1,2 @@
+import crc1 from '../crc1';
+export = crc1;

--- a/types/crc/lib/crc16.d.ts
+++ b/types/crc/lib/crc16.d.ts
@@ -1,0 +1,2 @@
+import crc16 from '../crc16';
+export = crc16;

--- a/types/crc/lib/crc16_ccitt.d.ts
+++ b/types/crc/lib/crc16_ccitt.d.ts
@@ -1,0 +1,2 @@
+import crc16_ccitt from '../crc16ccitt';
+export = crc16_ccitt;

--- a/types/crc/lib/crc16_kermit.d.ts
+++ b/types/crc/lib/crc16_kermit.d.ts
@@ -1,0 +1,2 @@
+import crc16_kermit from '../crc16kermit';
+export = crc16_kermit;

--- a/types/crc/lib/crc16_modbus.d.ts
+++ b/types/crc/lib/crc16_modbus.d.ts
@@ -1,0 +1,2 @@
+import crc16_modbus from '../crc16modbus';
+export = crc16_modbus;

--- a/types/crc/lib/crc16_xmodem.d.ts
+++ b/types/crc/lib/crc16_xmodem.d.ts
@@ -1,0 +1,2 @@
+import crc16_xmodem from '../crc16xmodem';
+export = crc16_xmodem;

--- a/types/crc/lib/crc24.d.ts
+++ b/types/crc/lib/crc24.d.ts
@@ -1,0 +1,2 @@
+import crc24 from '../crc24';
+export = crc24;

--- a/types/crc/lib/crc32.d.ts
+++ b/types/crc/lib/crc32.d.ts
@@ -1,0 +1,2 @@
+import crc32 from '../crc32';
+export = crc32;

--- a/types/crc/lib/crc8.d.ts
+++ b/types/crc/lib/crc8.d.ts
@@ -1,0 +1,2 @@
+import crc8 from '../crc8';
+export = crc8;

--- a/types/crc/lib/crc8_1wire.d.ts
+++ b/types/crc/lib/crc8_1wire.d.ts
@@ -1,0 +1,2 @@
+import crc8_1wire from '../crc81wire';
+export = crc8_1wire;

--- a/types/crc/lib/crcjam.d.ts
+++ b/types/crc/lib/crcjam.d.ts
@@ -1,0 +1,2 @@
+import crcjam from '../crcjam';
+export = crcjam;

--- a/types/crc/lib/index.d.ts
+++ b/types/crc/lib/index.d.ts
@@ -1,0 +1,1 @@
+export * from '..';

--- a/types/crc/test/lib.test.ts
+++ b/types/crc/test/lib.test.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as crc from 'crc/lib';
+
+crc.default; // $ExpectError
+
+/**
+ * The `expectType` function from https://www.npmjs.com/package/tsd,
+ * except instead of returning `void`, it returns `T`.
+ */
+declare function expectType<T>(t: T): T;
+
+// tests move from the readme of the module
+
+crc.crc32('hello').toString(16);
+// "3610a686"
+
+crc.crc32(fs.readFileSync('README.md', 'utf8')).toString(16);
+// "127ad531"
+crc.crc32(fs.readFileSync('README.md')).toString(16);
+// "127ad531"
+
+let value = crc.crc32('one');
+value = crc.crc32('two', value);
+value = crc.crc32('three', value);
+value.toString(16);
+
+// `crc.*`:
+expectType<typeof crc.crc1>(expectType<typeof import('crc/lib/crc1')>(crc.crc1));
+expectType<typeof crc.crc8>(expectType<typeof import('crc/lib/crc8')>(crc.crc8));
+expectType<typeof crc.crc81wire>(expectType<typeof import('crc/lib/crc8_1wire')>(crc.crc81wire));
+
+expectType<typeof crc.crc16>(expectType<typeof import('crc/lib/crc16')>(crc.crc16));
+expectType<typeof crc.crc16ccitt>(expectType<typeof import('crc/lib/crc16_ccitt')>(crc.crc16ccitt));
+expectType<typeof crc.crc16kermit>(expectType<typeof import('crc/lib/crc16_kermit')>(crc.crc16kermit));
+expectType<typeof crc.crc16modbus>(expectType<typeof import('crc/lib/crc16_modbus')>(crc.crc16modbus));
+expectType<typeof crc.crc16xmodem>(expectType<typeof import('crc/lib/crc16_xmodem')>(crc.crc16xmodem));
+
+expectType<typeof crc.crc24>(expectType<typeof import('crc/lib/crc24')>(crc.crc24));
+expectType<typeof crc.crc32>(expectType<typeof import('crc/lib/crc32')>(crc.crc32));
+expectType<typeof crc.crcjam>(expectType<typeof import('crc/lib/crcjam')>(crc.crcjam));

--- a/types/crc/tsconfig.json
+++ b/types/crc/tsconfig.json
@@ -17,7 +17,8 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts",
-        "crc-tests.ts"
+        "crc-tests.ts",
+        "test/lib.test.ts",
+        "index.d.ts"
     ]
 }

--- a/types/crc/tslint.json
+++ b/types/crc/tslint.json
@@ -1,1 +1,11 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true, {
+            "mode": "code",
+            "errors": [
+                ["NoDefaultExport", false]
+            ]
+        }]
+    }
+}


### PR DESCRIPTION
I didn’t add `crc/lib/crc9_1wire`, or the `crc/lib/crc17_*` variants, as importing those results in a `MODULE_NOT_FOUND` Error.

--------------------------------------------------------------------------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/alexgorbatchev/node-crc/tree/v3.8.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
