### PR TITLE
Update versions of mime and serve-static

### DIFF
--- a/types/mime/index.d.ts
+++ b/types/mime/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mime 2.0
+// Type definitions for mime 3.0
 // Project: https://github.com/broofa/node-mime
 // Definitions by: Jeff Goddard <https://github.com/jedigo>
 //                 Daniel Hritzkiv <https://github.com/dhritzkiv>

--- a/types/serve-static/index.d.ts
+++ b/types/serve-static/index.d.ts
@@ -1,10 +1,9 @@
-// Type definitions for serve-static 1.13
+// Type definitions for serve-static 1.15
 // Project: https://github.com/expressjs/serve-static
 // Definitions by: Uros Smolnik <https://github.com/urossmolnik>
 //                 Linus Unnebäck <https://github.com/LinusU>
 //                 Devansh Jethmalani <https://github.com/devanshj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 /// <reference types="node" />
 import * as m from "mime";

--- a/types/serve-static/tsconfig.json
+++ b/types/serve-static/tsconfig.json
@@ -13,10 +13,6 @@
             "../"
         ],
         "types": [],
-        "paths": {
-            "mime": ["mime/v1"],
-            "mime/*": ["mime/v1/*"]
-        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
The new versions haven't changed types significantly. The main thing this PR does is make serve-static@1.15 depend on mime@3, compared to serve-static@1.13 which depended on mime@1.

Although the types in the existing code are not quite accurate (the Mime constructor is actually variadic), they aren't different enough to be worth updating.