### PR TITLE
fix(ci): failing `node-sass` CI runs for @types/node

### DIFF
--- a/types/architect__functions/http.d.ts
+++ b/types/architect__functions/http.d.ts
@@ -3,7 +3,6 @@ import * as express from 'express';
 
 export type HttpMethods = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export type SessionData = Record<string, any>;
 export type JsonBody = any;
 export type HtmlBody = string;

--- a/types/mparticle__web-sdk/test/mparticle__web-sdk-instance-tests.ts
+++ b/types/mparticle__web-sdk/test/mparticle__web-sdk-instance-tests.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import mParticle = require('@mparticle/web-sdk');
 import { Batch } from '@mparticle/event-models';
 

--- a/types/mparticle__web-sdk/test/mparticle__web-sdk-tests.ts
+++ b/types/mparticle__web-sdk/test/mparticle__web-sdk-tests.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import { Batch } from '@mparticle/event-models';
 import mParticle = require('@mparticle/web-sdk');
 

--- a/types/node-sass/index.d.ts
+++ b/types/node-sass/index.d.ts
@@ -139,7 +139,6 @@ export type SassRenderCallback = (err: SassError, result: Result) => any;
 // Because of this, the new-able object notation is used here, a class does not
 // work for these types.
 export namespace types {
-    /* eslint-disable @typescript-eslint/ban-types */
     /* tslint:disable:ban-types */
     /**
      * Values that are received from Sass as an argument to a javascript function.


### PR DESCRIPTION
Remove unsupported rule.

```error
'eslint-disable' is forbidden. Per-line and per-rule disabling is allowed, for example: 'tslint:disable:rulename', tslint:disable-line' and 'tslint:disable-next-line' are allowed.
```

/cc @sapphi-red

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.