### PR TITLE
mjml-react: Allow Non-Number as MjmlButton fontWeight value

### DIFF
--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -200,7 +200,7 @@ export interface MjmlButtonProps {
     containerBackgroundColor?: React.CSSProperties['backgroundColor'] | undefined;
     fontStyle?: string | undefined;
     fontSize?: string | number | undefined;
-    fontWeight?: number | undefined;
+    fontWeight?: React.CSSProperties['fontWeight'] | undefined;
     fontFamily?: string | undefined;
     color?: React.CSSProperties['color'] | undefined;
     textAlign?: React.CSSProperties['textAlign'] | undefined;

--- a/types/mjml-react/mjml-react-tests.tsx
+++ b/types/mjml-react/mjml-react-tests.tsx
@@ -69,7 +69,7 @@ function renderOutTestEmail() {
                 </MjmlSection>
                 <MjmlSection>
                     <MjmlColumn>
-                        <MjmlButton padding="20px" backgroundColor="#346DB7" href="https://www.wix.com/">
+                        <MjmlButton padding="20px" backgroundColor="#346DB7" href="https://www.wix.com/" fontWeight="initial">
                             I like it!
                         </MjmlButton>
                     </MjmlColumn>


### PR DESCRIPTION
We can't use "initial", "bold" and other font-weight attributes because of the existing type that is `number | undefined`.
Using `React.CSSProperties['fontWeight']` to allow this kind of values.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


