### PR TITLE
Remove stray references to eslint rules

### DIFF
--- a/types/powerbi-visuals-tools/index.d.ts
+++ b/types/powerbi-visuals-tools/index.d.ts
@@ -190,7 +190,7 @@ declare namespace powerbi {
     /**
      * Represents an operation, to be completed (resolve/rejected) in the future.
      */
-    interface IPromise<T> extends IPromise2<T, T> {// eslint-disable-line interface-name
+    interface IPromise<T> extends IPromise2<T, T> {
     }
 
     /**

--- a/types/vscode/index.d.ts
+++ b/types/vscode/index.d.ts
@@ -1619,7 +1619,6 @@ declare module 'vscode' {
         /**
          * The event listeners can subscribe to.
          */
-        // eslint-disable-next-line vscode-dts-event-naming
         event: Event<T>;
 
         /**

--- a/types/wordpress__admin/components/media-views.d.ts
+++ b/types/wordpress__admin/components/media-views.d.ts
@@ -134,7 +134,6 @@ export interface StateMachine {
     trigger: (event: string, ...args: any[]) => StateMachine;
 }
 
-// eslint-disable-next-line prettier/prettier
 export type Frame = StateMachine &
     View & {
         initialize: () => void;


### PR DESCRIPTION
Now that eslint is checking DT packages, these previously unused references are undefined and cause eslint errors.