### PR TITLE
[ssh2] Update typings split from ssh2-streams

### DIFF
--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import * as crypto from "crypto";
 import * as ssh2 from 'ssh2';
-import * as ssh2_streams from 'ssh2-streams';
 
 declare var inspect: any;
 
@@ -135,7 +134,7 @@ conn.on('ready', () => {
     console.log('Client :: ready');
     conn.sftp( (err: Error, sftp: ssh2.SFTPWrapper) => {
         if (err) throw err;
-        sftp.readdir('foo', (err: Error, list: ssh2_streams.FileEntry[]) => {
+        sftp.readdir('foo', (err: Error | undefined, list: ssh2.FileEntry[]) => {
             if (err) throw err;
             console.dir(list);
             conn.end();
@@ -327,7 +326,7 @@ var buffersEqual = require('buffer-equal-constant-time'),
     //ssh2 = require('ssh2'),
     utils = ssh2.utils;
 
-var pubKey = utils.parseKey(fs.readFileSync('user.pub')) as ssh2_streams.ParsedKey;
+var pubKey = utils.parseKey(fs.readFileSync('user.pub')) as ssh2.ParsedKey;
 var pubKeySSH = Buffer.from(pubKey.getPublicSSH());
 
 var flags = utils.sftp.OPEN_MODE.READ | utils.sftp.OPEN_MODE.WRITE;
@@ -384,8 +383,8 @@ new ssh2.Server({
 // SFTP only server:
 
 //var ssh2 = require('ssh2');
-var OPEN_MODE = ssh2.SFTP_OPEN_MODE,
-    STATUS_CODE = ssh2.SFTP_STATUS_CODE;
+var OPEN_MODE = ssh2.utils.sftp.OPEN_MODE,
+    STATUS_CODE = ssh2.utils.sftp.STATUS_CODE;
 
 new ssh2.Server({
     hostKeys: [fs.readFileSync('host.key')]
@@ -461,4 +460,22 @@ new ssh2.Client().connect({
             callback(undefined, Buffer.concat([Buffer.from(publicKey), data]));
         }
     })()
+});
+
+new ssh2.HTTPAgent({
+    host: '192.168.100.100',
+    port: 22,
+    username: 'frylock',
+    privateKey: require('fs').readFileSync('/here/is/my/key')
+}, {
+    srcIP: '127.0.0.1',
+});
+
+new ssh2.HTTPSAgent({
+    host: '192.168.100.100',
+    port: 22,
+    username: 'frylock',
+    privateKey: require('fs').readFileSync('/here/is/my/key')
+}, {
+    srcIP: '127.0.0.1',
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/ssh2-streams
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

- Bumped the version number, we are now on 1.11
- Removed dependency on ssh2-streams (ssh2 has no such dependency - https://github.com/mscdex/ssh2/blob/master/package.json)
- Added type definitions for the types that were being imported from ssh2-streams
- Added missing types that were defined (HTTPAgent/HTTPSAgent)
- Updated typings to make them more accurate
- Removed the erroneous export of `SFTP_STATUS_CODE`
- Updated callback style to specify type for `err` parameter