### PR TITLE
support eot config for prompt-sync 4.2.0

### DIFF
--- a/types/prompt-sync/index.d.ts
+++ b/types/prompt-sync/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for prompt-sync 4.1.4
-// Project: https://github.com/0x00A/prompt-sync
-// Definitions by: TANAKA Koichi <https://github.com/MugeSo>
+// Type definitions for prompt-sync 4.2.0
+// Project: https://github.com/heapwolf/prompt-sync
+// Definitions by: TANAKA Koichi <https://github.com/MugeSo>, Yingbo Qiu <https://github.com/qyb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace PromptSync {
@@ -14,7 +14,7 @@ declare namespace PromptSync {
          * prompt -- sync function for reading user input from stdin
          *  @param {String} ask opening question/statement to prompt for
          *  @param {String} value initial value for the prompt
-         *  @param   {Object} opts {
+         *  @param {Object} opts {
          *   echo: set to a character to be echoed, default is '*'. Use '' for no echo
          *   value: {String} initial value for the prompt
          *   ask: {String} opening question/statement to prompt for, does not override ask param
@@ -38,6 +38,7 @@ declare namespace PromptSync {
 
     export interface Config {
         sigint?: boolean | undefined;
+        eot?: boolean | undefined;
         autocomplete?: AutoCompleteFunction | undefined;
         history?: History | undefined;
     }
@@ -63,6 +64,7 @@ declare namespace PromptSync {
  * create -- sync function for reading user input from stdin
  * @param   {Object} config {
  *   sigint: {Boolean} exit on ^C
+ *   eot: {Boolean} exit on ^D
  *   autocomplete: {StringArray} function({String})
  *   history: {String} a history control object (see `prompt-sync-history`)
  * }

--- a/types/prompt-sync/prompt-sync-tests.ts
+++ b/types/prompt-sync/prompt-sync-tests.ts
@@ -11,6 +11,7 @@ prompt = promptSync();
 prompt = promptSync({
     history: history,
     sigint: false,
+    eot: false,
     autocomplete: (input:string) => [input]
 });
 


### PR DESCRIPTION
- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [*] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
