### PR TITLE
[verror]: Fix `@types/verror` to work with `es2022.error` on TS `4.8`

### DIFF
--- a/types/verror/index.d.ts
+++ b/types/verror/index.d.ts
@@ -28,7 +28,7 @@ declare class VError extends Error {
     static errorFromList<T extends Error>(errors: T[]): null | T | VError.MultiError;
     static errorForEach(err: Error, func: (err: Error) => void): void;
 
-    cause(): Error | undefined;
+    cause: () => (Error | undefined);
     constructor(options: VError.Options | Error, message: string, ...params: any[]);
     constructor(message?: string, ...params: any[]);
 }

--- a/types/verror/tsconfig.json
+++ b/types/verror/tsconfig.json
@@ -3,7 +3,8 @@
         "module": "commonjs",
         "lib": [
             "es6",
-            "dom"
+            "es2021.promise",
+            "es2022.error"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
This commit fixes the following error, which appears when running TS `^4.8.0-dev.20220707` with eg. ` npx tsc --lib es2020,es2022.error,es2021.promise` or ` npx tsc --lib esnext`

> error TS2425: Class 'Error' defines instance member property 'cause', but extended class 'VError' defines it as instance member function.

Discovered in https://github.com/voxpelli/pony-cause/pull/41 when looking to extend the tests for https://github.com/voxpelli/pony-cause/issues/35 to detect whether the nightly of `4.8.0` now correctly fixes that, following the merge of https://github.com/microsoft/TypeScript/pull/49639

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/pull/49639
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
