### PR TITLE
fix: missing children in ImageBackgroundProps for react-native@0.66.x

### DIFF
--- a/types/react-native/v0.66/index.d.ts
+++ b/types/react-native/v0.66/index.d.ts
@@ -3842,6 +3842,7 @@ export class Image extends ImageBase {
 }
 
 export interface ImageBackgroundProps extends ImagePropsBase {
+    children?: React.ReactNode;
     imageStyle?: StyleProp<ImageStyle> | undefined;
     style?: StyleProp<ViewStyle> | undefined;
     imageRef?(image: Image): void;


### PR DESCRIPTION
The ImageBackgroundProps in @types/react-native@0.66.x is incorrect, according to the document https://reactnative.dev/docs/0.66/imagebackground says at the end of the first paragraph

> add whatever children to it you would like to layer on top of it

add a children prop for it and make things work.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/0.66/imagebackground