### PR TITLE
[@types/netease-captcha] Update types for Netease captcha

### DIFF
--- a/types/netease-captcha/index.d.ts
+++ b/types/netease-captcha/index.d.ts
@@ -7,6 +7,87 @@ interface Window {
     initNECaptcha?: NeteaseCaptcha.InitFunction | undefined;
 }
 
+type Lang =
+    | 'en'
+    | 'zh-CN'
+    | 'en-US'
+    | 'en-GB'
+    | 'zh-TW'
+    | 'zh-HK'
+    | 'ja'
+    | 'ko'
+    | 'th'
+    | 'vi'
+    | 'fr'
+    | 'ru'
+    | 'ar'
+    | 'de'
+    | 'it'
+    | 'he'
+    | 'hi'
+    | 'id'
+    | 'my'
+    | 'lo'
+    | 'ms'
+    | 'pl'
+    | 'pt'
+    | 'es'
+    | 'tr'
+    | 'ml'
+    | 'or'
+    | 'pa'
+    | 'as'
+    | 'mai'
+    | 'mn'
+    | 'ug'
+    | 'pt-br'
+    | 'es-la'
+    | 'sv'
+    | 'no'
+    | 'da'
+    | 'cs'
+    | 'hu'
+    | 'sk'
+    | 'ro'
+    | 'el'
+    | 'sr'
+    | 'bs'
+    | 'mk'
+    | 'bg'
+    | 'fi'
+    | 'et'
+    | 'lv'
+    | 'lt'
+    | 'sl'
+    | 'hr'
+    | 'uk'
+    | 'fa'
+    | 'nl'
+    | 'ca'
+    | 'gl'
+    | 'eu'
+    | 'ka'
+    | 'az'
+    | 'uz'
+    | 'km'
+    | 'si'
+    | 'ur'
+    | 'bo'
+    | 'be'
+    | 'kk'
+    | 'bn'
+    | 'fil'
+    | 'jv'
+    | 'ne'
+    | 'sw'
+    | 'mi'
+    | 'am'
+    | 'te'
+    | 'mr'
+    | 'ta'
+    | 'gu'
+    | 'kn';
+
 declare namespace NeteaseCaptcha {
     type InitFunction = (config: Config, onLoad?: onLoad, onError?: onError) => void;
 
@@ -39,11 +120,26 @@ declare namespace NeteaseCaptcha {
         /**
          * Defaults to 'zh-CN'
          */
-        lang?: 'zh-CN' | 'en' | undefined;
+        lang?: Lang | undefined;
 
         onReady?(instance: Instance): void;
 
         onVerify?(error: any, data: Data): void;
+
+        /**
+         * Only available on 'popup' mode. Selector string or HTMLElement for the captcha popup
+         */
+        appendTo?: string | HTMLElement | undefined;
+
+        /**
+         * Callback invoked when the captcha popup is closed
+         */
+        onClose?(): void;
+
+        /**
+         * Defaults to false. Used to enable the Instance.close method
+         */
+        enableClose?: boolean | undefined;
     }
 
     interface Instance {
@@ -65,6 +161,11 @@ declare namespace NeteaseCaptcha {
          * Available when the mode is set to 'bind' - verify token manually
          */
         verify?(): void;
+
+        /**
+         * Available when enableClose is true - closes the captcha bulletin
+         */
+        close?(): void;
     }
 
     interface Data {

--- a/types/netease-captcha/netease-captcha-tests.ts
+++ b/types/netease-captcha/netease-captcha-tests.ts
@@ -1,20 +1,26 @@
 const config: NeteaseCaptcha.Config = {
-        captchaId: 'FAKE ID',
-        element: '#captcha',
-        mode: 'popup',
-        protocol: 'https',
-        width: '200px',
-        lang: 'en',
-        onVerify: (error: any, data?: NeteaseCaptcha.Data) => {
-            console.log(error, data);
-        }
-    };
+    captchaId: 'FAKE ID',
+    element: '#captcha',
+    mode: 'popup',
+    protocol: 'https',
+    width: '200px',
+    lang: 'en',
+    appendTo: '#captcha2',
+    onVerify: (error: any, data?: NeteaseCaptcha.Data) => {
+        console.log(error, data);
+    },
+    onClose: () => {},
+    enableClose: false,
+};
 
 const onLoad: NeteaseCaptcha.onLoad = (instance: NeteaseCaptcha.Instance) => {
     instance.refresh();
     instance.destroy();
     if (instance.popUp) {
         instance.popUp();
+    }
+    if (instance.close) {
+        instance.close();
     }
 };
 
@@ -36,7 +42,7 @@ const invisibleConfig: NeteaseCaptcha.Config = {
         if (instance.verify) {
             instance.verify();
         }
-    }
+    },
 };
 
 if (window.initNECaptcha) {

--- a/types/netease-captcha/netease-captcha-tests.ts
+++ b/types/netease-captcha/netease-captcha-tests.ts
@@ -10,7 +10,7 @@ const config: NeteaseCaptcha.Config = {
         console.log(error, data);
     },
     onClose: () => {},
-    enableClose: false,
+    enableClose: true,
 };
 
 const onLoad: NeteaseCaptcha.onLoad = (instance: NeteaseCaptcha.Instance) => {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://support.dun.163.com/documents/312371656298516480?docId=312667827151753216>

To get all the possible locales, I used an unsupported locale which will make Netease throw the following error:

```
Uncaught Error: [NECaptcha] config: "lang x" is invalid, supported lang: zh-CN,en-US,en-GB,zh-TW,zh-HK,ja,ko,th,vi,fr,ru,ar,de,it,he,hi,id,my,lo,ms,pl,pt,es,tr,ml,or,pa,as,mai,mn,ug,pt-br,es-la,sv,no,da,cs,hu,sk,ro,el,sr,bs,mk,bg,fi,et,lv,lt,sl,hr,uk,fa,nl,ca,gl,eu,ka,az,uz,km,si,ur,bo,be,kk,bn,fil,jv,ne,sw,mi,am,te,mr,ta,gu,kn. By default, it's zh-CN
```