### PR TITLE
Add material-colors types

### DIFF
--- a/types/material-colors/index.d.ts
+++ b/types/material-colors/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for material-colors 1.2
 // Project: https://github.com/shuhei/material-colors
-// Definitions by: Noah Overcash <https://github.com/me>
+// Definitions by: Noah Overcash <https://github.com/ncovercash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace material;

--- a/types/material-colors/index.d.ts
+++ b/types/material-colors/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for materialColors 1.2
-// Project: https://github.com/shuhei/materialColors
+// Type definitions for material-colors 1.2
+// Project: https://github.com/shuhei/material-colors
 // Definitions by: Noah Overcash <https://github.com/ncovercash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export as namespace material;
+export as namespace materialColors;
 
 declare const colors: {
     [colorName in

--- a/types/material-colors/index.d.ts
+++ b/types/material-colors/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for material-colors 1.2
-// Project: https://github.com/shuhei/material-colors
+// Type definitions for materialColors 1.2
+// Project: https://github.com/shuhei/materialColors
 // Definitions by: Noah Overcash <https://github.com/ncovercash>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -10,19 +10,19 @@ declare const colors: {
         | 'red'
         | 'pink'
         | 'purple'
-        | 'deep-purple'
+        | 'deepPurple'
         | 'indigo'
         | 'blue'
-        | 'light-blue'
+        | 'lightBlue'
         | 'cyan'
         | 'teal'
         | 'green'
-        | 'light-green'
+        | 'lightGreen'
         | 'lime'
         | 'yellow'
         | 'amber'
         | 'orange'
-        | 'deep-orange']: {
+        | 'deepOrange']: {
         [intensity in
             | '50'
             | '100'
@@ -40,15 +40,15 @@ declare const colors: {
             | 'a700']: string;
     };
 } & {
-    [colorName in 'brown' | 'grey' | 'blue-grey']: {
+    [colorName in 'brown' | 'grey' | 'blueGrey']: {
         [intensity in '50' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900']: string;
     };
 } & {
-    [textColorName in 'dark-text' | 'light-text']: {
+    [textColorName in 'darkText' | 'lightText']: {
         [intensity in 'primary' | 'secondary' | 'disabled' | 'dividers']: string;
     };
 } & {
-    [iconTypeName in 'dark-icons' | 'light-icons']: {
+    [iconTypeName in 'darkIcons' | 'lightIcons']: {
         [mode in 'active' | 'inactive']: string;
     };
 } & {

--- a/types/material-colors/index.d.ts
+++ b/types/material-colors/index.d.ts
@@ -1,0 +1,59 @@
+// Type definitions for material-colors 1.2
+// Project: https://github.com/shuhei/material-colors
+// Definitions by: Noah Overcash <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace material;
+
+declare const colors: {
+    [colorName in
+        | 'red'
+        | 'pink'
+        | 'purple'
+        | 'deep-purple'
+        | 'indigo'
+        | 'blue'
+        | 'light-blue'
+        | 'cyan'
+        | 'teal'
+        | 'green'
+        | 'light-green'
+        | 'lime'
+        | 'yellow'
+        | 'amber'
+        | 'orange'
+        | 'deep-orange']: {
+        [intensity in
+            | '50'
+            | '100'
+            | '200'
+            | '300'
+            | '400'
+            | '500'
+            | '600'
+            | '700'
+            | '800'
+            | '900'
+            | 'a100'
+            | 'a200'
+            | 'a400'
+            | 'a700']: string;
+    };
+} & {
+    [colorName in 'brown' | 'grey' | 'blue-grey']: {
+        [intensity in '50' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900']: string;
+    };
+} & {
+    [textColorName in 'dark-text' | 'light-text']: {
+        [intensity in 'primary' | 'secondary' | 'disabled' | 'dividers']: string;
+    };
+} & {
+    [iconTypeName in 'dark-icons' | 'light-icons']: {
+        [mode in 'active' | 'inactive']: string;
+    };
+} & {
+    black: string;
+    white: string;
+};
+
+export = colors;

--- a/types/material-colors/material-colors-tests.ts
+++ b/types/material-colors/material-colors-tests.ts
@@ -1,0 +1,7 @@
+import * as colors from 'material-colors';
+
+const accentTest: string = colors.red.a700;
+const noAccentTest: string = colors.brown['700'];
+const blackTest: string = colors.black;
+const textTest: string = colors['dark-text']['primary'];
+const iconsTest: string = colors['dark-icons']['active'];

--- a/types/material-colors/material-colors-tests.ts
+++ b/types/material-colors/material-colors-tests.ts
@@ -1,4 +1,4 @@
-import * as colors from 'material-colors';
+import colors = require('material-colors');
 
 const accentTest: string = colors.red.a700;
 const noAccentTest: string = colors.brown['700'];

--- a/types/material-colors/material-colors-tests.ts
+++ b/types/material-colors/material-colors-tests.ts
@@ -3,5 +3,5 @@ import * as colors from 'material-colors';
 const accentTest: string = colors.red.a700;
 const noAccentTest: string = colors.brown['700'];
 const blackTest: string = colors.black;
-const textTest: string = colors['dark-text']['primary'];
-const iconsTest: string = colors['dark-icons']['active'];
+const textTest: string = colors.darkText.primary;
+const iconsTest: string = colors.darkIcons.active;

--- a/types/material-colors/tsconfig.json
+++ b/types/material-colors/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "material-colors-tests.ts"
+    ]
+}

--- a/types/material-colors/tslint.json
+++ b/types/material-colors/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

The [`material-colors` package](https://www.npmjs.com/package/material-colors) simply provides an easy method of accessing hardcoded color values.  This adds types for the giant object that it exports -- I figured the unions like this made the types slightly more readable, however, I can change this to a hardcoded object for every entry, if needed.
