### PR TITLE
[@types/parse] fix schema.addIndex()'s index parameter

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1267,7 +1267,7 @@ declare global {
             }
 
             interface Index {
-                [fieldName: string]: TYPE;
+                [fieldName: string]: number | string;
             }
 
             /**

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1055,9 +1055,11 @@ async function test_schema(
     // @ts-expect-error
     schema.addRelation('field', 'SomeClass', 'anything');
 
-    schema.addIndex('testIndex', { stringField: 'Number' });
-    // @ts-expect-error
+    schema.addIndex('testIndex', { stringField: 'text' });
     schema.addIndex('testIndex', { stringField: 1 });
+    schema.addIndex('testIndex', { stringField: -1 });
+    // @ts-expect-error
+    schema.addIndex('testIndex', { stringField: true });
 
     schema.deleteField('defaultFieldString');
     schema.deleteIndex('testIndex');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[Parse.Schema.html](https://parseplatform.org/Parse-SDK-JS/api/3.1.0/Parse.Schema.html)>>
The first section of the `Parse.Schema.html` shows that it accept `number` instead of `TYPE`: 
```js
const schema = new Parse.Schema('MyClass');
schema.addString('field');
schema.addIndex('index_name', {'field', 1});
schema.save();
```
The value should also accept possible [mongodb client value](https://github.com/mongodb/node-mongodb-native/blob/a2359e43d7a59acf69785104b5f6e6c1516a5e27/src/operations/indexes.ts#L55)
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
