### PR TITLE
Mark estree and estree-jsx as 1.0

### DIFF
--- a/types/estree-jsx/estree-jsx-tests.ts
+++ b/types/estree-jsx/estree-jsx-tests.ts
@@ -16,7 +16,7 @@ import {
     JSXClosingFragment,
     JSXElement,
     JSXFragment,
-    JSXText
+    JSXText,
 } from 'estree-jsx';
 
 declare let node: Node;
@@ -82,49 +82,49 @@ string = text.raw;
 // Test narrowing
 
 switch (node.type) {
-  case 'JSXAttribute':
-    attribute = node;
-    break;
-  case 'JSXClosingElement':
-    closingElement = node;
-    break;
-  case 'JSXClosingFragment':
-    closingFragment = node;
-    break;
-  case 'JSXElement':
-    element = node;
-    break;
-  case 'JSXEmptyExpression':
-    emptyExpression = node;
-    break;
-  case 'JSXExpressionContainer':
-    expressionContainer = node;
-    break;
-  case 'JSXFragment':
-    fragment = node;
-    break;
-  case 'JSXIdentifier':
-    identifier = node;
-    break;
-  case 'JSXMemberExpression':
-    memberExpression = node;
-    break;
-  case 'JSXNamespacedName':
-    namespacedName = node;
-    break;
-  case 'JSXOpeningElement':
-    openingElement = node;
-    break;
-  case 'JSXOpeningFragment':
-    openingFragment = node;
-    break;
-  case 'JSXSpreadAttribute':
-    spreadAttribute = node;
-    break;
-  case 'JSXText':
-    text = node;
-    break;
+    case 'JSXAttribute':
+        attribute = node;
+        break;
+    case 'JSXClosingElement':
+        closingElement = node;
+        break;
+    case 'JSXClosingFragment':
+        closingFragment = node;
+        break;
+    case 'JSXElement':
+        element = node;
+        break;
+    case 'JSXEmptyExpression':
+        emptyExpression = node;
+        break;
+    case 'JSXExpressionContainer':
+        expressionContainer = node;
+        break;
+    case 'JSXFragment':
+        fragment = node;
+        break;
+    case 'JSXIdentifier':
+        identifier = node;
+        break;
+    case 'JSXMemberExpression':
+        memberExpression = node;
+        break;
+    case 'JSXNamespacedName':
+        namespacedName = node;
+        break;
+    case 'JSXOpeningElement':
+        openingElement = node;
+        break;
+    case 'JSXOpeningFragment':
+        openingFragment = node;
+        break;
+    case 'JSXSpreadAttribute':
+        spreadAttribute = node;
+        break;
+    case 'JSXText':
+        text = node;
+        break;
 
-  default:
-    estreeNode = node;
+    default:
+        estreeNode = node;
 }

--- a/types/estree-jsx/index.d.ts
+++ b/types/estree-jsx/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package 1.0
+// Type definitions for non-npm package estree-jsx 1.0
 // Project: https://github.com/facebook/jsx
 // Definitions by: Tony Ross <https://github.com/antross>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/estree-jsx/index.d.ts
+++ b/types/estree-jsx/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for JSX extensions to ESTree AST specification
+// Type definitions for JSX extensions to ESTree AST specification 1.0
 // Project: https://github.com/facebook/jsx
 // Definitions by: Tony Ross <https://github.com/antross>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/estree-jsx/index.d.ts
+++ b/types/estree-jsx/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for JSX extensions to ESTree AST specification 1.0
+// Type definitions for non-npm package 1.0
 // Project: https://github.com/facebook/jsx
 // Definitions by: Tony Ross <https://github.com/antross>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/estree-jsx/tslint.json
+++ b/types/estree-jsx/tslint.json
@@ -1,7 +1,6 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
-        "dt-header": false,
         "npm-naming": false
     }
 }

--- a/types/estree-jsx/tslint.json
+++ b/types/estree-jsx/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
-        "dt-header": false
+        "dt-header": false,
+        "npm-naming": false
     }
 }

--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -186,13 +186,11 @@ expression = forInStatement.right;
 // ArrayExpression
 var arrayExpression: ESTree.ArrayExpression;
 string = arrayExpression.type;
-var expressionOrSpread: ESTree.Expression | ESTree.SpreadElement | null
-    = arrayExpression.elements[0];
+var expressionOrSpread: ESTree.Expression | ESTree.SpreadElement | null = arrayExpression.elements[0];
 
 // ObjectExpression
 var objectExpression: ESTree.ObjectExpression;
