### PR TITLE
fix(jest): improving spyOn for better auto complete suggestions

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -282,16 +282,24 @@ declare namespace jest {
      *   spy.mockRestore();
      * });
      */
-    function spyOn<T extends {}, M extends NonFunctionPropertyNames<Required<T>>>(
+    function spyOn<
+        T extends {},
+        M extends keyof T,
+        A extends M extends NonFunctionPropertyNames<Required<T>> ? 'get' | 'set' : never
+            = M extends NonFunctionPropertyNames<Required<T>> ? 'get' | 'set' : never,
+    >(
         object: T,
         method: M,
-        accessType: 'get'
-    ): SpyInstance<Required<T>[M], []>;
-    function spyOn<T extends {}, M extends NonFunctionPropertyNames<Required<T>>>(
-        object: T,
-        method: M,
-        accessType: 'set'
-    ): SpyInstance<void, [Required<T>[M]]>;
+        accessType: A,
+    ): M extends NonFunctionPropertyNames<Required<T>>
+        ? A extends 'set'
+            ? SpyInstance<void, [Required<T>[M]]>
+            : SpyInstance<Required<T>[M], []>
+        : Required<T>[M] extends new (...args: any[]) => any
+        ? SpyInstance<InstanceType<Required<T>[M]>, ConstructorArgsType<Required<T>[M]>>
+        : Required<T>[M] extends (...args: any) => any
+        ? SpyInstance<ReturnType<Required<T>[M]>, ArgsType<Required<T>[M]>>
+        : never;
     function spyOn<T extends {}, M extends FunctionPropertyNames<Required<T>>>(
         object: T,
         method: M

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -447,6 +447,8 @@ const spiedTarget2 = new SpiedTargetClass();
 // $ExpectError
 jest.spyOn(spiedTarget, 'setValue', 'get');
 // $ExpectError
+jest.spyOn(spiedTarget, 'setValue', undefined);
+// $ExpectError
 jest.spyOn(spiedTarget2, 'value');
 
 const spy1 = jest.spyOn(spiedTarget, 'returnsVoid');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/facebook/jest/blob/24e0472ac41ea03cdd89ffaea8c5f410ecf6054f/packages/jest-jasmine2/src/jasmine/spyRegistry.ts>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

### Additional info about the change:

The current spyOn overload declarations provide a 100% fit over all the use cases we have, but they don't allow a good enough code complete suggestion. This change doesn't really add anything new to the signatures, but it improves code complete suggestions.

For example, take a look at how the suggestions are shown before the change:
![image](https://user-images.githubusercontent.com/5713887/174496033-59c5b249-b208-47e4-8801-3368bafa8ed5.png)

And how it is shown after:
![image](https://user-images.githubusercontent.com/5713887/174496455-17d9c8e2-0b9b-4015-9a44-eedb2ad01b2e.png)

The return type still matches the previous one, the only real difference is that, when doing something like that:

```ts
jest.spyOn(console, 'error', undefined);
```

The error will be a bit different.
Before the change:
```
No overload matches this call.
  Overload 1 of 4, '(object: Console, method: "Console", accessType: "get"): SpyInstance<ConsoleConstructor, []>', gave the following error.
    Argument of type '"error"' is not assignable to parameter of type '"Console"'.
  Overload 2 of 4, '(object: Console, method: "Console", accessType: "set"): SpyInstance<void, [ConsoleConstructor]>', gave the following error.
    Argument of type '"error"' is not assignable to parameter of type '"Console"'.ts(2769)
```
After the change:
```
Argument of type 'undefined' is not assignable to parameter of type 'never'.ts(2345)
```

@sandersn @ErfanMirzapour @G-Rath FYK