### PR TITLE
[semantic-release] add Branch and improve Logger typings

### DIFF
--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -12,7 +12,7 @@ declare namespace SemanticRelease {
      * A semver release type.
      * See https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-types.js
      */
-    type ReleaseType = "prerelease" | "prepatch" | "patch" | "preminor" | "minor" | "premajor" | "major";
+    type ReleaseType = 'prerelease' | 'prepatch' | 'patch' | 'preminor' | 'minor' | 'premajor' | 'major';
 
     /**
      * semantic-release options.
@@ -216,83 +216,85 @@ declare namespace SemanticRelease {
      * a string is a shortcut for specifying that string as the `name` field,
      * for example `"master"` expands to `{name: "master"}`.
      */
-    type BranchSpec = string | {
-        /**
-         * The name of git branch.
-         *
-         * A `name` is required for all types of branch. It can be defined as a
-         * [glob](https://github.com/micromatch/micromatch#matching-features)
-         * in which case the definition will be expanded to one per matching
-         * branch existing in the repository.
-         *
-         * If `name` doesn't match any branch existing in the repository, the
-         * definition will be ignored. For example, the default configuration
-         * includes the definition `next` and `next-major` which will become
-         * active only  when the branches `next` and/or `next-major` are
-         * created in the repository.
-         */
-        name: string;
+    type BranchSpec =
+        | string
+        | {
+              /**
+               * The name of git branch.
+               *
+               * A `name` is required for all types of branch. It can be defined as a
+               * [glob](https://github.com/micromatch/micromatch#matching-features)
+               * in which case the definition will be expanded to one per matching
+               * branch existing in the repository.
+               *
+               * If `name` doesn't match any branch existing in the repository, the
+               * definition will be ignored. For example, the default configuration
+               * includes the definition `next` and `next-major` which will become
+               * active only  when the branches `next` and/or `next-major` are
+               * created in the repository.
+               */
+              name: string;
 
-        /**
-         * The distribution channel on which to publish releases from this
-         * branch.
-         *
-         * If this field is set to `false`, then the branch will be released
-         * on the default distribution channel (for example the `@latest`
-         * [dist-tag](https://docs.npmjs.com/cli/dist-tag) for npm). This is
-         * also the default behavior for the first
-         * [release branch](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#release-branches)
-         * if the channel property is not set.
-         *
-         * For all other branches, if the channel property is not set, then the
-         * channel name will be the same as the branch name.
-         *
-         * The value of `channel`, if defined as a string, is generated with
-         * [Lodash template](https://lodash.com/docs#template) with the
-         * variable `name` set to the branch name.
-         *
-         * For example `{name: 'next', channel: 'channel-${name}'}` will be
-         * expanded to `{name: 'next', channel: 'channel-next'}`.
-         */
-        channel?: string | false | undefined;
+              /**
+               * The distribution channel on which to publish releases from this
+               * branch.
+               *
+               * If this field is set to `false`, then the branch will be released
+               * on the default distribution channel (for example the `@latest`
+               * [dist-tag](https://docs.npmjs.com/cli/dist-tag) for npm). This is
+               * also the default behavior for the first
+               * [release branch](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#release-branches)
+               * if the channel property is not set.
+               *
+               * For all other branches, if the channel property is not set, then the
+               * channel name will be the same as the branch name.
+               *
+               * The value of `channel`, if defined as a string, is generated with
+               * [Lodash template](https://lodash.com/docs#template) with the
+               * variable `name` set to the branch name.
+               *
+               * For example `{name: 'next', channel: 'channel-${name}'}` will be
+               * expanded to `{name: 'next', channel: 'channel-next'}`.
+               */
+              channel?: string | false | undefined;
 
-        /**
-         * The range of [semantic versions](https://semver.org/) to support on
-         * this branch.
-         *
-         * A `range` only applies to maintenance branches and must be formatted
-         * like `N.N.x` or `N.x` (`N` is a number). If no range is specified
-         * but the `name` is formatted as a range, then the branch will be
-         * considered a maintenance branch and the `name` value will be used
-         * for the `range`.
-         *
-         * Required for maintenance branches, unless `name` is formatted like
-         * `N.N.x` or `N.x` (`N` is a number).
-         */
-        range?: string | undefined;
+              /**
+               * The range of [semantic versions](https://semver.org/) to support on
+               * this branch.
+               *
+               * A `range` only applies to maintenance branches and must be formatted
+               * like `N.N.x` or `N.x` (`N` is a number). If no range is specified
+               * but the `name` is formatted as a range, then the branch will be
+               * considered a maintenance branch and the `name` value will be used
+               * for the `range`.
+               *
+               * Required for maintenance branches, unless `name` is formatted like
+               * `N.N.x` or `N.x` (`N` is a number).
+               */
+              range?: string | undefined;
 
-        /**
-         * The pre-release identifier to append to [semantic versions](https://semver.org/)
-         * released from this branch.
-         *
-         * A `prerelease` property applies only to pre-release branches and
-         * the `prerelease` value must be valid per the [Semantic Versioning
-         * Specification](https://semver.org/#spec-item-9). It will determine
-         * the name of versions. For example if `prerelease` is set to
-         * `"beta"`, the version will be formatted like `2.0.0-beta.1`,
-         * `2.0.0-beta.2`, etc.
-         *
-         * The value of `prerelease`, if defined as a string, is generated with
-         * [Lodash template](https://lodash.com/docs#template) with the
-         * variable `name` set to the name of the branch.
-         *
-         * If the `prerelease property is set to `true` then the name of the
-         * branch is used as the pre-release identifier.
-         *
-         * Required for pre-release branches.
-         */
-        prerelease?: string | boolean | undefined;
-    };
+              /**
+               * The pre-release identifier to append to [semantic versions](https://semver.org/)
+               * released from this branch.
+               *
+               * A `prerelease` property applies only to pre-release branches and
+               * the `prerelease` value must be valid per the [Semantic Versioning
+               * Specification](https://semver.org/#spec-item-9). It will determine
+               * the name of versions. For example if `prerelease` is set to
+               * `"beta"`, the version will be formatted like `2.0.0-beta.1`,
+               * `2.0.0-beta.2`, etc.
+               *
+               * The value of `prerelease`, if defined as a string, is generated with
+               * [Lodash template](https://lodash.com/docs#template) with the
+               * variable `name` set to the name of the branch.
+               *
+               * If the `prerelease property is set to `true` then the name of the
+               * branch is used as the pre-release identifier.
+               *
+               * Required for pre-release branches.
+               */
+              prerelease?: string | boolean | undefined;
+          };
 
     /**
      * Specifies a plugin to use.
@@ -422,8 +424,8 @@ declare namespace SemanticRelease {
          * The shared logger instance of semantic release.
          */
         logger: {
-            log: (message: string, ...vars: any[]) => void,
-            error: (message: string, ...vars: any[]) => void,
+            log: (message: string, ...vars: any[]) => void;
+            error: (message: string, ...vars: any[]) => void;
         };
 
         /**
@@ -585,27 +587,29 @@ declare namespace SemanticRelease {
      * An object with details of the release if a release was published, or
      * false if no release was published.
      */
-    type Result = false | {
-        /**
-         * Information related to the last release found.
-         */
-        lastRelease: LastRelease;
+    type Result =
+        | false
+        | {
+              /**
+               * Information related to the last release found.
+               */
+              lastRelease: LastRelease;
 
-        /**
-         * The list of commits included in the new release.
-         */
-        commits: Commit[];
+              /**
+               * The list of commits included in the new release.
+               */
+              commits: Commit[];
 
-        /**
-         * Information related to the newly published release.
-         */
-        nextRelease: NextRelease;
+              /**
+               * Information related to the newly published release.
+               */
+              nextRelease: NextRelease;
 
-        /**
-         * The list of releases published, one release per publish plugin.
-         */
-        releases: Release[];
-    };
+              /**
+               * The list of releases published, one release per publish plugin.
+               */
+              releases: Release[];
+          };
 }
 
 /**
@@ -613,7 +617,9 @@ declare namespace SemanticRelease {
  * object.
  * @async
  */
