### PR TITLE
asana: Task/Section/User Task List/Typeahead bug fixes to current types

### DIFF
--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -251,3 +251,5 @@ client.sections.findById('123').then((section) => {
     const name: string = section.name;
     const createdAt: string = section.created_at;
 });
+
+client.userTaskLists.findByUser('123', {workspace: '456'});

--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -234,3 +234,14 @@ const typeaheadForWorkspaceQuery: asana.resources.Typeahead.TypeaheadParams = {
     opt_fields: ['name', 'completed', 'parent', 'custom_fields.gid', 'custom_fields.number_value'],
 };
 client.typeahead.typeaheadForWorkspace('workspace_gid', typeaheadForWorkspaceQuery);
+
+client.tasks.create({
+    workspace: '123',
+    name: 'my task',
+    memberships: [
+        {
+            project: '789',
+            section: '123',
+        },
+    ],
+});

--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -253,3 +253,55 @@ client.sections.findById('123').then((section) => {
 });
 
 client.userTaskLists.findByUser('123', {workspace: '456'});
+
+client.typeahead.typeaheadForWorkspace('123', {resource_type: 'custom_field', query: 'foo'})
+    .then((customFields) => {
+        const customField = customFields.data[0];
+        // $ExpectError
+        customField.completed_at;
+    });
+
+client.typeahead.typeaheadForWorkspace('123', {resource_type: 'project', query: 'foo'})
+    .then((projects) => {
+        const project = projects.data[0];
+        // $ExpectType string
+        project.color;
+        // $ExpectError
+        tag.completed_at;
+    });
+
+client.typeahead.typeaheadForWorkspace('123', {resource_type: 'portfolio', query: 'foo'})
+    .then((portfolios) => {
+        const portfolio = portfolios.data[0];
+        // $ExpectError
+        portfolio.completed_at;
+    });
+
+client.typeahead.typeaheadForWorkspace('123', {resource_type: 'tag', query: 'foo'})
+    .then((tags) => {
+        const tag = tags.data[0];
+        // $ExpectType string
+        tag.notes;
+        // $ExpectError
+        tag.completed_at;
+    });
+
+
+client.typeahead.typeaheadForWorkspace('123', {resource_type: 'task', query: 'foo'})
+    .then((tasks: asana.resources.ResourceList<asana.resources.Tasks.Type>) => {
+        const task = tasks.data[0];
+        // $ExpectType string
+        task.completed_at;
+        // $ExpectError
+        task.color;
+    });
+
+
+client.typeahead.typeaheadForWorkspace('123', {resource_type: 'user', query: 'foo'})
+    .then((users) => {
+        const user = users.data[0];
+        // $ExpectType Resource[]
+        user.workspaces;
+        // $ExpectError
+        user.completed_at;
+    });

--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -245,3 +245,9 @@ client.tasks.create({
         },
     ],
 });
+
+client.sections.findById('123').then((section) => {
+    const project: asana.resources.Projects.Type | undefined = section.project;
+    const name: string = section.name;
+    const createdAt: string = section.created_at;
+});

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -2692,7 +2692,7 @@ declare namespace asana {
              * @param {Object} [dispatchOptions] Options, if any, to pass the dispatcher for the request
              * @return {Promise} The requested resource
              */
-            findByUser(user: number | string, params?: Params, dispatchOptions?: any): Promise<UserTaskLists.Type>;
+            findByUser(user: number | string, params?: Params & { workspace?: string }, dispatchOptions?: any): Promise<UserTaskLists.Type>;
 
             /**
              * Returns the full record for a user task list.

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -3019,9 +3019,39 @@ declare namespace asana {
              */
             typeaheadForWorkspace(
                 workspaceGid: string,
-                params?: Typeahead.TypeaheadParams,
+                params?: Typeahead.TypeaheadParams & { resource_type: 'custom_field' },
+                dispatchOptions?: any,
+            ): Promise<ResourceList<CustomFields.Type>>;
+            typeaheadForWorkspace(
+                workspaceGid: string,
+                params?: Typeahead.TypeaheadParams & { resource_type: 'project' },
+                dispatchOptions?: any,
+            ): Promise<ResourceList<Projects.Type>>;
+            // typeaheadForWorkspace(
+            //     workspaceGid: string,
+            //     params?: Typeahead.TypeaheadParams & { resource_type: 'portfolio' },
+            //     dispatchOptions?: any,
+            // ): Promise<ResourceList<Portfolios.Type>>;
+            typeaheadForWorkspace(
+                workspaceGid: string,
+                params?: Typeahead.TypeaheadParams & { resource_type: 'tag' },
+                dispatchOptions?: any,
+            ): Promise<ResourceList<Tags.Type>>;
+            typeaheadForWorkspace(
+                workspaceGid: string,
+                params?: Typeahead.TypeaheadParams & { resource_type: 'task' },
                 dispatchOptions?: any,
             ): Promise<ResourceList<Tasks.Type>>;
+            typeaheadForWorkspace(
+                workspaceGid: string,
+                params?: Typeahead.TypeaheadParams & { resource_type: 'user' },
+                dispatchOptions?: any,
+            ): Promise<ResourceList<Users.Type>>;
+            typeaheadForWorkspace(
+                workspaceGid: string,
+                params?: Typeahead.TypeaheadParams,
+                dispatchOptions?: any,
+            ): Promise<ResourceList<Resource>>;
         }
     }
 

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -1601,12 +1601,18 @@ declare namespace asana {
                 custom_fields: CustomField[];
             }
 
+            // https://developers.asana.com/docs/create-a-task
+            // https://forum.asana.com/t/add-task-to-a-section-upon-creation-via-api-request/51957/5
             interface CreateParams {
                 name: string;
                 completed?: boolean | undefined;
                 hearted?: boolean | undefined;
                 notes?: string | undefined;
                 custom_fields?: Object | undefined;
+                memberships?: {
+                    project: string;
+                    section: string;
+                }[] | undefined;
             }
 
             // https://developers.asana.com/docs/update-a-task

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -2085,8 +2085,10 @@ declare namespace asana {
         }
 
         namespace Sections {
+            // https://developers.asana.com/docs/section
             interface Type extends Resource {
                 created_at: string;
+                project?: Projects.Type;
             }
 
             interface SectionsParams {


### PR DESCRIPTION
Various type improvements for node-asana (the SDK for the Asana REST API):

* Add poorly-documented memberships field to Tasks.CreateParams
* Add project field to Sections.Type
* Add workspace parameter to UserTasksList#findByUser
* Add signature overloads to typeahead.typeaheadForWorkspace


- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.asana.com/docs/asana
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - N/A