### PR TITLE
[carbon-components-react] Fix typo in ComposedModal#selectorPrimaryFocus prop name

### DIFF
--- a/types/carbon-components-react/lib/components/ComposedModal/ComposedModal.d.ts
+++ b/types/carbon-components-react/lib/components/ComposedModal/ComposedModal.d.ts
@@ -11,7 +11,7 @@ export interface ComposedModalProps extends Omit<ReactDivAttr, ExcludedAttribute
     onClose?(): boolean | void;
     open?: boolean | undefined;
     preventCloseOnClickOutside?: boolean | undefined;
-    selectedPrimaryFocus?: string | undefined;
+    selectorPrimaryFocus?: string | undefined;
     selectorsFloatingMenus?: readonly string[] | undefined;
     size?: 'xs' | 'sm' | 'md' | 'lg' | undefined;
     forwardedRef?: React.ForwardedRef<HTMLDivElement>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [NA] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).  NOTE: HAD TO RUN `npm install csstype` to get it to work.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/ComposedModal/ComposedModal.js#L85

Fixes #61471.