-declare function SemanticRelease(options: SemanticRelease.Options,
-    environment?: SemanticRelease.Config): Promise<SemanticRelease.Result>;
+declare function SemanticRelease(
+    options: SemanticRelease.Options,
+    environment?: SemanticRelease.Config,
+): Promise<SemanticRelease.Result>;
 
 export = SemanticRelease;

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -211,7 +211,7 @@ declare namespace SemanticRelease {
         plugins: ReadonlyArray<PluginSpec>;
     }
 
-    type BranchObject = {
+    interface BranchObject {
         /**
          * The name of git branch.
          *
@@ -287,7 +287,7 @@ declare namespace SemanticRelease {
          * Required for pre-release branches.
          */
         prerelease?: string | boolean | undefined;
-    };
+    }
 
     /**
      * Specifies a git branch holding commits to analyze and code to release.

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -209,6 +209,84 @@ declare namespace SemanticRelease {
         plugins: ReadonlyArray<PluginSpec>;
     }
 
+    type BranchObject = {
+        /**
+         * The name of git branch.
+         *
+         * A `name` is required for all types of branch. It can be defined as a
+         * [glob](https://github.com/micromatch/micromatch#matching-features)
+         * in which case the definition will be expanded to one per matching
+         * branch existing in the repository.
+         *
+         * If `name` doesn't match any branch existing in the repository, the
+         * definition will be ignored. For example, the default configuration
+         * includes the definition `next` and `next-major` which will become
+         * active only  when the branches `next` and/or `next-major` are
+         * created in the repository.
+         */
+        name: string;
+
+        /**
+         * The distribution channel on which to publish releases from this
+         * branch.
+         *
+         * If this field is set to `false`, then the branch will be released
+         * on the default distribution channel (for example the `@latest`
+         * [dist-tag](https://docs.npmjs.com/cli/dist-tag) for npm). This is
+         * also the default behavior for the first
+         * [release branch](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#release-branches)
+         * if the channel property is not set.
+         *
+         * For all other branches, if the channel property is not set, then the
+         * channel name will be the same as the branch name.
+         *
+         * The value of `channel`, if defined as a string, is generated with
+         * [Lodash template](https://lodash.com/docs#template) with the
+         * variable `name` set to the branch name.
+         *
+         * For example `{name: 'next', channel: 'channel-${name}'}` will be
+         * expanded to `{name: 'next', channel: 'channel-next'}`.
+         */
+        channel?: string | false | undefined;
+
+        /**
+         * The range of [semantic versions](https://semver.org/) to support on
+         * this branch.
+         *
+         * A `range` only applies to maintenance branches and must be formatted
+         * like `N.N.x` or `N.x` (`N` is a number). If no range is specified
+         * but the `name` is formatted as a range, then the branch will be
+         * considered a maintenance branch and the `name` value will be used
+         * for the `range`.
+         *
+         * Required for maintenance branches, unless `name` is formatted like
+         * `N.N.x` or `N.x` (`N` is a number).
+         */
+        range?: string | undefined;
+
+        /**
+         * The pre-release identifier to append to [semantic versions](https://semver.org/)
+         * released from this branch.
+         *
+         * A `prerelease` property applies only to pre-release branches and
+         * the `prerelease` value must be valid per the [Semantic Versioning
+         * Specification](https://semver.org/#spec-item-9). It will determine
+         * the name of versions. For example if `prerelease` is set to
+         * `"beta"`, the version will be formatted like `2.0.0-beta.1`,
+         * `2.0.0-beta.2`, etc.
+         *
+         * The value of `prerelease`, if defined as a string, is generated with
+         * [Lodash template](https://lodash.com/docs#template) with the
+         * variable `name` set to the name of the branch.
+         *
+         * If the `prerelease property is set to `true` then the name of the
+         * branch is used as the pre-release identifier.
+         *
+         * Required for pre-release branches.
+         */
+        prerelease?: string | boolean | undefined;
+    };
+
     /**
      * Specifies a git branch holding commits to analyze and code to release.
      *
@@ -216,86 +294,7 @@ declare namespace SemanticRelease {
      * a string is a shortcut for specifying that string as the `name` field,
      * for example `"master"` expands to `{name: "master"}`.
      */
