### PR TITLE
Fill out root eslintrc and update README

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,11 @@
 {
-    "root": true
+    "root": true,
+    "extends": [
+    ],
+    "parser": "@typescript-eslint/parser",
+    "plugins": [
+        "@typescript-eslint"
+    ],
+    "rules": {
+    }
 }

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Your package should have this structure:
 | [`<my-package>-tests.ts`](#my-package-teststs)  | This contains sample code which tests the typings. This code does *not* run, but it is type-checked. |
 | [`tsconfig.json`](#tsconfigjson) | This allows you to run `tsc` within the package. |
 | [`tslint.json`](#linter-tslintjson)   | Enables linting. |
-| [`.eslintrc.json`](#linter-eslintrc)   | (Rarely) Needed only to disable lint rules written for eslint. |
+| [`.eslintrc.json`](#linter-eslintrcjson)   | (Rarely) Needed only to disable lint rules written for eslint. |
 
 Generate these by running `npx dts-gen --dt --name <my-package> --template module` if you have npm ≥ 5.2.0, `npm install -g dts-gen` and `dts-gen --dt --name <my-package> --template module` otherwise.
 See all options at [dts-gen](https://github.com/Microsoft/dts-gen).

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Your package should have this structure:
 | [`<my-package>-tests.ts`](#my-package-teststs)  | This contains sample code which tests the typings. This code does *not* run, but it is type-checked. |
 | [`tsconfig.json`](#tsconfigjson) | This allows you to run `tsc` within the package. |
 | [`tslint.json`](#linter-tslintjson)   | Enables linting. |
+| [`.eslintrc.json`](#linter-eslintrc)   | (Rarely) Needed only to disable lint rules written for eslint. |
 
 Generate these by running `npx dts-gen --dt --name <my-package> --template module` if you have npm ≥ 5.2.0, `npm install -g dts-gen` and `dts-gen --dt --name <my-package> --template module` otherwise.
 See all options at [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -285,6 +286,21 @@ For more details, see [dtslint](https://github.com/Microsoft/DefinitelyTyped-too
 The linter configuration file, `tslint.json` should contain `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
 
 If for some reason some rule needs to be disabled, [disable it for that specific line](https://palantir.github.io/tslint/usage/rule-flags/#comment-flags-in-source-code:~:text=%2F%2F%20tslint%3Adisable%2Dnext%2Dline%3Arule1%20rule2%20rule3...%20%2D%20Disables%20the%20listed%20rules%20for%20the%20next%20line) using `// tslint:disable-next-line:[ruleName]` — not for the whole package, so that disabling can be reviewed. (There are some legacy lint configs that have additional contents, but these should not happen in new work.)
+
+##### Linter: `.eslintrc.json`
+
+Definitely Typed is in the process of switching to eslint for linting.
+Unlike tslint, you don't need a config file to enable linting.
+Like tslint, you should disable specific rules only on specific lines:
+
+
+```ts
+// eslint-disable-next-line no-const-enum
+const enum Const { One }
+const enum Enum { Two } // eslint-disable-line no-const-enum
+```
+
+You can still disable rules with an .eslintrc.json, but should not in new packages.
 
 #### `tsconfig.json`
 


### PR DESCRIPTION
Add typescript-eslint configuration in the root .eslintrc.json. I decided to move it here from `@definitelytype/eslint-config-dtslint` because there's no reason to have a standalone package right now. I didn't understand eslint config cascading as well until a couple of days ago.

I also documented eslint a bit in README, although there shouldn't be any configuration needed until I ship the first few rules.
I didn't touch the non-English README files because I'm not confident enough to write up the change in any of the supported languages.