### PR TITLE
[@types/node] Add allowHalfOpen to ConnectionOptions in tls.d.ts

### DIFF
--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -516,10 +516,27 @@ declare module 'tls' {
     interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions {
         host?: string | undefined;
         port?: number | undefined;
-        path?: string | undefined; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
-        socket?: stream.Duplex | undefined; // Establish secure connection on a given socket rather than creating a new socket
+        /**
+         * Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
+         */
+        path?: string | undefined;
+        /**
+         * Establish secure connection on a given socket rather than creating a new socket.
+         * If this option is specified, path, host, and port are ignored, except for certificate validation.
+         */
+        socket?: stream.Duplex | undefined;
+        /**
+         * If set to false, then the socket will automatically end the writable side when the readable side ends. 
+         * If the socket option is set, this option has no effect.
+         * @default false
+         */
+        allowHalfOpen?: boolean | undefined;
         checkServerIdentity?: typeof checkServerIdentity | undefined;
-        servername?: string | undefined; // SNI TLS Extension
+        /**
+         * Server name for the SNI (Server Name Indication) TLS extension.
+         * It is the name of the host being connected to, and must be a host name, and not an IP address.
+         */
+        servername?: string | undefined;
         session?: Buffer | undefined;
         minDHSize?: number | undefined;
         lookup?: net.LookupFunction | undefined;


### PR DESCRIPTION
- Add allowHalfOpen option 
- Update comments to better quote the Node.js documentation

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/tls.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
