### PR TITLE
node-fetch: make implementeation compatible with lib.dom.d.ts

### DIFF
--- a/types/node-fetch/externals.d.ts
+++ b/types/node-fetch/externals.d.ts
@@ -17,5 +17,5 @@ export interface AbortSignal {
 
     dispatchEvent: (event: any) => boolean;
 
-    onabort: null | ((this: AbortSignal, event: any) => void);
+    onabort: null | ((this: AbortSignal, event: any) => any);
 }

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -67,7 +67,7 @@ function test_fetchUrlWithRequestObject() {
             }) => undefined,
 
             dispatchEvent: (event: any) => false,
-            onabort: null,
+            onabort: (event: string) => false,
         }
     };
     const request: Request = new Request(
@@ -119,7 +119,7 @@ function test_fetchUrlObjectWithRequestObject() {
             }) => undefined,
 
             dispatchEvent: (event: any) => false,
-            onabort: null,
+            onabort: (event: any) => "something",
         }
     };
     const request: Request = new Request(

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -4,7 +4,7 @@ import fetch, {
     Request,
     RequestInit,
     Response,
-    FetchError
+    FetchError,
 } from "node-fetch";
 import { URL } from "url";
 import { Agent } from "http";
@@ -67,7 +67,7 @@ function test_fetchUrlWithRequestObject() {
             }) => undefined,
 
             dispatchEvent: (event: any) => false,
-            onabort: (event: string) => false,
+            onabort: null,
         }
     };
     const request: Request = new Request(
@@ -119,7 +119,7 @@ function test_fetchUrlObjectWithRequestObject() {
             }) => undefined,
 
             dispatchEvent: (event: any) => false,
-            onabort: (event: any) => "something",
+            onabort: null,
         }
     };
     const request: Request = new Request(
@@ -214,4 +214,65 @@ function test_ResponseInit() {
 
 async function test_BlobText() {
     const someString = await new Blob(["Hello world"]).text(); // $ExpectType string
+}
+
+function test_AbortSignal() {
+    let abortSignal: AbortSignal;
+    const requestOptions: RequestInit = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+    };
+
+    requestOptions.signal = {
+        aborted: false,
+        addEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+            capture?: boolean | undefined,
+            once?: boolean | undefined,
+            passive?: boolean | undefined
+        }) => undefined,
+
+        removeEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+            capture?: boolean | undefined
+        }) => undefined,
+
+        dispatchEvent: (event: any) => false,
+        onabort: (event: any) => "something",
+    };
+    abortSignal = requestOptions.signal;
+
+    requestOptions.signal = {
+        aborted: false,
+        addEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+            capture?: boolean | undefined,
+            once?: boolean | undefined,
+            passive?: boolean | undefined
+        }) => { },
+
+        removeEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+            capture?: boolean | undefined
+        }) => { },
+
+        dispatchEvent: (event: any) => true,
+        onabort: (event: any) => false,
+    };
+    abortSignal = requestOptions.signal;
+
+    requestOptions.signal = {
+        aborted: true,
+        addEventListener: (type: "abort", listener: ((event: string) => string), options?: boolean | {
+            capture?: boolean | undefined,
+            once?: boolean | undefined,
+            passive?: boolean | undefined
+        }) => undefined,
+
+        removeEventListener: (type: "abort", listener: ((event: any) => any), options?: boolean | {
+            capture?: boolean | undefined
+        }) => undefined,
+
+        dispatchEvent: (event: any) => false,
+        onabort: null,
+    };
+    abortSignal = requestOptions.signal;
 }


### PR DESCRIPTION
This should make the implementation compatible to: https://github.com/microsoft/TypeScript/blob/3fc5f968ca002562508bb1ffb863b8b5e2df4492/lib/lib.dom.d.ts#L1926

This should fix the problem from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44649

Maybe there is a better way to test this change.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/blob/3fc5f968ca002562508bb1ffb863b8b5e2df4492/lib/lib.dom.d.ts#L1926
