### PR TITLE
Rearrange amap-js-api test types

### DIFF
--- a/types/amap-js-api/amap-js-api-tests.ts
+++ b/types/amap-js-api/amap-js-api-tests.ts
@@ -1347,7 +1347,7 @@ testLabelsLayer.on('click', (event: AMap.LabelsLayer.EventMap['click']) => {
         data.id;
         // $ExpectType string
         data.name;
-        // $ExpectType [number, number] | [string, string]
+        // $ExpectType [number, number] | [string, string] || [string, string] | [number, number]
         data.position;
         // $ExpectType number | undefined
         data.rank;
@@ -2707,7 +2707,7 @@ const testLabelMarker = new AMap.LabelMarker({
 // $ExpectType void
 testLabelMarker.setPosition(lnglatTuple);
 
-// $ExpectType [number, number] | [string, string]
+// $ExpectType [number, number] | [string, string] || [string, string] | [number, number]
 testLabelMarker.getPosition();
 
 // $ExpectType [number, number]


### PR DESCRIPTION
Typescript 4.8 prints a few of the tuples in a different order.
