### PR TITLE
add ExecError type to teen_process

### DIFF
--- a/types/teen_process/index.d.ts
+++ b/types/teen_process/index.d.ts
@@ -201,3 +201,12 @@ export class SubProcess extends EventEmitter {
     prependOnceListener(event: 'lines-stdout' | 'lines-stderr', listener: (lines: string[]) => void): this;
     prependOnceListener(event: 'stream-line', listener: (line: string) => void): this;
 }
+
+/**
+ * {@link exec} can reject with this error
+ */
+export interface ExecError extends Error {
+    code?: number;
+    stdout: string;
+    stderr: string;
+}

--- a/types/teen_process/teen_process-tests.ts
+++ b/types/teen_process/teen_process-tests.ts
@@ -1,4 +1,4 @@
-import { exec, SubProcess, SubProcessOptions } from 'teen_process';
+import { exec, ExecError, SubProcess, SubProcessOptions } from 'teen_process';
 
 exec('bigfix');
 exec('echo', ['my name is bob', 'lol']);
@@ -36,6 +36,11 @@ const props: {
     pid: number | null | undefined;
 } = new SubProcess('ls');
 
+try {
+    exec('exit', ['1'], {shell: true});
+} catch (err) {
+    const {stdout, stderr, code} = err as ExecError;
+}
 const subproc = new SubProcess('ls', [], { cwd: process.cwd() });
 subproc.on('lines-stdout', (newLines: string[]) => {});
 subproc.once('lines-stderr', (newLines: string[]) => {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/appium/node-teen_process/blob/master/lib/exec.js#L130](https://github.com/appium/node-teen_process/blob/master/lib/exec.js#L130)

* * *

I cannot run tests locally (in Node.js 14.x w/ npm 6.x _and_ Node.js 18.x w/ npm 8.x) for unknown reasons (and I'm unable to spend more time debugging this):

```
DefinitelyTyped on  update-teen_process via  v14.20.0 took 12s
❯ npm test teen_process

> definitely-typed@0.0.3 test /Users/boneskull/projects/DefinitelyTyped/DefinitelyTyped
> cross-env NODE_OPTIONS="--require source-map-support/register" dtslint types "teen_process"

dtslint@0.0.121
Installing to /Users/boneskull/.dts/typescript-installs/4.2...
internal/modules/cjs/loader.js:905
  throw err;
  ^

Error: Cannot find module 'source-map-support/register'
Require stack:
- internal/preload
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at Module._preloadModules (internal/modules/cjs/loader.js:1244:12)
    at loadPreloadModules (internal/bootstrap/pre_execution.js:475:5)
    at prepareMainThreadExecution (internal/bootstrap/pre_execution.js:72:3)
    at internal/main/run_main_module.js:7:1 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ 'internal/preload' ]
}

Error: Command failed: npm install --ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links
internal/modules/cjs/loader.js:905
  throw err;
  ^

Error: Cannot find module 'source-map-support/register'
Require stack:
- internal/preload
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at Module._preloadModules (internal/modules/cjs/loader.js:1244:12)
    at loadPreloadModules (internal/bootstrap/pre_execution.js:475:5)
    at prepareMainThreadExecution (internal/bootstrap/pre_execution.js:72:3)
    at internal/main/run_main_module.js:7:1 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ 'internal/preload' ]
}

    at ChildProcess.exithandler (child_process.js:383:12)
    at ChildProcess.emit (events.js:400:28)
    at maybeClose (internal/child_process.js:1088:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:296:5)
npm ERR! Test failed.  See above for more details.
```
