### PR TITLE
update(update-notifier): v6 (ESM rewrite)

### DIFF
--- a/types/update-notifier/index.d.ts
+++ b/types/update-notifier/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for update-notifier 5.1
+// Type definitions for update-notifier 6.0
 // Project: https://github.com/yeoman/update-notifier
 // Definitions by: vvakame <https://github.com/vvakame>
 //                 Noah Chen <https://github.com/nchen63>
@@ -6,78 +6,11 @@
 //                 Michael Grinich <https://github.com/grinich>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import boxen = require('boxen');
-import ConfigStore = require('configstore');
+// Minimum TypeScript Version: 4.1
 
-export = UpdateNotifier;
+import UpdateNotifier, { NotifyOptions, Package, Settings, UpdateInfo } from './update-notifier';
 
 /** Checks if there is an available update */
-declare function UpdateNotifier(settings?: UpdateNotifier.Settings): UpdateNotifier.UpdateNotifier;
+export default function updateNotifier(settings?: Settings): UpdateNotifier;
 
-declare namespace UpdateNotifier {
-    class UpdateNotifier {
-        constructor(settings?: Settings);
-
-        readonly config: ConfigStore;
-        readonly update?: UpdateInfo | undefined;
-        check(): void;
-        /**
-         * Check update information
-         * @async
-         */
-        fetchInfo(): UpdateInfo | Promise<UpdateInfo>;
-        /** Convenience method to display a notification message */
-        notify(customMessage?: NotifyOptions): void;
-    }
-
-    interface Settings {
-        /**
-         * Which dist-tag to use to find the latest version
-         * @default 'latest'
-         */
-        distTag?: string | undefined;
-        pkg?: Package | undefined;
-        /**
-         * @deprecated use `pkg.name`
-         */
-        packageName?: string | undefined;
-        /**
-         * @deprecated use `pkg.version`
-         */
-        packageVersion?: string | undefined;
-        /** How often to check for updates */
-        updateCheckInterval?: number | undefined;
-        /** Allows notification to be shown when running as an npm script */
-        shouldNotifyInNpmScript?: boolean | undefined;
-    }
-
-    interface NotifyOptions {
-        /** Message that will be shown when an update is available */
-        message?: string | undefined;
-        /** Defer showing the notification to after the process has exited */
-        defer?: boolean | undefined;
-        /** Include the -g argument in the default message's npm i recommendation */
-        isGlobal?: boolean | undefined;
-        /**
-         * Options object that will be passed to `boxen`
-         * See https://github.com/sindresorhus/boxen/blob/master/index.d.ts
-         */
-        boxenOptions?: boxen.Options | undefined;
-    }
-
-    interface Package {
-        name: string;
-        version: string;
-    }
-
-    interface UpdateInfo {
-        /** Latest version */
-        readonly latest: string;
-        /** Current version */
-        readonly current: string;
-        /** Type of current update */
-        readonly type: 'latest' | 'major' | 'minor' | 'patch' | 'prerelease' | 'build';
-        /** Package name */
-        name: string;
-    }
-}
+export type { NotifyOptions, Package, Settings, UpdateInfo };

--- a/types/update-notifier/package.json
+++ b/types/update-notifier/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
+    "type": "module",
     "dependencies": {
-        "boxen": "^4.2.0"
+        "boxen": "^7.0.0"
     }
 }

--- a/types/update-notifier/tsconfig.json
+++ b/types/update-notifier/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "ES2020"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/update-notifier/update-notifier-tests.ts
+++ b/types/update-notifier/update-notifier-tests.ts
@@ -1,7 +1,10 @@
-import boxen = require('boxen');
-import UpdateNotifier = require('update-notifier');
+import updateNotifier, { Package } from 'update-notifier';
 
-let notifier = UpdateNotifier();
+declare const packageJson: Package;
+
+let notifier = updateNotifier({
+    pkg: packageJson,
+});
 
 if (notifier.update) {
     notifier.notify();
@@ -10,7 +13,7 @@ if (notifier.update) {
 notifier.update; // $ExpectType UpdateInfo | undefined
 
 // Also exposed as a class
-notifier = new UpdateNotifier.UpdateNotifier({
+notifier = updateNotifier({
     updateCheckInterval: 1000 * 60 * 60 * 24 * 7, // 1 week
 });
 
@@ -33,7 +36,7 @@ if (notifier.update) {
             },
             align: 'center',
             borderColor: 'yellow',
-            borderStyle: boxen.BorderStyle.Round,
+            borderStyle: 'round',
         },
     });
 }

--- a/types/update-notifier/update-notifier.d.ts
+++ b/types/update-notifier/update-notifier.d.ts
@@ -1,0 +1,70 @@
+import * as ConfigStore from 'configstore';
+
+import type { Options as BoxenOptions } from 'boxen';
+
+export default class UpdateNotifier {
+    constructor(settings?: Settings);
+    readonly config: ConfigStore;
+    readonly update?: UpdateInfo | undefined;
+    check(): void;
+    /**
+     * Check update information
+     * @async
+     */
+    fetchInfo(): UpdateInfo | Promise<UpdateInfo>;
+    /** Convenience method to display a notification message */
+    notify(customMessage?: NotifyOptions): void;
+}
+
+interface Settings {
+    /**
+     * Which dist-tag to use to find the latest version
+     * @default 'latest'
+     */
+    distTag?: string | undefined;
+    pkg?: Package | undefined;
+    /**
+     * @deprecated use `pkg.name`
+     */
+    packageName?: string | undefined;
+    /**
+     * @deprecated use `pkg.version`
+     */
+    packageVersion?: string | undefined;
+    /** How often to check for updates */
+    updateCheckInterval?: number | undefined;
+    /** Allows notification to be shown when running as an npm script */
+    shouldNotifyInNpmScript?: boolean | undefined;
+}
+
+interface NotifyOptions {
+    /** Message that will be shown when an update is available */
+    message?: string | undefined;
+    /** Defer showing the notification to after the process has exited */
+    defer?: boolean | undefined;
+    /** Include the -g argument in the default message's npm i recommendation */
+    isGlobal?: boolean | undefined;
+    /**
+     * Options object that will be passed to `boxen`
+     * See https://github.com/sindresorhus/boxen/blob/master/index.d.ts
+     */
+    boxenOptions?: BoxenOptions | undefined;
+}
+
+interface Package {
+    name: string;
+    version: string;
+}
+
+interface UpdateInfo {
+    /** Latest version */
+    readonly latest: string;
+    /** Current version */
+    readonly current: string;
+    /** Type of current update */
+    readonly type: 'latest' | 'major' | 'minor' | 'patch' | 'prerelease' | 'build';
+    /** Package name */
+    name: string;
+}
+
+export type { NotifyOptions, Package, Settings, UpdateInfo };


### PR DESCRIPTION
Update notifier is now ESM module. It's dependencies are also ESM
modules. The direct dependency tree, including type-fest utils library,
required bump to minumum TS version 4.1 and bump in `lib` definition, as
DT cannot use skip library check option.

- ESM module rewrite
- reflect actual module naming and structure

https://github.com/yeoman/update-notifier/releases/tag/v6.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.