### PR TITLE
[sharedb] bump major version

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sharedb 2.2
+// Type definitions for sharedb 3.0
 // Project: https://github.com/share/sharedb
 // Definitions by: Steve Oney <https://github.com/soney>
 //                 Eric Hwang <https://github.com/ericyhwang>


### PR DESCRIPTION
This change bumps the targetted version of ShareDB to [v3][1]. No
changes to the types are needed, because the only breaking change was
dropping Node.js v12 support.

[1]: https://github.com/share/sharedb/releases/tag/v3.0.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
