### PR TITLE
[sync-fetch] Replace $ExpectError with @ts-expect-error

### DIFF
--- a/types/sync-fetch/sync-fetch-tests.ts
+++ b/types/sync-fetch/sync-fetch-tests.ts
@@ -23,10 +23,12 @@ syncFetch('', {
     body: new ArrayBuffer(0),
 });
 syncFetch('', {
-    agent: undefined, // $ExpectError
+    // @ts-expect-error
+    agent: undefined,
 });
 syncFetch('', {
-    signal: undefined, // $ExpectError
+    // @ts-expect-error
+    signal: undefined,
 });
 
 new Request(''); // $ExpectType SyncRequest
@@ -44,14 +46,16 @@ new Request('', {
     timeout: 0,
 });
 const request = new Request('');
-request.agent; // $ExpectError
+// @ts-expect-error
+request.agent;
 request.arrayBuffer(); // $ExpectType ArrayBuffer
 request.blob(); // $ExpectType Promise<Blob>
 request.buffer(); // $ExpectType Buffer
 request.clone(); // $ExpectType SyncRequest
 request.json(); // $ExpectType any
 request.text(); // $ExpectType string
-request.textConverted; // $ExpectError
+// @ts-expect-error
+request.textConverted;
 
 new Response(); // $ExpectType SyncResponse
 new Response('');
@@ -66,8 +70,10 @@ new Response('', {
     timeout: 0,
     url: '',
 });
-Response.error; // $ExpectError
-Response.redirect; // $ExpectError
+// @ts-expect-error
+Response.error;
+// @ts-expect-error
+Response.redirect;
 const response = new Response();
 response.arrayBuffer(); // $ExpectType ArrayBuffer
 response.blob(); // $ExpectType Promise<Blob>
@@ -75,7 +81,8 @@ response.buffer(); // $ExpectType Buffer
 response.clone(); // $ExpectType SyncResponse
 response.json(); // $ExpectType any
 response.text(); // $ExpectType string
-response.textConverted; // $ExpectError
+// @ts-expect-error
+response.textConverted;
 
 new Headers();
 new Headers({ '': '' });


### PR DESCRIPTION
Like https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60697#issue-1262554095 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61027#issue-1290499623, replace `$ExpectError` with `@ts-expect-error`, in preparation for [retiring `$ExpectError` from dtslint](https://github.com/microsoft/DefinitelyTyped-tools/pull/495#issue-1291728528).