### PR TITLE
[pdfmake] Small fixes and improvements

### DIFF
--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -1426,7 +1426,11 @@ export interface TableOfContent {
  * Additional properties of {@link Content} objects that are used as columns.
  */
 export interface ColumnProperties {
-    /** Column width. */
+    /**
+     * Column width.
+     *
+     * Defaults to `*`.
+     */
     width?: Size | undefined;
 }
 

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -884,13 +884,6 @@ export interface ContentStack extends ContentBase, ForbidOtherElementProperties<
      * For simple stacks without properties, a content array can be used instead.
      */
     stack: Content[];
-
-    /**
-     * Controls whether the contents of the stack should be kept together on the same page.
-     *
-     * Defaults to `false`.
-     */
-    unbreakable?: boolean | undefined;
 }
 
 /**
@@ -1339,6 +1332,13 @@ export interface ContentBase extends Style {
      * can use it to automatically insert page breaks before elements with certain headline levels.
      */
     headlineLevel?: number | undefined;
+
+    /**
+     * Controls whether the element should be kept together on the same page.
+     *
+     * Defaults to `false`.
+     */
+    unbreakable?: boolean | undefined;
 }
 
 /**

--- a/types/pdfmake/test/pdfmake-interfaces-tests.ts
+++ b/types/pdfmake/test/pdfmake-interfaces-tests.ts
@@ -369,3 +369,8 @@ const defaultPosition: Content = {
     text: 'foobar',
     absolutePosition: {} // defaults to 0-0
 };
+
+const unbreakableList: Content = {
+    unbreakable: true,
+    ul: ['One', 'Two', 'Three']
+}

--- a/types/pdfmake/test/pdfmake-interfaces-tests.ts
+++ b/types/pdfmake/test/pdfmake-interfaces-tests.ts
@@ -373,4 +373,4 @@ const defaultPosition: Content = {
 const unbreakableList: Content = {
     unbreakable: true,
     ul: ['One', 'Two', 'Three']
-}
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

----

Just a quick follow-up for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61092, I noticed two little oversights:

- `unbreakable` was specified as property for stacks only; it however seems to be supported for all kinds of elements (not documented though), so I moved it into `ContentBase`
- I had overlooked documenting the default value for column widths (which is `*`)