### PR TITLE
Update index.d.ts Fix for the default export from MiniPass.

### DIFF
--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -249,7 +249,7 @@ export interface FileStat extends stream.Readable, Fields {
     size: number;
 }
 
-export interface ReadEntry extends MiniPass, HeaderProperties {
+export interface ReadEntry extends MiniPass.default, HeaderProperties {
     /** The extended metadata object provided to the constructor. */
     extended: any;
     /** The global extended metadata object provided to the constructor. */


### PR DESCRIPTION
The intended import is for the default export from MiniPass I guess. Typescript sees MiniPass as a namespace instead of a type, because of the require on line 12. This breaks builds. And ".default" is to fix that.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:



If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: Simply use this module with a typescript project and you will see the build error.
