### PR TITLE
Update dependencies of various storybook types

### DIFF
--- a/types/storybook-addon-jsx/package.json
+++ b/types/storybook-addon-jsx/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@storybook/addons": "5.2.4",
-        "@storybook/react": "5.2.4"
+        "@storybook/addons": "^6.5.9",
+        "@storybook/react": "^6.5.9"
     }
 }

--- a/types/storybook-react-router/index.d.ts
+++ b/types/storybook-react-router/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 3.1
 
 import { DecoratorFunction, StoryApi } from '@storybook/addons';
-import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { StoryFnReactReturnType } from '@storybook/react/dist/ts3.9/client/preview/types';
 import { ComponentType } from 'react';
 import { MemoryRouterProps } from 'react-router';
 

--- a/types/storybook-react-router/package.json
+++ b/types/storybook-react-router/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@storybook/addons": "^5.2.0",
-        "@storybook/react": "^5.2.0"
+        "@storybook/addons": "^6.5.9",
+        "@storybook/react": "^6.5.9"
     }
 }

--- a/types/storybook-readme/index.d.ts
+++ b/types/storybook-readme/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 3.1
 
 import { DecoratorFunction, StoryFn } from '@storybook/addons';
-import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { StoryFnReactReturnType } from '@storybook/react/dist/ts3.9/client/preview/types';
 import { ReactNode } from 'react';
 
 // Shared Types

--- a/types/storybook-readme/package.json
+++ b/types/storybook-readme/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@storybook/addons": "^5.2.0",
-        "@storybook/react": "^5.2.0"
+        "@storybook/addons": "^6.5.9",
+        "@storybook/react": "^6.5.9"
     }
 }

--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -8,7 +8,7 @@
 
 import { ComponentType, ReactElement } from 'react';
 import { DecoratorFunction, StoryFn, Parameters, StoryApi } from '@storybook/addons';
-import { StoryContext } from '@storybook/csf';
+import { StoryContext } from '@storybook/csf/dist/story';
 
 export interface WrapStoryProps {
     storyFn?: StoryFn | undefined;

--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -7,7 +7,8 @@
 // TypeScript Version: 3.1
 
 import { ComponentType, ReactElement } from 'react';
-import { DecoratorFunction, StoryFn, StoryContext, Parameters, StoryApi } from '@storybook/addons';
+import { DecoratorFunction, StoryFn, Parameters, StoryApi } from '@storybook/addons';
+import { StoryContext } from '@storybook/csf';
 
 export interface WrapStoryProps {
     storyFn?: StoryFn | undefined;
@@ -50,7 +51,7 @@ export interface Options {
 
 export function withInfo<A = unknown>(
     story: StoryFn<A>,
-    context: StoryContext
+    context: StoryContext<{ component: any; storyResult: A; }>
 ): ReturnType<DecoratorFunction<A>>;
 
 // Legacy, but supported

--- a/types/storybook__addon-info/package.json
+++ b/types/storybook__addon-info/package.json
@@ -1,7 +1,8 @@
 {
     "private": true,
     "dependencies": {
-        "@storybook/addons": "^5.2.0",
-        "@storybook/react": "^5.2.0"
+        "@storybook/addons": "^6.5.9",
+        "@storybook/csf": "^0.0.1",
+        "@storybook/react": "^6.5.9"
     }
 }

--- a/types/storybook__addon-info/package.json
+++ b/types/storybook__addon-info/package.json
@@ -2,7 +2,6 @@
     "private": true,
     "dependencies": {
         "@storybook/addons": "^6.5.9",
-        "@storybook/csf": "^0.0.1",
         "@storybook/react": "^6.5.9"
     }
 }


### PR DESCRIPTION
Four DT packages depend indirectly on prismjs 1.17.1, which has the security alert CVE-2020-15138.  This PR upgrades those packages to the newest version of `@storybook/addons` and `@storybook/react`, which in turn updates the version of prismjs that is installed.

- storybook-addon-jsx
- storybook-react-router
- storybook-readme
- `@storybook/addon-info`
