### PR TITLE
asana: Propose self as a Definition Owner

### DIFF
--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -4,6 +4,7 @@
 //                 Tasyp <https://github.com/tasyp>
 //                 Filippo Sarzana <https://github.com/filipposarzana>
 //                 Lorant Szakacs <https://github.com/szlori>
+//                 Vince Broz <https://github.com/apiology>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
 import * as Promise from 'bluebird';


### PR DESCRIPTION
I'm pulling out the approved addition of myself as a definition owner for the types/asana package from this PR so that it can be merged without awaiting those unrelated changes to work their way through review: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60589

As context, I've been a contributor to these types in previous PRs and existing definition owners are not responding to review requests.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.) (N/A)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. (N/A)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. - N/A