### PR TITLE
[react-refresh] Replace $ExpectError with @ts-expect-error

### DIFF
--- a/types/react-refresh/react-refresh-tests.ts
+++ b/types/react-refresh/react-refresh-tests.ts
@@ -10,7 +10,7 @@ ReactRefreshRuntime.collectCustomHooksForSignature(noop);
 ReactRefreshRuntime.createSignatureFunctionForTransform();
 ReactRefreshRuntime.findAffectedHostInstances([]);
 ReactRefreshRuntime.findAffectedHostInstances([{ current: noop }]);
-// $ExpectError
+// @ts-expect-error
 ReactRefreshRuntime.getFamilyByID(1);
 ReactRefreshRuntime.getFamilyByID(STRING);
 ReactRefreshRuntime.getFamilyByType(STRING);
@@ -18,7 +18,7 @@ ReactRefreshRuntime.getFamilyByType(noop);
 // $ExpectType boolean
 const hasUnrecoverableErrors = ReactRefreshRuntime.hasUnrecoverableErrors();
 ReactRefreshRuntime.injectIntoGlobalHook(window);
-// $ExpectError
+// @ts-expect-error
 ReactRefreshRuntime.injectIntoGlobalHook(STRING);
 ReactRefreshRuntime.performReactRefresh();
 ReactRefreshRuntime.register('unknown type', STRING);


### PR DESCRIPTION
Like https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60697#issue-1262554095 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61027#issue-1290499623, replace `$ExpectError` with `@ts-expect-error`, in preparation for [retiring `$ExpectError` from dtslint](https://github.com/microsoft/DefinitelyTyped-tools/pull/495#issue-1291728528).