### PR TITLE
feat(ssh2-sftp-client): better type inference on get

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -32,9 +32,21 @@ declare class sftp {
 
     get(
         path: string,
-        dst?: string | NodeJS.WritableStream,
+        dst: string,
         options?: sftp.TransferOptions,
-    ): Promise<string | NodeJS.WritableStream | Buffer>;
+    ): Promise<string>;
+
+    get(
+        path: string,
+        dst: NodeJS.WritableStream,
+        options?: sftp.TransferOptions,
+    ): Promise<NodeJS.WritableStream>;
+
+    get(
+        path: string,
+        dst?: undefined,
+        options?: sftp.TransferOptions,
+    ): Promise<Buffer>;
 
     fastGet(remoteFilePath: string, localPath: string, options?: sftp.FastGetTransferOptions): Promise<string>;
 

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -34,8 +34,9 @@ import * as fs from 'fs';
 
     client.realPath('/remote/path').then(() => null);
 
-    client.get('/remote/path').then(() => null);
-    client.get('/remote/path', fs.createWriteStream('/local/path/copy.txt')).then(() => null);
+    client.get('/remote/path').then((responseBuffer: Buffer) => null);
+    client.get('/remote/path', 'local/path').then((responseString: string) => null);
+    client.get('/remote/path', fs.createWriteStream('/local/path/copy.txt')).then((responseStream: NodeJS.WritableStream) => null);
     client
         .get('/remote/path', fs.createWriteStream('/local/path/copy.txt'), {
             readStreamOptions: {


### PR DESCRIPTION
- Returned type is based on the type passed to the `dst`. The developer no longer has to use `as` to infer type e.g. `as Buffer`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.npmjs.com/package/ssh2-sftp-client#org02a3dc5>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

