### PR TITLE
[infra] Bump dtslint-runner -> >=0.0.121

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "devDependencies": {
         "@definitelytyped/definitions-parser": "latest",
         "@definitelytyped/dtslint": "latest",
-        "@definitelytyped/dtslint-runner": "latest",
+        "@definitelytyped/dtslint-runner": "^0.0.121",
         "@definitelytyped/header-parser": "^0.0.100",
         "@definitelytyped/utils": "latest",
         "@octokit/core": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "devDependencies": {
         "@definitelytyped/definitions-parser": "latest",
         "@definitelytyped/dtslint": "latest",
-        "@definitelytyped/dtslint-runner": "^0.0.121",
+        "@definitelytyped/dtslint-runner": ">=0.0.121",
         "@definitelytyped/header-parser": "^0.0.100",
         "@definitelytyped/utils": "latest",
         "@octokit/core": "^3.5.1",


### PR DESCRIPTION
I think we depend on dtslint-runner ^0.0.121
- since https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61104/commits/0036aa528d712275115a588ab2f8b976940e286f (added `.eslintrc.json` files)
- for https://github.com/microsoft/DefinitelyTyped-tools/pull/496/files#diff-70e7e23868487b648175b94c54917a408ca00f70196e535ba2b0ff1923333d0cR195 (allowed them)
- to avoid https://github.com/DefinitelyTyped/DefinitelyTyped/issues/61192#issue-1301458585

I can't say how many people bumping the package.json dependency will help. It sounds like if you have an existing DT repo, you need to remove node_modules and/or any project lockfiles, currently. After this change, re-running `npm install` should be sufficient. It shouldn't hurt?

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/61192#issue-1301458585