### PR TITLE
[make-fetch-happen] Convert strictSSL to a boolean

### DIFF
--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for make-fetch-happen 9.0
+// Type definitions for make-fetch-happen 10.0
 // Project: https://github.com/npm/make-fetch-happen
 // Definitions by: Jesse Rosenberger <https://github.com/abernix>
 //                 Trevor Scheer <https://github.com/trevor-scheer>
@@ -6,7 +6,7 @@
 // TypeScript Version: 3.0
 /// <reference lib="dom" />
 import { ClientRequestArgs, AgentOptions } from 'http';
-import { CommonConnectionOptions, SecureContextOptions } from 'tls';
+import { SecureContextOptions } from 'tls';
 import { URL as NodeURL } from 'url';
 
 import { RequestInit, Response } from 'node-fetch';
@@ -26,7 +26,7 @@ declare namespace fetch {
     >;
 
     type TlsOptions = Pick<SecureContextOptions, 'ca' | 'cert' | 'key'> & {
-        strictSSL?: CommonConnectionOptions['rejectUnauthorized'] | undefined;
+        strictSSL?: boolean | undefined;
     };
 
     interface MakeFetchHappenOptions {

--- a/types/make-fetch-happen/index.d.ts
+++ b/types/make-fetch-happen/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jesse Rosenberger <https://github.com/abernix>
 //                 Trevor Scheer <https://github.com/trevor-scheer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 4.0
 /// <reference lib="dom" />
 import { ClientRequestArgs, AgentOptions } from 'http';
 import { SecureContextOptions } from 'tls';

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -73,10 +73,14 @@ fetcher('http://url', { proxy: new URL('http://secure-proxy') });
 // $ExpectType Promise<Response>
 fetcher('http://url', { proxy: new NodeURL('http://secure-proxy') });
 
-// Test the imported `tls` type `CommonConnectionOptions.rejectUnauthorized` remapped to `strictSSL`.
+// Test strictSSL options
 // $ExpectType Promise<Response>
 fetcher('https://url', { strictSSL: true });
+// $ExpectType Promise<Response>
+fetcher('https://url', { strictSSL: false });
 
+// Test the imported `tls` type `CommonConnectionOptions.rejectUnauthorized` matches the
+// type used in `strictSSL`.
 const options: CommonConnectionOptions = {
     rejectUnauthorized: true
 };

--- a/types/make-fetch-happen/make-fetch-happen-tests.ts
+++ b/types/make-fetch-happen/make-fetch-happen-tests.ts
@@ -3,6 +3,7 @@ import { Integrity } from 'ssri';
 import { URL as NodeURL } from 'url';
 import { Agent } from 'http';
 import { Headers } from 'node-fetch';
+import { CommonConnectionOptions } from 'tls';
 
 // Needs arguments when invoked
 // @ts-expect-error
@@ -72,9 +73,15 @@ fetcher('http://url', { proxy: new URL('http://secure-proxy') });
 // $ExpectType Promise<Response>
 fetcher('http://url', { proxy: new NodeURL('http://secure-proxy') });
 
-// Test the imported `tls` type `rejectUnauthorized` remapped to `strictSSL`.
+// Test the imported `tls` type `CommonConnectionOptions.rejectUnauthorized` remapped to `strictSSL`.
 // $ExpectType Promise<Response>
 fetcher('https://url', { strictSSL: true });
+
+const options: CommonConnectionOptions = {
+    rejectUnauthorized: true
+};
+// $ExpectType Promise<Response>
+fetcher('https://url', { strictSSL: options.rejectUnauthorized });
 
 // Test the various types of `headers` that can be passed in as options
 // $ExpectType Promise<Response>


### PR DESCRIPTION
There seems to be a change in the exported types for some of the node versions of `tls`. I am getting the following error when trying to use:

* `make-fetch-happen` v10
* `@types/make-fetch-happen` v9
* Typescript v4
* Node v16

```
node_modules/@types/make-fetch-happen/index.d.ts:9:10 - error TS2305: Module '"tls"' has no exported member 'CommonConnectionOptions'.

9 import { CommonConnectionOptions, SecureContextOptions } from 'tls';
```

To simply things instead of importing `CommonConnectionOptions`, we can directly set the type of our parameter `strictSSL` to `boolean | undefined` as that is the underlying type anyway.

You can see the error with a build here:
https://ci.codesandbox.io/status/apollographql/federation/pr/1964/builds/270406

------
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

