### PR TITLE
[saml2-js] Fix type of SAMLAssertResponse['response_header']['id']

### DIFF
--- a/types/saml2-js/index.d.ts
+++ b/types/saml2-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for SAML2-js 3.1.1
+// Type definitions for SAML2-js 3.0.2
 // Project: https://github.com/Clever/saml2
 // Definitions by: horiuchi <https://github.com/horiuchi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/saml2-js/index.d.ts
+++ b/types/saml2-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for SAML2-js 3.0.1
+// Type definitions for SAML2-js 3.1.1
 // Project: https://github.com/Clever/saml2
 // Definitions by: horiuchi <https://github.com/horiuchi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -154,7 +154,11 @@ declare module 'saml2-js' {
     }
 
     export interface SAMLAssertResponse {
-        response_header: { id: 'string'; destination: string; in_response_to: string };
+        response_header: {
+            id: string;
+            destination: string;
+            in_response_to: string;
+        };
         type: string;
         user: {
             name_id: string;

--- a/types/saml2-js/saml2-js-tests.ts
+++ b/types/saml2-js/saml2-js-tests.ts
@@ -87,12 +87,15 @@ import * as saml2 from 'saml2-js';
         sp.post_assert(idp, options, function(err, saml_response) {
             if (err != null) return res.send(500);
 
+            let response_id: string = saml_response.response_header.id;
+            let request_id: string = saml_response.response_header.in_response_to;
+
             // Save name_id and session_index for logout
             // Note:  In practice these should be saved in the user session, not globally.
-            let name_id = saml_response.user.name_id;
-            let session_index = saml_response.user.session_index;
+            let name_id: string = saml_response.user.name_id;
+            let session_index: string | undefined = saml_response.user.session_index;
 
-            res.send('Hello #{saml_response.user.name_id}!');
+            res.send(`Hello ${saml_response.user.name_id}!`);
         });
     });
 


### PR DESCRIPTION
The type of the `SAMLAssertResponse['response_header']['id']` field was mistakenly set to `'string'` (a type that only accepts the string literal "string") instead of `string` (a type that accepts any string).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

