### PR TITLE
fix(@types/node): use correct return types for performance.mark and performance.measure

### DIFF
--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -86,6 +86,13 @@ declare module 'perf_hooks' {
          */
         readonly detail?: NodeGCPerformanceDetail | unknown | undefined; // TODO: Narrow this based on entry type.
     }
+    class PerformanceMark extends PerformanceEntry {
+        readonly duration: 0;
+        readonly entryType: 'mark';
+    }
+    class PerformanceMeasure extends PerformanceEntry {
+        readonly entryType: 'measure';
+    }
     /**
      * _This property is an extension by Node.js. It is not available in Web browsers._
      *
@@ -226,8 +233,9 @@ declare module 'perf_hooks' {
          * and whose performanceEntry.duration is always 0.
          * Performance marks are used to mark specific significant moments in the Performance Timeline.
          * @param name
+         * @return The PerformanceMark entry that was created
          */
-        mark(name?: string, options?: MarkOptions): void;
+        mark(name?: string, options?: MarkOptions): PerformanceMark;
         /**
          * Creates a new PerformanceMeasure entry in the Performance Timeline.
          * A PerformanceMeasure is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'measure',
@@ -242,9 +250,10 @@ declare module 'perf_hooks' {
          * @param name
          * @param startMark
          * @param endMark
+         * @return The PerformanceMeasure entry that was created
          */
-        measure(name: string, startMark?: string, endMark?: string): void;
-        measure(name: string, options: MeasureOptions): void;
+        measure(name: string, startMark?: string, endMark?: string): PerformanceMeasure;
+        measure(name: string, options: MeasureOptions): PerformanceMeasure;
         /**
          * An instance of the PerformanceNodeTiming class that provides performance metrics for specific Node.js operational milestones.
          */

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -85,6 +85,7 @@ declare module 'perf_hooks' {
          * @since v16.0.0
          */
         readonly detail?: NodeGCPerformanceDetail | unknown | undefined; // TODO: Narrow this based on entry type.
+        toJSON(): any;
     }
     class PerformanceMark extends PerformanceEntry {
         readonly duration: 0;

--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -11,9 +11,11 @@ import {
     RecordableHistogram,
     createHistogram,
     NodeGCPerformanceDetail,
+    PerformanceMeasure,
+    PerformanceMark,
 } from 'node:perf_hooks';
 
-performance.mark('start');
+const startMark: PerformanceMark = performance.mark('start');
 (() => {})();
 performance.mark('end');
 
@@ -25,7 +27,7 @@ performance.mark('test', {
 performance.measure('test', {
     detail: 'something',
     duration: 123,
-    start: 'startMark',
+    start: startMark.name,
     end: 'endMark',
 });
 
@@ -36,8 +38,8 @@ performance.measure('test', {
     end: 456,
 });
 
-performance.measure('name', 'startMark', 'endMark');
-performance.measure('name', 'startMark');
+const measure1: PerformanceMeasure = performance.measure('name', startMark.name, 'endMark');
+performance.measure('name', startMark.name);
 performance.measure('name');
 
 const timeOrigin: number = performance.timeOrigin;

--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -39,6 +39,7 @@ performance.measure('test', {
 });
 
 const measure1: PerformanceMeasure = performance.measure('name', startMark.name, 'endMark');
+measure1.toJSON();
 performance.measure('name', startMark.name);
 performance.measure('name');
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Node.js docs are vague about what `performance.measure` returns but otherwise generally match the MDN wording: https://nodejs.org/api/perf_hooks.html#performancemeasurename-startmarkoroptions-endmark
   - Node.js docs are vague about what `performance.mark` returns but otherwise generally match the MDN wording: https://nodejs.org/api/perf_hooks.html#performancemarkname-options
  - `performance.measure` is documented to return a `PerformanceMeasure` instance in MDN docs (where Node.js is listed as "compatible"): https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure#return_value
  - `performance.mark` is documented to return a `PerformanceMark` instance in MDN docs (where Node.js is listed as "compatible"): https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark#return_value
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
