### PR TITLE
react-imgix: make SrcSetParams props optional

### DIFF
--- a/types/react-imgix/index.d.ts
+++ b/types/react-imgix/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-imgix 9.4
+// Type definitions for react-imgix 9.5
 // Project: https://github.com/imgix/react-imgix
 // Definitions by: Sherwin Heydarbeygi <https://github.com/sherwinski>
 //                 Luis Ball <https://github.com/luqven>
@@ -221,10 +221,10 @@ interface AttributeConfig {
 }
 
 interface SrcSetParams {
-    widths: number[];
-    widthTolerance: number;
-    minWidth: number;
-    maxWidth: number;
+    widths?: number[];
+    widthTolerance?: number;
+    minWidth?: number;
+    maxWidth?: number;
 }
 
 type ImgixHTMLAttributes =

--- a/types/react-imgix/index.d.ts
+++ b/types/react-imgix/index.d.ts
@@ -225,6 +225,7 @@ interface SrcSetParams {
     widthTolerance?: number;
     minWidth?: number;
     maxWidth?: number;
+    devicePixelRatios?: number[];
 }
 
 type ImgixHTMLAttributes =

--- a/types/react-imgix/index.d.ts
+++ b/types/react-imgix/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Sherwin Heydarbeygi <https://github.com/sherwinski>
 //                 Luis Ball <https://github.com/luqven>
 //                 Frederick Fogerty <https://github.com/frederickfogerty>
+//                 Alice Lawrie <https://github.com/atlawrie/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as React from 'react';

--- a/types/react-imgix/react-imgix-tests.tsx
+++ b/types/react-imgix/react-imgix-tests.tsx
@@ -23,6 +23,7 @@ const ImgixTest = () => (
             minWidth: 100,
             maxWidth: 2000,
             widthTolerance: 0.2,
+            devicePixelRatios: [1, 1.5, 2],
         }}
         className="lazyload"
         htmlAttributes={{


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/imgix/react-imgix/blob/main/src/react-imgix.jsx#L50-L55
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Resolves https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/61504