### PR TITLE
Replace remaining $ExpectErrors with @ts-expect-error

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -78,7 +78,7 @@ untypedCallback(null, str);
 untypedCallback(null, num);
 untypedCallback(null, { foo: 123 });
 untypedCallback(null, { bar: 123 });
-// $ExpectError
+// @ts-expect-error
 untypedCallback(null, anyObj, anyObj);
 
 interface TestResult { foo: number; }
@@ -90,9 +90,9 @@ typedCallback(error);
 typedCallback(str); // https://docs.aws.amazon.com/apigateway/latest/developerguide/handle-errors-in-lambda-integration.html
 typedCallback(null, anyObj);
 typedCallback(null, { foo: 123 });
-// $ExpectError
+// @ts-expect-error
 typedCallback(null, str);
-// $ExpectError
+// @ts-expect-error
 typedCallback(null, { bar: 123 });
 
 /* Compatibility functions */
@@ -152,7 +152,7 @@ const untypedCallbackHandler: AWSLambda.Handler = (event, context, cb) => {
  */
 
 // Test we get error for unsafe old style
-// $ExpectError
+// @ts-expect-error
 const unsafeAsyncHandler: CustomHandler = async (event, context, cb) => {
     cb(null, { resultString: 'No longer valid' });
 };
@@ -170,10 +170,10 @@ const typedCallbackHandler: CustomHandler = (event, context, cb) => {
     cb();
     cb(null);
     cb(new Error());
-    // $ExpectError
+    // @ts-expect-error
     cb(null, {});
     cb(null, { resultString: str });
-    // $ExpectError
+    // @ts-expect-error
     cb(null, { resultString: bool });
 };
 
@@ -190,7 +190,7 @@ const typedAsyncHandler: CustomHandler = async (event, context, cb) => {
     return { resultString: 'Is now valid!' };
 };
 
-// $ExpectError
+// @ts-expect-error
 const badTypedAsyncHandler: CustomHandler = async (event, context, cb) => ({ resultString: bool });
 
 // Test using untyped Callback type still works.

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -61,14 +61,14 @@ interface CustomAuthorizerContext extends APIGatewayAuthorizerResultContext {
 // Can't serialize objects in the response from an authorizer
 interface CustomAuthorizerInvalidResponseContext extends APIGatewayAuthorizerResultContext {
     valid: string | number | boolean | null | undefined;
-    // $ExpectError
+    // @ts-expect-error
     invalid: {
         id: number;
     };
 }
 
 // Enforce custom response contexts extend APIGatewayAuthorizerResultContext for use in authorizer,
-// $ExpectError
+// @ts-expect-error
 type InvalidCustomAuthorizerHandler = APIGatewayAuthorizerWithContextHandler<{
     valid: string | number | boolean | null | undefined;
     invalid: {
@@ -102,7 +102,7 @@ let proxyHandler: APIGatewayProxyHandler = async (event, context, callback) => {
     let requestContext: APIGatewayEventRequestContext;
     requestContext = event.requestContext;
     let requestContextWithCustomAuthorizer: APIGatewayEventRequestContextWithAuthorizer<CustomAuthorizerContext>;
-    // $ExpectError
+    // @ts-expect-error
     requestContextWithCustomAuthorizer = event.requestContext;
     str = event.resource;
 
@@ -243,7 +243,7 @@ const proxyHandlerWithCustomAuthorizer: APIGatewayProxyWithLambdaAuthorizerHandl
 
     // It seems like it would be easy to make this mistake, but it's still a useful type.
     let requestContextWithAuthorizerDirectly: APIGatewayEventRequestContextWithAuthorizer<CustomAuthorizerContext>;
-    // $ExpectError
+    // @ts-expect-error
     requestContextWithAuthorizerDirectly = event.requestContext;
 
     // Check assignable to named types
@@ -285,7 +285,7 @@ const proxyHandlerV2WithLambdaAuthorizer: APIGatewayProxyHandlerV2WithLambdaAuth
 
     // It seems like it would be easy to make this mistake, but it's still a useful type.
     let requestContextWithAuthorizerDirectly: APIGatewayEventRequestContextLambdaAuthorizer<CustomAuthorizerContext>;
-    // $ExpectError
+    // @ts-expect-error
     requestContextWithAuthorizerDirectly = event.requestContext;
 
     // Check assignable to named types
@@ -323,7 +323,7 @@ const proxyHandlerv2WithJKTAuthorizer: APIGatewayProxyHandlerV2WithJWTAuthorizer
 
     // It seems like it would be easy to make this mistake, but it's still a useful type.
     let requestContextWithAuthorizerDirectly: APIGatewayEventRequestContextJWTAuthorizer;
-    // $ExpectError
+    // @ts-expect-error
     requestContextWithAuthorizerDirectly = event.requestContext;
 
     // Check assignable to named types
@@ -424,25 +424,27 @@ function createProxyObjectResultV2(): APIGatewayProxyResultV2<Response> {
     return result;
 }
 
-// $ExpectError
+// @ts-expect-error
 const proxyHandlerV2ForObjectResultFailure: APIGatewayProxyHandlerV2<Response> = async (event, context, callback) => {
     const result = {
         wrongExample: 'wrong example'
     };
 
     callback(new Error());
-    callback(undefined, result); // $ExpectError
+    // @ts-expect-error
+    callback(undefined, result);
     return result;
 };
 
-// $ExpectError
+// @ts-expect-error
 const proxyHandlerV2ForObjectResultFailure2: APIGatewayProxyHandlerV2 = async (event, context, callback) => {
     const result = {
         wrongExample: 'wrong example',
     };
 
     callback(new Error());
-    callback(undefined, result); // $ExpectError
+    // @ts-expect-error
+    callback(undefined, result);
     return result;
 };
 
@@ -450,7 +452,8 @@ const authorizer: APIGatewayAuthorizerHandler = async (event, context, callback)
     if (event.type === "TOKEN") {
         str = event.methodArn;
         str = event.authorizationToken;
-        str = event.resource; // $ExpectError
+        // @ts-expect-error
+        str = event.resource;
     } else {
         event.type; // $ExpectType "REQUEST"
         str = event.resource;
@@ -574,7 +577,8 @@ const authorizerWithCustomContext: APIGatewayAuthorizerWithContextHandler<Custom
     if (event.type === "TOKEN") {
         str = event.methodArn;
         str = event.authorizationToken;
-        str = event.resource; // $ExpectError
+        // @ts-expect-error
+        str = event.resource;
     } else {
         event.type; // $ExpectType "REQUEST"
         str = event.resource;
@@ -584,7 +588,7 @@ const authorizerWithCustomContext: APIGatewayAuthorizerWithContextHandler<Custom
     result = createAuthorizerResultWithCustomContext();
 
     // Can't convert up from existing type
-    // $ExpectError
+    // @ts-expect-error
     result = createAuthorizerResult();
 
     callback(new Error());
@@ -598,7 +602,8 @@ const tokenAuthorizer: APIGatewayTokenAuthorizerHandler = async (event, context,
     str = event.type;
     str = event.methodArn;
     str = event.authorizationToken;
-    strOrUndefined = event.resource; // $ExpectError
+    // @ts-expect-error
+    strOrUndefined = event.resource;
     // etc...
 
     const result = createAuthorizerResult();
@@ -614,7 +619,8 @@ const tokenAuthorizerWithCustomContext: APIGatewayTokenAuthorizerWithContextHand
     str = event.type;
     str = event.methodArn;
     str = event.authorizationToken;
-    strOrUndefined = event.resource; // $ExpectError
+    // @ts-expect-error
+    strOrUndefined = event.resource;
     // etc...
 
     const result = createAuthorizerResultWithCustomContext();
@@ -629,7 +635,8 @@ const requestAuthorizer: APIGatewayRequestAuthorizerHandler = async (event, cont
 
     str = event.type;
     str = event.methodArn;
-    str = event.authorizationToken; // $ExpectError
+    // @ts-expect-error
+    str = event.authorizationToken;
     str = event.resource;
     str = event.path;
     str = event.httpMethod;
@@ -663,7 +670,8 @@ const requestAuthorizerWithCustomContext: APIGatewayRequestAuthorizerWithContext
 
     str = event.type;
     str = event.methodArn;
-    str = event.authorizationToken; // $ExpectError
+    // @ts-expect-error
+    str = event.authorizationToken;
 
     const result = createAuthorizerResultWithCustomContext();
 
@@ -704,23 +712,23 @@ function createPolicyDocument(): PolicyDocument {
         Resource: str,
     };
 
-    // $ExpectError
+    // @ts-expect-error
     statement = { Effect: str, Action: str, Principal: 123, };
 
     // Bad Resource
-    // $ExpectError
+    // @ts-expect-error
     statement = { Effect: str, Action: str, Resource: 123, };
 
     // Bad Resource with valid Principal
-    // $ExpectError
+    // @ts-expect-error
     statement = { Effect: str, Action: str, Principal: { Service: str }, Resource: 123, };
 
     // Bad principal with valid Resource
-    // $ExpectError
+    // @ts-expect-error
     statement = { Effect: str, Action: str, Principal: 123, Resource: str, };
 
     // No Effect
-    // $ExpectError
+    // @ts-expect-error
     statement = { Action: str, Principal: str };
 
     statement = {
@@ -761,7 +769,7 @@ function createAuthorizerResultWithCustomContext(): APIGatewayAuthorizerWithCont
     let result: APIGatewayAuthorizerWithContextResult<CustomAuthorizerContext>;
 
     // Requires context
-    // $ExpectError
+    // @ts-expect-error
     result = {
         principalId: str,
         policyDocument: createPolicyDocument(),
@@ -772,7 +780,8 @@ function createAuthorizerResultWithCustomContext(): APIGatewayAuthorizerWithCont
     result = {
         principalId: str,
         policyDocument: createPolicyDocument(),
-        context: {}, // $ExpectError
+        // @ts-expect-error
+        context: {},
         usageIdentifierKey: strOrUndefinedOrNull,
     };
 
@@ -797,7 +806,7 @@ function createIAMAuthorizerResultWithCustomContext(): APIGatewayIAMAuthorizerWi
     let result: APIGatewayIAMAuthorizerWithContextResult<CustomAuthorizerContext>;
 
     // Requires context
-    // $ExpectError
+    // @ts-expect-error
     result = {
         principalId: str,
         policyDocument: createPolicyDocument(),
@@ -808,7 +817,8 @@ function createIAMAuthorizerResultWithCustomContext(): APIGatewayIAMAuthorizerWi
     result = {
         principalId: str,
         policyDocument: createPolicyDocument(),
-        context: {}, // $ExpectError
+        // @ts-expect-error
+        context: {},
         usageIdentifierKey: strOrUndefinedOrNull,
     };
 

--- a/types/aws-lambda/test/cdk-custom-resource-tests.ts
+++ b/types/aws-lambda/test/cdk-custom-resource-tests.ts
@@ -18,9 +18,9 @@ const onEventHandler: CdkCustomResourceHandler = async (event, context) => {
             str = event.ServiceToken;
             str = event.StackId;
 
-            // $ExpectError
+            // @ts-expect-error
             anyObj = event.OldResourceProperties;
-            // $ExpectError
+            // @ts-expect-error
             str = event.PhysicalResourceId;
             break;
         case 'Update':
@@ -41,9 +41,9 @@ const onEventHandler: CdkCustomResourceHandler = async (event, context) => {
     };
 
     const invalidResponse: CdkCustomResourceResponse = {
-        // $ExpectError
+        // @ts-expect-error
         PhysicalResourceId: num,
-        // $ExpectError
+        // @ts-expect-error
         Data: str
     };
 
@@ -78,13 +78,13 @@ const onIsCompleteHandler: CdkCustomResourceIsCompleteHandler = async (event, co
         Data: {
             stringKey: str,
         },
-        // $ExpectError
+        // @ts-expect-error
         otherProperties: anyObj,
     };
 
     const responseWaiting: CdkCustomResourceIsCompleteResponse = {
         IsComplete: false,
-        // $ExpectError
+        // @ts-expect-error
         Data: {
             stringKey: str,
         },

--- a/types/aws-lambda/test/cloudfront-tests.ts
+++ b/types/aws-lambda/test/cloudfront-tests.ts
@@ -38,10 +38,10 @@ const requestHandler: CloudFrontRequestHandler = async (event, context, cb) => {
         request.origin.custom.domainName;
         request.origin.custom.domainName = 'example2.com';
 
-        // $ExpectError
+        // @ts-expect-error
         s3Origin = request.origin.s3;
 
-        // $ExpectError
+        // @ts-expect-error
         request.origin.s3.path = '/';
     }
 
@@ -64,10 +64,10 @@ const requestHandler: CloudFrontRequestHandler = async (event, context, cb) => {
         request.origin.s3.path;
         request.origin.s3.path = '/new_path';
 
-        // $ExpectError
+        // @ts-expect-error
         customOrigin = request.origin.custom;
 
-        // $ExpectError
+        // @ts-expect-error
         request.origin.custom.path = '/';
     }
 
@@ -78,7 +78,7 @@ const requestHandler: CloudFrontRequestHandler = async (event, context, cb) => {
     result = { clientIp: str, method: str, uri: str, querystring: str, headers: cloudFrontHeaders };
     result = { status: str };
     result = { status: str, statusDescription: str, headers: cloudFrontHeaders, bodyEncoding: 'text', body: str };
-    // $ExpectError
+    // @ts-expect-error
     result = {};
 
     cb(new Error());
@@ -92,11 +92,11 @@ const responseHandler: CloudFrontResponseHandler = async (event, context, callba
     result = undefined;
     result = null;
     result = { status: str };
-    // $ExpectError
+    // @ts-expect-error
     result = { clientIp: str, method: str, uri: str, querystring: str, headers: cloudFrontHeaders };
     result = { status: str, statusDescription: str, headers: cloudFrontHeaders, bodyEncoding: 'text', body: str };
     result = { status: str, bodyEncoding: 'base64', body: str };
-    // $ExpectError
+    // @ts-expect-error
     result = { status: str, bodyEncoding: 'invalid-encoding', body: str };
 
     callback(new Error());

--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -61,10 +61,10 @@ const preSignUp: PreSignUpTriggerHandler = async (event, _, callback) => {
     triggerSource === 'PreSignUp_ExternalProvider';
     triggerSource === 'PreSignUp_AdminCreateUser';
 
-    // $ExpectError
+    // @ts-expect-error
     triggerSource === 'PostConfirmation_ConfirmSignUp';
 
-    // $ExpectError
+    // @ts-expect-error
     request.session[0].challengeName === 'CUSTOM_CHALLENGE';
 };
 
@@ -80,15 +80,15 @@ const postConfirmation: PostConfirmationTriggerHandler = async (event, _, callba
     triggerSource === 'PostConfirmation_ConfirmSignUp';
     triggerSource === 'PostConfirmation_ConfirmForgotPassword';
 
-    // $ExpectError
+    // @ts-expect-error
     triggerSource === 'PreSignUp_ExternalProvider';
-    // $ExpectError
+    // @ts-expect-error
     request.session[0].challengeName === 'CUSTOM_CHALLENGE';
-    // $ExpectError
+    // @ts-expect-error
     str = request.validationData['k1'];
-    // $ExpectError
+    // @ts-expect-error
     bool = response.autoVerifyEmail;
-    // $ExpectError
+    // @ts-expect-error
     bool = response.autoVerifyPhone;
 };
 
@@ -116,7 +116,7 @@ const defineAuthChallenge: DefineAuthChallengeTriggerHandler = async (event, _, 
 
     triggerSource === 'DefineAuthChallenge_Authentication';
 
-    // $ExpectError
+    // @ts-expect-error
     nullOrUndefined = request.userAttributes;
 };
 
@@ -140,7 +140,7 @@ const createAuthChallenge: CreateAuthChallengeTriggerHandler = async (event, _, 
 
     triggerSource === 'CreateAuthChallenge_Authentication';
 
-    // $ExpectError
+    // @ts-expect-error
     nullOrUndefined = request.userAttributes;
 };
 

--- a/types/aws-lambda/test/lex-tests.ts
+++ b/types/aws-lambda/test/lex-tests.ts
@@ -133,10 +133,11 @@ lexSlotDetail.resolutions[1];
 lexSlotDetail.resolutions[2];
 lexSlotDetail.resolutions[3];
 lexSlotDetail.resolutions[4];
-lexSlotDetail.resolutions[5]; // $ExpectError
+// @ts-expect-error
+lexSlotDetail.resolutions[5];
 
 lexSlotDetail = {
-    // $ExpectError
+    // @ts-expect-error
     resolutions: [
         { value: 'value0' },
         { value: 'value1' },

--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -581,7 +581,8 @@ class SVGView extends Backbone.View<Backbone.Model, SVGGraphicsElement> {
 
 function testViewWithoutModel() {
     const view = new Backbone.View<undefined>();
-    view.model.id; // $ExpectError
+    // @ts-expect-error
+    view.model.id;
     const view2 = new Backbone.View<Backbone.Model>({
         model: new Backbone.Model()
     });
@@ -597,43 +598,60 @@ class TypedModel extends Backbone.Model<TypedModelAttributes> {}
 
 function testTypedModel() {
     const model = new TypedModel();
-    model.set('unknownAttr', 'stringValue'); // $ExpectError
-    model.set('stringAttr', 1); // $ExpectError
+    // @ts-expect-error
+    model.set('unknownAttr', 'stringValue');
+    // @ts-expect-error
+    model.set('stringAttr', 1);
     model.set('stringAttr', 'stringValue'); // $ExpectType TypedModel
-    model.get('unknownAttr'); // $ExpectError
+    // @ts-expect-error
+    model.get('unknownAttr');
     model.get('stringAttr'); // $ExpectType string | undefined
     model.attributes; // $ExpectType Partial<TypedModelAttributes>
     model.changedAttributes(); // $ExpectType false | Partial<TypedModelAttributes>
-    model.changedAttributes({ unknownAttr: 1 }); // $ExpectError
+    // @ts-expect-error
+    model.changedAttributes({ unknownAttr: 1 });
     model.clear(); // $ExpectType TypedModel
     model.destroy(); // $ExpectType false | JQueryXHR
-    model.escape('unknownAttr'); // $ExpectError
+    // @ts-expect-error
+    model.escape('unknownAttr');
     model.escape('stringAttr'); // $ExpectType string
-    model.has('unknownAttr'); // $ExpectError
+    // @ts-expect-error
+    model.has('unknownAttr');
     model.has('stringAttr'); // $ExpectType boolean
-    model.hasChanged('unknownAttr'); // $ExpectError
+    // @ts-expect-error
+    model.hasChanged('unknownAttr');
     model.hasChanged('stringAttr'); // $ExpectType boolean
-    model.previous('unknownAttr'); // $ExpectError
+    // @ts-expect-error
+    model.previous('unknownAttr');
     model.previous('numberAttr'); // $ExpectType number | null | undefined
     model.previousAttributes(); // $ExpectType Partial<TypedModelAttributes>
-    model.save({ unknownAttr: 'value' }); // $ExpectError
+    // @ts-expect-error
+    model.save({ unknownAttr: 'value' });
     model.save(); // $ExpectType JQueryXHR
     model.save({ stringAttr: 'stringValue' }); // $ExpectType JQueryXHR
     model.save(null, { patch: true }); // $ExpectType JQueryXHR
-    model.unset('unknownAttr'); // $ExpectError
+    // @ts-expect-error
+    model.unset('unknownAttr');
     model.unset('stringAttr'); // $ExpectType TypedModel
-    model.validate({ unknownAttr: 'value' }); // $ExpectError
+    // @ts-expect-error
+    model.validate({ unknownAttr: 'value' });
     model.validate({ stringAttr: 'value' });
-    model.pick('unknownAttr'); // $ExpectError
-    model.pick(['unknownAttr', 'numberAttr']); // $ExpectError
+    // @ts-expect-error
+    model.pick('unknownAttr');
+    // @ts-expect-error
+    model.pick(['unknownAttr', 'numberAttr']);
     model.pick('stringAttr', 'numberAttr');
-    model.pick(['stringAttr'])['numberAttr']; // $ExpectError
+    // @ts-expect-error
+    model.pick(['stringAttr'])['numberAttr'];
     model.pick(['stringAttr'])['stringAttr']; // $ExpectType string | undefined
     model.pick(['stringAttr', 'numberAttr']);
-    model.omit('unknownAttr'); // $ExpectError
-    model.omit(['unknownAttr', 'numberAttr']); // $ExpectError
+    // @ts-expect-error
+    model.omit('unknownAttr');
+    // @ts-expect-error
+    model.omit(['unknownAttr', 'numberAttr']);
     model.omit(['stringAttr'])['numberAttr']; // $ExpectType number | undefined
-    model.omit(['stringAttr'])['stringAttr']; // $ExpectError
+    // @ts-expect-error
+    model.omit(['stringAttr'])['stringAttr'];
     model.omit('stringAttr', 'numberAttr');
     model.omit(['stringAttr', 'numberAttr']);
 }
@@ -648,7 +666,8 @@ function testRouter() {
         },
     });
 
-    router = new Backbone.Router({ routes: 'not object' }); // $ExpectError
+    // @ts-expect-error
+    router = new Backbone.Router({ routes: 'not object' });
 
     router.route('search/:query/p:num', 'search', (query, num) => {});
     router.route(/search/, (query, num) => {});

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -898,7 +898,7 @@ normalMethod('foo', (err, data) => {
 // We want to test the return type of the standard methods, so we disable the no void rule for these lines
 // tslint:disable-next-line:no-void-expression
 const normalMethodValue = normalMethod('foo', emtpyFn);
-// $ExpectError
+// @ts-expect-error
 normalMethodValue.then();
 
 const asyncMethod = promiseModule.movedMethodAsync;
@@ -910,10 +910,10 @@ const ignoredMethod = promiseModule.ignoredMethod;
 // tslint:disable-next-line:no-void-expression
 const ignoredMethodValue = ignoredMethod('foo');
 
-// $ExpectError
+// @ts-expect-error
 ignoredMethodValue.then();
 
-// $ExpectError
+// @ts-expect-error
 const ignoredMethodAsync = promiseModule.ignoredMethodAsync;
 
 anyProm = Bluebird.fromNode(nodeCallbackFunc);

--- a/types/bookshelf/bookshelf-tests.ts
+++ b/types/bookshelf/bookshelf-tests.ts
@@ -581,7 +581,7 @@ new Posts().fetch().then(collection => {
             JSON.stringify(model);
         });
     // withRelated is not a valid option in model.load()
-    // $ExpectError
+    // @ts-expect-error
     collection.at(1).load(['author', 'content'], { withRelated: ['comments.tags'] })
     collection.at(2).load({ comments(qb) {
         qb.where('comments.is_approved', '=', true)

--- a/types/deep-eql/deep-eql-tests.ts
+++ b/types/deep-eql/deep-eql-tests.ts
@@ -25,10 +25,9 @@ interface Foo {
 
 deepEqual({ bar: 1 }, { bar: '1' }, { comparator: (a: Foo, b: Foo) => String(a.bar) === String(b.bar) });
 
-// $ExpectError leftHandOperand should be a number as typed in the comparator function
 deepEqual(
     1,
-    // @ts-expect-error
+    // @ts-expect-error rightHandOperand should be a number as typed in the comparator function
     '2',
     { comparator: (a: number, b: number) => Math.floor(a) === Math.floor(b) },
 );

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -142,7 +142,8 @@ namespace express_tests {
     // Params defaults to typed object
     router.get('/:foo', req => {
         req.params.foo; // $ExpectType string
-        req.params[0]; // $ExpectError
+        // @ts-expect-error
+        req.params[0];
     });
 
     // Params can used as an array
@@ -168,27 +169,31 @@ namespace express_tests {
     router.get<{ foo: string; bar: number }>('/:foo/:bar', req => {
         req.params.foo; // $ExpectType string
         req.params.bar; // $ExpectType number
-        req.params.baz; // $ExpectError
+        // @ts-expect-error
+        req.params.baz;
     });
 
     // Params can be a custom type and can be specified via an explicit param type (express-serve-static-core)
     router.get('/:foo/:bar', (req: Request<{ foo: string; bar: number }>) => {
         req.params.foo; // $ExpectType string
         req.params.bar; // $ExpectType number
-        req.params.baz; // $ExpectError
+        // @ts-expect-error
+        req.params.baz;
     });
 
     // Params can be a custom type and can be specified via an explicit param type (express)
     router.get('/:foo/:bar', (req: express.Request<{ foo: string; bar: number }>) => {
         req.params.foo; // $ExpectType string
         req.params.bar; // $ExpectType number
-        req.params.baz; // $ExpectError
+        // @ts-expect-error
+        req.params.baz;
     });
 
     // Query can be a custom type
     router.get('/:foo', (req: express.Request<{}, any, any, { q: string }>) => {
         req.query.q; // $ExpectType string
-        req.query.a; // $ExpectError
+        // @ts-expect-error
+        req.query.a;
     });
 
     // Query will be defaulted to any
@@ -199,7 +204,8 @@ namespace express_tests {
     // Locals can be a custom type
     router.get('/locals', (req, res: express.Response<any, { foo: boolean }>) => {
         res.locals.foo; // $ExpectType boolean
-        res.locals.bar; // $ExpectError
+        // @ts-expect-error
+        res.locals.bar;
     });
 
     // Response will default to any type
@@ -210,8 +216,10 @@ namespace express_tests {
     // Response will be of Type provided
     router.get('/', (req: Request, res: express.Response<string>) => {
         res.json();
-        res.json(1); // $ExpectError
-        res.send(1); // $ExpectError
+        // @ts-expect-error
+        res.json(1);
+        // @ts-expect-error
+        res.send(1);
     });
 
     app.use((req, res, next) => {

--- a/types/express/ts4.0/express-tests.ts
+++ b/types/express/ts4.0/express-tests.ts
@@ -168,27 +168,31 @@ namespace express_tests {
     router.get<{ foo: string; bar: number }>('/:foo/:bar', req => {
         req.params.foo; // $ExpectType string
         req.params.bar; // $ExpectType number
-        req.params.baz; // $ExpectError
+        // @ts-expect-error
+        req.params.baz;
     });
 
     // Params can be a custom type and can be specified via an explicit param type (express-serve-static-core)
     router.get('/:foo/:bar', (req: Request<{ foo: string; bar: number }>) => {
         req.params.foo; // $ExpectType string
         req.params.bar; // $ExpectType number
-        req.params.baz; // $ExpectError
+        // @ts-expect-error
+        req.params.baz;
     });
 
     // Params can be a custom type and can be specified via an explicit param type (express)
     router.get('/:foo/:bar', (req: express.Request<{ foo: string; bar: number }>) => {
         req.params.foo; // $ExpectType string
         req.params.bar; // $ExpectType number
-        req.params.baz; // $ExpectError
+        // @ts-expect-error
+        req.params.baz;
     });
 
     // Query can be a custom type
     router.get('/:foo', (req: express.Request<{}, any, any, { q: string }>) => {
         req.query.q; // $ExpectType string
-        req.query.a; // $ExpectError
+        // @ts-expect-error
+        req.query.a;
     });
 
     // Query will be defaulted to any
@@ -199,7 +203,8 @@ namespace express_tests {
     // Locals can be a custom type
     router.get('/locals', (req, res: express.Response<any, { foo: boolean }>) => {
         res.locals.foo; // $ExpectType boolean
-        res.locals.bar; // $ExpectError
+        // @ts-expect-error
+        res.locals.bar;
     });
 
     // Response will default to any type
@@ -210,8 +215,10 @@ namespace express_tests {
     // Response will be of Type provided
     router.get('/', (req: Request, res: express.Response<string>) => {
         res.json();
-        res.json(1); // $ExpectError
-        res.send(1); // $ExpectError
+        // @ts-expect-error
+        res.json(1);
+        // @ts-expect-error
+        res.send(1);
     });
 
     app.use((req, res, next) => {

--- a/types/knex-cleaner/knex-cleaner-tests.ts
+++ b/types/knex-cleaner/knex-cleaner-tests.ts
@@ -12,4 +12,5 @@ clean(knexInstance, { ignoreTables: ['table1', 'table2'] }); // $ExpectType Prom
 clean(knexInstance, { restartIdentity: false, ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
 clean(knexInstance, { mode: 'delete', ignoreTables: ['table1', 'table2'] }); // $ExpectType Promise<void>
 clean(knexInstance, { mode: 'delete', restartIdentity: false }); // $ExpectType Promise<void>
-clean(knexInstance, { unknown: 1 }); // $ExpectError
+// @ts-expect-error
+clean(knexInstance, { unknown: 1 });

--- a/types/koa/test/typed-response-body.ts
+++ b/types/koa/test/typed-response-body.ts
@@ -14,7 +14,7 @@ const middleware: Koa.Middleware<Koa.DefaultState, Koa.DefaultContext, CustomRes
     ctx.response.body = {
         a: 1,
         b: 'text',
-        // $ExpectError
+        // @ts-expect-error
         c: true
     };
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3586,7 +3586,8 @@ fp.now(); // $ExpectType number
     _.chain(fnWithRestParameters).negate(); // $ExpectType FunctionChain<(...args: number[]) => boolean>
     fp.negate(fnWithRestParameters); // $ExpectType (...args: number[]) => boolean
 
-    _.negate(() => 'foo'); // $ExpectError
+    // @ts-expect-error
+    _.negate(() => 'foo');
 
     _.negate((a1: number, a2: number): boolean => true); // $ExpectType (a1: number, a2: number) => boolean
     _((a1: number, a2: number): boolean => true).negate(); // $ExpectType Function<(a1: number, a2: number) => boolean>
@@ -6032,11 +6033,11 @@ fp.now(); // $ExpectType number
     _.values(list); // $ExpectType AbcObject[]
     _.values(abcObject); // $ExpectType (string | number | boolean)[]
 
-    // _(true).values(); // $ExpectError
+    // _(true).values(); // @ts-expect-error
     _("hi").values(); // $ExpectType Collection<string>
     _(dict).values(); // $ExpectType Collection<AbcObject>
 
-    // _.chain(true).values(); // $ExpectError
+    // _.chain(true).values(); // @ts-expect-error
     _.chain("hi").values(); // $ExpectType CollectionChain<string>
     _.chain(dict).values(); // $ExpectType CollectionChain<AbcObject>
 

--- a/types/node-red-node-test-helper/node-red-node-test-helper-tests.ts
+++ b/types/node-red-node-test-helper/node-red-node-test-helper-tests.ts
@@ -20,7 +20,7 @@ function helperTests(testHelper: typeof anotherHelper) {
         item.type;
         // $ExpectType string | undefined
         item.key;
-        // $ExpectError
+        // @ts-expect-error
         item.invalidKey;
     }
 

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -60,7 +60,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const buf6: Buffer = Buffer.from(buf1);
     const sb: SharedArrayBuffer = {} as any;
     const buf7: Buffer = Buffer.from(sb);
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from({});
 }
 
@@ -74,7 +74,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     buf = Buffer.from(arr.buffer, 1);
     buf = Buffer.from(arr.buffer, 0, 1);
 
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from("this is a test", 1, 1);
     // Ideally passing a normal Buffer would be a type error too, but it's not
     //  since Buffer is assignable to ArrayBuffer currently
@@ -85,7 +85,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
     /* tslint:disable-next-line no-construct */
     Buffer.from(new String("DEADBEEF"), "hex");
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from(buf2, 'hex');
 }
 
@@ -96,7 +96,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const pseudoString = { valueOf() { return "Hello"; }};
     buf = Buffer.from(pseudoString);
     buf = Buffer.from(pseudoString, "utf-8");
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from(pseudoString, 1, 2);
     const pseudoArrayBuf = { valueOf() { return new Uint16Array(2); } };
     buf = Buffer.from(pseudoArrayBuf, 1, 1);

--- a/types/node/test/dns.ts
+++ b/types/node/test/dns.ts
@@ -139,9 +139,9 @@ resolve6("nodejs.org", { ttl: true }, (err, addresses) => {
 
 setDefaultResultOrder('ipv4first');
 setDefaultResultOrder('verbatim');
-// $ExpectError
+// @ts-expect-error
 setDefaultResultOrder('wrong');
 promises.setDefaultResultOrder('ipv4first');
 promises.setDefaultResultOrder('verbatim');
-// $ExpectError
+// @ts-expect-error
 promises.setDefaultResultOrder('wrong');

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -21,33 +21,33 @@ import { CopyOptions, cpSync, cp } from 'fs';
         assert.ifError);
 
     fs.writeFile("testfile", "content", "utf8", assert.ifError);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
+    // @ts-expect-error
+    fs.writeFile("testfile", "content", "invalid encoding", assert.ifError);
 
     fs.writeFileSync("testfile", "content", "utf8");
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
+    // @ts-expect-error
+    fs.writeFileSync("testfile", "content", "invalid encoding");
     fs.writeFileSync("testfile", "content", { encoding: "utf8" });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
+    // @ts-expect-error
+    fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" });
     fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "utf8" });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
+    // @ts-expect-error
+    fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" });
 }
 
 {
     fs.appendFile("testfile", "foobar", "utf8", assert.ifError);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
+    // @ts-expect-error
+    fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError);
     fs.appendFile("testfile", "foobar", { encoding: "utf8" }, assert.ifError);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
+    // @ts-expect-error
+    fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError);
     fs.appendFileSync("testfile", "foobar", "utf8");
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
+    // @ts-expect-error
+    fs.appendFileSync("testfile", "foobar", "invalid encoding");
     fs.appendFileSync("testfile", "foobar", { encoding: "utf8" });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
+    // @ts-expect-error
+    fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" });
 }
 
 {
@@ -58,11 +58,11 @@ import { CopyOptions, cpSync, cp } from 'fs';
     const stringEncoding: BufferEncoding | null = 'utf8';
 
     content = fs.readFileSync('testfile', 'utf8');
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
+    // @ts-expect-error
+    content = fs.readFileSync('testfile', 'invalid encoding');
     content = fs.readFileSync('testfile', { encoding: 'utf8' });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
+    // @ts-expect-error
+    content = fs.readFileSync('testfile', { encoding: 'invalid encoding' });
     stringOrBuffer = fs.readFileSync('testfile', stringEncoding);
     stringOrBuffer = fs.readFileSync('testfile', { encoding: stringEncoding });
 
@@ -75,11 +75,11 @@ import { CopyOptions, cpSync, cp } from 'fs';
     buffer = fs.readFileSync('testfile', { flag: 'r' });
 
     fs.readFile('testfile', 'utf8', (err, data) => content = data);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
+    // @ts-expect-error
+    fs.readFile('testfile', 'invalid encoding', (err, data) => content = data);
     fs.readFile('testfile', { encoding: 'utf8', signal: new AbortSignal() }, (err, data) => content = data);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data); // $ExpectError
+    // @ts-expect-error
+    fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data);
     fs.readFile('testfile', stringEncoding, (err, data) => stringOrBuffer = data);
     fs.readFile('testfile', { encoding: stringEncoding }, (err, data) => stringOrBuffer = data);
 
@@ -470,19 +470,19 @@ async () => {
 {
     fs.createWriteStream('./index.d.ts');
     fs.createWriteStream('./index.d.ts', 'utf8');
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // @ts-expect-error
+    fs.createWriteStream('./index.d.ts', 'invalid encoding');
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // @ts-expect-error
+    fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' });
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // @ts-expect-error
+    fs.createReadStream('./index.d.ts', 'invalid encoding');
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // @ts-expect-error
+    fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' });
 }
 
 async () => {

--- a/types/node/test/process.ts
+++ b/types/node/test/process.ts
@@ -131,43 +131,43 @@ process.env.TZ = 'test';
 }
 
 {
-    // $ExpectError
+    // @ts-expect-error
     process.getgid();
     // $ExpectType number | undefined
     process.getgid?.();
-    // $ExpectError
+    // @ts-expect-error
     process.setgid(1);
     // $ExpectType void | undefined
     process.setgid?.(1);
-    // $ExpectError
+    // @ts-expect-error
     process.getuid();
     // $ExpectType number | undefined
     process.getuid?.();
-    // $ExpectError
+    // @ts-expect-error
     process.setuid(1);
     // $ExpectType void | undefined
     process.setuid?.(1);
-    // $ExpectError
+    // @ts-expect-error
     process.geteuid();
     // $ExpectType number | undefined
     process.geteuid?.();
-    // $ExpectError
+    // @ts-expect-error
     process.seteuid(1);
     // $ExpectType void | undefined
     process.seteuid?.(1);
-    // $ExpectError
+    // @ts-expect-error
     process.getegid();
     // $ExpectType number | undefined
     process.getegid?.();
-    // $ExpectError
+    // @ts-expect-error
     process.setegid(1);
     // $ExpectType void | undefined
     process.setegid?.(1);
-    // $ExpectError
+    // @ts-expect-error
     process.getgroups();
     // $ExpectType number[] | undefined
     process.getgroups?.();
-    // $ExpectError
+    // @ts-expect-error
     process.setgroups([1]);
     // $ExpectType void | undefined
     process.setgroups?.([1]);

--- a/types/node/test/querystring.ts
+++ b/types/node/test/querystring.ts
@@ -17,8 +17,10 @@ interface SampleObject { [key: string]: string; }
     result = querystring.stringify(obj, sep, eq);
     result = querystring.stringify(obj, sep, eq, options);
 
-    querystring.stringify({ foo: () => {} }); // $ExpectError
-    querystring.stringify({ foo: { bar: 1 } }); // $ExpectError
+    // @ts-expect-error
+    querystring.stringify({ foo: () => {} });
+    // @ts-expect-error
+    querystring.stringify({ foo: { bar: 1 } });
 
     querystring.stringify({
         foo: 'foo',
@@ -60,6 +62,6 @@ interface SampleObject { [key: string]: string; }
 
 {
     const queryInput: string | null | querystring.ParsedUrlQueryInput = {};
-    // $ExpectError
+    // @ts-expect-error
     const query: string | null | querystring.ParsedUrlQuery = queryInput;
 }

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -553,7 +553,7 @@ addAbortSignal(new AbortSignal(), new Readable());
     Readable.fromWeb(web, { objectMode: true });
 
     // When the param includes unsupported ReadableOptions
-    // $ExpectError
+    // @ts-expect-error
     Readable.fromWeb(web, { emitClose: true });
 }
 

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -61,5 +61,5 @@ test((t) => {
   sub;
 });
 
-// $ExpectError
+// @ts-expect-error
 test(1, () => {});

--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -20,7 +20,7 @@ import * as url from 'node:url';
     url.format(myURL, { fragment: false, unicode: true, auth: false });
 
     // `format doesn't work with `path`: use `pathname` and `search` instead
-    // $ExpectError
+    // @ts-expect-error
     url.format({ path: '/foo' });
 }
 
@@ -148,7 +148,7 @@ import * as url from 'node:url';
 }
 
 {
-    // $ExpectError
+    // @ts-expect-error
     new url.URLSearchParams({ foobar: undefined });
 }
 

--- a/types/node/v14/test/buffer.ts
+++ b/types/node/v14/test/buffer.ts
@@ -58,7 +58,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const buf6: Buffer = Buffer.from(buf1);
     const sb: SharedArrayBuffer = {} as any;
     const buf7: Buffer = Buffer.from(sb);
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from({});
 }
 
@@ -72,7 +72,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     buf = Buffer.from(arr.buffer, 1);
     buf = Buffer.from(arr.buffer, 0, 1);
 
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from("this is a test", 1, 1);
     // Ideally passing a normal Buffer would be a type error too, but it's not
     //  since Buffer is assignable to ArrayBuffer currently
@@ -83,7 +83,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
     /* tslint:disable-next-line no-construct */
     Buffer.from(new String("DEADBEEF"), "hex");
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from(buf2, 'hex');
 }
 
@@ -94,7 +94,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const pseudoString = { valueOf() { return "Hello"; }};
     buf = Buffer.from(pseudoString);
     buf = Buffer.from(pseudoString, "utf-8");
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from(pseudoString, 1, 2);
     const pseudoArrayBuf = { valueOf() { return new Uint16Array(2); } };
     buf = Buffer.from(pseudoArrayBuf, 1, 1);

--- a/types/node/v14/test/dns.ts
+++ b/types/node/v14/test/dns.ts
@@ -139,9 +139,9 @@ resolve6("nodejs.org", { ttl: true }, (err, addresses) => {
 
 setDefaultResultOrder('ipv4first');
 setDefaultResultOrder('verbatim');
-// $ExpectError
+// @ts-expect-error
 setDefaultResultOrder('wrong');
 promises.setDefaultResultOrder('ipv4first');
 promises.setDefaultResultOrder('verbatim');
-// $ExpectError
+// @ts-expect-error
 promises.setDefaultResultOrder('wrong');

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -18,33 +18,33 @@ import * as url from 'node:url';
         assert.ifError);
 
     fs.writeFile("testfile", "content", "utf8", assert.ifError);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
+    // @ts-expect-error
+    fs.writeFile("testfile", "content", "invalid encoding", assert.ifError);
 
     fs.writeFileSync("testfile", "content", "utf8");
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
+    // @ts-expect-error
+    fs.writeFileSync("testfile", "content", "invalid encoding");
     fs.writeFileSync("testfile", "content", { encoding: "utf8" });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
+    // @ts-expect-error
+    fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" });
     fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "utf8" });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
+    // @ts-expect-error
+    fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" });
 }
 
 {
     fs.appendFile("testfile", "foobar", "utf8", assert.ifError);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
+    // @ts-expect-error
+    fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError);
     fs.appendFile("testfile", "foobar", { encoding: "utf8" }, assert.ifError);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
+    // @ts-expect-error
+    fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError);
     fs.appendFileSync("testfile", "foobar", "utf8");
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
+    // @ts-expect-error
+    fs.appendFileSync("testfile", "foobar", "invalid encoding");
     fs.appendFileSync("testfile", "foobar", { encoding: "utf8" });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
+    // @ts-expect-error
+    fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" });
 }
 
 {
@@ -55,11 +55,11 @@ import * as url from 'node:url';
     const stringEncoding: BufferEncoding | null = 'utf8';
 
     content = fs.readFileSync('testfile', 'utf8');
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
+    // @ts-expect-error
+    content = fs.readFileSync('testfile', 'invalid encoding');
     content = fs.readFileSync('testfile', { encoding: 'utf8' });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
+    // @ts-expect-error
+    content = fs.readFileSync('testfile', { encoding: 'invalid encoding' });
     stringOrBuffer = fs.readFileSync('testfile', stringEncoding);
     stringOrBuffer = fs.readFileSync('testfile', { encoding: stringEncoding });
 
@@ -72,11 +72,11 @@ import * as url from 'node:url';
     buffer = fs.readFileSync('testfile', { flag: 'r' });
 
     fs.readFile('testfile', 'utf8', (err, data) => content = data);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
+    // @ts-expect-error
+    fs.readFile('testfile', 'invalid encoding', (err, data) => content = data);
     fs.readFile('testfile', { encoding: 'utf8' }, (err, data) => content = data);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.readFile('testfile', { encoding: 'invalid encoding' }, (err, data) => content = data); // $ExpectError
+    // @ts-expect-error
+    fs.readFile('testfile', { encoding: 'invalid encoding' }, (err, data) => content = data);
     fs.readFile('testfile', stringEncoding, (err, data) => stringOrBuffer = data);
     fs.readFile('testfile', { encoding: stringEncoding }, (err, data) => stringOrBuffer = data);
 
@@ -422,19 +422,19 @@ async () => {
 {
     fs.createWriteStream('./index.d.ts');
     fs.createWriteStream('./index.d.ts', 'utf8');
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // @ts-expect-error
+    fs.createWriteStream('./index.d.ts', 'invalid encoding');
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // @ts-expect-error
+    fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' });
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // @ts-expect-error
+    fs.createReadStream('./index.d.ts', 'invalid encoding');
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // @ts-expect-error
+    fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' });
 }
 
 {

--- a/types/node/v14/test/querystring.ts
+++ b/types/node/v14/test/querystring.ts
@@ -17,8 +17,10 @@ interface SampleObject { [key: string]: string; }
     result = querystring.stringify(obj, sep, eq);
     result = querystring.stringify(obj, sep, eq, options);
 
-    querystring.stringify({ foo: () => {} }); // $ExpectError
-    querystring.stringify({ foo: { bar: 1 } }); // $ExpectError
+    // @ts-expect-error
+    querystring.stringify({ foo: () => {} });
+    // @ts-expect-error
+    querystring.stringify({ foo: { bar: 1 } });
 
     querystring.stringify({
         foo: 'foo',
@@ -60,6 +62,6 @@ interface SampleObject { [key: string]: string; }
 
 {
     const queryInput: string | null | querystring.ParsedUrlQueryInput = {};
-    // $ExpectError
+    // @ts-expect-error
     const query: string | null | querystring.ParsedUrlQuery = queryInput;
 }

--- a/types/node/v14/test/url.ts
+++ b/types/node/v14/test/url.ts
@@ -18,7 +18,7 @@ import * as url from 'node:url';
     url.format(myURL, { fragment: false, unicode: true, auth: false });
 
     // `format doesn't work with `path`: use `pathname` and `search` instead
-    // $ExpectError
+    // @ts-expect-error
     url.format({ path: '/foo' });
 }
 
@@ -142,7 +142,7 @@ import * as url from 'node:url';
 }
 
 {
-    // $ExpectError
+    // @ts-expect-error
     new url.URLSearchParams({ foobar: undefined });
 }
 

--- a/types/node/v16/test/buffer.ts
+++ b/types/node/v16/test/buffer.ts
@@ -60,7 +60,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const buf6: Buffer = Buffer.from(buf1);
     const sb: SharedArrayBuffer = {} as any;
     const buf7: Buffer = Buffer.from(sb);
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from({});
 }
 
@@ -74,7 +74,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     buf = Buffer.from(arr.buffer, 1);
     buf = Buffer.from(arr.buffer, 0, 1);
 
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from("this is a test", 1, 1);
     // Ideally passing a normal Buffer would be a type error too, but it's not
     //  since Buffer is assignable to ArrayBuffer currently
@@ -85,7 +85,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
     /* tslint:disable-next-line no-construct */
     Buffer.from(new String("DEADBEEF"), "hex");
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from(buf2, 'hex');
 }
 
@@ -96,7 +96,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const pseudoString = { valueOf() { return "Hello"; }};
     buf = Buffer.from(pseudoString);
     buf = Buffer.from(pseudoString, "utf-8");
-    // $ExpectError
+    // @ts-expect-error
     Buffer.from(pseudoString, 1, 2);
     const pseudoArrayBuf = { valueOf() { return new Uint16Array(2); } };
     buf = Buffer.from(pseudoArrayBuf, 1, 1);

--- a/types/node/v16/test/dns.ts
+++ b/types/node/v16/test/dns.ts
@@ -139,9 +139,9 @@ resolve6("nodejs.org", { ttl: true }, (err, addresses) => {
 
 setDefaultResultOrder('ipv4first');
 setDefaultResultOrder('verbatim');
-// $ExpectError
+// @ts-expect-error
 setDefaultResultOrder('wrong');
 promises.setDefaultResultOrder('ipv4first');
 promises.setDefaultResultOrder('verbatim');
-// $ExpectError
+// @ts-expect-error
 promises.setDefaultResultOrder('wrong');

--- a/types/node/v16/test/fs.ts
+++ b/types/node/v16/test/fs.ts
@@ -21,33 +21,33 @@ import { CopyOptions, cpSync, cp } from 'fs';
         assert.ifError);
 
     fs.writeFile("testfile", "content", "utf8", assert.ifError);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFile("testfile", "content", "invalid encoding", assert.ifError); // $ExpectError
+    // @ts-expect-error
+    fs.writeFile("testfile", "content", "invalid encoding", assert.ifError);
 
     fs.writeFileSync("testfile", "content", "utf8");
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFileSync("testfile", "content", "invalid encoding"); // $ExpectError
+    // @ts-expect-error
+    fs.writeFileSync("testfile", "content", "invalid encoding");
     fs.writeFileSync("testfile", "content", { encoding: "utf8" });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" }); // $ExpectError
+    // @ts-expect-error
+    fs.writeFileSync("testfile", "content", { encoding: "invalid encoding" });
     fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "utf8" });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" }); // $ExpectError
+    // @ts-expect-error
+    fs.writeFileSync("testfile", new DataView(new ArrayBuffer(1)), { encoding: "invalid encoding" });
 }
 
 {
     fs.appendFile("testfile", "foobar", "utf8", assert.ifError);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError); // $ExpectError
+    // @ts-expect-error
+    fs.appendFile("testfile", "foobar", "invalid encoding", assert.ifError);
     fs.appendFile("testfile", "foobar", { encoding: "utf8" }, assert.ifError);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError); // $ExpectError
+    // @ts-expect-error
+    fs.appendFile("testfile", "foobar", { encoding: "invalid encoding" }, assert.ifError);
     fs.appendFileSync("testfile", "foobar", "utf8");
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFileSync("testfile", "foobar", "invalid encoding"); // $ExpectError
+    // @ts-expect-error
+    fs.appendFileSync("testfile", "foobar", "invalid encoding");
     fs.appendFileSync("testfile", "foobar", { encoding: "utf8" });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" }); // $ExpectError
+    // @ts-expect-error
+    fs.appendFileSync("testfile", "foobar", { encoding: "invalid encoding" });
 }
 
 {
@@ -58,11 +58,11 @@ import { CopyOptions, cpSync, cp } from 'fs';
     const stringEncoding: BufferEncoding | null = 'utf8';
 
     content = fs.readFileSync('testfile', 'utf8');
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // content = fs.readFileSync('testfile', 'invalid encoding'); // $ExpectError
+    // @ts-expect-error
+    content = fs.readFileSync('testfile', 'invalid encoding');
     content = fs.readFileSync('testfile', { encoding: 'utf8' });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // content = fs.readFileSync('testfile', { encoding: 'invalid encoding' }); // $ExpectError
+    // @ts-expect-error
+    content = fs.readFileSync('testfile', { encoding: 'invalid encoding' });
     stringOrBuffer = fs.readFileSync('testfile', stringEncoding);
     stringOrBuffer = fs.readFileSync('testfile', { encoding: stringEncoding });
 
@@ -75,11 +75,11 @@ import { CopyOptions, cpSync, cp } from 'fs';
     buffer = fs.readFileSync('testfile', { flag: 'r' });
 
     fs.readFile('testfile', 'utf8', (err, data) => content = data);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.readFile('testfile', 'invalid encoding', (err, data) => content = data); // $ExpectError
+    // @ts-expect-error
+    fs.readFile('testfile', 'invalid encoding', (err, data) => content = data);
     fs.readFile('testfile', { encoding: 'utf8', signal: new AbortSignal() }, (err, data) => content = data);
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data); // $ExpectError
+    // @ts-expect-error
+    fs.readFile('testfile', { encoding: 'invalid encoding', signal: new AbortSignal() }, (err, data) => content = data);
     fs.readFile('testfile', stringEncoding, (err, data) => stringOrBuffer = data);
     fs.readFile('testfile', { encoding: stringEncoding }, (err, data) => stringOrBuffer = data);
 
@@ -455,19 +455,19 @@ async () => {
 {
     fs.createWriteStream('./index.d.ts');
     fs.createWriteStream('./index.d.ts', 'utf8');
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createWriteStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // @ts-expect-error
+    fs.createWriteStream('./index.d.ts', 'invalid encoding');
     fs.createWriteStream('./index.d.ts', { encoding: 'utf8' });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // @ts-expect-error
+    fs.createWriteStream('./index.d.ts', { encoding: 'invalid encoding' });
 
     fs.createReadStream('./index.d.ts');
     fs.createReadStream('./index.d.ts', 'utf8');
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createReadStream('./index.d.ts', 'invalid encoding'); // $ExpectError
+    // @ts-expect-error
+    fs.createReadStream('./index.d.ts', 'invalid encoding');
     fs.createReadStream('./index.d.ts', { encoding: 'utf8' });
-    // FIXME: $ExpectError is currently broken (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54711)
-    // fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' }); // $ExpectError
+    // @ts-expect-error
+    fs.createReadStream('./index.d.ts', { encoding: 'invalid encoding' });
 }
 
 async () => {

--- a/types/node/v16/test/querystring.ts
+++ b/types/node/v16/test/querystring.ts
@@ -17,8 +17,10 @@ interface SampleObject { [key: string]: string; }
     result = querystring.stringify(obj, sep, eq);
     result = querystring.stringify(obj, sep, eq, options);
 
-    querystring.stringify({ foo: () => {} }); // $ExpectError
-    querystring.stringify({ foo: { bar: 1 } }); // $ExpectError
+    // @ts-expect-error
+    querystring.stringify({ foo: () => {} });
+    // @ts-expect-error
+    querystring.stringify({ foo: { bar: 1 } });
 
     querystring.stringify({
         foo: 'foo',
@@ -60,6 +62,6 @@ interface SampleObject { [key: string]: string; }
 
 {
     const queryInput: string | null | querystring.ParsedUrlQueryInput = {};
-    // $ExpectError
+    // @ts-expect-error
     const query: string | null | querystring.ParsedUrlQuery = queryInput;
 }

--- a/types/node/v16/test/url.ts
+++ b/types/node/v16/test/url.ts
@@ -20,7 +20,7 @@ import * as url from 'node:url';
     url.format(myURL, { fragment: false, unicode: true, auth: false });
 
     // `format doesn't work with `path`: use `pathname` and `search` instead
-    // $ExpectError
+    // @ts-expect-error
     url.format({ path: '/foo' });
 }
 
@@ -148,7 +148,7 @@ import * as url from 'node:url';
 }
 
 {
-    // $ExpectError
+    // @ts-expect-error
     new url.URLSearchParams({ foobar: undefined });
 }
 

--- a/types/react-native/v0.68/test/globals.tsx
+++ b/types/react-native/v0.68/test/globals.tsx
@@ -13,17 +13,20 @@ function testInterval() {
     handle = setInterval((arg1: number, arg2: string) => {
         console.log('arg1', arg1);
         console.log('arg2', arg2);
-    }, 0, 'wrong-type', '200'); // $ExpectError
+    // @ts-expect-error
+    }, 0, 'wrong-type', '200');
     clearInterval(handle);
 
-    handle = setInterval((missingArg: any) => { // $ExpectError
+    // @ts-expect-error
+    handle = setInterval((missingArg: any) => {
         console.log('missingArg', missingArg);
     }, 0);
     clearInterval(handle);
 
     handle = setInterval((arg1: number) => {
         console.log('arg1', arg1);
-    }, 0, 100, 'missing-arg'); // $ExpectError
+    // @ts-expect-error
+    }, 0, 100, 'missing-arg');
     clearInterval(handle);
 }
 
@@ -40,17 +43,20 @@ function testTimeout() {
     handle = setTimeout((arg1: number, arg2: string) => {
         console.log('arg1', arg1);
         console.log('arg2', arg2);
-    }, 0, 'wrong-type', '200'); // $ExpectError
+    // @ts-expect-error
+    }, 0, 'wrong-type', '200');
     clearTimeout(handle);
 
-    handle = setTimeout((missingArg: any) => { // $ExpectError
+    // @ts-expect-error
+    handle = setTimeout((missingArg: any) => {
         console.log('missingArg', missingArg);
     }, 0);
     clearTimeout(handle);
 
     handle = setTimeout((arg1: number) => {
         console.log('arg1', arg1);
-    }, 0, 100, 'missing-arg'); // $ExpectError
+    // @ts-expect-error
+    }, 0, 100, 'missing-arg');
     clearTimeout(handle);
 }
 
@@ -67,17 +73,20 @@ function testImmediate() {
     handle = setImmediate((arg1: number, arg2: string) => {
         console.log('arg1', arg1);
         console.log('arg2', arg2);
-    }, 'wrong-type', '200'); // $ExpectError
+    // @ts-expect-error
+    }, 'wrong-type', '200');
     clearImmediate(handle);
 
-    handle = setImmediate((missingArg: any) => { // $ExpectError
+    // @ts-expect-error
+    handle = setImmediate((missingArg: any) => {
         console.log('missingArg', missingArg);
     });
     clearImmediate(handle);
 
     handle = setImmediate((arg1: number) => {
         console.log('arg1', arg1);
-    }, 100, 'missing-arg'); // $ExpectError
+    // @ts-expect-error
+    }, 100, 'missing-arg');
     clearImmediate(handle);
 }
 

--- a/types/react-native/v0.68/test/index.tsx
+++ b/types/react-native/v0.68/test/index.tsx
@@ -273,13 +273,17 @@ const combinedStyle5: StyleProp<TextStyle> = StyleSheet.compose(
 const combinedStyle6: StyleProp<TextStyle | null> = StyleSheet.compose(null, null);
 
 // The following use of the compose method is invalid:
-const combinedStyle7 = StyleSheet.compose(composeImageStyle, composeTextStyle); // $ExpectError
+// @ts-expect-error
+const combinedStyle7 = StyleSheet.compose(composeImageStyle, composeTextStyle);
 
-const combinedStyle8: StyleProp<ImageStyle> = StyleSheet.compose(composeTextStyle, composeTextStyle); // $ExpectError
+// @ts-expect-error
+const combinedStyle8: StyleProp<ImageStyle> = StyleSheet.compose(composeTextStyle, composeTextStyle);
 
-const combinedStyle9: StyleProp<ImageStyle> = StyleSheet.compose([composeTextStyle], null); // $ExpectError
+// @ts-expect-error
+const combinedStyle9: StyleProp<ImageStyle> = StyleSheet.compose([composeTextStyle], null);
 
-const combinedStyle10: StyleProp<ImageStyle> = StyleSheet.compose(Math.random() < 0.5 ? composeTextStyle : null, null); // $ExpectError
+// @ts-expect-error
+const combinedStyle10: StyleProp<ImageStyle> = StyleSheet.compose(Math.random() < 0.5 ? composeTextStyle : null, null);
 
 const testNativeSyntheticEvent = <T extends {}>(e: NativeSyntheticEvent<T>): void => {
     e.isDefaultPrevented();
@@ -1613,7 +1617,7 @@ DynamicColorIOS({
 // Test you cannot set internals of ColorValue directly
 const OpaqueTest1 = () => (
     <View
-        // $ExpectError
+        // @ts-expect-error
         style={{
             backgroundColor: {
                 resource_paths: ['?attr/colorControlNormal'],
@@ -1624,7 +1628,7 @@ const OpaqueTest1 = () => (
 
 const OpaqueTest2 = () => (
     <View
-        // $ExpectError
+        // @ts-expect-error
         style={{
             backgroundColor: {
                 semantic: 'string',
@@ -1638,7 +1642,8 @@ const OpaqueTest2 = () => (
 );
 
 // Test you cannot amend opaque type
-PlatformColor('?attr/colorControlNormal').resource_paths.push('foo'); // $ExpectError
+// @ts-expect-error
+PlatformColor('?attr/colorControlNormal').resource_paths.push('foo');
 
 const someColorProp: ColorValue = PlatformColor('test');
 

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -39,7 +39,7 @@ const testCases = [
     <input accept="image/*" capture />,
     <input accept="video/*" capture="user" />,
     <input accept="video/*" capture="environment" />,
-    // $ExpectError
+    // @ts-expect-error
     <input accept="video/*" capture="haha" />,
     <input accept="video/*" capture />,
     <input accept="audio/*" capture />,
@@ -51,7 +51,7 @@ const testCases = [
     <a target="some-frame"></a>,
     <input type="button" />,
     <input type="some-type" />,
-    // $ExpectError
+    // @ts-expect-error
     <input enterKeyHint="don" />,
     <video disableRemotePlayback />,
     <picture>

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -17,7 +17,7 @@ function suspenseTest() {
 }
 
 // Unsupported `revealOrder` triggers a runtime warning
-// $ExpectError
+// @ts-expect-error
 <React.SuspenseList revealOrder="something">
     <React.Suspense fallback="Loading">Content</React.Suspense>
 </React.SuspenseList>;

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -105,7 +105,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useReducer(reducer, { age: 42, name: 'The Answer' });
 
     // Implicit any
-    // $ExpectError
+    // @ts-expect-error
     const anyCallback = React.useCallback(value => {
         // $ExpectType any
         return value;
@@ -119,7 +119,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType number
     typedCallback("1");
     // Argument of type '{}' is not assignable to parameter of type 'string'.
-    // $ExpectError
+    // @ts-expect-error
     typedCallback({});
 
     function useContextuallyTypedCallback(fn: (event: Event) => string) {}
@@ -155,7 +155,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>();
     // don't just accept a potential undefined if there is a generic argument
-    // $ExpectError
+    // @ts-expect-error
     React.useRef<number>(undefined);
     // make sure once again there's no |undefined if the initial value doesn't either
     // $ExpectType MutableRefObject<number>
@@ -173,7 +173,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     const id = React.useMemo(() => Math.random(), []);
     React.useImperativeHandle(ref, () => ({ id }), [id]);
     // was named like this in the first alpha, renamed before release
-    // $ExpectError
+    // @ts-expect-error
     React.useImperativeMethods(ref, () => ({}), [id]);
 
     // make sure again this is not going to the |null convenience overload
@@ -187,7 +187,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     }, []);
     React.useEffect(() => {
         dispatch({ type: 'getOlder' });
-        // $ExpectError
+        // @ts-expect-error
         dispatch();
 
         simpleDispatch();
@@ -198,17 +198,17 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useEffect(() => () => {});
     // indistinguishable
     React.useEffect(() => () => undefined);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => null);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => Math.random() ? null : undefined);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => () => null);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => () => Math.random() ? null : undefined);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => async () => {});
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(async () => () => {});
 
     React.useDebugValue(id, value => value.toFixed());
@@ -217,7 +217,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // allow passing an explicit undefined
     React.useMemo(() => {}, undefined);
     // but don't allow it to be missing
-    // $ExpectError
+    // @ts-expect-error
     React.useMemo(() => {});
 
     // useState convenience overload
@@ -232,7 +232,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType undefined
     React.useState(undefined)[0];
     // make sure the generic argument does reject actual potentially undefined inputs
-    // $ExpectError
+    // @ts-expect-error
     React.useState<number>(undefined)[0];
     // make sure useState does not widen
     const [toggle, setToggle] = React.useState(false);
@@ -299,11 +299,11 @@ function useExperimentalHooks() {
 
         // The function must be synchronous, even if it can start an asynchronous update
         // it's no different from an useEffect callback in this respect
-        // $ExpectError
+        // @ts-expect-error
         startTransition(async () => {});
 
         // Unlike Effect callbacks, though, there is no possible destructor to return
-        // $ExpectError
+        // @ts-expect-error
         startTransition(() => () => {});
     };
 
@@ -319,7 +319,7 @@ function startTransitionTest() {
         transitionToPage('/');
     });
 
-    // $ExpectError
+    // @ts-expect-error
     React.startTransition(async () => {});
 }
 
@@ -351,7 +351,7 @@ function useVersion(): number {
 function useStoreWrong() {
     useSyncExternalStore(
         // no unsubscribe returned
-        // $ExpectError
+        // @ts-expect-error
         () => {
             return null;
         },
@@ -359,7 +359,7 @@ function useStoreWrong() {
     );
 
     // `string` is not assignable to `number`
-    // $ExpectError
+    // @ts-expect-error
     const version: number = useSyncExternalStore(
         () => () => {},
         () => '1',

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -70,7 +70,7 @@ declare const container: Element;
     class SettingStateFromCtorComponent extends React.Component<Props, State, Snapshot> {
         constructor(props: Props) {
             super(props);
-            // $ExpectError
+            // @ts-expect-error
             this.state = {
                 inputValue: 'hello'
             };
@@ -79,7 +79,6 @@ declare const container: Element;
     }
 
     class BadlyInitializedState extends React.Component<Props, State, Snapshot> {
-        // $ExpectError -> this throws error on TS 2.6 uncomment once TS requirement is TS >= 2.7
         // state = {
         //     secondz: 0,
         //     inputValuez: 'hello'
@@ -89,11 +88,10 @@ declare const container: Element;
     class BetterPropsAndStateChecksComponent extends React.Component<Props, State, Snapshot> {
         render() { return null; }
         componentDidMount() {
-            // $ExpectError -> this will be true in next BC release where state is gonna be `null | Readonly<S>`
             console.log(this.state.inputValue);
         }
         mutateState() {
-            // $ExpectError
+            // @ts-expect-error
             this.state = {
                 inputValue: 'hello'
             };
@@ -101,18 +99,18 @@ declare const container: Element;
             // Even if state is not set, this is allowed by React
             this.setState({ inputValue: 'hello' });
             this.setState((prevState, props) => {
-                // $ExpectError
+                // @ts-expect-error
                 props = { foo: 'nope' };
-                // $ExpectError
+                // @ts-expect-error
                 props.foo = 'nope';
 
                 return { inputValue: prevState.inputValue + ' foo' };
             });
         }
         mutateProps() {
-            // $ExpectError
+            // @ts-expect-error
             this.props = {};
-            // $ExpectError
+            // @ts-expect-error
             this.props = {
                 key: 42,
                 ref: "myComponent42",
@@ -224,7 +222,8 @@ const FunctionComponent4: React.FunctionComponent = props => null;
 
 // undesired: Rejects `false` because of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
 // leaving here to document limitation and inspect error message
-const FunctionComponent5: React.FunctionComponent = () => false; // $ExpectError
+// @ts-expect-error
+const FunctionComponent5: React.FunctionComponent = () => false;
 
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =
@@ -392,12 +391,12 @@ ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 // need the explicit type declaration for typescript < 3.1
 const ForwardRefRenderFunctionWithPropTypes: { (): null, propTypes?: {} | undefined } = () => null;
 // Warning: forwardRef render functions do not support propTypes or defaultProps
-// $ExpectError
+// @ts-expect-error
 React.forwardRef(ForwardRefRenderFunctionWithPropTypes);
 
 const ForwardRefRenderFunctionWithDefaultProps: { (): null, defaultProps?: {} | undefined } = () => null;
 // Warning: forwardRef render functions do not support propTypes or defaultProps
-// $ExpectError
+// @ts-expect-error
 React.forwardRef(ForwardRefRenderFunctionWithDefaultProps);
 
 function RefCarryingComponent() {
@@ -567,7 +566,7 @@ type mappedChildrenArray5Type = typeof mappedChildrenArray5 extends React.Key[] 
 // $ExpectType string[]
 const mappedChildrenArray6 = React.Children.map(renderPropsChildren, element => element.name);
 // The return type may not be an array
-// $ExpectError
+// @ts-expect-error
 const mappedChildrenArray7 = React.Children.map(nodeChildren, node => node).map;
 
 //
@@ -757,7 +756,7 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
         return label;
     });
     // But just an empty return results in `void`.
-    // $ExpectError
+    // @ts-expect-error
     const emptyReturn: React.ReactNode = ['a', 'b'].map(label => {
         return;
     });
@@ -768,7 +767,7 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
         }
     });
     // But no return results in `void`.
-    // $ExpectError
+    // @ts-expect-error
     const noReturn: React.ReactNode = ['a', 'b'].map(label => {});
 }
 
@@ -794,7 +793,7 @@ type UnionProps =
     | ({ type: 'single'; value?: number } & React.RefAttributes<HTMLDivElement>)
     | ({ type: 'multiple'; value?: number[] } & React.RefAttributes<HTMLDivElement>);
 
-// $ExpectError
+// @ts-expect-error
 const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     type: 'single',
     value: [2],
@@ -816,9 +815,9 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     // we don't care about the value created by `new Wrapper()`.
     // We only care about the props we can pass to the component.
     let Wrapper: React.JSXElementConstructor<ExactProps>;
-    // $ExpectError
+    // @ts-expect-error
     Wrapper = class Narrower extends React.Component<NarrowerProps> {};
-    // $ExpectError
+    // @ts-expect-error
     Wrapper = (props: NarrowerProps) => null;
     Wrapper = class Exact extends React.Component<ExactProps> {};
     Wrapper = (props: ExactProps) => null;
@@ -827,7 +826,7 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
 
     React.createElement(Wrapper, { value: 'A' });
     React.createElement(Wrapper, { value: 'B' });
-    // $ExpectError
+    // @ts-expect-error
     React.createElement(Wrapper, { value: 'C' });
 }
 
@@ -839,12 +838,12 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     type InferredProps = React.ComponentPropsWithRef<React.JSXElementConstructor<Props>>;
     const props: Props = {
         value: 'inferred',
-        // $ExpectError
+        // @ts-expect-error
         notImplemented: 5
     };
     const inferredProps: InferredProps = {
         value: 'inferred',
-        // $ExpectError
+        // @ts-expect-error
         notImplemented: 5
     };
 }

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -32,10 +32,10 @@ class AnnotatedPropTypesAndDefaultProps extends React.Component<Props> {
 }
 
 const annotatedPropTypesAndDefaultPropsTests = [
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
     <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
     <AnnotatedPropTypesAndDefaultProps
         bool={true}
@@ -56,10 +56,10 @@ class UnannotatedPropTypesAndDefaultProps extends React.Component {
 }
 
 const unannotatedPropTypesAndDefaultPropsTests = [
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
     <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
     <UnannotatedPropTypesAndDefaultProps
         bool={true}
@@ -79,12 +79,12 @@ class AnnotatedPropTypes extends React.Component<Props> {
 }
 
 const annotatedPropTypesTests = [
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
     <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} />,
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
     <AnnotatedPropTypes
         bool={false}
@@ -103,12 +103,12 @@ class UnannotatedPropTypes extends React.Component {
 }
 
 const unannotatedPropTypesTests = [
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypes />, // str, extraStr and fnc are required
     <UnannotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
     <UnannotatedPropTypes
         bool={false}
@@ -126,11 +126,11 @@ class AnnotatedDefaultProps extends React.Component<Props> {
 }
 
 const annotatedDefaultPropsTests = [
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedDefaultProps />, // str is required
     <AnnotatedDefaultProps str='abc' />,
     <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
     <AnnotatedDefaultProps
         bool={true}
@@ -162,7 +162,7 @@ function FunctionalComponent(props: Props) { return <>{props.reqNode}</>; }
 FunctionalComponent.defaultProps = defaultProps;
 
 const functionalComponentTests = [
-    // $ExpectError
+    // @ts-expect-error
     <FunctionalComponent />,
     <FunctionalComponent str='' />
 ];
@@ -173,20 +173,16 @@ const LazyMemoFunctionalComponent = React.lazy(async () => ({ default: MemoFunct
 const LazyMemoAnnotatedDefaultProps = React.lazy(async () => ({ default: MemoAnnotatedDefaultProps }));
 
 const memoTests = [
-    // $ExpectError
+    // @ts-expect-error
     <MemoFunctionalComponent />,
-    // $ExpectError won't work as long as FunctionalComponent doesn't work either
     <MemoFunctionalComponent str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <MemoAnnotatedDefaultProps />,
     <AnnotatedDefaultProps str='abc' />,
-    // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
     <MemoAnnotatedDefaultProps str='abc' />,
-    // $ExpectError won't work as long as FunctionalComponent doesn't work either
     <LazyMemoFunctionalComponent str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <LazyMemoAnnotatedDefaultProps />,
-    // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
     <LazyMemoAnnotatedDefaultProps str='abc' />
 ];
 
@@ -196,7 +192,7 @@ const ForwardRef = React.forwardRef((props: Props, ref: React.Ref<ComponentWithN
 ForwardRef.defaultProps = defaultProps;
 
 const forwardRefTests = [
-    // $ExpectError
+    // @ts-expect-error
     <ForwardRef />,
     <ForwardRef
         fnc={() => {}}
@@ -204,7 +200,7 @@ const forwardRefTests = [
         str=''
     />,
     // same bug as MemoFunctionalComponent and React.SFC-typed things
-    // $ExpectError
+    // @ts-expect-error
     <ForwardRef str='abc' />
 ];
 
@@ -241,7 +237,7 @@ type weakComponentTest3 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakC
     bar: boolean
 } ? true : false;
 
-// $ExpectError
+// @ts-expect-error
 const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { foo: '' };
 const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { bar: true };
 
@@ -253,7 +249,7 @@ interface WeakIndexedComponentProps {
 }
 
 const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { };
-// $ExpectError
+// @ts-expect-error
 const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { foo: '' };
 const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: '' };
 const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: 4 };

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -14,7 +14,7 @@ FunctionComponent.defaultProps = {
 <FunctionComponent />;
 <slot name="slot1"></slot>;
 // `FunctionComponent` has no `children`
-// $ExpectError
+// @ts-expect-error
 <FunctionComponent>24</FunctionComponent>;
 
 const VoidFunctionComponent: React.VoidFunctionComponent<SCProps> = ({ foo }: SCProps) => {
@@ -26,7 +26,7 @@ VoidFunctionComponent.defaultProps = {
 };
 <VoidFunctionComponent />;
 
-// $ExpectError
+// @ts-expect-error
 const VoidFunctionComponent2: React.VoidFunctionComponent<SCProps> = ({ foo, children }) => {
     return <div>{foo}{children}</div>;
 };
@@ -34,16 +34,21 @@ VoidFunctionComponent2.displayName = "VoidFunctionComponent2";
 VoidFunctionComponent2.defaultProps = {
     foo: 42
 };
-<VoidFunctionComponent2>24</VoidFunctionComponent2>; // $ExpectError
+// @ts-expect-error
+<VoidFunctionComponent2>24</VoidFunctionComponent2>;
 
 const ComponentWithChildren1: React.FunctionComponent<React.PropsWithChildren> = ({children}) => {
     return <div>{children}</div>;
 };
 <ComponentWithChildren1></ComponentWithChildren1>;
-<ComponentWithChildren1 foo={42}></ComponentWithChildren1>; // $ExpectError
-<ComponentWithChildren1 foo="42"></ComponentWithChildren1>; // $ExpectError
-<ComponentWithChildren1 bar={42}></ComponentWithChildren1>; // $ExpectError
-<ComponentWithChildren1 bar="42"></ComponentWithChildren1>; // $ExpectError
+// @ts-expect-error
+<ComponentWithChildren1 foo={42}></ComponentWithChildren1>;
+// @ts-expect-error
+<ComponentWithChildren1 foo="42"></ComponentWithChildren1>;
+// @ts-expect-error
+<ComponentWithChildren1 bar={42}></ComponentWithChildren1>;
+// @ts-expect-error
+<ComponentWithChildren1 bar="42"></ComponentWithChildren1>;
 
 interface ComponentWithChildren2Props {
     foo?: number | undefined;
@@ -53,9 +58,12 @@ const ComponentWithChildren2: React.FunctionComponent<React.PropsWithChildren<Co
 };
 <ComponentWithChildren2></ComponentWithChildren2>;
 <ComponentWithChildren2 foo={42}></ComponentWithChildren2>;
-<ComponentWithChildren2 foo="42"></ComponentWithChildren2>; // $ExpectError
-<ComponentWithChildren2 bar={42}></ComponentWithChildren2>; // $ExpectError
-<ComponentWithChildren2 bar="42"></ComponentWithChildren2>; // $ExpectError
+// @ts-expect-error
+<ComponentWithChildren2 foo="42"></ComponentWithChildren2>;
+// @ts-expect-error
+<ComponentWithChildren2 bar={42}></ComponentWithChildren2>;
+// @ts-expect-error
+<ComponentWithChildren2 bar="42"></ComponentWithChildren2>;
 
 interface ComponentWithChildren3Props {
     foo?: number | undefined;
@@ -64,11 +72,15 @@ interface ComponentWithChildren3Props {
 const ComponentWithChildren3: React.FunctionComponent<React.PropsWithChildren<ComponentWithChildren3Props>> = ({children}) => {
     return <div>{children}</div>;
 };
-<ComponentWithChildren3></ComponentWithChildren3>; // $ExpectError
-<ComponentWithChildren3 foo={42}></ComponentWithChildren3>; // $ExpectError
-<ComponentWithChildren3 foo="42"></ComponentWithChildren3>; // $ExpectError
+// @ts-expect-error
+<ComponentWithChildren3></ComponentWithChildren3>;
+// @ts-expect-error
+<ComponentWithChildren3 foo={42}></ComponentWithChildren3>;
+// @ts-expect-error
+<ComponentWithChildren3 foo="42"></ComponentWithChildren3>;
 <ComponentWithChildren3 bar={42}></ComponentWithChildren3>;
-<ComponentWithChildren3 bar="42"></ComponentWithChildren3>; // $ExpectError
+// @ts-expect-error
+<ComponentWithChildren3 bar="42"></ComponentWithChildren3>;
 
 // svg sanity check
 <svg viewBox="0 0 1000 1000">
@@ -110,8 +122,10 @@ const ComponentWithChildren3: React.FunctionComponent<React.PropsWithChildren<Co
 <button type="submit">foo</button>;
 <button type="reset">foo</button>;
 <button type="button">foo</button>;
-<button type="botton">foo</button>; // $ExpectError
-<button type={"botton" as string}>foo</button>; // $ExpectError
+// @ts-expect-error
+<button type="botton">foo</button>;
+// @ts-expect-error
+<button type={"botton" as string}>foo</button>;
 
 interface Props {
     hello: string;
@@ -140,9 +154,9 @@ const FunctionComponentWithoutProps: React.FunctionComponent = (props) => {
 const ContextWithRenderProps = React.createContext('defaultValue');
 
 // unstable APIs should not be part of the typings
-// $ExpectError
+// @ts-expect-error
 const ContextUsingUnstableObservedBits = React.createContext(undefined, (previous, next) => 7);
-// $ExpectError
+// @ts-expect-error
 <ContextWithRenderProps.Consumer unstable_observedBits={4}>
     {(value: unknown) => null}
 </ContextWithRenderProps.Consumer>;
@@ -171,19 +185,25 @@ const ContextUsingUnstableObservedBits = React.createContext(undefined, (previou
 // Below tests that setState() works properly for both regular and callback modes
 class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
     handleSomething = () => {
-      this.setState({ foo: '' }); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: '' });
       this.setState({ foo: true });
       this.setState({ foo: true, bar: true });
       this.setState({});
       this.setState(null);
-      this.setState({ foo: true, foo2: true }); // $ExpectError
-      this.setState(() => ({ foo: '' })); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: true, foo2: true });
+      // @ts-expect-error
+      this.setState(() => ({ foo: '' }));
       this.setState(() => ({ foo: true }));
       this.setState(() => ({ foo: true, bar: true }));
-      this.setState(() => ({ foo: true, foo2: true })); // $ExpectError
-      this.setState(() => ({ foo: '', foo2: true })); // $ExpectError
+      // @ts-expect-error
+      this.setState(() => ({ foo: true, foo2: true }));
+      // @ts-expect-error
+      this.setState(() => ({ foo: '', foo2: true }));
       this.setState(() => ({ })); // ok!
-      this.setState({ foo: true, bar: undefined}); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: true, bar: undefined});
       this.setState(prevState => (prevState.bar ? { bar: false } : null));
     }
 }
@@ -260,10 +280,12 @@ class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', st
 const AssignedComponentWithLargeState: React.ComponentClass = ComponentWithLargeState;
 
 const componentWithBadLifecycle = new (class extends React.Component<{}, {}, number> {})({});
-componentWithBadLifecycle.getSnapshotBeforeUpdate = () => { // $ExpectError
+// @ts-expect-error
+componentWithBadLifecycle.getSnapshotBeforeUpdate = () => {
     return 'number';
 };
-componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, snapshot?: string) => { // $ExpectError
+// @ts-expect-error
+componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, snapshot?: string) => {
     return;
 };
 
@@ -292,7 +314,7 @@ const Memoized5 = React.memo<{ test: boolean }>(
 
 const Memoized6: React.NamedExoticComponent<object> = React.memo(props => null);
 <Memoized6/>;
-// $ExpectError
+// @ts-expect-error
 <Memoized6 foo/>;
 
 // NOTE: this test _requires_ TypeScript 3.1
@@ -322,7 +344,7 @@ const LazyRefForwarding = React.lazy(async () => ({ default: Memoized4 }));
 <React.Suspense/>;
 
 // unstable API should not be part of the typings
-// $ExpectError
+// @ts-expect-error
 <React.Suspense fallback={null} unstable_avoidThisFallback />;
 
 class LegacyContext extends React.Component {
@@ -364,10 +386,12 @@ const divRef = React.createRef<HTMLDivElement>();
 
 <ForwardRef ref={divFnRef}/>;
 <ForwardRef ref={divRef}/>;
-<ForwardRef ref='string'/>; // $ExpectError
+// @ts-expect-error
+<ForwardRef ref='string'/>;
 <ForwardRef2 ref={divFnRef}/>;
 <ForwardRef2 ref={divRef}/>;
-<ForwardRef2 ref='string'/>; // $ExpectError
+// @ts-expect-error
+<ForwardRef2 ref='string'/>;
 
 const htmlElementFnRef = (instance: HTMLElement | null) => {};
 const htmlElementRef = React.createRef<HTMLElement>();
@@ -388,7 +412,8 @@ const newContextRef = React.createRef<NewContext>();
 
 const ForwardNewContext = React.forwardRef((_props: {}, ref?: React.Ref<NewContext>) => <NewContext ref={ref}/>);
 <ForwardNewContext ref={newContextRef}/>;
-<ForwardNewContext ref='string'/>; // $ExpectError
+// @ts-expect-error
+<ForwardNewContext ref='string'/>;
 
 const ForwardRef3 = React.forwardRef(
     (props: JSX.IntrinsicElements['div'] & Pick<JSX.IntrinsicElements['div'] & { theme?: {} | undefined }, 'ref'|'theme'>, ref?: React.Ref<HTMLDivElement>) =>
@@ -401,11 +426,14 @@ const ForwardRef3 = React.forwardRef(
 const { Profiler } = React;
 
 // 'id' is missing
-<Profiler />; // $ExpectError
+// @ts-expect-error
+<Profiler />;
 // 'onRender' is missing
-<Profiler id="test" />; // $ExpectError
+// @ts-expect-error
+<Profiler id="test" />;
 // 'number' is not assignable to 'string'
-<Profiler id={2} />; // $ExpectError
+// @ts-expect-error
+<Profiler id={2} />;
 
 <Profiler
   id="test"
@@ -442,9 +470,9 @@ imgProps.decoding = 'auto';
 imgProps.decoding = 'sync';
 imgProps.loading = 'eager';
 imgProps.loading = 'lazy';
-// $ExpectError
+// @ts-expect-error
 imgProps.loading = 'nonsense';
-// $ExpectError
+// @ts-expect-error
 imgProps.decoding = 'nonsense';
 type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
 // $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
@@ -454,13 +482,17 @@ type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
 type ImgPropsHasRef = 'ref' extends keyof ImgPropsWithoutRef ? true : false;
 
 const HasClassName: React.ElementType<{ className?: string | undefined }> = 'a';
-const HasFoo: React.ElementType<{ foo: boolean }> = 'a'; // $ExpectError
+// @ts-expect-error
+const HasFoo: React.ElementType<{ foo: boolean }> = 'a';
 const HasFoo2: React.ElementType<{ foo: boolean }> = (props: { foo: boolean }) => null;
-const HasFoo3: React.ElementType<{ foo: boolean }> = (props: { foo: string }) => null; // $ExpectError
+// @ts-expect-error
+const HasFoo3: React.ElementType<{ foo: boolean }> = (props: { foo: string }) => null;
 const HasHref: React.ElementType<{ href?: string | undefined }> = 'a';
-const HasHref2: React.ElementType<{ href?: string | undefined }> = 'div'; // $ExpectError
+// @ts-expect-error
+const HasHref2: React.ElementType<{ href?: string | undefined }> = 'div';
 
-const CustomElement: React.ElementType = 'my-undeclared-element'; // $ExpectError
+// @ts-expect-error
+const CustomElement: React.ElementType = 'my-undeclared-element';
 
 // custom elements now need to be declared as intrinsic elements
 declare global {

--- a/types/react/v15/test/tsx.tsx
+++ b/types/react/v15/test/tsx.tsx
@@ -77,18 +77,24 @@ const StatelessComponentWithoutProps: React.SFC = (props) => {
 // Below tests that setState() works properly for both regular and callback modes
 class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
     handleSomething = () => {
-      this.setState({ foo: '' }); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: '' });
       this.setState({ foo: true });
       this.setState({ foo: true, bar: true });
       this.setState({});
-      this.setState({ foo: true, foo2: true }); // $ExpectError
-      this.setState(() => ({ foo: '' })); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: true, foo2: true });
+      // @ts-expect-error
+      this.setState(() => ({ foo: '' }));
       this.setState(() => ({ foo: true }));
       this.setState(() => ({ foo: true, bar: true }));
-      this.setState(() => ({ foo: true, foo2: true })); // $ExpectError
-      this.setState(() => ({ foo: '', foo2: true })); // $ExpectError
+      // @ts-expect-error
+      this.setState(() => ({ foo: true, foo2: true }));
+      // @ts-expect-error
+      this.setState(() => ({ foo: '', foo2: true }));
       this.setState(() => ({ })); // ok!
-      this.setState({ foo: true, bar: undefined}); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: true, bar: undefined});
     }
 }
 

--- a/types/react/v16/test/hooks.tsx
+++ b/types/react/v16/test/hooks.tsx
@@ -118,7 +118,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType number
     typedCallback("1");
     // Argument of type '{}' is not assignable to parameter of type 'string'.
-    // $ExpectError
+    // @ts-expect-error
     typedCallback({});
 
     // test useRef and its convenience overloads
@@ -147,7 +147,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>();
     // don't just accept a potential undefined if there is a generic argument
-    // $ExpectError
+    // @ts-expect-error
     React.useRef<number>(undefined);
     // make sure once again there's no |undefined if the initial value doesn't either
     // $ExpectType MutableRefObject<number>
@@ -165,7 +165,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     const id = React.useMemo(() => Math.random(), []);
     React.useImperativeHandle(ref, () => ({ id }), [id]);
     // was named like this in the first alpha, renamed before release
-    // $ExpectError
+    // @ts-expect-error
     React.useImperativeMethods(ref, () => ({}), [id]);
 
     // make sure again this is not going to the |null convenience overload
@@ -179,7 +179,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     }, []);
     React.useEffect(() => {
         dispatch({ type: 'getOlder' });
-        // $ExpectError
+        // @ts-expect-error
         dispatch();
 
         simpleDispatch();
@@ -190,17 +190,17 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useEffect(() => () => {});
     // indistinguishable
     React.useEffect(() => () => undefined);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => null);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => Math.random() ? null : undefined);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => () => null);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => () => Math.random() ? null : undefined);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => async () => {});
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(async () => () => {});
 
     React.useDebugValue(id, value => value.toFixed());
@@ -209,7 +209,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // allow passing an explicit undefined
     React.useMemo(() => {}, undefined);
     // but don't allow it to be missing
-    // $ExpectError
+    // @ts-expect-error
     React.useMemo(() => {});
 
     // useState convenience overload
@@ -224,7 +224,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType undefined
     React.useState(undefined)[0];
     // make sure the generic argument does reject actual potentially undefined inputs
-    // $ExpectError
+    // @ts-expect-error
     React.useState<number>(undefined)[0];
     // make sure useState does not widen
     const [toggle, setToggle] = React.useState(false);

--- a/types/react/v16/test/index.ts
+++ b/types/react/v16/test/index.ts
@@ -70,7 +70,7 @@ declare const container: Element;
     class SettingStateFromCtorComponent extends React.Component<Props, State, Snapshot> {
         constructor(props: Props) {
             super(props);
-            // $ExpectError
+            // @ts-expect-error
             this.state = {
                 inputValue: 'hello'
             };
@@ -79,7 +79,6 @@ declare const container: Element;
     }
 
     class BadlyInitializedState extends React.Component<Props, State, Snapshot> {
-        // $ExpectError -> this throws error on TS 2.6 uncomment once TS requirement is TS >= 2.7
         // state = {
         //     secondz: 0,
         //     inputValuez: 'hello'
@@ -89,11 +88,10 @@ declare const container: Element;
     class BetterPropsAndStateChecksComponent extends React.Component<Props, State, Snapshot> {
         render() { return null; }
         componentDidMount() {
-            // $ExpectError -> this will be true in next BC release where state is gonna be `null | Readonly<S>`
             console.log(this.state.inputValue);
         }
         mutateState() {
-            // $ExpectError
+            // @ts-expect-error
             this.state = {
                 inputValue: 'hello'
             };
@@ -101,18 +99,18 @@ declare const container: Element;
             // Even if state is not set, this is allowed by React
             this.setState({ inputValue: 'hello' });
             this.setState((prevState, props) => {
-                // $ExpectError
+                // @ts-expect-error
                 props = { foo: 'nope' };
-                // $ExpectError
+                // @ts-expect-error
                 props.foo = 'nope';
 
                 return { inputValue: prevState.inputValue + ' foo' };
             });
         }
         mutateProps() {
-            // $ExpectError
+            // @ts-expect-error
             this.props = {};
-            // $ExpectError
+            // @ts-expect-error
             this.props = {
                 key: 42,
                 ref: "myComponent42",
@@ -242,7 +240,8 @@ const FunctionComponent4: React.FunctionComponent = props => null;
 
 // undesired: Rejects `false` because of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
 // leaving here to document limitation and inspect error message
-const FunctionComponent5: React.FunctionComponent = () => false; // $ExpectError
+// @ts-expect-error
+const FunctionComponent5: React.FunctionComponent = () => false;
 
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =
@@ -421,12 +420,12 @@ ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 // need the explicit type declaration for typescript < 3.1
 const ForwardRefRenderFunctionWithPropTypes: { (): null, propTypes?: {} | undefined } = () => null;
 // Warning: forwardRef render functions do not support propTypes or defaultProps
-// $ExpectError
+// @ts-expect-error
 React.forwardRef(ForwardRefRenderFunctionWithPropTypes);
 
 const ForwardRefRenderFunctionWithDefaultProps: { (): null, defaultProps?: {} | undefined } = () => null;
 // Warning: forwardRef render functions do not support propTypes or defaultProps
-// $ExpectError
+// @ts-expect-error
 React.forwardRef(ForwardRefRenderFunctionWithDefaultProps);
 
 function RefCarryingComponent() {
@@ -596,7 +595,7 @@ type mappedChildrenArray5Type = typeof mappedChildrenArray5 extends React.Key[] 
 // $ExpectType string[]
 const mappedChildrenArray6 = React.Children.map(renderPropsChildren, element => element.name);
 // The return type may not be an array
-// $ExpectError
+// @ts-expect-error
 const mappedChildrenArray7 = React.Children.map(nodeChildren, node => node).map;
 
 //
@@ -789,7 +788,7 @@ const specialSfc1: React.ExoticComponent<any> = Memoized1;
 const functionComponent: React.FunctionComponent<any> = Memoized2;
 const sfc: React.SFC<any> = Memoized2;
 // this $ExpectError is failing on TypeScript@next
-// // $ExpectError Property '$$typeof' is missing in type
+// // @ts-expect-error Property '$$typeof' is missing in type
 // const specialSfc2: React.SpecialSFC = props => null;
 
 const propsWithChildren: React.PropsWithChildren<Props> = {
@@ -814,9 +813,9 @@ const propsWithChildren: React.PropsWithChildren<Props> = {
     // we don't care about the value created by `new Wrapper()`.
     // We only care about the props we can pass to the component.
     let Wrapper: React.JSXElementConstructor<ExactProps>;
-    // $ExpectError
+    // @ts-expect-error
     Wrapper = class Narrower extends React.Component<NarrowerProps> {};
-    // $ExpectError
+    // @ts-expect-error
     Wrapper = (props: NarrowerProps) => null;
     Wrapper = class Exact extends React.Component<ExactProps> {};
     Wrapper = (props: ExactProps) => null;
@@ -825,7 +824,7 @@ const propsWithChildren: React.PropsWithChildren<Props> = {
 
     React.createElement(Wrapper, { value: 'A' });
     React.createElement(Wrapper, { value: 'B' });
-    // $ExpectError
+    // @ts-expect-error
     React.createElement(Wrapper, { value: 'C' });
 }
 
@@ -837,12 +836,12 @@ const propsWithChildren: React.PropsWithChildren<Props> = {
     type InferredProps = React.ComponentPropsWithRef<React.JSXElementConstructor<Props>>;
     const props: Props = {
         value: 'inferred',
-        // $ExpectError
+        // @ts-expect-error
         notImplemented: 5
     };
     const inferredProps: InferredProps = {
         value: 'inferred',
-        // $ExpectError
+        // @ts-expect-error
         notImplemented: 5
     };
 }

--- a/types/react/v16/test/managedAttributes.tsx
+++ b/types/react/v16/test/managedAttributes.tsx
@@ -32,10 +32,10 @@ class AnnotatedPropTypesAndDefaultProps extends React.Component<Props> {
 }
 
 const annotatedPropTypesAndDefaultPropsTests = [
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
     <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
     <AnnotatedPropTypesAndDefaultProps
         bool={true}
@@ -56,10 +56,10 @@ class UnannotatedPropTypesAndDefaultProps extends React.Component {
 }
 
 const unannotatedPropTypesAndDefaultPropsTests = [
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
     <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
     <UnannotatedPropTypesAndDefaultProps
         bool={true}
@@ -79,12 +79,12 @@ class AnnotatedPropTypes extends React.Component<Props> {
 }
 
 const annotatedPropTypesTests = [
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
     <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} />,
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
     <AnnotatedPropTypes
         bool={false}
@@ -103,12 +103,12 @@ class UnannotatedPropTypes extends React.Component {
 }
 
 const unannotatedPropTypesTests = [
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypes />, // str, extraStr and fnc are required
     <UnannotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
-    // $ExpectError
+    // @ts-expect-error
     <UnannotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
     <UnannotatedPropTypes
         bool={false}
@@ -126,11 +126,11 @@ class AnnotatedDefaultProps extends React.Component<Props> {
 }
 
 const annotatedDefaultPropsTests = [
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedDefaultProps />, // str is required
     <AnnotatedDefaultProps str='abc' />,
     <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
-    // $ExpectError
+    // @ts-expect-error
     <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
     <AnnotatedDefaultProps
         bool={true}
@@ -162,7 +162,7 @@ function FunctionalComponent(props: Props) { return <>{props.reqNode}</>; }
 FunctionalComponent.defaultProps = defaultProps;
 
 const functionalComponentTests = [
-    // $ExpectError
+    // @ts-expect-error
     <FunctionalComponent />,
     <FunctionalComponent str='' />
 ];
@@ -173,20 +173,16 @@ const LazyMemoFunctionalComponent = React.lazy(async () => ({ default: MemoFunct
 const LazyMemoAnnotatedDefaultProps = React.lazy(async () => ({ default: MemoAnnotatedDefaultProps }));
 
 const memoTests = [
-    // $ExpectError
+    // @ts-expect-error
     <MemoFunctionalComponent />,
-    // $ExpectError won't work as long as FunctionalComponent doesn't work either
     <MemoFunctionalComponent str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <MemoAnnotatedDefaultProps />,
     <AnnotatedDefaultProps str='abc' />,
-    // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
     <MemoAnnotatedDefaultProps str='abc' />,
-    // $ExpectError won't work as long as FunctionalComponent doesn't work either
     <LazyMemoFunctionalComponent str='abc' />,
-    // $ExpectError
+    // @ts-expect-error
     <LazyMemoAnnotatedDefaultProps />,
-    // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
     <LazyMemoAnnotatedDefaultProps str='abc' />
 ];
 
@@ -196,7 +192,7 @@ const ForwardRef = React.forwardRef((props: Props, ref: React.Ref<ComponentWithN
 ForwardRef.defaultProps = defaultProps;
 
 const forwardRefTests = [
-    // $ExpectError
+    // @ts-expect-error
     <ForwardRef />,
     <ForwardRef
         fnc={() => {}}
@@ -204,7 +200,7 @@ const forwardRefTests = [
         str=''
     />,
     // same bug as MemoFunctionalComponent and React.SFC-typed things
-    // $ExpectError
+    // @ts-expect-error
     <ForwardRef str='abc' />
 ];
 
@@ -241,7 +237,7 @@ type weakComponentTest3 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakC
     bar: boolean
 } ? true : false;
 
-// $ExpectError
+// @ts-expect-error
 const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { foo: '' };
 const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { bar: true };
 
@@ -253,7 +249,7 @@ interface WeakIndexedComponentProps {
 }
 
 const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { };
-// $ExpectError
+// @ts-expect-error
 const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { foo: '' };
 const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: '' };
 const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: 4 };

--- a/types/react/v16/test/tsx.tsx
+++ b/types/react/v16/test/tsx.tsx
@@ -32,7 +32,7 @@ VoidFunctionComponent.defaultProps = {
 };
 <VoidFunctionComponent />;
 
-// $ExpectError
+// @ts-expect-error
 const VoidFunctionComponent2: React.VoidFunctionComponent<SCProps> = ({ foo, children }) => {
     return <div>{foo}{children}</div>;
 };
@@ -40,7 +40,8 @@ VoidFunctionComponent2.displayName = "VoidFunctionComponent2";
 VoidFunctionComponent2.defaultProps = {
     foo: 42
 };
-<VoidFunctionComponent2>24</VoidFunctionComponent2>; // $ExpectError
+// @ts-expect-error
+<VoidFunctionComponent2>24</VoidFunctionComponent2>;
 
 // svg sanity check
 <svg viewBox="0 0 1000 1000">
@@ -82,8 +83,10 @@ VoidFunctionComponent2.defaultProps = {
 <button type="submit">foo</button>;
 <button type="reset">foo</button>;
 <button type="button">foo</button>;
-<button type="botton">foo</button>; // $ExpectError
-<button type={"botton" as string}>foo</button>; // $ExpectError
+// @ts-expect-error
+<button type="botton">foo</button>;
+// @ts-expect-error
+<button type={"botton" as string}>foo</button>;
 
 interface Props {
     hello: string;
@@ -112,9 +115,9 @@ const FunctionComponentWithoutProps: React.FunctionComponent = (props) => {
 const ContextWithRenderProps = React.createContext('defaultValue');
 
 // unstable APIs should not be part of the typings
-// $ExpectError
+// @ts-expect-error
 const ContextUsingUnstableObservedBits = React.createContext(undefined, (previous, next) => 7);
-// $ExpectError
+// @ts-expect-error
 <ContextWithRenderProps.Consumer unstable_observedBits={4}>
     {(value: unknown) => null}
 </ContextWithRenderProps.Consumer>;
@@ -143,19 +146,25 @@ const ContextUsingUnstableObservedBits = React.createContext(undefined, (previou
 // Below tests that setState() works properly for both regular and callback modes
 class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
     handleSomething = () => {
-      this.setState({ foo: '' }); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: '' });
       this.setState({ foo: true });
       this.setState({ foo: true, bar: true });
       this.setState({});
       this.setState(null);
-      this.setState({ foo: true, foo2: true }); // $ExpectError
-      this.setState(() => ({ foo: '' })); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: true, foo2: true });
+      // @ts-expect-error
+      this.setState(() => ({ foo: '' }));
       this.setState(() => ({ foo: true }));
       this.setState(() => ({ foo: true, bar: true }));
-      this.setState(() => ({ foo: true, foo2: true })); // $ExpectError
-      this.setState(() => ({ foo: '', foo2: true })); // $ExpectError
+      // @ts-expect-error
+      this.setState(() => ({ foo: true, foo2: true }));
+      // @ts-expect-error
+      this.setState(() => ({ foo: '', foo2: true }));
       this.setState(() => ({ })); // ok!
-      this.setState({ foo: true, bar: undefined}); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: true, bar: undefined});
       this.setState(prevState => (prevState.bar ? { bar: false } : null));
     }
 }
@@ -232,10 +241,12 @@ class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', st
 const AssignedComponentWithLargeState: React.ComponentClass = ComponentWithLargeState;
 
 const componentWithBadLifecycle = new (class extends React.Component<{}, {}, number> {})({});
-componentWithBadLifecycle.getSnapshotBeforeUpdate = () => { // $ExpectError
+// @ts-expect-error
+componentWithBadLifecycle.getSnapshotBeforeUpdate = () => {
     return 'number';
 };
-componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, snapshot?: string) => { // $ExpectError
+// @ts-expect-error
+componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, snapshot?: string) => {
     return;
 };
 
@@ -264,7 +275,7 @@ const Memoized5 = React.memo<{ test: boolean }>(
 
 const Memoized6: React.NamedExoticComponent<object> = React.memo(props => null);
 <Memoized6/>;
-// $ExpectError
+// @ts-expect-error
 <Memoized6 foo/>;
 
 // NOTE: this test _requires_ TypeScript 3.1
@@ -291,11 +302,11 @@ const LazyRefForwarding = React.lazy(async () => ({ default: Memoized4 }));
 </React.Suspense>;
 
 <React.Suspense fallback={null}/>;
-// $ExpectError
+// @ts-expect-error
 <React.Suspense/>;
 
 // unstable API should not be part of the typings
-// $ExpectError
+// @ts-expect-error
 <React.Suspense fallback={null} unstable_avoidThisFallback />;
 
 class LegacyContext extends React.Component {
@@ -337,10 +348,12 @@ const divRef = React.createRef<HTMLDivElement>();
 
 <ForwardRef ref={divFnRef}/>;
 <ForwardRef ref={divRef}/>;
-<ForwardRef ref='string'/>; // $ExpectError
+// @ts-expect-error
+<ForwardRef ref='string'/>;
 <ForwardRef2 ref={divFnRef}/>;
 <ForwardRef2 ref={divRef}/>;
-<ForwardRef2 ref='string'/>; // $ExpectError
+// @ts-expect-error
+<ForwardRef2 ref='string'/>;
 
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef}/>;
@@ -348,7 +361,8 @@ const newContextRef = React.createRef<NewContext>();
 
 const ForwardNewContext = React.forwardRef((_props: {}, ref?: React.Ref<NewContext>) => <NewContext ref={ref}/>);
 <ForwardNewContext ref={newContextRef}/>;
-<ForwardNewContext ref='string'/>; // $ExpectError
+// @ts-expect-error
+<ForwardNewContext ref='string'/>;
 
 const ForwardRef3 = React.forwardRef(
     (props: JSX.IntrinsicElements['div'] & Pick<JSX.IntrinsicElements['div'] & { theme?: {} | undefined }, 'ref'|'theme'>, ref?: React.Ref<HTMLDivElement>) =>
@@ -361,11 +375,14 @@ const ForwardRef3 = React.forwardRef(
 const { Profiler } = React;
 
 // 'id' is missing
-<Profiler />; // $ExpectError
+// @ts-expect-error
+<Profiler />;
 // 'onRender' is missing
-<Profiler id="test" />; // $ExpectError
+// @ts-expect-error
+<Profiler id="test" />;
 // 'number' is not assignable to 'string'
-<Profiler id={2} />; // $ExpectError
+// @ts-expect-error
+<Profiler id={2} />;
 
 <Profiler
   id="test"
@@ -402,9 +419,9 @@ imgProps.decoding = 'auto';
 imgProps.decoding = 'sync';
 imgProps.loading = 'eager';
 imgProps.loading = 'lazy';
-// $ExpectError
+// @ts-expect-error
 imgProps.loading = 'nonsense';
-// $ExpectError
+// @ts-expect-error
 imgProps.decoding = 'nonsense';
 type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
 // $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
@@ -414,13 +431,17 @@ type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
 type ImgPropsHasRef = 'ref' extends keyof ImgPropsWithoutRef ? true : false;
 
 const HasClassName: React.ReactType<{ className?: string | undefined }> = 'a';
-const HasFoo: React.ReactType<{ foo: boolean }> = 'a'; // $ExpectError
+// @ts-expect-error
+const HasFoo: React.ReactType<{ foo: boolean }> = 'a';
 const HasFoo2: React.ReactType<{ foo: boolean }> = (props: { foo: boolean }) => null;
-const HasFoo3: React.ReactType<{ foo: boolean }> = (props: { foo: string }) => null; // $ExpectError
+// @ts-expect-error
+const HasFoo3: React.ReactType<{ foo: boolean }> = (props: { foo: string }) => null;
 const HasHref: React.ReactType<{ href?: string | undefined }> = 'a';
-const HasHref2: React.ReactType<{ href?: string | undefined }> = 'div'; // $ExpectError
+// @ts-expect-error
+const HasHref2: React.ReactType<{ href?: string | undefined }> = 'div';
 
-const CustomElement: React.ReactType = 'my-undeclared-element'; // $ExpectError
+// @ts-expect-error
+const CustomElement: React.ReactType = 'my-undeclared-element';
 
 // custom elements now need to be declared as intrinsic elements
 declare global {

--- a/types/react/v17/test/elementAttributes.tsx
+++ b/types/react/v17/test/elementAttributes.tsx
@@ -39,7 +39,7 @@ const testCases = [
     <input accept="image/*" capture />,
     <input accept="video/*" capture="user" />,
     <input accept="video/*" capture="environment" />,
-    // $ExpectError
+    // @ts-expect-error
     <input accept="video/*" capture="haha" />,
     <input accept="video/*" capture />,
     <input accept="audio/*" capture />,
@@ -51,7 +51,7 @@ const testCases = [
     <a target="some-frame"></a>,
     <input type="button" />,
     <input type="some-type" />,
-    // $ExpectError
+    // @ts-expect-error
     <input enterKeyHint="don" />,
     <video disableRemotePlayback />,
     <picture>

--- a/types/react/v17/test/hooks.tsx
+++ b/types/react/v17/test/hooks.tsx
@@ -118,7 +118,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType number
     typedCallback("1");
     // Argument of type '{}' is not assignable to parameter of type 'string'.
-    // $ExpectError
+    // @ts-expect-error
     typedCallback({});
 
     // test useRef and its convenience overloads
@@ -147,7 +147,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>();
     // don't just accept a potential undefined if there is a generic argument
-    // $ExpectError
+    // @ts-expect-error
     React.useRef<number>(undefined);
     // make sure once again there's no |undefined if the initial value doesn't either
     // $ExpectType MutableRefObject<number>
@@ -165,7 +165,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     const id = React.useMemo(() => Math.random(), []);
     React.useImperativeHandle(ref, () => ({ id }), [id]);
     // was named like this in the first alpha, renamed before release
-    // $ExpectError
+    // @ts-expect-error
     React.useImperativeMethods(ref, () => ({}), [id]);
 
     // make sure again this is not going to the |null convenience overload
@@ -179,7 +179,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     }, []);
     React.useEffect(() => {
         dispatch({ type: 'getOlder' });
-        // $ExpectError
+        // @ts-expect-error
         dispatch();
 
         simpleDispatch();
@@ -190,17 +190,17 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     React.useEffect(() => () => {});
     // indistinguishable
     React.useEffect(() => () => undefined);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => null);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => Math.random() ? null : undefined);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => () => null);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => () => Math.random() ? null : undefined);
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(() => async () => {});
-    // $ExpectError
+    // @ts-expect-error
     React.useEffect(async () => () => {});
 
     React.useDebugValue(id, value => value.toFixed());
@@ -209,7 +209,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // allow passing an explicit undefined
     React.useMemo(() => {}, undefined);
     // but don't allow it to be missing
-    // $ExpectError
+    // @ts-expect-error
     React.useMemo(() => {});
 
     // useState convenience overload
@@ -224,7 +224,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectType undefined
     React.useState(undefined)[0];
     // make sure the generic argument does reject actual potentially undefined inputs
-    // $ExpectError
+    // @ts-expect-error
     React.useState<number>(undefined)[0];
     // make sure useState does not widen
     const [toggle, setToggle] = React.useState(false);

--- a/types/react/v17/test/index.ts
+++ b/types/react/v17/test/index.ts
@@ -70,7 +70,7 @@ declare const container: Element;
     class SettingStateFromCtorComponent extends React.Component<Props, State, Snapshot> {
         constructor(props: Props) {
             super(props);
-            // $ExpectError
+            // @ts-expect-error
             this.state = {
                 inputValue: 'hello'
             };
@@ -79,7 +79,6 @@ declare const container: Element;
     }
 
     class BadlyInitializedState extends React.Component<Props, State, Snapshot> {
-        // $ExpectError -> this throws error on TS 2.6 uncomment once TS requirement is TS >= 2.7
         // state = {
         //     secondz: 0,
         //     inputValuez: 'hello'
@@ -89,11 +88,10 @@ declare const container: Element;
     class BetterPropsAndStateChecksComponent extends React.Component<Props, State, Snapshot> {
         render() { return null; }
         componentDidMount() {
-            // $ExpectError -> this will be true in next BC release where state is gonna be `null | Readonly<S>`
             console.log(this.state.inputValue);
         }
         mutateState() {
-            // $ExpectError
+            // @ts-expect-error
             this.state = {
                 inputValue: 'hello'
             };
@@ -101,18 +99,18 @@ declare const container: Element;
             // Even if state is not set, this is allowed by React
             this.setState({ inputValue: 'hello' });
             this.setState((prevState, props) => {
-                // $ExpectError
+                // @ts-expect-error
                 props = { foo: 'nope' };
-                // $ExpectError
+                // @ts-expect-error
                 props.foo = 'nope';
 
                 return { inputValue: prevState.inputValue + ' foo' };
             });
         }
         mutateProps() {
-            // $ExpectError
+            // @ts-expect-error
             this.props = {};
-            // $ExpectError
+            // @ts-expect-error
             this.props = {
                 key: 42,
                 ref: "myComponent42",
@@ -242,7 +240,8 @@ const FunctionComponent4: React.FunctionComponent = props => null;
 
 // undesired: Rejects `false` because of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
 // leaving here to document limitation and inspect error message
-const FunctionComponent5: React.FunctionComponent = () => false; // $ExpectError
+// @ts-expect-error
+const FunctionComponent5: React.FunctionComponent = () => false;
 
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =
@@ -420,12 +419,12 @@ ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 // need the explicit type declaration for typescript < 3.1
 const ForwardRefRenderFunctionWithPropTypes: { (): null, propTypes?: {} | undefined } = () => null;
 // Warning: forwardRef render functions do not support propTypes or defaultProps
-// $ExpectError
+// @ts-expect-error
 React.forwardRef(ForwardRefRenderFunctionWithPropTypes);
 
 const ForwardRefRenderFunctionWithDefaultProps: { (): null, defaultProps?: {} | undefined } = () => null;
 // Warning: forwardRef render functions do not support propTypes or defaultProps
-// $ExpectError
+// @ts-expect-error
 React.forwardRef(ForwardRefRenderFunctionWithDefaultProps);
 
 function RefCarryingComponent() {
@@ -595,7 +594,7 @@ type mappedChildrenArray5Type = typeof mappedChildrenArray5 extends React.Key[] 
 // $ExpectType string[]
 const mappedChildrenArray6 = React.Children.map(renderPropsChildren, element => element.name);
 // The return type may not be an array
-// $ExpectError
+// @ts-expect-error
 const mappedChildrenArray7 = React.Children.map(nodeChildren, node => node).map;
 
 //
@@ -788,7 +787,7 @@ const specialSfc1: React.ExoticComponent<any> = Memoized1;
 const functionComponent: React.FunctionComponent<any> = Memoized2;
 const sfc: React.SFC<any> = Memoized2;
 // this $ExpectError is failing on TypeScript@next
-// // $ExpectError Property '$$typeof' is missing in type
+// // @ts-expect-error Property '$$typeof' is missing in type
 // const specialSfc2: React.SpecialSFC = props => null;
 
 const propsWithChildren: React.PropsWithChildren<Props> = {
@@ -801,7 +800,7 @@ type UnionProps =
     | ({ type: 'single'; value?: number } & React.RefAttributes<HTMLDivElement>)
     | ({ type: 'multiple'; value?: number[] } & React.RefAttributes<HTMLDivElement>);
 
-// $ExpectError
+// @ts-expect-error
 const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     type: 'single',
     value: [2],
@@ -823,9 +822,9 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     // we don't care about the value created by `new Wrapper()`.
     // We only care about the props we can pass to the component.
     let Wrapper: React.JSXElementConstructor<ExactProps>;
-    // $ExpectError
+    // @ts-expect-error
     Wrapper = class Narrower extends React.Component<NarrowerProps> {};
-    // $ExpectError
+    // @ts-expect-error
     Wrapper = (props: NarrowerProps) => null;
     Wrapper = class Exact extends React.Component<ExactProps> {};
     Wrapper = (props: ExactProps) => null;
@@ -834,7 +833,7 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
 
     React.createElement(Wrapper, { value: 'A' });
     React.createElement(Wrapper, { value: 'B' });
-    // $ExpectError
+    // @ts-expect-error
     React.createElement(Wrapper, { value: 'C' });
 }
 
@@ -846,12 +845,12 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     type InferredProps = React.ComponentPropsWithRef<React.JSXElementConstructor<Props>>;
     const props: Props = {
         value: 'inferred',
-        // $ExpectError
+        // @ts-expect-error
         notImplemented: 5
     };
     const inferredProps: InferredProps = {
         value: 'inferred',
-        // $ExpectError
+        // @ts-expect-error
         notImplemented: 5
     };
 }

--- a/types/react/v17/test/managedAttributes.tsx
+++ b/types/react/v17/test/managedAttributes.tsx
@@ -35,10 +35,10 @@ interface LeaveMeAloneDtslint { foo: string; }
 // }
 
 // const annotatedPropTypesAndDefaultPropsTests = [
-//     // $ExpectError
+//     // @ts-expect-error
 //     <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
 //     <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-//     // $ExpectError
+//     // @ts-expect-error
 //     <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
 //     <AnnotatedPropTypesAndDefaultProps
 //         bool={true}
@@ -59,10 +59,10 @@ interface LeaveMeAloneDtslint { foo: string; }
 // }
 
 // const unannotatedPropTypesAndDefaultPropsTests = [
-//     // $ExpectError
+//     // @ts-expect-error
 //     <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
 //     <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-//     // $ExpectError
+//     // @ts-expect-error
 //     <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
 //     <UnannotatedPropTypesAndDefaultProps
 //         bool={true}
@@ -82,12 +82,12 @@ interface LeaveMeAloneDtslint { foo: string; }
 // }
 
 // const annotatedPropTypesTests = [
-//     // $ExpectError
+//     // @ts-expect-error
 //     <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
 //     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />,
-//     // $ExpectError
+//     // @ts-expect-error
 //     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
-//     // $ExpectError
+//     // @ts-expect-error
 //     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
 //     <AnnotatedPropTypes
 //         bool={false}
@@ -106,12 +106,12 @@ interface LeaveMeAloneDtslint { foo: string; }
 // }
 
 // const unannotatedPropTypesTests = [
-//     // $ExpectError
+//     // @ts-expect-error
 //     <UnannotatedPropTypes />, // str, extraStr and fnc are required
 //     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' />,
-//     // $ExpectError
+//     // @ts-expect-error
 //     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
-//     // $ExpectError
+//     // @ts-expect-error
 //     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
 //     <UnannotatedPropTypes
 //         bool={false}
@@ -129,11 +129,11 @@ interface LeaveMeAloneDtslint { foo: string; }
 // }
 
 // const annotatedDefaultPropsTests = [
-//     // $ExpectError
+//     // @ts-expect-error
 //     <AnnotatedDefaultProps />, // str is required
 //     <AnnotatedDefaultProps str='abc' />,
 //     <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
-//     // $ExpectError
+//     // @ts-expect-error
 //     <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
 //     <AnnotatedDefaultProps
 //         bool={true}
@@ -165,12 +165,12 @@ interface LeaveMeAloneDtslint { foo: string; }
 // FunctionalComponent.defaultProps = defaultProps;
 
 // const functionalComponentTests = [
-//     // $ExpectError
+//     // @ts-expect-error
 //     <FunctionalComponent />,
 //     // This is possibly a bug/limitation of TS
 //     // Even if JSX.LibraryManagedAttributes returns the correct type, it doesn't seem to work with non-classes
 //     // This also doesn't work with things typed React.SFC<P> because defaultProps will always be Partial<P>
-//     // $ExpectError
+//     // @ts-expect-error
 //     <FunctionalComponent str='' />
 // ];
 
@@ -180,20 +180,16 @@ interface LeaveMeAloneDtslint { foo: string; }
 // const LazyMemoAnnotatedDefaultProps = React.lazy(async () => ({ default: MemoAnnotatedDefaultProps }));
 
 // const memoTests = [
-//     // $ExpectError
+//     // @ts-expect-error
 //     <MemoFunctionalComponent />,
-//     // $ExpectError won't work as long as FunctionalComponent doesn't work either
 //     <MemoFunctionalComponent str='abc' />,
-//     // $ExpectError
+//     // @ts-expect-error
 //     <MemoAnnotatedDefaultProps />,
 //     <AnnotatedDefaultProps str='abc' />,
-//     // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
 //     <MemoAnnotatedDefaultProps str='abc' />,
-//     // $ExpectError won't work as long as FunctionalComponent doesn't work either
 //     <LazyMemoFunctionalComponent str='abc' />,
-//     // $ExpectError
+//     // @ts-expect-error
 //     <LazyMemoAnnotatedDefaultProps />,
-//     // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
 //     <LazyMemoAnnotatedDefaultProps str='abc' />
 // ];
 
@@ -211,7 +207,7 @@ interface LeaveMeAloneDtslint { foo: string; }
 // ForwardRef.defaultProps = defaultProps;
 
 // const forwardRefTests = [
-//     // $ExpectError
+//     // @ts-expect-error
 //     <ForwardRef />,
 //     <ForwardRef
 //         fnc={console.log}
@@ -219,7 +215,7 @@ interface LeaveMeAloneDtslint { foo: string; }
 //         str=''
 //     />,
 //     // same bug as MemoFunctionalComponent and React.SFC-typed things
-//     // $ExpectError the type of ForwardRef.defaultProps stays Partial<P> anyway even if assigned
+//     // @ts-expect-error the type of ForwardRef.defaultProps stays Partial<P> anyway even if assigned
 //     <ForwardRef str='abc' />
 // ];
 
@@ -256,7 +252,7 @@ interface LeaveMeAloneDtslint { foo: string; }
 //     bar: boolean
 // } ? true : false;
 
-// // $ExpectError
+// // @ts-expect-error
 // const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { foo: '' };
 // const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { bar: true };
 
@@ -268,7 +264,7 @@ interface LeaveMeAloneDtslint { foo: string; }
 // }
 
 // const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { };
-// // $ExpectError
+// // @ts-expect-error
 // const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { foo: '' };
 // const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: '' };
 // const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: 4 };

--- a/types/react/v17/test/tsx.tsx
+++ b/types/react/v17/test/tsx.tsx
@@ -32,7 +32,7 @@ VoidFunctionComponent.defaultProps = {
 };
 <VoidFunctionComponent />;
 
-// $ExpectError
+// @ts-expect-error
 const VoidFunctionComponent2: React.VoidFunctionComponent<SCProps> = ({ foo, children }) => {
     return <div>{foo}{children}</div>;
 };
@@ -40,7 +40,8 @@ VoidFunctionComponent2.displayName = "VoidFunctionComponent2";
 VoidFunctionComponent2.defaultProps = {
     foo: 42
 };
-<VoidFunctionComponent2>24</VoidFunctionComponent2>; // $ExpectError
+// @ts-expect-error
+<VoidFunctionComponent2>24</VoidFunctionComponent2>;
 
 // svg sanity check
 <svg viewBox="0 0 1000 1000">
@@ -82,8 +83,10 @@ VoidFunctionComponent2.defaultProps = {
 <button type="submit">foo</button>;
 <button type="reset">foo</button>;
 <button type="button">foo</button>;
-<button type="botton">foo</button>; // $ExpectError
-<button type={"botton" as string}>foo</button>; // $ExpectError
+// @ts-expect-error
+<button type="botton">foo</button>;
+// @ts-expect-error
+<button type={"botton" as string}>foo</button>;
 
 interface Props {
     hello: string;
@@ -112,9 +115,9 @@ const FunctionComponentWithoutProps: React.FunctionComponent = (props) => {
 const ContextWithRenderProps = React.createContext('defaultValue');
 
 // unstable APIs should not be part of the typings
-// $ExpectError
+// @ts-expect-error
 const ContextUsingUnstableObservedBits = React.createContext(undefined, (previous, next) => 7);
-// $ExpectError
+// @ts-expect-error
 <ContextWithRenderProps.Consumer unstable_observedBits={4}>
     {(value: unknown) => null}
 </ContextWithRenderProps.Consumer>;
@@ -143,19 +146,25 @@ const ContextUsingUnstableObservedBits = React.createContext(undefined, (previou
 // Below tests that setState() works properly for both regular and callback modes
 class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
     handleSomething = () => {
-      this.setState({ foo: '' }); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: '' });
       this.setState({ foo: true });
       this.setState({ foo: true, bar: true });
       this.setState({});
       this.setState(null);
-      this.setState({ foo: true, foo2: true }); // $ExpectError
-      this.setState(() => ({ foo: '' })); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: true, foo2: true });
+      // @ts-expect-error
+      this.setState(() => ({ foo: '' }));
       this.setState(() => ({ foo: true }));
       this.setState(() => ({ foo: true, bar: true }));
-      this.setState(() => ({ foo: true, foo2: true })); // $ExpectError
-      this.setState(() => ({ foo: '', foo2: true })); // $ExpectError
+      // @ts-expect-error
+      this.setState(() => ({ foo: true, foo2: true }));
+      // @ts-expect-error
+      this.setState(() => ({ foo: '', foo2: true }));
       this.setState(() => ({ })); // ok!
-      this.setState({ foo: true, bar: undefined}); // $ExpectError
+      // @ts-expect-error
+      this.setState({ foo: true, bar: undefined});
       this.setState(prevState => (prevState.bar ? { bar: false } : null));
     }
 }
@@ -232,10 +241,12 @@ class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', st
 const AssignedComponentWithLargeState: React.ComponentClass = ComponentWithLargeState;
 
 const componentWithBadLifecycle = new (class extends React.Component<{}, {}, number> {})({});
-componentWithBadLifecycle.getSnapshotBeforeUpdate = () => { // $ExpectError
+// @ts-expect-error
+componentWithBadLifecycle.getSnapshotBeforeUpdate = () => {
     return 'number';
 };
-componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, snapshot?: string) => { // $ExpectError
+// @ts-expect-error
+componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, snapshot?: string) => {
     return;
 };
 
@@ -264,7 +275,7 @@ const Memoized5 = React.memo<{ test: boolean }>(
 
 const Memoized6: React.NamedExoticComponent<object> = React.memo(props => null);
 <Memoized6/>;
-// $ExpectError
+// @ts-expect-error
 <Memoized6 foo/>;
 
 // NOTE: this test _requires_ TypeScript 3.1
@@ -291,11 +302,11 @@ const LazyRefForwarding = React.lazy(async () => ({ default: Memoized4 }));
 </React.Suspense>;
 
 <React.Suspense fallback={null}/>;
-// $ExpectError
+// @ts-expect-error
 <React.Suspense/>;
 
 // unstable API should not be part of the typings
-// $ExpectError
+// @ts-expect-error
 <React.Suspense fallback={null} unstable_avoidThisFallback />;
 
 class LegacyContext extends React.Component {
@@ -337,10 +348,12 @@ const divRef = React.createRef<HTMLDivElement>();
 
 <ForwardRef ref={divFnRef}/>;
 <ForwardRef ref={divRef}/>;
-<ForwardRef ref='string'/>; // $ExpectError
+// @ts-expect-error
+<ForwardRef ref='string'/>;
 <ForwardRef2 ref={divFnRef}/>;
 <ForwardRef2 ref={divRef}/>;
-<ForwardRef2 ref='string'/>; // $ExpectError
+// @ts-expect-error
+<ForwardRef2 ref='string'/>;
 
 const htmlElementFnRef = (instance: HTMLElement | null) => {};
 const htmlElementRef = React.createRef<HTMLElement>();
@@ -361,7 +374,8 @@ const newContextRef = React.createRef<NewContext>();
 
 const ForwardNewContext = React.forwardRef((_props: {}, ref?: React.Ref<NewContext>) => <NewContext ref={ref}/>);
 <ForwardNewContext ref={newContextRef}/>;
-<ForwardNewContext ref='string'/>; // $ExpectError
+// @ts-expect-error
+<ForwardNewContext ref='string'/>;
 
 const ForwardRef3 = React.forwardRef(
     (props: JSX.IntrinsicElements['div'] & Pick<JSX.IntrinsicElements['div'] & { theme?: {} | undefined }, 'ref'|'theme'>, ref?: React.Ref<HTMLDivElement>) =>
@@ -374,11 +388,14 @@ const ForwardRef3 = React.forwardRef(
 const { Profiler } = React;
 
 // 'id' is missing
-<Profiler />; // $ExpectError
+// @ts-expect-error
+<Profiler />;
 // 'onRender' is missing
-<Profiler id="test" />; // $ExpectError
+// @ts-expect-error
+<Profiler id="test" />;
 // 'number' is not assignable to 'string'
-<Profiler id={2} />; // $ExpectError
+// @ts-expect-error
+<Profiler id={2} />;
 
 <Profiler
   id="test"
@@ -415,9 +432,9 @@ imgProps.decoding = 'auto';
 imgProps.decoding = 'sync';
 imgProps.loading = 'eager';
 imgProps.loading = 'lazy';
-// $ExpectError
+// @ts-expect-error
 imgProps.loading = 'nonsense';
-// $ExpectError
+// @ts-expect-error
 imgProps.decoding = 'nonsense';
 type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
 // $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
@@ -427,13 +444,17 @@ type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
 type ImgPropsHasRef = 'ref' extends keyof ImgPropsWithoutRef ? true : false;
 
 const HasClassName: React.ReactType<{ className?: string | undefined }> = 'a';
-const HasFoo: React.ReactType<{ foo: boolean }> = 'a'; // $ExpectError
+// @ts-expect-error
+const HasFoo: React.ReactType<{ foo: boolean }> = 'a';
 const HasFoo2: React.ReactType<{ foo: boolean }> = (props: { foo: boolean }) => null;
-const HasFoo3: React.ReactType<{ foo: boolean }> = (props: { foo: string }) => null; // $ExpectError
+// @ts-expect-error
+const HasFoo3: React.ReactType<{ foo: boolean }> = (props: { foo: string }) => null;
 const HasHref: React.ReactType<{ href?: string | undefined }> = 'a';
-const HasHref2: React.ReactType<{ href?: string | undefined }> = 'div'; // $ExpectError
+// @ts-expect-error
+const HasHref2: React.ReactType<{ href?: string | undefined }> = 'div';
 
-const CustomElement: React.ReactType = 'my-undeclared-element'; // $ExpectError
+// @ts-expect-error
+const CustomElement: React.ReactType = 'my-undeclared-element';
 
 // custom elements now need to be declared as intrinsic elements
 declare global {

--- a/types/redux-orm/redux-orm-tests.ts
+++ b/types/redux-orm/redux-orm-tests.ts
@@ -145,7 +145,8 @@ const sessionFixture = () => {
     /**
      * 1.B. `string` identifiers are mandatory
      */
-    Book.create({ publisher: 1, coverArt: 'foo.bmp' }); // $ExpectError
+    // @ts-expect-error
+    Book.create({ publisher: 1, coverArt: 'foo.bmp' });
 
     /**
      * 2. non-relational fields with corresponding descriptors that contain defined `getDefault` callback: (`attr({ getDefault: () => 'empty.png' })`)
@@ -168,11 +169,16 @@ const sessionFixture = () => {
     Book.create({ title: 'B1', publisher: 1, coverArt: 'foo.png', authors: ['A1'] });
 
     /* Incompatible property types: */
-    Book.create({ title: 1, publisher: 1 }); // $ExpectError
-    Book.create({ title: 'B1', publisher: 'P1' }); // $ExpectError
-    Book.create({ title: 'B1', publisher: 1, coverArt: 4 }); // $ExpectError
-    Book.create({ title: 'B1', publisher: 1, authors: {} }); // $ExpectError
-    Book.create({ title: 'B1', publisher: 1, authors: () => null }); // $ExpectError
+    // @ts-expect-error
+    Book.create({ title: 1, publisher: 1 });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: 'P1' });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: 1, coverArt: 4 });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: 1, authors: {} });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: 1, authors: () => null });
 
     /**
      * Properties associated to relational fields may be supplied with:
@@ -192,10 +198,14 @@ const sessionFixture = () => {
     });
 
     /** Id types are verified to match relation target */
-    Book.create({ title: 'B1', publisher: authorModel }); // $ExpectError
-    Book.create({ title: 'B1', publisher: publisherModel.ref, authors: [publisherModel.ref, 'A1'] }); // $ExpectError
-    Book.create({ title: 'B1', publisher: { index: 'P1 ' } }); // $ExpectError
-    Book.create({ title: 'B1', publisher: { index: 0 }, authors: [authorModel, true] }); // $ExpectError
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: authorModel });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: publisherModel.ref, authors: [publisherModel.ref, 'A1'] });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: { index: 'P1 ' } });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: { index: 0 }, authors: [authorModel, true] });
 })();
 
 // argPropertyTypeRestrictionsOnUpsert - ModelFields contribute to type constraints within ModelType.create arguments
@@ -203,17 +213,23 @@ const sessionFixture = () => {
     const { Book, Publisher, Person } = sessionFixture();
 
     /** Upsert requires id to be provided */
-    Book.upsert({ publisher: 1 }); // $ExpectError
+    // @ts-expect-error
+    Book.upsert({ publisher: 1 });
 
     // $ExpectType SessionBoundModel<Book, Pick<{ title: string; publisher: number; }, never>> || SessionBoundModel<Book, CustomInstanceProps<Book, { title: string; publisher: number; }>>
     Book.upsert({ title: 'B1', publisher: 1 });
 
     /* Incompatible property types: */
-    Book.upsert({ title: 4, publisher: 'P1' }); // $ExpectError
-    Book.upsert({ title: 'B1', publisher: 'P1' }); // $ExpectError
-    Book.upsert({ title: 'B1', publisher: 1, coverArt: 4 }); // $ExpectError
-    Book.upsert({ title: 'B1', publisher: 1, authors: {} }); // $ExpectError
-    Book.upsert({ title: 'B1', publisher: 1, authors: () => null }); // $ExpectError
+    // @ts-expect-error
+    Book.upsert({ title: 4, publisher: 'P1' });
+    // @ts-expect-error
+    Book.upsert({ title: 'B1', publisher: 'P1' });
+    // @ts-expect-error
+    Book.upsert({ title: 'B1', publisher: 1, coverArt: 4 });
+    // @ts-expect-error
+    Book.upsert({ title: 'B1', publisher: 1, authors: {} });
+    // @ts-expect-error
+    Book.upsert({ title: 'B1', publisher: 1, authors: () => null });
 
     /**
      * Properties associated to relational fields may be supplied with:
@@ -231,17 +247,22 @@ const sessionFixture = () => {
     Book.upsert({ title: 'B1', publisher: publisherModel, authors: [authorModel] });
 
     /** Id types are verified to match relation target */
-    Book.create({ title: 'B1', publisher: authorModel }); // $ExpectError
-    Book.create({ title: 'B1', publisher: publisherModel.ref, authors: [publisherModel.ref, 'A1'] }); // $ExpectError
-    Book.create({ title: 'B1', publisher: { index: 'P1 ' } }); // $ExpectError
-    Book.create({ title: 'B1', publisher: { index: 0 }, authors: [authorModel, true] }); // $ExpectError
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: authorModel });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: publisherModel.ref, authors: [publisherModel.ref, 'A1'] });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: { index: 'P1 ' } });
+    // @ts-expect-error
+    Book.create({ title: 'B1', publisher: { index: 0 }, authors: [authorModel, true] });
 })();
 
 // restriction of allowed ORM.register args
 (() => {
     const incompleteSchema = { Book, Authorship, Person };
     const orm = new ORM<typeof incompleteSchema>();
-    orm.register(Book, Authorship, Person, Publisher); // $ExpectError
+    // @ts-expect-error
+    orm.register(Book, Authorship, Person, Publisher);
 })();
 
 // inference of ORM branch state type
@@ -282,7 +303,8 @@ const sessionFixture = () => {
     type basicBookKeys = Exclude<keyof typeof basicBook, keyof Model>; // $ExpectType "title" | "coverArt" | "publisher" | "authors" || keyof BookFields
     const basicBookTitle = basicBook.title; // $ExpectType string
     const authors = basicBook.authors; // $ExpectType MutableQuerySet<Person, {}>
-    const unknownPropertyError = basicBook.customProp; // $ExpectError
+    // @ts-expect-error
+    const unknownPropertyError = basicBook.customProp;
 
     const customProp = { foo: 0, bar: true };
 
@@ -336,14 +358,22 @@ const sessionFixture = () => {
         .orderBy([book => book.title, 'publisher'], ['desc', false])
         .toRefArray();
 
-    booksQuerySet.orderBy('notABookPropertyKey'); // $ExpectError
-    booksQuerySet.orderBy([book => book.notABookPropertyKey], false); // $ExpectError
-    booksQuerySet.orderBy('title', 'inc'); // $ExpectError
-    booksQuerySet.orderBy('title', 4); // $ExpectError
-    booksQuerySet.orderBy(['notABookPropertyKey']); // $ExpectError
-    booksQuerySet.orderBy([book => book.notABookPropertyKey]); // $ExpectError
-    booksQuerySet.orderBy(['title'], ['inc']); // $ExpectError
-    booksQuerySet.orderBy(['title'], [4]); // $ExpectError
+    // @ts-expect-error
+    booksQuerySet.orderBy('notABookPropertyKey');
+    // @ts-expect-error
+    booksQuerySet.orderBy([book => book.notABookPropertyKey], false);
+    // @ts-expect-error
+    booksQuerySet.orderBy('title', 'inc');
+    // @ts-expect-error
+    booksQuerySet.orderBy('title', 4);
+    // @ts-expect-error
+    booksQuerySet.orderBy(['notABookPropertyKey']);
+    // @ts-expect-error
+    booksQuerySet.orderBy([book => book.notABookPropertyKey]);
+    // @ts-expect-error
+    booksQuerySet.orderBy(['title'], ['inc']);
+    // @ts-expect-error
+    booksQuerySet.orderBy(['title'], [4]);
 })();
 
 // selectors
@@ -369,7 +399,8 @@ const sessionFixture = () => {
 
     createSelector<RootState, OrmState<Schema>, Ref<Person>>(
         ({ db }) => db,
-        ormSelector // $ExpectError
+        // @ts-expect-error
+        ormSelector
     );
 
     selector({ db: orm.getEmptyState() }); // $ExpectType Ref<Book>
@@ -450,14 +481,16 @@ const sessionFixture = () => {
         orm,
         s => s.db,
         s => s.foo,
-        (session, foo, missingArg) => foo // $ExpectError
+        // @ts-expect-error
+        (session, foo, missingArg) => foo
     ) as (state: RootState) => number;
 
     const invalidSelector2: TestSelector = createOrmSelector(
         orm,
         s => s.db,
         s => s.foo,
-        (session, foo) => session.Book.withId(foo)!.ref // $ExpectError
+        // @ts-expect-error
+        (session, foo) => session.Book.withId(foo)!.ref
     );
 
     const state = { db: orm.getEmptyState(), foo: 1, bar: 'foo' };
@@ -478,9 +511,12 @@ const sessionFixture = () => {
     Book.exists({ title: 'foo' });
     Book.all().exists();
 
-    Book.exists(); // $ExpectError
-    Book.exists('foo'); // $ExpectError
-    Book.all().exists({}); // $ExpectError
+    // @ts-expect-error
+    Book.exists();
+    // @ts-expect-error
+    Book.exists('foo');
+    // @ts-expect-error
+    Book.all().exists({});
 })();
 
 // redux-orm-types#8
@@ -489,8 +525,10 @@ const sessionFixture = () => {
 
     Book.all().toModelArray();
     Book.all().toRefArray();
-    Book.toModelArray(); // $ExpectError
-    Book.toRefArray(); // $ExpectError
+    // @ts-expect-error
+    Book.toModelArray();
+    // @ts-expect-error
+    Book.toRefArray();
 })();
 
 // redux-orm-types#9
@@ -503,9 +541,12 @@ const sessionFixture = () => {
     Book.create({ title: 'foo', publisher: 1, coverArt: 'bar' });
     Book.create({ title: 'foo', publisher, coverArt: 'bar', authors: ['foo', author] });
 
-    Book.create({ title: 'foo', publisher: author }); // $ExpectError
-    Book.create({ title: 'foo', publisher: 'error' }); // $ExpectError
-    Book.create({ title: 'foo', publisher, coverArt: 'bar', authors: [3, author] }); // $ExpectError
+    // @ts-expect-error
+    Book.create({ title: 'foo', publisher: author });
+    // @ts-expect-error
+    Book.create({ title: 'foo', publisher: 'error' });
+    // @ts-expect-error
+    Book.create({ title: 'foo', publisher, coverArt: 'bar', authors: [3, author] });
 })();
 
 // redux-orm-types#18

--- a/types/superagent-retry-delay/superagent-retry-delay-tests.ts
+++ b/types/superagent-retry-delay/superagent-retry-delay-tests.ts
@@ -4,7 +4,7 @@ import wrapSuperagent = require('superagent-retry-delay');
 // $ExpectType EnhancedSuperAgentStatic
 const request = wrapSuperagent(superagent);
 
-// $ExpectError
+// @ts-expect-error
 const badRequest = wrapSuperagent({ something: 'else' });
 
 // typical usage
@@ -16,6 +16,6 @@ request
 // standard .retry() usage should no longer work
 request
   .get('http://my.url')
-  // $ExpectError
+  // @ts-expect-error
   .retry(5, () => 'callback')
   .ok(res => res.status === 200);

--- a/types/webpack/v4/test/index.ts
+++ b/types/webpack/v4/test/index.ts
@@ -137,11 +137,11 @@ configuration = {
             callback(new Error('Boom!'));
 
             // A null error should include external parameters
-            // $ExpectError
+            // @ts-expect-error
             callback(null);
 
             // An error should include no other parameters
-            // $ExpectError
+            // @ts-expect-error
             callback('An error', 'externalName');
 
             // Continue without externalizing the import


### PR DESCRIPTION
This PR is a continuation of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60697#issue-1262554095. It includes edits to packages I excluded earlier because they were on (or were dependencies of packages on) the [list of expected failures](https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint-runner/expectedFailures.txt). Because of those expected failures, I'll need some maintainer assistance to land this, please. :pray: