### PR TITLE
[@types/screeps] Flexible entities memory

### DIFF
--- a/types/screeps/index.d.ts
+++ b/types/screeps/index.d.ts
@@ -3198,11 +3198,14 @@ interface Memory {
     spawns: { [name: string]: SpawnMemory };
 }
 
-interface CreepMemory {}
-interface FlagMemory {}
-interface PowerCreepMemory {}
-interface RoomMemory {}
-interface SpawnMemory {}
+interface BaseMemory {
+    [name: string]: any;
+}
+interface CreepMemory extends BaseMemory {}
+interface FlagMemory extends BaseMemory {}
+interface PowerCreepMemory extends BaseMemory {}
+interface RoomMemory extends BaseMemory {}
+interface SpawnMemory extends BaseMemory {}
 
 declare const Memory: Memory;
 /**


### PR DESCRIPTION
Entities memory (Creep, Spawn, Room etc) layout is defined by the user.
Considering the following snippet:
```javascript
const creep = Game.creeps[name]
creep.memory.role = 'harvester'
```

In typescript this can be done by extending the CreepMemory interface like this:
```typescript
interface CreepMemory {
    role: string;
}
```

But in javascript this is not possible.
In this case, tsc (vscode by extrension) will complain that `Property 'role' does not exist on type 'CreepMemory'.`

The proposed change makes all entities Memory to have a `[name: string]: any;` definition, allowing easy extension, both in TS and JS, while keeping code completion available.
The only downside is that, in TS projects, if the user misspell a memory property previously defined it will be a bit harder to find the typo, but I assume that the advantage for JS users (beign able to actually use the memory property) far outweighs this possible situation.