### PR TITLE
- Support for new JQuery and jquery message types

### DIFF
--- a/types/toastr/index.d.ts
+++ b/types/toastr/index.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-
 /// <reference types="jquery" />
 
 interface ToastrOptions {
@@ -76,7 +75,7 @@ interface ToastrOptions {
      * Closing cannot be prevented by ev.stopPropagation() etc.
      * @default undefined
      */
-    onCloseClick?: ((ev: JQueryMouseEventObject) => void) | undefined;
+    onCloseClick?: ((ev: JQuery.ClickEvent) => void) | undefined;
     /**
      * Should clicking on toast dismiss it?
      * @default true
@@ -117,7 +116,7 @@ interface ToastrOptions {
      * @default undefined
      */
     onHidden?: (() => void) | undefined;
-    /**
+     /**
      * Time in milliseconds the toast should be displayed after leaving mouse over.
      * Set timeOut and extendedTimeOut to 0 to make it sticky.
      * @default 1000
@@ -207,7 +206,7 @@ interface ToastrOptions {
      * Function to execute on toast click. Closing cannot be prevented by ev.stopPropagation() etc.
      * @default undefined
      */
-    onclick?: ((ev: JQueryMouseEventObject) => void) | undefined;
+    onclick?: ((ev: JQuery.ClickEvent) => void) | undefined;
     /**
      * Should the title and message text be escaped?
      * @default false
@@ -224,11 +223,11 @@ interface ToastrDisplayMethod {
     /**
      * Create a toast
      *
-     * @param message Message to display in toast
+     * @param message Message to display in toast, or HTML content
      * @param title Title to display on toast
      * @param overrides Option values for toast
      */
-    (message: string, title?: string, overrides?: ToastrOptions): JQuery;
+    (message: string | JQuery, title?: string, overrides?: ToastrOptions): JQuery;
 }
 
 type ToastrType = 'error'|'info'|'success'|'warning';
@@ -302,13 +301,13 @@ interface Toastr {
     remove: {
         /**
          * Removes all toasts (without animation)
-          */
+         */
         (): void;
         /**
          * Removes specific toast (without animation)
          *
          * @param toast Toast to remove
-          */
+         */
         (toast: JQuery): void;
     };
     /**

--- a/types/toastr/toastr-tests.ts
+++ b/types/toastr/toastr-tests.ts
@@ -15,7 +15,7 @@ declare let clearOptionsOrUndefinedVal: typeof clearOptionsVal | undefined;
 function test_basic() {
     var t: JQuery[] = [];
     t.push(toastr.info('Are you the 6 fingered man?'));
-    t.push(toastr.warning('My name is Inigo Montoya. You Killed my father, prepare to die!'));
+    t.push(toastr.warning($('<span>My name is Inigo Montoya. You Killed my father, prepare to die!<span>')));
     t.push(toastr.success('Have fun storming the castle!', 'Miracle Max Says'));
     t.push(toastr.error('I do not think that word means what you think it means.', 'Inconceivable!'));
     toastr.clear(t[0]); // clear 1


### PR DESCRIPTION
The `JQueryMouseEventObject` is now obsolete in recent JQuery definitions, so fixed now.
In addition, the toastr `ToastrDisplayMethod` accepts also JQuery object, in addition to strings, since it internally uses JQuery to append the content.
Thanks, L

Please fill in this template.

- [ X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X ] Test the change in your own code. (Compile and run.)
- [ X ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
