### PR TITLE
[terminal-kit] Allow string colors; Add width, height to ScreenBuffer

### DIFF
--- a/types/terminal-kit/ScreenBuffer.d.ts
+++ b/types/terminal-kit/ScreenBuffer.d.ts
@@ -9,6 +9,8 @@ declare class ScreenBuffer extends NextGenEvents {
   readonly x: number;
   readonly y: number;
   readonly blending: boolean | ScreenBufferHD.IsBlending;
+  readonly width: number;
+  readonly height: number;
 
   constructor(options: ScreenBuffer.Options);
 
@@ -108,9 +110,9 @@ declare namespace ScreenBuffer {
   }
 
   interface Attributes {
-    color?: number | undefined;
+    color?: number | string | undefined;
     defaultColor?: boolean | undefined;
-    bgColor?: number | undefined;
+    bgColor?: number | string | undefined;
     bgDefaultColor?: boolean | undefined;
     bold?: boolean | undefined;
     dim?: boolean | undefined;

--- a/types/terminal-kit/terminal-kit-tests.ts
+++ b/types/terminal-kit/terminal-kit-tests.ts
@@ -483,6 +483,12 @@ screen1.fill({
     bgColor: 0
   }
 });
+screen1.fill({
+    attr: {
+        color: 'black',
+        bgColor: 'black',
+    },
+});
 
 ScreenBuffer.loadImage(
   path_to_image,
@@ -516,3 +522,6 @@ term.table([
   width: 60,
   fit: true
 });
+
+term.width; // $ExpectType number
+term.height; // $ExpectType number


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [width, height](https://github.com/cronvel/terminal-kit/blob/376ae1a797d079bbc82f5dfc7d302290c87afda5/lib/ScreenBuffer.js#L55), [colors](https://github.com/cronvel/terminal-kit/blob/master/doc/ScreenBuffer.md#the-attributes-object)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.