### PR TITLE
[react-resizable] make width and height prop conditionally required

### DIFF
--- a/types/react-resizable/index.d.ts
+++ b/types/react-resizable/index.d.ts
@@ -33,15 +33,12 @@ export interface ResizeCallbackData {
     handle: ResizeHandle;
 }
 
-export interface ResizableProps {
+export type ResizableProps = {
     children?: React.ReactNode;
     className?: string | undefined;
-    width: number;
-    height: number;
     handle?: React.ReactNode | ((resizeHandle: ResizeHandle, ref: React.RefObject<any>) => React.ReactNode) | undefined;
     handleSize?: [number, number] | undefined;
     lockAspectRatio?: boolean | undefined;
-    axis?: Axis | undefined;
     minConstraints?: [number, number] | undefined;
     maxConstraints?: [number, number] | undefined;
     onResizeStop?: ((e: React.SyntheticEvent, data: ResizeCallbackData) => any) | undefined;
@@ -50,7 +47,23 @@ export interface ResizableProps {
     draggableOpts?: any;
     resizeHandles?: ResizeHandle[] | undefined;
     transformScale?: number;
-}
+} & (
+    | {
+          width: number;
+          height?: number | undefined;
+          axis: 'x';
+      }
+    | {
+          width?: number | undefined;
+          height: number;
+          axis: 'y';
+      }
+    | {
+          width: number;
+          height: number;
+          axis?: 'both';
+      }
+);
 
 export class Resizable extends React.Component<ResizableProps, ResizableState> {}
 

--- a/types/react-resizable/index.d.ts
+++ b/types/react-resizable/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-resizable 3.0.4
+// Type definitions for react-resizable 3.0
 // Project: https://github.com/react-grid-layout/react-resizable
 // Definitions by: Harry Brrundage <https://github.com/airhorns>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-resizable/index.d.ts
+++ b/types/react-resizable/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-resizable 3.0
+// Type definitions for react-resizable 3.0.4
 // Project: https://github.com/react-grid-layout/react-resizable
 // Definitions by: Harry Brrundage <https://github.com/airhorns>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-resizable/react-resizable-tests.tsx
+++ b/types/react-resizable/react-resizable-tests.tsx
@@ -47,3 +47,73 @@ class TestResizableBoxComponent extends React.Component<{ children?: React.React
         );
     }
 }
+
+class TestXResizableComponent extends React.Component<{ children?: React.ReactNode }> {
+    render() {
+        return (
+            <Resizable
+                width={10}
+                axis="x"
+                className={'foobar'}
+                minConstraints={[20, 20]}
+                maxConstraints={[42, 42]}
+                handleSize={[5, 5]}
+                lockAspectRatio={false}
+                draggableOpts={{ opaque: true }}
+                onResizeStart={resizeCallback}
+                onResizeStop={resizeCallback}
+                onResize={resizeCallback}
+                transformScale={1}
+            >
+                <div>{this.props.children} </div>
+            </Resizable>
+        );
+    }
+}
+
+class TestYResizableComponent extends React.Component<{ children?: React.ReactNode }> {
+    render() {
+        return (
+            <Resizable
+                height={20}
+                axis="y"
+                className={'foobar'}
+                minConstraints={[20, 20]}
+                maxConstraints={[42, 42]}
+                handleSize={[5, 5]}
+                lockAspectRatio={false}
+                draggableOpts={{ opaque: true }}
+                onResizeStart={resizeCallback}
+                onResizeStop={resizeCallback}
+                onResize={resizeCallback}
+                transformScale={1}
+            >
+                <div>{this.props.children} </div>
+            </Resizable>
+        );
+    }
+}
+
+class TestXYResizableComponent extends React.Component<{ children?: React.ReactNode }> {
+    render() {
+        return (
+            <Resizable
+                width={10}
+                height={20}
+                axis="both"
+                className={'foobar'}
+                minConstraints={[20, 20]}
+                maxConstraints={[42, 42]}
+                handleSize={[5, 5]}
+                lockAspectRatio={false}
+                draggableOpts={{ opaque: true }}
+                onResizeStart={resizeCallback}
+                onResizeStop={resizeCallback}
+                onResize={resizeCallback}
+                transformScale={1}
+            >
+                <div>{this.props.children} </div>
+            </Resizable>
+        );
+    }
+}

--- a/types/react-resizable/tslint.json
+++ b/types/react-resizable/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
+        "no-outside-dependencies": false,
         "npm-naming": [
             true,
             {


### PR DESCRIPTION
The react-resizable has merged this https://github.com/react-grid-layout/react-resizable/pull/196 to make `width` and `height` prop conditionally required.