### PR TITLE
node: Add Server.closeIdleConnections and Server.closeAllConnections

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -249,6 +249,16 @@ declare module 'http' {
          * @since v14.11.0
          */
         requestTimeout: number;
+        /**
+         * Closes all connections connected to this server.
+         * @since v18.2.0
+         */
+        closeAllConnections(): void;
+        /**
+         * Closes all connections connected to this server which are not sending a request or waiting for a response.
+         * @since v18.2.0
+         */
+        closeIdleConnections(): void;
         addListener(event: string, listener: (...args: any[]) => void): this;
         addListener(event: 'close', listener: () => void): this;
         addListener(event: 'connection', listener: (socket: Socket) => void): this;

--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -34,6 +34,16 @@ declare module 'https' {
     class Server extends tls.Server {
         constructor(requestListener?: http.RequestListener);
         constructor(options: ServerOptions, requestListener?: http.RequestListener);
+        /**
+         * Closes all connections connected to this server.
+         * @since v18.2.0
+         */
+        closeAllConnections(): void;
+        /**
+         * Closes all connections connected to this server which are not sending a request or waiting for a response.
+         * @since v18.2.0
+         */
+        closeIdleConnections(): void;
         addListener(event: string, listener: (...args: any[]) => void): this;
         addListener(event: 'keylog', listener: (line: Buffer, tlsSocket: tls.TLSSocket) => void): this;
         addListener(event: 'newSession', listener: (sessionId: Buffer, sessionData: Buffer, callback: (err: Error, resp: Buffer) => void) => void): this;

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -39,6 +39,8 @@ import * as dns from 'node:dns';
     const keepAliveTimeout: number = server.keepAliveTimeout;
     const requestTimeout: number = server.requestTimeout;
     server.setTimeout().setTimeout(1000).setTimeout(() => {}).setTimeout(100, () => {});
+    server.closeIdleConnections(); // $ExpectType void
+    server.closeAllConnections(); // $ExpectType void
 }
 
 // http IncomingMessage

--- a/types/node/test/https.ts
+++ b/types/node/test/https.ts
@@ -88,6 +88,8 @@ import * as dns from 'node:dns';
         const maxRequestsPerSocket: number | null = server.maxRequestsPerSocket;
         const headersTimeout: number = server.headersTimeout;
         server.setTimeout().setTimeout(1000).setTimeout(() => {}).setTimeout(100, () => {});
+        server.closeIdleConnections(); // $ExpectType void
+        server.closeAllConnections(); // $ExpectType void
     }
 }
 


### PR DESCRIPTION
These functions are available specifically on http.Server and
https.Server, but not their common ancestor or for http2. They were added
in Node v18.2.0.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * https://nodejs.org/api/http.html#servercloseallconnections
  * https://nodejs.org/api/http.html#servercloseidleconnections
  * https://nodejs.org/api/https.html#servercloseallconnections
  * https://nodejs.org/api/https.html#servercloseidleconnections
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  * I am unsure about this one, what's the process for Node minor releases?