### PR TITLE
[infra] Show original context in CI stack traces

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
         "compile-scripts": "tsc -p scripts",
         "not-needed": "node scripts/not-needed.js",
         "update-codeowners": "node scripts/update-codeowners.js",
-        "test-all": "node node_modules/@definitelytyped/dtslint-runner/dist/index.js --path .",
+        "test-all": "node --require source-map-support/register node_modules/@definitelytyped/dtslint-runner/ --path .",
         "clean": "node scripts/remove-empty.js",
-        "test": "dtslint types",
-        "lint": "dtslint types",
+        "test": "NODE_OPTIONS='--require source-map-support/register' dtslint types",
+        "lint": "NODE_OPTIONS='--require source-map-support/register' dtslint types",
         "prettier": "prettier"
     },
     "devDependencies": {
@@ -43,6 +43,7 @@
         "prettier": "^2.1.1",
         "remark-cli": "^9.0.0",
         "remark-validate-links": "^10.0.2",
+        "source-map-support": "^0.5.21",
         "typescript": "next",
         "w3c-xmlserializer": "^2.0.0",
         "yargs": "^17.1.1"


### PR DESCRIPTION
Can we use [Source Map Support](https://github.com/evanw/node-source-map-support#readme) to make the stack traces in the CI logs more helpful ([like we do in the tools repo](https://github.com/microsoft/types-publisher/pull/723/commits/f8caef3c7d7101f5000288e88421f7d301a1595e#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519))? Mostly intended for dtslint(-runner). Does nothing in the case of the JS scripts (`ghostbuster.js`, `not-needed.js`, `update-codeowners.js`, `remove-empty.js`), but doesn't hurt, either.