### PR TITLE
fix(@styled-system/css): Adds `size` property to AliasesCSSProperties

### DIFF
--- a/types/styled-system__css/index.d.ts
+++ b/types/styled-system__css/index.d.ts
@@ -132,7 +132,7 @@ export interface AliasesCSSProperties {
      */
     ml?: StandardCSSProperties['marginLeft'] | undefined;
     /**
-     * The **`mx`** is shorthand for using both **`margin-left`** and **`margin-right`** CSS properties. They set the margin area on the left and right side of an element. A positive value placesit
+     * The **`mx`** is shorthand for using both **`margin-left`** and **`margin-right`** CSS properties. They set the margin area on the left and right side of an element. A positive value places it
      * farther from its neighbors, while a negative value places it closer.
      *
      * **Initial value**: `0`
@@ -305,6 +305,19 @@ export interface AliasesCSSProperties {
      * @see https://developer.mozilla.org/docs/Web/CSS/padding-bottom
      */
     paddingY?: StandardCSSProperties['paddingTop'] | undefined;
+    /**
+     * The **`size`** is shorthand for using both **`width`** and **`height`** CSS properties. They set the width and height of an element.
+     *
+     * **Initial value**: `0`
+     *
+     * | Chrome | Firefox | Safari |  Edge  |  IE   |
+     * | :----: | :-----: | :----: | :----: | :---: |
+     * | **1**  |  **1**  | **1**  | **12** | **3** |
+     *
+     * @see https://developer.mozilla.org/docs/Web/CSS/width
+     * @see https://developer.mozilla.org/docs/Web/CSS/height
+     */
+    size?: StandardCSSProperties['width'] | undefined;
 }
 
 export interface OverwriteCSSProperties {

--- a/types/styled-system__css/styled-system__css-tests.ts
+++ b/types/styled-system__css/styled-system__css-tests.ts
@@ -266,4 +266,14 @@ css({
     WebkitTouchCallout: 'none'
 });
 
+// size (number)
+css({
+    size: 4
+});
+
+// size (token)
+css({
+    size: 'xl'
+});
+
 const result: CssFunctionReturnType = css({});


### PR DESCRIPTION
The `@styled-system/css` types miss a valid, and very useful `size` property (which is baiscally an alias for both `width` and `height`).

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://styled-system.com/table
