### PR TITLE
[sinon] support missing fake timer options

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -786,12 +786,6 @@ declare namespace Sinon {
         restore(): void;
     };
 
-    interface SinonFakeTimersConfig {
-        now: number | Date;
-        toFake: string[];
-        shouldAdvanceTime: boolean;
-    }
-
     interface SinonFakeUploadProgress {
         eventListeners: {
             progress: any[];
@@ -1450,7 +1444,7 @@ declare namespace Sinon {
          * If set to true, the sandbox will have a clock property.
          * You can optionally pass in a configuration object that follows the specification for fake timers, such as { toFake: ["setTimeout", "setInterval"] }.
          */
-        useFakeTimers: boolean | Partial<SinonFakeTimersConfig>;
+        useFakeTimers: boolean | Partial<FakeTimers.FakeTimerInstallOpts>;
         /**
          * If true, server and requests properties are added to the sandbox. Can also be an object to use for fake server.
          * The default one is sinon.fakeServer, but if you’re using jQuery 1.3.x or some other library that does not set the XHR’s onreadystatechange handler,
@@ -1572,7 +1566,7 @@ declare namespace Sinon {
          * You would have to call either clock.next(), clock.tick(), clock.runAll() or clock.runToLast() (see example below). Please refer to the lolex documentation for more information.
          * @param config
          */
-        useFakeTimers(config?: number | Date | Partial<SinonFakeTimersConfig>): SinonFakeTimers;
+        useFakeTimers(config?: number | Date | Partial<FakeTimers.FakeTimerInstallOpts>): SinonFakeTimers;
         /**
          * Causes Sinon to replace the native XMLHttpRequest object in browsers that support it with a custom implementation which does not send actual requests.
          * In browsers that support ActiveXObject, this constructor is replaced, and fake objects are returned for XMLHTTP progIds.

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -38,6 +38,7 @@ function testSandbox() {
     sb.useFakeTimers(new Date());
     sb.useFakeTimers({
         now: 1000,
+        shouldClearNativeTimers: true,
     });
 
     const xhr = sb.useFakeXMLHttpRequest();


### PR DESCRIPTION
At the moment, it's not possible to use some of the fake timer options,
such as [`shouldClearNativeTimers`][1], because the `sinon` types uses
its own hand-rolled [options object][2] which is missing the property.

`@types/sinon` already has a [dependency][3] on the `fake-timers`
typings, which defines its own [config object][4] with the missing
properties, so this change just uses that interface directly.

[1]: https://github.com/sinonjs/fake-timers/blob/3a77a0978eaccd73ccc87dd42204b54e2bac0f6f/src/fake-timers-src.js#L99
[2]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/658b4ded756f0c98e1a22e9592014c3c6bc4323a/types/sinon/index.d.ts#L789-L793
[3]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/658b4ded756f0c98e1a22e9592014c3c6bc4323a/types/sinon/index.d.ts#L13
[4]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/658b4ded756f0c98e1a22e9592014c3c6bc4323a/types/sinonjs__fake-timers/index.d.ts#L335-L369

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
