### PR TITLE
[react-native] remove reference to automaticallyAdjustKeyboardInsets in 0.67

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6337,12 +6337,6 @@ export interface ScrollViewPropsIOS {
     automaticallyAdjustContentInsets?: boolean | undefined; // true
 
     /**
-     * Controls whether the ScrollView should automatically adjust its `contentInset`
-     * and `scrollViewInsets` when the Keyboard changes its size. The default value is false.
-     */
-    automaticallyAdjustKeyboardInsets?: boolean | undefined;
-
-    /**
      * Controls whether iOS should automatically adjust the scroll indicator
      * insets. The default value is true. Available on iOS 13 and later.
      */

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1446,13 +1446,6 @@ const ScrollViewMaintainVisibleContentPositionTest = () => (
     <ScrollView maintainVisibleContentPosition={{ autoscrollToTopThreshold: 1, minIndexForVisible: 10 }}></ScrollView>
 );
 
-const ScrollViewInsetsTest = () => (
-  <>
-    <ScrollView automaticallyAdjustKeyboardInsets />
-    <ScrollView automaticallyAdjustKeyboardInsets={false} />
-  </>
-);
-
 const MaxFontSizeMultiplierTest = () => <Text maxFontSizeMultiplier={0}>Text</Text>;
 
 const ShareTest = () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59641#issuecomment-1137462964
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR acts on the issue that is ongoing on the `@types/react-native` package. Basically, @fedorov-xyz made a PR to the types https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59641 to add a **new 0.68-only type** ([commit upstream](https://github.com/facebook/react-native/commit/49a1460a379e3a71358fb38888477ce6ea17e81a)); but because he didn't update the version number in the header, the change got published under the 0.67.x versioning. (cc @kuasha420 @rbuckton who approved that PR)

This means that *currently* the latest version of the types, still at 0.67.x, contains a 0.68.x specific type. With this PR (if I understood correctly how releasing works in the DT repo), once merged, a new version of 0.67.x types will be published without this extra type (that should not have been there in the first place).

There's a separate PR I made (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60889) that will tackle bumping the header to 0.68 and create a v0.67 folder (with this "revert" in it). Ideally, after this one gets merged, that one should get merged right away so that similar issues will be avoided (and it will also pave the way for 0.69, since `react-native` core 0.69.0 will be released later this week)