### PR TITLE
[@types/sharp] Use export default so that import default works

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -22,8 +22,8 @@ import { Duplex } from 'stream';
  * @throws {Error} Invalid parameters
  * @returns A sharp instance that can be used to chain operations
  */
-declare function sharp(options?: sharp.SharpOptions): sharp.Sharp;
-declare function sharp(
+export default function sharp(options?: sharp.SharpOptions): sharp.Sharp;
+export default function sharp(
     input?:
         | Buffer
         | Uint8Array
@@ -1365,5 +1365,3 @@ declare namespace sharp {
 
     type Matrix3x3 = [[number, number, number], [number, number, number], [number, number, number]];
 }
-
-export = sharp;


### PR DESCRIPTION
Current declaration had no default export. As such, `import sharp from 'sharp'` was only working with the `allowSyntheticDefaultImports` hack.

This commit sets the `sharp` function as default export. As far as I can tell, the namespace does not need to be exported.

See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60862

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lovell/sharp/blob/main/lib/index.js#L13
