### PR TITLE
[accept-language-parser] Allow passing `null` to pick

### DIFF
--- a/types/accept-language-parser/accept-language-parser-tests.ts
+++ b/types/accept-language-parser/accept-language-parser-tests.ts
@@ -32,6 +32,7 @@ const pick3: string | null = AcceptLanguageParser.pick([''], '', {});
 const pick4: string | null = AcceptLanguageParser.pick([''], '', { loose: true });
 const pick5: Lang | null = AcceptLanguageParser.pick<Lang>([enUs, koKr], [l1, l2, l3]);
 const pick6: Lang | null = AcceptLanguageParser.pick([enUs, koKr], [l1, l2, l3]);
+const pick7: Lang | null = AcceptLanguageParser.pick<Lang>([enUs, koKr], null, {});
 
 const pickOptions: AcceptLanguageParser.PickOptions = {
     loose: true

--- a/types/accept-language-parser/index.d.ts
+++ b/types/accept-language-parser/index.d.ts
@@ -10,7 +10,7 @@
 export function parse(acceptLanguage?: string): Language[];
 export function pick<T extends string>(
     supportedLanguages: T[],
-    acceptLanguage: string | Language[],
+    acceptLanguage: string | Language[] | null,
     options?: PickOptions
 ): T | null;
 


### PR DESCRIPTION
`pick` accepts any falsy values for its parameters: https://github.com/opentable/accept-language-parser/blob/3a1133a42889482e768f01d0b4e4384bb14aa762/index.js#L34

In general passing a falsy value is probably a bug. However, since `Headers#get` returns `string | null` (https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts#L8877), it's handy to allow `null` as `acceptedLanguage` so that this pattern is accepted:

```js
pick(supportedLanguages, headers.get("accepted-language"));
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/opentable/accept-language-parser/blob/3a1133a42889482e768f01d0b4e4384bb14aa762/index.js#L34
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
