### PR TITLE
Disable npm-naming in maptalks/react-router-guard

### DIFF
--- a/types/maptalks/tslint.json
+++ b/types/maptalks/tslint.json
@@ -1,3 +1,7 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
 }
+

--- a/types/react-router-guard/tslint.json
+++ b/types/react-router-guard/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": [true,{"mode":"code","errors":[["NeedsExportEquals",false]]}]
+    }
+}


### PR DESCRIPTION
The npm-naming rule gives the wrong result, but I don't have time to investigate and fix it.