### PR TITLE
Update underscore and weak-napi tests for TS 4.8

### DIFF
--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -258,7 +258,7 @@ explicitDictionaryLiteralItem; // $ExpectType StringRecord
         return element.a;
     };
     if (_.isFunction(anyFunctionIteratee)) {
-        anyFunctionIteratee(recordDictionary['a'], 'a', recordDictionary); // $ExpectType string
+        anyFunctionIteratee(recordDictionary['a'], 'a', recordDictionary); // $ExpectType string || any
     }
 
     // matchers
@@ -308,7 +308,7 @@ explicitDictionaryLiteralItem; // $ExpectType StringRecord
 
     const anyDeepPropertyIteratee: _.Iteratee<any, string> = deepProperty;
     if (_.isArray(anyDeepPropertyIteratee)) {
-        anyDeepPropertyIteratee; // $ExpectType (string | number)[]
+        anyDeepPropertyIteratee; // $ExpectType (string | number)[] || any[] | (string | number)[]
     }
 
     // identity

--- a/types/weak-napi/weak-napi-tests.ts
+++ b/types/weak-napi/weak-napi-tests.ts
@@ -24,6 +24,6 @@ if (weak.isWeakRef(anyVar)) {
 }
 
 if (weak.isDead(weakReference)) {
-    const a = weakReference; // $ExpectType WeakRef<undefined>
+    const a = weakReference; // $ExpectType WeakRef<undefined> || WeakRef<{ a: number; }>
     const value = weak.get(weakReference); // undefined only possible
 }


### PR DESCRIPTION
TS 4.8 improves narrowing of type predicates when a union is passed in. This changes the return type of a couple of underscore and weak-napi functions. For now I just updated the tests, since underscore's change is pretty minor. And weak-napi's types probably need to be rewritten substantially, which would probably result in fixing this change.

See microsoft/typescript#49625 for the change.
