### PR TITLE
Update node types.isMap tests

### DIFF
--- a/types/node/test/util_types.ts
+++ b/types/node/test/util_types.ts
@@ -60,7 +60,7 @@ if (types.isMap(object)) {
     object; // $ExpectType Map<unknown, unknown>
 
     if (types.isMap(readonlyMapOrRecord)) {
-        readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any>
+        readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any> || ReadonlyMap<any, any> | Map<unknown, unknown>
     }
 }
 if (types.isNativeError(object)) {

--- a/types/node/v14/test/util.ts
+++ b/types/node/v14/test/util.ts
@@ -289,7 +289,7 @@ function testUtilTypes(
         object; // $ExpectType Set<any>
 
         if (util.types.isSet(readonlySetOrArray)) {
-            readonlySetOrArray; // $ExpectType ReadonlySet<any>
+            readonlySetOrArray; // $ExpectType ReadonlySet<any> || Set<any> | ReadonlySet<any>
         }
     }
     if (util.types.isSharedArrayBuffer(object)) {

--- a/types/node/v14/test/util.ts
+++ b/types/node/v14/test/util.ts
@@ -257,7 +257,7 @@ function testUtilTypes(
         object; // $ExpectType Map<any, any>
 
         if (util.types.isMap(readonlyMapOrRecord)) {
-            readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any>
+            readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any> || Map<any, any> | ReadonlyMap<any, any>
         }
     }
     if (util.types.isNativeError(object)) {

--- a/types/node/v16/test/util_types.ts
+++ b/types/node/v16/test/util_types.ts
@@ -56,11 +56,12 @@ if (types.isInt16Array(object)) {
 if (types.isInt32Array(object)) {
     object; // $ExpectType Int32Array
 }
+
 if (types.isMap(object)) {
     object; // $ExpectType Map<unknown, unknown>
 
     if (types.isMap(readonlyMapOrRecord)) {
-        readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any>
+        readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any> || ReadonlyMap<any, any> | Map<unknown, unknown>
     }
 }
 if (types.isNativeError(object)) {


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/pull/49625 improves handling of unions in type predicates so that unions are correctly preserved. This breaks types.isMap in node.

For now I just changed the tests' expected type, but the type of isMap doesn't make much sense to me. It should probably be changed, but that's a much more complex task.

Edit: isSet is broken on node 14 too. 

This break is tracked at https://github.com/microsoft/TypeScript/issues/49988 although it's correct, I think, so not very likely to be reverted.