### PR TITLE
Issue: @type/node@18 is missing type definition

### DIFF
--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -507,6 +507,12 @@ declare module 'perf_hooks' {
          * @since v15.9.0, v14.18.0
          */
         recordDelta(): void;
+        /**
+         * Combines other histograms into a single one
+         *
+         * @since v17.4.0, v16.14.0
+         */
+         add(other: RecordableHistogram): RecordableHistogram;
     }
     /**
      * _This property is an extension by Node.js. It is not available in Web browsers._

--- a/types/perf_hooks/index.d.ts
+++ b/types/perf_hooks/index.d.ts
@@ -1,0 +1,66 @@
+export interface Histogram {
+    /**
+     * Returns a `Map` object detailing the accumulated percentile distribution.
+     * @since v11.10.0
+     */
+    readonly percentiles: Map<number, number>;
+    /**
+     * The number of times the event loop delay exceeded the maximum 1 hour event
+     * loop delay threshold.
+     * @since v11.10.0
+     */
+    readonly exceeds: number;
+    /**
+     * The minimum recorded event loop delay.
+     * @since v11.10.0
+     */
+    readonly min: number;
+    /**
+     * The maximum recorded event loop delay.
+     * @since v11.10.0
+     */
+    readonly max: number;
+    /**
+     * The mean of the recorded event loop delays.
+     * @since v11.10.0
+     */
+    readonly mean: number;
+    /**
+     * The standard deviation of the recorded event loop delays.
+     * @since v11.10.0
+     */
+    readonly stddev: number;
+    /**
+     * Resets the collected histogram data.
+     * @since v11.10.0
+     */
+    reset(): void;
+    /**
+     * Returns the value at the given percentile.
+     * @since v11.10.0
+     * @param percentile A percentile value in the range (0, 100].
+     */
+    percentile(percentile: number): number;
+}
+
+export interface RecordableHistogram extends Histogram {
+    /**
+     * @since v15.9.0, v14.18.0
+     * @param val The amount to record in the histogram.
+     */
+    record(val: number | bigint): void;
+    /**
+     * Calculates the amount of time (in nanoseconds) that has passed since the
+     * previous call to `recordDelta()` and records that amount in the histogram.
+     *
+     * ## Examples
+     * @since v15.9.0, v14.18.0
+     */
+    recordDelta(): void;
+    /**
+     * Combines other histograms into a single one
+     *
+     * @since v17.4.0, v16.14.0
+     */
+     add(other: RecordableHistogram): RecordableHistogram;
+}

--- a/types/perf_hooks/perf_hooks-histogram-add-tests.ts
+++ b/types/perf_hooks/perf_hooks-histogram-add-tests.ts
@@ -1,0 +1,10 @@
+import { RecordableHistogram, Histogram } from "perf_hooks";
+
+declare const histogram1: RecordableHistogram;
+declare const histogram2: RecordableHistogram;
+declare const histogram3: RecordableHistogram;
+
+async () => {
+    histogram1.add(histogram2);
+    histogram1.add(histogram3);
+};

--- a/types/perf_hooks/tsconfig.json
+++ b/types/perf_hooks/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "perf_hooks-histogram-add-tests.ts"
+    ]
+}

--- a/types/perf_hooks/tslint.json
+++ b/types/perf_hooks/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dtslint.json" }


### PR DESCRIPTION
Issue: @type/node@18.4.0 is missing type definition for histogram.add(other) 
    According to docs, this function was Added in: v17.4.0, v16.14.0
    
    The function is under Recordable Histogram Class which is defined on the following file
    https://github.com/nodejs/node/blob/v18.4.0/lib/internal/histogram.js
    At line 308

Without this definition Vs Code, does not provide intelligence when working with Histograms returned by histogram.add(other)
After adding the definition under the corresponding interface, VS Code removed all the Intelligence errors

![image](https://user-images.githubusercontent.com/108168608/175789289-6ba1fd1e-f794-439f-a6f2-d36fb83ce94a.png)

