### PR TITLE
Fix spelling for DrawModeChangeEvent

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -102,7 +102,7 @@ declare namespace MapboxDraw {
         type: 'draw.selectionchange';
     }
 
-    interface DrawModeChageEvent extends DrawEvent {
+    interface DrawModeChangeEvent extends DrawEvent {
         mode: DrawMode; // The next mode, i.e. the mode that Draw is changing to
         type: 'draw.modechange';
     }


### PR DESCRIPTION
Changed spelling from DrawModeChageEvent (no 'n' in Change) to DrawModeChangeEvent
