### PR TITLE
[bootstrap] Allow usage of string literals for event names

### DIFF
--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -21,6 +21,9 @@ import Tab from './js/dist/tab';
 import Toast from './js/dist/toast';
 import Tooltip from './js/dist/tooltip';
 
+type A = `${Modal.Events}`;
+type B = Modal.Events;
+
 declare global {
     interface JQuery {
         alert: Alert.jQueryInterface;
@@ -39,13 +42,13 @@ declare global {
 
     interface Element {
         addEventListener(
-            type: Carousel.Events,
+            type: Carousel.Events | `${Carousel.Events}`,
             listener: (this: Element, ev: Carousel.Event) => any,
             options?: boolean | AddEventListenerOptions,
         ): void;
 
         addEventListener(
-            type: Modal.Events,
+            type: Modal.Events | `${Modal.Events}`,
             listener: (this: Element, ev: Modal.Event) => any,
             options?: boolean | AddEventListenerOptions,
         ): void;

--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -21,9 +21,6 @@ import Tab from './js/dist/tab';
 import Toast from './js/dist/toast';
 import Tooltip from './js/dist/tooltip';
 
-type A = `${Modal.Events}`;
-type B = Modal.Events;
-
 declare global {
     interface JQuery {
         alert: Alert.jQueryInterface;
@@ -42,13 +39,19 @@ declare global {
 
     interface Element {
         addEventListener(
-            type: Carousel.Events | `${Carousel.Events}`,
+            type: Carousel.Events | 'slide.bs.carousel' | 'slid.bs.carousel',
             listener: (this: Element, ev: Carousel.Event) => any,
             options?: boolean | AddEventListenerOptions,
         ): void;
 
         addEventListener(
-            type: Modal.Events | `${Modal.Events}`,
+            type:
+                | Modal.Events
+                | 'show.bs.modal'
+                | 'shown.bs.modal'
+                | 'hide.bs.modal'
+                | 'hidden.bs.modal'
+                | 'hidePrevented.bs.modal',
             listener: (this: Element, ev: Modal.Event) => any,
             options?: boolean | AddEventListenerOptions,
         ): void;

--- a/types/bootstrap/test/carousel-tests.ts
+++ b/types/bootstrap/test/carousel-tests.ts
@@ -42,6 +42,15 @@ element.addEventListener(Carousel.Events.slid, event => {
     event.to; // $ExpectType number
 });
 
+// Ensure that using a string literal as the event type works the same as using
+// the `Modal.Events` enum.
+element.addEventListener('slid.bs.carousel', event => {
+    event.direction; // $ExpectType Direction
+    event.relatedTarget; // $ExpectType Element
+    event.from; // $ExpectType number
+    event.to; // $ExpectType number
+});
+
 element.addEventListener(Carousel.Events.slide, event => {
     event.direction; // $ExpectType Direction
     event.relatedTarget; // $ExpectType Element

--- a/types/bootstrap/test/carousel-tests.ts
+++ b/types/bootstrap/test/carousel-tests.ts
@@ -43,7 +43,7 @@ element.addEventListener(Carousel.Events.slid, event => {
 });
 
 // Ensure that using a string literal as the event type works the same as using
-// the `Modal.Events` enum.
+// the `Carousel.Events` enum.
 element.addEventListener('slid.bs.carousel', event => {
     event.direction; // $ExpectType Direction
     event.relatedTarget; // $ExpectType Element

--- a/types/bootstrap/test/modal-tests.ts
+++ b/types/bootstrap/test/modal-tests.ts
@@ -22,6 +22,13 @@ element.addEventListener(Modal.Events.show, event => {
     event.relatedTarget; // $ExpectType HTMLElement | undefined
 });
 
+// Ensure that using a string literal as the event type works the same as using
+// the `Modal.Events` enum.
+element.addEventListener('show.bs.modal', event => {
+    event.target; // $ExpectType HTMLElement
+    event.relatedTarget; // $ExpectType HTMLElement | undefined
+});
+
 element.addEventListener(Modal.Events.shown, event => {
     event.target; // $ExpectType HTMLElement
     event.relatedTarget; // $ExpectType HTMLElement | undefined


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

This PR ensures that `el.addEventListener('show.bs.modal')` works the same as `el.addEventListener(window.bootstrap.Modal.Events.show)`, both of which are equally valid.

