### PR TITLE
[ssh2 ] `EventEmitter` - replace require with import

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -13,7 +13,7 @@
 /// <reference types="node" />
 
 import { Duplex, Writable, Readable, ReadableOptions, WritableOptions } from "stream";
-import EventEmitter = require("events");
+import { EventEmitter } from "events";
 import { Socket, Server as NetServer } from "net";
 import { Agent as BaseHTTPAgent, AgentOptions } from "http";
 import { Agent as BaseHTTPSAgent } from "https";


### PR DESCRIPTION
This PR fixes an error related to `@types/node` which got a breaking change on `EventEmitter` type definition :

> error TS2507: Type 'typeof EventEmitter' is not a constructor function type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/42164
https://github.com/slackapi/node-slack-sdk/issues/951#issuecomment-603602844


