### PR TITLE
[check-types] allowed any for empty/nonEmpty checks

### DIFF
--- a/types/check-types/check-types-tests.ts
+++ b/types/check-types/check-types-tests.ts
@@ -30,6 +30,26 @@ check.assert.maybe.like(undefined, { foo: 'bar' }, 'with a message');
 
 check.assert.nonEmptyArray([1, 2], 'With a message');
 
+check.emptyArray([1, 2, 3]);
+check.emptyArray([]);
+check.emptyArray('foo');
+check.emptyArray(true);
+check.emptyArray(undefined);
+check.emptyArray(null);
+check.emptyArray(Symbol(''));
+check.emptyArray(0);
+check.emptyArray({});
+
+check.nonEmptyArray([1, 2, 3]);
+check.nonEmptyArray([]);
+check.nonEmptyArray('foo');
+check.nonEmptyArray(true);
+check.nonEmptyArray(undefined);
+check.nonEmptyArray(null);
+check.nonEmptyArray(Symbol(''));
+check.nonEmptyArray(0);
+check.nonEmptyArray({});
+
 check.assert.not.inRange(1, 2, 3);
 
 check.assert.not.inRange(1, 2, 3, 'With a message');
@@ -52,7 +72,25 @@ check.assert(
     Error,
 );
 
-check.apply(['foo', 'bar', ''], check.nonEmptyString);
+check.emptyString('foo');
+check.emptyString('');
+check.emptyString(true);
+check.emptyString(undefined);
+check.emptyString(null);
+check.emptyString(Symbol(''));
+check.emptyString(0);
+check.emptyString({});
+check.emptyString([]);
+
+check.nonEmptyString('foo');
+check.nonEmptyString('');
+check.nonEmptyString(true);
+check.nonEmptyString(undefined);
+check.nonEmptyString(null);
+check.nonEmptyString(Symbol(''));
+check.nonEmptyString(0);
+check.nonEmptyString({});
+check.nonEmptyString([]);
 
 check.any(check.apply([1, 2, 3, ''], check.string));
 
@@ -61,3 +99,23 @@ check.any(check.map({ foo: 0, bar: '' }, { foo: check.number, bar: check.string 
 check.all(check.map({ foo: 0, bar: '' }, { foo: check.number, bar: check.string }));
 
 check.all(check.apply([1, 2, 3, ''], check.string));
+
+check.emptyObject({});
+check.emptyObject({x: 1});
+check.emptyObject('foo');
+check.emptyObject(true);
+check.emptyObject(undefined);
+check.emptyObject(null);
+check.emptyObject(Symbol(''));
+check.emptyObject(0);
+check.emptyObject([]);
+
+check.nonEmptyObject({});
+check.nonEmptyObject({x: 1});
+check.nonEmptyObject('foo');
+check.nonEmptyObject(true);
+check.nonEmptyObject(undefined);
+check.nonEmptyObject(null);
+check.nonEmptyObject(Symbol(''));
+check.nonEmptyObject(0);
+check.nonEmptyObject([]);

--- a/types/check-types/index.d.ts
+++ b/types/check-types/index.d.ts
@@ -99,8 +99,8 @@ interface CheckType {
     /* String predicates */
 
     string(a: any): a is string;
-    emptyString(a: string): boolean;
-    nonEmptyString(a: string): boolean;
+    emptyString(a: any): boolean;
+    nonEmptyString(a: any): boolean;
     contains(a: string, substring: string): boolean;
     match(a: string, b: RegExp): boolean;
 
@@ -134,8 +134,8 @@ interface CheckType {
     /* Object predicates */
 
     object: ObjectFunction;
-    emptyObject(a: object): boolean;
-    nonEmptyObject(a: object): boolean;
+    emptyObject(a: any): boolean;
+    nonEmptyObject(a: any): boolean;
     /**
      * Checking via instanceof
      */
@@ -152,8 +152,8 @@ interface CheckType {
     /* Array predicates */
 
     array: ArrayFunction;
-    emptyArray(a: any[]): boolean;
-    nonEmptyArray(a: any[]): boolean;
+    emptyArray(a: any): boolean;
+    nonEmptyArray(a: any): boolean;
     arrayLike: ArrayLikeFunction;
     iterable: IterableFunction;
     includes(a: any[], value: any): boolean;

--- a/types/check-types/index.d.ts
+++ b/types/check-types/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for check-types 7.3
 // Project: https://gitlab.com/philbooth/check-types.js
 // Definitions by: idchlife <https://github.com/idchlife>
+//                 shov <https://github.com/shov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.0
 


### PR DESCRIPTION
Practically it might be an often case a programmer wants to check if a variable is a non-empty string (either array or object). 
There are only two logical conclusions after the compare: it is an empty string or it is **any**thing else, even not a string at all.
In the source code of check-types lib the nonEmptyString() contain internal check if it's string or not. So there is no point to strictly allow strings only to be passed as the argument there. The same is truly for emptyString, nonEmptyArray, emptyArray, nonEmptyObject and emptyObject.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://gitlab.com/philbooth/check-types.js/-/blob/master/src/check-types.js#L337>

