### PR TITLE
[cytoscape] Update bounding box functions `options` parameter to be optional

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -772,7 +772,7 @@ cy.elements().tsc();
 // TODO: compound nodes (there aren't any in current test case)
 
 // Check eles.boundingBox return type: https://js.cytoscape.org/#eles.boundingBox
-const box1 = eles.boundingBox({});
+const box1 = eles.boundingBox();
 box1.x1;
 box1.x2;
 box1.y1;
@@ -780,7 +780,7 @@ box1.y2;
 box1.w;
 box1.h;
 // Check eles.renderedBoundingBox return type: https://js.cytoscape.org/#eles.renderedBoundingBox
-const box2 = eles.renderedBoundingBox({});
+const box2 = eles.renderedBoundingBox();
 box2.x1;
 box2.x2;
 box2.y1;

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -1970,14 +1970,14 @@ declare namespace cytoscape {
          * @param options An object containing options for the function.
          * http://js.cytoscape.org/#eles.boundingBox
          */
-        boundingBox(options: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
-        boundingbox(options: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
+        boundingBox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
+        boundingbox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
         /**
          * Get the bounding box of the elements in rendered coordinates.
          * @param options An object containing options for the function.
          */
-        renderedBoundingBox(options: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
-        renderedBoundingbox(options: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
+        renderedBoundingBox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
+        renderedBoundingbox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
     }
 
     /**


### PR DESCRIPTION

As detailed in #61219, `boundingBox()` takes a parameter `options` which should be optional. Same applies for `renderedBoundingBox()`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation](https://js.cytoscape.org/#eles.boundingBox), [source code](https://github.com/cytoscape/cytoscape.js/blob/128061baeeefadb5cbd5955a56e59ca64af9cc04/src/collection/dimensions/bounds.js#L851), [more](https://github.com/cytoscape/cytoscape.js/blob/e6541de603f5714f572238573ea06ef17503282b/test/collection-compound-nodes.js#L136)
