### PR TITLE
Carbone 2.2+ allows setting the default timezone

### DIFF
--- a/types/carbone/carbone-tests.ts
+++ b/types/carbone/carbone-tests.ts
@@ -6,6 +6,7 @@ const currencySource = 'EUR';
 const currencyTarget = 'PLN';
 const extension = 'odt';
 const lang = 'pl';
+const timezone = 'Asia/Tokyo';
 const tempPath = '/tmp';
 const templatePath = './templates';
 
@@ -62,6 +63,7 @@ const options: carbone.Options = {
     tempPath,
     templatePath,
     lang,
+    timezone,
     translations,
     currencySource,
     currencyTarget,
@@ -78,6 +80,7 @@ const renderOptions: carbone.RenderOptions = {
     currencyTarget,
     enum: enums,
     lang,
+    timezone,
     translations,
     variableStr: '',
 };
@@ -101,6 +104,7 @@ const renderXMLOptions: carbone.RenderXMLOptions = {
     complement: data,
     formatters,
     lang,
+    timezone,
     translations,
     existingVariables: variables,
     extension,

--- a/types/carbone/index.d.ts
+++ b/types/carbone/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for carbone 1.2
+// Type definitions for carbone 3.2
 // Project: https://carbone.io
 // Definitions by: Artur Nerkowski <https://github.com/apatryda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -49,6 +49,7 @@ export interface Options {
     tempPath?: string | undefined;
     templatePath?: string | undefined;
     lang?: string | undefined;
+    timezone?: string | undefined;
     translations?: Translations | undefined;
     currencySource?: string | undefined;
     currencyTarget?: string | undefined;
@@ -65,6 +66,7 @@ export interface RenderXMLOptions {
     complement?: object | undefined;
     formatters?: Formatters | undefined;
     lang?: string | undefined;
+    timezone?: string | undefined;
     translations?: Translations | undefined;
     existingVariables?: Variable[] | undefined;
     extension?: string | undefined;
@@ -78,6 +80,7 @@ export interface RenderOptions {
     convertTo?: string | object | undefined;
     variableStr?: string | undefined;
     lang?: string | undefined;
+    timezone?: string | undefined;
     translations?: Translations | undefined;
     enum?: Enums | undefined;
     currencySource?: string | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). (See comments below.)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carboneio/carbone/commit/6c78351c747a4094cb6ec87f1ae406f15a2fc189
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

When I run the test (`npm test carbone`) errors similar to the following are printed:

> ERROR: 1:1  no-outside-dependencies  File C:/Users/alext/Projects/DefinitelyTyped/node_modules/@types/node/assert.d.ts comes from a `node_modules` but is not declared in this type's `package.json`.  See: https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/dtslint/docs/no-outside-dependencies.md

I think this has nothing to do with the changes but I have no idea how to resolve this.