### PR TITLE
fix `find` types for `language-tags`

### DIFF
--- a/types/language-tags/Tag.d.ts
+++ b/types/language-tags/Tag.d.ts
@@ -63,22 +63,22 @@ declare class Tag {
     /**
      * Shortcut for `tag.find('language')`.
      */
-    language(): Subtag;
+    language(): ReturnType<Tag['find']>;
 
     /**
      * Shortcut for `tag.find('region')`.
      */
-    region(): Subtag;
+    region(): ReturnType<Tag['find']>;
 
     /**
      * Shortcut for `tag.find('script')`.
      */
-    script(): Subtag;
+    script(): ReturnType<Tag['find']>;
 
     /**
      * Find a subtag of the given type from those making up the tag.
      */
-    find(type: string): Subtag;
+    find(type: string): Subtag | undefined;
 
     /**
      * Returns `true` if the tag is valid, `false` otherwise.

--- a/types/language-tags/Tag.d.ts
+++ b/types/language-tags/Tag.d.ts
@@ -63,17 +63,17 @@ declare class Tag {
     /**
      * Shortcut for `tag.find('language')`.
      */
-    language(): ReturnType<Tag['find']>;
+    language(): Subtag | undefined;
 
     /**
      * Shortcut for `tag.find('region')`.
      */
-    region(): ReturnType<Tag['find']>;
+    region(): Subtag | undefined;
 
     /**
      * Shortcut for `tag.find('script')`.
      */
-    script(): ReturnType<Tag['find']>;
+    script(): Subtag | undefined;
 
     /**
      * Find a subtag of the given type from those making up the tag.

--- a/types/language-tags/language-tags-tests.ts
+++ b/types/language-tags/language-tags-tests.ts
@@ -33,22 +33,22 @@ tags.date(); // $ExpectType string
 tag.preferred(); // $ExpectType Tag
 tag.type(); // $ExpectType "grandfathered" | "redundant" | "tag"
 tag.subtags(); // $ExpectType Subtag[]
-const subtag = tag.language(); // $ExpectType Subtag
-tag.region(); // $ExpectType Subtag
-tag.script(); // $ExpectType Subtag
-tag.find('us'); // $ExpectType Subtag
+const subtag = tag.language(); // $ExpectType Subtag | undefined
+tag.region(); // $ExpectType Subtag | undefined
+tag.script(); // $ExpectType Subtag | undefined
+tag.find('us'); // $ExpectType Subtag | undefined
 tag.valid(); // $ExpectType boolean
 tag.format(); // $ExpectType string
 tag.deprecated(); // $ExpectType string | null
 tag.added(); // $ExpectType string
 tag.descriptions(); // $ExpectType string[]
 
-subtag.type(); // $ExpectType "language" | "extlang" | "script" | "region" | "variant"
-subtag.descriptions(); // $ExpectType string[]
-subtag.preferred(); // $ExpectType Subtag | null
-subtag.script(); // $ExpectType Subtag | null
-subtag.scope(); // $ExpectType string | null
-subtag.deprecated(); // $ExpectType string | null
-subtag.added(); // $ExpectType string
-subtag.comments(); // $ExpectType string[]
-subtag.format(); // $ExpectType string
+subtag!.type(); // $ExpectType "language" | "extlang" | "script" | "region" | "variant"
+subtag!.descriptions(); // $ExpectType string[]
+subtag!.preferred(); // $ExpectType Subtag | null
+subtag!.script(); // $ExpectType Subtag | null
+subtag!.scope(); // $ExpectType string | null
+subtag!.deprecated(); // $ExpectType string | null
+subtag!.added(); // $ExpectType string
+subtag!.comments(); // $ExpectType string[]
+subtag!.format(); // $ExpectType string


### PR DESCRIPTION
Fixes the return type for `Tag.find` method and methods that derive from it by adding that `Tag.find` may return `undefined` if no item it found.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mattcg/language-tags/blob/master/lib/Tag.js#L157-L167
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
