### PR TITLE
Update lodash tests for TS 4.8

### DIFF
--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4214,13 +4214,13 @@ fp.now(); // $ExpectType number
     const value: number | (() => void) = anything;
 
     if (_.isFunction(value)) {
-        value; // $ExpectType () => void
+        value; // $ExpectType () => void || (...args: any[]) => any
     } else {
         value; // $ExpectType number
     }
 
     if (fp.isFunction(value)) {
-        value; // $ExpectType () => void
+        value; // $ExpectType () => void || (...args: any[]) => any
     } else {
         value; // $ExpectType number
     }
@@ -4317,13 +4317,13 @@ fp.now(); // $ExpectType number
     const value: number | (() => void) = anything;
 
     if (_.isNative(value)) {
-        value; // $ExpectType () => void
+        value; // $ExpectType () => void || (...args: any[]) => any
     } else {
         value; // $ExpectType number
     }
 
     if (fp.isNative(value)) {
-        value; // $ExpectType () => void
+        value; // $ExpectType () => void || (...args: any[]) => any
     } else {
         value; // $ExpectType number
     }


### PR DESCRIPTION
Typescript 4.8 [now prefers the asserted type in type predicate narrowing](https://github.com/microsoft/TypeScript/pull/50044) in the rare case where both types are assignable to each other. Previously it preferred the type of the provided parameter.

Usually this is desired, since type predicates are essentially type assertions. For example, narrowing `unknown` to a specific type is very common. But in _.isFunction, the intent is to keep the original signature when narrowing a union:

```ts
declare const value: number | (() => void);
if (_.isFunction(value)) {
   value; // $ExpectType () => void
}
```

Unfortunately functions that return void are assignable to functions that return any *and vice versa*, so the new result is that `value` is narrowed to isFunctions' return type:

```ts
declare const value: number | (() => void);
if (_.isFunction(value)) {
   value; // $ExpectType (...args: any[]) => any
}
```

I've updated the tests to reflect that. This change doesn't apply to functions that return types besides void, but the tests happen to use such a function.

I poked at `_.isFunction` to try to find a workaround but couldn't find one that worked.