### PR TITLE
Mapbox-gl-draw: modes property, custom modes extention

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @mapbox/mapbox-gl-draw 1.2
+// Type definitions for @mapbox/mapbox-gl-draw 1.3
 // Project: https://github.com/mapbox/mapbox-gl-draw
 // Definitions by: Tudor Gergely <https://github.com/tudorgergely>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -159,51 +159,65 @@ declare namespace MapboxDraw {
     }
 
     interface DrawCustomMode<CustomModeState = any, CustomModeOptions = any> {
-        onSetup?(this: DrawCustomModeThis, options: CustomModeOptions): CustomModeState;
+        onSetup?(this: DrawCustomModeThis & this, options: CustomModeOptions): CustomModeState;
 
-        onDrag?(this: DrawCustomModeThis, state: CustomModeState, e: MapMouseEvent): void;
+        onDrag?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapMouseEvent): void;
 
-        onClick?(this: DrawCustomModeThis, state: CustomModeState, e: MapMouseEvent): void;
+        onClick?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapMouseEvent): void;
 
-        onMouseMove?(this: DrawCustomModeThis, state: CustomModeState, e: MapMouseEvent): void;
+        onMouseMove?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapMouseEvent): void;
 
-        onMouseDown?(this: DrawCustomModeThis, state: CustomModeState, e: MapMouseEvent): void;
+        onMouseDown?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapMouseEvent): void;
 
-        onMouseUp?(this: DrawCustomModeThis, state: CustomModeState, e: MapMouseEvent): void;
+        onMouseUp?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapMouseEvent): void;
 
-        onMouseOut?(this: DrawCustomModeThis, state: CustomModeState, e: MapMouseEvent): void;
+        onMouseOut?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapMouseEvent): void;
 
-        onKeyUp?(this: DrawCustomModeThis, state: CustomModeState, e: KeyboardEvent): void;
+        onKeyUp?(this: DrawCustomModeThis & this, state: CustomModeState, e: KeyboardEvent): void;
 
-        onKeyDown?(this: DrawCustomModeThis, state: CustomModeState, e: KeyboardEvent): void;
+        onKeyDown?(this: DrawCustomModeThis & this, state: CustomModeState, e: KeyboardEvent): void;
 
-        onTouchStart?(this: DrawCustomModeThis, state: CustomModeState, e: MapTouchEvent): void;
+        onTouchStart?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapTouchEvent): void;
 
-        onTouchMove?(this: DrawCustomModeThis, state: CustomModeState, e: MapTouchEvent): void;
+        onTouchMove?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapTouchEvent): void;
 
-        onTouchEnd?(this: DrawCustomModeThis, state: CustomModeState, e: MapTouchEvent): void;
+        onTouchEnd?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapTouchEvent): void;
 
-        onTap?(this: DrawCustomModeThis, state: CustomModeState, e: MapTouchEvent): void;
+        onTap?(this: DrawCustomModeThis & this, state: CustomModeState, e: MapTouchEvent): void;
 
-        onStop?(this: DrawCustomModeThis, state: CustomModeState): void;
+        onStop?(this: DrawCustomModeThis & this, state: CustomModeState): void;
 
-        onTrash?(this: DrawCustomModeThis, state: CustomModeState): void;
+        onTrash?(this: DrawCustomModeThis & this, state: CustomModeState): void;
 
-        onCombineFeature?(this: DrawCustomModeThis, state: CustomModeState): void;
+        onCombineFeature?(this: DrawCustomModeThis & this, state: CustomModeState): void;
 
-        onUncombineFeature?(this: DrawCustomModeThis, state: CustomModeState): void;
+        onUncombineFeature?(this: DrawCustomModeThis & this, state: CustomModeState): void;
 
         toDisplayFeatures(
-            this: DrawCustomModeThis,
+            this: DrawCustomModeThis & this,
             state: CustomModeState,
             geojson: GeoJSON,
             display: (geojson: GeoJSON) => void,
         ): void;
     }
+
+    interface Modes {
+        [modeKey: string]: DrawCustomMode;
+        draw_line_string: DrawCustomMode;
+        draw_polygon: DrawCustomMode;
+        draw_point: DrawCustomMode;
+        simple_select: DrawCustomMode;
+        direct_select: DrawCustomMode;
+        static: DrawCustomMode;
+    }
+
+    type IMapboxDrawOptions = ConstructorParameters<typeof MapboxDraw>[0];
 }
 
 declare class MapboxDraw implements IControl {
-    static modes: MapboxDraw.DrawModes;
+    static modes: MapboxDraw.Modes;
+
+    modes: MapboxDraw.DrawModes;
 
     getDefaultPosition: () => string;
 
@@ -216,7 +230,7 @@ declare class MapboxDraw implements IControl {
         touchBuffer?: number | undefined;
         controls?: MapboxDraw.MapboxDrawControls | undefined;
         styles?: object[] | undefined;
-        modes?: { [modeKey: string]: MapboxDraw.DrawMode | MapboxDraw.DrawCustomMode } | undefined;
+        modes?: { [modeKey: string]: MapboxDraw.DrawCustomMode } | undefined;
         defaultMode?: string | undefined;
         userProperties?: boolean | undefined;
     });
