### PR TITLE
[react-native] fix animated component ref type (help wanted)

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8915,8 +8915,6 @@ export namespace Animated {
 
     export type ComponentProps<T> = T extends React.ComponentType<infer P> | React.Component<infer P> ? P : never;
 
-    export type LegacyRef<C> = { getNode(): C };
-
     type Nullable = undefined | null;
     type Primitive = string | number | boolean | symbol;
     type Builtin = Function | Date | Error | RegExp;
@@ -8938,13 +8936,9 @@ export namespace Animated {
 
     type NonAnimatedProps = 'key' | 'ref';
 
-    type TAugmentRef<T> = T extends React.Ref<infer R> ? React.Ref<R | LegacyRef<R>> : never;
-
     export type AnimatedProps<T> = {
         [key in keyof T]: key extends NonAnimatedProps
-            ? key extends 'ref'
-                ? TAugmentRef<T[key]>
-                : T[key]
+            ? T[key]
             : WithAnimatedValue<T[key]>;
     };
 


### PR DESCRIPTION
[Animated components](https://reactnative.dev/docs/animated#animatable-components) should have `ref` type [forwarded from base component](https://github.com/facebook/react-native/blob/v0.69.1/Libraries/Animated/createAnimatedComponent.js#L262-L269).  This kind of works for `Animated.Image`, `Animated.ScrollView`, `Animated.Text`, and `Animated.View`, however `TAugmentRef<T>` makes the result very liberal (I can pass a ref object of any type, without ts complaining).  I propose removing `LegacyRef` support, to which I can find no documentation.

Refs do not work at all for `Animated.FlatList`  and `Animated.SectionList`.  It appears that in order to keep data type inference, they were written as new classes, using only props from the non-animated components.  As such, ref attribute is strongly typed, but [no methods](https://reactnative.dev/docs/flatlist#methods) are available on said ref object.

The only way I could determine to make the methods available, without losing data type inference, is to copy all the methods over, which seems unwise.  Suggestions?

---

_(Will fill the template when this pr is ready.)_

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
