### PR TITLE
[node-forge] pbkdf2 allows message digest to be string

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -844,12 +844,14 @@ declare module "node-forge" {
 
     namespace pkcs5 {
         function pbkdf2(password: string, salt: string, iterations: number, keySize: number): string;
-        function pbkdf2(password: string, salt: string, iterations: number, keySize: number, messageDigest: md.MessageDigest): string;
+        function pbkdf2(password: string, salt: string, iterations: number, keySize: number, messageDigest: md.MessageDigest | md.Algorithm): string;
         function pbkdf2(password: string, salt: string, iterations: number, keySize: number, callback: (err: Error | null, dk: string | null) => any): void;
-        function pbkdf2(password: string, salt: string, iterations: number, keySize: number, messageDigest?: md.MessageDigest, callback?: (err: Error | null, dk: string | null) => any): void;
+        function pbkdf2(password: string, salt: string, iterations: number, keySize: number, messageDigest?: md.MessageDigest | md.Algorithm, callback?: (err: Error | null, dk: string) => any): void;
     }
 
     namespace md {
+
+        type Algorithm = "md5" | "sha1" | "sha256" | "sha384" | "sha512";
 
         interface MessageDigest {
             update(msg: string, encoding?: Encoding): MessageDigest;

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -357,6 +357,8 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
         else
             throw Error("pbkdf2 key derivation fail");
     });
+
+    const key5: string = forge.pkcs5.pbkdf2("password", "salt", 1000, 32, 'sha256');
 }
 
 {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/digitalbazaar/forge/blob/v1.0.0/lib/pbkdf2.js#L50
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
