### PR TITLE
Fix sftp `exists` method callback parameter type

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1695,7 +1695,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    exists(path: string, callback: (err: Error | undefined) => void): boolean;
+    exists(path: string, callback: (hasError: boolen) => void): boolean;
 
     /**
      * (Client-only)

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1695,7 +1695,7 @@ export interface SFTPWrapper extends events.EventEmitter {
      *
      * Returns `false` if you should wait for the `continue` event before sending any more traffic.
      */
-    exists(path: string, callback: (hasError: boolen) => void): boolean;
+    exists(path: string, callback: (hasError: boolean) => void): boolean;
 
     /**
      * (Client-only)


### PR DESCRIPTION
The type of the parameter in exists callback is wrong. You can check here https://github.com/mscdex/ssh2/blob/v1.11.0/lib/protocol/SFTP.js#L726

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/ssh2/blob/v1.11.0/lib/protocol/SFTP.js#L726
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
