### PR TITLE
[asana] Replace $ExpectError with @ts-expect-error

### DIFF
--- a/types/asana/asana-tests.ts
+++ b/types/asana/asana-tests.ts
@@ -133,7 +133,7 @@ client.webhooks.dispatchGet('/foo');
 
 // but not included in response objects
 client.tasks.getTask('123').then(task => {
-    // $ExpectError
+    // @ts-expect-error
     task.dispatchGet('/foo');
 });
 


### PR DESCRIPTION
Like https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61139#issue-1297962701, replace `$ExpectError` with `@ts-expect-error`, in preparation for [retiring `$ExpectError` from dtslint](https://github.com/microsoft/DefinitelyTyped-tools/pull/495#issue-1291728528).