### PR TITLE
Revert "🤖 Merge PR #60691 [react] Allow `TrustedHTML` in `dangerously…

### DIFF
--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -153,5 +153,3 @@ interface Text { }
 interface TouchList { }
 interface WebGLRenderingContext { }
 interface WebGL2RenderingContext { }
-
-interface TrustedHTML { }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1372,9 +1372,7 @@ declare namespace React {
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
         dangerouslySetInnerHTML?: {
-            // Should be InnerHTML['innerHTML'].
-            // But unfortunately we're mixing renderer-specific type declarations.
-            __html: string | TrustedHTML;
+            __html: string;
         } | undefined;
 
         // Clipboard Events

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -527,16 +527,6 @@ DOM.svg({
     })
 );
 
-declare const trustedHtml: TrustedHTML;
-
-const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
-    dangerouslySetInnerHTML: {
-        __html: trustedHtml
-    }
-};
-DOM.div(trustedTypesHTMLAttr);
-DOM.span(trustedTypesHTMLAttr);
-
 //
 // React.Children
 // --------------------------------------------------------------------------

--- a/types/react/v16/global.d.ts
+++ b/types/react/v16/global.d.ts
@@ -149,5 +149,3 @@ interface Text { }
 interface TouchList { }
 interface WebGLRenderingContext { }
 interface WebGL2RenderingContext { }
-
-interface TrustedHTML { }

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1340,9 +1340,7 @@ declare namespace React {
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
         dangerouslySetInnerHTML?: {
-            // Should be InnerHTML['innerHTML'].
-            // But unfortunately we're mixing renderer-specific type declarations.
-            __html: string | TrustedHTML;
+            __html: string;
         } | undefined;
 
         // Clipboard Events

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -526,16 +526,6 @@ DOM.div(htmlAttr);
 DOM.span(htmlAttr);
 DOM.input(htmlAttr);
 
-declare const trustedHtml: TrustedHTML;
-
-const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
-    dangerouslySetInnerHTML: {
-        __html: trustedHtml
-    }
-};
-DOM.div(trustedTypesHTMLAttr);
-DOM.span(trustedTypesHTMLAttr);
-
 DOM.svg({
     viewBox: "0 0 48 48",
     xmlns: "http://www.w3.org/2000/svg"

--- a/types/react/v17/global.d.ts
+++ b/types/react/v17/global.d.ts
@@ -153,5 +153,3 @@ interface Text { }
 interface TouchList { }
 interface WebGLRenderingContext { }
 interface WebGL2RenderingContext { }
-
-interface TrustedHTML { }

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1339,9 +1339,7 @@ declare namespace React {
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
         dangerouslySetInnerHTML?: {
-            // Should be InnerHTML['innerHTML'].
-            // But unfortunately we're mixing renderer-specific type declarations.
-            __html: string | TrustedHTML;
+            __html: string;
         } | undefined;
 
         // Clipboard Events

--- a/types/react/v17/test/index.ts
+++ b/types/react/v17/test/index.ts
@@ -525,16 +525,6 @@ DOM.div(htmlAttr);
 DOM.span(htmlAttr);
 DOM.input(htmlAttr);
 
-declare const trustedHtml: TrustedHTML;
-
-const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
-    dangerouslySetInnerHTML: {
-        __html: trustedHtml
-    }
-};
-DOM.div(trustedTypesHTMLAttr);
-DOM.span(trustedTypesHTMLAttr);
-
 DOM.svg({
     viewBox: "0 0 48 48",
     xmlns: "http://www.w3.org/2000/svg"


### PR DESCRIPTION
…SetInnerHTML` by @eps1lon"

This reverts commit 9c58088a931fdab5737f2e1343f3946421bf0de8.

We cannot force people to use skip lib check option to avoid introduced problem (`trusted-types` are custom types, not library type from `lib.dom`, so default approach with overrides/redeclaration does not work and was missed on review)

Reerts #60691

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)