### PR TITLE
feat(node): add promise typings to readline

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -108,6 +108,7 @@
 /// <reference path="punycode.d.ts" />
 /// <reference path="querystring.d.ts" />
 /// <reference path="readline.d.ts" />
+/// <reference path="readline/promises.d.ts" />
 /// <reference path="repl.d.ts" />
 /// <reference path="stream.d.ts" />
 /// <reference path="stream/promises.d.ts" />

--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -34,7 +34,10 @@
  */
 declare module 'readline' {
     import { Abortable, EventEmitter } from 'node:events';
-    interface Key {
+    import * as promises from 'node:readline/promises';
+
+    export { promises };
+    export interface Key {
         sequence?: string | undefined;
         name?: string | undefined;
         ctrl?: boolean | undefined;
@@ -48,7 +51,7 @@ declare module 'readline' {
      * and is read from, the `input` stream.
      * @since v0.1.104
      */
-    class Interface extends EventEmitter {
+    export class Interface extends EventEmitter {
         readonly terminal: boolean;
         /**
          * The current input data being processed by node.
@@ -315,11 +318,11 @@ declare module 'readline' {
         prependOnceListener(event: 'history', listener: (history: string[]) => void): this;
         [Symbol.asyncIterator](): AsyncIterableIterator<string>;
     }
-    type ReadLine = Interface; // type forwarded for backwards compatibility
-    type Completer = (line: string) => CompleterResult;
-    type AsyncCompleter = (line: string, callback: (err?: null | Error, result?: CompleterResult) => void) => void;
-    type CompleterResult = [string[], string];
-    interface ReadLineOptions {
+    export type ReadLine = Interface; // type forwarded for backwards compatibility
+    export type Completer = (line: string) => CompleterResult;
+    export type AsyncCompleter = (line: string, callback: (err?: null | Error, result?: CompleterResult) => void) => void;
+    export type CompleterResult = [string[], string];
+    export interface ReadLineOptions {
         input: NodeJS.ReadableStream;
         output?: NodeJS.WritableStream | undefined;
         completer?: Completer | AsyncCompleter | undefined;
@@ -380,8 +383,8 @@ declare module 'readline' {
      * ```
      * @since v0.1.98
      */
-    function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;
-    function createInterface(options: ReadLineOptions): Interface;
+    export function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;
+    export function createInterface(options: ReadLineOptions): Interface;
     /**
      * The `readline.emitKeypressEvents()` method causes the given `Readable` stream to begin emitting `'keypress'` events corresponding to received input.
      *
@@ -503,9 +506,9 @@ declare module 'readline' {
      * ```
      * @since v0.7.7
      */
-    function emitKeypressEvents(stream: NodeJS.ReadableStream, readlineInterface?: Interface): void;
-    type Direction = -1 | 0 | 1;
-    interface CursorPos {
+    export function emitKeypressEvents(stream: NodeJS.ReadableStream, readlineInterface?: Interface): void;
+    export type Direction = -1 | 0 | 1;
+    export interface CursorPos {
         rows: number;
         cols: number;
     }
@@ -516,7 +519,7 @@ declare module 'readline' {
      * @param callback Invoked once the operation completes.
      * @return `false` if `stream` wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.
      */
-    function clearLine(stream: NodeJS.WritableStream, dir: Direction, callback?: () => void): boolean;
+    export function clearLine(stream: NodeJS.WritableStream, dir: Direction, callback?: () => void): boolean;
     /**
      * The `readline.clearScreenDown()` method clears the given `TTY` stream from
      * the current position of the cursor down.
@@ -524,7 +527,7 @@ declare module 'readline' {
      * @param callback Invoked once the operation completes.
      * @return `false` if `stream` wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.
      */
-    function clearScreenDown(stream: NodeJS.WritableStream, callback?: () => void): boolean;
+    export function clearScreenDown(stream: NodeJS.WritableStream, callback?: () => void): boolean;
     /**
      * The `readline.cursorTo()` method moves cursor to the specified position in a
      * given `TTY` `stream`.
@@ -532,7 +535,7 @@ declare module 'readline' {
      * @param callback Invoked once the operation completes.
      * @return `false` if `stream` wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.
      */
-    function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number, callback?: () => void): boolean;
+    export function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number, callback?: () => void): boolean;
     /**
      * The `readline.moveCursor()` method moves the cursor _relative_ to its current
      * position in a given `TTY` `stream`.
@@ -643,7 +646,7 @@ declare module 'readline' {
      * @param callback Invoked once the operation completes.
      * @return `false` if `stream` wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.
      */
-    function moveCursor(stream: NodeJS.WritableStream, dx: number, dy: number, callback?: () => void): boolean;
+    export function moveCursor(stream: NodeJS.WritableStream, dx: number, dy: number, callback?: () => void): boolean;
 }
 declare module 'node:readline' {
     export * from 'readline';

--- a/types/node/readline/promises.d.ts
+++ b/types/node/readline/promises.d.ts
@@ -1,0 +1,143 @@
+/**
+ * The `readline/promise` module provides an API for reading lines of input from a Readable stream one line at a time.
+ *
+ * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/readline/promises.js)
+ * @since v17.0.0
+ */
+declare module 'readline/promises' {
+    import { Interface as _Interface, ReadLineOptions, Completer, AsyncCompleter, Direction } from 'node:readline';
+    import { Abortable } from 'node:events';
+
+    class Interface extends _Interface {
+        /**
+         * The rl.question() method displays the query by writing it to the output, waits for user input to be provided on input,
+         * then invokes the callback function passing the provided input as the first argument.
+         *
+         * When called, rl.question() will resume the input stream if it has been paused.
+         *
+         * If the readlinePromises.Interface was created with output set to null or undefined the query is not written.
+         *
+         * If the question is called after rl.close(), it returns a rejected promise.
+         *
+         * Example usage:
+         *
+         * ```js
+         * const answer = await rl.question('What is your favorite food? ');
+         * console.log(`Oh, so your favorite food is ${answer}`);
+         * ```
+         *
+         * Using an AbortSignal to cancel a question.
+         *
+         * ```js
+         * const signal = AbortSignal.timeout(10_000);
+         *
+         * signal.addEventListener('abort', () => {
+         *   console.log('The food question timed out');
+         * }, { once: true });
+         *
+         * const answer = await rl.question('What is your favorite food? ', { signal });
+         * console.log(`Oh, so your favorite food is ${answer}`);
+         * ```
+         *
+         * @since v17.0.0
+         * @param query A statement or query to write to output, prepended to the prompt.
+         */
+        question(query: string): Promise<string>;
+        question(query: string, options: Abortable): Promise<string>;
+    }
+
+    class Readline {
+        /**
+         * @param stream A TTY stream.
+         */
+        constructor(stream: NodeJS.WritableStream, options?: { autoCommit?: boolean });
+        /**
+         * The `rl.clearLine()` method adds to the internal list of pending action an action that clears current line of the associated `stream` in a specified direction identified by `dir`.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true` was passed to the constructor.
+         */
+        clearLine(dir: Direction): this;
+        /**
+         * The `rl.clearScreenDown()` method adds to the internal list of pending action an action that clears the associated `stream` from the current position of the cursor down.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true` was passed to the constructor.
+         */
+        clearScreenDown(): this;
+        /**
+         * The `rl.commit()` method sends all the pending actions to the associated `stream` and clears the internal list of pending actions.
+         */
+        commit(): Promise<void>;
+        /**
+         * The `rl.cursorTo()` method adds to the internal list of pending action an action that moves cursor to the specified position in the associated `stream`.
+         * Call `rl.commit()` to see the effect of this method, unless `autoCommit: true` was passed to the constructor.
+         */
+        cursorTo(x: number, y?: number): this;
+        /**
+         * The `rl.moveCursor()` method adds to the internal list of pending action an action that moves the cursor relative to its current position in the associated `stream`.
+         * Call `rl.commit()` to see the effect of this method, unless autoCommit: true was passed to the constructor.
+         */
+        moveCursor(dx: number, dy: number): this;
+        /**
+         * The `rl.rollback()` method clears the internal list of pending actions without sending it to the associated `stream`.
+         */
+        rollback(): this;
+    }
+
+    /**
+     * The `readlinePromises.createInterface()` method creates a new `readlinePromises.Interface` instance.
+     *
+     * ```js
+     * const readlinePromises = require('node:readline/promises');
+     * const rl = readlinePromises.createInterface({
+     *   input: process.stdin,
+     *   output: process.stdout
+     * });
+     * ```
+     *
+     * Once the `readlinePromises.Interface` instance is created, the most common case is to listen for the `'line'` event:
+     *
+     * ```js
+     * rl.on('line', (line) => {
+     *   console.log(`Received: ${line}`);
+     * });
+     * ```
+     *
+     * If `terminal` is `true` for this instance then the `output` stream will get the best compatibility if it defines an `output.columns` property,
+     * and emits a `'resize'` event on the `output`, if or when the columns ever change (`process.stdout` does this automatically when it is a TTY).
+     *
+     * ## Use of the `completer` function
+     *
+     * The `completer` function takes the current line entered by the user as an argument, and returns an `Array` with 2 entries:
+     *
+     * - An Array with matching entries for the completion.
+     * - The substring that was used for the matching.
+     *
+     * For instance: `[[substr1, substr2, ...], originalsubstring]`.
+     *
+     * ```js
+     * function completer(line) {
+     *   const completions = '.help .error .exit .quit .q'.split(' ');
+     *   const hits = completions.filter((c) => c.startsWith(line));
+     *   // Show all completions if none found
+     *   return [hits.length ? hits : completions, line];
+     * }
+     * ```
+     *
+     * The `completer` function can also returns a `Promise`, or be asynchronous:
+     *
+     * ```js
+     * async function completer(linePartial) {
+     *   await someAsyncWork();
+     *   return [['123'], linePartial];
+     * }
+     * ```
+     */
+    function createInterface(
+        input: NodeJS.ReadableStream,
+        output?: NodeJS.WritableStream,
+        completer?: Completer | AsyncCompleter,
+        terminal?: boolean,
+    ): Interface;
+    function createInterface(options: ReadLineOptions): Interface;
+}
+declare module 'node:readline/promises' {
+    export * from 'readline/promises';
+}

--- a/types/node/test/readline.ts
+++ b/types/node/test/readline.ts
@@ -1,3 +1,4 @@
+import * as readlinePromises from 'node:readline/promises';
 import * as readline from 'node:readline';
 import * as stream from 'node:stream';
 import * as fs from 'node:fs';
@@ -243,4 +244,112 @@ const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
         input: process.stdin,
     });
     const pos: readline.CursorPos = rl.getCursorPos();
+}
+
+const rlPromise = readlinePromises.createInterface(new stream.Readable());
+
+{
+    async () => {
+        const signal = new AbortSignal();
+
+        // @ts-expect-error
+        rlPromise.question();
+        // @ts-expect-error
+        rlPromise.question('test', { signal: 'bad' });
+
+        rlPromise.question('test'); // $ExpectType Promise<string>
+        rlPromise.question('test', { signal }); // $ExpectType Promise<string>
+    };
+}
+
+{
+    // @ts-expect-error
+    new readlinePromises.Readline(new stream.Readable());
+    // @ts-expect-error
+    new readlinePromises.Readline(new stream.Writable(), { autoCommit: 'bad' });
+
+    new readlinePromises.Readline(new stream.Writable(), { autoCommit: true });
+    new readlinePromises.Readline(new stream.Writable(), { autoCommit: false });
+}
+
+const readlineInstance = new readlinePromises.Readline(new stream.Writable());
+
+{
+    // @ts-expect-error
+    readlineInstance.clearLine();
+    // @ts-expect-error
+    readlineInstance.clearLine(2);
+    // @ts-expect-error
+    readlineInstance.clearLine(-2);
+
+    readlineInstance.clearLine(1); // $ExpectType Readline
+    readlineInstance.clearLine(0); // $ExpectType Readline
+    readlineInstance.clearLine(-1); // $ExpectType Readline
+}
+
+{
+    readlineInstance.clearScreenDown(); // $ExpectType Readline
+}
+
+{
+    readlineInstance.commit(); // $ExpectType Promise<void>
+}
+
+{
+    // @ts-expect-error
+    readlineInstance.cursorTo();
+    // @ts-expect-error
+    readlineInstance.cursorTo('bad');
+
+    readlineInstance.cursorTo(1); // $ExpectType Readline
+    readlineInstance.cursorTo(1, 2); // $ExpectType Readline
+}
+
+{
+    // @ts-expect-error
+    readlineInstance.moveCursor();
+    // @ts-expect-error
+    readlineInstance.moveCursor(1);
+    // @ts-expect-error
+    readlineInstance.moveCursor('bad');
+
+    readlineInstance.moveCursor(0, 1); // $ExpectType Readline
+}
+
+{
+    readlineInstance.rollback(); // $ExpectType Readline
+}
+
+{
+    const options: readline.ReadLineOptions = {
+        input: new fs.ReadStream(),
+    };
+    const input: NodeJS.ReadableStream = new stream.Readable();
+    const output: NodeJS.WritableStream = new stream.Writable();
+    const completer: readline.Completer = str => [['asd'], 'asd'];
+    const terminal = false;
+
+    let result: readlinePromises.Interface;
+
+    result = readlinePromises.createInterface(options);
+    result = readlinePromises.createInterface(input);
+    result = readlinePromises.createInterface(input, output);
+    result = readlinePromises.createInterface(input, output, completer);
+    result = readlinePromises.createInterface(input, output, completer, terminal);
+    result = readlinePromises.createInterface({
+        input,
+        completer(str: string): readline.CompleterResult {
+            return [['test'], 'test'];
+        },
+    });
+    result = readlinePromises.createInterface({
+        input,
+        completer(str: string, callback: (err: any, result: readline.CompleterResult) => void): any {
+            callback(null, [['test'], 'test']);
+        },
+    });
+    result = readlinePromises.createInterface({
+        input,
+        tabSize: 4,
+    });
 }


### PR DESCRIPTION
These are all additions, except for the removal of the Readline class in the main typings for `node:readline`. Looking at the [source code](https://github.com/nodejs/node/blob/v18.0.0/lib/readline.js) of `node:readline`, Readline is no longer exported as of node v18.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/readline.html#promises-api
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.