### PR TITLE
fix(parse): do not use `const enum`

### DIFF
--- a/types/parse/v1/index.d.ts
+++ b/types/parse/v1/index.d.ts
@@ -1017,7 +1017,7 @@ declare namespace Parse {
     /*
      * We need to inline the codes in order to make compilation work without this type definition as dependency.
      */
-    const enum ErrorCode {
+    enum ErrorCode {
         OTHER_CAUSE = -1,
         INTERNAL_SERVER_ERROR = 1,
         CONNECTION_FAILED = 100,


### PR DESCRIPTION
This is now banned by linter, but barely surfaces from time to time,
like in this case:
https://github.com/DefinitelyTyped/DefinitelyTyped/runs/7225578093?check_suite_focus=true#step:6:3241

Removing as per handbook:
https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls

Thanks!

/cc @nicolas377
ref: #61115

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)