### PR TITLE
(express-serve-static-core) res.redirect(url, status) deprecated

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -978,6 +978,7 @@ export interface Response<
      *
      * Examples:
      *
+     *    res.redirect('back');
      *    res.redirect('/foo/bar');
      *    res.redirect('http://example.com');
      *    res.redirect(301, 'http://example.com');
@@ -986,6 +987,7 @@ export interface Response<
      */
     redirect(url: string): void;
     redirect(status: number, url: string): void;
+    /** @deprecated use res.redirect(status, url) instead */
     redirect(url: string, status: number): void;
 
     /**


### PR DESCRIPTION
We get a [runtime warning](https://github.com/expressjs/express/blob/2c47827053233e707536019a15499ccf5496dc9d/lib/response.js#L947) when using `res.redirect(url, status)`, saying it will get removed in the next major version.

The docs also don't mention the signature: https://expressjs.com/en/api.html#res.redirect

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
