### PR TITLE
[amplitude-js] Replace $ExpectError with @ts-expect-error

### DIFF
--- a/types/amplitude-js/amplitude-js-tests.ts
+++ b/types/amplitude-js/amplitude-js-tests.ts
@@ -257,7 +257,8 @@ amplitude.getInstance().init('API_KEY', 'USER_ID', defaults);
 
 // Checking for a Failed Library Initialization Case
 amplitude.getInstance().init('API_KEY', 'USER_ID', {
-    sessionId: Date.now().toString(), // $ExpectError
+    // @ts-expect-error
+    sessionId: Date.now().toString(),
 });
 
 // For versions starting from 8.9.0


### PR DESCRIPTION
Like https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60697#issue-1262554095 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61027#issue-1290499623, replace `$ExpectError` with `@ts-expect-error`, in preparation for [retiring `$ExpectError` from dtslint](https://github.com/microsoft/DefinitelyTyped-tools/pull/495#issue-1291728528).