### PR TITLE
[ssh2] Tweaks to SSH2 typings

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1040,7 +1040,7 @@ export interface Session extends ServerChannel {
     /**
      * Emitted when the client has requested the SFTP subsystem.
      */
-    on(event: "sftp", listener: (accept: () => AcceptSftpConnection, reject: RejectConnection) => void): this;
+    on(event: "sftp", listener: (accept: AcceptSftpConnection, reject: RejectConnection) => void): this;
 
     /**
      * Emitted when the client has requested an arbitrary subsystem.
@@ -1636,14 +1636,15 @@ export type KnownPublicKeys<T extends string | Buffer | ParsedKey = string | Buf
 
 export type PrivateKeys = (Buffer | ParsedKey | EncryptedPrivateKey | string)[];
 
-export type Callback = (err: Error | undefined) => void;
+export type Callback = (err?: Error | null) => void;
+
 export type ErrorCallback = (err: Error) => void;
 
-export type IdentityCallback<T extends string | Buffer | ParsedKey = string | Buffer | ParsedKey> = (err: Error | undefined, keys: KnownPublicKeys<T>) => void;
+export type IdentityCallback<T extends string | Buffer | ParsedKey = string | Buffer | ParsedKey> = (err?: Error | null, keys?: KnownPublicKeys<T>) => void;
 
-export type SignCallback = (err: Error | undefined, signature: Buffer) => void;
+export type SignCallback = (err?: Error | null, signature?: Buffer) => void;
 
-export type GetStreamCallback = (err: Error | undefined, stream: Duplex) => void;
+export type GetStreamCallback = (err?: Error | null, stream?: Duplex) => void;
 
 /**
  * Interface representing an inbound agent request. This is defined as an
@@ -1655,7 +1656,7 @@ export interface AgentInboundRequest {
 }
 
 export interface SigningRequestOptions  {
-    hash?: 'sha256' | 'sha512';
+    hash: 'sha256' | 'sha512';
 }
 
 export class AgentProtocol extends Duplex {
@@ -1690,7 +1691,7 @@ export class AgentProtocol extends Duplex {
      * Signs the datawith the given public key, and calls back with its signature.
      */
     sign(pubKey: ParsedKey | Buffer | string, data: Buffer, options?: SigningRequestOptions, callback?: SignCallback): boolean;
-    sign(pubKey: ParsedKey | Buffer | string, data: Buffer, cb?: SignCallback): boolean;
+    sign(pubKey: ParsedKey | Buffer | string, data: Buffer, callback?: SignCallback): boolean;
 
     /**
      * (Server mode only)

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -100,8 +100,10 @@ export interface Algorithms {
     compress?: AlgorithmList<CompressionAlgorithm>;
 }
 
+export type KeyType = 'ssh-rsa' | 'ssh-dss' | 'ssh-ed25519' | 'ecdsa-sha2-nistp256' | 'ecdsa-sha2-nistp384' | 'ecdsa-sha2-nistp521';
+
 export interface ParsedKey {
-    type: string;
+    type: KeyType;
     comment: string;
     sign(data: Buffer | string, algo?: string): Buffer;
     verify(data: Buffer | string, signature: Buffer, algo?: string): boolean;

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -498,6 +498,8 @@ export class Client extends EventEmitter {
 
 export type HostVerifier = (key: Buffer, verify: VerifyCallback) => void;
 export type SyncHostVerifier = (key: Buffer) => boolean;
+export type HostFingerprintVerifier = (fingerprint: string, verify: VerifyCallback) => boolean;
+export type SyncHostFingerprintVerifier = (fingerprint: string) => boolean;
 export type DebugFunction = (message: string) => void;
 export type AuthenticationType = "password" | "publickey" | "hostbased" | "agent" | "keyboard-interactive" | "none";
 
@@ -513,7 +515,7 @@ export interface ConnectConfig {
     /** The host's key is hashed using this method and passed to `hostVerifier`. */
     hostHash?: string;
     /** Verifies a hexadecimal hash of the host's key. */
-    hostVerifier?: HostVerifier | SyncHostVerifier;
+    hostVerifier?: HostVerifier | SyncHostVerifier | HostFingerprintVerifier | SyncHostFingerprintVerifier;
     /** Username for authentication. */
     username?: string;
     /** Password for password-based user authentication. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

1. Define the list of supported KeyTypes for better interoperability with ServerHostKeyAlgorithm type
2. Allow hostVerifier function that accepts a string (instead of buffer) as was the "old style" for host verification and is what is used if `hostHash` prop is provided.
3. Fix issues with callback parameters that are optional; sftp event callback parameter; and SignRequestOptions.hash is not optional