### PR TITLE
Adding type definitions for react-spotify-auth

### DIFF
--- a/types/react-spotify-auth/index.d.ts
+++ b/types/react-spotify-auth/index.d.ts
@@ -17,7 +17,7 @@ export interface SpotifyAuthProps {
     redirectUri: string;
     clientID: string;
     scopes: string[];
-    onAccessToken?: (arg0: string) => {};
+    onAccessToken?: (arg0: string) => void;
     logoClassName?: string;
     title?: string;
     noLogo?: boolean;

--- a/types/react-spotify-auth/index.d.ts
+++ b/types/react-spotify-auth/index.d.ts
@@ -1,0 +1,57 @@
+// Type definitions for react-spotify-auth 1.4
+// Project: https://github.com/kevin51jiang/react-spotify-auth
+// Definitions by: jsarlo <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.8
+
+import Window = require('trusted-types');
+import * as React from 'react';
+
+export as namespace ReactSpotifyAuth;
+
+export function getRedirectUrl(clientId: string, scopes: string[], redirectUri: string, showDialog: string): string;
+export function getHash(): Window | object | '';
+
+export default class SpotifyAuth extends React.PureComponent<SpotifyAuthProps> {}
+export interface SpotifyAuthProps {
+    redirectUri: string;
+    clientID: string;
+    scopes: string[];
+    onAccessToken?: (arg0: string) => {};
+    logoClassName?: string;
+    title?: string;
+    noLogo?: boolean;
+    noCookie?: boolean;
+    showDialog?: boolean;
+    localStorage?: boolean;
+    children?: React.ReactNode;
+}
+
+export class SpotifyAuthListener extends React.PureComponent<SpotifyAuthListenerProps> {}
+export interface SpotifyAuthListenerProps {
+    noCookie: boolean;
+    localStorage: boolean;
+    onAccessToken: () => {};
+}
+
+export const Scopes: {
+    ugcImageUpload: 'ugc-image-upload',
+    userFollowRead: 'user-follow-read',
+    userFollowModify: 'user-follow-modify',
+    userReadRecentlyPlayed: 'user-read-recently-played',
+    userTopRead: 'user-top-read',
+    userReadPlaybackPosition: 'user-read-playback-position',
+    userLibraryRead: 'user-library-read',
+    userLibraryModify: 'user-library-modify',
+    userReadPlaybackState: 'user-read-playback-state',
+    userReadCurrentlyPlaying: 'user-read-currently-playing',
+    userModifyPlaybackState: 'user-modify-playback-state',
+    playlistReadCollaborative: 'playlist-read-collaborative',
+    playlistModifyPrivate: 'playlist-modify-private',
+    playlistModifyPublic: 'playlist-modify-public',
+    playlistReadPrivate: 'playlist-read-private',
+    streaming: 'streaming',
+    appRemoteControl: 'app-remote-control',
+    userReadEmail: 'user-read-email',
+    userReadPrivate: 'user-read-private'
+};

--- a/types/react-spotify-auth/react-spotify-auth-tests.tsx
+++ b/types/react-spotify-auth/react-spotify-auth-tests.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import SpotifyAuth, { Scopes, SpotifyAuthListener, SpotifyAuthListenerProps, SpotifyAuthProps } from 'react-spotify-auth';
+
+export class SpotifyAuthTest extends React.PureComponent {
+    render(): JSX.Element {
+        const props: SpotifyAuthProps = {
+            redirectUri: 'localhost:1',
+            clientID: 'test',
+            scopes: [Scopes.streaming]
+        };
+        return (<SpotifyAuth {...props}>
+            <div></div>
+        </SpotifyAuth>
+        );
+    }
+}
+
+export class SpotifyAuthListenerTest extends React.PureComponent {
+    render(): JSX.Element {
+        const props: SpotifyAuthListenerProps = {
+            noCookie: false,
+            localStorage: false,
+            onAccessToken() { return {}; }
+        };
+
+        return (
+            <SpotifyAuthListener {...props}>
+                <div></div>
+            </SpotifyAuthListener>
+        );
+    }
+}

--- a/types/react-spotify-auth/tsconfig.json
+++ b/types/react-spotify-auth/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "jsx": "react",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-spotify-auth-tests.tsx"
+    ]
+}

--- a/types/react-spotify-auth/tslint.json
+++ b/types/react-spotify-auth/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/react/package.json
+++ b/types/react/package.json
@@ -1,8 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "csstype": "^3.0.2",
-    "definitely-typed": "file:../.."
+    "csstype": "^3.0.2"
   },
   "exports": {
     ".": {

--- a/types/react/package.json
+++ b/types/react/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "dependencies": {
-    "csstype": "^3.0.2"
+    "csstype": "^3.0.2",
+    "definitely-typed": "file:../.."
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Adding types for the react-spotify-auth package by @kevin51jiang.
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
