### PR TITLE
[compare-pdf] Add type definitions for compare-pdf

### DIFF
--- a/types/compare-pdf/compare-pdf-tests.ts
+++ b/types/compare-pdf/compare-pdf-tests.ts
@@ -1,0 +1,71 @@
+import ComparePdf = require('compare-pdf');
+
+// @ts-expect-error
+new ComparePdf();
+
+const config = {
+    paths: {
+        actualPdfRootFolder: '/data/actualPdfs',
+        baselinePdfRootFolder: '/data/baselinePdfs',
+        actualPngRootFolder: '/data/actualPngs',
+        baselinePngRootFolder: '/data/baselinePngs',
+        diffPngRootFolder: '/data/diffPngs',
+    },
+    settings: {
+        imageEngine: 'graphicsMagick',
+        density: 100,
+        quality: 70,
+        tolerance: 0,
+        threshold: 0.05,
+        cleanPngPaths: true,
+        matchPageCount: true,
+        disableFontFace: true,
+        verbosity: 0,
+    },
+};
+
+let comparePdfTest = new ComparePdf(config)
+    .actualPdfFile('actualFilePath')
+    .baselinePdfFile('baselineFilePath')
+    .addMask(1, { x0: 20, y0: 40, x1: 100, y1: 70 })
+    .cropPage(1, { width: 530, height: 210, x: 0, y: 415 })
+    .onlyPageIndexes([0, 1, 5]);
+
+comparePdfTest.opts.crops // $ExpectType Array<PageCrop>
+comparePdfTest.opts.crops[0].pageIndex // $ExpectType number
+comparePdfTest.opts.crops[0].coordinates // $ExpectType Dimension
+
+comparePdfTest.opts.masks // $ExpectType Array<PageMask>
+comparePdfTest.opts.masks[0].pageIndex // $ExpectType number
+comparePdfTest.opts.masks[0].coordinates // $ExpectType Coordinates
+comparePdfTest.opts.masks[0].color // $ExpectType string
+
+comparePdfTest.opts.onlyPageIndexes // $ExpectType Array<string | number>
+comparePdfTest.opts.skipPageIndexes // $ExpectType Array<string | number>
+
+
+let cropPagesList = [
+    { pageIndex: 0, coordinates: { width: 210, height: 180, x: 615, y: 265 } },
+    { pageIndex: 0, coordinates: { width: 210, height: 180, x: 615, y: 520 } },
+    { pageIndex: 1, coordinates: { width: 530, height: 210, x: 0, y: 415 } },
+];
+
+let maskPagesList = [
+    { pageIndex: 1, coordinates: { x0: 20, y0: 40, x1: 100, y1: 70 } },
+    { pageIndex: 1, coordinates: { x0: 330, y0: 40, x1: 410, y1: 70 }, color: 'yellow' },
+];
+
+let results = new ComparePdf(config)
+    .actualPdfBuffer(new Uint8Array(100), 'actualFilePath')
+    .baselinePdfBuffer(new Uint8Array(100), 'baselineFilePath')
+    .cropPages(cropPagesList)
+    .addMasks(maskPagesList)
+    .skipPageIndexes([2, 4, 6])
+    .compare();
+
+results.status // $ExpectType string
+results.message // $ExpectType string
+results.details // $ExpectType string
+results.details?.status // $ExpectType string
+results.details?.numDiffPixels // $ExpectType string
+results.details?.diffPng // $ExpectType string

--- a/types/compare-pdf/compare-pdf-tests.ts
+++ b/types/compare-pdf/compare-pdf-tests.ts
@@ -24,38 +24,37 @@ const config = {
     },
 };
 
-let comparePdfTest = new ComparePdf(config)
+const comparePdfTest = new ComparePdf(config)
     .actualPdfFile('actualFilePath')
     .baselinePdfFile('baselineFilePath')
     .addMask(1, { x0: 20, y0: 40, x1: 100, y1: 70 })
     .cropPage(1, { width: 530, height: 210, x: 0, y: 415 })
     .onlyPageIndexes([0, 1, 5]);
 