-var propertyOrSpread: ESTree.Property | ESTree.SpreadElement
-    = objectExpression.properties[0];
+var propertyOrSpread: ESTree.Property | ESTree.SpreadElement = objectExpression.properties[0];
 
 string = property.type;
 if (property.type === 'Property') {
@@ -213,7 +211,7 @@ booleanMaybe = functionExpression.async;
 
 // SequenceExpression
 var sequenceExpression: ESTree.SequenceExpression;
-expression = sequenceExpression.expressions[0]
+expression = sequenceExpression.expressions[0];
 
 // UnaryExpression
 var unaryExpression: ESTree.UnaryExpression;
@@ -252,12 +250,12 @@ var chainExpression: ESTree.ChainExpression;
 var memberExpressionOrCallExpression = chainExpression.expression;
 boolean = memberExpressionOrCallExpression.optional;
 if (memberExpressionOrCallExpression.type === 'MemberExpression') {
-  expressionOrSuper = memberExpressionOrCallExpression.object;
-  privateIdentifierOrExpression = memberExpressionOrCallExpression.property;
-  boolean = memberExpressionOrCallExpression.computed;
+    expressionOrSuper = memberExpressionOrCallExpression.object;
+    privateIdentifierOrExpression = memberExpressionOrCallExpression.property;
+    boolean = memberExpressionOrCallExpression.computed;
 } else {
-  expressionOrSuper = memberExpressionOrCallExpression.callee;
-  expressionOrSpread = callExpression.arguments[0];
+    expressionOrSuper = memberExpressionOrCallExpression.callee;
+    expressionOrSpread = callExpression.arguments[0];
 }
 
 // Declarations
@@ -308,493 +306,493 @@ expression = awaitExpression.argument;
 // Test narrowing
 
 switch (node.type) {
-  case 'Identifier':
-    identifier = node;
-    break;
-  case 'PrivateIdentifier':
-    privateIdentifier = node;
-    break;
-  case 'Literal':
-    literal = node;
-    break;
-  case 'Program':
-    program = node;
-    break;
-  case 'FunctionExpression':
-    functionExpression = node
-    break;
-  case 'SwitchCase':
-    switchCase = node
-    break;
-  case 'CatchClause':
-    catchClause = node
-    break;
-  case 'VariableDeclarator':
-    variableDeclarator = node
-    break;
-  // Narrowing of Statement
-  case 'ExpressionStatement':
-    expressionStatement = node;
-    break;
-  case 'BlockStatement':
-    blockStatement = node;
-    break;
-  case 'EmptyStatement':
-    emptyStatement = node;
-    break;
-  case 'DebuggerStatement':
-    debuggerStatement = node;
-    break;
-  case 'WithStatement':
-    withStatement = node;
-    break;
-  case 'ReturnStatement':
-    returnStatement = node;
-    break;
-  case 'LabeledStatement':
-    labeledStatement = node;
-    break;
-  case 'BreakStatement':
-    breakStatement = node;
-    break;
-  case 'ContinueStatement':
-    continueStatement = node;
-    break;
-  case 'IfStatement':
-    ifStatement = node;
-    break;
-  case 'SwitchStatement':
-    switchStatement = node;
-    break;
-  case 'ThrowStatement':
-    throwStatement = node;
-    break;
-  case 'TryStatement':
-    tryStatement = node;
-    break;
-  case 'WhileStatement':
-    whileStatement = node;
-    break;
-  case 'DoWhileStatement':
-    doWhileStatement = node;
-    break;
-  case 'ForStatement':
-    forStatement = node;
-    break;
-  case 'ForInStatement':
-    forInStatement = node;
-    break;
-  case 'ForOfStatement':
-    forOfStatement = node;
-    break;
-  // end narrowing of Statement
+    case 'Identifier':
+        identifier = node;
+        break;
+    case 'PrivateIdentifier':
+        privateIdentifier = node;
+        break;
+    case 'Literal':
+        literal = node;
+        break;
+    case 'Program':
+        program = node;
+        break;
+    case 'FunctionExpression':
+        functionExpression = node;
+        break;
+    case 'SwitchCase':
+        switchCase = node;
+        break;
+    case 'CatchClause':
+        catchClause = node;
+        break;
+    case 'VariableDeclarator':
+        variableDeclarator = node;
+        break;
+    // Narrowing of Statement
+    case 'ExpressionStatement':
+        expressionStatement = node;
+        break;
+    case 'BlockStatement':
+        blockStatement = node;
+        break;
+    case 'EmptyStatement':
+        emptyStatement = node;
+        break;
+    case 'DebuggerStatement':
+        debuggerStatement = node;
+        break;
+    case 'WithStatement':
+        withStatement = node;
+        break;
+    case 'ReturnStatement':
+        returnStatement = node;
+        break;
+    case 'LabeledStatement':
+        labeledStatement = node;
+        break;
+    case 'BreakStatement':
+        breakStatement = node;
+        break;
+    case 'ContinueStatement':
+        continueStatement = node;
+        break;
+    case 'IfStatement':
+        ifStatement = node;
+        break;
+    case 'SwitchStatement':
+        switchStatement = node;
+        break;
+    case 'ThrowStatement':
+        throwStatement = node;
+        break;
+    case 'TryStatement':
+        tryStatement = node;
+        break;
+    case 'WhileStatement':
+        whileStatement = node;
+        break;
+    case 'DoWhileStatement':
+        doWhileStatement = node;
+        break;
+    case 'ForStatement':
+        forStatement = node;
+        break;
+    case 'ForInStatement':
+        forInStatement = node;
+        break;
+    case 'ForOfStatement':
+        forOfStatement = node;
+        break;
+    // end narrowing of Statement
 
-  // narrowing of Declaration
-  case 'FunctionDeclaration':
-    functionDeclaration = node;
-    break;
-  case 'VariableDeclaration':
-    variableDeclaration = node;
-    break;
-  case 'ClassDeclaration':
-    classDeclaration = node;
-    break;
-  // end narrowing of Declaration
+    // narrowing of Declaration
+    case 'FunctionDeclaration':
+        functionDeclaration = node;
+        break;
+    case 'VariableDeclaration':
+        variableDeclaration = node;
+        break;
+    case 'ClassDeclaration':
+        classDeclaration = node;
+        break;
+    // end narrowing of Declaration
 
-  // narrowing of Expression
-  case 'ThisExpression':
-    thisExpression = node;
-    break;
-  case 'ArrayExpression':
-    arrayExpression = node;
-    break;
-  case 'ObjectExpression':
-    objectExpression = node;
-    break;
-  case 'ArrowFunctionExpression':
-    arrowFunctionExpression = node;
-    break;
-  case 'YieldExpression':
-    yieldExpression = node;
-    break;
-  case 'UnaryExpression':
-    unaryExpression = node;
-    break;
-  case 'UpdateExpression':
-    updateExpression = node;
-    break;
-  case 'BinaryExpression':
-    binaryExpression = node;
-    break;
-  case 'AssignmentExpression':
-    assignmentExpression = node;
-    break;
-  case 'LogicalExpression':
-    logicalExpression = node;
-    break;
-  case 'MemberExpression':
-    memberExpression = node;
-    break;
-  case 'ChainExpression':
-    chainExpression = node;
-    break;
-  case 'ConditionalExpression':
-    conditionalExpression = node;
-    break;
-  case 'CallExpression':
-    callExpression = node;
-    break;
-  case 'NewExpression':
-    newExpression = node;
-    break;
-  case 'SequenceExpression':
-    sequenceExpression = node;
-    break;
-  case 'TemplateLiteral':
-    templateLiteral = node;
-    break;
-  case 'TaggedTemplateExpression':
-    taggedTemplateExpression = node;
-    break;
-  case 'ClassExpression':
-    classExpression = node;
-    break;
-  case 'MetaProperty':
-    metaProperty = node;
-    break;
-  case 'AwaitExpression':
-    awaitExpression = node;
-    break;
-  case 'ImportExpression':
-    importExpression = node;
-    break;
-  // end narrowing of Expression
+    // narrowing of Expression
+    case 'ThisExpression':
+        thisExpression = node;
+        break;
+    case 'ArrayExpression':
+        arrayExpression = node;
+        break;
+    case 'ObjectExpression':
+        objectExpression = node;
+        break;
+    case 'ArrowFunctionExpression':
+        arrowFunctionExpression = node;
+        break;
+    case 'YieldExpression':
+        yieldExpression = node;
+        break;
+    case 'UnaryExpression':
+        unaryExpression = node;
+        break;
+    case 'UpdateExpression':
+        updateExpression = node;
+        break;
+    case 'BinaryExpression':
+        binaryExpression = node;
+        break;
+    case 'AssignmentExpression':
+        assignmentExpression = node;
+        break;
+    case 'LogicalExpression':
+        logicalExpression = node;
+        break;
+    case 'MemberExpression':
+        memberExpression = node;
+        break;
+    case 'ChainExpression':
+        chainExpression = node;
+        break;
+    case 'ConditionalExpression':
+        conditionalExpression = node;
+        break;
+    case 'CallExpression':
+        callExpression = node;
+        break;
+    case 'NewExpression':
+        newExpression = node;
+        break;
+    case 'SequenceExpression':
+        sequenceExpression = node;
+        break;
+    case 'TemplateLiteral':
+        templateLiteral = node;
+        break;
+    case 'TaggedTemplateExpression':
+        taggedTemplateExpression = node;
+        break;
+    case 'ClassExpression':
+        classExpression = node;
+        break;
+    case 'MetaProperty':
+        metaProperty = node;
+        break;
+    case 'AwaitExpression':
+        awaitExpression = node;
+        break;
+    case 'ImportExpression':
+        importExpression = node;
+        break;
+    // end narrowing of Expression
 
-  case 'Property':
-    property = node
-    break;
-  case 'Super':
-    superAst = node
-    break;
-  case 'TemplateElement':
-    templateElement = node
-    break;
-  case 'SpreadElement':
-    spreadElement = node
-    break;
+    case 'Property':
+        property = node;
+        break;
+    case 'Super':
+        superAst = node;
+        break;
+    case 'TemplateElement':
+        templateElement = node;
+        break;
+    case 'SpreadElement':
+        spreadElement = node;
+        break;
 
-  // narrowing of Pattern
-  case 'ObjectPattern':
-    objectPattern = node;
-    break;
-  case 'ArrayPattern':
-    arrayPattern = node;
-    break;
-  case 'RestElement':
-    restElement = node;
-    break;
-  case 'AssignmentPattern':
-    assignmentPattern = node;
-    break;
-  // end narrowing of Pattern
+    // narrowing of Pattern
+    case 'ObjectPattern':
+        objectPattern = node;
+        break;
+    case 'ArrayPattern':
+        arrayPattern = node;
+        break;
+    case 'RestElement':
+        restElement = node;
+        break;
+    case 'AssignmentPattern':
+        assignmentPattern = node;
+        break;
+    // end narrowing of Pattern
 
-  case 'ClassBody':
-    classBody = node
-    break;
-  case 'MethodDefinition':
-    methodDefinition = node
-    break;
-  case 'PropertyDefinition':
-    propertyDefinition = node
-    break;
-  case 'StaticBlock':
-    staticBlock = node
-    break;
+    case 'ClassBody':
+        classBody = node;
+        break;
+    case 'MethodDefinition':
+        methodDefinition = node;
+        break;
+    case 'PropertyDefinition':
+        propertyDefinition = node;
+        break;
+    case 'StaticBlock':
+        staticBlock = node;
+        break;
 
-  // narrowing of ModuleDeclaration
-  case 'ImportDeclaration':
-    importDeclaration = node;
-    break;
-  case 'ExportNamedDeclaration':
-    exportNamedDeclaration = node;
-    break;
-  case 'ExportDefaultDeclaration':
-    exportDefaultDeclaration = node;
-    break;
-  case 'ExportAllDeclaration':
-    exportAllDeclaration = node;
-    break;
-  // end narrowing of ModuleDeclaration
+    // narrowing of ModuleDeclaration
+    case 'ImportDeclaration':
+        importDeclaration = node;
+        break;
+    case 'ExportNamedDeclaration':
+        exportNamedDeclaration = node;
+        break;
+    case 'ExportDefaultDeclaration':
+        exportDefaultDeclaration = node;
+        break;
+    case 'ExportAllDeclaration':
+        exportAllDeclaration = node;
+        break;
+    // end narrowing of ModuleDeclaration
 
-  // narrowing of ModuleSpecifier
-  case 'ImportSpecifier':
-    importSpecifier = node;
-    break;
-  case 'ImportDefaultSpecifier':
-    importDefaultSpecifier = node;
-    break;
-  case 'ImportNamespaceSpecifier':
-    importNamespaceSpecifier = node;
-    break;
-  case 'ExportSpecifier':
-    exportSpecifier = node;
-    break;
-  // end narrowing of ModuleSpecifier
+    // narrowing of ModuleSpecifier
+    case 'ImportSpecifier':
+        importSpecifier = node;
+        break;
+    case 'ImportDefaultSpecifier':
+        importDefaultSpecifier = node;
+        break;
+    case 'ImportNamespaceSpecifier':
+        importNamespaceSpecifier = node;
+        break;
+    case 'ExportSpecifier':
+        exportSpecifier = node;
+        break;
+    // end narrowing of ModuleSpecifier
 
-  default:
-    never = node;
+    default:
+        never = node;
 }
 
 switch (statement.type) {
-  case 'ExpressionStatement':
-    expressionStatement = statement;
-    break;
-  case 'BlockStatement':
-    blockStatement = statement;
-    break;
-  case 'StaticBlock':
-    staticBlock = statement;
-    break;
-  case 'EmptyStatement':
-    emptyStatement = statement;
-    break;
-  case 'DebuggerStatement':
-    debuggerStatement = statement;
-    break;
-  case 'WithStatement':
-    withStatement = statement;
-    break;
-  case 'ReturnStatement':
-    returnStatement = statement;
-    break;
-  case 'LabeledStatement':
-    labeledStatement = statement;
-    break;
-  case 'BreakStatement':
-    breakStatement = statement;
-    break;
-  case 'ContinueStatement':
-    continueStatement = statement;
-    break;
-  case 'IfStatement':
-    ifStatement = statement;
-    break;
-  case 'SwitchStatement':
-    switchStatement = statement;
-    break;
-  case 'ThrowStatement':
-    throwStatement = statement;
-    break;
-  case 'TryStatement':
-    tryStatement = statement;
-    break;
-  case 'WhileStatement':
-    whileStatement = statement;
-    break;
-  case 'DoWhileStatement':
-    doWhileStatement = statement;
-    break;
-  case 'ForStatement':
-    forStatement = statement;
-    break;
-  case 'ForInStatement':
-    forInStatement = statement;
-    break;
-  case 'ForOfStatement':
-    forOfStatement = statement;
-    break;
-  // narrowing of Declaration
-  case 'FunctionDeclaration':
-    functionDeclaration = statement;
-    break;
-  case 'VariableDeclaration':
-    variableDeclaration = statement;
-    break;
-  case 'ClassDeclaration':
-    classDeclaration = statement;
-    break;
-  // end narrowing of Declaration
-  default:
-    never = statement;
+    case 'ExpressionStatement':
+        expressionStatement = statement;
+        break;
+    case 'BlockStatement':
+        blockStatement = statement;
+        break;
+    case 'StaticBlock':
+        staticBlock = statement;
+        break;
+    case 'EmptyStatement':
+        emptyStatement = statement;
+        break;
+    case 'DebuggerStatement':
+        debuggerStatement = statement;
+        break;
+    case 'WithStatement':
+        withStatement = statement;
+        break;
+    case 'ReturnStatement':
+        returnStatement = statement;
+        break;
+    case 'LabeledStatement':
+        labeledStatement = statement;
+        break;
+    case 'BreakStatement':
+        breakStatement = statement;
+        break;
+    case 'ContinueStatement':
+        continueStatement = statement;
+        break;
+    case 'IfStatement':
+        ifStatement = statement;
+        break;
+    case 'SwitchStatement':
+        switchStatement = statement;
+        break;
+    case 'ThrowStatement':
+        throwStatement = statement;
+        break;
+    case 'TryStatement':
+        tryStatement = statement;
+        break;
+    case 'WhileStatement':
+        whileStatement = statement;
+        break;
+    case 'DoWhileStatement':
+        doWhileStatement = statement;
+        break;
+    case 'ForStatement':
+        forStatement = statement;
+        break;
+    case 'ForInStatement':
+        forInStatement = statement;
+        break;
+    case 'ForOfStatement':
+        forOfStatement = statement;
+        break;
+    // narrowing of Declaration
+    case 'FunctionDeclaration':
+        functionDeclaration = statement;
+        break;
+    case 'VariableDeclaration':
+        variableDeclaration = statement;
+        break;
+    case 'ClassDeclaration':
+        classDeclaration = statement;
+        break;
+    // end narrowing of Declaration
+    default:
+        never = statement;
 }
 
 switch (expression.type) {
-  case 'ThisExpression':
-    thisExpression = expression;
-    break;
-  case 'ArrayExpression':
-    arrayExpression = expression;
-    break;
-  case 'ObjectExpression':
-    objectExpression = expression;
-    break;
-  case 'FunctionExpression':
-    functionExpression = expression;
-    break;
-  case 'ArrowFunctionExpression':
-    arrowFunctionExpression = expression;
-    break;
-  case 'YieldExpression':
-    yieldExpression = expression;
-    break;
-  case 'Literal':
-    literal = expression;
-    break;
-  case 'UnaryExpression':
-    unaryExpression = expression;
-    break;
-  case 'UpdateExpression':
-    updateExpression = expression;
-    break;
-  case 'BinaryExpression':
-    binaryExpression = expression;
-    break;
-  case 'AssignmentExpression':
-    assignmentExpression = expression;
-    break;
-  case 'LogicalExpression':
-    logicalExpression = expression;
-    break;
-  case 'MemberExpression':
-    memberExpression = expression;
-    break;
-  case 'ChainExpression':
-    chainExpression = expression;
-    break;
-  case 'ConditionalExpression':
-    conditionalExpression = expression;
-    break;
-  case 'CallExpression':
-    callExpression = expression;
-    break;
-  case 'NewExpression':
-    newExpression = expression;
-    break;
-  case 'SequenceExpression':
-    sequenceExpression = expression;
-    break;
-  case 'TemplateLiteral':
-    templateLiteral = expression;
-    break;
-  case 'TaggedTemplateExpression':
-    taggedTemplateExpression = expression;
-    break;
-  case 'ClassExpression':
-    classExpression = expression;
-    break;
-  case 'MetaProperty':
-    metaProperty = expression;
-    break;
-  case 'Identifier':
-    identifier = expression;
-    break;
-  case 'AwaitExpression':
-    awaitExpression = expression;
-    break;
-  case 'ImportExpression':
-    importExpression = expression;
-    break;
-  default:
-    never = expression;
+    case 'ThisExpression':
+        thisExpression = expression;
+        break;
+    case 'ArrayExpression':
+        arrayExpression = expression;
+        break;
+    case 'ObjectExpression':
+        objectExpression = expression;
+        break;
+    case 'FunctionExpression':
+        functionExpression = expression;
+        break;
+    case 'ArrowFunctionExpression':
+        arrowFunctionExpression = expression;
+        break;
+    case 'YieldExpression':
+        yieldExpression = expression;
+        break;
+    case 'Literal':
+        literal = expression;
+        break;
+    case 'UnaryExpression':
+        unaryExpression = expression;
+        break;
+    case 'UpdateExpression':
+        updateExpression = expression;
+        break;
+    case 'BinaryExpression':
+        binaryExpression = expression;
+        break;
+    case 'AssignmentExpression':
+        assignmentExpression = expression;
+        break;
+    case 'LogicalExpression':
+        logicalExpression = expression;
+        break;
+    case 'MemberExpression':
+        memberExpression = expression;
+        break;
+    case 'ChainExpression':
+        chainExpression = expression;
+        break;
+    case 'ConditionalExpression':
+        conditionalExpression = expression;
+        break;
+    case 'CallExpression':
+        callExpression = expression;
+        break;
+    case 'NewExpression':
+        newExpression = expression;
+        break;
+    case 'SequenceExpression':
+        sequenceExpression = expression;
+        break;
+    case 'TemplateLiteral':
+        templateLiteral = expression;
+        break;
+    case 'TaggedTemplateExpression':
+        taggedTemplateExpression = expression;
+        break;
+    case 'ClassExpression':
+        classExpression = expression;
+        break;
+    case 'MetaProperty':
+        metaProperty = expression;
+        break;
+    case 'Identifier':
+        identifier = expression;
+        break;
+    case 'AwaitExpression':
+        awaitExpression = expression;
+        break;
+    case 'ImportExpression':
+        importExpression = expression;
+        break;
+    default:
+        never = expression;
 }
 
 switch (declaration.type) {
-  case 'FunctionDeclaration':
-    functionDeclaration = declaration;
-    break;
-  case 'VariableDeclaration':
-    variableDeclaration = declaration;
-    break;
-  case 'ClassDeclaration':
-    classDeclaration = declaration;
-    break;
-  default:
-    never = declaration;
+    case 'FunctionDeclaration':
+        functionDeclaration = declaration;
+        break;
+    case 'VariableDeclaration':
+        variableDeclaration = declaration;
+        break;
+    case 'ClassDeclaration':
+        classDeclaration = declaration;
+        break;
+    default:
+        never = declaration;
 }
 
 switch (pattern.type) {
-  case 'Identifier':
-    identifier = pattern;
-    break;
-  case 'ObjectPattern':
-    objectPattern = pattern;
-    break;
-  case 'ArrayPattern':
-    arrayPattern = pattern;
-    break;
-  case 'RestElement':
-    restElement = pattern;
-    break;
-  case 'AssignmentPattern':
-    assignmentPattern = pattern;
-    break;
-  case 'MemberExpression':
-    memberExpression = pattern;
-    break;
-  default:
-    never = pattern;
+    case 'Identifier':
+        identifier = pattern;
+        break;
+    case 'ObjectPattern':
+        objectPattern = pattern;
+        break;
+    case 'ArrayPattern':
+        arrayPattern = pattern;
+        break;
+    case 'RestElement':
+        restElement = pattern;
+        break;
+    case 'AssignmentPattern':
+        assignmentPattern = pattern;
+        break;
+    case 'MemberExpression':
+        memberExpression = pattern;
+        break;
+    default:
+        never = pattern;
 }
 
 switch (moduleDeclaration.type) {
-  case 'ImportDeclaration':
-    importDeclaration = moduleDeclaration;
-    break;
-  case 'ExportNamedDeclaration':
-    exportNamedDeclaration = moduleDeclaration;
-    break;
-  case 'ExportDefaultDeclaration':
-    exportDefaultDeclaration = moduleDeclaration;
-    break;
-  case 'ExportAllDeclaration':
-    exportAllDeclaration = moduleDeclaration;
-    break;
-  default:
-    never = moduleDeclaration;
+    case 'ImportDeclaration':
+        importDeclaration = moduleDeclaration;
+        break;
+    case 'ExportNamedDeclaration':
+        exportNamedDeclaration = moduleDeclaration;
+        break;
+    case 'ExportDefaultDeclaration':
+        exportDefaultDeclaration = moduleDeclaration;
+        break;
+    case 'ExportAllDeclaration':
+        exportAllDeclaration = moduleDeclaration;
+        break;
+    default:
+        never = moduleDeclaration;
 }
 
 switch (moduleSpecifier.type) {
-  case 'ImportSpecifier':
-    importSpecifier = moduleSpecifier;
-    break;
-  case 'ImportDefaultSpecifier':
-    importDefaultSpecifier = moduleSpecifier;
-    break;
-  case 'ImportNamespaceSpecifier':
-    importNamespaceSpecifier = moduleSpecifier;
-    break;
-  case 'ExportSpecifier':
-    exportSpecifier = moduleSpecifier;
-    break;
-  default:
-    never = moduleSpecifier;
+    case 'ImportSpecifier':
+        importSpecifier = moduleSpecifier;
+        break;
+    case 'ImportDefaultSpecifier':
+        importDefaultSpecifier = moduleSpecifier;
+        break;
+    case 'ImportNamespaceSpecifier':
+        importNamespaceSpecifier = moduleSpecifier;
+        break;
+    case 'ExportSpecifier':
+        exportSpecifier = moduleSpecifier;
+        break;
+    default:
+        never = moduleSpecifier;
 }
 
 switch (forInStatement.left.type) {
-  case 'Identifier':
-    identifier = forInStatement.left;
-    break;
-  case 'ObjectPattern':
-    objectPattern = forInStatement.left;
-    break;
-  case 'ArrayPattern':
-    arrayPattern = forInStatement.left;
-    break;
-  case 'MemberExpression':
-    memberExpression = forInStatement.left;
-    break;
+    case 'Identifier':
+        identifier = forInStatement.left;
+        break;
+    case 'ObjectPattern':
+        objectPattern = forInStatement.left;
+        break;
+    case 'ArrayPattern':
+        arrayPattern = forInStatement.left;
+        break;
+    case 'MemberExpression':
+        memberExpression = forInStatement.left;
+        break;
 }
 
 switch (forOfStatement.left.type) {
-  case 'Identifier':
-    identifier = forOfStatement.left;
-    break;
-  case 'ObjectPattern':
-    objectPattern = forOfStatement.left;
-    break;
-  case 'ArrayPattern':
-    arrayPattern = forOfStatement.left;
-    break;
-  case 'MemberExpression':
-    memberExpression = forOfStatement.left;
-    break;
+    case 'Identifier':
+        identifier = forOfStatement.left;
+        break;
+    case 'ObjectPattern':
+        objectPattern = forOfStatement.left;
+        break;
+    case 'ArrayPattern':
+        arrayPattern = forOfStatement.left;
+        break;
+    case 'MemberExpression':
+        memberExpression = forOfStatement.left;
+        break;
 }

--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -116,7 +116,7 @@ number = program.loc!.start.line;
 number = program.loc!.start.column;
 number = program.loc!.end.line;
 number = program.loc!.end.column;
-number = program!.range![0];
+number = program.range![0];
 
 // Statement
 // BlockStatement
@@ -262,13 +262,13 @@ if (memberExpressionOrCallExpression.type === 'MemberExpression') {
 var functionDeclaration: ESTree.FunctionDeclaration;
 var identifierOrNull: ESTree.Identifier | null = functionDeclaration.id;
 functionDeclaration.id = null;
-var params: Array<ESTree.Pattern> = functionDeclaration.params;
+var params: ESTree.Pattern[] = functionDeclaration.params;
 blockStatement = functionDeclaration.body;
 booleanMaybe = functionDeclaration.generator;
 booleanMaybe = functionDeclaration.async;
 
 var variableDeclaration: ESTree.VariableDeclaration;
-var declarations: Array<ESTree.VariableDeclarator> = variableDeclaration.declarations;
+var declarations: ESTree.VariableDeclarator[] = variableDeclaration.declarations;
 string = variableDeclaration.kind; // "var" | "let" | "const"
 
 var variableDeclarator: ESTree.VariableDeclarator;

--- a/types/estree/flow.d.ts
+++ b/types/estree/flow.d.ts
@@ -3,172 +3,170 @@
 // Definitions by: RReverser <https://github.com/RReverser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
-
 declare namespace ESTree {
-  interface FlowTypeAnnotation extends Node {}
+    interface FlowTypeAnnotation extends Node {}
 
-  interface FlowBaseTypeAnnotation extends FlowTypeAnnotation {}
+    interface FlowBaseTypeAnnotation extends FlowTypeAnnotation {}
 
-  interface FlowLiteralTypeAnnotation extends FlowTypeAnnotation, Literal {}
+    interface FlowLiteralTypeAnnotation extends FlowTypeAnnotation, Literal {}
 
-  interface FlowDeclaration extends Declaration {}
+    interface FlowDeclaration extends Declaration {}
 
-  interface AnyTypeAnnotation extends FlowBaseTypeAnnotation {}
+    interface AnyTypeAnnotation extends FlowBaseTypeAnnotation {}
 
-  interface ArrayTypeAnnotation extends FlowTypeAnnotation {
-    elementType: FlowTypeAnnotation;
-  }
+    interface ArrayTypeAnnotation extends FlowTypeAnnotation {
+        elementType: FlowTypeAnnotation;
+    }
 
-  interface BooleanLiteralTypeAnnotation extends FlowLiteralTypeAnnotation {}
+    interface BooleanLiteralTypeAnnotation extends FlowLiteralTypeAnnotation {}
 
-  interface BooleanTypeAnnotation extends FlowBaseTypeAnnotation {}
+    interface BooleanTypeAnnotation extends FlowBaseTypeAnnotation {}
 
-  interface ClassImplements extends Node {
-    id: Identifier;
-    typeParameters?: TypeParameterInstantiation | null;
-  }
+    interface ClassImplements extends Node {
+        id: Identifier;
+        typeParameters?: TypeParameterInstantiation | null;
+    }
 
-  interface ClassProperty {
-    key: Expression;
-    value?: Expression | null;
-    typeAnnotation?: TypeAnnotation | null;
-    computed: boolean;
-    static: boolean;
-  }
+    interface ClassProperty {
+        key: Expression;
+        value?: Expression | null;
+        typeAnnotation?: TypeAnnotation | null;
+        computed: boolean;
+        static: boolean;
+    }
 
-  interface DeclareClass extends FlowDeclaration {
-    id: Identifier;
-    typeParameters?: TypeParameterDeclaration | null;
-    body: ObjectTypeAnnotation;
-    extends: Array<InterfaceExtends>;
-  }
+    interface DeclareClass extends FlowDeclaration {
+        id: Identifier;
+        typeParameters?: TypeParameterDeclaration | null;
+        body: ObjectTypeAnnotation;
+        extends: Array<InterfaceExtends>;
+    }
 
-  interface DeclareFunction extends FlowDeclaration {
-    id: Identifier;
-  }
+    interface DeclareFunction extends FlowDeclaration {
+        id: Identifier;
+    }
 
-  interface DeclareModule extends FlowDeclaration {
-    id: Literal | Identifier;
-    body: BlockStatement;
-  }
+    interface DeclareModule extends FlowDeclaration {
+        id: Literal | Identifier;
+        body: BlockStatement;
+    }
 
-  interface DeclareVariable extends FlowDeclaration {
-    id: Identifier;
-  }
+    interface DeclareVariable extends FlowDeclaration {
+        id: Identifier;
+    }
 
-  interface FunctionTypeAnnotation extends FlowTypeAnnotation {
-    params: Array<FunctionTypeParam>;
-    returnType: FlowTypeAnnotation;
-    rest?: FunctionTypeParam | null;
-    typeParameters?: TypeParameterDeclaration | null;
-  }
+    interface FunctionTypeAnnotation extends FlowTypeAnnotation {
+        params: Array<FunctionTypeParam>;
+        returnType: FlowTypeAnnotation;
+        rest?: FunctionTypeParam | null;
+        typeParameters?: TypeParameterDeclaration | null;
+    }
 
-  interface FunctionTypeParam {
-    name: Identifier;
-    typeAnnotation: FlowTypeAnnotation;
-    optional: boolean;
-  }
+    interface FunctionTypeParam {
+        name: Identifier;
+        typeAnnotation: FlowTypeAnnotation;
+        optional: boolean;
+    }
 
-  interface GenericTypeAnnotation extends FlowTypeAnnotation {
-    id: Identifier | QualifiedTypeIdentifier;
-    typeParameters?: TypeParameterInstantiation | null;
-  }
+    interface GenericTypeAnnotation extends FlowTypeAnnotation {
+        id: Identifier | QualifiedTypeIdentifier;
+        typeParameters?: TypeParameterInstantiation | null;
+    }
 
-  interface InterfaceExtends extends Node {
-    id: Identifier | QualifiedTypeIdentifier;
-    typeParameters?: TypeParameterInstantiation | null;
-  }
+    interface InterfaceExtends extends Node {
+        id: Identifier | QualifiedTypeIdentifier;
+        typeParameters?: TypeParameterInstantiation | null;
+    }
 
-  interface InterfaceDeclaration extends FlowDeclaration {
-    id: Identifier;
-    typeParameters?: TypeParameterDeclaration | null;
-    extends: Array<InterfaceExtends>;
-    body: ObjectTypeAnnotation;
-  }
+    interface InterfaceDeclaration extends FlowDeclaration {
+        id: Identifier;
+        typeParameters?: TypeParameterDeclaration | null;
+        extends: Array<InterfaceExtends>;
+        body: ObjectTypeAnnotation;
+    }
 
-  interface IntersectionTypeAnnotation extends FlowTypeAnnotation {
-    types: Array<FlowTypeAnnotation>;
-  }
+    interface IntersectionTypeAnnotation extends FlowTypeAnnotation {
+        types: Array<FlowTypeAnnotation>;
+    }
 
-  interface MixedTypeAnnotation extends FlowBaseTypeAnnotation {}
+    interface MixedTypeAnnotation extends FlowBaseTypeAnnotation {}
 
-  interface NullableTypeAnnotation extends FlowTypeAnnotation {
-    typeAnnotation: TypeAnnotation;
-  }
+    interface NullableTypeAnnotation extends FlowTypeAnnotation {
+        typeAnnotation: TypeAnnotation;
+    }
 
-  interface NumberLiteralTypeAnnotation extends FlowLiteralTypeAnnotation {}
+    interface NumberLiteralTypeAnnotation extends FlowLiteralTypeAnnotation {}
 
-  interface NumberTypeAnnotation extends FlowBaseTypeAnnotation {}
+    interface NumberTypeAnnotation extends FlowBaseTypeAnnotation {}
 
-  interface StringLiteralTypeAnnotation extends FlowLiteralTypeAnnotation {}
+    interface StringLiteralTypeAnnotation extends FlowLiteralTypeAnnotation {}
 
-  interface StringTypeAnnotation extends FlowBaseTypeAnnotation {}
+    interface StringTypeAnnotation extends FlowBaseTypeAnnotation {}
 
-  interface TupleTypeAnnotation extends FlowTypeAnnotation {
-    types: Array<FlowTypeAnnotation>;
-  }
+    interface TupleTypeAnnotation extends FlowTypeAnnotation {
+        types: Array<FlowTypeAnnotation>;
+    }
 
-  interface TypeofTypeAnnotation extends FlowTypeAnnotation {
-    argument: FlowTypeAnnotation;
-  }
+    interface TypeofTypeAnnotation extends FlowTypeAnnotation {
+        argument: FlowTypeAnnotation;
+    }
 
-  interface TypeAlias extends FlowDeclaration {
-    id: Identifier;
-    typeParameters?: TypeParameterDeclaration | null;
-    right: FlowTypeAnnotation;
-  }
+    interface TypeAlias extends FlowDeclaration {
+        id: Identifier;
+        typeParameters?: TypeParameterDeclaration | null;
+        right: FlowTypeAnnotation;
+    }
 
-  interface TypeAnnotation extends Node {
-    typeAnnotation: FlowTypeAnnotation;
-  }
+    interface TypeAnnotation extends Node {
+        typeAnnotation: FlowTypeAnnotation;
+    }
 
-  interface TypeCastExpression extends Expression {
-    expression: Expression;
-    typeAnnotation: TypeAnnotation;
-  }
+    interface TypeCastExpression extends Expression {
+        expression: Expression;
+        typeAnnotation: TypeAnnotation;
+    }
 
-  interface TypeParameterDeclaration extends Node {
-    params: Array<Identifier>;
-  }
+    interface TypeParameterDeclaration extends Node {
+        params: Array<Identifier>;
+    }
 
-  interface TypeParameterInstantiation extends Node {
-    params: Array<FlowTypeAnnotation>;
-  }
+    interface TypeParameterInstantiation extends Node {
+        params: Array<FlowTypeAnnotation>;
+    }
 
-  interface ObjectTypeAnnotation extends FlowTypeAnnotation {
-    properties: Array<ObjectTypeProperty>;
-    indexers: Array<ObjectTypeIndexer>;
-    callProperties: Array<ObjectTypeCallProperty>;
-  }
+    interface ObjectTypeAnnotation extends FlowTypeAnnotation {
+        properties: Array<ObjectTypeProperty>;
+        indexers: Array<ObjectTypeIndexer>;
+        callProperties: Array<ObjectTypeCallProperty>;
+    }
 
-  interface ObjectTypeCallProperty extends Node {
-    value: FunctionTypeAnnotation;
-    static: boolean;
-  }
+    interface ObjectTypeCallProperty extends Node {
+        value: FunctionTypeAnnotation;
+        static: boolean;
+    }
 
-  interface ObjectTypeIndexer extends Node {
-    id: Identifier;
-    key: FlowTypeAnnotation;
-    value: FlowTypeAnnotation;
-    static: boolean;
-  }
+    interface ObjectTypeIndexer extends Node {
+        id: Identifier;
+        key: FlowTypeAnnotation;
+        value: FlowTypeAnnotation;
+        static: boolean;
+    }
 
-  interface ObjectTypeProperty extends Node {
-    key: Expression;
-    value: FlowTypeAnnotation;
-    optional: boolean;
-    static: boolean;
-  }
+    interface ObjectTypeProperty extends Node {
+        key: Expression;
+        value: FlowTypeAnnotation;
+        optional: boolean;
+        static: boolean;
+    }
 
-  interface QualifiedTypeIdentifier extends Node {
-    qualification: Identifier | QualifiedTypeIdentifier;
-    id: Identifier;
-  }
+    interface QualifiedTypeIdentifier extends Node {
+        qualification: Identifier | QualifiedTypeIdentifier;
+        id: Identifier;
+    }
 
-  interface UnionTypeAnnotation extends FlowTypeAnnotation {
-    types: Array<FlowTypeAnnotation>;
-  }
+    interface UnionTypeAnnotation extends FlowTypeAnnotation {
+        types: Array<FlowTypeAnnotation>;
+    }
 
-  interface VoidTypeAnnotation extends FlowBaseTypeAnnotation {}
+    interface VoidTypeAnnotation extends FlowBaseTypeAnnotation {}
 }

--- a/types/estree/flow.d.ts
+++ b/types/estree/flow.d.ts
@@ -1,8 +1,3 @@
-// Type definitions for ESTree AST extensions for Facebook Flow
-// Project: https://github.com/estree/estree
-// Definitions by: RReverser <https://github.com/RReverser>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 declare namespace ESTree {
     interface FlowTypeAnnotation extends Node {}
 
@@ -39,7 +34,7 @@ declare namespace ESTree {
         id: Identifier;
         typeParameters?: TypeParameterDeclaration | null;
         body: ObjectTypeAnnotation;
-        extends: Array<InterfaceExtends>;
+        extends: InterfaceExtends[];
     }
 
     interface DeclareFunction extends FlowDeclaration {
@@ -56,7 +51,7 @@ declare namespace ESTree {
     }
 
     interface FunctionTypeAnnotation extends FlowTypeAnnotation {
-        params: Array<FunctionTypeParam>;
+        params: FunctionTypeParam[];
         returnType: FlowTypeAnnotation;
         rest?: FunctionTypeParam | null;
         typeParameters?: TypeParameterDeclaration | null;
@@ -81,12 +76,12 @@ declare namespace ESTree {
     interface InterfaceDeclaration extends FlowDeclaration {
         id: Identifier;
         typeParameters?: TypeParameterDeclaration | null;
-        extends: Array<InterfaceExtends>;
+        extends: InterfaceExtends[];
         body: ObjectTypeAnnotation;
     }
 
     interface IntersectionTypeAnnotation extends FlowTypeAnnotation {
-        types: Array<FlowTypeAnnotation>;
+        types: FlowTypeAnnotation[];
     }
 
     interface MixedTypeAnnotation extends FlowBaseTypeAnnotation {}
@@ -104,7 +99,7 @@ declare namespace ESTree {
     interface StringTypeAnnotation extends FlowBaseTypeAnnotation {}
 
     interface TupleTypeAnnotation extends FlowTypeAnnotation {
-        types: Array<FlowTypeAnnotation>;
+        types: FlowTypeAnnotation[];
     }
 
     interface TypeofTypeAnnotation extends FlowTypeAnnotation {
@@ -127,17 +122,17 @@ declare namespace ESTree {
     }
 
     interface TypeParameterDeclaration extends Node {
-        params: Array<Identifier>;
+        params: Identifier[];
     }
 
     interface TypeParameterInstantiation extends Node {
-        params: Array<FlowTypeAnnotation>;
+        params: FlowTypeAnnotation[];
     }
 
     interface ObjectTypeAnnotation extends FlowTypeAnnotation {
-        properties: Array<ObjectTypeProperty>;
-        indexers: Array<ObjectTypeIndexer>;
-        callProperties: Array<ObjectTypeCallProperty>;
+        properties: ObjectTypeProperty[];
+        indexers: ObjectTypeIndexer[];
+        callProperties: ObjectTypeCallProperty[];
     }
 
     interface ObjectTypeCallProperty extends Node {
@@ -165,7 +160,7 @@ declare namespace ESTree {
     }
 
     interface UnionTypeAnnotation extends FlowTypeAnnotation {
-        types: Array<FlowTypeAnnotation>;
+        types: FlowTypeAnnotation[];
     }
 
     interface VoidTypeAnnotation extends FlowBaseTypeAnnotation {}

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package 1.0
+// Type definitions for non-npm package estree 1.0
 // Project: https://github.com/estree/estree
 // Definitions by: RReverser <https://github.com/RReverser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -21,7 +21,7 @@
 // but it has the notable advantage of making ESTree much easier to use as
 // an end user.
 
-interface BaseNodeWithoutComments {
+export interface BaseNodeWithoutComments {
     // Every leaf interface that extends BaseNode must specify a type property.
     // The type property should be a string literal. For example, Identifier
     // has: `type: "Identifier"`
@@ -30,12 +30,12 @@ interface BaseNodeWithoutComments {
     range?: [number, number] | undefined;
 }
 
-interface BaseNode extends BaseNodeWithoutComments {
-    leadingComments?: Array<Comment> | undefined;
-    trailingComments?: Array<Comment> | undefined;
+export interface BaseNode extends BaseNodeWithoutComments {
+    leadingComments?: Comment[] | undefined;
+    trailingComments?: Comment[] | undefined;
 }
 
-interface NodeMap {
+export interface NodeMap {
     AssignmentProperty: AssignmentProperty;
     CatchClause: CatchClause;
     Class: Class;
@@ -67,7 +67,7 @@ export interface Comment extends BaseNodeWithoutComments {
     value: string;
 }
 
-interface SourceLocation {
+export interface SourceLocation {
     source?: string | null | undefined;
     start: Position;
     end: Position;
@@ -84,7 +84,7 @@ export interface Program extends BaseNode {
     type: 'Program';
     sourceType: 'script' | 'module';
     body: Array<Directive | Statement | ModuleDeclaration>;
-    comments?: Array<Comment> | undefined;
+    comments?: Comment[] | undefined;
 }
 
 export interface Directive extends BaseNode {
@@ -93,8 +93,8 @@ export interface Directive extends BaseNode {
     directive: string;
 }
 
-interface BaseFunction extends BaseNode {
-    params: Array<Pattern>;
+export interface BaseFunction extends BaseNode {
+    params: Pattern[];
     generator?: boolean | undefined;
     async?: boolean | undefined;
     // The body is either BlockStatement or Expression because arrow functions
@@ -127,7 +127,7 @@ export type Statement =
     | ForOfStatement
     | Declaration;
 
-interface BaseStatement extends BaseNode {}
+export interface BaseStatement extends BaseNode {}
 
 export interface EmptyStatement extends BaseStatement {
     type: 'EmptyStatement';
@@ -135,8 +135,8 @@ export interface EmptyStatement extends BaseStatement {
 
 export interface BlockStatement extends BaseStatement {
     type: 'BlockStatement';
-    body: Array<Statement>;
-    innerComments?: Array<Comment> | undefined;
+    body: Statement[];
+    innerComments?: Comment[] | undefined;
 }
 
 export interface StaticBlock extends Omit<BlockStatement, 'type'> {
@@ -180,7 +180,7 @@ export interface WithStatement extends BaseStatement {
 export interface SwitchStatement extends BaseStatement {
     type: 'SwitchStatement';
     discriminant: Expression;
-    cases: Array<SwitchCase>;
+    cases: SwitchCase[];
 }
 
 export interface ReturnStatement extends BaseStatement {
@@ -220,7 +220,7 @@ export interface ForStatement extends BaseStatement {
     body: Statement;
 }
 
-interface BaseForXStatement extends BaseStatement {
+export interface BaseForXStatement extends BaseStatement {
     left: VariableDeclaration | Pattern;
     right: Expression;
     body: Statement;
@@ -236,7 +236,7 @@ export interface DebuggerStatement extends BaseStatement {
 
 export type Declaration = FunctionDeclaration | VariableDeclaration | ClassDeclaration;
 
-interface BaseDeclaration extends BaseStatement {}
+export interface BaseDeclaration extends BaseStatement {}
 
 export interface FunctionDeclaration extends BaseFunction, BaseDeclaration {
     type: 'FunctionDeclaration';
@@ -247,7 +247,7 @@ export interface FunctionDeclaration extends BaseFunction, BaseDeclaration {
 
 export interface VariableDeclaration extends BaseDeclaration {
     type: 'VariableDeclaration';
-    declarations: Array<VariableDeclarator>;
+    declarations: VariableDeclarator[];
     kind: 'var' | 'let' | 'const';
 }
 
@@ -285,11 +285,11 @@ export interface ExpressionMap {
     YieldExpression: YieldExpression;
 }
 
-type Expression = ExpressionMap[keyof ExpressionMap];
+export type Expression = ExpressionMap[keyof ExpressionMap];
 
 export interface BaseExpression extends BaseNode {}
 
-type ChainElement = SimpleCallExpression | MemberExpression;
+export type ChainElement = SimpleCallExpression | MemberExpression;
 
 export interface ChainExpression extends BaseExpression {
     type: 'ChainExpression';
@@ -341,7 +341,7 @@ export interface FunctionExpression extends BaseFunction, BaseExpression {
 
 export interface SequenceExpression extends BaseExpression {
     type: 'SequenceExpression';
-    expressions: Array<Expression>;
+    expressions: Expression[];
 }
 
 export interface UnaryExpression extends BaseExpression {
@@ -386,7 +386,7 @@ export interface ConditionalExpression extends BaseExpression {
     consequent: Expression;
 }
 
-interface BaseCallExpression extends BaseExpression {
+export interface BaseCallExpression extends BaseExpression {
     callee: Expression | Super;
     arguments: Array<Expression | SpreadElement>;
 }
@@ -411,12 +411,12 @@ export interface MemberExpression extends BaseExpression, BasePattern {
 
 export type Pattern = Identifier | ObjectPattern | ArrayPattern | RestElement | AssignmentPattern | MemberExpression;
 
-interface BasePattern extends BaseNode {}
+export interface BasePattern extends BaseNode {}
 
 export interface SwitchCase extends BaseNode {
     type: 'SwitchCase';
     test?: Expression | null | undefined;
-    consequent: Array<Statement>;
+    consequent: Statement[];
 }
 
 export interface CatchClause extends BaseNode {
@@ -528,8 +528,8 @@ export interface YieldExpression extends BaseExpression {
 
 export interface TemplateLiteral extends BaseExpression {
     type: 'TemplateLiteral';
-    quasis: Array<TemplateElement>;
-    expressions: Array<Expression>;
+    quasis: TemplateElement[];
+    expressions: Expression[];
 }
 
 export interface TaggedTemplateExpression extends BaseExpression {
@@ -576,7 +576,7 @@ export interface AssignmentPattern extends BasePattern {
 }
 
 export type Class = ClassDeclaration | ClassExpression;
-interface BaseClass extends BaseNode {
+export interface BaseClass extends BaseNode {
     superClass?: Expression | null | undefined;
     body: ClassBody;
 }
@@ -617,10 +617,10 @@ export type ModuleDeclaration =
     | ExportNamedDeclaration
     | ExportDefaultDeclaration
     | ExportAllDeclaration;
-interface BaseModuleDeclaration extends BaseNode {}
+export interface BaseModuleDeclaration extends BaseNode {}
 
 export type ModuleSpecifier = ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier;
-interface BaseModuleSpecifier extends BaseNode {
+export interface BaseModuleSpecifier extends BaseNode {
     local: Identifier;
 }
 
@@ -651,7 +651,7 @@ export interface ImportNamespaceSpecifier extends BaseModuleSpecifier {
 export interface ExportNamedDeclaration extends BaseModuleDeclaration {
     type: 'ExportNamedDeclaration';
     declaration?: Declaration | null | undefined;
-    specifiers: Array<ExportSpecifier>;
+    specifiers: ExportSpecifier[];
     source?: Literal | null | undefined;
 }
 

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ESTree AST specification 1.0
+// Type definitions for non-npm package 1.0
 // Project: https://github.com/estree/estree
 // Definitions by: RReverser <https://github.com/RReverser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ESTree AST specification
+// Type definitions for ESTree AST specification 1.0
 // Project: https://github.com/estree/estree
 // Definitions by: RReverser <https://github.com/RReverser>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -22,298 +22,311 @@
 // an end user.
 
 interface BaseNodeWithoutComments {
-  // Every leaf interface that extends BaseNode must specify a type property.
-  // The type property should be a string literal. For example, Identifier
-  // has: `type: "Identifier"`
-  type: string;
-  loc?: SourceLocation | null | undefined;
-  range?: [number, number] | undefined;
+    // Every leaf interface that extends BaseNode must specify a type property.
+    // The type property should be a string literal. For example, Identifier
+    // has: `type: "Identifier"`
+    type: string;
+    loc?: SourceLocation | null | undefined;
+    range?: [number, number] | undefined;
 }
 
 interface BaseNode extends BaseNodeWithoutComments {
-  leadingComments?: Array<Comment> | undefined;
-  trailingComments?: Array<Comment> | undefined;
+    leadingComments?: Array<Comment> | undefined;
+    trailingComments?: Array<Comment> | undefined;
 }
 
 interface NodeMap {
-  AssignmentProperty: AssignmentProperty;
-  CatchClause: CatchClause;
-  Class: Class;
-  ClassBody: ClassBody;
-  Expression: Expression;
-  Function: Function;
-  Identifier: Identifier;
-  Literal: Literal;
-  MethodDefinition: MethodDefinition;
-  ModuleDeclaration: ModuleDeclaration;
-  ModuleSpecifier: ModuleSpecifier;
-  Pattern: Pattern;
-  PrivateIdentifier: PrivateIdentifier;
-  Program: Program;
-  Property: Property;
-  PropertyDefinition: PropertyDefinition;
-  SpreadElement: SpreadElement;
-  Statement: Statement;
-  Super: Super;
-  SwitchCase: SwitchCase;
-  TemplateElement: TemplateElement;
-  VariableDeclarator: VariableDeclarator;
+    AssignmentProperty: AssignmentProperty;
+    CatchClause: CatchClause;
+    Class: Class;
+    ClassBody: ClassBody;
+    Expression: Expression;
+    Function: Function;
+    Identifier: Identifier;
+    Literal: Literal;
+    MethodDefinition: MethodDefinition;
+    ModuleDeclaration: ModuleDeclaration;
+    ModuleSpecifier: ModuleSpecifier;
+    Pattern: Pattern;
+    PrivateIdentifier: PrivateIdentifier;
+    Program: Program;
+    Property: Property;
+    PropertyDefinition: PropertyDefinition;
+    SpreadElement: SpreadElement;
+    Statement: Statement;
+    Super: Super;
+    SwitchCase: SwitchCase;
+    TemplateElement: TemplateElement;
+    VariableDeclarator: VariableDeclarator;
 }
 
-export type Node = NodeMap[keyof NodeMap]
+export type Node = NodeMap[keyof NodeMap];
 
 export interface Comment extends BaseNodeWithoutComments {
-  type: "Line" | "Block";
-  value: string;
+    type: 'Line' | 'Block';
+    value: string;
 }
 
 interface SourceLocation {
-  source?: string | null | undefined;
-  start: Position;
-  end: Position;
+    source?: string | null | undefined;
+    start: Position;
+    end: Position;
 }
 
 export interface Position {
-  /** >= 1 */
-  line: number;
-  /** >= 0 */
-  column: number;
+    /** >= 1 */
+    line: number;
+    /** >= 0 */
+    column: number;
 }
 
 export interface Program extends BaseNode {
-  type: "Program";
-  sourceType: "script" | "module";
-  body: Array<Directive | Statement | ModuleDeclaration>;
-  comments?: Array<Comment> | undefined;
+    type: 'Program';
+    sourceType: 'script' | 'module';
+    body: Array<Directive | Statement | ModuleDeclaration>;
+    comments?: Array<Comment> | undefined;
 }
 
 export interface Directive extends BaseNode {
-  type: "ExpressionStatement";
-  expression: Literal;
-  directive: string;
+    type: 'ExpressionStatement';
+    expression: Literal;
+    directive: string;
 }
 
 interface BaseFunction extends BaseNode {
-  params: Array<Pattern>;
-  generator?: boolean | undefined;
-  async?: boolean | undefined;
-  // The body is either BlockStatement or Expression because arrow functions
-  // can have a body that's either. FunctionDeclarations and
-  // FunctionExpressions have only BlockStatement bodies.
-  body: BlockStatement | Expression;
+    params: Array<Pattern>;
+    generator?: boolean | undefined;
+    async?: boolean | undefined;
+    // The body is either BlockStatement or Expression because arrow functions
+    // can have a body that's either. FunctionDeclarations and
+    // FunctionExpressions have only BlockStatement bodies.
+    body: BlockStatement | Expression;
 }
 
-export type Function =
-    FunctionDeclaration | FunctionExpression | ArrowFunctionExpression;
+export type Function = FunctionDeclaration | FunctionExpression | ArrowFunctionExpression;
 
 export type Statement =
-    ExpressionStatement | BlockStatement | StaticBlock | EmptyStatement |
-    DebuggerStatement | WithStatement | ReturnStatement | LabeledStatement |
-    BreakStatement | ContinueStatement | IfStatement | SwitchStatement |
-    ThrowStatement | TryStatement | WhileStatement | DoWhileStatement |
-    ForStatement | ForInStatement | ForOfStatement | Declaration;
+    | ExpressionStatement
+    | BlockStatement
+    | StaticBlock
+    | EmptyStatement
+    | DebuggerStatement
+    | WithStatement
+    | ReturnStatement
+    | LabeledStatement
+    | BreakStatement
+    | ContinueStatement
+    | IfStatement
+    | SwitchStatement
+    | ThrowStatement
+    | TryStatement
+    | WhileStatement
+    | DoWhileStatement
+    | ForStatement
+    | ForInStatement
+    | ForOfStatement
+    | Declaration;
 
-interface BaseStatement extends BaseNode { }
+interface BaseStatement extends BaseNode {}
 
 export interface EmptyStatement extends BaseStatement {
-  type: "EmptyStatement";
+    type: 'EmptyStatement';
 }
 
 export interface BlockStatement extends BaseStatement {
-  type: "BlockStatement";
-  body: Array<Statement>;
-  innerComments?: Array<Comment> | undefined;
+    type: 'BlockStatement';
+    body: Array<Statement>;
+    innerComments?: Array<Comment> | undefined;
 }
 
 export interface StaticBlock extends Omit<BlockStatement, 'type'> {
-    type: "StaticBlock";
+    type: 'StaticBlock';
 }
 
 export interface ExpressionStatement extends BaseStatement {
-  type: "ExpressionStatement";
-  expression: Expression;
+    type: 'ExpressionStatement';
+    expression: Expression;
 }
 
 export interface IfStatement extends BaseStatement {
-  type: "IfStatement";
-  test: Expression;
-  consequent: Statement;
-  alternate?: Statement | null | undefined;
+    type: 'IfStatement';
+    test: Expression;
+    consequent: Statement;
+    alternate?: Statement | null | undefined;
 }
 
 export interface LabeledStatement extends BaseStatement {
-  type: "LabeledStatement";
-  label: Identifier;
-  body: Statement;
+    type: 'LabeledStatement';
+    label: Identifier;
+    body: Statement;
 }
 
 export interface BreakStatement extends BaseStatement {
-  type: "BreakStatement";
-  label?: Identifier | null | undefined;
+    type: 'BreakStatement';
+    label?: Identifier | null | undefined;
 }
 
 export interface ContinueStatement extends BaseStatement {
-  type: "ContinueStatement";
-  label?: Identifier | null | undefined;
+    type: 'ContinueStatement';
+    label?: Identifier | null | undefined;
 }
 
 export interface WithStatement extends BaseStatement {
-  type: "WithStatement";
-  object: Expression;
-  body: Statement;
+    type: 'WithStatement';
+    object: Expression;
+    body: Statement;
 }
 
 export interface SwitchStatement extends BaseStatement {
-  type: "SwitchStatement";
-  discriminant: Expression;
-  cases: Array<SwitchCase>;
+    type: 'SwitchStatement';
+    discriminant: Expression;
+    cases: Array<SwitchCase>;
 }
 
 export interface ReturnStatement extends BaseStatement {
-  type: "ReturnStatement";
-  argument?: Expression | null | undefined;
+    type: 'ReturnStatement';
+    argument?: Expression | null | undefined;
 }
 
 export interface ThrowStatement extends BaseStatement {
-  type: "ThrowStatement";
-  argument: Expression;
+    type: 'ThrowStatement';
+    argument: Expression;
 }
 
 export interface TryStatement extends BaseStatement {
-  type: "TryStatement";
-  block: BlockStatement;
-  handler?: CatchClause | null | undefined;
-  finalizer?: BlockStatement | null | undefined;
+    type: 'TryStatement';
+    block: BlockStatement;
+    handler?: CatchClause | null | undefined;
+    finalizer?: BlockStatement | null | undefined;
 }
 
 export interface WhileStatement extends BaseStatement {
-  type: "WhileStatement";
-  test: Expression;
-  body: Statement;
+    type: 'WhileStatement';
+    test: Expression;
+    body: Statement;
 }
 
 export interface DoWhileStatement extends BaseStatement {
-  type: "DoWhileStatement";
-  body: Statement;
-  test: Expression;
+    type: 'DoWhileStatement';
+    body: Statement;
+    test: Expression;
 }
 
 export interface ForStatement extends BaseStatement {
-  type: "ForStatement";
-  init?: VariableDeclaration | Expression | null | undefined;
-  test?: Expression | null | undefined;
-  update?: Expression | null | undefined;
-  body: Statement;
+    type: 'ForStatement';
+    init?: VariableDeclaration | Expression | null | undefined;
+    test?: Expression | null | undefined;
+    update?: Expression | null | undefined;
+    body: Statement;
 }
 
 interface BaseForXStatement extends BaseStatement {
-  left: VariableDeclaration | Pattern;
-  right: Expression;
-  body: Statement;
+    left: VariableDeclaration | Pattern;
+    right: Expression;
+    body: Statement;
 }
 
 export interface ForInStatement extends BaseForXStatement {
-  type: "ForInStatement";
+    type: 'ForInStatement';
 }
 
 export interface DebuggerStatement extends BaseStatement {
-  type: "DebuggerStatement";
+    type: 'DebuggerStatement';
 }
 
-export type Declaration =
-      FunctionDeclaration | VariableDeclaration | ClassDeclaration;
+export type Declaration = FunctionDeclaration | VariableDeclaration | ClassDeclaration;
 
-interface BaseDeclaration extends BaseStatement { }
+interface BaseDeclaration extends BaseStatement {}
 
 export interface FunctionDeclaration extends BaseFunction, BaseDeclaration {
-  type: "FunctionDeclaration";
-  /** It is null when a function declaration is a part of the `export default function` statement */
-  id: Identifier | null;
-  body: BlockStatement;
+    type: 'FunctionDeclaration';
+    /** It is null when a function declaration is a part of the `export default function` statement */
+    id: Identifier | null;
+    body: BlockStatement;
 }
 
 export interface VariableDeclaration extends BaseDeclaration {
-  type: "VariableDeclaration";
-  declarations: Array<VariableDeclarator>;
-  kind: "var" | "let" | "const";
+    type: 'VariableDeclaration';
+    declarations: Array<VariableDeclarator>;
+    kind: 'var' | 'let' | 'const';
 }
 
 export interface VariableDeclarator extends BaseNode {
-  type: "VariableDeclarator";
-  id: Pattern;
-  init?: Expression | null | undefined;
+    type: 'VariableDeclarator';
+    id: Pattern;
+    init?: Expression | null | undefined;
 }
 
 export interface ExpressionMap {
-  ArrayExpression: ArrayExpression;
-  ArrowFunctionExpression: ArrowFunctionExpression;
-  AssignmentExpression: AssignmentExpression;
-  AwaitExpression: AwaitExpression;
-  BinaryExpression: BinaryExpression;
-  CallExpression: CallExpression;
-  ChainExpression: ChainExpression;
-  ClassExpression: ClassExpression;
-  ConditionalExpression: ConditionalExpression;
-  FunctionExpression: FunctionExpression;
-  Identifier: Identifier;
-  ImportExpression: ImportExpression;
-  Literal: Literal;
-  LogicalExpression: LogicalExpression;
-  MemberExpression: MemberExpression;
-  MetaProperty: MetaProperty;
-  NewExpression: NewExpression;
-  ObjectExpression: ObjectExpression;
-  SequenceExpression: SequenceExpression;
-  TaggedTemplateExpression: TaggedTemplateExpression;
-  TemplateLiteral: TemplateLiteral;
-  ThisExpression: ThisExpression;
-  UnaryExpression: UnaryExpression;
-  UpdateExpression: UpdateExpression;
-  YieldExpression: YieldExpression;
+    ArrayExpression: ArrayExpression;
+    ArrowFunctionExpression: ArrowFunctionExpression;
+    AssignmentExpression: AssignmentExpression;
+    AwaitExpression: AwaitExpression;
+    BinaryExpression: BinaryExpression;
+    CallExpression: CallExpression;
+    ChainExpression: ChainExpression;
+    ClassExpression: ClassExpression;
+    ConditionalExpression: ConditionalExpression;
+    FunctionExpression: FunctionExpression;
+    Identifier: Identifier;
+    ImportExpression: ImportExpression;
+    Literal: Literal;
+    LogicalExpression: LogicalExpression;
+    MemberExpression: MemberExpression;
+    MetaProperty: MetaProperty;
+    NewExpression: NewExpression;
+    ObjectExpression: ObjectExpression;
+    SequenceExpression: SequenceExpression;
+    TaggedTemplateExpression: TaggedTemplateExpression;
+    TemplateLiteral: TemplateLiteral;
+    ThisExpression: ThisExpression;
+    UnaryExpression: UnaryExpression;
+    UpdateExpression: UpdateExpression;
+    YieldExpression: YieldExpression;
 }
 
-type Expression = ExpressionMap[keyof ExpressionMap]
+type Expression = ExpressionMap[keyof ExpressionMap];
 
-export interface BaseExpression extends BaseNode { }
+export interface BaseExpression extends BaseNode {}
 
 type ChainElement = SimpleCallExpression | MemberExpression;
 
 export interface ChainExpression extends BaseExpression {
-  type: "ChainExpression";
-  expression: ChainElement;
+    type: 'ChainExpression';
+    expression: ChainElement;
 }
 
 export interface ThisExpression extends BaseExpression {
-  type: "ThisExpression";
+    type: 'ThisExpression';
 }
 
 export interface ArrayExpression extends BaseExpression {
-  type: "ArrayExpression";
-  elements: Array<Expression | SpreadElement | null>;
+    type: 'ArrayExpression';
+    elements: Array<Expression | SpreadElement | null>;
 }
 
 export interface ObjectExpression extends BaseExpression {
-  type: "ObjectExpression";
-  properties: Array<Property | SpreadElement>;
+    type: 'ObjectExpression';
+    properties: Array<Property | SpreadElement>;
 }
 
 export interface PrivateIdentifier extends BaseNode {
-    type: "PrivateIdentifier";
+    type: 'PrivateIdentifier';
     name: string;
 }
 
 export interface Property extends BaseNode {
-  type: "Property";
-  key: Expression | PrivateIdentifier;
-  value: Expression | Pattern; // Could be an AssignmentProperty
-  kind: "init" | "get" | "set";
-  method: boolean;
-  shorthand: boolean;
-  computed: boolean;
+    type: 'Property';
+    key: Expression | PrivateIdentifier;
+    value: Expression | Pattern; // Could be an AssignmentProperty
+    kind: 'init' | 'get' | 'set';
+    method: boolean;
+    shorthand: boolean;
+    computed: boolean;
 }
 
 export interface PropertyDefinition extends BaseNode {
-    type: "PropertyDefinition";
+    type: 'PropertyDefinition';
     key: Expression | PrivateIdentifier;
     value?: Expression | null | undefined;
     computed: boolean;
@@ -321,317 +334,344 @@ export interface PropertyDefinition extends BaseNode {
 }
 
 export interface FunctionExpression extends BaseFunction, BaseExpression {
-  id?: Identifier | null | undefined;
-  type: "FunctionExpression";
-  body: BlockStatement;
+    id?: Identifier | null | undefined;
+    type: 'FunctionExpression';
+    body: BlockStatement;
 }
 
 export interface SequenceExpression extends BaseExpression {
-  type: "SequenceExpression";
-  expressions: Array<Expression>;
+    type: 'SequenceExpression';
+    expressions: Array<Expression>;
 }
 
 export interface UnaryExpression extends BaseExpression {
-  type: "UnaryExpression";
-  operator: UnaryOperator;
-  prefix: true;
-  argument: Expression;
+    type: 'UnaryExpression';
+    operator: UnaryOperator;
+    prefix: true;
+    argument: Expression;
 }
 
 export interface BinaryExpression extends BaseExpression {
-  type: "BinaryExpression";
-  operator: BinaryOperator;
-  left: Expression;
-  right: Expression;
+    type: 'BinaryExpression';
+    operator: BinaryOperator;
+    left: Expression;
+    right: Expression;
 }
 
 export interface AssignmentExpression extends BaseExpression {
-  type: "AssignmentExpression";
-  operator: AssignmentOperator;
-  left: Pattern | MemberExpression;
-  right: Expression;
+    type: 'AssignmentExpression';
+    operator: AssignmentOperator;
+    left: Pattern | MemberExpression;
+    right: Expression;
 }
 
 export interface UpdateExpression extends BaseExpression {
-  type: "UpdateExpression";
-  operator: UpdateOperator;
-  argument: Expression;
-  prefix: boolean;
+    type: 'UpdateExpression';
+    operator: UpdateOperator;
+    argument: Expression;
+    prefix: boolean;
 }
 
 export interface LogicalExpression extends BaseExpression {
-  type: "LogicalExpression";
-  operator: LogicalOperator;
-  left: Expression;
-  right: Expression;
+    type: 'LogicalExpression';
+    operator: LogicalOperator;
+    left: Expression;
+    right: Expression;
 }
 
 export interface ConditionalExpression extends BaseExpression {
-  type: "ConditionalExpression";
-  test: Expression;
-  alternate: Expression;
-  consequent: Expression;
+    type: 'ConditionalExpression';
+    test: Expression;
+    alternate: Expression;
+    consequent: Expression;
 }
 
 interface BaseCallExpression extends BaseExpression {
-  callee: Expression | Super;
-  arguments: Array<Expression | SpreadElement>;
+    callee: Expression | Super;
+    arguments: Array<Expression | SpreadElement>;
 }
 export type CallExpression = SimpleCallExpression | NewExpression;
 
 export interface SimpleCallExpression extends BaseCallExpression {
-  type: "CallExpression";
-  optional: boolean;
+    type: 'CallExpression';
+    optional: boolean;
 }
 
 export interface NewExpression extends BaseCallExpression {
-  type: "NewExpression";
+    type: 'NewExpression';
 }
 
 export interface MemberExpression extends BaseExpression, BasePattern {
-  type: "MemberExpression";
-  object: Expression | Super;
-  property: Expression | PrivateIdentifier;
-  computed: boolean;
-  optional: boolean;
+    type: 'MemberExpression';
+    object: Expression | Super;
+    property: Expression | PrivateIdentifier;
+    computed: boolean;
+    optional: boolean;
 }
 
-export type Pattern =
-    Identifier | ObjectPattern | ArrayPattern | RestElement |
-    AssignmentPattern | MemberExpression;
+export type Pattern = Identifier | ObjectPattern | ArrayPattern | RestElement | AssignmentPattern | MemberExpression;
 
-interface BasePattern extends BaseNode { }
+interface BasePattern extends BaseNode {}
 
 export interface SwitchCase extends BaseNode {
-  type: "SwitchCase";
-  test?: Expression | null | undefined;
-  consequent: Array<Statement>;
+    type: 'SwitchCase';
+    test?: Expression | null | undefined;
+    consequent: Array<Statement>;
 }
 
 export interface CatchClause extends BaseNode {
-  type: "CatchClause";
-  param: Pattern | null;
-  body: BlockStatement;
+    type: 'CatchClause';
+    param: Pattern | null;
+    body: BlockStatement;
 }
 
 export interface Identifier extends BaseNode, BaseExpression, BasePattern {
-  type: "Identifier";
-  name: string;
+    type: 'Identifier';
+    name: string;
 }
 
 export type Literal = SimpleLiteral | RegExpLiteral | BigIntLiteral;
 
 export interface SimpleLiteral extends BaseNode, BaseExpression {
-  type: "Literal";
-  value: string | boolean | number | null;
-  raw?: string | undefined;
+    type: 'Literal';
+    value: string | boolean | number | null;
+    raw?: string | undefined;
 }
 
 export interface RegExpLiteral extends BaseNode, BaseExpression {
-  type: "Literal";
-  value?: RegExp | null | undefined;
-  regex: {
-    pattern: string;
-    flags: string;
-  };
-  raw?: string | undefined;
+    type: 'Literal';
+    value?: RegExp | null | undefined;
+    regex: {
+        pattern: string;
+        flags: string;
+    };
+    raw?: string | undefined;
 }
 
 export interface BigIntLiteral extends BaseNode, BaseExpression {
-  type: "Literal";
-  value?: bigint | null | undefined;
-  bigint: string;
-  raw?: string | undefined;
+    type: 'Literal';
+    value?: bigint | null | undefined;
+    bigint: string;
+    raw?: string | undefined;
 }
 
-export type UnaryOperator =
-    "-" | "+" | "!" | "~" | "typeof" | "void" | "delete";
+export type UnaryOperator = '-' | '+' | '!' | '~' | 'typeof' | 'void' | 'delete';
 
 export type BinaryOperator =
-    "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "<<" |
-    ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "**" | "|" | "^" | "&" | "in" |
-    "instanceof";
+    | '=='
+    | '!='
+    | '==='
+    | '!=='
+    | '<'
+    | '<='
+    | '>'
+    | '>='
+    | '<<'
+    | '>>'
+    | '>>>'
+    | '+'
+    | '-'
+    | '*'
+    | '/'
+    | '%'
+    | '**'
+    | '|'
+    | '^'
+    | '&'
+    | 'in'
+    | 'instanceof';
 
-export type LogicalOperator = "||" | "&&" | "??";
+export type LogicalOperator = '||' | '&&' | '??';
 
 export type AssignmentOperator =
-    "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | ">>>=" |
-    "|=" | "^=" | "&=";
+    | '='
+    | '+='
+    | '-='
+    | '*='
+    | '/='
+    | '%='
+    | '**='
+    | '<<='
+    | '>>='
+    | '>>>='
+    | '|='
+    | '^='
+    | '&=';
 
-export type UpdateOperator = "++" | "--";
+export type UpdateOperator = '++' | '--';
 
 export interface ForOfStatement extends BaseForXStatement {
-  type: "ForOfStatement";
-  await: boolean;
+    type: 'ForOfStatement';
+    await: boolean;
 }
 
 export interface Super extends BaseNode {
-  type: "Super";
+    type: 'Super';
 }
 
 export interface SpreadElement extends BaseNode {
-  type: "SpreadElement";
-  argument: Expression;
+    type: 'SpreadElement';
+    argument: Expression;
 }
 
 export interface ArrowFunctionExpression extends BaseExpression, BaseFunction {
-  type: "ArrowFunctionExpression";
-  expression: boolean;
-  body: BlockStatement | Expression;
+    type: 'ArrowFunctionExpression';
+    expression: boolean;
+    body: BlockStatement | Expression;
 }
 
 export interface YieldExpression extends BaseExpression {
-  type: "YieldExpression";
-  argument?: Expression | null | undefined;
-  delegate: boolean;
+    type: 'YieldExpression';
+    argument?: Expression | null | undefined;
+    delegate: boolean;
 }
 
 export interface TemplateLiteral extends BaseExpression {
-  type: "TemplateLiteral";
-  quasis: Array<TemplateElement>;
-  expressions: Array<Expression>;
+    type: 'TemplateLiteral';
+    quasis: Array<TemplateElement>;
+    expressions: Array<Expression>;
 }
 
 export interface TaggedTemplateExpression extends BaseExpression {
-  type: "TaggedTemplateExpression";
-  tag: Expression;
-  quasi: TemplateLiteral;
+    type: 'TaggedTemplateExpression';
+    tag: Expression;
+    quasi: TemplateLiteral;
 }
 
 export interface TemplateElement extends BaseNode {
-  type: "TemplateElement";
-  tail: boolean;
-  value: {
-    /** It is null when the template literal is tagged and the text has an invalid escape (e.g. - tag`\unicode and \u{55}`) */
-    cooked?: string | null | undefined;
-    raw: string;
-  };
+    type: 'TemplateElement';
+    tail: boolean;
+    value: {
+        /** It is null when the template literal is tagged and the text has an invalid escape (e.g. - tag`\unicode and \u{55}`) */
+        cooked?: string | null | undefined;
+        raw: string;
+    };
 }
 
 export interface AssignmentProperty extends Property {
-  value: Pattern;
-  kind: "init";
-  method: boolean; // false
+    value: Pattern;
+    kind: 'init';
+    method: boolean; // false
 }
 
 export interface ObjectPattern extends BasePattern {
-  type: "ObjectPattern";
-  properties: Array<AssignmentProperty | RestElement>;
+    type: 'ObjectPattern';
+    properties: Array<AssignmentProperty | RestElement>;
 }
 
 export interface ArrayPattern extends BasePattern {
-  type: "ArrayPattern";
-  elements: Array<Pattern | null>;
+    type: 'ArrayPattern';
+    elements: Array<Pattern | null>;
 }
 
 export interface RestElement extends BasePattern {
-  type: "RestElement";
-  argument: Pattern;
+    type: 'RestElement';
+    argument: Pattern;
 }
 
 export interface AssignmentPattern extends BasePattern {
-  type: "AssignmentPattern";
-  left: Pattern;
-  right: Expression;
+    type: 'AssignmentPattern';
+    left: Pattern;
+    right: Expression;
 }
 
 export type Class = ClassDeclaration | ClassExpression;
 interface BaseClass extends BaseNode {
-  superClass?: Expression | null | undefined;
-  body: ClassBody;
+    superClass?: Expression | null | undefined;
+    body: ClassBody;
 }
 
 export interface ClassBody extends BaseNode {
-  type: "ClassBody";
-  body: Array<MethodDefinition | PropertyDefinition | StaticBlock>;
+    type: 'ClassBody';
+    body: Array<MethodDefinition | PropertyDefinition | StaticBlock>;
 }
 
 export interface MethodDefinition extends BaseNode {
-  type: "MethodDefinition";
-  key: Expression | PrivateIdentifier;
-  value: FunctionExpression;
-  kind: "constructor" | "method" | "get" | "set";
-  computed: boolean;
-  static: boolean;
+    type: 'MethodDefinition';
+    key: Expression | PrivateIdentifier;
+    value: FunctionExpression;
+    kind: 'constructor' | 'method' | 'get' | 'set';
+    computed: boolean;
+    static: boolean;
 }
 
 export interface ClassDeclaration extends BaseClass, BaseDeclaration {
-  type: "ClassDeclaration";
-  /** It is null when a class declaration is a part of the `export default class` statement */
-  id: Identifier | null;
+    type: 'ClassDeclaration';
+    /** It is null when a class declaration is a part of the `export default class` statement */
+    id: Identifier | null;
 }
 
 export interface ClassExpression extends BaseClass, BaseExpression {
-  type: "ClassExpression";
-  id?: Identifier | null | undefined;
+    type: 'ClassExpression';
+    id?: Identifier | null | undefined;
 }
 
 export interface MetaProperty extends BaseExpression {
-  type: "MetaProperty";
-  meta: Identifier;
-  property: Identifier;
+    type: 'MetaProperty';
+    meta: Identifier;
+    property: Identifier;
 }
 
 export type ModuleDeclaration =
-    ImportDeclaration | ExportNamedDeclaration | ExportDefaultDeclaration |
-    ExportAllDeclaration;
-interface BaseModuleDeclaration extends BaseNode { }
+    | ImportDeclaration
+    | ExportNamedDeclaration
+    | ExportDefaultDeclaration
+    | ExportAllDeclaration;
+interface BaseModuleDeclaration extends BaseNode {}
 
-export type ModuleSpecifier =
-    ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier |
-    ExportSpecifier;
+export type ModuleSpecifier = ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier;
 interface BaseModuleSpecifier extends BaseNode {
-  local: Identifier;
+    local: Identifier;
 }
 
 export interface ImportDeclaration extends BaseModuleDeclaration {
-  type: "ImportDeclaration";
-  specifiers: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
-  source: Literal;
+    type: 'ImportDeclaration';
+    specifiers: Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>;
+    source: Literal;
 }
 
 export interface ImportSpecifier extends BaseModuleSpecifier {
-  type: "ImportSpecifier";
-  imported: Identifier;
+    type: 'ImportSpecifier';
+    imported: Identifier;
 }
 
 export interface ImportExpression extends BaseExpression {
-  type: "ImportExpression";
-  source: Expression;
+    type: 'ImportExpression';
+    source: Expression;
 }
 
 export interface ImportDefaultSpecifier extends BaseModuleSpecifier {
-  type: "ImportDefaultSpecifier";
+    type: 'ImportDefaultSpecifier';
 }
 
 export interface ImportNamespaceSpecifier extends BaseModuleSpecifier {
-  type: "ImportNamespaceSpecifier";
+    type: 'ImportNamespaceSpecifier';
 }
 
 export interface ExportNamedDeclaration extends BaseModuleDeclaration {
-  type: "ExportNamedDeclaration";
-  declaration?: Declaration | null | undefined;
-  specifiers: Array<ExportSpecifier>;
-  source?: Literal | null | undefined;
+    type: 'ExportNamedDeclaration';
+    declaration?: Declaration | null | undefined;
+    specifiers: Array<ExportSpecifier>;
+    source?: Literal | null | undefined;
 }
 
 export interface ExportSpecifier extends BaseModuleSpecifier {
-  type: "ExportSpecifier";
-  exported: Identifier;
+    type: 'ExportSpecifier';
+    exported: Identifier;
 }
 
 export interface ExportDefaultDeclaration extends BaseModuleDeclaration {
-  type: "ExportDefaultDeclaration";
-  declaration: Declaration | Expression;
+    type: 'ExportDefaultDeclaration';
+    declaration: Declaration | Expression;
 }
 
 export interface ExportAllDeclaration extends BaseModuleDeclaration {
-  type: "ExportAllDeclaration";
-  exported: Identifier | null;
-  source: Literal;
+    type: 'ExportAllDeclaration';
+    exported: Identifier | null;
+    source: Literal;
 }
 
 export interface AwaitExpression extends BaseExpression {
-  type: "AwaitExpression";
-  argument: Expression;
+    type: 'AwaitExpression';
+    argument: Expression;
 }

--- a/types/estree/tslint.json
+++ b/types/estree/tslint.json
@@ -1,15 +1,10 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
-        "array-type": false,
         "ban-types": false,
-        "dt-header": false,
         "no-duplicate-variable": false,
         "no-empty-interface": false,
-        "no-unnecessary-type-assertion": false,
         "no-var-keyword": false,
-        "prefer-const": false,
-        "semicolon": false,
-        "strict-export-declare-modifiers": false
+        "prefer-const": false
     }
 }

--- a/types/estree/tslint.json
+++ b/types/estree/tslint.json
@@ -8,7 +8,6 @@
         "no-empty-interface": false,
         "no-unnecessary-type-assertion": false,
         "no-var-keyword": false,
-        "npm-naming": false,
         "prefer-const": false,
         "semicolon": false,
         "strict-export-declare-modifiers": false


### PR DESCRIPTION
Both are type definitions for a specification, not a package. By marking them as version 1.0, people can use “normal” semver ranges to depend on them. Also they are stable, so in that regard it makes sense to mark them as 1.0 too.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

cc @wooorm