### PR TITLE
getLicense takes a string as argument

### DIFF
--- a/types/react-native-video/index.d.ts
+++ b/types/react-native-video/index.d.ts
@@ -91,7 +91,7 @@ export interface DRMSettings {
   contentId?: string | undefined;
   certificateUrl?: string | undefined;
   base64Certificate?: boolean | undefined;
-  getLicense?(): Promise<string>;
+  getLicense?(spcString: string): Promise<string>;
 }
 
 export const TextTrackType: {


### PR DESCRIPTION
As can be seen here
https://github.com/react-native-video/react-native-video/blob/master/docs/DRM.md#getlicense

Had to ts-ignore the drm prop because getLicense was incorrectly typed, this PR fixes that.