### PR TITLE
[yargs] Fix: option default value does not guarantee option type

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -847,10 +847,9 @@ declare namespace yargs {
     // prettier-ignore
     type InferredOptionTypeInner<O extends Options | PositionalOptions> =
         O extends { default: any, coerce: (arg: any) => infer T } ? T :
-        O extends { default: infer D } ? D :
         O extends { type: "count" } ? number :
         O extends { count: true } ? number :
-        RequiredOptionType<O> | undefined;
+        (O extends { default: infer D } ? D : undefined) | RequiredOptionType<O>;
 
     // prettier-ignore
     type RequiredOptionType<O extends Options | PositionalOptions> =

--- a/types/yargs/ts4.1/index.d.ts
+++ b/types/yargs/ts4.1/index.d.ts
@@ -798,10 +798,9 @@ declare namespace yargs {
     // prettier-ignore
     type InferredOptionTypeInner<O extends Options | PositionalOptions> =
         O extends { default: any, coerce: (arg: any) => infer T } ? T :
-        O extends { default: infer D } ? D :
         O extends { type: "count" } ? number :
         O extends { count: true } ? number :
-        RequiredOptionType<O> | undefined;
+        (O extends { default: infer D } ? D : undefined) | RequiredOptionType<O>;
 
     // prettier-ignore
     type RequiredOptionType<O extends Options | PositionalOptions> =

--- a/types/yargs/ts4.1/yargs-tests.ts
+++ b/types/yargs/ts4.1/yargs-tests.ts
@@ -386,29 +386,29 @@ async function Argv$commandModule() {
         }
     };
 
-    class Configure implements yargs.CommandModule<{ verbose: boolean }, { verbose: boolean, key: string, value: boolean }> {
+    class Configure implements yargs.CommandModule<{ verbose: boolean }, { verbose: boolean, key: string | number, value: string | number | boolean }> {
         command = 'configure <key> [value]';
         aliases = ['config', 'cfg'];
         describe = 'Set a config variable';
 
         builder(yargs: yargs.Argv<{ verbose: boolean }>) {
-            return yargs.positional('key', { default: '' }).positional('value', { default: true });
+            return yargs.positional('key', { default: '', type: 'string' }).positional('value', { default: true, type: 'boolean' });
         }
 
-        handler(argv: yargs.Arguments<{ verbose: boolean, key: string, value: string | boolean }>) {
+        handler(argv: yargs.Arguments<{ verbose: boolean, key: string | number, value: string | number | boolean }>) {
             if (argv.verbose) {
                 console.log(`setting ${argv.key} to ${argv.value}`);
             }
         }
     }
 
-    const Configure2: yargs.CommandModule<{ verbose: boolean }, { verbose: boolean, key: string, value: boolean }> = {
+    const Configure2: yargs.CommandModule<{ verbose: boolean }, { verbose: boolean, key: string | number, value: string | number | boolean }> = {
         command: 'configure <key> [value]',
         aliases: ['config', 'cfg'],
         describe: 'Set a config variable',
 
         builder: yargs => {
-            return yargs.positional('key', { default: '' }).positional('value', { default: true });
+            return yargs.positional('key', { default: '', type: 'string' }).positional('value', { default: true, type: 'boolean' });
         },
 
         handler: argv => {
@@ -917,7 +917,7 @@ async function Argv$inferOptionTypes() {
         .option("s", { type: "string" })
         .parseAsync();
 
-    // $ExpectType { [x: string]: unknown; a: number; b: boolean; c: string; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: unknown; b: unknown; c: unknown; _: (string | number)[]; $0: string; }
     yargs
         .option("a", { default: 42 })
         .option("b", { default: false })
@@ -1027,28 +1027,30 @@ function Argv$inferRequiredOptionTypes() {
     // $ExpectType (string | number)[]
     yargs.option("x", { array: true, demandOption: true }).parseSync().x;
 
-    // $ExpectType string
+    // $ExpectType unknown
     yargs.option("x", { default: "default" as string | undefined, demandOption: true }).parseSync().x;
 
-    // $ExpectType string
+    // $ExpectType unknown
     yargs.option("x", { default: "default" as string | undefined, demand: true }).parseSync().x;
 
-    // $ExpectType string
+    // $ExpectType unknown
     yargs.option("x", { default: "default" as string | undefined, require: true }).parseSync().x;
 
-    // $ExpectType string
+    // $ExpectType unknown
     yargs.option("x", { default: "default" as string | undefined, required: true }).parseSync().x;
 }
 
 function Argv$inferMultipleOptionTypes() {
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
+    // tslint:disable-next-line
+    // $ExpectType { [x: string]: unknown; a: string | number; b: string | number | boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; a: unknown; b: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .option({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
         .demandOption(["c", "d", "e"])
         .parseSync();
 
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
+    // tslint:disable-next-line
+    // $ExpectType { [x: string]: unknown; a: string | number; b: string | number | boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; a: unknown; b: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .options({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
@@ -1094,7 +1096,8 @@ function Argv$inferOptionTypesForAliases() {
         .alias("u", "url")
         .parseSync();
 
-    // $ExpectType { [x: string]: unknown; v: boolean; loud: boolean; noisy: boolean; verbose: boolean; n: boolean; _: (string | number)[]; $0: string; }
+    // tslint:disable-next-line
+    // $ExpectType { [x: string]: unknown; v: unknown; loud: unknown; noisy: unknown; verbose: unknown; n: unknown; _: (string | number)[]; $0: string; }
     yargs
         .option("v", { default: false })
         .alias("v", ["loud", "noisy", "verbose"])

--- a/types/yargs/v15/index.d.ts
+++ b/types/yargs/v15/index.d.ts
@@ -774,14 +774,13 @@ declare namespace yargs {
 
     type InferredOptionType<O extends Options | PositionalOptions> =
         O extends { default: any, coerce: (arg: any) => infer T } ? T :
-        O extends { default: infer D } ? D :
         O extends { type: "count" } ? number :
         O extends { count: true } ? number :
         O extends { required: string | true } ? RequiredOptionType<O> :
         O extends { require: string | true } ? RequiredOptionType<O> :
         O extends { demand: string | true } ? RequiredOptionType<O> :
         O extends { demandOption: string | true } ? RequiredOptionType<O> :
-        RequiredOptionType<O> | undefined;
+        (O extends { default: infer D } ? D : undefined) | RequiredOptionType<O>;
 
     type RequiredOptionType<O extends Options | PositionalOptions> =
         O extends { type: "array", string: true } ? string[] :

--- a/types/yargs/v15/yargs-tests.ts
+++ b/types/yargs/v15/yargs-tests.ts
@@ -397,7 +397,7 @@ function Argv$commandModule() {
         describe = 'Set a config variable';
 
         builder(yargs: yargs.Argv<{ verbose: boolean }>) {
-            return yargs.positional('key', { default: '' }).positional('value', { default: true });
+            return yargs.positional('key', { default: '', type: 'string' }).positional('value', { default: true, type: 'boolean' });
         }
 
         handler(argv: yargs.Arguments<{ verbose: boolean, key: string, value: string | boolean }>) {
@@ -413,7 +413,7 @@ function Argv$commandModule() {
         describe: 'Set a config variable',
 
         builder: yargs => {
-            return yargs.positional('key', { default: '' }).positional('value', { default: true });
+            return yargs.positional('key', { default: '', type: 'string' }).positional('value', { default: true, type: 'boolean' });
         },
 
         handler: argv => {
@@ -940,7 +940,7 @@ function Argv$inferOptionTypes() {
         .option("s", { type: "string" })
         .argv;
 
-    // $ExpectType { [x: string]: unknown; a: number; b: boolean; c: string; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: unknown; b: unknown; c: unknown; _: (string | number)[]; $0: string; }
     yargs
         .option("a", { default: 42 })
         .option("b", { default: false })
@@ -1053,7 +1053,7 @@ function Argv$inferRequiredOptionTypes() {
 
 function Argv$inferMultipleOptionTypes() {
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; b: unknown; a: unknown; d: number; e: number; c: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: unknown; a: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; a: unknown; b: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .option({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
@@ -1061,7 +1061,7 @@ function Argv$inferMultipleOptionTypes() {
         .argv;
 
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; b: unknown; a: unknown; d: number; e: number; c: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: unknown; a: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; a: unknown; b: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .options({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
@@ -1111,7 +1111,7 @@ function Argv$inferOptionTypesForAliases() {
         .argv;
 
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; v: boolean; loud: boolean; noisy: boolean; verbose: boolean; n: boolean; _: (string | number)[]; $0: string; } || { [x: string]: unknown; v: boolean; verbose: boolean; loud: boolean; noisy: boolean; n: boolean; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; v: unknown; verbose: unknown; loud: unknown; noisy: unknown; n: unknown; _: (string | number)[]; $0: string; } || { [x: string]: unknown; v: unknown; loud: unknown; noisy: unknown; verbose: unknown; n: unknown; _: (string | number)[]; $0: string; }
     yargs
         .option("v", { default: false })
         .alias("v", ["loud", "noisy", "verbose"])

--- a/types/yargs/v16/index.d.ts
+++ b/types/yargs/v16/index.d.ts
@@ -782,14 +782,13 @@ declare namespace yargs {
 
     type InferredOptionType<O extends Options | PositionalOptions> =
         O extends { default: any, coerce: (arg: any) => infer T } ? T :
-        O extends { default: infer D } ? D :
         O extends { type: "count" } ? number :
         O extends { count: true } ? number :
         O extends { required: string | true } ? RequiredOptionType<O> :
         O extends { require: string | true } ? RequiredOptionType<O> :
         O extends { demand: string | true } ? RequiredOptionType<O> :
         O extends { demandOption: string | true } ? RequiredOptionType<O> :
-        RequiredOptionType<O> | undefined;
+        (O extends { default: infer D } ? D : undefined) | RequiredOptionType<O>;
 
     type RequiredOptionType<O extends Options | PositionalOptions> =
         O extends { type: "array", string: true } ? string[] :

--- a/types/yargs/v16/yargs-tests.ts
+++ b/types/yargs/v16/yargs-tests.ts
@@ -398,7 +398,7 @@ function Argv$commandModule() {
         describe = 'Set a config variable';
 
         builder(yargs: yargs.Argv<{ verbose: boolean }>) {
-            return yargs.positional('key', { default: '' }).positional('value', { default: true });
+            return yargs.positional('key', { default: '', type: 'string' }).positional('value', { default: true, type: 'boolean' });
         }
 
         handler(argv: yargs.Arguments<{ verbose: boolean, key: string, value: string | boolean }>) {
@@ -414,7 +414,7 @@ function Argv$commandModule() {
         describe: 'Set a config variable',
 
         builder: yargs => {
-            return yargs.positional('key', { default: '' }).positional('value', { default: true });
+            return yargs.positional('key', { default: '', type: 'string' }).positional('value', { default: true, type: 'boolean' });
         },
 
         handler: argv => {
@@ -941,7 +941,7 @@ function Argv$inferOptionTypes() {
         .option("s", { type: "string" })
         .argv;
 
-    // $ExpectType { [x: string]: unknown; a: number; b: boolean; c: string; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: unknown; b: unknown; c: unknown; _: (string | number)[]; $0: string; }
     yargs
         .option("a", { default: 42 })
         .option("b", { default: false })
@@ -1054,7 +1054,7 @@ function Argv$inferRequiredOptionTypes() {
 
 function Argv$inferMultipleOptionTypes() {
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; b: unknown; a: unknown; d: number; e: number; c: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: unknown; a: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; a: unknown; b: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .option({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
@@ -1062,7 +1062,7 @@ function Argv$inferMultipleOptionTypes() {
         .argv;
 
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; b: unknown; a: unknown; d: number; e: number; c: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: unknown; a: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; a: unknown; b: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .options({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
@@ -1112,7 +1112,7 @@ function Argv$inferOptionTypesForAliases() {
         .argv;
 
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; v: boolean; loud: boolean; noisy: boolean; verbose: boolean; n: boolean; _: (string | number)[]; $0: string; } || { [x: string]: unknown; v: boolean; verbose: boolean; loud: boolean; noisy: boolean; n: boolean; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; v: unknown; verbose: unknown; loud: unknown; noisy: unknown; n: unknown; _: (string | number)[]; $0: string; } || { [x: string]: unknown; v: unknown; loud: unknown; noisy: unknown; verbose: unknown; n: unknown; _: (string | number)[]; $0: string; }
     yargs
         .option("v", { default: false })
         .alias("v", ["loud", "noisy", "verbose"])

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -123,7 +123,7 @@ function camelCase() {
         'my-command',
         'a command',
         { 'some-opt-in-command': { describe: 'Some option', default: 2 } },
-        (args: Arguments<{ someOptInCommand: number }>) => {}
+        (args: Arguments<{ someOptInCommand: unknown }>) => {}
     );
 }
 
@@ -409,7 +409,7 @@ async function Argv$commandModule() {
         describe = 'Set a config variable';
 
         builder(yargs: yargs.Argv<{ verbose: boolean }>) {
-            return yargs.positional('key', { default: '' }).positional('value', { default: true });
+            return yargs.positional('key', { default: '', type: 'string' }).positional('value', { default: true, type: 'boolean' });
         }
 
         handler(argv: yargs.Arguments<{ verbose: boolean, key: string, value: string | boolean }>) {
@@ -425,7 +425,7 @@ async function Argv$commandModule() {
         describe: 'Set a config variable',
 
         builder: yargs => {
-            return yargs.positional('key', { default: '' }).positional('value', { default: true });
+            return yargs.positional('key', { default: '', type: 'string' }).positional('value', { default: true, type: 'boolean' });
         },
 
         handler: argv => {
@@ -949,7 +949,7 @@ async function Argv$inferOptionTypes() {
         .option("s", { type: "string" })
         .parseAsync();
 
-    // $ExpectType { [x: string]: unknown; a: number; b: boolean; c: string; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: unknown; b: unknown; c: unknown; _: (string | number)[]; $0: string; }
     yargs
         .option("a", { default: 42 })
         .option("b", { default: false })
@@ -1059,30 +1059,32 @@ function Argv$inferRequiredOptionTypes() {
     // $ExpectType (string | number)[]
     yargs.option("x", { array: true, demandOption: true }).parseSync().x;
 
-    // $ExpectType string
+    // $ExpectType unknown
     yargs.option("x", { default: "default" as string | undefined, demandOption: true }).parseSync().x;
 
-    // $ExpectType string
+    // $ExpectType unknown
     yargs.option("x", { default: "default" as string | undefined, demand: true }).parseSync().x;
 
-    // $ExpectType string
+    // $ExpectType unknown
     yargs.option("x", { default: "default" as string | undefined, require: true }).parseSync().x;
 
-    // $ExpectType string
+    // $ExpectType unknown
     yargs.option("x", { default: "default" as string | undefined, required: true }).parseSync().x;
 }
 
-function Argv$inferMultipleOptionTypes() {
+function Argv$2() {
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; b: unknown; a: unknown; d: number; e: number; c: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: unknown; a: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; a: unknown; b: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .option({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
         .demandOption(["c", "d", "e"])
         .parseSync();
+}
 
+function Argv$inferMultipleOptionTypes() {
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; b: unknown; a: unknown; d: number; e: number; c: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: unknown; a: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; a: unknown; b: unknown; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .options({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
@@ -1132,7 +1134,7 @@ function Argv$inferOptionTypesForAliases() {
         .parseSync();
 
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; v: boolean; loud: boolean; noisy: boolean; verbose: boolean; n: boolean; _: (string | number)[]; $0: string; } || { [x: string]: unknown; v: boolean; verbose: boolean; loud: boolean; noisy: boolean; n: boolean; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; v: unknown; verbose: unknown; loud: unknown; noisy: unknown; n: unknown; _: (string | number)[]; $0: string; } || { [x: string]: unknown; v: unknown; loud: unknown; noisy: unknown; verbose: unknown; n: unknown; _: (string | number)[]; $0: string; }
     yargs
         .option("v", { default: false })
         .alias("v", ["loud", "noisy", "verbose"])


### PR DESCRIPTION
When a `yargs().options({default:t})` is specified, previously `@types/yargs` assumed that the arg would be whatever the default type was. This is an invalid assumption; a default does not prevent the arg from being parsed as a string or number.

I encountered this incorrect type when I tried to use a boolean arg: `yargs().options({verbose: {default: true as boolean}})`. According to the previous typings, `verbose` is a `boolean`. But yargs does not actually convert this to a boolean! So when I ran the program with `--verbose=false`, then my conditionals `if (args.verbose) {…}` accidentally were evaluated because `args.verbose` was the string `"false"`. In order to ensure that `verbose` is a boolean, you have to tell yargs to convert it to boolean (`boolean: true`); setting the default does not guarantee the type of the option.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
  * [x] `npm test yargs`
  * [x] `npm test yargs/v16`
  * [x] `npm test yargs/v15`

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [yargs v17 api: default](https://github.com/yargs/yargs/blob/v17.5.1/docs/api.md#defaultkey-value-description): “Set `argv[key]` to `value` if no option was specified in `process.argv`.” But this means that if the option *is* specified in `process.argv`, the arg will be `string | number`, not the same type as the default as previously assumed.
- N/A If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I tested the typings and yargs behavior on this unit test:

```ts
import assert from 'assert';
import yargs from 'yargs/yargs';

describe('yargs default', () => {
    const options = {
        defaultNumber: {
            default: 3,
        },
        number: {
            default: 3,
            number: true,
        },
        defaultBoolean: {
            default: true,
        },
        boolean: {
            default: true,
            boolean: true,
        },
    } as const;
    it('untyped flag with numeric default coerces given value to number', () => {
        const args = yargs(['--defaultNumber=4']).options(options).parseSync();
        assert.strictEqual(args.defaultNumber, 4);
    });
    it('untyped flag with numberic default does not coerce to number if given value is NaN', () => {
        const args = yargs(['--defaultNumber=hi']).options(options).parseSync();
        assert.strictEqual(args.defaultNumber, 'hi');
    });
    it('untyped flag with default boolean does not coerce to boolean', () => {
        const args = yargs(['--defaultBoolean=false']).options(options).parseSync();
        assert.strictEqual(args.defaultBoolean, 'false');
    });
    it('number-typed flag forces coercion', () => {
        const args = yargs(['--number=hi']).options(options).parseSync();
        assert.strictEqual(args.number, NaN);
    });
    it('boolean-typed flag forces coercion to false', () => {
        const args = yargs(['--boolean=hi']).options(options).parseSync();
        assert.strictEqual(args.boolean, false);
    });
});
```
