### PR TITLE
Update rappid deps to newest version of jointjs

### DIFF
--- a/types/rappid/package.json
+++ b/types/rappid/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "jointjs": "^2.0.1"
+        "jointjs": "^3.5.5"
     }
 }


### PR DESCRIPTION
Cleans up security warnings when running tests.
These are not consequential because they were all in outdated demos that previously shipped with jointjs.