### PR TITLE
test @ember/object: use `unknown` and add tests for `guidFor`

### DIFF
--- a/types/ember__object/OTHER_FILES.txt
+++ b/types/ember__object/OTHER_FILES.txt
@@ -1,3 +1,2 @@
 -private/action-handler.d.ts
-internals.d.ts
 promise-proxy-mixin.d.ts

--- a/types/ember__object/index.d.ts
+++ b/types/ember__object/index.d.ts
@@ -6,16 +6,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.4
 
-import CoreObject from "@ember/object/core";
-import Observable from "@ember/object/observable";
+import CoreObject from '@ember/object/core';
+import Observable from '@ember/object/observable';
 import {
     ComputedPropertyCallback,
     UnwrapComputedPropertyGetter,
     UnwrapComputedPropertySetter,
     UnwrapComputedPropertyGetters,
     UnwrapComputedPropertySetters,
-} from "@ember/object/-private/types";
-import ComputedProperty from "@ember/object/computed";
+} from '@ember/object/-private/types';
+import ComputedProperty from '@ember/object/computed';
 
 /**
  * `Ember.Object` is the main base class for all Ember objects. It is a subclass
@@ -43,20 +43,14 @@ export function computed(...dependentKeys: string[]): MethodDecorator;
  * @param callback The computed property function.
  */
 export function computed<Get, Set = Get>(
-    ...args: [
-        ...dependentKeys: string[],
-        callback: ComputedPropertyCallback<Get, Set>
-    ]
+    ...args: [...dependentKeys: string[], callback: ComputedPropertyCallback<Get, Set>]
 ): ComputedProperty<Get, Set>;
 
 /**
  * Specify a method that observes property changes.
  */
 export function observer<Fn extends (target: any, key: string) => void>(
-    ...args: [
-        ...propertyNames: string[],
-        func: Fn,
-    ]
+    ...args: [...propertyNames: string[], func: Fn]
 ): Fn;
 
 /**
@@ -64,10 +58,7 @@ export function observer<Fn extends (target: any, key: string) => void>(
  * the function will be invoked. If the property is not defined but the
  * object implements the `unknownProperty` method then that will be invoked.
  */
-export function get<T, K extends keyof T>(
-    obj: T,
-    key: K
-): UnwrapComputedPropertyGetter<T[K]>;
+export function get<T, K extends keyof T>(obj: T, key: K): UnwrapComputedPropertyGetter<T[K]>;
 export function get(obj: unknown, key: string): unknown;
 
 /**
@@ -79,7 +70,7 @@ export function get(obj: unknown, key: string): unknown;
 export function set<T, K extends keyof T>(
     obj: T,
     key: K,
-    value: UnwrapComputedPropertySetter<T[K]>
+    value: UnwrapComputedPropertySetter<T[K]>,
 ): UnwrapComputedPropertyGetter<T[K]>;
 export function set<T, K extends keyof T>(obj: T, key: K, value: T[K]): T[K];
 
@@ -87,14 +78,8 @@ export function set<T, K extends keyof T>(obj: T, key: K, value: T[K]): T[K];
  * To get multiple properties at once, call `Ember.getProperties`
  * with an object followed by a list of strings or an array:
  */
-export function getProperties<T, K extends keyof T>(
-    obj: T,
-    list: K[]
-): Pick<UnwrapComputedPropertyGetters<T>, K>; // for dynamic K
-export function getProperties<T, K extends keyof T>(
-    obj: T,
-    ...list: K[]
-): Pick<UnwrapComputedPropertyGetters<T>, K>;
+export function getProperties<T, K extends keyof T>(obj: T, list: K[]): Pick<UnwrapComputedPropertyGetters<T>, K>; // for dynamic K
+export function getProperties<T, K extends keyof T>(obj: T, ...list: K[]): Pick<UnwrapComputedPropertyGetters<T>, K>;
 
 /**
  * Set a list of properties on an object. These properties are set inside
@@ -103,12 +88,9 @@ export function getProperties<T, K extends keyof T>(
  */
 export function setProperties<T, K extends keyof T>(
     obj: T,
-    hash: Pick<UnwrapComputedPropertySetters<T>, K>
+    hash: Pick<UnwrapComputedPropertySetters<T>, K>,
 ): Pick<UnwrapComputedPropertyGetters<T>, K>;
-export function setProperties<T, K extends keyof T>(
-    obj: T,
-    hash: Pick<T, K>
-): Pick<T, K>;
+export function setProperties<T, K extends keyof T>(obj: T, hash: Pick<T, K>): Pick<T, K>;
 
 /**
  * Error-tolerant form of `Ember.set`. Will not blow up if any part of the
@@ -134,7 +116,7 @@ export function defineProperty(
     obj: object,
     keyName: string,
     desc: PropertyDescriptor | ComputedProperty<unknown>,
-    meta?: unknown
+    meta?: unknown,
 ): void;
 
 /**
@@ -149,18 +131,13 @@ export function defineProperty(
  * @param data something other than a descriptor, that will become the explicit
  *   value of this property.
  */
-export function defineProperty(
-    obj: object,
-    keyName: string,
-    desc: undefined,
-    data: unknown,
-): void;
+export function defineProperty(obj: object, keyName: string, desc: undefined, data: unknown): void;
 
 export function notifyPropertyChange(obj: object, keyName: string): void;
 
 export const action: MethodDecorator;
 
-declare module "@ember/utils/-private/types" {
+declare module '@ember/utils/-private/types' {
     interface TypeLookup {
         class: typeof EmberObject;
         instance: EmberObject;

--- a/types/ember__object/internals.d.ts
+++ b/types/ember__object/internals.d.ts
@@ -17,4 +17,4 @@ export function cacheFor<T, K extends keyof T>(
  * `Ember.Object`-based or not, but be aware that it will add a `_guid`
  * property.
  */
-export function guidFor(obj: any): string;
+export function guidFor(obj: unknown): string;

--- a/types/ember__object/test/internals.ts
+++ b/types/ember__object/test/internals.ts
@@ -1,0 +1,10 @@
+import { guidFor } from '@ember/object/internals';
+
+// $ExpectType string
+const strGuid = guidFor('a string');
+// $ExpectType string
+const numGuid = guidFor(123);
+// $ExpectType string
+const objGuid = guidFor({ hello: 'world' });
+// $ExpectType string
+const arrGuid = guidFor([1, 2, 3]);

--- a/types/ember__object/tsconfig.json
+++ b/types/ember__object/tsconfig.json
@@ -33,6 +33,7 @@
         "test/create-negative.ts",
         "test/event.ts",
         "test/extend.ts",
+        "test/internals.ts",
         "test/object.ts",
         "test/observable.ts",
         "test/octane.ts",


### PR DESCRIPTION
This is a nice little fix in its own right, buuuuut it also helps make `"@types/ember__object": "*"` resolve correctly to a v4 version, since `"*"` resolutions (apparently!) resolve to the most-recently-published version, regardless of whether it is the `latest` tag or not.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://api.emberjs.com/ember/4.4/functions/@ember%2Fobject%2Finternals/guidFor>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.