### PR TITLE
Revert "[react] fix: missing target types at KeyboardEvent"

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1272,7 +1272,6 @@ declare namespace React {
         shiftKey: boolean;
         /** @deprecated */
         which: number;
-        target: EventTarget & T;
     }
 
     interface MouseEvent<T = Element, E = NativeMouseEvent> extends UIEvent<T, E> {


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#60696

This is a common pitfall we have documented in https://github.com/eps1lon/DefinitelyTyped/blob/b246ab4535951fdd45a37fe1eba4babf2fa573f2/types/react/index.d.ts#L1202-L1208