### PR TITLE
fix(hexo-util): add 4th arg `escape` to `htmlTag()`

### DIFF
--- a/types/hexo-util/hexo-util-tests.ts
+++ b/types/hexo-util/hexo-util-tests.ts
@@ -151,6 +151,7 @@ string = htmlTag('img', {
     height: 300
 });
 string = htmlTag('a', { href: 'http://zespia.tw' }, 'My blog');
+string = htmlTag('ul', {}, '<li>Hello!</il>', false);
 
 {
     const pattern = new Pattern('posts/:id');

--- a/types/hexo-util/index.d.ts
+++ b/types/hexo-util/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for hexo-util 0.6
 // Project: https://hexo.io/
 // Definitions by: sega yuu <https://github.com/segayuu>
+//                 KentarouTakeda <https://github.com/KentarouTakeda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -38,7 +39,7 @@ export function highlight(str: string, options?: {
     autoDetect?: boolean | undefined;
 }): string;
 
-export function htmlTag(tag: string, attrs?: string[] | ArrayLike<string> | { [x: string]: any }, text?: string | null): string;
+export function htmlTag(tag: string, attrs?: string[] | ArrayLike<string> | { [x: string]: any }, text?: string | null, escape?: boolean): string;
 
 export interface Pattern<T> {
     test(str: string): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  https://github.com/hexojs/hexo-util#htmltagtag-attrs-text-escape
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
