### PR TITLE
Add missing argument to `@types/prettier`

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -374,7 +374,7 @@ export interface Parser<T = any> {
 }
 
 export interface Printer<T = any> {
-    print(path: AstPath<T>, options: ParserOptions<T>, print: (path: AstPath<T>) => Doc): Doc;
+    print(path: AstPath<T>, options: ParserOptions<T>, print: (path: AstPath<T>) => Doc, args: any): Doc;
     embed?:
         | ((
               path: AstPath<T>,

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -374,7 +374,7 @@ export interface Parser<T = any> {
 }
 
 export interface Printer<T = any> {
-    print(path: AstPath<T>, options: ParserOptions<T>, print: (path: AstPath<T>) => Doc, args: any): Doc;
+    print(path: AstPath<T>, options: ParserOptions<T>, print: (path: AstPath<T>) => Doc, args?: unknown): Doc;
     embed?:
         | ((
               path: AstPath<T>,


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/prettier/prettier/blob/ab72a2c11c806f3a8a5ef42314e291843e1b3e68/src/main/ast-to-doc.js#L76
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
