### PR TITLE
Define exports for React 15, 16, and 17

### DIFF
--- a/types/react/v15/package.json
+++ b/types/react/v15/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "dependencies": {
-    "csstype": "^3.0.2"
-  },
   "exports": {
     ".": {
       "types": {

--- a/types/react/v15/package.json
+++ b/types/react/v15/package.json
@@ -6,16 +6,6 @@
         "default": "./index.d.ts"
       }
     },
-    "./next": {
-      "types": {
-        "default": "./next.d.ts"
-      }
-    },
-    "./experimental": {
-      "types": {
-        "default": "./experimental.d.ts"
-      }
-    },
     "./jsx-runtime": {
       "types": {
         "default": "./jsx-runtime.d.ts"

--- a/types/react/v16/package.json
+++ b/types/react/v16/package.json
@@ -2,5 +2,32 @@
     "private": true,
     "dependencies": {
       "csstype": "^3.0.2"
+    },
+    "exports": {
+      ".": {
+        "types": {
+          "default": "./index.d.ts"
+        }
+      },
+      "./next": {
+        "types": {
+          "default": "./next.d.ts"
+        }
+      },
+      "./experimental": {
+        "types": {
+          "default": "./experimental.d.ts"
+        }
+      },
+      "./jsx-runtime": {
+        "types": {
+          "default": "./jsx-runtime.d.ts"
+        }
+      },
+      "./jsx-dev-runtime": {
+        "types": {
+          "default": "./jsx-dev-runtime.d.ts"
+        }
+      }
     }
   }

--- a/types/react/v16/package.json
+++ b/types/react/v16/package.json
@@ -9,16 +9,6 @@
           "default": "./index.d.ts"
         }
       },
-      "./next": {
-        "types": {
-          "default": "./next.d.ts"
-        }
-      },
-      "./experimental": {
-        "types": {
-          "default": "./experimental.d.ts"
-        }
-      },
       "./jsx-runtime": {
         "types": {
           "default": "./jsx-runtime.d.ts"

--- a/types/react/v17/package.json
+++ b/types/react/v17/package.json
@@ -9,16 +9,6 @@
         "default": "./index.d.ts"
       }
     },
-    "./next": {
-      "types": {
-        "default": "./next.d.ts"
-      }
-    },
-    "./experimental": {
-      "types": {
-        "default": "./experimental.d.ts"
-      }
-    },
     "./jsx-runtime": {
       "types": {
         "default": "./jsx-runtime.d.ts"


### PR DESCRIPTION
This is required for React to work with the automatic runtime and the `node16` TypeScript module resolution.

This was already added for React 18, but it’s also relevant for older versions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/package.json
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
