### PR TITLE
Fixing typing of data-url package (#61060)

### DIFF
--- a/types/data-urls/index.d.ts
+++ b/types/data-urls/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for data-urls 2.0
+// Type definitions for data-urls 3.0.2
 // Project: https://github.com/jsdom/data-urls#readme
 // Definitions by: Jaime Filho <https://github.com/jaimeadf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/data-urls/index.d.ts
+++ b/types/data-urls/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for data-urls 3.0.2
+// Type definitions for data-urls 3.0
 // Project: https://github.com/jsdom/data-urls#readme
 // Definitions by: Jaime Filho <https://github.com/jaimeadf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/data-urls/index.d.ts
+++ b/types/data-urls/index.d.ts
@@ -14,7 +14,7 @@ declare function parseDataURL(stringInput: string): parseDataURL.DataURL | null;
 declare namespace parseDataURL {
     interface DataURL {
         mimeType: MIMEType;
-        body: Buffer;
+        body: Uint8Array;
     }
 
     function fromURLRecord(urlRecord: URLRecord): DataURL | null;


### PR DESCRIPTION
As far as I can tell, the package switched to returning Uint8Arrays about a year ago. 
As seen [here](https://github.com/jsdom/data-urls/blob/f061877a7d517b3160ce7a7752fee0262308886c/lib/utils.js#L17), the utility function that is used to decode the body builds a Uint8Array.

**Note**: Updated library version to 3.0
