### PR TITLE
node: Add missing typings for AbortSignal in node

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -57,7 +57,7 @@ interface AbortController {
 }
 
 interface AbortSignalEventMap {
-    "abort": Event;
+    "abort": NodeJS.Event;
 }
 
 /** A signal object that allows you to communicate with a DOM request (such as a Fetch) and abort it if required via an AbortController object. */
@@ -66,7 +66,7 @@ interface AbortSignal {
      * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
      */
     readonly aborted: boolean;
-    onabort: ((this: AbortSignal, ev: Event) => any) | null;
+    onabort: ((this: AbortSignal, ev: NodeJS.Event) => any) | null;
     /**
      * An optional reason specified when the AbortSignal was triggered.
      * @since v17.2.0
@@ -310,7 +310,48 @@ declare namespace NodeJS {
     interface ReadOnlyDict<T> {
         readonly [key: string]: T | undefined;
     }
-
+/** An event which takes place in the DOM. */
+interface Event {
+    /** Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise. */
+    readonly bubbles: boolean;
+    cancelBubble: boolean;
+    /** Returns true or false depending on how event was initialized. Its return value does not always carry meaning, but true can indicate that part of the operation during which event was dispatched, can be canceled by invoking the preventDefault() method. */
+    readonly cancelable: boolean;
+    /** Returns true or false depending on how event was initialized. True if event invokes listeners past a ShadowRoot node that is the root of its target, and false otherwise. */
+    readonly composed: boolean;
+    /** Returns the object whose event listener's callback is currently being invoked. */
+    readonly currentTarget: EventTarget | null;
+    /** Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise. */
+    readonly defaultPrevented: boolean;
+    /** Returns the event's phase, which is one of NONE, CAPTURING_PHASE, AT_TARGET, and BUBBLING_PHASE. */
+    readonly eventPhase: number;
+    /** Returns true if event was dispatched by the user agent, and false otherwise. */
+    readonly isTrusted: boolean;
+    /** @deprecated */
+    returnValue: boolean;
+    /** @deprecated */
+    readonly srcElement: EventTarget | null;
+    /** Returns the object to which event is dispatched (its target). */
+    readonly target: EventTarget | null;
+    /** Returns the event's timestamp as the number of milliseconds measured relative to the time origin. */
+    readonly timeStamp: DOMHighResTimeStamp;
+    /** Returns the type of event, e.g. "click", "hashchange", or "submit". */
+    readonly type: string;
+    /** Returns the invocation target objects of event's path (objects on which listeners will be invoked), except for any nodes in shadow trees of which the shadow root's mode is "closed" that are not reachable from event's currentTarget. */
+    composedPath(): EventTarget[];
+    /** @deprecated */
+    initEvent(type: string, bubbles?: boolean, cancelable?: boolean): void;
+    /** If invoked when the cancelable attribute value is true, and while executing a listener for the event with passive set to false, signals to the operation that caused event to be dispatched that it needs to be canceled. */
+    preventDefault(): void;
+    /** Invoking this method prevents event from reaching any registered event listeners after the current one finishes running and, when dispatched in a tree, also prevents event from reaching any other objects. */
+    stopImmediatePropagation(): void;
+    /** When dispatched in a tree, invoking this method prevents event from reaching any objects other than the current object. */
+    stopPropagation(): void;
+    readonly AT_TARGET: number;
+    readonly BUBBLING_PHASE: number;
+    readonly CAPTURING_PHASE: number;
+    readonly NONE: number;
+}
     interface EventListener {
         (evt: Event): void;
     }

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -56,12 +56,31 @@ interface AbortController {
     abort(): void;
 }
 
+interface AbortSignalEventMap {
+    "abort": Event;
+}
+
 /** A signal object that allows you to communicate with a DOM request (such as a Fetch) and abort it if required via an AbortController object. */
 interface AbortSignal {
     /**
      * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
      */
     readonly aborted: boolean;
+    onabort: ((this: AbortSignal, ev: Event) => any) | null;
+    /**
+     * An optional reason specified when the AbortSignal was triggered.
+     * @since v17.2.0
+     */
+    readonly reason: any;
+    /**
+     * If {@link aborted} is true, throws {@link reason}.
+     * @since v17.3.0
+     */
+    throwIfAborted(): void;
+    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare var AbortController: {

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -77,10 +77,10 @@ interface AbortSignal {
      * @since v17.3.0
      */
     throwIfAborted(): void;
-    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | NodeJS.AddEventListenerOptions): void;
+    addEventListener(type: string, listener: NodeJS.EventListenerOrEventListenerObject, options?: boolean | NodeJS.AddEventListenerOptions): void;
+    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | NodeJS.EventListenerOptions): void;
+    removeEventListener(type: string, listener: NodeJS.EventListenerOrEventListenerObject, options?: boolean | NodeJS.EventListenerOptions): void;
 }
 
 declare var AbortController: {
@@ -309,5 +309,25 @@ declare namespace NodeJS {
 
     interface ReadOnlyDict<T> {
         readonly [key: string]: T | undefined;
+    }
+
+    interface EventListener {
+        (evt: Event): void;
+    }
+
+    interface EventListenerObject {
+        handleEvent(object: Event): void;
+    }
+
+    type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+
+    interface EventListenerOptions {
+        capture?: boolean;
+    }
+
+    interface AddEventListenerOptions extends EventListenerOptions {
+        once?: boolean;
+        passive?: boolean;
+        signal?: AbortSignal;
     }
 }

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -37,3 +37,16 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     const arrayBuffer = new ArrayBuffer(0);
     structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
 }
+
+// AbortController & AbortSignal
+{
+    const controller = new AbortController();
+    let bool: boolean;
+    bool = controller.signal.aborted;
+    const listener = (event: Event) => {};
+    controller.signal.addEventListener("abort", listener);
+    controller.signal.removeEventListener("abort", listener);
+    controller.signal.onabort = listener;
+    controller.signal.throwIfAborted();
+    controller.abort();
+}

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -109,10 +109,10 @@ interface AbortSignal {
      */
     readonly aborted: boolean;
     onabort: ((this: AbortSignal, ev: Event) => any) | null;
-    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | NodeJS.AddEventListenerOptions): void;
+    addEventListener(type: string, listener: NodeJS.EventListenerOrEventListenerObject, options?: boolean | NodeJS.AddEventListenerOptions): void;
+    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | NodeJS.EventListenerOptions): void;
+    removeEventListener(type: string, listener: NodeJS.EventListenerOrEventListenerObject, options?: boolean | NodeJS.EventListenerOptions): void;
 }
 
 declare var AbortController: {
@@ -751,5 +751,24 @@ declare namespace NodeJS {
 
     interface ReadOnlyDict<T> {
         readonly [key: string]: T | undefined;
+    }
+
+    interface EventListener {
+        (evt: Event): void;
+    }
+
+    interface EventListenerObject {
+        handleEvent(object: Event): void;
+    }
+
+    type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+
+    interface EventListenerOptions {
+        capture?: boolean;
+    }
+
+    interface AddEventListenerOptions extends EventListenerOptions {
+        once?: boolean;
+        passive?: boolean;
     }
 }

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -94,6 +94,10 @@ interface AbortController {
     abort(): void;
 }
 
+interface AbortSignalEventMap {
+    "abort": Event;
+}
+
 /**
  * A signal object that allows you to communicate with a DOM request (such as a Fetch) and abort it if required via an AbortController object.
  * @since v14.7.0
@@ -104,6 +108,11 @@ interface AbortSignal {
      * @since v14.7.0
      */
     readonly aborted: boolean;
+    onabort: ((this: AbortSignal, ev: Event) => any) | null;
+    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare var AbortController: {

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -95,7 +95,7 @@ interface AbortController {
 }
 
 interface AbortSignalEventMap {
-    "abort": Event;
+    "abort": NodeJS.Event;
 }
 
 /**
@@ -108,7 +108,7 @@ interface AbortSignal {
      * @since v14.7.0
      */
     readonly aborted: boolean;
-    onabort: ((this: AbortSignal, ev: Event) => any) | null;
+    onabort: ((this: AbortSignal, ev: NodeJS.Event) => any) | null;
     addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | NodeJS.AddEventListenerOptions): void;
     addEventListener(type: string, listener: NodeJS.EventListenerOrEventListenerObject, options?: boolean | NodeJS.AddEventListenerOptions): void;
     removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | NodeJS.EventListenerOptions): void;
