### PR TITLE
sinon: add comment about zero-based index of spy call

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -332,7 +332,7 @@ declare namespace Sinon {
         /**
          * Returns the nth call.
          * Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
-         * @param n Zero based index of the spy call.
+         * @param n Zero-based index of the spy call.
          */
         getCall(n: number): SinonSpyCall<TArgs, TReturnValue>;
         /**
@@ -569,7 +569,7 @@ declare namespace Sinon {
          * Defines the behavior of the stub on the @param n call. Useful for testing sequential interactions.
          * There are methods onFirstCall, onSecondCall,onThirdCall to make stub definitions read more naturally.
          * onCall can be combined with all of the behavior defining methods in this section. In particular, it can be used together with withArgs.
-         * @param n
+         * @param n Zero-based index of the spy call.
          */
         onCall(n: number): SinonStub<TArgs, TReturnValue>;
         /**


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

Clarifies the comments of `getCall(n: number)` and `onCall(n: number)` to indicate this parameter is a zero-based index. Starting the index at 1 is an easy mistake to make. Now both of these functions have consistent comments to point this out.

Documentation showing examples of `getCall(0)` and `onCall(0)`:
* https://sinonjs.org/releases/latest/stubs/
* https://sinonjs.org/releases/latest/spies/

No testing added since this is a documentation-only change.
