### PR TITLE
Add downloadLimit field to Options v4.10.0

### DIFF
--- a/types/open-graph-scraper/index.d.ts
+++ b/types/open-graph-scraper/index.d.ts
@@ -270,6 +270,8 @@ declare namespace run {
         urlValidatorSettings?: URLValidatorSettings | undefined;
         /** Here you can define custom meta tags you want to scrape. */
         customMetaTags?: CustomMetaTag[] | undefined;
+        /** Maximum size of the content downloaded from the server, in bytes */
+        downloadLimit?: number | undefined;
     }
 }
 


### PR DESCRIPTION
Added `downloadLimit` field to `Options` which was added in v4.10.0 as seen here: [CHANGELOG](https://github.com/jshemas/openGraphScraper/blob/master/CHANGELOG.md#4100)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [CHANGELOG](https://github.com/jshemas/openGraphScraper/blob/master/CHANGELOG.md#4100)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
