### PR TITLE
fix(dialogify-browser): correct param types to correspond jquery function

### DIFF
--- a/types/dialogify-browser/dialogify-browser-tests.ts
+++ b/types/dialogify-browser/dialogify-browser-tests.ts
@@ -77,13 +77,13 @@ dialog.buttons(buttons, options, '');
 // @ts-expect-error
 dialog.on();
 // @ts-expect-error
-dialog.on('', () => {});
+dialog.on('', event => event.target.$content);
 // $ExpectType Dialogify
-dialog.on('show', () => {});
+dialog.on('show', event => event.target.$content);
 // $ExpectType Dialogify
-dialog.on('close', () => {});
+dialog.on('close', event => event.target.$content);
 // $ExpectType Dialogify
-dialog.on('cancel', () => {});
+dialog.on('cancel', event => event.target.$content);
 // @ts-expect-error
 dialog.on('', {});
 

--- a/types/dialogify-browser/dialogify.d.ts
+++ b/types/dialogify-browser/dialogify.d.ts
@@ -109,7 +109,7 @@ declare namespace Dialogify {
          * @param this Dialogify instance.
          * @param event Mouse click event
          */
-        click?: (this: Dialogify, event: JQuery.ClickEvent) => void;
+        click?: JQuery.TypeEventHandler<Dialogify, null, Dialogify, Dialogify, 'click'>;
         /** Set `autofocus` property or not, `false` by default. */
         focused?: boolean;
         /** Set button as disabled or not, `false` by default. */
@@ -188,7 +188,10 @@ declare class Dialogify {
      * @param callback Callback function.
      * @returns Dialogify instance for chaining.
      */
-    on(event: Dialogify.DialogifyEvent, callback: (this: Dialogify, event: JQuery.Event) => void): Dialogify;
+    on<TType extends Dialogify.DialogifyEvent>(
+        event: TType,
+        callback: JQuery.TypeEventHandler<Dialogify, undefined, Dialogify, Dialogify, TType>,
+    ): Dialogify;
 
     /**
      * Shows a dialog directly.


### PR DESCRIPTION
Some parameters are using JQuery directly in source code, but current type is not exactly match source JQuery type. Digged the correct type in JQuery and corrected it.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OneupNetwork/dialogify/blob/master/src/js/dialogify.js#L162
which referenced to 
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jquery/JQuery.d.ts#L7913
and click event at
https://github.com/OneupNetwork/dialogify/blob/master/src/js/dialogify.js#L234
which referenced to 
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jquery/JQuery.d.ts#L1921
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
