### PR TITLE
fix(video.js): add missing player's options and methods

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -4262,6 +4262,18 @@ declare namespace videojs {
 
     type Preload = 'auto' | 'metadata' | 'none';
 
+    type Autoplay =  boolean | 'muted' | 'play' | 'any';
+
+    interface Breakpoint {
+        tiny: number;
+        xsmall: number;
+        small: number;
+        medium: number;
+        large: number;
+        xlarge: number;
+        huge: number;
+    }
+
     interface ProgressControl extends Component {
         /**
          * Create the `Component`'s DOM element
@@ -6196,6 +6208,35 @@ export interface VideoJsPlayer extends videojs.Component {
     aspectRatio(): string;
 
     /**
+     * Get the current audioOnlyMode state or set audioOnlyMode to true or false.
+     *
+     * Setting this to `true` will hide all player components except the control bar,
+     * as well as control bar components needed only for video.
+     *
+     * @param [value]
+     *         The value to set audioOnlyMode to.
+     *
+     * @return A Promise is returned when setting the state, and a boolean when getting
+     *         the present state
+     */
+    audioOnlyMode(value: boolean): void;
+
+    audioOnlyMode(): Promise<void> | boolean;
+
+    /**
+     * Get the current audioPosterMode state or set audioPosterMode to true or false
+     *
+     * @param [value]
+     *         The value to set audioPosterMode to.
+     *
+     * @return A Promise is returned when setting the state, and a boolean when getting
+     *         the present state
+     */
+    audioPosterMode(value: boolean): void;
+
+    audioPosterMode(): Promise<void> | boolean;
+
+    /**
      * Get or set the autoplay option. When this is a boolean it will
      * modify the attribute on the tech. When this is a string the attribute on
      * the tech will be removed and `Player` will handle autoplay on loadstarts.
@@ -6210,9 +6251,9 @@ export interface VideoJsPlayer extends videojs.Component {
      *
      * @return The current value of autoplay when getting
      */
-    autoplay(value: boolean | string): void;
+    autoplay(value: videojs.Autoplay): void;
 
-    autoplay(): boolean | string;
+    autoplay(): videojs.Autoplay;
 
     /**
      * Get the remote {@link TextTrackList}
@@ -6270,6 +6311,45 @@ export interface VideoJsPlayer extends videojs.Component {
      *         if there is no tech
      */
     addTextTrack(kind?: string, label?: string, language?: string): void;
+
+    /**
+     * Get or set breakpoints on the player.
+     *
+     * Calling this method with an object or `true` will remove any previous
+     * custom breakpoints and start from the defaults again.
+     *
+     * @param  [breakpoints]
+     *         If an object is given, it can be used to provide custom
+     *         breakpoints. If `true` is given, will set default breakpoints.
+     *         If this argument is not given, will simply return the current
+     *         breakpoints.
+     *
+     * @param  [breakpoints.tiny]
+     *         The maximum width for the "vjs-layout-tiny" class.
+     *
+     * @param  [breakpoints.xsmall]
+     *         The maximum width for the "vjs-layout-x-small" class.
+     *
+     * @param  [breakpoints.small]
+     *         The maximum width for the "vjs-layout-small" class.
+     *
+     * @param  [breakpoints.medium]
+     *         The maximum width for the "vjs-layout-medium" class.
+     *
+     * @param  [breakpoints.large]
+     *         The maximum width for the "vjs-layout-large" class.
+     *
+     * @param  [breakpoints.xlarge]
+     *         The maximum width for the "vjs-layout-x-large" class.
+     *
+     * @param  [breakpoints.huge]
+     *         The maximum width for the "vjs-layout-huge" class.
+     *
+     * @return An object mapping breakpoint names to maximum width values.
+     */
+    breakpoints(breakpoints: Partial<videojs.Breakpoint>): void;
+
+    breakpoints(): videojs.Breakpoint;
 
     /**
      * Get a TimeRange object with an array of the times of the video
@@ -6353,6 +6433,22 @@ export interface VideoJsPlayer extends videojs.Component {
     createModal(content: string | (() => any) | Element | any[], options: any): videojs.ModalDialog;
 
     /**
+     * Get or set the `Player`'s crossOrigin option. For the HTML5 player, this
+     * sets the `crossOrigin` property on the `<video>` tag to control the CORS
+     * behavior.
+     *
+     * @param [value]
+     *        The value to set the `Player`'s crossOrigin to. If an argument is
+     *        given, must be one of `anonymous` or `use-credentials`.
+     *
+     * @return - The current crossOrigin value of the `Player` when getting.
+     *         - undefined when setting
+     */
+    crossOrigin(value: string): void;
+
+    crossOrigin(): string;
+
+    /**
      * Get current breakpoint name, if any.
      *
      * @return If there is currently a breakpoint set, returns a the key from the
@@ -6411,6 +6507,13 @@ export interface VideoJsPlayer extends videojs.Component {
      * @return The source MIME type
      */
     currentType(): string;
+
+    /**
+     * Set debug mode to enable/disable logs at info level.
+     *
+     * @param enabled
+     */
+    debug(enabled: boolean): void;
 
     /**
      * Get the current defaultMuted state, or turn defaultMuted on or off. defaultMuted
@@ -6475,6 +6578,15 @@ export interface VideoJsPlayer extends videojs.Component {
     dimension(dimension: 'width' | 'height', value: number): void;
 
     dimension(dimension: 'width' | 'height'): number;
+
+    /**
+     * Disable Picture-in-Picture mode.
+     *
+     * @param value
+     *        - true will disable Picture-in-Picture mode
+     *        - false will enable Picture-in-Picture mode
+     */
+    disablePictureInPicture(value: boolean): void;
 
     /**
      * An instance of the `Player` class is created when any of the Video.js setup methods
@@ -6686,6 +6798,20 @@ export interface VideoJsPlayer extends videojs.Component {
     isFullscreen(isFS: boolean): void;
 
     isFullscreen(): boolean;
+
+    /**
+     * Check if the player is in Picture-in-Picture mode or tell the player that it
+     * is or is not in Picture-in-Picture mode.
+     *
+     * @param  [isPiP]
+     *         Set the players current Picture-in-Picture state
+     *
+     * @return - true if Picture-in-Picture is on and getting
+     *         - false if Picture-in-Picture is off and getting
+     */
+    isInPictureInPicture(isPiP: boolean): void;
+
+    isInPictureInPicture(): boolean;
 
     /**
      * The player's language code
@@ -7111,11 +7237,11 @@ export interface VideoJsPlayer extends videojs.Component {
     width(value: number): void;
 
     width(): number;
-}
+  }
 
 export interface VideoJsPlayerOptions extends videojs.ComponentOptions {
     aspectRatio?: string | undefined;
-    autoplay?: boolean | string | undefined;
+    autoplay?: videojs.Autoplay | undefined;
     bigPlayButton?: boolean | undefined;
     controlBar?: videojs.ControlBarOptions | false | undefined;
     textTrackSettings?: videojs.TextTrackSettingsOptions | undefined;
@@ -7146,6 +7272,27 @@ export interface VideoJsPlayerOptions extends videojs.ComponentOptions {
     tracks?: videojs.TextTrackOptions[] | undefined;
     userActions?: videojs.UserActions | undefined;
     width?: number | undefined;
+
+    audioOnlyMode?: boolean | undefined;
+    audioPosterMode?: boolean | undefined;
+    autoSetup?: boolean | undefined;
+    breakpoints?: Partial<videojs.Breakpoint> | undefined;
+    fullscreen?: { options: { navigationUI: 'hide' } } | undefined;
+    id?: string | undefined;
+    liveTracker?: {
+      trackingThreshold?: number | undefined;
+      liveTolerance?: number | undefined;
+    } | undefined;
+    normalizeAutoplay?: boolean | undefined;
+    preferFullWindow?: boolean | undefined;
+    restoreEl?: boolean | Element | undefined;
+    suppressNotSupportedError?: boolean | undefined;
+    techCanOverridePoster?: boolean | undefined;
+    'vtt.js'?: string | undefined;
+    playsinline?: boolean | undefined;
+    disablePictureInPicture?: boolean | undefined;
+    enableSourceset?: boolean | undefined;
+    retryOnError?: boolean | undefined;
 }
 
 export interface VideoJsPlayerPluginOptions {

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -6232,9 +6232,8 @@ export interface VideoJsPlayer extends videojs.Component {
      * @return A Promise is returned when setting the state, and a boolean when getting
      *         the present state
      */
-    audioPosterMode(value: boolean): void;
-
-    audioPosterMode(): Promise<void> | boolean;
+    audioPosterMode(value: boolean): Promise<void>
+    audioPosterMode(): boolean;
 
     /**
      * Get or set the autoplay option. When this is a boolean it will

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -6221,7 +6221,7 @@ export interface VideoJsPlayer extends videojs.Component {
      */
     audioOnlyMode(value: boolean): Promise<void>;
 
-    audioOnlyMode(): Promise<void> | boolean;
+    audioOnlyMode(): boolean;
 
     /**
      * Get the current audioPosterMode state or set audioPosterMode to true or false

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -7236,7 +7236,7 @@ export interface VideoJsPlayer extends videojs.Component {
     width(value: number): void;
 
     width(): number;
-  }
+}
 
 export interface VideoJsPlayerOptions extends videojs.ComponentOptions {
     aspectRatio?: string | undefined;

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -6232,7 +6232,7 @@ export interface VideoJsPlayer extends videojs.Component {
      * @return A Promise is returned when setting the state, and a boolean when getting
      *         the present state
      */
-    audioPosterMode(value: boolean): Promise<void>
+    audioPosterMode(value: boolean): Promise<void>;
     audioPosterMode(): boolean;
 
     /**

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -6443,7 +6443,7 @@ export interface VideoJsPlayer extends videojs.Component {
      * @return - The current crossOrigin value of the `Player` when getting.
      *         - undefined when setting
      */
-    crossOrigin(value: string): void;
+    crossOrigin(value: 'anonymous' | 'use-credentials'): void;
 
     crossOrigin(): string;
 

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -6346,7 +6346,7 @@ export interface VideoJsPlayer extends videojs.Component {
      *
      * @return An object mapping breakpoint names to maximum width values.
      */
-    breakpoints(breakpoints: Partial<videojs.Breakpoint>): void;
+    breakpoints(breakpoints: true | Partial<videojs.Breakpoint>): void;
 
     breakpoints(): videojs.Breakpoint;
 

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -6219,7 +6219,7 @@ export interface VideoJsPlayer extends videojs.Component {
      * @return A Promise is returned when setting the state, and a boolean when getting
      *         the present state
      */
-    audioOnlyMode(value: boolean): void;
+    audioOnlyMode(value: boolean): Promise<void>;
 
     audioOnlyMode(): Promise<void> | boolean;
 

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -7288,7 +7288,6 @@ export interface VideoJsPlayerOptions extends videojs.ComponentOptions {
     suppressNotSupportedError?: boolean | undefined;
     techCanOverridePoster?: boolean | undefined;
     'vtt.js'?: string | undefined;
-    playsinline?: boolean | undefined;
     disablePictureInPicture?: boolean | undefined;
     enableSourceset?: boolean | undefined;
     retryOnError?: boolean | undefined;

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -12,25 +12,25 @@ videojs(videoElement);
 const audioElement = document.createElement('audio');
 
 const playerOptions: VideoJsPlayerOptions = {
+    aspectRatio: '16:9',
     autoplay: 'muted',
     bigPlayButton: false,
-    controls: true,
     controlBar: {
         playToggle: false,
         captionsButton: false,
         chaptersButton: false,
         pictureInPictureToggle: audioElement.tagName !== 'AUDIO',
     },
-    height: 10,
-    loop: true,
-    muted: true,
-    poster: 'https://example.com/poster.png',
-    preload: 'auto',
-    src: 'https://example.com/video.mp4',
-    width: 10,
-    aspectRatio: '16:9',
-    children: [{ name: 'name' }],
+    textTrackSettings: {
+        persistTextTrackSettings: false,
+    },
+    controls: true,
+    defaultVolume: 100,
+    fill: false,
     fluid: false,
+    height: 10,
+    html5: {
+    },
     inactivityTimeout: 42,
     language: 'en',
     languages: {
@@ -39,6 +39,8 @@ const playerOptions: VideoJsPlayerOptions = {
         },
     },
     liveui: true,
+    loop: true,
+    muted: true,
     nativeControlsForTouch: true,
     notSupportedMessage: 'Oh no! :(',
     playbackRates: [0.5, 1],
@@ -48,20 +50,52 @@ const playerOptions: VideoJsPlayerOptions = {
             myOption: true,
         },
     },
-    fill: false,
+    poster: 'https://example.com/poster.png',
+    preload: 'auto',
     responsive: false,
+    sourceOrder: false,
     sources: [
         {
             src: 'https://example.com/video.mp4',
             type: 'video/mp4',
         },
     ],
+    src: 'https://example.com/video.mp4',
     techOrder: ['html5', 'anotherTech'],
+    tracks: [],
     userActions: {
         click: event => {},
         doubleClick: event => {},
         hotkeys: true,
     },
+    width: 10,
+    children: [{ name: 'name' }],
+    audioOnlyMode: false,
+    audioPosterMode: false,
+    autoSetup: false,
+    breakpoints: {
+        xsmall: 20
+    },
+    fullscreen: {
+        options: {
+            navigationUI: 'hide',
+        }
+    },
+    id: 'some-id',
+    liveTracker: {
+        trackingThreshold: 100,
+        liveTolerance: 100
+    },
+    normalizeAutoplay: false,
+    preferFullWindow: false,
+    restoreEl: false,
+    suppressNotSupportedError: false,
+    techCanOverridePoster: false,
+    "vtt.js": 'https://example.com/vtt.js',
+    playsinline: true,
+    disablePictureInPicture: false,
+    enableSourceset: true,
+    retryOnError: true
 };
 
 playerOptions.userActions!.hotkeys = event => {
@@ -200,6 +234,34 @@ videojs('example_video_1', playerOptions).ready(function playerReady() {
     const fill: boolean = this.fill();
 
     this.fill(false);
+
+    const autoplay: videojs.Autoplay = this.autoplay();
+
+    this.autoplay(false);
+
+    const audioOnlyMode: boolean | Promise<void>  = this.audioOnlyMode();
+
+    this.audioOnlyMode(true);
+
+    const audioPosterMode: boolean | Promise<void> = this.audioPosterMode();
+
+    this.audioPosterMode(true);
+
+    const breakpoints: videojs.Breakpoint = this.breakpoints();
+
+    this.breakpoints({ huge: 1000 });
+
+    const crossOrigin: string = this.crossOrigin();
+
+    this.crossOrigin('*');
+
+    this.debug(true);
+
+    this.disablePictureInPicture(false);
+
+    const isInPictureInPicture: boolean = this.isInPictureInPicture();
+
+    this.isInPictureInPicture(false);
 
     testEvents(this);
 

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -252,7 +252,7 @@ videojs('example_video_1', playerOptions).ready(function playerReady() {
 
     const crossOrigin: string = this.crossOrigin();
 
-    this.crossOrigin('*');
+    this.crossOrigin('anonymous');
 
     this.debug(true);
 

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -92,7 +92,6 @@ const playerOptions: VideoJsPlayerOptions = {
     suppressNotSupportedError: false,
     techCanOverridePoster: false,
     "vtt.js": 'https://example.com/vtt.js',
-    playsinline: true,
     disablePictureInPicture: false,
     enableSourceset: true,
     retryOnError: true


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Player's options
    - `autoplay` https://videojs.com/guides/options/#autoplay
    - `audioOnlyMode` https://videojs.com/guides/options/#audioonlymode
    - `audioPosterMode` https://videojs.com/guides/options/#audiopostermode
    - `autoSetup` https://videojs.com/guides/options/#autosetup
    - `breakpoints` https://videojs.com/guides/options/#breakpoints
    - `fullscreen` https://videojs.com/guides/options/#fullscreen
    - `id` https://videojs.com/guides/options/#id
    - `liveTracker`
      - https://videojs.com/guides/options/#livetrackertrackingthreshold
      - https://videojs.com/guides/options/#livetrackerlivetolerance
    - `normalizeAutoplay` https://videojs.com/guides/options/#normalizeautoplay
    - `preferFullWindow` https://videojs.com/guides/options/#preferfullwindow
    - `restoreEl` https://videojs.com/guides/options/#restoreel
    - `suppressNotSupportedError` https://videojs.com/guides/options/#suppressnotsupportederror
    - `techCanOverridePoster` https://videojs.com/guides/options/#techcanoverrideposter
    - `vtt.js` https://videojs.com/guides/options/#vttjs
    - `playsinline` https://github.com/videojs/video.js/blob/main/src/js/player.js#L1170
    - `disablePictureInPicture` https://github.com/videojs/video.js/blob/main/src/js/player.js#L1173
    - `enableSourceset` https://github.com/videojs/video.js/blob/main/src/js/player.js#L1180
    - `retryOnError` https://github.com/videojs/video.js/blob/main/src/js/player.js#L3464
  - Player's methods
    - `audioOnlyMode` https://github.com/videojs/video.js/blob/main/src/js/player.js#L4370
    - `audioPosterMode`https://github.com/videojs/video.js/blob/main/src/js/player.js#L4447
    - `breakpoints` https://github.com/videojs/video.js/blob/main/src/js/player.js#L4800
    - `crossOrigin` https://github.com/videojs/video.js/blob/main/src/js/player.js#L849
    - `debug` https://github.com/videojs/video.js/blob/main/src/js/player.js#L5097
    - `disablePictureInPicture` https://github.com/videojs/video.js/blob/main/src/js/player.js#L3074
    - `isInPictureInPicture` https://github.com/videojs/video.js/blob/main/src/js/player.js#L3094
