### PR TITLE
feat(node): types for util.parseArgs

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 18.6
+// Type definitions for non-npm package Node.js 18.7
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -200,3 +200,33 @@ access('file/that/does/not/exist', (err) => {
 {
     util.stripVTControlCharacters('\u001B[4mvalue\u001B[0m'); // $ExpectType string
 }
+
+{
+    // tslint:disable-next-line:no-object-literal-type-assertion
+    const config = {
+        allowPositionals: true,
+        options: {
+            foo: { type: 'string' },
+            bar: { type: 'boolean', multiple: true },
+        },
+    } as const;
+
+    // $ExpectType { values: { foo: string | undefined; bar: boolean[] | undefined; }; positionals: string[]; }
+    util.parseArgs(config);
+}
+
+{
+    // tslint:disable-next-line:no-object-literal-type-assertion
+    const config = {
+        tokens: true,
+        allowPositionals: true,
+        options: {
+            foo: { type: 'string' },
+            bar: { type: 'boolean' },
+        },
+    } as const;
+
+    // tslint:disable-next-line:max-line-length
+    // $ExpectType { kind: "positional"; index: number; value: string; } | { kind: "option-terminator"; index: number; } | { kind: "option"; index: number; name: "foo"; rawName: string; value: string; inlineValue: boolean; } | { kind: "option"; index: number; name: "bar"; rawName: string; value: undefined; inlineValue: undefined; }
+    util.parseArgs(config).tokens[0];
+}

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -249,13 +249,11 @@ access('file/that/does/not/exist', (err) => {
 
 {
     // util.parseArgs: strict: false
-    // tslint:disable-next-line:no-object-literal-type-assertion
-    const config = {
-        strict: false,
-    } as const;
 
     // $ExpectType { values: { [longOption: string]: string | boolean | undefined; }; positionals: string[]; }
-    const result = util.parseArgs(config);
+    const result = util.parseArgs({
+        strict: false,
+    });
 }
 
 {

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -202,6 +202,7 @@ access('file/that/does/not/exist', (err) => {
 }
 
 {
+    // util.parseArgs: happy path
     // tslint:disable-next-line:no-object-literal-type-assertion
     const config = {
         allowPositionals: true,
@@ -216,6 +217,21 @@ access('file/that/does/not/exist', (err) => {
 }
 
 {
+    // util.parseArgs: positionals not enabled
+    // tslint:disable-next-line:no-object-literal-type-assertion
+    const config = {
+        options: {
+            foo: { type: 'string' },
+            bar: { type: 'boolean', multiple: true },
+        },
+    } as const;
+
+    // @ts-expect-error
+    util.parseArgs(config).positionals[0];
+}
+
+{
+    // util.parseArgs: tokens
     // tslint:disable-next-line:no-object-literal-type-assertion
     const config = {
         tokens: true,
@@ -229,4 +245,23 @@ access('file/that/does/not/exist', (err) => {
     // tslint:disable-next-line:max-line-length
     // $ExpectType { kind: "positional"; index: number; value: string; } | { kind: "option-terminator"; index: number; } | { kind: "option"; index: number; name: "foo"; rawName: string; value: string; inlineValue: boolean; } | { kind: "option"; index: number; name: "bar"; rawName: string; value: undefined; inlineValue: undefined; }
     util.parseArgs(config).tokens[0];
+}
+
+{
+    // util.parseArgs: strict: false
+    // tslint:disable-next-line:no-object-literal-type-assertion
+    const config = {
+        strict: false,
+    } as const;
+
+    // $ExpectType { values: { [longOption: string]: string | boolean | undefined; }; positionals: string[]; }
+    const result = util.parseArgs(config);
+}
+
+{
+    // util.parseArgs: config not inferred precisely
+    const config = {};
+
+    // $ExpectType { values: { [longOption: string]: string | boolean | (string | boolean)[] | undefined; }; positionals: string[]; tokens?: Token[] | undefined; }
+    const result = util.parseArgs(config);
 }

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -257,6 +257,21 @@ access('file/that/does/not/exist', (err) => {
 }
 
 {
+    // util.parseArgs: strict: false
+
+    const result = util.parseArgs({
+        strict: false,
+        options: {
+            x: { type: 'string', multiple: true },
+        },
+    });
+    // $ExpectType (string | boolean)[] | undefined
+    result.values.x;
+    // $ExpectType string | boolean | undefined
+    result.values.y;
+}
+
+{
     // util.parseArgs: config not inferred precisely
     const config = {};
 

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1291,7 +1291,7 @@ declare module 'util' {
     // So we can't rely on the `"not definitely present" implies "definitely not present"` assumption mentioned above.
     type ParsedResults<T extends ParseArgsConfig> = ParseArgsConfig extends T
         ? {
-              values: { [longOption: string]: undefined | string | boolean | string[] | boolean[] };
+              values: { [longOption: string]: undefined | string | boolean | Array<string | boolean> };
               positionals: string[];
               tokens?: Token[];
           }

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1179,7 +1179,7 @@ declare module 'util' {
         ? IfFalse
         : IfTrue;
 
-    // we put the `extends false` condition first here because `undefined` comparse like `any` when `strictNullChecks: false`
+    // we put the `extends false` condition first here because `undefined` compares like `any` when `strictNullChecks: false`
     type IfDefaultsFalse<T, IfTrue, IfFalse> = T extends false
         ? IfFalse
         : T extends true

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1161,6 +1161,7 @@ declare module 'util' {
         allowPositionals?: boolean;
         tokens?: boolean;
         options?: ParseArgsOptionsConfig;
+        args?: string[];
     }
 
     /*

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1105,6 +1105,214 @@ declare module 'util' {
          */
         encodeInto(src: string, dest: Uint8Array): EncodeIntoResult;
     }
+
+    /**
+     * Provides a high-level API for command-line argument parsing. Takes a
+     * specification for the expected arguments and returns a structured object
+     * with the parsed values and positionals.
+     *
+     * `config` provides arguments for parsing and configures the parser. It
+     * supports the following properties:
+     *
+     *   - `args` The array of argument strings. **Default:** `process.argv` with
+     *     `execPath` and `filename` removed.
+     *   - `options` Arguments known to the parser. Keys of `options` are the long
+     *     names of options and values are objects accepting the following properties:
+     *
+     *     - `type` Type of argument, which must be either `boolean` (for options
+     *        which do not take values) or `string` (for options which do).
+     *     - `multiple` Whether this option can be provided multiple
+     *       times. If `true`, all values will be collected in an array. If
+     *       `false`, values for the option are last-wins. **Default:** `false`.
+     *     - `short` A single character alias for the option.
+     *
+     *   - `strict`: Whether an error should be thrown when unknown arguments
+     *     are encountered, or when arguments are passed that do not match the
+     *     `type` configured in `options`. **Default:** `true`.
+     *   - `allowPositionals`: Whether this command accepts positional arguments.
+     *     **Default:** `false` if `strict` is `true`, otherwise `true`.
+     *   - `tokens`: Whether tokens {boolean} Return the parsed tokens. This is useful
+     *     for extending the built-in behavior, from adding additional checks through
+     *     to reprocessing the tokens in different ways.
+     *     **Default:** `false`.
+     *
+     * @returns The parsed command line arguments:
+     *
+     *   - `values` A mapping of parsed option names with their string
+     *     or boolean values.
+     *   - `positionals` Positional arguments.
+     *   - `tokens` Detailed parse information (only if `tokens` was specified).
+     *
+     */
+    export function parseArgs<T extends Exact<ParseArgsConfig, T>>(config: T): ParsedResults<T>;
+
+    interface ParseArgsOptionConfig {
+        type: 'string' | 'boolean';
+        short?: string;
+        multiple?: boolean;
+    }
+
+    interface ParseArgsOptionsConfig {
+        [longOption: string]: ParseArgsOptionConfig;
+    }
+
+    interface ParseArgsConfig {
+        strict?: boolean;
+        allowPositionals?: boolean;
+        tokens?: boolean;
+        options?: ParseArgsOptionsConfig;
+    }
+
+    /*
+    IfDefaultsTrue and IfDefaultsFalse are helpers to handle default values for missing boolean properties.
+    TypeScript does not have exact types for objects: https://github.com/microsoft/TypeScript/issues/12936
+    This means it is impossible to distinguish between "field X is definitely not present" and "field X may or may not be present".
+    But we expect users to generally provide their config inline or `as const`, which means TS will always know whether a given field is present.
+    So this helper treats "not definitely present" (i.e., not `extends boolean`) as being "definitely not present", i.e. it should have its default value.
+    This is technically incorrect but is a much nicer UX for the common case.
+    The IfDefaultsTrue version is for things which default to true; the IfDefaultsFalse version is for things which default to false.
+    They differ only in the final item of the if-else chain.
+    */
+    type IfDefaultsTrue<T, IfTrue, IfFalse> = T extends true
+        ? IfTrue
+        : T extends false
+        ? IfFalse
+        : T extends boolean
+        ? IfTrue | IfFalse
+        : IfTrue;
+
+    type IfDefaultsFalse<T, IfTrue, IfFalse> = T extends true
+        ? IfTrue
+        : T extends false
+        ? IfFalse
+        : T extends boolean
+        ? IfTrue | IfFalse
+        : IfFalse;
+
+    type ExtractOptionValue<T extends ParseArgsConfig, O extends ParseArgsOptionConfig> = IfDefaultsTrue<
+        T['strict'],
+        O['type'] extends 'string' ? string : O['type'] extends 'boolean' ? boolean : string | boolean,
+        string | boolean
+    >;
+
+    type ParsedValues<T extends ParseArgsConfig> = (T['options'] extends ParseArgsOptionsConfig
+        ? {
+              [LongOption in keyof T['options']]: IfDefaultsFalse<
+                  T['options'][LongOption]['multiple'],
+                  undefined | Array<ExtractOptionValue<T, T['options'][LongOption]>>,
+                  undefined | ExtractOptionValue<T, T['options'][LongOption]>
+              >;
+          }
+        : {}) &
+        IfDefaultsTrue<T['strict'], unknown, { [longOption: string]: undefined | string | boolean }>;
+
+    type ParsedPositionals<T extends ParseArgsConfig> = IfDefaultsTrue<
+        T['strict'],
+        IfDefaultsFalse<T['allowPositionals'], string[], []>,
+        IfDefaultsTrue<T['allowPositionals'], string[], []>
+    >;
+
+    type RawNameForOption<LongName extends string, O extends ParseArgsOptionConfig> =
+        | `--${LongName}`
+        | (O['short'] extends string ? `-${O['short']}` : never);
+
+    type PreciseTokenForOptions<
+        T extends ParseArgsConfig,
+        K extends keyof T['options'] & string,
+        O extends ParseArgsOptionConfig,
+    > = O['type'] extends 'string'
+        ? {
+              kind: 'option';
+              index: number;
+              name: K;
+              rawName: RawNameForOption<K, O>;
+              value: string;
+              inlineValue: boolean;
+          }
+        : O['type'] extends 'boolean'
+        ? {
+              kind: 'option';
+              index: number;
+              name: K;
+              rawName: RawNameForOption<K, O>;
+              value: undefined;
+              inlineValue: undefined;
+          }
+        : OptionToken & { name: K; rawName: RawNameForOption<K, O> };
+
+    type TokenForOptions<
+        T extends ParseArgsConfig,
+        K extends keyof T['options'] = keyof T['options'],
+    > = K extends unknown
+        ? T['options'] extends ParseArgsOptionsConfig
+            ? PreciseTokenForOptions<T, K & string, T['options'][K]>
+            : OptionToken
+        : never;
+
+    type ParsedOptionsToken<T extends ParseArgsConfig> = IfDefaultsTrue<T['strict'], TokenForOptions<T>, OptionToken>;
+
+    type ParsedPositionalToken<T extends ParseArgsConfig> = IfDefaultsTrue<
+        T['strict'],
+        IfDefaultsFalse<T['allowPositionals'], { kind: 'positional'; index: number; value: string }, never>,
+        IfDefaultsTrue<T['allowPositionals'], { kind: 'positional'; index: number; value: string }, never>
+    >;
+
+    type ParsedTokens<T extends ParseArgsConfig> = Array<
+        ParsedOptionsToken<T> | ParsedPositionalToken<T> | { kind: 'option-terminator'; index: number }
+    >;
+
+    type PreciseParsedResults<T extends ParseArgsConfig> = IfDefaultsFalse<
+        T['tokens'],
+        {
+            values: ParsedValues<T>;
+            positionals: ParsedPositionals<T>;
+            tokens: ParsedTokens<T>;
+        },
+        {
+            values: ParsedValues<T>;
+            positionals: ParsedPositionals<T>;
+        }
+    >;
+
+    type OptionToken =
+        | { kind: 'option'; index: number; name: string; rawName: `-${string}`; value: string; inlineValue: boolean }
+        | {
+              kind: 'option';
+              index: number;
+              name: string;
+              rawName: `-${string}`;
+              value: undefined;
+              inlineValue: undefined;
+          };
+
+    type Token =
+        | OptionToken
+        | { kind: 'positional'; index: number; value: string }
+        | { kind: 'option-terminator'; index: number };
+
+    // If ParseArgsConfig extends T, then the user passed config constructed elsewhere.
+    // So we can't rely on the `"not definitely present" implies "definitely not present"` assumption mentioned above.
+    type ParsedResults<T extends ParseArgsConfig> = ParseArgsConfig extends T
+        ? {
+              values: { [longOption: string]: undefined | string | boolean | string[] | boolean[] };
+              positionals: string[];
+              tokens?: Token[];
+          }
+        : PreciseParsedResults<T>;
+
+    type ParseArgs<T extends Exact<ParseArgsConfig, T>> = ParsedResults<T>;
+
+    type Primitive = null | undefined | string | number | boolean | symbol | bigint;
+
+    type KeysOfUnion<T> = T extends T ? keyof T : never;
+
+    // https://github.com/sindresorhus/type-fest/blob/dfaba0eb253a2d291d45924905643b013b6409aa/source/exact.d.ts#L34
+    type Exact<ParameterType, InputType extends ParameterType> = ParameterType extends Primitive
+        ? ParameterType
+        : { [Key in keyof ParameterType]: Exact<ParameterType[Key], InputType[Key]> } & Record<
+              Exclude<keyof InputType, KeysOfUnion<ParameterType>>,
+              never
+          >;
 }
 declare module 'util/types' {
     export * from 'util/types';

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1212,10 +1212,6 @@ declare module 'util' {
         IfDefaultsTrue<T['allowPositionals'], string[], []>
     >;
 
-    type RawNameForOption<LongName extends string, O extends ParseArgsOptionConfig> =
-        | `--${LongName}`
-        | (O['short'] extends string ? `-${O['short']}` : never);
-
     type PreciseTokenForOptions<
         T extends ParseArgsConfig,
         K extends keyof T['options'] & string,
@@ -1225,7 +1221,7 @@ declare module 'util' {
               kind: 'option';
               index: number;
               name: K;
-              rawName: RawNameForOption<K, O>;
+              rawName: string;
               value: string;
               inlineValue: boolean;
           }
@@ -1234,11 +1230,11 @@ declare module 'util' {
               kind: 'option';
               index: number;
               name: K;
-              rawName: RawNameForOption<K, O>;
+              rawName: string;
               value: undefined;
               inlineValue: undefined;
           }
-        : OptionToken & { name: K; rawName: RawNameForOption<K, O> };
+        : OptionToken & { name: K };
 
     type TokenForOptions<
         T extends ParseArgsConfig,
@@ -1275,12 +1271,12 @@ declare module 'util' {
     >;
 
     type OptionToken =
-        | { kind: 'option'; index: number; name: string; rawName: `-${string}`; value: string; inlineValue: boolean }
+        | { kind: 'option'; index: number; name: string; rawName: string; value: string; inlineValue: boolean }
         | {
               kind: 'option';
               index: number;
               name: string;
-              rawName: `-${string}`;
+              rawName: string;
               value: undefined;
               inlineValue: undefined;
           };

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1246,7 +1246,7 @@ declare module 'util' {
             : OptionToken
         : never;
 
-    type ParsedOptionsToken<T extends ParseArgsConfig> = IfDefaultsTrue<T['strict'], TokenForOptions<T>, OptionToken>;
+    type ParsedOptionToken<T extends ParseArgsConfig> = IfDefaultsTrue<T['strict'], TokenForOptions<T>, OptionToken>;
 
     type ParsedPositionalToken<T extends ParseArgsConfig> = IfDefaultsTrue<
         T['strict'],
@@ -1255,7 +1255,7 @@ declare module 'util' {
     >;
 
     type ParsedTokens<T extends ParseArgsConfig> = Array<
-        ParsedOptionsToken<T> | ParsedPositionalToken<T> | { kind: 'option-terminator'; index: number }
+        ParsedOptionToken<T> | ParsedPositionalToken<T> | { kind: 'option-terminator'; index: number }
     >;
 
     type PreciseParsedResults<T extends ParseArgsConfig> = IfDefaultsFalse<

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1197,7 +1197,7 @@ declare module 'util' {
 
     type ParsedValues<T extends ParseArgsConfig> = (T['options'] extends ParseArgsOptionsConfig
         ? {
-              [LongOption in keyof T['options']]: IfDefaultsFalse<
+              -readonly [LongOption in keyof T['options']]: IfDefaultsFalse<
                   T['options'][LongOption]['multiple'],
                   undefined | Array<ExtractOptionValue<T, T['options'][LongOption]>>,
                   undefined | ExtractOptionValue<T, T['options'][LongOption]>

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1144,7 +1144,7 @@ declare module 'util' {
      *   - `tokens` Detailed parse information (only if `tokens` was specified).
      *
      */
-    export function parseArgs<T extends Exact<ParseArgsConfig, T>>(config: T): ParsedResults<T>;
+    export function parseArgs<T extends ParseArgsConfig>(config: T): ParsedResults<T>;
 
     interface ParseArgsOptionConfig {
         type: 'string' | 'boolean';
@@ -1296,20 +1296,6 @@ declare module 'util' {
               tokens?: Token[];
           }
         : PreciseParsedResults<T>;
-
-    type ParseArgs<T extends Exact<ParseArgsConfig, T>> = ParsedResults<T>;
-
-    type Primitive = null | undefined | string | number | boolean | symbol | bigint;
-
-    type KeysOfUnion<T> = T extends T ? keyof T : never;
-
-    // https://github.com/sindresorhus/type-fest/blob/dfaba0eb253a2d291d45924905643b013b6409aa/source/exact.d.ts#L34
-    type Exact<ParameterType, InputType extends ParameterType> = ParameterType extends Primitive
-        ? ParameterType
-        : { [Key in keyof ParameterType]: Exact<ParameterType[Key], InputType[Key]> } & Record<
-              Exclude<keyof InputType, KeysOfUnion<ParameterType>>,
-              never
-          >;
 }
 declare module 'util/types' {
     export * from 'util/types';

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1156,7 +1156,7 @@ declare module 'util' {
         [longOption: string]: ParseArgsOptionConfig;
     }
 
-    interface ParseArgsConfig {
+    export interface ParseArgsConfig {
         strict?: boolean;
         allowPositionals?: boolean;
         tokens?: boolean;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/pull/42675 / https://github.com/nodejs/node/pull/43459
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

(actually there's [a few other additions in 18.7](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.7.0), but I didn't feel up to adding those in this PR.

---

This PR has a lot of type-level logic used to get actually useful types from the new API. I don't know what this project's policy on those is. You can read the thread where we iterated on these at https://github.com/pkgjs/parseargs/issues/127.