### PR TITLE
[ember-data] Bump target version to fix `latest` dist-tag on npm

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ember-data 4.0
+// Type definitions for ember-data 4.4
 // Project: https://github.com/emberjs/data
 // Definitions by: Derek Wickern <https://github.com/dwickern>
 //                 Mike North <https://github.com/mike-north>


### PR DESCRIPTION
The change in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60742 resulted in `@types/ember-data@2.14.28` getting tagged as `latest` in the npm registry, which means folks who `npm install @types/ember-data` are getting old 2.x types instead of the current 4.x ones.

This change is just the simplest way I saw to trigger a new 4.x release and hopefully fix the `latest` dist-tag.