### PR TITLE
Update type definitions for `spdx-correct`, bringing it up to date with versions 3.1.0 and 3.1.1

### DIFF
--- a/types/spdx-correct/index.d.ts
+++ b/types/spdx-correct/index.d.ts
@@ -3,5 +3,5 @@
 // Definitions by: Jinwoo Lee <https://github.com/jinwoo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function spdxCorrect(identifier: string): string|null;
+declare function spdxCorrect(identifier: string, options?: { upgrade: boolean }): string|null;
 export = spdxCorrect;

--- a/types/spdx-correct/index.d.ts
+++ b/types/spdx-correct/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for spdx-correct 2.0
+// Type definitions for spdx-correct 3.1
 // Project: https://github.com/jslicense/spdx-correct.js#readme
 // Definitions by: Jinwoo Lee <https://github.com/jinwoo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/spdx-correct/spdx-correct-tests.ts
+++ b/types/spdx-correct/spdx-correct-tests.ts
@@ -1,3 +1,5 @@
 import spdxCorrect = require('spdx-correct');
 
-spdxCorrect('BSD');
+spdxCorrect('BSD');                            // $ExpectType string | null
+spdxCorrect('GPL-3.0', { upgrade: false });    // $ExpectType string | null
+spdxCorrect('GPL-3.0', { upgrade: 1 });        // $ExpectError


### PR DESCRIPTION
Update the type definition for `spdx-correct` to include the optional `options` argument that the [spdx-correct](https://www.npmjs.com/package/spdx-correct) package has had [since version 3.1.0](https://github.com/jslicense/spdx-correct.js/commit/2386b0d79cbcb47477601e1b02dc29a3ff786dcf) (published to npmjs.com on December 6, 2018).

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-tests) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [project's README](https://github.com/jslicense/spdx-correct.js/blob/master/README.md)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
