### PR TITLE
feat: add types for `language-name-map`

### DIFF
--- a/types/language-name-map/index.d.ts
+++ b/types/language-name-map/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for language-name-map 0.3
+// Project: https://github.com/dejurin/language-name-map
+// Definitions by: Hakan Güçlü <https://github.com/CreatorX64>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function getLangNameFromCode(langCode: string): { name: string; native: string; dir: 'ltr' | 'rtl' } | undefined;
+
+export function getLangCodeList(): string[];
+
+export const languageNameMap: { [key: string]: { name: string; native: string; dir: 0 | 1 } };

--- a/types/language-name-map/language-name-map-tests.ts
+++ b/types/language-name-map/language-name-map-tests.ts
@@ -1,0 +1,13 @@
+import { getLangNameFromCode, getLangCodeList, languageNameMap } from 'language-name-map';
+
+// $ExpectType { name: string; native: string; dir: "ltr" | "rtl"; } | undefined
+getLangNameFromCode('uk');
+
+// $ExpectType { name: string; native: string; dir: "ltr" | "rtl"; } | undefined
+getLangNameFromCode('thiscountrydoesntexist');
+
+// $ExpectType string[]
+getLangCodeList();
+
+// $ExpectType { [key: string]: { name: string; native: string; dir: 0 | 1; }; }
+languageNameMap;

--- a/types/language-name-map/tsconfig.json
+++ b/types/language-name-map/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "language-name-map-tests.ts"
+    ]
+}

--- a/types/language-name-map/tslint.json
+++ b/types/language-name-map/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
This PR adds type definitions for npm package `language-name-map`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

