### PR TITLE
[chai] Fix Assert.throws and Assert.doesNotThrow typings

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1791,7 +1791,9 @@ suite('assert', () => {
 
     test('throws', () => {
         const errorInstance = new ReferenceError('foo');
-        const fn = () => { throw errorInstance; };
+        const fn = () => {
+            throw errorInstance;
+        };
 
         assert.throws(fn);
         assert.throws(fn, 'foo');
@@ -1816,7 +1818,9 @@ suite('assert', () => {
 
     test('doesNotThrow', () => {
         const errorInstance = new ReferenceError('foo');
-        const fn = () => { throw new Error('bar'); };
+        const fn = () => {
+            throw new Error('bar');
+        };
 
         assert.doesNotThrow(() => {});
         assert.doesNotThrow(fn, 'foo');

--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1790,59 +1790,53 @@ suite('assert', () => {
     });
 
     test('throws', () => {
-        assert.throws(() => {
-            throw new Error('foo');
-        });
-        assert.throws(() => {
-            throw new Error('bar');
-        }, 'bar');
-        assert.throws(() => {
-            throw new Error('bar');
-        }, /bar/);
-        assert.throws(() => {
-            throw new Error('bar');
-        }, Error);
-        assert.throws(() => {
-            throw new Error('bar');
-        }, Error, 'bar');
+        const errorInstance = new ReferenceError('foo');
+        const fn = () => { throw errorInstance; };
 
-        assert.throws(() => {
-            throw new Error('foo');
-        }, TypeError);
+        assert.throws(fn);
+        assert.throws(fn, 'foo');
+        assert.throws(fn, /foo/);
+        assert.throws(fn, ReferenceError);
+        assert.throws(fn, errorInstance);
+        assert.throws(fn, ReferenceError, 'foo');
+        assert.throws(fn, errorInstance, 'foo');
+        assert.throws(fn, ReferenceError, /foo/);
+        assert.throws(fn, errorInstance, /foo/);
 
-        assert.throws(() => {
-            throw new Error('foo');
-        }, 'bar');
-
-        assert.throws(() => {
-            throw new Error('foo');
-        }, Error, 'bar');
-
-        assert.throws(() => {
-            throw new Error('foo');
-        }, TypeError, 'bar');
-
-        assert.throws(() => {
-        });
-
-        assert.throws(() => {
-            throw new Error('');
-        }, 'bar');
-
-        assert.throws(() => {
-            throw new Error('');
-        }, /bar/);
+        assert.throws(fn, null, null, 'message');
+        assert.throws(fn, 'foo', null, 'message');
+        assert.throws(fn, /foo/, null, 'message');
+        assert.throws(fn, ReferenceError, null, 'message');
+        assert.throws(fn, errorInstance, null, 'message');
+        assert.throws(fn, ReferenceError, 'foo', 'message');
+        assert.throws(fn, errorInstance, 'foo', 'message');
+        assert.throws(fn, ReferenceError, /foo/, 'message');
+        assert.throws(fn, errorInstance, /foo/, 'message');
     });
 
     test('doesNotThrow', () => {
-        assert.doesNotThrow(() => {
-        });
-        assert.doesNotThrow(() => {
-        }, 'foo');
+        const errorInstance = new ReferenceError('foo');
+        const fn = () => { throw new Error('bar'); };
 
-        assert.doesNotThrow(() => {
-            throw new Error('foo');
-        });
+        assert.doesNotThrow(() => {});
+        assert.doesNotThrow(fn, 'foo');
+        assert.doesNotThrow(fn, /foo/);
+        assert.doesNotThrow(fn, ReferenceError);
+        assert.doesNotThrow(fn, errorInstance);
+        assert.doesNotThrow(fn, ReferenceError, 'foo');
+        assert.doesNotThrow(fn, errorInstance, 'foo');
+        assert.doesNotThrow(fn, ReferenceError, /foo/);
+        assert.doesNotThrow(fn, errorInstance, /foo/);
+
+        assert.doesNotThrow(fn, null, null, 'message');
+        assert.doesNotThrow(fn, 'foo', null, 'message');
+        assert.doesNotThrow(fn, /foo/, null, 'message');
+        assert.doesNotThrow(fn, ReferenceError, null, 'message');
+        assert.doesNotThrow(fn, errorInstance, null, 'message');
+        assert.doesNotThrow(fn, ReferenceError, 'foo', 'message');
+        assert.doesNotThrow(fn, errorInstance, 'foo', 'message');
+        assert.doesNotThrow(fn, ReferenceError, /foo/, 'message');
+        assert.doesNotThrow(fn, errorInstance, /foo/, 'message');
     });
 
     test('ifError', () => {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1206,7 +1206,7 @@ declare namespace Chai {
          * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-        throws(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
+        throw(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
          * Asserts that fn will throw an error.
@@ -1216,7 +1216,7 @@ declare namespace Chai {
          * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-        throws(
+        throw(
             fn: () => void,
             errorLike?: ErrorConstructor | Error | null,
             errMsgMatcher?: RegExp | string | null,
@@ -1231,7 +1231,7 @@ declare namespace Chai {
          * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-        throw(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
+        throws(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
          * Asserts that fn will throw an error.
@@ -1241,7 +1241,7 @@ declare namespace Chai {
          * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-        throw(
+        throws(
             fn: () => void,
             errorLike?: ErrorConstructor | Error | null,
             errMsgMatcher?: RegExp | string | null,

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1202,136 +1202,81 @@ declare namespace Chai {
          * Asserts that fn will throw an error.
          *
          * @param fn   Function that may throw.
+         * @param errMsgMatcher   Expected error message matcher.
+         * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-        throw(fn: () => void, message?: string): void;
-
-        /**
-         * Asserts that function will throw an error with message matching regexp.
-         *
-         * @param fn   Function that may throw.
-         * @param regExp   Potential expected message match.
-         * @param message   Message to display on error.
-         */
-        throw(fn: () => void, regExp: RegExp): void;
-
-        /**
-         * Asserts that function will throw an error that is an instance of constructor.
-         *
-         * @param fn   Function that may throw.
-         * @param constructor   Potential expected error constructor.
-         * @param message   Message to display on error.
-         */
-        throw(fn: () => void, constructor: ErrorConstructor, message?: string): void;
-
-        /**
-         * Asserts that function will throw an error that is an instance of constructor
-         * and an error with message matching regexp.
-         *
-         * @param fn   Function that may throw.
-         * @param constructor   Potential expected error constructor.
-         * @param message   Message to display on error.
-         */
-        throw(fn: () => void, constructor: ErrorConstructor, regExp: RegExp): void;
+         throws(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
          * Asserts that fn will throw an error.
          *
          * @param fn   Function that may throw.
+         * @param errorLike   Expected error constructor or error instance.
+         * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-        throws(fn: () => void, message?: string): void;
-
-        /**
-         * Asserts that function will throw an error with message matching regexp.
-         *
-         * @param fn   Function that may throw.
-         * @param errType  Potential expected message match or error constructor.
-         * @param message   Message to display on error.
-         */
-        throws(fn: () => void, errType: RegExp | ErrorConstructor, message?: string): void;
-
-        /**
-         * Asserts that function will throw an error that is an instance of constructor
-         * and an error with message matching regexp.
-         *
-         * @param fn   Function that may throw.
-         * @param constructor   Potential expected error constructor.
-         * @param message   Message to display on error.
-         */
-        throws(fn: () => void, constructor: ErrorConstructor, regExp: RegExp): void;
+        throws(fn: () => void, errorLike?: ErrorConstructor | Error | null, errMsgMatcher?: RegExp | string | null, message?: string): void;
 
         /**
          * Asserts that fn will throw an error.
          *
          * @param fn   Function that may throw.
+         * @param errMsgMatcher   Expected error message matcher.
+         * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-        Throw(fn: () => void, message?: string): void;
+         throw(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
-         * Asserts that function will throw an error with message matching regexp.
+         * Asserts that fn will throw an error.
          *
          * @param fn   Function that may throw.
-         * @param regExp   Potential expected message match.
+         * @param errorLike   Expected error constructor or error instance.
+         * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-        Throw(fn: () => void, regExp: RegExp): void;
+        throw(fn: () => void, errorLike?: ErrorConstructor | Error | null, errMsgMatcher?: RegExp | string | null, message?: string): void;
 
         /**
-         * Asserts that function will throw an error that is an instance of constructor.
+         * Asserts that fn will throw an error.
          *
          * @param fn   Function that may throw.
-         * @param constructor   Potential expected error constructor.
+         * @param errMsgMatcher   Expected error message matcher.
+         * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-        Throw(fn: () => void, constructor: ErrorConstructor, message?: string): void;
+         Throw(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
-         * Asserts that function will throw an error that is an instance of constructor
-         * and an error with message matching regexp.
+         * Asserts that fn will throw an error.
          *
          * @param fn   Function that may throw.
-         * @param constructor   Potential expected error constructor.
+         * @param errorLike   Expected error constructor or error instance.
+         * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-        Throw(fn: () => void, constructor: ErrorConstructor, regExp: RegExp): void;
+        Throw(fn: () => void, errorLike?: ErrorConstructor | Error | null, errMsgMatcher?: RegExp | string | null, message?: string): void;
 
         /**
          * Asserts that fn will not throw an error.
          *
          * @param fn   Function that may throw.
+         * @param errMsgMatcher   Expected error message matcher.
+         * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-        doesNotThrow(fn: () => void, message?: string): void;
+         doesNotThrow(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
-         * Asserts that function will throw an error with message matching regexp.
+         * Asserts that fn will not throw an error.
          *
          * @param fn   Function that may throw.
-         * @param regExp   Potential expected message match.
+         * @param errorLike   Expected error constructor or error instance.
+         * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-        doesNotThrow(fn: () => void, regExp: RegExp): void;
-
-        /**
-         * Asserts that function will throw an error that is an instance of constructor.
-         *
-         * @param fn   Function that may throw.
-         * @param constructor   Potential expected error constructor.
-         * @param message   Message to display on error.
-         */
-        doesNotThrow(fn: () => void, constructor: ErrorConstructor, message?: string): void;
-
-        /**
-         * Asserts that function will throw an error that is an instance of constructor
-         * and an error with message matching regexp.
-         *
-         * @param fn   Function that may throw.
-         * @param constructor   Potential expected error constructor.
-         * @param message   Message to display on error.
-         */
-        doesNotThrow(fn: () => void, constructor: ErrorConstructor, regExp: RegExp): void;
+         doesNotThrow(fn: () => void, errorLike?: ErrorConstructor | Error | null, errMsgMatcher?: RegExp | string | null, message?: string): void;
 
         /**
          * Compares two values using operator.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1206,7 +1206,7 @@ declare namespace Chai {
          * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-         throws(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
+        throws(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
          * Asserts that fn will throw an error.
@@ -1216,7 +1216,12 @@ declare namespace Chai {
          * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-        throws(fn: () => void, errorLike?: ErrorConstructor | Error | null, errMsgMatcher?: RegExp | string | null, message?: string): void;
+        throws(
+            fn: () => void,
+            errorLike?: ErrorConstructor | Error | null,
+            errMsgMatcher?: RegExp | string | null,
+            message?: string,
+        ): void;
 
         /**
          * Asserts that fn will throw an error.
@@ -1226,7 +1231,7 @@ declare namespace Chai {
          * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-         throw(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
+        throw(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
          * Asserts that fn will throw an error.
@@ -1236,7 +1241,12 @@ declare namespace Chai {
          * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-        throw(fn: () => void, errorLike?: ErrorConstructor | Error | null, errMsgMatcher?: RegExp | string | null, message?: string): void;
+        throw(
+            fn: () => void,
+            errorLike?: ErrorConstructor | Error | null,
+            errMsgMatcher?: RegExp | string | null,
+            message?: string,
+        ): void;
 
         /**
          * Asserts that fn will throw an error.
@@ -1246,7 +1256,7 @@ declare namespace Chai {
          * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-         Throw(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
+        Throw(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
          * Asserts that fn will throw an error.
@@ -1256,7 +1266,12 @@ declare namespace Chai {
          * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-        Throw(fn: () => void, errorLike?: ErrorConstructor | Error | null, errMsgMatcher?: RegExp | string | null, message?: string): void;
+        Throw(
+            fn: () => void,
+            errorLike?: ErrorConstructor | Error | null,
+            errMsgMatcher?: RegExp | string | null,
+            message?: string,
+        ): void;
 
         /**
          * Asserts that fn will not throw an error.
@@ -1266,7 +1281,7 @@ declare namespace Chai {
          * @param ignored   Ignored parameter.
          * @param message   Message to display on error.
          */
-         doesNotThrow(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
+        doesNotThrow(fn: () => void, errMsgMatcher?: RegExp | string, ignored?: any, message?: string): void;
 
         /**
          * Asserts that fn will not throw an error.
@@ -1276,7 +1291,12 @@ declare namespace Chai {
          * @param errMsgMatcher   Expected error message matcher.
          * @param message   Message to display on error.
          */
-         doesNotThrow(fn: () => void, errorLike?: ErrorConstructor | Error | null, errMsgMatcher?: RegExp | string | null, message?: string): void;
+        doesNotThrow(
+            fn: () => void,
+            errorLike?: ErrorConstructor | Error | null,
+            errMsgMatcher?: RegExp | string | null,
+            message?: string,
+        ): void;
 
         /**
          * Compares two values using operator.


### PR DESCRIPTION
`assert.throws()` and `assert.doesNotThrow()` definitions did not match the underlying library's code.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.chaijs.com/api/assert/#method_throws and https://github.com/chaijs/chai/blob/4.x.x/lib/chai/interface/assert.js#L1981>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.