### PR TITLE
feat: added isoWeek type

### DIFF
--- a/types/react-calendar-timeline/index.d.ts
+++ b/types/react-calendar-timeline/index.d.ts
@@ -311,7 +311,7 @@ declare module 'react-calendar-timeline' {
     }
     export class SidebarHeader<Data = any> extends React.Component<SidebarHeaderProps<Data>> {}
 
-    export type Unit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+    export type Unit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'isoWeek' | 'month' | 'year';
 
     export interface IntervalContext {
         interval: { startTime: number; endTime: number; labelWidth: number; left: number };


### PR DESCRIPTION
### Update react-calendar-timeline types

Adds 'isoWeek' to Unit type in order to create DateHeaders with unit of isoWeek.

Currently there is no option to let the week start on a monday in the DateHeader.

See: [https://github.com/namespace-ee/react-calendar-timeline](https://github.com/namespace-ee/react-calendar-timeline)

@radziksh @acemac @rip21 @joncar 
