### PR TITLE
[d3-selection] Fix return type of d3-selection's Local#set method 

### DIFF
--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -1106,13 +1106,13 @@ str = d3Selection.style(n, 'opacity');
 // Tests of Local
 // ---------------------------------------------------------------------------------------
 
-let  xElement: Element = d3Selection.select<Element, any>('foo').node()!;
+const xElement: Element = d3Selection.select<Element, any>('foo').node()!;
 const foo: d3Selection.Local<number[]> = d3Selection.local<number[]>();
 const propName: string = foo.toString();
 
-// direct set & get on Local<T> object
-xElement = foo.set(xElement, [1, 2, 3]);
+// direct get & set on Local<T> object
 let array: number[] | undefined = foo.get(xElement);
+array = foo.set(xElement, [1, 2, 3]);
 
 // test read & write of .property() access to locals
 array = d3Selection.select(xElement)

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -987,7 +987,7 @@ export interface Local<T> {
      * @param node A node element.
      * @param value Value to store locally
      */
-    set(node: Element, value: T): Element;
+    set(node: Element, value: T): T;
     /**
      * Obtain a string with the internally assigned property name for the local
      * which is used to store the value on a node


### PR DESCRIPTION
It returns the value set, as evidenced by the implementation:

https://github.com/d3/d3-selection/blob/464cb9a0af622375fee526ebbb66f709d5d92a2b/src/local.js#L18-L20
```javascript
  set: function(node, value) {
    return node[this._] = value;
  },
```

I merely changed the type of the corresponding interface as follows:
```diff
-set(node: Element, value: T): Element;
+set(node: Element, value: T): T;
```

I also updated the `d3-selection-tests.ts` file in accordance with the readjusted typings.

~~Disclaimer: I couldn't get `npm test <package to test>` to execute properly; I would get errors from `dtslint@0.0.121` about modules that cannot be found.~~
Got it to work, just had to not use a shallow checkout and manually drill into `.dts/typescript-installs/4.8` and `npm install` there.

---

PS: something seems weird, the CI actually thinks `ldapjs` was also updated, while I didn't touch anything there, neither now nor ever before: see [line 26 in the `npm run test-all` task of the CI logs](https://github.com/DefinitelyTyped/DefinitelyTyped/runs/7256868932?check_suite_focus=true#step:6:27):

```
Testing 2 changed packages: d3-selection,ldapjs
```