### PR TITLE
Update kap-plugin dependencies

### DIFF
--- a/types/kap-plugin/index.d.ts
+++ b/types/kap-plugin/index.d.ts
@@ -2,13 +2,13 @@
 // Project: https://github.com/wulkano/kap/blob/master/docs/plugins.md
 // Definitions by: Connor Peet <https://github.com/connor4312>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.8
+// Minimum TypeScript Version: 4.2
 
 import * as got from 'got';
 import * as ElectronStore from 'electron-store';
 import { JSONSchema7 } from 'json-schema';
 
-export interface KapContext<T> {
+export interface KapContext<T extends Record<string, any>> {
     /**
      * The file format the user chose in the editor window
      */
@@ -92,7 +92,7 @@ export type ConfigSchema<TValue> = Pick<JSONSchema7, Exclude<keyof JSONSchema7, 
     default?: TValue | undefined;
 };
 
-export interface KapShareService<T = unknown> {
+export interface KapShareService<T extends Record<string, any> = Record<string, any>> {
     /**
      * The function that is run when the user clicks the menu item.
      */

--- a/types/kap-plugin/package.json
+++ b/types/kap-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "electron-store": ">=5.1.0"
+        "electron-store": ">=8.0.2"
     }
 }


### PR DESCRIPTION
type-fest requires TS 4.2 now; electron-store 8.0.2 is required to work with TS 4.8