### PR TITLE
@types/wordpress__blocks: Added missing types and keys for block supports

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -5,6 +5,7 @@
 //                 Dennis Snell <https://github.com/dmsnell>
 //                 Tomasz Tunik <https://github.com/tomasztunik>
 //                 Lucio Giannotta <https://github.com/sunyatasattva>
+//                 Bas Tolen <https://github.com/bastolen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
@@ -89,6 +90,32 @@ export interface ColorProps {
      * @defaultValue true
      */
     text: string;
+}
+
+export interface TypographyProps {
+    /**
+     * This value signals that a block supports the font-size
+     * CSS style property. When it does, the block editor will
+     * show an UI control for the user to set its value.
+     *
+     * The values shown in this control are the ones declared
+     * by the theme via the editor-font-sizes theme support,
+     * or the default ones if none are provided.
+     *
+     * @defaultValue false
+     * @see {@link https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#block-font-sizes}
+     */
+    fontSize: boolean;
+    /**
+     * This value signals that a block supports the line-height
+     * CSS style property. When it does, the block editor will
+     * show an UI control for the user to set its value if the
+     * theme declares support.
+     *
+     * @defaultValue false
+     * @see {@link https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#supporting-custom-line-heights}
+     */
+    lineHeight: boolean;
 }
 
 export interface SpacingProps {
@@ -414,6 +441,20 @@ export interface BlockSupports {
      * the attributes definition is extended to include the `style` attribute.
      */
     readonly spacing?: Partial<SpacingProps> | undefined;
+    /**
+     * A block may want to disable the ability to toggle the lock state.
+     * It can be locked/unlocked by a user from the block “Options”
+     * dropdown by default. To disable this behavior, set `lock` to `false`.
+     *
+     * @defaultValue true
+     */
+    readonly lock?: boolean | undefined;
+    /**
+     * A block may want to disable the ability to toggle the lock state.
+     * It can be locked/unlocked by a user from the block “Options”
+     * dropdown by default. To disable this behavior, set `lock` to `false`.
+     */
+    readonly typography?: Partial<TypographyProps> | undefined;
 }
 
 //

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -418,6 +418,11 @@ blocks.registerBlockType({
             blockGap: ['horizontal'],
             margin: ['top', 'left'],
         },
+        typography: {
+            fontSize: true,
+            lineHeight: false,
+        },
+        lock:true
     },
     styles: [
         { name: 'default', label: 'Default', isDefault: true },

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -20,7 +20,7 @@ const BLOCK: blocks.Block<{ foo: string }> = {
                 return { foo: attributes.bar };
             },
             save: () => null,
-        }
+        },
     ],
     edit: () => null,
     icon: {
@@ -422,7 +422,7 @@ blocks.registerBlockType({
             fontSize: true,
             lineHeight: false,
         },
-        lock:true
+        lock: true,
     },
     styles: [
         { name: 'default', label: 'Default', isDefault: true },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
