### PR TITLE
fix(auth0): add scope to auth0.SignInOptions

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -1029,6 +1029,8 @@ async () => {
     };
     signInUserData.realm = 'email';
     signInUserData.realm = 'sms';
+
+    signInUserData.scope = 'openid profile email';
     const emailUserData: auth0.RequestEmailCodeOrLinkOptions = {
         email: '{YOUR_EMAIL}',
         send: 'code',

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -996,6 +996,7 @@ export interface SignInOptions {
     otp: string;
     realm?: 'email' | 'sms';
     audience?: string | undefined;
+    scope?: string | undefined;
     /**
      * @deprecated
      */


### PR DESCRIPTION
See https://auth0.com/docs/api/authentication#authenticate-user
where you can optionally pass scope as a `string`

The `auth0` client actually will include scope in the API call, you just had to ignore TS complaining. So this PR is really just making the types here match the lib.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
~- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
