### PR TITLE
MapboxGeocoder mapboxgl option should refer to mapbox-gl instance

### DIFF
--- a/types/mapbox__mapbox-gl-geocoder/index.d.ts
+++ b/types/mapbox__mapbox-gl-geocoder/index.d.ts
@@ -4,8 +4,10 @@
 //                 Dmytro Gokun <https://github.com/dmytro-gokun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="mapbox-gl" />
 /// <reference types="geojson" />
+
+import mapboxgl = require('mapbox-gl');
+
 export as namespace MapboxGeocoder;
 export = MapboxGeocoder;
 
@@ -38,7 +40,7 @@ declare namespace MapboxGeocoder {
         /**
          * A [mapbox-gl](https://github.com/mapbox/mapbox-gl-js) instance to use when creating [Markers](https://docs.mapbox.com/mapbox-gl-js/api/#marker). Required if `options.marker` is `true`.
          */
-        mapboxgl?: mapboxgl.Map | undefined;
+        mapboxgl?: typeof mapboxgl | undefined;
         /**
          * On geocoded result what zoom level should the map animate to when a bbox isn't found in the response. If a bbox is found the map will fit to the bbox. (optional, default 16)
          */


### PR DESCRIPTION
MapboxGeocoder expected the mapboxgl option to be a Map instance, but MapboxGeocoder expects the entire mapboxgl instance. I've attempted a fix for this by using `typeof mapboxgl`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/mapbox/mapbox-gl-geocoder/blob/main/API.md?plain=1#L92](https://github.com/mapbox/mapbox-gl-geocoder/blob/main/API.md?plain=1#L92)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.