### PR TITLE
fix(typings): mapbox-gl setPaintProperty options argument

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -366,11 +366,11 @@ declare namespace mapboxgl {
 
         getPaintProperty(layer: string, name: string): any;
 
-        setLayoutProperty(layer: string, name: string, value: any): this;
+        setLayoutProperty(layer: string, name: string, value: any, options?: FilterOptions): this;
 
         getLayoutProperty(layer: string, name: string): any;
 
-        setLight(options: mapboxgl.Light, lightOptions?: any): this;
+        setLight(light: mapboxgl.Light, options?: FilterOptions): this;
 
         getLight(): mapboxgl.Light;
 
@@ -777,10 +777,18 @@ declare namespace mapboxgl {
          *
          * @default 'mercator'
          */
-         projection?: {
-            name: 'albers' | 'equalEarth' | 'equirectangular' | 'lambertConformalConic' | 'mercator' | 'naturalEarth' | 'winkelTripel' | 'globe',
-            center?: [number, number],
-            parallels?: [number, number]
+        projection?: {
+            name:
+                | 'albers'
+                | 'equalEarth'
+                | 'equirectangular'
+                | 'lambertConformalConic'
+                | 'mercator'
+                | 'naturalEarth'
+                | 'winkelTripel'
+                | 'globe';
+            center?: [number, number];
+            parallels?: [number, number];
         };
 
         /**
@@ -1610,10 +1618,10 @@ declare namespace mapboxgl {
         tileSize?: number;
         attribution?: string;
         bounds?: [number, number, number, number];
-        hasTile?: (tileID: { z: number, x: number, y: number }) => boolean;
-        loadTile: (tileID: { z: number, x: number, y: number }, options: { signal: AbortSignal }) => Promise<T>;
-        prepareTile?: (tileID: { z: number, x: number, y: number }) => T | undefined;
-        unloadTile?: (tileID: { z: number, x: number, y: number }) => void;
+        hasTile?: (tileID: { z: number; x: number; y: number }) => boolean;
+        loadTile: (tileID: { z: number; x: number; y: number }, options: { signal: AbortSignal }) => Promise<T>;
+        prepareTile?: (tileID: { z: number; x: number; y: number }) => T | undefined;
+        unloadTile?: (tileID: { z: number; x: number; y: number }) => void;
         onAdd?: (map: Map) => void;
         onRemove?: (map: Map) => void;
     }

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -8,6 +8,7 @@
 //                 André Fonseca <https://github.com/amxfonseca>
 //                 makspetrov <https://github.com/Nosfit>
 //                 Michael Bullington <https://github.com/mbullington>
+//                 Olivier Pascal <https://github.com/pascaloliv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -361,7 +362,7 @@ declare namespace mapboxgl {
 
         getFilter(layer: string): any[];
 
-        setPaintProperty(layer: string, name: string, value: any, klass?: string): this;
+        setPaintProperty(layer: string, name: string, value: any, options?: FilterOptions): this;
 
         getPaintProperty(layer: string, name: string): any;
 

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -937,6 +937,12 @@ map.getPadding();
 // $ExpectType Map
 map.setPadding({ top: 10, bottom: 20, left: 30, right: 40 }, { myData: 'MY DATA' });
 
+map.setPaintProperty('layerId', 'layerName', null, { validate: true });
+map.setPaintProperty('layerId', 'layerName', null, { validate: false });
+map.setPaintProperty('layerId', 'layerName', null, {});
+// @ts-expect-error
+map.setPaintProperty('layerId', 'layerName', null, { some_option: 'some_string' });
+
 // $ExpectType boolean
 map.showPadding;
 map.showPadding = false;
@@ -1380,7 +1386,7 @@ expectType<mapboxgl.Expression>([
 expectType<mapboxgl.Expression>([
     'number-format',
     ['get', 'quantity'],
-    { 'min-fraction-digits': 1, 'max-fraction-digits': 1 }
+    { 'min-fraction-digits': 1, 'max-fraction-digits': 1 },
 ]);
 const expression = expectType<mapboxgl.Expression>(['coalesce', ['get', 'property'], ['get', 'property']]);
 

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -943,6 +943,18 @@ map.setPaintProperty('layerId', 'layerName', null, {});
 // @ts-expect-error
 map.setPaintProperty('layerId', 'layerName', null, { some_option: 'some_string' });
 
+map.setLayoutProperty('layerId', 'layerName', null, { validate: true });
+map.setLayoutProperty('layerId', 'layerName', null, { validate: false });
+map.setLayoutProperty('layerId', 'layerName', null, {});
+// @ts-expect-error
+map.setLayoutProperty('layerId', 'layerName', null, { some_option: 'some_string' });
+
+map.setLight({ anchor: 'viewport', color: 'blue', intensity: 0.5 }, { validate: true });
+map.setLight({ anchor: 'viewport', color: 'blue', intensity: 0.5 }, { validate: false });
+map.setLight({ anchor: 'viewport', color: 'blue', intensity: 0.5 }, {});
+// @ts-expect-error
+map.setLight({ anchor: 'viewport', color: 'blue', intensity: 0.5 }, { some_option: 'some_string' });
+
 // $ExpectType boolean
 map.showPadding;
 map.showPadding = false;

--- a/types/mapbox-gl/v1/index.d.ts
+++ b/types/mapbox-gl/v1/index.d.ts
@@ -7,6 +7,7 @@
 //                 Vladimir Dashukevich <https://github.com/life777>
 //                 Marko Klopets <https://github.com/mklopets>
 //                 André Fonseca <https://github.com/amxfonseca>
+//                 Olivier Pascal <https://github.com/pascaloliv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -340,7 +341,7 @@ declare namespace mapboxgl {
 
         getFilter(layer: string): any[];
 
-        setPaintProperty(layer: string, name: string, value: any, klass?: string): this;
+        setPaintProperty(layer: string, name: string, value: any, options?: FilterOptions): this;
 
         getPaintProperty(layer: string, name: string): any;
 

--- a/types/mapbox-gl/v1/index.d.ts
+++ b/types/mapbox-gl/v1/index.d.ts
@@ -292,7 +292,10 @@ declare namespace mapboxgl {
             } & FilterOptions,
         ): MapboxGeoJSONFeature[];
 
-        setStyle(style: mapboxgl.Style | string, options?: { diff?: boolean | undefined; localIdeographFontFamily?: string | undefined }): this;
+        setStyle(
+            style: mapboxgl.Style | string,
+            options?: { diff?: boolean | undefined; localIdeographFontFamily?: string | undefined },
+        ): this;
 
         getStyle(): mapboxgl.Style;
 
@@ -345,11 +348,11 @@ declare namespace mapboxgl {
 
         getPaintProperty(layer: string, name: string): any;
 
-        setLayoutProperty(layer: string, name: string, value: any): this;
+        setLayoutProperty(layer: string, name: string, value: any, options?: FilterOptions): this;
 
         getLayoutProperty(layer: string, name: string): any;
 
-        setLight(options: mapboxgl.Light, lightOptions?: any): this;
+        setLight(light: mapboxgl.Light, options?: FilterOptions): this;
 
         getLight(): mapboxgl.Light;
 
@@ -820,7 +823,10 @@ declare namespace mapboxgl {
      * DragRotateHandler
      */
     export class DragRotateHandler {
-        constructor(map: mapboxgl.Map, options?: { bearingSnap?: number | undefined; pitchWithRotate?: boolean | undefined });
+        constructor(
+            map: mapboxgl.Map,
+            options?: { bearingSnap?: number | undefined; pitchWithRotate?: boolean | undefined },
+        );
 
         isEnabled(): boolean;
 
@@ -934,7 +940,11 @@ declare namespace mapboxgl {
      * Navigation
      */
     export class NavigationControl extends Control {
-        constructor(options?: { showCompass?: boolean | undefined; showZoom?: boolean | undefined; visualizePitch?: boolean | undefined });
+        constructor(options?: {
+            showCompass?: boolean | undefined;
+            showZoom?: boolean | undefined;
+            visualizePitch?: boolean | undefined;
+        });
     }
 
     export class PositionOptions {

--- a/types/mapbox-gl/v1/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/v1/mapbox-gl-tests.ts
@@ -848,6 +848,12 @@ map.getPadding();
 // $ExpectType Map
 map.setPadding({ top: 10, bottom: 20, left: 30, right: 40 }, { myData: 'MY DATA' });
 
+map.setPaintProperty('layerId', 'layerName', null, { validate: true });
+map.setPaintProperty('layerId', 'layerName', null, { validate: false });
+map.setPaintProperty('layerId', 'layerName', null, {});
+// @ts-expect-error
+map.setPaintProperty('layerId', 'layerName', null, { some_option: 'some_string' });
+
 // $ExpectType boolean
 map.showPadding;
 map.showPadding = false;

--- a/types/mapbox-gl/v1/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/v1/mapbox-gl-tests.ts
@@ -854,6 +854,18 @@ map.setPaintProperty('layerId', 'layerName', null, {});
 // @ts-expect-error
 map.setPaintProperty('layerId', 'layerName', null, { some_option: 'some_string' });
 
+map.setLayoutProperty('layerId', 'layerName', null, { validate: true });
+map.setLayoutProperty('layerId', 'layerName', null, { validate: false });
+map.setLayoutProperty('layerId', 'layerName', null, {});
+// @ts-expect-error
+map.setLayoutProperty('layerId', 'layerName', null, { some_option: 'some_string' });
+
+map.setLight({ anchor: 'viewport', color: 'blue', intensity: 0.5 }, { validate: true });
+map.setLight({ anchor: 'viewport', color: 'blue', intensity: 0.5 }, { validate: false });
+map.setLight({ anchor: 'viewport', color: 'blue', intensity: 0.5 }, {});
+// @ts-expect-error
+map.setLight({ anchor: 'viewport', color: 'blue', intensity: 0.5 }, { some_option: 'some_string' });
+
 // $ExpectType boolean
 map.showPadding;
 map.showPadding = false;


### PR DESCRIPTION
Hi everyone,

The method `map.setPaintProperty()` was defining a wrong `klass?: string` argument.
I dig into source code of v1 and v2 (you can find exact link below) to fix the types.

Thanks in advance.
Olivier

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
You can find in [Mapbox-gl v1](https://github.com/mapbox/mapbox-gl-js/blob/release-v1.13.2/src/ui/map.js#L2032) and [Mapbox-gl v2](https://github.com/mapbox/mapbox-gl-js/blob/v2.9.2/src/ui/map.js#L2533).