### PR TITLE
Add types definitions for Scaleway serverless functions runtime

### DIFF
--- a/types/scaleway-functions/index.d.ts
+++ b/types/scaleway-functions/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for scaleway-functions 1.0
+// Project: https://www.scaleway.com/en/serverless-functions/
+// Definitions by: MrMicky <https://github.com/MrMicky-FR>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export type Handler<TResult = Response | object> = (
+    event: Event,
+    context: Context,
+    callback: Callback<TResult>,
+) => void | TResult | Promise<TResult>;
+
+export type Callback<TResult = Response | object> = (error?: Error | string | null, result?: TResult) => void;
+
+// https://github.com/scaleway/scaleway-functions-runtimes/blob/master/events/context.go
+export interface Context {
+    memoryLimitInMb: number;
+    functionName: string;
+    functionVersion: string;
+}
+
+// https://github.com/scaleway/scaleway-functions-runtimes/blob/master/events/http.go
+export interface Event {
+    path: string;
+    httpMethod: string;
+    headers: Record<string, string>;
+    queryStringParameters: Record<string, string>;
+    stageVariables: Record<string, string>;
+    body: string;
+    isBase64Encoded: boolean;
+    requestContext: RequestContext;
+}
+
+export interface RequestContext {
+    stage: string;
+    httpMethod: string;
+}
+
+// https://github.com/scaleway/scaleway-functions-runtimes/blob/master/handler/utils.go
+export interface Response {
+    statusCode: number;
+    body?: string | object;
+    headers?: Record<string, string>;
+    isBase64Encoded?: boolean;
+}

--- a/types/scaleway-functions/index.d.ts
+++ b/types/scaleway-functions/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for scaleway-functions 1.0
+// Type definitions for non-npm package scaleway-functions 1.0
 // Project: https://www.scaleway.com/en/serverless-functions/
 // Definitions by: MrMicky <https://github.com/MrMicky-FR>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/scaleway-functions/scaleway-functions-tests.ts
+++ b/types/scaleway-functions/scaleway-functions-tests.ts
@@ -1,0 +1,52 @@
+// Tests based on examples from https://developers.scaleway.com/en/products/functions/api/#node
+
+import { Callback, Context, Event, Handler } from 'scaleway-functions';
+
+const handler1: Handler = () => {
+    return {
+        statusCode: 201,
+        body: JSON.stringify({
+            message: 'async function',
+        }),
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    };
+};
+
+const handler2: Handler = (event: Event, context: Context, callback: Callback) => {
+    const response = {
+        statusCode: 201,
+        body: {
+            message: 'async function',
+        },
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    };
+
+    try {
+        // Successful response
+        callback(undefined, response);
+    } catch (err) {
+        // Error response
+        callback(err);
+    }
+};
+
+const handler3: Handler = async (event: Event, context: Context, callback: Callback) => {
+    const response = {
+        statusCode: 201,
+        body: {
+            message: 'async function',
+        },
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    };
+
+    return new Promise(resolve => {
+        // do something
+        resolve(response);
+    });
+};

--- a/types/scaleway-functions/tsconfig.json
+++ b/types/scaleway-functions/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "scaleway-functions-tests.ts"
+    ]
+}

--- a/types/scaleway-functions/tslint.json
+++ b/types/scaleway-functions/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}

--- a/types/scaleway-functions/tslint.json
+++ b/types/scaleway-functions/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "@definitelytyped/dtslint/dt.json",
-    "rules": {
-        "npm-naming": false
-    }
-}
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
This PR adds types definitions for [Scaleway serverless functions](https://www.scaleway.com/en/serverless-functions/) runtime (not an NPM package). These types are based on the AWS Lambda ones, but as only some properties are implemented I find it's easier to have only the existing types during development (rather than unexpected errors during testing). I used the implementation details available on the [GitHub repository of the functions runtime](https://github.com/scaleway/scaleway-functions-runtimes/blob/b1baa76eac3e13731e8f831b1c56550fda222a85/events/http.go#L70-L82).

The tests are based on the [Scaleway documentation](https://developers.scaleway.com/en/products/functions/api/).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
