### PR TITLE
[spdx-expression-parse] Fix typo `s/Conjuction/Conjunction/`

### DIFF
--- a/types/spdx-expression-parse/index.d.ts
+++ b/types/spdx-expression-parse/index.d.ts
@@ -10,17 +10,17 @@
 declare function parse(source: string): parse.Info;
 
 declare namespace parse {
-    type Info = LicenseInfo | ConjuctionInfo;
+    type Info = LicenseInfo | ConjunctionInfo;
 
     interface LicenseInfo {
         license: string;
         plus?: true | undefined;
     }
 
-    interface ConjuctionInfo {
+    interface ConjunctionInfo {
         conjunction: 'and' | 'or';
-        left: LicenseInfo | ConjuctionInfo;
-        right: LicenseInfo | ConjuctionInfo;
+        left: LicenseInfo | ConjunctionInfo;
+        right: LicenseInfo | ConjunctionInfo;
     }
 
     interface Token {

--- a/types/spdx-expression-parse/spdx-expression-parse-tests.ts
+++ b/types/spdx-expression-parse/spdx-expression-parse-tests.ts
@@ -8,6 +8,16 @@ scan(source); // $ExpectType Token[]
 parseTokens(scan(source)); // $ExpectType Info
 parse(source); // $ExpectType Info
 
+const conjunctionInfo: parse.ConjunctionInfo = {
+    left: { license: 'LGPL-2.1' },
+    conjunction: 'or',
+    right: {
+        left: { license: 'BSD-3-Clause' },
+        conjunction: 'and',
+        right: { license: 'MIT' },
+    },
+};
+
 const infos: Info[] = [
     {
         license: 'MIT',
@@ -28,13 +38,5 @@ const infos: Info[] = [
             },
         },
     },
-    {
-        left: { license: 'LGPL-2.1' },
-        conjunction: 'or',
-        right: {
-            left: { license: 'BSD-3-Clause' },
-            conjunction: 'and',
-            right: { license: 'MIT' },
-        },
-    },
+    conjunctionInfo,
 ];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Actual naming in implementation](https://github.com/jslicense/spdx-expression-parse.js/blob/d7daff468ce455f636838a8375d8699cf36be64d/parse.js#L124) and [current typo looks not yet spread (7 in public GitHub repositories)](https://github.com/search?l=TypeScript&q=ConjuctionInfo+-org%3ADefinitelyTyped&type=Code)

Looks some other packages have same typo. However I have focused to this package.