### PR TITLE
node: Fix doc spacing for domain module

### DIFF
--- a/types/node/domain.d.ts
+++ b/types/node/domain.d.ts
@@ -1,6 +1,7 @@
 /**
  * **This module is pending deprecation.** Once a replacement API has been
- * finalized, this module will be fully deprecated. Most developers should**not** have cause to use this module. Users who absolutely must have
+ * finalized, this module will be fully deprecated. Most developers should
+ * **not** have cause to use this module. Users who absolutely must have
  * the functionality that domains provide may rely on it for the time being
  * but should expect to have to migrate to a different solution
  * in the future.

--- a/types/node/v16/domain.d.ts
+++ b/types/node/v16/domain.d.ts
@@ -1,6 +1,7 @@
 /**
  * **This module is pending deprecation.** Once a replacement API has been
- * finalized, this module will be fully deprecated. Most developers should**not** have cause to use this module. Users who absolutely must have
+ * finalized, this module will be fully deprecated. Most developers should
+ * **not** have cause to use this module. Users who absolutely must have
  * the functionality that domains provide may rely on it for the time being
  * but should expect to have to migrate to a different solution
  * in the future.


### PR DESCRIPTION
This PR updates the docstring for the `domain` module so that there is a space between `should` and `not` in the second sentence. Right now, my editor shows this when hovering over it:

>Most developers should**not** have cause to use this module.

which doesn't look very nice.

-------

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