-    type BranchSpec =
-        | string
-        | {
-              /**
-               * The name of git branch.
-               *
-               * A `name` is required for all types of branch. It can be defined as a
-               * [glob](https://github.com/micromatch/micromatch#matching-features)
-               * in which case the definition will be expanded to one per matching
-               * branch existing in the repository.
-               *
-               * If `name` doesn't match any branch existing in the repository, the
-               * definition will be ignored. For example, the default configuration
-               * includes the definition `next` and `next-major` which will become
-               * active only  when the branches `next` and/or `next-major` are
-               * created in the repository.
-               */
-              name: string;
-
-              /**
-               * The distribution channel on which to publish releases from this
-               * branch.
-               *
-               * If this field is set to `false`, then the branch will be released
-               * on the default distribution channel (for example the `@latest`
-               * [dist-tag](https://docs.npmjs.com/cli/dist-tag) for npm). This is
-               * also the default behavior for the first
-               * [release branch](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#release-branches)
-               * if the channel property is not set.
-               *
-               * For all other branches, if the channel property is not set, then the
-               * channel name will be the same as the branch name.
-               *
-               * The value of `channel`, if defined as a string, is generated with
-               * [Lodash template](https://lodash.com/docs#template) with the
-               * variable `name` set to the branch name.
-               *
-               * For example `{name: 'next', channel: 'channel-${name}'}` will be
-               * expanded to `{name: 'next', channel: 'channel-next'}`.
-               */
-              channel?: string | false | undefined;
-
-              /**
-               * The range of [semantic versions](https://semver.org/) to support on
-               * this branch.
-               *
-               * A `range` only applies to maintenance branches and must be formatted
-               * like `N.N.x` or `N.x` (`N` is a number). If no range is specified
-               * but the `name` is formatted as a range, then the branch will be
-               * considered a maintenance branch and the `name` value will be used
-               * for the `range`.
-               *
-               * Required for maintenance branches, unless `name` is formatted like
-               * `N.N.x` or `N.x` (`N` is a number).
-               */
-              range?: string | undefined;
-
-              /**
-               * The pre-release identifier to append to [semantic versions](https://semver.org/)
-               * released from this branch.
-               *
-               * A `prerelease` property applies only to pre-release branches and
-               * the `prerelease` value must be valid per the [Semantic Versioning
-               * Specification](https://semver.org/#spec-item-9). It will determine
-               * the name of versions. For example if `prerelease` is set to
-               * `"beta"`, the version will be formatted like `2.0.0-beta.1`,
-               * `2.0.0-beta.2`, etc.
-               *
-               * The value of `prerelease`, if defined as a string, is generated with
-               * [Lodash template](https://lodash.com/docs#template) with the
-               * variable `name` set to the name of the branch.
-               *
-               * If the `prerelease property is set to `true` then the name of the
-               * branch is used as the pre-release identifier.
-               *
-               * Required for pre-release branches.
-               */
-              prerelease?: string | boolean | undefined;
-          };
-
+    type BranchSpec = string | BranchObject;
     /**
      * Specifies a plugin to use.
      *
@@ -439,6 +438,11 @@ declare namespace SemanticRelease {
          * Commits to analyze.
          */
         commits?: Commit[];