-comparePdfTest.opts.crops // $ExpectType Array<PageCrop>
-comparePdfTest.opts.crops[0].pageIndex // $ExpectType number
-comparePdfTest.opts.crops[0].coordinates // $ExpectType Dimension
+comparePdfTest.opts.crops; // $ExpectType PageCrop[]
+comparePdfTest.opts.crops[0].pageIndex; // $ExpectType number
+comparePdfTest.opts.crops[0].coordinates; // $ExpectType Dimension
 
-comparePdfTest.opts.masks // $ExpectType Array<PageMask>
-comparePdfTest.opts.masks[0].pageIndex // $ExpectType number
-comparePdfTest.opts.masks[0].coordinates // $ExpectType Coordinates
-comparePdfTest.opts.masks[0].color // $ExpectType string
+comparePdfTest.opts.masks; // $ExpectType PageMask[]
+comparePdfTest.opts.masks[0].pageIndex; // $ExpectType number
+comparePdfTest.opts.masks[0].coordinates; // $ExpectType Coordinates
+comparePdfTest.opts.masks[0].color; // $ExpectType string | undefined
 
-comparePdfTest.opts.onlyPageIndexes // $ExpectType Array<string | number>
-comparePdfTest.opts.skipPageIndexes // $ExpectType Array<string | number>
+comparePdfTest.opts.onlyPageIndexes; // $ExpectType (string | number)[]
+comparePdfTest.opts.skipPageIndexes; // $ExpectType (string | number)[]
 
