### PR TITLE
fix(video.js): preload options isn't any old string

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -4262,6 +4262,8 @@ declare namespace videojs {
         }
     }
 
+    type Preload = 'audio' | 'metadata' | 'none';
+
     interface ProgressControl extends Component {
         /**
          * Create the `Component`'s DOM element
@@ -7137,7 +7139,7 @@ export interface VideoJsPlayerOptions extends videojs.ComponentOptions {
     noUITitleAttributes?: boolean | undefined;
     plugins?: Partial<VideoJsPlayerPluginOptions> | undefined;
     poster?: string | undefined;
-    preload?: string | undefined;
+    preload?: videojs.Preload | undefined;
     responsive?: boolean | undefined;
     sourceOrder?: boolean | undefined;
     sources?: videojs.Tech.SourceObject[] | undefined;

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -4262,7 +4262,7 @@ declare namespace videojs {
         }
     }
 
-    type Preload = 'audio' | 'metadata' | 'none';
+    type Preload = 'auto' | 'metadata' | 'none';
 
     interface ProgressControl extends Component {
         /**

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -110,8 +110,7 @@ videojs('example_video_1', playerOptions).ready(function playerReady() {
     ]);
 
     // the option passed when initializing player is a string
-    // $ExpectType Preload | undefined
-    this.options_.preload;
+    const preload: videojs.Preload | undefined = this.options_.preload;
     // but the option when setting preload later is boolean
     this.preload(false);
 

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -110,7 +110,7 @@ videojs('example_video_1', playerOptions).ready(function playerReady() {
     ]);
 
     // the option passed when initializing player is a string
-    // $ExpectType videojs.Preload
+    // $ExpectType Preload | undefined
     this.options_.preload;
     // but the option when setting preload later is boolean
     this.preload(false);

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -109,6 +109,12 @@ videojs('example_video_1', playerOptions).ready(function playerReady() {
         { type: 'video/ogg', src: 'http://www.example.com/path/to/video.ogv' },
     ]);
 
+    // the option passed when initializing player is a string
+    // $ExpectType videojs.Preload
+    this.options_.preload;
+    // but the option when setting preload later is boolean
+    this.preload(false);
+
     const liveTracker = this.liveTracker;
     liveTracker.on('seekableendchange', () => {});
     liveTracker.on('liveedgechange', () => {});
@@ -214,14 +220,14 @@ videojs('example_video_1', playerOptions).ready(function playerReady() {
 });
 
 function testEvents(player: videojs.Player) {
-    const myFunc = function(this: videojs.Player) {
+    const myFunc = function (this: videojs.Player) {
         // Do something when the event is fired
     };
     player.on('error', myFunc);
     // Removes the specified listener only.
     player.off('error', myFunc);
 
-    const myFuncWithArg = function(this: videojs.Player, e: Event) {
+    const myFuncWithArg = function (this: videojs.Player, e: Event) {
         // Do something when the event is fired
     };
     player.on('volumechange', myFuncWithArg);
@@ -278,7 +284,7 @@ function testPlugin(player: videojs.Player, options: {}) {
         return;
     }
 
-    videojs.registerPlugin('uloztoExample', function({}: typeof options) {
+    videojs.registerPlugin('uloztoExample', function ({}: typeof options) {
         this.play();
         this.one('ended', () => {
             // do something

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -220,14 +220,14 @@ videojs('example_video_1', playerOptions).ready(function playerReady() {
 });
 
 function testEvents(player: videojs.Player) {
-    const myFunc = function (this: videojs.Player) {
+    const myFunc = function(this: videojs.Player) {
         // Do something when the event is fired
     };
     player.on('error', myFunc);
     // Removes the specified listener only.
     player.off('error', myFunc);
 
-    const myFuncWithArg = function (this: videojs.Player, e: Event) {
+    const myFuncWithArg = function(this: videojs.Player, e: Event) {
         // Do something when the event is fired
     };
     player.on('volumechange', myFuncWithArg);
@@ -284,7 +284,7 @@ function testPlugin(player: videojs.Player, options: {}) {
         return;
     }
 
-    videojs.registerPlugin('uloztoExample', function ({}: typeof options) {
+    videojs.registerPlugin('uloztoExample', function({}: typeof options) {
         this.play();
         this.one('ended', () => {
             // do something


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.videojs.com/docs/guides/options.html#preload
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
