### PR TITLE
fix(ldapjs): Add missing Attribute constructor

### DIFF
--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -512,7 +512,11 @@ export interface AttributeJson {
 }
 
 export class Attribute {
-    private type: string;
+    constructor(options?: {
+        type?: string,
+        vals?: any;
+    })
+    readonly type: string;
     readonly buffers: Buffer[];
 
     /**

--- a/types/ldapjs/ldapjs-tests.ts
+++ b/types/ldapjs/ldapjs-tests.ts
@@ -173,3 +173,14 @@ server.listen(1389, '127.0.0.1', () => {
         // Server closed
     });
 });
+
+let attribute = new ldap.Attribute({
+    type: 'foo',
+    vals: [42, undefined, null, {key: 'value'}, 'string', Buffer.from('buffer')],
+});
+// $ExpectType string
+attribute.type;
+// $ExpectType string | string[]
+attribute.vals;
+attribute.vals = 'string'
+ldap.Attribute.isAttribute(attribute);


### PR DESCRIPTION
Also correct overly narrow type for Attribute's vals member, and fix `type` incorrectly being marked private.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). I couldn't get the test suite to work, but CI passes.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ldapjs/node-ldapjs/blob/v2.2.4/lib/attribute.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
