### PR TITLE
ssh2: Overload Channel.exit method with proper parameter types

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -219,7 +219,8 @@ export interface Channel extends Duplex {
      */
     setWindow(rows: string, cols: string, height: string, width: string): void;
     signal(signalName: string): void;
-    exit(statusOrSignal: string, coreDumped: string, msg: string): void;
+    exit(status: number): void;
+    exit(signalName: string, coreDumped: boolean, msg: string): void;
 
     /**
      * Emitted once the channel is completely closed on both the client and the server.

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -220,7 +220,7 @@ export interface Channel extends Duplex {
     setWindow(rows: string, cols: string, height: string, width: string): void;
     signal(signalName: string): void;
     exit(status: number): void;
-    exit(signalName: string, coreDumped: boolean, msg: string): void;
+    exit(signalName: string, coreDumped?: boolean, msg?: string): void;
 
     /**
      * Emitted once the channel is completely closed on both the client and the server.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/ssh2

    From that docs page:

    > For exec-enabled channel instances there is an additional method available that may be called right before you close the channel. It has two different signatures:
    > 
    > - exit(< integer >exitCode) - (void) - Sends an exit status code to the client.
    > 
    > - exit(< string >signalName[, < boolean >coreDumped[, < string >errorMsg]]) - (void) - Sends an exit status code to the client.

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.