### PR TITLE
fix(react-native): animated component type

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8950,7 +8950,7 @@ export namespace Animated {
     };
 
     export interface AnimatedComponent<T extends React.ComponentType<any>>
-        extends React.FC<AnimatedProps<React.ComponentPropsWithRef<T>>> {}
+        extends React.FC<React.PropsWithChildren<AnimatedProps<React.ComponentPropsWithRef<T>>>> {}
 
     export type AnimatedComponentOptions = {
         collapsable?: boolean;


### PR DESCRIPTION
we have to implicitly define children from react 18.