### PR TITLE
[react-big-calendar] Pass through TResource to ResourceHeaderProps

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -177,10 +177,10 @@ export interface DateHeaderProps {
     onDrillDown: () => void;
 }
 
-export interface ResourceHeaderProps {
+export interface ResourceHeaderProps<TResource extends object = object> {
     label: React.ReactNode;
     index: number;
-    resource: object;
+    resource: TResource;
 }
 
 export interface DateCellWrapperProps {
@@ -235,7 +235,7 @@ export interface Components<TEvent extends object = Event, TResource extends obj
      * component used as a header for each column in the TimeGridHeader
      */
     header?: React.ComponentType<HeaderProps> | undefined;
-    resourceHeader?: React.ComponentType<ResourceHeaderProps> | undefined;
+    resourceHeader?: React.ComponentType<ResourceHeaderProps<TResource>> | undefined;
 }
 
 export interface ToolbarProps<TEvent extends object = Event, TResource extends object = object> {

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -28,6 +28,7 @@ import {
     Week,
     HeaderProps,
     DateHeaderProps,
+    ResourceHeaderProps,
 } from 'react-big-calendar';
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
 
@@ -350,6 +351,7 @@ class CalendarResource {
                         toolbar: Toolbar,
                         eventWrapper: EventWrapper,
                         header: CustomHeader,
+                        resourceHeader: ResourceHeader,
                     }}
                     dayPropGetter={customDayPropGetter}
                     slotPropGetter={customSlotPropGetter}
@@ -503,6 +505,15 @@ function EventWrapper(props: EventWrapperProps<CalendarEvent>) {
                 {continuesEarlier}-{label}-{accessors.title && event && accessors.title(event)}
             </div>
         </div>
+    );
+}
+
+function ResourceHeader(props: ResourceHeaderProps<CalendarResource>) {
+    return (
+        <span>
+            <strong>{props.resource.title}</strong>
+            {props.resource.id}
+        </span>
     );
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **There aren't explicit docs for this functionality, but the resources that are provided to the Calendar component are passed down to the `ResourceHeader`. I tested it on my own codebase, and it works. And [this](https://github.com/jquense/react-big-calendar/blob/e5721ef127d407a12ac74514981b311a1558fd2b/src/TimeGridHeader.js#L150-L158) is where it's passed through in the source code.**
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
