### PR TITLE
Bump dependency versions for postcss-preset-env

### DIFF
--- a/types/postcss-preset-env/index.d.ts
+++ b/types/postcss-preset-env/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for postcss-preset-env 6.7
-// Project: https://github.com/csstools/postcss-preset-env
+// Type definitions for postcss-preset-env 7.7
+// Project: https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env
 // Definitions by: Latif Sulistyo <https://github.com/latipun7>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.0
 
-import { Plugin as PostCSSPlugin } from 'postcss';
+import { PluginCreator as PostCSSPlugin } from 'postcss';
 import { Options as AutoprefixerOptions } from 'autoprefixer';
 
 declare namespace postcssPresetEnv {

--- a/types/postcss-preset-env/package.json
+++ b/types/postcss-preset-env/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@types/autoprefixer": "^9.0.0",
-        "postcss": "^7.0.32"
+        "autoprefixer": "^10.4.7",
+        "postcss": "^8.4.14"
     }
 }

--- a/types/postcss-preset-env/postcss-preset-env-tests.ts
+++ b/types/postcss-preset-env/postcss-preset-env-tests.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import * as postcss from 'postcss';
+import postcss from 'postcss';
 import * as postcssPresetEnv from 'postcss-preset-env';
 
 postcss([postcssPresetEnv({ autoprefixer: true })])


### PR DESCRIPTION
autoprefixer provides its own type definitions
Update project URL

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
