### PR TITLE
asana: updated DispatcherOptions to include defaultHeaders

### DIFF
--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -100,7 +100,10 @@ client.users.me()
 // Client should be a constructor and accept a dispatcher (e.g. for rate limiting)
 // see: https://github.com/Asana/node-asana/blob/e8400cb386710bf9d310b9a538e291ce908f1291/test/client_spec.js#L33-L37
 
-let dispatcher = new asana.Dispatcher({retryOnRateLimit: true});
+let dispatcher = new asana.Dispatcher({
+  retryOnRateLimit: true,
+  defaultHeaders: {'Asana-Enable': 'feature'}, // dispatcher options can include headers
+});
 client = new asana.Client(dispatcher);
 
 // GIDs should handle both strings and numbers

--- a/types/asana/index.d.ts
+++ b/types/asana/index.d.ts
@@ -34,15 +34,7 @@ declare namespace asana {
     }
 
     /** Options to configure the client */
-    interface ClientOptions extends DispatcherOptions {
-        clientId?: string | number | undefined;
-        clientSecret?: string | undefined;
-        redirectUri?: string | undefined;
-        asanaBaseUrl?: string | undefined;
-        defaultHeaders?: {
-            [key: string]: string;
-        } | undefined;
-    }
+    type ClientOptions = auth.AppOptions & DispatcherOptions;
 
     interface Client {
         /**
@@ -218,6 +210,9 @@ declare namespace asana {
         retryOnRateLimit?: boolean | undefined;
         handleUnauthorized?: (() => boolean | Promise<boolean>) | undefined;
         requestTimeout?: string | undefined;
+        defaultHeaders?: {
+            [key: string]: string;
+        } | undefined;
     }
 
     interface Dispatcher {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Asana/node-asana/blob/bebf5f20394d797c5c38af02bedd127a171eb7de/lib/dispatcher.js#L59 

***

As per the library source code: https://github.com/Asana/node-asana/blob/bebf5f20394d797c5c38af02bedd127a171eb7de/lib/dispatcher.js#L59 
`DispatcherOptions` can include the `defaultHeaders` property.

On top of that, the `ClientOptions` type should be the intersection of `auth.AppOptions` and `DispatcherOptions`, because the [`options` passed to `Client.create()`](https://github.com/Asana/node-asana/blob/bebf5f20394d797c5c38af02bedd127a171eb7de/lib/client.js#L238) are simply passed as is to the [`App` constructor](https://github.com/Asana/node-asana/blob/bebf5f20394d797c5c38af02bedd127a171eb7de/lib/client.js#L149) and to the [`Dispatcher` constructor](https://github.com/Asana/node-asana/blob/bebf5f20394d797c5c38af02bedd127a171eb7de/lib/client.js#L241)
