### PR TITLE
Add missing event arg to callback signature

### DIFF
--- a/types/wordpress__components/keyboard-shortcuts/index.d.ts
+++ b/types/wordpress__components/keyboard-shortcuts/index.d.ts
@@ -16,7 +16,7 @@ declare namespace KeyboardShortcuts {
          * separate `KeyboardShortcuts` element, which can be achieved by
          * assigning a unique `key` prop.
          */
-        shortcuts: Record<string, () => void>;
+        shortcuts: Record<string, ( event: KeyboardEvent ) => void>;
         /**
          * By default, a callback will not be invoked if the key combination
          * occurs in an editable field. Pass `bindGlobal` as `true` if the key

--- a/types/wordpress__components/keyboard-shortcuts/index.d.ts
+++ b/types/wordpress__components/keyboard-shortcuts/index.d.ts
@@ -16,7 +16,7 @@ declare namespace KeyboardShortcuts {
          * separate `KeyboardShortcuts` element, which can be achieved by
          * assigning a unique `key` prop.
          */
-        shortcuts: Record<string, (event: KeyboardEvent) => void>;
+        shortcuts: Record<string, (event: KeyboardEvent, combo: string) => void>;
         /**
          * By default, a callback will not be invoked if the key combination
          * occurs in an editable field. Pass `bindGlobal` as `true` if the key

--- a/types/wordpress__components/keyboard-shortcuts/index.d.ts
+++ b/types/wordpress__components/keyboard-shortcuts/index.d.ts
@@ -16,7 +16,7 @@ declare namespace KeyboardShortcuts {
          * separate `KeyboardShortcuts` element, which can be achieved by
          * assigning a unique `key` prop.
          */
-        shortcuts: Record<string, ( event: KeyboardEvent ) => void>;
+        shortcuts: Record<string, (event: KeyboardEvent) => void>;
         /**
          * By default, a callback will not be invoked if the key combination
          * occurs in an editable field. Pass `bindGlobal` as `true` if the key

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -489,7 +489,7 @@ const IconFunctionComponent = (props: { foo: number; bar: number }) => (
 // keyboard-shortcuts
 //
 const kbshortcutActionOne = () => console.log('action 1');
-const kbshortcutActionTwo = () => console.log('action 1');
+const kbshortcutActionTwo = (event) => console.log('action 1', event);
 const kbshortcuts = {
     'mod+a': kbshortcutActionOne,
     'ctrl+shift+j': kbshortcutActionTwo,

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -489,7 +489,7 @@ const IconFunctionComponent = (props: { foo: number; bar: number }) => (
 // keyboard-shortcuts
 //
 const kbshortcutActionOne = () => console.log('action 1');
-const kbshortcutActionTwo = (event) => console.log('action 1', event);
+const kbshortcutActionTwo = (event: KeyboardEvent) => console.log('action 1', event);
 const kbshortcuts = {
     'mod+a': kbshortcutActionOne,
     'ctrl+shift+j': kbshortcutActionTwo,


### PR DESCRIPTION
The original event arg is passed into each callback as the first parameter currently allowing things like `event.preventDefault()`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- https://github.com/WordPress/gutenberg/blob/trunk/packages/compose/src/hooks/use-keyboard-shortcut/index.js#L109
- https://github.com/WordPress/gutenberg/tree/trunk/packages/compose#usekeyboardshortcut