+
+        /**
+         * Current branch being published.
+         */
+        branch: BranchObject;
     }
 
     interface Commit {

--- a/types/semantic-release/index.d.ts
+++ b/types/semantic-release/index.d.ts
@@ -14,6 +14,8 @@ declare namespace SemanticRelease {
      */
     type ReleaseType = 'prerelease' | 'prepatch' | 'patch' | 'preminor' | 'minor' | 'premajor' | 'major';
 
+    type LoggerFunction = (...message: any[]) => void;
+
     /**
      * semantic-release options.
      *
@@ -423,8 +425,23 @@ declare namespace SemanticRelease {
          * The shared logger instance of semantic release.
          */
         logger: {
-            log: (message: string, ...vars: any[]) => void;
-            error: (message: string, ...vars: any[]) => void;
+            await: LoggerFunction;
+            complete: LoggerFunction;
+            debug: LoggerFunction;
+            error: LoggerFunction;
+            fatal: LoggerFunction;
+            fav: LoggerFunction;
+            info: LoggerFunction;
+            log: LoggerFunction;
+            note: LoggerFunction;
+            pause: LoggerFunction;
+            pending: LoggerFunction;
+            star: LoggerFunction;
+            start: LoggerFunction;
+            success: LoggerFunction;
+            wait: LoggerFunction;
+            warn: LoggerFunction;
+            watch: LoggerFunction;
         };
 
         /**

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -72,7 +72,25 @@ const context: lib.Context = {
         gitHead: 'f1eed296d2ffe184fb15f52b1c5ad778f5c87645',
         notes: 'New release',
     },
-    logger: console,
+    logger: {
+        await: (...message: string[]) => {},
+        complete: (...message: string[]) => {},
+        debug: (...message: string[]) => {},
+        error: (...message: string[]) => {},
+        fatal: (...message: string[]) => {},
+        fav: (...message: string[]) => {},
+        info: (...message: string[]) => {},
+        log: (...message: string[]) => {},
+        note: (...message: string[]) => {},
+        pause: (...message: string[]) => {},
+        pending: (...message: string[]) => {},
+        star: (...message: string[]) => {},
+        start: (...message: string[]) => {},
+        success: (...message: string[]) => {},
+        wait: (...message: string[]) => {},
+        warn: (...message: string[]) => {},
+        watch: (...message: string[]) => {},
+    },
     env: {
         AWS_ACCESS_KEY_ID: '12345',
         SHELL: '/bin/bash',
@@ -105,6 +123,9 @@ const context: lib.Context = {
             committerDate: '2019-10-22',
         },
     ],
+    branch: {
+        name: 'main',
+    },
 };
 
 analyzeCommits({}, context);

--- a/types/semantic-release/semantic-release-tests.ts
+++ b/types/semantic-release/semantic-release-tests.ts
@@ -6,8 +6,8 @@ function analyzeCommits(pluginConfig: any, context: lib.Context) {
 }
 
 function verify(pluginConfig: any, context: lib.Context) {
-    if (!("AWS_ACCESS_KEY_ID" in context.env)) {
-        throw new Error("AWS_ACCESS_KEY_ID not set");
+    if (!('AWS_ACCESS_KEY_ID' in context.env)) {
+        throw new Error('AWS_ACCESS_KEY_ID not set');
     }
 }
 
@@ -17,87 +17,94 @@ function publish(pluginConfig: any, context: lib.Context) {
 }
 
 const options: lib.GlobalConfig = {
-    branches: "master",
-    repositoryUrl: "https://github.com/semantic-release/semantic-release.git",
+    branches: 'master',
+    repositoryUrl: 'https://github.com/semantic-release/semantic-release.git',
     // Lint check disabled for the following line because this is the actual
     // format used by semantic-release. This is not a broken template string.
-    tagFormat: "v${version}", // tslint:disable-line: no-invalid-template-strings
-    plugins: ["@semantic-release/commit-analyzer",
-        "@semantic-release/release-notes-generator",
-        "@semantic-release/npm",
-        "@semantic-release/github",
-        ["@qiwi/semantic-release-gh-pages-plugin", {
-            msg: "updated",
-            branch: "docs"
-        }]],
+    tagFormat: 'v${version}', // tslint:disable-line: no-invalid-template-strings
+    plugins: [
+        '@semantic-release/commit-analyzer',
+        '@semantic-release/release-notes-generator',
+        '@semantic-release/npm',
+        '@semantic-release/github',
+        [
+            '@qiwi/semantic-release-gh-pages-plugin',
+            {
+                msg: 'updated',
+                branch: 'docs',
+            },
+        ],
+    ],
     dryRun: false,
     ci: true,
     // Example of extended options supported by plugins.
     assets: [
         {
-            path: "app.zip"
-        }
-    ]
+            path: 'app.zip',
+        },
+    ],
 };
 
 const options2: lib.Options = {
     branches: [
-        "master",
+        'master',
         {
-            name: "next",
-            channel: "next",
-            prerelease: "beta"
+            name: 'next',
+            channel: 'next',
+            prerelease: 'beta',
         },
         {
-            name: "rc*",
-            prerelease: true
+            name: 'rc*',
+            prerelease: true,
         },
         {
-            name: "legacy",
-            range: "1.x"
-        }
-    ]
+            name: 'legacy',
+            range: '1.x',
+        },
+    ],
 };
 
 const context: lib.Context = {
     nextRelease: {
-        type: "major",
+        type: 'major',
         version: '1.0.0',
         gitTag: '1.0.0',
         gitHead: 'f1eed296d2ffe184fb15f52b1c5ad778f5c87645',
-        notes: 'New release'
+        notes: 'New release',
     },
     logger: console,
     env: {
-        AWS_ACCESS_KEY_ID: "12345",
-        SHELL: "/bin/bash",
-        PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        AWS_ACCESS_KEY_ID: '12345',
+        SHELL: '/bin/bash',
+        PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     },
-    commits: [{
-        commit: {
-            long: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
-            short: "a018aff"
+    commits: [
+        {
+            commit: {
+                long: 'a018aff59995a17c0564fa3fd0cb96223f4d4096',
+                short: 'a018aff',
+            },
+            tree: {
+                long: 'c8d47c8f9026337f780299eddcd6bbf69aec5db6',
+                short: 'c8d47c8',
+            },
+            author: {
+                name: 'Lillian Devold',
+                email: 'lillian.devold@example.org',
+                short: '2019-10-22',
+            },
+            committer: {
+                name: 'Lillian Devold',
+                email: 'lillian.devold@example.org',
+                short: '2019-10-22',
+            },
+            subject: 'fix: encode text to HTML',
+            body: 'This closes a potential script injection vector.',
+            message: 'fix: encode text to HTML\n\nThis closes a potential script injection vector.',
+            hash: 'a018aff59995a17c0564fa3fd0cb96223f4d4096',
+            committerDate: '2019-10-22',
         },
-        tree: {
-            long: "c8d47c8f9026337f780299eddcd6bbf69aec5db6",
-            short: "c8d47c8"
-        },
-        author: {
-            name: "Lillian Devold",
-            email: "lillian.devold@example.org",
-            short: "2019-10-22"
-        },
-        committer: {
-            name: "Lillian Devold",
-            email: "lillian.devold@example.org",
-            short: "2019-10-22"
-        },
-        subject: "fix: encode text to HTML",
-        body: "This closes a potential script injection vector.",
-        message: "fix: encode text to HTML\n\nThis closes a potential script injection vector.",
-        hash: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
-        committerDate: "2019-10-22"
-    }]
+    ],
 };
 
 analyzeCommits({}, context);
@@ -105,14 +112,14 @@ verify({}, context);
 publish({}, context);
 
 const config: lib.Config = {
-    cwd: "/home/example/code/semantic-release",
+    cwd: '/home/example/code/semantic-release',
     env: {
-        AWS_ACCESS_KEY_ID: "12345",
-        SHELL: "/bin/bash",
-        PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        AWS_ACCESS_KEY_ID: '12345',
+        SHELL: '/bin/bash',
+        PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     },
     stdout: process.stdout,
-    stderr: process.stderr
+    stderr: process.stderr,
 };
 
 const result: Promise<lib.Result> = semanticRelease(options, config);
@@ -121,59 +128,64 @@ const result2: Promise<lib.Result> = semanticRelease(options2);
 
 const result3: lib.Result = {
     lastRelease: {
-        version: "1.1.0",
-        gitTag: "v1.1.0",
-        gitHead: "ce5e4bb0624ffaf1deec298b6c79962efec7dd3b"
+        version: '1.1.0',
+        gitTag: 'v1.1.0',
+        gitHead: 'ce5e4bb0624ffaf1deec298b6c79962efec7dd3b',
     },
-    commits: [{
-        commit: {
-            long: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
-            short: "a018aff"
+    commits: [
+        {
+            commit: {
+                long: 'a018aff59995a17c0564fa3fd0cb96223f4d4096',
+                short: 'a018aff',
+            },
+            tree: {
+                long: 'c8d47c8f9026337f780299eddcd6bbf69aec5db6',
+                short: 'c8d47c8',
+            },
+            author: {
+                name: 'Lillian Devold',
+                email: 'lillian.devold@example.org',
+                short: '2019-10-22',
+            },
+            committer: {
+                name: 'Lillian Devold',
+                email: 'lillian.devold@example.org',
+                short: '2019-10-22',
+            },
+            subject: 'fix: encode text to HTML',
+            body: 'This closes a potential script injection vector.',
+            message: 'fix: encode text to HTML\n\nThis closes a potential script injection vector.',
+            hash: 'a018aff59995a17c0564fa3fd0cb96223f4d4096',
+            committerDate: '2019-10-22',
         },
-        tree: {
-            long: "c8d47c8f9026337f780299eddcd6bbf69aec5db6",
-            short: "c8d47c8"
-        },
-        author: {
-            name: "Lillian Devold",
-            email: "lillian.devold@example.org",
-            short: "2019-10-22"
-        },
-        committer: {
-            name: "Lillian Devold",
-            email: "lillian.devold@example.org",
-            short: "2019-10-22"
-        },
-        subject: "fix: encode text to HTML",
-        body: "This closes a potential script injection vector.",
-        message: "fix: encode text to HTML\n\nThis closes a potential script injection vector.",
-        hash: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
-        committerDate: "2019-10-22"
-    }],
+    ],
     nextRelease: {
-        type: "minor",
-        version: "1.2.0",
-        gitTag: "v1.2.0",
-        notes: "",
-        gitHead: "a018aff59995a17c0564fa3fd0cb96223f4d4096"
+        type: 'minor',
+        version: '1.2.0',
+        gitTag: 'v1.2.0',
+        notes: '',
+        gitHead: 'a018aff59995a17c0564fa3fd0cb96223f4d4096',
     },
-    releases: [{
-        name: "example-lib",
-        url: "https://www.npmjs.com/package/example-lib",
-        type: "minor",
-        version: "1.2.0",
-        gitHead: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
-        gitTag: "v1.2.0",
-        notes: "",
-        pluginName: "@semantic"
-    }, {
-        name: "example-lib",
-        url: "https://www.npmjs.com/package/example-lib",
-        type: "prerelease",
-        version: "1.2.0-pre.2",
-        gitHead: "a018aff59995a17c0564fa3fd0cb96223f4d4096",
-        gitTag: "v1.2.0-pre.2",
-        notes: "",
-        pluginName: "@semantic"
-    }]
+    releases: [
+        {
+            name: 'example-lib',
+            url: 'https://www.npmjs.com/package/example-lib',
+            type: 'minor',
+            version: '1.2.0',
+            gitHead: 'a018aff59995a17c0564fa3fd0cb96223f4d4096',
+            gitTag: 'v1.2.0',
+            notes: '',
+            pluginName: '@semantic',
+        },
+        {
+            name: 'example-lib',
+            url: 'https://www.npmjs.com/package/example-lib',
+            type: 'prerelease',
+            version: '1.2.0-pre.2',
+            gitHead: 'a018aff59995a17c0564fa3fd0cb96223f4d4096',
+            gitTag: 'v1.2.0-pre.2',
+            notes: '',
+            pluginName: '@semantic',
+        },
+    ],
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [branch](https://github.com/semantic-release/semantic-release/blob/master/docs/developer-guide/plugin.md#verifyconditions) and [logger](https://github.com/klaussinani/signale/blob/master/types/signale.d.ts#L105) (semantic release uses signale for logging, so I just took their type definitions
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

PS.: Prettier styling was a bit out of date, so the first commit just runs prettier through the typings
