### PR TITLE
types/nightwatch - Fix acceptable input types for frame command (allow CSS string)

### DIFF
--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -4154,7 +4154,7 @@ export interface WebDriverProtocolCommandContexts {
      * }
      */
     frame(
-        frameId?: WebElement | number | null,
+        frameId?: WebElement | string | number | null,
         callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<void>) => void,
     ): this;
 

--- a/types/nightwatch/test/nightwatch-tests.ts
+++ b/types/nightwatch/test/nightwatch-tests.ts
@@ -167,17 +167,17 @@ interface MenuSection
         { apps: AppsSection }
     > {}
 
+const googleCommands = {
+    submit(this: GooglePage) {
+        this.api.pause(1000);
+        return this.waitForElementVisible('@submitButton', 1000)
+            .click('@submitButton')
+            .waitForElementNotPresent('@submitButton');
+    },
+};
+
 const googlePage: PageObjectModel = {
-    commands: [
-        {
-            submit(this: GooglePage) {
-                this.api.pause(1000);
-                return this.waitForElementVisible('@submitButton', 1000)
-                    .click('@submitButton')
-                    .waitForElementNotPresent('@submitButton');
-            },
-        },
-    ],
+    commands: [googleCommands],
     elements: {
         searchBar: {
             selector: 'input[type=text]',
@@ -210,7 +210,7 @@ const iFrame: PageObjectModel = {
 // export = iFrame
 
 interface GooglePage
-    extends EnhancedPageObject<typeof googlePage.commands[0], typeof googlePage.elements, { menu: MenuSection }> {}
+    extends EnhancedPageObject<typeof googleCommands, typeof googlePage.elements, { menu: MenuSection }> {}
 
 interface iFramePage extends EnhancedPageObject<typeof iFrame.commands[0], typeof iFrame.elements> {}
 
@@ -248,7 +248,7 @@ const testPage = {
     },
 
     'Test assertions on page': () => {
-        const google: EnhancedPageObject<GooglePage> = browser.page.google();
+        const google: GooglePage = browser.page.google();
 
         google
             .navigate()

--- a/types/nightwatch/test/nightwatch-tests.ts
+++ b/types/nightwatch/test/nightwatch-tests.ts
@@ -272,6 +272,14 @@ const testPage = {
         browser.end();
     },
 
+    'Test passing CSS selector string to frame': () => {
+        const iFrame = browser.page.IFrame();
+        iFrame.navigate().waitForElementPresent('#mce_0_ifr', 10000);
+        browser.frame('#mce_0_ifr');
+        iFrame.expect.element('@textbox').text.to.equal('Your content goes here.');
+        browser.end();
+    },
+
     'Test nested page objects': () => {
         const google = browser.page.subfolder1.subfolder2.subfolder3.google();
     },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Updating acceptable inputs for .frame command to accept CSS selectors as strings to match fix in underlying framework https://github.com/nightwatchjs/nightwatch/pull/3205