@@ -751,6 +751,49 @@ declare namespace NodeJS {
 
     interface ReadOnlyDict<T> {
         readonly [key: string]: T | undefined;
+    }
+
+    /** An event which takes place in the DOM. */
+    interface Event {
+        /** Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise. */
+        readonly bubbles: boolean;
+        cancelBubble: boolean;
+        /** Returns true or false depending on how event was initialized. Its return value does not always carry meaning, but true can indicate that part of the operation during which event was dispatched, can be canceled by invoking the preventDefault() method. */
+        readonly cancelable: boolean;
+        /** Returns true or false depending on how event was initialized. True if event invokes listeners past a ShadowRoot node that is the root of its target, and false otherwise. */
+        readonly composed: boolean;
+        /** Returns the object whose event listener's callback is currently being invoked. */
+        readonly currentTarget: EventTarget | null;
+        /** Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise. */
+        readonly defaultPrevented: boolean;
+        /** Returns the event's phase, which is one of NONE, CAPTURING_PHASE, AT_TARGET, and BUBBLING_PHASE. */
+        readonly eventPhase: number;
+        /** Returns true if event was dispatched by the user agent, and false otherwise. */
+        readonly isTrusted: boolean;
+        /** @deprecated */
+        returnValue: boolean;
+        /** @deprecated */
+        readonly srcElement: EventTarget | null;
+        /** Returns the object to which event is dispatched (its target). */
+        readonly target: EventTarget | null;
+        /** Returns the event's timestamp as the number of milliseconds measured relative to the time origin. */
+        readonly timeStamp: DOMHighResTimeStamp;
+        /** Returns the type of event, e.g. "click", "hashchange", or "submit". */
+        readonly type: string;
+        /** Returns the invocation target objects of event's path (objects on which listeners will be invoked), except for any nodes in shadow trees of which the shadow root's mode is "closed" that are not reachable from event's currentTarget. */
+        composedPath(): EventTarget[];
+        /** @deprecated */
+        initEvent(type: string, bubbles?: boolean, cancelable?: boolean): void;
+        /** If invoked when the cancelable attribute value is true, and while executing a listener for the event with passive set to false, signals to the operation that caused event to be dispatched that it needs to be canceled. */
+        preventDefault(): void;
+        /** Invoking this method prevents event from reaching any registered event listeners after the current one finishes running and, when dispatched in a tree, also prevents event from reaching any other objects. */
+        stopImmediatePropagation(): void;
+        /** When dispatched in a tree, invoking this method prevents event from reaching any objects other than the current object. */
+        stopPropagation(): void;
+        readonly AT_TARGET: number;
+        readonly BUBBLING_PHASE: number;
+        readonly CAPTURING_PHASE: number;
+        readonly NONE: number;
     }
 
     interface EventListener {

--- a/types/node/v14/test/globals.ts
+++ b/types/node/v14/test/globals.ts
@@ -13,3 +13,15 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
 
 const abortController = new global.AbortController();
 abortController.signal; // $ExpectType AbortSignal
+
+// AbortController & AbortSignal
+{
+    const controller = new AbortController();
+    let bool: boolean;
+    bool = controller.signal.aborted;
+    const listener = (event: Event) => {};
+    controller.signal.addEventListener("abort", listener);
+    controller.signal.removeEventListener("abort", listener);
+    controller.signal.onabort = listener;
+    controller.abort();
+}

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -56,12 +56,26 @@ interface AbortController {
     abort(): void;
 }
 
+interface AbortSignalEventMap {
+    "abort": Event;
+}
+
 /** A signal object that allows you to communicate with a DOM request (such as a Fetch) and abort it if required via an AbortController object. */
 interface AbortSignal {
     /**
      * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
      */
     readonly aborted: boolean;
+    onabort: ((this: AbortSignal, ev: Event) => any) | null;
+    /**
+     * An optional reason specified when the AbortSignal was triggered.
+     * @since v16.14.0
+     */
+    readonly reason: any;
+    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare var AbortController: {

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -72,10 +72,10 @@ interface AbortSignal {
      * @since v16.14.0
      */
     readonly reason: any;
-    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | NodeJS.AddEventListenerOptions): void;
+    addEventListener(type: string, listener: NodeJS.EventListenerOrEventListenerObject, options?: boolean | NodeJS.AddEventListenerOptions): void;
+    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | NodeJS.EventListenerOptions): void;
+    removeEventListener(type: string, listener: NodeJS.EventListenerOrEventListenerObject, options?: boolean | NodeJS.EventListenerOptions): void;
 }
 
 declare var AbortController: {
@@ -294,5 +294,24 @@ declare namespace NodeJS {
 
     interface ReadOnlyDict<T> {
         readonly [key: string]: T | undefined;
+    }
+
+    interface EventListener {
+        (evt: Event): void;
+    }
+
+    interface EventListenerObject {
+        handleEvent(object: Event): void;
+    }
+
+    type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+
+    interface EventListenerOptions {
+        capture?: boolean;
+    }
+
+    interface AddEventListenerOptions extends EventListenerOptions {
+        once?: boolean;
+        passive?: boolean;
     }
 }

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -57,7 +57,7 @@ interface AbortController {
 }
 
 interface AbortSignalEventMap {
-    "abort": Event;
+    "abort": NodeJS.Event;
 }
 
 /** A signal object that allows you to communicate with a DOM request (such as a Fetch) and abort it if required via an AbortController object. */
@@ -66,7 +66,7 @@ interface AbortSignal {
      * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
      */
     readonly aborted: boolean;
-    onabort: ((this: AbortSignal, ev: Event) => any) | null;
+    onabort: ((this: AbortSignal, ev: NodeJS.Event) => any) | null;
     /**
      * An optional reason specified when the AbortSignal was triggered.
      * @since v16.14.0
@@ -294,6 +294,49 @@ declare namespace NodeJS {
 
     interface ReadOnlyDict<T> {
         readonly [key: string]: T | undefined;
+    }
+
+    /** An event which takes place in the DOM. */
+    interface Event {
+        /** Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise. */
+        readonly bubbles: boolean;
+        cancelBubble: boolean;
+        /** Returns true or false depending on how event was initialized. Its return value does not always carry meaning, but true can indicate that part of the operation during which event was dispatched, can be canceled by invoking the preventDefault() method. */
+        readonly cancelable: boolean;
+        /** Returns true or false depending on how event was initialized. True if event invokes listeners past a ShadowRoot node that is the root of its target, and false otherwise. */
+        readonly composed: boolean;
+        /** Returns the object whose event listener's callback is currently being invoked. */
+        readonly currentTarget: EventTarget | null;
+        /** Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise. */
+        readonly defaultPrevented: boolean;
+        /** Returns the event's phase, which is one of NONE, CAPTURING_PHASE, AT_TARGET, and BUBBLING_PHASE. */
+        readonly eventPhase: number;
+        /** Returns true if event was dispatched by the user agent, and false otherwise. */
+        readonly isTrusted: boolean;
+        /** @deprecated */
+        returnValue: boolean;
+        /** @deprecated */
+        readonly srcElement: EventTarget | null;
+        /** Returns the object to which event is dispatched (its target). */
+        readonly target: EventTarget | null;
+        /** Returns the event's timestamp as the number of milliseconds measured relative to the time origin. */
+        readonly timeStamp: DOMHighResTimeStamp;
+        /** Returns the type of event, e.g. "click", "hashchange", or "submit". */
+        readonly type: string;
+        /** Returns the invocation target objects of event's path (objects on which listeners will be invoked), except for any nodes in shadow trees of which the shadow root's mode is "closed" that are not reachable from event's currentTarget. */
+        composedPath(): EventTarget[];
+        /** @deprecated */
+        initEvent(type: string, bubbles?: boolean, cancelable?: boolean): void;
+        /** If invoked when the cancelable attribute value is true, and while executing a listener for the event with passive set to false, signals to the operation that caused event to be dispatched that it needs to be canceled. */
+        preventDefault(): void;
+        /** Invoking this method prevents event from reaching any registered event listeners after the current one finishes running and, when dispatched in a tree, also prevents event from reaching any other objects. */
+        stopImmediatePropagation(): void;
+        /** When dispatched in a tree, invoking this method prevents event from reaching any objects other than the current object. */
+        stopPropagation(): void;
+        readonly AT_TARGET: number;
+        readonly BUBBLING_PHASE: number;
+        readonly CAPTURING_PHASE: number;
+        readonly NONE: number;
     }
 
     interface EventListener {

--- a/types/node/v16/test/globals.ts
+++ b/types/node/v16/test/globals.ts
@@ -26,3 +26,16 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
         gc();
     }
 }
+
+// AbortController & AbortSignal
+{
+    const controller = new AbortController();
+    let bool: boolean;
+    bool = controller.signal.aborted;
+    controller.signal.reason;
+    const listener = (event: Event) => {};
+    controller.signal.addEventListener("abort", listener);
+    controller.signal.removeEventListener("abort", listener);
+    controller.signal.onabort = listener;
+    controller.abort();
+}


### PR DESCRIPTION
Add missing typings for AbortSignal in node
    
This still omits the static `abort` * `timeout` methods as they are not currently declared in TypeScript's lib. Based on definitions included with TypeScript.
    
Fixes #60868

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#class-abortsignal
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

