### PR TITLE
[@wordpress/blocks] Fix `BlockDeprecation` type.

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -177,16 +177,18 @@ export interface Block<T extends Record<string, any> = {}> {
     /**
      * Block transformations.
      */
-    readonly transforms?: {
-        /**
-         * Transforms from another block type to this block type.
-         */
-        readonly from?: ReadonlyArray<Transform<T>> | undefined;
-        /**
-         * Transforms from this block type to another block type.
-         */
-        readonly to?: readonly Transform[] | undefined;
-    } | undefined;
+    readonly transforms?:
+        | {
+              /**
+               * Transforms from another block type to this block type.
+               */
+              readonly from?: ReadonlyArray<Transform<T>> | undefined;
+              /**
+               * Transforms from this block type to another block type.
+               */
+              readonly to?: readonly Transform[] | undefined;
+          }
+        | undefined;
     /**
      * Array of the names of context values to inherit from an ancestor
      * provider.
@@ -244,8 +246,12 @@ export interface BlockInstance<T extends Record<string, any> = { [k: string]: an
     readonly originalContent?: string | undefined;
 }
 
-export interface BlockDeprecation<T extends Record<string, any>>
-    extends Pick<Block<T>, 'attributes' | 'save' | 'supports'> {
+export interface BlockDeprecation<
+    // The new block attribute types.
+    N extends Record<string, any>,
+    // The old block attribute types.
+    O extends Record<string, any> = Record<string, any>,
+> extends Pick<Block<O>, 'attributes' | 'save' | 'supports'> {
     /**
      * A function which, given the attributes and inner blocks of the
      * parsed block, returns true if the deprecation can handle the block
@@ -253,14 +259,13 @@ export interface BlockDeprecation<T extends Record<string, any>>
      * technically valid even once deprecated, and requires updates to its
      * attributes or inner blocks.
      */
-    isEligible?(attributes: Record<string, any>, innerBlocks: BlockInstance[]): boolean;
+    isEligible?(attributes: O, innerBlocks: BlockInstance[]): boolean;
     /**
      * A function which, given the old attributes and inner blocks is
      * expected to return either the new attributes or a tuple array of
      * [attributes, innerBlocks] compatible with the block.
      */
-    migrate?(attributes: Record<string, any>): T;
-    migrate?(attributes: Record<string, any>, innerBlocks: BlockInstance[]): [T, BlockInstance[]];
+    migrate?(attributes: O, innerBlocks: BlockInstance[]): N | [N, BlockInstance[]];
 }
 
 //
@@ -354,7 +359,8 @@ export namespace AttributeSource {
         | {
               type: 'string';
               default?: string | undefined;
-          });
+          }
+    );
 
     interface Children {
         source: 'children';
@@ -394,29 +400,31 @@ export namespace AttributeSource {
         default?: string | undefined;
     }
 
-    type None = {
-        source?: never | undefined;
-    } & (
-        | {
-              type: 'array';
-              default?: any[] | undefined;
-          }
-        | {
-              type: 'object';
-              default?: object | undefined;
-          }
-        | {
-              type: 'boolean';
-              default?: boolean | undefined;
-          }
-        | {
-              type: 'number';
-              default?: number | undefined;
-          }
-        | {
-              type: 'string';
-              default?: string | undefined;
-          })
+    type None =
+        | ({
+              source?: never | undefined;
+          } & (
+              | {
+                    type: 'array';
+                    default?: any[] | undefined;
+                }
+              | {
+                    type: 'object';
+                    default?: object | undefined;
+                }
+              | {
+                    type: 'boolean';
+                    default?: boolean | undefined;
+                }
+              | {
+                    type: 'number';
+                    default?: number | undefined;
+                }
+              | {
+                    type: 'string';
+                    default?: string | undefined;
+                }
+          ))
         | 'array'
         | 'object'
         | 'boolean'

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -259,7 +259,7 @@ export interface BlockDeprecation<
      * technically valid even once deprecated, and requires updates to its
      * attributes or inner blocks.
      */
-    isEligible?(attributes: O, innerBlocks: BlockInstance[]): boolean;
+    isEligible?(attributes: Record<string, any>, innerBlocks: BlockInstance[]): boolean;
     /**
      * A function which, given the old attributes and inner blocks is
      * expected to return either the new attributes or a tuple array of

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -9,6 +9,19 @@ const BLOCK: blocks.Block<{ foo: string }> = {
         },
     },
     category: 'common',
+    deprecated: [
+        {
+            attributes: {
+                bar: {
+                    type: 'string',
+                },
+            },
+            migrate(attributes) {
+                return { foo: attributes.bar };
+            },
+            save: () => null,
+        }
+    ],
     edit: () => null,
     icon: {
         src: 'block-default',


### PR DESCRIPTION
This PR fixes the `BlockDeprecation` type, which was rather broken. The `migrate` method overloads were unnecessary and even incorrect, since the block is not required to have been using inner-blocks to start using them in a migration, [as demonstrated in WP core](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/quote/v2/deprecated.js#L18-L41). I have changed the `migrate` method to use a single and more accurate signature.

Furthermore, the type parameter of `BlockDeprecation` was misapplied, effectively making it only possible to define deprecations that had identical input and output `attributes` schemas. I have fixed this by adding an optional second type parameter representing the attribute types of the deprecated version of the block. Since the second type parameter is optional, I don't think it counts as a breaking change. I would have liked to have this parameter be inferred from the type of the `attributes` property, but this [does not appear to be possible](https://stackoverflow.com/questions/55736088/infer-generic-type-in-property-like-in-a-function-for-proper-type-checking), so I just default it to `Record<string, any>` instead.

The changes to `Block.transforms` and `None` are just automatic formatting tweaks and have nothing to do with the purpose of this PR.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
