### PR TITLE
fix(@types/ember__test-helpers): fix getContext return type

### DIFF
--- a/types/ember__test-helpers/ember__test-helpers-tests.ts
+++ b/types/ember__test-helpers/ember__test-helpers-tests.ts
@@ -5,6 +5,7 @@ import { setupTest, setupRenderingTest } from 'ember-qunit';
 
 import {
     TestContext,
+    getContext,
     click,
     doubleClick,
     tap,
@@ -35,6 +36,11 @@ import {
     setupOnerror,
     resetOnerror
 } from '@ember/test-helpers';
+
+/** Static assertion that `value` has type `T` */
+declare function assertType<T>(value: T): T;
+
+assertType<TestContext>(getContext());
 
 interface LocalContext extends TestContext {
     something: 'cool';

--- a/types/ember__test-helpers/setup-context.d.ts
+++ b/types/ember__test-helpers/setup-context.d.ts
@@ -1,7 +1,8 @@
 import Resolver from 'ember-resolver';
+import { TestContext } from './index';
 
 export default function setupContext<C extends object>(context: C, options?: { resolver?: Resolver | undefined }): Promise<C>;
-export function getContext(): object;
+export function getContext(): TestContext;
 export function setContext(context: object): void;
 export function unsetContext(): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - Per [API docs](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#getcontext), `getContext()` should return the test execution context and currently returning `object` requires workarounds to use `getContext()` in TS.