### PR TITLE
react: componentDidCatch/getDerivedStateFromError error as unknown

### DIFF
--- a/types/create-react-class/create-react-class-tests.ts
+++ b/types/create-react-class/create-react-class-tests.ts
@@ -24,9 +24,11 @@ const container: Element = document.createElement("div");
 const ClassicComponent: React.ClassicComponentClass<Props> = createReactClass<Props, State>({
     childContextTypes: {},
     componentDidCatch(err, errorInfo) {
-        const msg: string = err.message;
-        const name: string = err.name;
-        const stack: string | undefined = err.stack;
+        if (err instanceof Error) {
+            const msg: string = err.message;
+            const name: string = err.name;
+            const stack: string | undefined = err.stack;
+        }
         const componentStack: string = errorInfo.componentStack;
     },
     componentDidMount() {},

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -613,7 +613,7 @@ declare namespace React {
          * Catches exceptions generated in descendant components. Unhandled exceptions will cause
          * the entire component tree to unmount.
          */
-        componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+        componentDidCatch?(error: unknown, errorInfo: ErrorInfo): void;
     }
 
     // Unfortunately, we have no way of declaring that the component constructor must implement this
@@ -637,7 +637,7 @@ declare namespace React {
          *
          * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
          */
-        (error: any) => Partial<S> | null;
+        (error: unknown) => Partial<S> | null;
 
     // This should be "infer SS" but can't use it yet
     interface NewLifecycle<P, S, SS> {

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -636,7 +636,7 @@ declare namespace React {
          * Catches exceptions generated in descendant components. Unhandled exceptions will cause
          * the entire component tree to unmount.
          */
-        componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+        componentDidCatch?(error: unknown, errorInfo: ErrorInfo): void;
     }
 
     // Unfortunately, we have no way of declaring that the component constructor must implement this
@@ -660,7 +660,7 @@ declare namespace React {
          *
          * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
          */
-        (error: any) => Partial<S> | null;
+        (error: unknown) => Partial<S> | null;
 
     // This should be "infer SS" but can't use it yet
     interface NewLifecycle<P, S, SS> {

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -636,7 +636,7 @@ declare namespace React {
          * Catches exceptions generated in descendant components. Unhandled exceptions will cause
          * the entire component tree to unmount.
          */
-        componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+        componentDidCatch?(error: unknown, errorInfo: ErrorInfo): void;
     }
 
     // Unfortunately, we have no way of declaring that the component constructor must implement this
@@ -660,7 +660,7 @@ declare namespace React {
          *
          * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
          */
-        (error: any) => Partial<S> | null;
+        (error: unknown) => Partial<S> | null;
 
     // This should be "infer SS" but can't use it yet
     interface NewLifecycle<P, S, SS> {


### PR DESCRIPTION
_this is a breaking change_

In JavaScript, any type of value can be thrown and caught in a `catch` clause. React's `componentDidCatch` exhibits the same semantics. The current type of `Error` for the first argument to `componentDidCatch` is not type safe, because at runtime the value could be anything. This sets users up for issues in production in a particularly vulnerable location: their error handling and reporting.

Eg:

```ts
  componentDidCatch(error, errorInfo) {
    // this will be undefined (or error if throwing `undefined` or `null`) at runtime if a non `Error` value is thrown, such as `throw "Oh no"`
    console.log(error.message);
  }
```

[Runnable example](https://codesandbox.io/s/react-typescript-forked-5vklbx).

TypeScript historically typed catch clause variables as `any`, but [since TypeScript 4.4 catch clause variables can be typed as unknown](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables). 

While `any` could work here, `unknown` is the preferable type from a type safety perspective. For symmetry, `getDerivedStateFromError` should also be typed as `unknown`. Currently it is typed as `any`, which is at odds with the current definition of `componentDidCatch`.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
