### PR TITLE
Remove `git log --follow` from FAQ

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -386,10 +386,6 @@ Cuando `dts-gen` es utilizado como scaffold en un paquete scoped, las propiedade
 }
 ```
 
-#### El historial de archivos en GitHub parece incompleto.
-
-GitHub no le hace [support](https://stackoverflow.com/questions/5646174/how-to-make-github-follow-directory-history-after-renames) historial de archivos para archivos renombrados. Utilice [`git log --follow`](https://www.git-scm.com/docs/git-log) en su lugar.
-
 #### Debería añadir un namespace que no exporte un módulo que utilice que utilice imports estilo ES6?
 
 Algunos paquetes, como [chai-http](https://github.com/chaijs/chai-http), exportan una función.

--- a/README.it.md
+++ b/README.it.md
@@ -547,10 +547,6 @@ Quando `dts-gen` viene usato per uno pacchetto con scope, nel `tsconfig.json`, l
 }
 ```
 
-#### La cronologia dei file su Github sembra incompleta.
-
-Github non [supporta](https://stackoverflow.com/questions/5646174/how-to-make-github-follow-directory-history-after-renames) la cronologia per file rinominati. Usa invece [`git log --follow`](https://www.git-scm.com/docs/git-log) instead.
-
 ## Licenza
 
 Questo progetto è sotto la licenza MIT.

--- a/README.ja.md
+++ b/README.ja.md
@@ -526,10 +526,6 @@ TypeScript ハンドブックには、[型定義を書くにあたっての一�
 }
 ```
 
-#### GitHub のファイル履歴がおかしいです。
-
-GitHubは、名前が変更されたファイルの履歴には[対応していない](https://stackoverflow.com/questions/5646174/how-to-make-github-follow-directory-history-after-renames)ので、代わりに [`git log --follow`](https://www.git-scm.com/docs/git-log) を使用してください。
-
 ## ライセンス
 
 このプロジェクトは MIT License でライセンスされています。

--- a/README.ko.md
+++ b/README.ko.md
@@ -413,11 +413,6 @@ npm 패키지의 경우, `node -p 'require("foo")'` 가 원하는 값이라면 `
 }
 ```
 
-
-#### 깃헙(GitHub)이 보여주는 파일 히스토리(History)가 불완전해요.
-
-깃헙은 이름이 바뀐 파일의 히스토리(History)를 [지원하지 않습니다](https://stackoverflow.com/questions/5646174/how-to-make-github-follow-directory-history-after-renames). 대신 [`git log --follow`](https://www.git-scm.com/docs/git-log) 명령을 사용하세요.
-
 #### ES6 에서 사용하는 임포트(Import)를 사용하기 위해 모듈을 익스포트(Export)하지 않는 패키지들에 빈 이름공간을 추가해야 하나요?
 
 [chai-http](https://github.com/chaijs/chai-http) 패키지와 같은 몇몇 패키지들은 함수를 익스포트(Export)합니다.

--- a/README.md
+++ b/README.md
@@ -603,10 +603,6 @@ When `dts-gen` is used to scaffold a scoped package, the `paths` property has to
 }
 ```
 
-#### The file history in GitHub looks incomplete.
-
-GitHub doesn't [support](https://stackoverflow.com/questions/5646174/how-to-make-github-follow-directory-history-after-renames) file history for renamed files. Use [`git log --follow`](https://www.git-scm.com/docs/git-log) instead.
-
 ## License
 
 This project is licensed under the MIT license.

--- a/README.pt.md
+++ b/README.pt.md
@@ -523,11 +523,6 @@ Quando `dts-gen` for usado para montar um pacote com escopo, a propriedade `path
 }
 ```
 
-
-#### O histórico do arquivo no GitHub parece incompleto.
-
-O GitHub não [suporta](https://stackoverflow.com/questions/5646174/how-to-make-github-follow-directory-history-after-renames) histórico de arquivos renomeados. Use [`git log --follow`](https://www.git-scm.com/docs/git-log) ao invés disso.
-
 ## Licença
 
 Esse projeto é licenciado sob a licença MIT.

--- a/README.ru.md
+++ b/README.ru.md
@@ -405,10 +405,6 @@ Once a week the Definition Owners are synced to the file [.github/CODEOWNERS](ht
 }
 ```
 
-#### История файлов в GitHub выглядит неполной.
-
-GitHub не [поддерживает](https://stackoverflow.com/questions/5646174/how-to-make-github-follow-directory-history-after-renames) историю файлов для переименованных файлов. Вместо этого используйте [`git log --follow`](https://www.git-scm.com/docs/git-log).
-
 #### Должен ли я добавить пустой namespace в пакет, который не экспортирует модуль для использования импорта в стиле ES6?
 
 Некоторые пакеты, такие как [chai-http](https://github.com/chaijs/chai-http), экспортируют функцию.

--- a/README.zh.md
+++ b/README.zh.md
@@ -537,10 +537,6 @@ TypeScript 手册包含了优秀的 [关于编写类型定义的概括信息](ht
 }
 ```
 
-#### GitHub 中的文件记录看起来不完整。
-
-GitHub 不 [支持](https://stackoverflow.com/questions/5646174/how-to-make-github-follow-directory-history-after-renames) 重命名文件的历史记录。请使用 [`git log --follow`](https://www.git-scm.com/docs/git-log) 命令代替。
-
 ## 许可证
 
 该项目根据 MIT 许可证授权。


### PR DESCRIPTION
GitHub now shows a link to the history of the old file name, making this suggestion obsolete.