### PR TITLE
Update Imgix to use React.FC instead of React.Component for better support

### DIFF
--- a/types/react-imgix/index.d.ts
+++ b/types/react-imgix/index.d.ts
@@ -267,9 +267,9 @@ export interface ImgixProviderProps extends CommonProps {
     attributeConfig?: AttributeConfig | undefined;
 }
 
-export class Picture extends React.Component<React.PropsWithChildren<CommonProps>> {}
-export class Source extends React.Component<SharedImgixAndSourceProps> {}
-export class ImgixProvider extends React.Component<React.PropsWithChildren<ImgixProviderProps>> {}
+export const Picture: React.FC<React.PropsWithChildren<CommonProps>>;
+export const Source: React.FC<SharedImgixAndSourceProps>;
+export const ImgixProvider: React.FC<React.PropsWithChildren<ImgixProviderProps>>;
 export function buildURL(src: string, imgixParams?: ImgixParams, options?: SharedImgixAndSourceProps): string;
 
 type Warnings = 'fallbackImage' | 'sizesAttribute' | 'invalidARFormat';
@@ -289,5 +289,5 @@ export interface BackgroundProps {
 
 export const Background: React.FunctionComponent<React.PropsWithChildren<BackgroundProps>>;
 
-declare class Imgix extends React.Component<SharedImgixAndSourceProps> {}
+declare const Imgix: React.FC<SharedImgixAndSourceProps>;
 export default Imgix;


### PR DESCRIPTION

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

This is a fix for react 18