### PR TITLE
fix(papaparse): if node stream, return `Duplex`

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -14,6 +14,8 @@
 
 /// <reference types="node" />
 
+import { Duplex } from "stream";
+
 export as namespace Papa;
 
 /**
@@ -69,11 +71,11 @@ export function parse<T>(
  * Parse in a node streaming style
  * @param stream `NODE_STREAM_INPUT`
  * @param config a config object.
- * @returns a node stream.
+ * @returns a node duplex stream.
  *
  * @see https://github.com/mholt/PapaParse#papa-parse-for-node
  */
-export function parse(stream: typeof NODE_STREAM_INPUT, config?: ParseConfig): NodeJS.ReadWriteStream;
+export function parse(stream: typeof NODE_STREAM_INPUT, config?: ParseConfig): Duplex;
 
 /**
  * Unparses javascript data objects and returns a csv string

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -1,5 +1,5 @@
 import Papa = require('papaparse');
-import { Readable } from 'stream';
+import { Duplex, Readable } from 'stream';
 
 /**
  * Change global config
@@ -141,10 +141,10 @@ Papa.parse(file);
 // @ts-expect-error
 Papa.parse(file, {});
 
-// $ExpectType ReadWriteStream
+// $ExpectType Duplex
 Papa.parse(Papa.NODE_STREAM_INPUT, {});
 
-// $ExpectType ReadWriteStream
+// $ExpectType Duplex
 Papa.parse(Papa.NODE_STREAM_INPUT);
 
 const readable = new Readable();
@@ -154,7 +154,7 @@ rows.forEach(r => {
     readable.push(r);
 });
 
-const papaStream: NodeJS.ReadWriteStream = Papa.parse(Papa.NODE_STREAM_INPUT);
+const papaStream: Duplex = Papa.parse(Papa.NODE_STREAM_INPUT);
 
 readable.pipe(papaStream);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mholt/PapaParse/blob/master/papaparse.js#L229-L235, https://github.com/mholt/PapaParse/blob/master/papaparse.js#L991-L1000
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header: Not applicable
