### PR TITLE
Switch three's recent changes to use @ts-expect-error

### DIFF
--- a/types/three/test/core/core-eventDispatcher.ts
+++ b/types/three/test/core/core-eventDispatcher.ts
@@ -26,17 +26,18 @@ eveDisForTestEvent.addEventListener('foo', e => {
 
     // NOTE: Error in ts lower than 3.9. The minimum typescript version cannot be raised from 3.6 because of the dependency from aframe.
     // e.foo; // $ExpectType number
-    e.bar; // $ExpectError
+    // @ts-expect-error
+    e.bar;
 });
 // call addEventListener with an invalid event
-// $ExpectError
+// @ts-expect-error
 eveDisForTestEvent.addEventListener('baz', () => {});
 
 eveDisForTestEvent.dispatchEvent({ type: 'foo', foo: 42 });
 // call dispatchEvent with an invalid event
-// $ExpectError
+// @ts-expect-error
 eveDisForTestEvent.dispatchEvent({ type: 'foo', foo: '42' });
-// $ExpectError
+// @ts-expect-error
 eveDisForTestEvent.dispatchEvent({ type: 'foo', bar: '42' });
 
 eveDisForTestEvent.removeEventListener('bar', () => {});


### PR DESCRIPTION
The PR #61490 is only 4 days old, but most of its commits predate the deprecation of $ExpectError