### PR TITLE
Update luxon tests for TS 4.8

### DIFF
--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -109,7 +109,7 @@ dt.toISOWeekDate(); // $ExpectType string
 dt.toJSDate(); // $ExpectType Date
 dt.toJSON(); // $ExpectType string
 dt.toLocaleParts(); // $ExpectType DateTimeFormatPart[]
-dt.toLocaleParts()[0].type; // $ExpectType DateTimeFormatPartTypes
+dt.toLocaleParts()[0].type; // $ExpectType DateTimeFormatPartTypes || keyof DateTimeFormatPartTypesRegistry
 dt.toLocaleParts()[0].value; // $ExpectType string
 dt.toLocaleString(); // $ExpectType string
 dt.toLocaleString({ month: 'long', day: 'numeric' }); // $ExpectType string


### PR DESCRIPTION
DateTimeFormatPartTypes changed in 4.8 because part of them are defined in es2017 and part in es2021. There is now a "registry interface" that merges between the two, which changes the type.