### PR TITLE
fix(rollup-plugin-less): remove JSDom reference

### DIFF
--- a/types/rollup-plugin-less/index.d.ts
+++ b/types/rollup-plugin-less/index.d.ts
@@ -2,11 +2,10 @@
 // Project: https://github.com/xiaofuzi/rollup-plugin-less##readme
 // Definitions by: Tristan <https://github.com/LeoDog896>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.5
 
 /// <reference types="node" />
-/// <reference types="jsdom" />
 /// <reference types="less" />
+
 import { Plugin } from 'rollup';
 
 declare namespace less {

--- a/types/rollup-plugin-less/rollup-plugin-less-tests.ts
+++ b/types/rollup-plugin-less/rollup-plugin-less-tests.ts
@@ -2,4 +2,10 @@ import less = require('rollup-plugin-less');
 
 less(); // $ExpectType Plugin
 
-less({ output: "dist/file.css" }); // $ExpectType Plugin
+less({}); // $ExpectType Plugin
+
+less({ output: 'dist/file.css' }); // $ExpectType Plugin
+less({ include: 'styles/file.css' }); // $ExpectType Plugin
+less({ include: ['styles/file.css'] }); // $ExpectType Plugin
+less({ exclude: 'styles/file.css' }); // $ExpectType Plugin
+less({ exclude: ['styles/file.css'] }); // $ExpectType Plugin

--- a/types/rollup-plugin-less/tsconfig.json
+++ b/types/rollup-plugin-less/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
There is no dependency (direct/indirect) in native code. Somehow
'types/jsom' were added here to fix parent (less) types resolution at CI
builds, by providing 'JSDom', instead of adding 'dom' library as
dependency.

Aftermath of: #61171

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).