### PR TITLE
Update html-to-text version 8.1.0+ was Pr/58922

### DIFF
--- a/types/html-to-text/html-to-text-tests.ts
+++ b/types/html-to-text/html-to-text-tests.ts
@@ -53,6 +53,7 @@ const htmlOptions: HtmlToTextOptions = {
                 linkBrackets: ['===> ', ' <==='],
                 hideLinkHrefIfSameAsText: true,
             },
+            format: "anchor",
         },
         h1: headerOptions,
         h3: {

--- a/types/html-to-text/html-to-text-tests.ts
+++ b/types/html-to-text/html-to-text-tests.ts
@@ -241,3 +241,20 @@ console.log(htmlToText("<a href=\"https://github.com/DefinitelyTyped\">Link</a>"
         }
     ]
 }));
+
+console.log('Test with user defined options that should be in output');
+console.log(htmlToText("<h1>Starting foo test</h1><foo>bar</foo>", {
+    formatters: {
+        fooFormatter: (elem, walk, builder, options) => {
+            builder.addInline(`beginning ${options.foo} fooFormatter: `, { noWordTransform: false });
+            walk(elem.children, builder);
+        }
+    },
+    selectors: [
+        {
+            selector: "foo",
+            format: 'fooFormatter',
+            options: { foo: "show-me" },
+        },
+    ]
+}));

--- a/types/html-to-text/html-to-text-tests.ts
+++ b/types/html-to-text/html-to-text-tests.ts
@@ -210,3 +210,33 @@ console.log(htmlToText("<h1>Starting foo test</h1><foo>bar</foo>", {
         },
     ]
 }));
+
+console.log('Test with linkBrackets false');
+console.log(htmlToText("<a href=\"https://github.com/DefinitelyTyped\">Link</a>", {
+    selectors: [
+        {
+            selector: "a",
+            options: { linkBrackets: false }
+        }
+    ]
+}));
+
+console.log('Test with custom linkBrackets');
+console.log(htmlToText("<a href=\"https://github.com/DefinitelyTyped\">Link</a>", {
+    selectors: [
+        {
+            selector: "a",
+            options: { linkBrackets: ['@', '@'] }
+        }
+    ]
+}));
+
+console.log('Test without linkBrackets');
+console.log(htmlToText("<a href=\"https://github.com/DefinitelyTyped\">Link</a>", {
+    selectors: [
+        {
+            selector: "a",
+            options: { linkBrackets: undefined }
+        }
+    ]
+}));

--- a/types/html-to-text/index.d.ts
+++ b/types/html-to-text/index.d.ts
@@ -310,6 +310,7 @@ export interface FormatOptions {
      */
     noAnchorUrl?: boolean | undefined;
     /**
+     * @deprecated. Use linkBrackets instead.
      * (Only for: `anchor` formatter.) Don't print brackets around links.
      */
     noLinkBrackets?: boolean | undefined;

--- a/types/html-to-text/index.d.ts
+++ b/types/html-to-text/index.d.ts
@@ -357,6 +357,10 @@ export interface FormatOptions {
      * (Only for: `table`, `dataTable` formatter.) Number of empty lines between data table rows.
      */
     rowSpacing?: number | undefined;
+    /**
+     * User defined values are supported.
+     */
+    [key: string]: any;
 }
 
 /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/html-to-text/node-html-to-text/blob/master/CHANGELOG.md#version-810)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This expands on the previous PR with two more changes.

- the 8.2.0 version of html-to-text broke the test of a deprecated feature.  The test is updated to bypass the issue.
- the options that can be passed to selectors were intended to be user extensible.  That feature is now available.