### PR TITLE
[react-native]: fix missing callback typing for Modal props `onRequestClose`

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -4830,7 +4830,7 @@ export interface ModalBaseProps {
      *
      * This is required on Apple TV and Android.
      */
-     onRequestClose?: ((event: NativeSyntheticEvent<any>) => void) | undefined;
+    onRequestClose?: ((event: NativeSyntheticEvent<any>) => void) | undefined;
     /**
      * The `onShow` prop allows passing a function that will be called once the modal has been shown.
      */

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -4826,10 +4826,11 @@ export interface ModalBaseProps {
      */
     visible?: boolean | undefined;
     /**
-     * The `onRequestClose` prop allows passing a function that will be called once the modal has been dismissed.
-     * _On the Android platform, this is a required function._
+     * The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV.
+     *
+     * This is required on Apple TV and Android.
      */
-    onRequestClose?: (() => void) | undefined;
+     onRequestClose?: ((event: NativeSyntheticEvent<any>) => void) | undefined;
     /**
      * The `onShow` prop allows passing a function that will be called once the modal has been shown.
      */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/Libraries/Modal/Modal.js#L123
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.