### PR TITLE
Use `never` for methods that exit in cli

### DIFF
--- a/types/cli/cli-tests.ts
+++ b/types/cli/cli-tests.ts
@@ -179,3 +179,27 @@ cli.main(function (args, options) {
 
     this.ok('Listening on port ' + options.port);
 });
+
+// Example of exiting the app + type narrowing
+
+function sampleFatalLog(data: string | null) {
+    if (typeof data !== "string") {
+        cli.fatal("Canot proceed without data being a string");
+    }
+
+    cli.ok(`Data received and string has length ${data.length} ✅`);
+    return data;
+}
+
+function sampleCliExit(data: number | string | boolean) {
+    if (typeof data === "boolean") {
+        return cli.exit(2)
+    }
+
+    if (typeof data === "number") {
+        return cli.exit(data);
+    }
+
+    cli.ok(`String data received, exiting OK`);
+    return cli.exit(0);
+}

--- a/types/cli/index.d.ts
+++ b/types/cli/index.d.ts
@@ -18,7 +18,7 @@ interface CLI {
     option_width: number;
     native: any;
     output(message?: any, ...optionalParams: any[]): void;
-    exit(code: number): void;
+    exit(code: number): never;
     no_color: boolean;
     enable(...plugins: string[]): CLI;
     disable(...plugins: string[]): CLI;
@@ -31,7 +31,7 @@ interface CLI {
     error(msg: string): void;
     ok(msg: string): void;
     debug(msg: string): void;
-    fatal(msg: string): void;
+    fatal(msg: string): never;
     setApp(appName: string, version: string): CLI;
     setApp(packageJson: string): CLI;
     parsePackageJson(path?: string): void;


### PR DESCRIPTION
The `exit` and `fatal` methods invoke cli.exit which invokes
the [`exit` module](https://github.com/node-js-libs/cli/blob/master/cli.js#L68)

The exit module is a wrapper around the
nodejs [`process.exit` function](https://github.com/cowboy/node-exit/blob/master/lib/exit.js#L17)

The `process.exit` function has the `never` return type, which should
be reflected in `cli.fatal` and `cli.exit`. This will help in Typescript's
control flow analysis, which can help narrowing types.

For more details on `never` see here:
- https://www.typescriptlang.org/docs/handbook/2/functions.html#never
- https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-never-type
- https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#other-important-typescript-types

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests) (see [this comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61163#issuecomment-1179573681) 😢)

Select one of these and delete the others:

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [See here](https://github.com/node-js-libs/cli/blob/master/cli.js#L455-L458) and the commit message
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.