@@ -256,6 +270,7 @@ declare class MapboxDraw implements IControl {
         options?: { featureId: string; from: Feature<Point> | Point | number[] },
     ): this;
     changeMode(mode: Exclude<MapboxDraw.DrawMode, 'direct_select' | 'simple_select' | 'draw_line_string'>): this;
+    changeMode<T extends string>(mode: T & (T extends MapboxDraw.DrawMode ? never : T), options?: any): this;
 
     setFeatureProperty(featureId: string, property: string, value: any): this;
 

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -1,4 +1,4 @@
-import MapboxDraw, { DrawMode, DrawUpdateEvent, DrawCustomMode } from '@mapbox/mapbox-gl-draw';
+import MapboxDraw, { DrawMode, DrawUpdateEvent, DrawCustomMode, IMapboxDrawOptions } from '@mapbox/mapbox-gl-draw';
 
 const draw = new MapboxDraw({});
 
@@ -32,19 +32,53 @@ const drawLineSelect: DrawMode = 'draw_line_string';
 // $ExpectType MapboxDraw
 draw.changeMode(drawLineSelect, { featureId: '1', from: [1] });
 
+// $ExpectType MapboxDraw
+draw.changeMode('draw_point');
+
+// @ts-expect-error
+draw.changeMode('draw_point', {});
+
+// $ExpectType MapboxDraw
+draw.changeMode('custom_mode');
+
+// $ExpectType MapboxDraw
+draw.changeMode('custom_mode', {});
+
 function callback(event: DrawUpdateEvent) {
     // $ExpectType "draw.update"
     event.type;
 }
 
-const CustomMode: DrawCustomMode<{}, {}> = {
-  onClick(state, e) {
-    // $ExpectType LngLat
-    e.lngLat;
-  },
+interface ICustomMode extends DrawCustomMode<{}, {}> {
+    customMethod(): number;
+}
 
-  toDisplayFeatures(state, geojson, display) {}
+const CustomMode: ICustomMode = {
+    onClick(state, e) {
+        // $ExpectType LngLat
+        e.lngLat;
+
+        // $ExpectType number
+        this.customMethod();
+    },
+
+    toDisplayFeatures(state, geojson, display) {},
+
+    customMethod(): number {
+        return 1;
+    },
 };
 
 // @ts-expect-error
 const CustomModeMissingDisplayFeatures: DrawCustomMode<{}, {}> = {};
+
+const options: IMapboxDrawOptions = {
+    modes: Object.assign(
+        {
+            custom_mode: CustomMode,
+        },
+        MapboxDraw.modes,
+    ),
+};
+
+const drawWithCustomMode = new MapboxDraw(options);

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -1,4 +1,4 @@
-import MapboxDraw, { DrawMode, DrawUpdateEvent, DrawCustomMode, IMapboxDrawOptions } from '@mapbox/mapbox-gl-draw';
+import MapboxDraw, { DrawCustomMode, DrawMode, DrawUpdateEvent, IMapboxDrawOptions } from '@mapbox/mapbox-gl-draw';
 
 const draw = new MapboxDraw({});
 
@@ -49,11 +49,11 @@ function callback(event: DrawUpdateEvent) {
     event.type;
 }
 
-interface ICustomMode extends DrawCustomMode<{}, {}> {
+interface CustomMode extends DrawCustomMode<{}, {}> {
     customMethod(): number;
 }
 
-const CustomMode: ICustomMode = {
+const customMode: CustomMode = {
     onClick(state, e) {
         // $ExpectType LngLat
         e.lngLat;
@@ -73,12 +73,10 @@ const CustomMode: ICustomMode = {
 const CustomModeMissingDisplayFeatures: DrawCustomMode<{}, {}> = {};
 
 const options: IMapboxDrawOptions = {
-    modes: Object.assign(
-        {
-            custom_mode: CustomMode,
-        },
-        MapboxDraw.modes,
-    ),
+    modes: {
+        custom_mode: customMode,
+        ...MapboxDraw.modes,
+    },
 };
 
 const drawWithCustomMode = new MapboxDraw(options);


### PR DESCRIPTION
@types/mapbox-gl-draw

Modes are static proporty
Modes enum is not static property
Extend DrawCustomMode type
Add constructor options type


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Modes List](https://github.com/mapbox/mapbox-gl-draw/blob/0efdb4d14a0ecae37cfe467334aaa5b2e501f702/index.js#L31), [Modes names enum](https://github.com/mapbox/mapbox-gl-draw/blob/0efdb4d14a0ecae37cfe467334aaa5b2e501f702/src/api.js#L25)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
