### PR TITLE
react-copy-to-clipboard: Remove usage of deprecated React.ReactChild

### DIFF
--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -21,7 +21,7 @@ declare namespace CopyToClipboard {
     }
 
     interface Props {
-        children?: React.ReactChild;
+        children?: React.ReactNode;
         text: string;
         onCopy?(text: string, result: boolean): void;
         options?: Options | undefined;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The PR reverts the usage of the deprecated `React.ReactChild` that was introduced as part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60779 - additionally it now allows ecosystem developers to safely upgrade without it breaking their code. (Please see the comments in the linked PR with the fallout by introducing this React-deprecated type)