-
-let cropPagesList = [
+const cropPagesList = [
     { pageIndex: 0, coordinates: { width: 210, height: 180, x: 615, y: 265 } },
     { pageIndex: 0, coordinates: { width: 210, height: 180, x: 615, y: 520 } },
     { pageIndex: 1, coordinates: { width: 530, height: 210, x: 0, y: 415 } },
 ];
 
-let maskPagesList = [
+const maskPagesList = [
     { pageIndex: 1, coordinates: { x0: 20, y0: 40, x1: 100, y1: 70 } },
     { pageIndex: 1, coordinates: { x0: 330, y0: 40, x1: 410, y1: 70 }, color: 'yellow' },
 ];
 
-let results = new ComparePdf(config)
+const results = new ComparePdf(config)
     .actualPdfBuffer(new Uint8Array(100), 'actualFilePath')
     .baselinePdfBuffer(new Uint8Array(100), 'baselineFilePath')
     .cropPages(cropPagesList)
@@ -63,9 +62,9 @@ let results = new ComparePdf(config)
     .skipPageIndexes([2, 4, 6])
     .compare();
 
-results.status // $ExpectType string
-results.message // $ExpectType string
-results.details // $ExpectType string
-results.details?.status // $ExpectType string
-results.details?.numDiffPixels // $ExpectType string
-results.details?.diffPng // $ExpectType string
+results.status; // $ExpectType string
+results.message; // $ExpectType string
+results.details; // $ExpectType Details | undefined
+results.details?.status; // $ExpectType string | undefined
+results.details?.numDiffPixels; // $ExpectType string | undefined
+results.details?.diffPng; // $ExpectType string | undefined

--- a/types/compare-pdf/index.d.ts
+++ b/types/compare-pdf/index.d.ts
@@ -1,0 +1,101 @@
+// Type definitions for compare-pdf 1.1.7
+// Project: https://github.com/marcdacz/compare-pdf
+// Definitions by: Marc Dacanay <https://github.com/marcdacz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace ComparePdf;
+
+export = ComparePdf;
+
+interface ComparePdfConfig {
+    paths: {
+        actualPdfRootFolder: string;
+        baselinePdfRootFolder: string;
+        actualPngRootFolder: string;
+        baselinePngRootFolder: string;
+        diffPngRootFolder: string;
+    };
+    settings: {
+        imageEngine: string;
+        density: number | string;
+        quality: number | string;
+        tolerance: number | string;
+        threshold: number | string;
+        cleanPngPaths?: boolean;
+        matchPageCount?: boolean;
+        disableFontFace?: boolean;
+        verbosity?: number | string;
+    };
+}
+
+interface ComparePdfOpts {
+    masks: Array<PageMask>;
+    crops: Array<PageCrop>;
+    onlyPageIndexes: Array<string | number>;
+    skipPageIndexes: Array<string | number>;
+}
+
+interface Coordinates {
+    x0: number;
+    y0: number;
+    x1: number;
+    y1: number;
+}
+
+interface Dimension {
+    width: number;
+    height: number;
+    x: number;
+    y: number;
+}
+
+interface PageMask {
+    pageIndex: number;
+    coordinates: Coordinates;
+    color?: string;
+}
+
+interface PageCrop {
+    pageIndex: number;
+    coordinates: Dimension;
+}
+
+interface Details {
+    status: string;
+    numDiffPixels: string;
+    diffPng: string;
+}
+
+interface Results {
+    status: string;
+    message: string;
+    details?: Details;
+}
+
+declare class ComparePdf {
+    constructor(config: ComparePdfConfig);
+
+    opts: ComparePdfOpts
+
+    baselinePdfBuffer(baselinePdfBuffer: Uint8Array, baselinePdfFilename: string): ComparePdf;
+
+    baselinePdfFile(baselinePdf: string): ComparePdf;
+
+    actualPdfBuffer(actualPdfBuffer: Uint8Array, actualPdfFilename: string): ComparePdf;
+
+    actualPdfFile(actualPdf: string): ComparePdf;
+
+    addMask(pageIndex: number, coordinates?: Coordinates, color?: string): ComparePdf;
+
+    addMasks(masks: Array<PageMask>): ComparePdf;
+
+    onlyPageIndexes(pageIndexes: Array<string | number>): ComparePdf;
+
+    skipPageIndexes(pageIndexes: Array<string | number>): ComparePdf;
+
+    cropPage(pageIndex: number, coordinates?: Dimension): ComparePdf;
+
+    cropPages(cropPagesList: Array<PageCrop>): ComparePdf;
+
+    compare(comparisonType?: string): Results;
+}

--- a/types/compare-pdf/index.d.ts
+++ b/types/compare-pdf/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for compare-pdf 1.1.7
+// Type definitions for compare-pdf 1.1
 // Project: https://github.com/marcdacz/compare-pdf
 // Definitions by: Marc Dacanay <https://github.com/marcdacz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -29,8 +29,8 @@ interface ComparePdfConfig {
 }
 
 interface ComparePdfOpts {
-    masks: Array<PageMask>;
-    crops: Array<PageCrop>;
+    masks: PageMask[];
+    crops: PageCrop[];
     onlyPageIndexes: Array<string | number>;
     skipPageIndexes: Array<string | number>;
 }
@@ -75,7 +75,7 @@ interface Results {
 declare class ComparePdf {
     constructor(config: ComparePdfConfig);
 
-    opts: ComparePdfOpts
+    opts: ComparePdfOpts;
 
     baselinePdfBuffer(baselinePdfBuffer: Uint8Array, baselinePdfFilename: string): ComparePdf;
 
@@ -87,7 +87,7 @@ declare class ComparePdf {
 
     addMask(pageIndex: number, coordinates?: Coordinates, color?: string): ComparePdf;
 
-    addMasks(masks: Array<PageMask>): ComparePdf;
+    addMasks(masks: PageMask[]): ComparePdf;
 
     onlyPageIndexes(pageIndexes: Array<string | number>): ComparePdf;
 
@@ -95,7 +95,7 @@ declare class ComparePdf {
 
     cropPage(pageIndex: number, coordinates?: Dimension): ComparePdf;
 
-    cropPages(cropPagesList: Array<PageCrop>): ComparePdf;
+    cropPages(cropPagesList: PageCrop[]): ComparePdf;
 
     compare(comparisonType?: string): Results;
 }

--- a/types/compare-pdf/tsconfig.json
+++ b/types/compare-pdf/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "compare-pdf-tests.ts"
+    ]
+}

--- a/types/compare-pdf/tslint.json
+++ b/types/compare-pdf/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


