### PR TITLE
Fix up inconsistent minimum TS versions

### DIFF
--- a/types/meteor-astronomy/index.d.ts
+++ b/types/meteor-astronomy/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jagi/meteor-astronomy/
 // Definitions by: Igor Golovin <https://github.com/Deadly0>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="meteor" />
 

--- a/types/meteor-dburles-collection-helpers/index.d.ts
+++ b/types/meteor-dburles-collection-helpers/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/dburles/meteor-collection-helpers
 // Definitions by: Artemis Kearney <https://github.com/artemiswkearney>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference path="./mongo.d.ts" />
 /// <reference path="./collectionHelpers.d.ts" />

--- a/types/meteor-mdg-validation-error/index.d.ts
+++ b/types/meteor-mdg-validation-error/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/meteor/validation-error
 // Definitions by: ToastHawaii <https://github.com/ToastHawaii>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="meteor"/>
 

--- a/types/meteor-publish-composite/index.d.ts
+++ b/types/meteor-publish-composite/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Robert Van Gorkom <https://github.com/vangorra>
 //                 Matthew Zartman <https://github.com/mrz5018>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="meteor" />
 

--- a/types/meteor-roles/index.d.ts
+++ b/types/meteor-roles/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 //                 Matthew Zartman <https://github.com/mattmm3d>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="meteor" />
 

--- a/types/meteor-sjobs/index.d.ts
+++ b/types/meteor-sjobs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/msavin/SteveJobs
 // Definitions by: Witold H <https://github.com/LinearMilk/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.1
 
 /// <reference types="meteor" />
 


### PR DESCRIPTION
https://github.com/microsoft/DefinitelyTyped-tools/pull/384#issue-1107485477 omitted some legitimate dependencies and https://github.com/microsoft/DefinitelyTyped-tools/pull/484#issue-1275254272 restores them, but in the meantime [Meteor's minimum TS version increased](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58433/files#diff-ef89e5118433044f8d04797eec2e5e6098aebc6d3d8989f72a0b18209a43e424R22). Dependents' minimum TS versions [must be greater than or equal to](https://github.com/microsoft/types-publisher/pull/398#issue-271617256) their dependencies', so this PR fixes up the dependents that were omitted for a spell.

- Without https://github.com/microsoft/DefinitelyTyped-tools/pull/484#issue-1275254272 I suspect the DT CI will fail when editing any of Meteor's omitted dependents, because it won't install Meteor's transitive dependencies ([MongoDB](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/83a8aa9beee7030fc469b8d8f4e19af81321efb4/types/meteor/package.json#L4)) (with and without this PR).
- With it but without this PR, every DT PR will fail in [`checkParseResults()`](https://github.com/microsoft/types-publisher/blob/2112c650ef0fd2bb1e0fbf98757a468e2f791e9f/src/check-parse-results.ts#L59) because of the inconsistent minimum TS versions.
- With both PRs the CI should be happy again, so ideally this PR will land first (minus the cherry pick https://github.com/microsoft/DefinitelyTyped-tools/pull/484 commit).