### PR TITLE
chore(fix): correct padding length

### DIFF
--- a/scripts/update-codeowners.js
+++ b/scripts/update-codeowners.js
@@ -67,7 +67,7 @@ function getEntry(pkg, maxPathLen) {
         return undefined;
     }
 
-    const path = `${pkg.subDirectoryPath}/`.padEnd(maxPathLen);
+    const path = `${pkg.subDirectoryPath}/`.padEnd(maxPathLen + 1);
     return `/types/${path} ${users.map(u => `@${u}`).join(' ')}`;
 }
 


### PR DESCRIPTION
Adjust the padding length to account for the added `/` in `update-codeowners`, this is seriously triggering my OCD.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/be5d0b1919a8b98a6dc8c016438360941c6ad7d2/.github/CODEOWNERS#L8255-L8257