### PR TITLE
[infra] Remove NODE_OPTIONS

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
         "update-codeowners": "node scripts/update-codeowners.js",
         "test-all": "node --require source-map-support/register node_modules/@definitelytyped/dtslint-runner/ --path .",
         "clean": "node scripts/remove-empty.js",
-        "test": "cross-env NODE_OPTIONS=\"--require source-map-support/register\" dtslint types",
-        "lint": "cross-env NODE_OPTIONS=\"--require source-map-support/register\" dtslint types",
+        "test": "node --require source-map-support/register node_modules/@definitelytyped/dtslint/ types",
+        "lint": "node --require source-map-support/register node_modules/@definitelytyped/dtslint/ types",
         "prettier": "prettier"
     },
     "devDependencies": {
@@ -31,7 +31,6 @@
         "@definitelytyped/utils": "latest",
         "@octokit/core": "^3.5.1",
         "@octokit/rest": "^16.0.0",
-        "cross-env": "^7.0.3",
         "d3-array": "^3.0.2",
         "d3-axis": "^3.0.0",
         "d3-scale": "^4.0.0",


### PR DESCRIPTION
Since adding `NODE_OPTIONS='--require source-map-support/register'` in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60859#discussion_r914906399 we've worked around it twice, once for [Windows cmd](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61113#issue-1296131436) and once for [child processes](https://github.com/microsoft/DefinitelyTyped-tools/pull/502#issue-1301153911). I now regret adding it: We can get the same result without environment variables or NODE_OPTIONS. I tested Windows cmd and confirmed it works. What do you think?

/cc @jakebailey and @giact

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/61184#issue-1301092949. This was already fixed by https://github.com/microsoft/DefinitelyTyped-tools/pull/502#issue-1301153911, thanks @giact!