### PR TITLE
[mp4frag] Move interfaces into a namespace for exporting

### DIFF
--- a/types/mp4frag/index.d.ts
+++ b/types/mp4frag/index.d.ts
@@ -7,68 +7,68 @@
 import { Transform } from 'stream';
 import 'node/buffer';
 
-export = Mp4Frag;
-
-/**
- * An SegmentObject.
- *
- * An object with values
- * <code>
- * {
- *     segment: null,
- *     sequence: -1,
- *     duration: -1;
- *     timestamp: -1,
- *     keyframe: true
- * }
- * </code
- * is returned in erroneous conditions (before a segment has been generated, etc. Refer to individual function docs.
- */
-interface SegmentObject {
-    segment?: Buffer;
-    sequence: number;
-    duration: number;
-    timestamp: number;
-    keyframe: boolean;
-}
-
-interface Mp4FragOptions {
+declare namespace Mp4Frag {
     /**
-     * Base name of files in m3u8 playlist. Affects the generated m3u8 playlist by naming file fragments.
+     * A SegmentObject.
      *
-     * Must be set to generate m3u8 playlist. e.g. 'front_door'
+     * An object with values
+     * <code>
+     * {
+     *     segment: null,
+     *     sequence: -1,
+     *     duration: -1;
+     *     timestamp: -1,
+     *     keyframe: true
+     * }
+     * </code
+     * is returned in erroneous conditions (before a segment has been generated, etc. Refer to individual function docs.
      */
-    hlsPlaylistBase?: string;
+    interface SegmentObject {
+        segment?: Buffer;
+        sequence: number;
+        duration: number;
+        timestamp: number;
+        keyframe: boolean;
+    }
 
-    /**
-     * Number of segments to use in m3u8 playlist. Must be an integer ranging from 2 to 20.
-     *
-     * Defaults to 4.
-     */
-    hlsPlaylistSize?: number;
+    interface Mp4FragOptions {
+        /**
+         * Base name of files in m3u8 playlist. Affects the generated m3u8 playlist by naming file fragments.
+         *
+         * Must be set to generate m3u8 playlist. e.g. 'front_door'
+         */
+        hlsPlaylistBase?: string;
 
-    /**
-     * Number of extra segments to keep in memory. Must be an integer ranging from 0 to 10.
-     *
-     * Defaults to 0.
-     */
-    hlsPlaylistExtra?: number;
+        /**
+         * Number of segments to use in m3u8 playlist. Must be an integer ranging from 2 to 20.
+         *
+         * Defaults to 4.
+         */
+        hlsPlaylistSize?: number;
 
-    /**
-     * Indicates that m3u8 playlist should be generated after [initialization]{@link Mp4Frag#initialization}
-     * is created and before media segments are created.
-     *
-     * Defaults to true.
-     */
-    hlsPlaylistInit?: boolean;
+        /**
+         * Number of extra segments to keep in memory. Must be an integer ranging from 0 to 10.
+         *
+         * Defaults to 0.
+         */
+        hlsPlaylistExtra?: number;
 
-    /**
-     * Number of segments to keep in memory. Has no effect if using options.hlsPlaylistBase.
-     * Must be an integer ranging from 2 to 30.
-     *
-     * Defaults to 2.
-     */
-    segmentCount?: number;
+        /**
+         * Indicates that m3u8 playlist should be generated after [initialization]{@link Mp4Frag#initialization}
+         * is created and before media segments are created.
+         *
+         * Defaults to true.
+         */
+        hlsPlaylistInit?: boolean;
+
+        /**
+         * Number of segments to keep in memory. Has no effect if using options.hlsPlaylistBase.
+         * Must be an integer ranging from 2 to 30.
+         *
+         * Defaults to 2.
+         */
+        segmentCount?: number;
+    }
 }
 
 declare class Mp4Frag extends Transform {
@@ -77,7 +77,7 @@ declare class Mp4Frag extends Transform {
      *
      * @throws If options.hlsPlaylistBase contains characters other than letters(a-zA-Z) and underscores(_).
      */
-    constructor(options?: Mp4FragOptions);
+    constructor(options?: Mp4Frag.Mp4FragOptions);
 
     /**
      * Returns the audio codec information as a <b>string</b>.
@@ -113,7 +113,7 @@ declare class Mp4Frag extends Transform {
      * Returns <b>{segment: null, sequence: -1, duration: -1; timestamp: -1, keyframe: true}</b> if requested before
      * first [segment event]{@link Mp4Frag#event:segment}.
      */
-    get segmentObject(): SegmentObject;
+    get segmentObject(): Mp4Frag.SegmentObject;
 
     /**
      * Returns the timestamp of the latest [SegmentObject]{@link SegmentObject} as an <b>Integer</b>(<i>milliseconds</i>).
@@ -168,16 +168,18 @@ declare class Mp4Frag extends Transform {
      * Returns an array of [SegmentObject]{@link SegmentObject}
      * Returns <b>null</b> if requested before first [segment event]{@link Mp4Frag#event:segment}.
      */
-    get segmentObjects(): SegmentObject[] | null;
+    get segmentObjects(): Mp4Frag.SegmentObject[] | null;
 
     /**
      * - Returns the [SegmentObject]{@link SegmentObject} that corresponds to the sequence number.
      * - Returns <b>null</b> if there is no segment that corresponds to sequence number.
      */
-    getSegmentObject(sequence: number | string): SegmentObject | null;
+    getSegmentObject(sequence: number | string): Mp4Frag.SegmentObject | null;
 
     /**
      * Clear cached values
      */
     resetCache(): void;
 }
+
+export = Mp4Frag;

--- a/types/mp4frag/mp4frag-tests.ts
+++ b/types/mp4frag/mp4frag-tests.ts
@@ -69,3 +69,21 @@ m4f.getSegmentObject(null);
 
 // $ExpectType void
 m4f.resetCache();
+
+// $ExpectType SegmentObject
+const segmentObject = {
+    segment: Buffer.of(1, 2, 3),
+    sequence: -1,
+    duration: -1,
+    timestamp: -1,
+    keyframe: true,
+} as unknown as Mp4Frag.SegmentObject;
+
+// $ExpectType Mp4FragOptions
+const mp4FragOptions = {
+    hlsPlaylistBase: 'abc',
+    hlsPlaylistSize: 1,
+    hlsPlaylistExtra: 1,
+    hlsPlaylistInit: true,
+    segmentCount: 1,
+} as unknown as Mp4Frag.Mp4FragOptions;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Mp4FragOptions](https://github.com/kevinGodell/mp4frag/blob/master/index.js#L47-L56) & [SegmentObject](https://github.com/kevinGodell/mp4frag/blob/master/index.js#L271-L286)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This PR allows the use of `SegmentObject` and `Mp4FragOptions` types outside the type declarations themselves. This makes sense since those two interfaces are used to interact with the `Mp4Frag` class.

Thank you for looking!