### PR TITLE
Fix react-dom/test-utils types entry point

### DIFF
--- a/types/react-dom/package.json
+++ b/types/react-dom/package.json
@@ -25,6 +25,11 @@
       "types": {
         "default": "./experimental.d.ts"
       }
+    },
+    "./test-utils": {
+      "types": {
+          "default": "./test-utils/index.d.ts"
+      }
     }
   }
 }


### PR DESCRIPTION
* Add entry to exports attribute in package.json to allow ts projects with NodeNext moduleResolution to use these types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This url supports adding the entry point for typescript project using NodeNext moduleResolution
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing


