### PR TITLE
@ember/owner: introduce new Ember public types

### DIFF
--- a/types/ember__engine/-private/container-proxy-mixin.d.ts
+++ b/types/ember__engine/-private/container-proxy-mixin.d.ts
@@ -1,22 +1,15 @@
+import Owner from '@ember/owner';
 import Mixin from '@ember/object/mixin';
 
 /**
  * Given a fullName return a factory manager.
  */
-interface ContainerProxyMixin {
+interface ContainerProxyMixin extends Owner {
     /**
      * Returns an object that can be used to provide an owner to a
      * manually created instance.
      */
     ownerInjection(): {};
-    /**
-     * Given a fullName return a corresponding instance.
-     */
-    lookup(fullName: string, options?: {}): unknown;
-    /**
-     * Given a fullName return a corresponding factory.
-     */
-    factoryFor(fullName: string, options?: {}): unknown;
 }
 declare const ContainerProxyMixin: Mixin<ContainerProxyMixin>;
 export default ContainerProxyMixin;

--- a/types/ember__engine/-private/registry-proxy-mixin.d.ts
+++ b/types/ember__engine/-private/registry-proxy-mixin.d.ts
@@ -1,20 +1,15 @@
+import Owner from '@ember/owner';
 import Mixin from '@ember/object/mixin';
 
 /**
  * RegistryProxyMixin is used to provide public access to specific
  * registry functionality.
  */
-interface RegistryProxyMixin {
+interface RegistryProxyMixin extends Owner {
     /**
      * Given a fullName return the corresponding factory.
      */
     resolveRegistration(fullName: string): unknown;
-    /**
-     * Registers a factory or value that can be used for dependency injection (with
-     * `inject`) or for service lookup. Each factory is registered with
-     * a full name including two parts: `type:name`.
-     */
-    register(fullName: string, factory: unknown, options?: { singleton?: boolean | undefined; instantiate?: boolean | undefined }): unknown;
     /**
      * Unregister a factory.
      */

--- a/types/ember__engine/instance.d.ts
+++ b/types/ember__engine/instance.d.ts
@@ -6,10 +6,7 @@ import EmberObject from "@ember/object";
  * The `EngineInstance` encapsulates all of the stateful aspects of a
  * running `Engine`.
  */
-export default class EngineInstance extends EmberObject.extend(
-    RegistryProxyMixin,
-    ContainerProxyMixin
-) {
+export default class EngineInstance extends EmberObject {
     /**
      * Unregister a factory.
      */
@@ -21,3 +18,5 @@ export default class EngineInstance extends EmberObject.extend(
      */
     boot(): Promise<EngineInstance>;
 }
+
+export default interface EngineInstance extends RegistryProxyMixin, ContainerProxyMixin {}

--- a/types/ember__owner/ember__owner-tests.ts
+++ b/types/ember__owner/ember__owner-tests.ts
@@ -1,0 +1,80 @@
+import Owner, { Factory, FactoryManager, RegisterOptions } from '@ember/owner';
+
+// Just a class we can construct in the Factory and FactoryManager tests
+declare class ConstructThis {
+    hasProps: boolean;
+}
+
+// And a POJO, since `Factory(Manager)` don't have to deal in actual classes
+const Creatable = {
+    hasProps: true,
+};
+
+// ----- RegisterOptions ----- //
+declare let regOptionsA: RegisterOptions;
+regOptionsA.instantiate; // $ExpectType boolean | undefined
+regOptionsA.singleton; // $ExpectType boolean | undefined
+
+// ----- Factory ----- //
+// This gives us coverage for the cases where you are *casting*.
+declare let aFactory: Factory<ConstructThis, typeof ConstructThis>;
+aFactory.class; // $ExpectType typeof ConstructThis
+new aFactory.class(); // $ExpectType ConstructThis
+aFactory.create();
+aFactory.create({});
+aFactory.create({
+    hasProps: true,
+});
+aFactory.create({
+    hasProps: false,
+});
+
+// These should be rejected by way of EPC
+aFactory.create({ unrelatedNonsense: 'yep yep yep' }); // $ExpectError
+aFactory.create({ hasProps: true, unrelatedNonsense: 'yep yep yep' }); // $ExpectError
+
+// But this should be legal.
+const goodPojo = { hasProps: true, unrelatedNonsense: 'also true' };
+aFactory.create(goodPojo);
+
+// while this should be rejected for *type error* reasons, not EPC
+const badPojo = { hasProps: 'huzzah', unrelatedNonsense: 'also true' };
+aFactory.create(badPojo); // $ExpectError
+
+// ----- FactoryManager ----- //
+declare let aFactoryManager: FactoryManager<ConstructThis, typeof ConstructThis>;
+aFactoryManager.class; // $ExpectType Factory<ConstructThis, typeof ConstructThis>
+aFactoryManager.create({}); // $ExpectType ConstructThis
+aFactoryManager.create({ hasProps: true }); // $ExpectType ConstructThis
+aFactoryManager.create({ hasProps: false }); // $ExpectType ConstructThis
+aFactoryManager.create({ otherStuff: 'nope' }); // $ExpectError
+aFactoryManager.create({ hasProps: true, otherStuff: 'nope' }); // $ExpectError
+aFactoryManager.create(goodPojo); // $ExpectType ConstructThis
+aFactoryManager.create(badPojo); // $ExpectError
+
+// This one is last so it can reuse the bits from above!
+// ----- Owner ----- //
+declare let owner: Owner;
+
+owner.lookup(); // $ExpectError
+owner.lookup('type:name'); // $ExpectType unknown
+owner.lookup('non-namespace-string'); // $ExpectError
+
+owner.register('type:name', aFactory); // $ExpectType void
+owner.register('type:name', aFactory, {}); // $ExpectType void
+owner.register('type:name', aFactory, { instantiate: true }); // $ExpectType void
+owner.register('type:name', aFactory, { instantiate: false }); // $ExpectType void
+owner.register('type:name', aFactory, { singleton: true }); // $ExpectType void
+owner.register('type:name', aFactory, { singleton: false }); // $ExpectType void
+owner.register('type:name', aFactory, { instantiate: true, singleton: true }); // $ExpectType void
+owner.register('type:name', aFactory, { instantiate: true, singleton: false }); // $ExpectType void
+owner.register('type:name', aFactory, { instantiate: false, singleton: true }); // $ExpectType void
+owner.register('type:name', aFactory, { instantiate: false, singleton: false }); // $ExpectType void
+owner.register('non-namespace-string', aFactory); // $ExpectError
+
+owner.factoryFor('type:name'); // $ExpectType FactoryManager<unknown, object> | undefined
+owner.factoryFor('type:name')?.class; // $ExpectType Factory<unknown, object> | undefined
+owner.factoryFor('type:name')?.create(); // $ExpectType unknown
+owner.factoryFor('type:name')?.create({}); // $ExpectType unknown
+owner.factoryFor('type:name')?.create({ anythingGoes: true }); // $ExpectType unknown
+owner.factoryFor('non-namespace-string'); // $ExpectError

--- a/types/ember__owner/ember__owner-tests.ts
+++ b/types/ember__owner/ember__owner-tests.ts
@@ -1,4 +1,4 @@
-import Owner, { Factory, FactoryManager, RegisterOptions } from '@ember/owner';
+import Owner, { Factory, FactoryManager, FullName, RegisterOptions } from '@ember/owner';
 
 // Just a class we can construct in the Factory and FactoryManager tests
 declare class ConstructThis {
@@ -88,3 +88,24 @@ owner.factoryFor('type:name')?.create({}); // $ExpectType unknown
 owner.factoryFor('type:name')?.create({ anythingGoes: true }); // $ExpectType unknown
 // @ts-expect-error
 owner.factoryFor('non-namespace-string');
+
+// Tests deal with the fact that string literals are a special case! `let`
+// bindings will accordingly not "just work" as a result.
+let aName = 'type:name';
+// @ts-expect-error
+owner.lookup(aName);
+
+let aTypedName: FullName = 'type:name';
+owner.lookup(aTypedName); // $ExpectType unknown
+
+// Nor will callbacks work "out of the box". But they can work if they have the
+// correct type.
+declare let justStrings: Array<string>;
+// @ts-expect-error
+justStrings.map(aString => owner.lookup(aString));
+declare let typedStrings: Array<FullName>;
+typedStrings.map(aString => owner.lookup(aString));
+
+// Also make sure it keeps working with const bindings
+const aConstName = 'type:name';
+owner.lookup(aConstName); // $ExpectType unknown

--- a/types/ember__owner/ember__owner-tests.ts
+++ b/types/ember__owner/ember__owner-tests.ts
@@ -30,8 +30,10 @@ aFactory.create({
 });
 
 // These should be rejected by way of EPC
-aFactory.create({ unrelatedNonsense: 'yep yep yep' }); // $ExpectError
-aFactory.create({ hasProps: true, unrelatedNonsense: 'yep yep yep' }); // $ExpectError
+// @ts-expect-error
+aFactory.create({ unrelatedNonsense: 'yep yep yep' });
+// @ts-expect-error
+aFactory.create({ hasProps: true, unrelatedNonsense: 'yep yep yep' });
 
 // But this should be legal.
 const goodPojo = { hasProps: true, unrelatedNonsense: 'also true' };
@@ -39,7 +41,8 @@ aFactory.create(goodPojo);
 
 // while this should be rejected for *type error* reasons, not EPC
 const badPojo = { hasProps: 'huzzah', unrelatedNonsense: 'also true' };
-aFactory.create(badPojo); // $ExpectError
+// @ts-expect-error
+aFactory.create(badPojo);
 
 // ----- FactoryManager ----- //
 declare let aFactoryManager: FactoryManager<ConstructThis, typeof ConstructThis>;
@@ -47,18 +50,23 @@ aFactoryManager.class; // $ExpectType Factory<ConstructThis, typeof ConstructThi
 aFactoryManager.create({}); // $ExpectType ConstructThis
 aFactoryManager.create({ hasProps: true }); // $ExpectType ConstructThis
 aFactoryManager.create({ hasProps: false }); // $ExpectType ConstructThis
-aFactoryManager.create({ otherStuff: 'nope' }); // $ExpectError
-aFactoryManager.create({ hasProps: true, otherStuff: 'nope' }); // $ExpectError
+// @ts-expect-error
+aFactoryManager.create({ otherStuff: 'nope' });
+// @ts-expect-error
+aFactoryManager.create({ hasProps: true, otherStuff: 'nope' });
 aFactoryManager.create(goodPojo); // $ExpectType ConstructThis
-aFactoryManager.create(badPojo); // $ExpectError
+// @ts-expect-error
+aFactoryManager.create(badPojo);
 
 // This one is last so it can reuse the bits from above!
 // ----- Owner ----- //
 declare let owner: Owner;
 
-owner.lookup(); // $ExpectError
+// @ts-expect-error
+owner.lookup();
 owner.lookup('type:name'); // $ExpectType unknown
-owner.lookup('non-namespace-string'); // $ExpectError
+// @ts-expect-error
+owner.lookup('non-namespace-string');
 
 owner.register('type:name', aFactory); // $ExpectType void
 owner.register('type:name', aFactory, {}); // $ExpectType void
@@ -70,11 +78,13 @@ owner.register('type:name', aFactory, { instantiate: true, singleton: true }); /
 owner.register('type:name', aFactory, { instantiate: true, singleton: false }); // $ExpectType void
 owner.register('type:name', aFactory, { instantiate: false, singleton: true }); // $ExpectType void
 owner.register('type:name', aFactory, { instantiate: false, singleton: false }); // $ExpectType void
-owner.register('non-namespace-string', aFactory); // $ExpectError
+// @ts-expect-error
+owner.register('non-namespace-string', aFactory);
 
 owner.factoryFor('type:name'); // $ExpectType FactoryManager<unknown, object> | undefined
 owner.factoryFor('type:name')?.class; // $ExpectType Factory<unknown, object> | undefined
 owner.factoryFor('type:name')?.create(); // $ExpectType unknown
 owner.factoryFor('type:name')?.create({}); // $ExpectType unknown
 owner.factoryFor('type:name')?.create({ anythingGoes: true }); // $ExpectType unknown
-owner.factoryFor('non-namespace-string'); // $ExpectError
+// @ts-expect-error
+owner.factoryFor('non-namespace-string');

--- a/types/ember__owner/ember__owner-tests.ts
+++ b/types/ember__owner/ember__owner-tests.ts
@@ -62,6 +62,7 @@ owner.lookup();
 owner.lookup('type:name'); // $ExpectType unknown
 // @ts-expect-error
 owner.lookup('non-namespace-string');
+owner.lookup('namespace@type:name'); // $ExpectType unknown
 
 owner.register('type:name', aFactory); // $ExpectType void
 owner.register('type:name', aFactory, {}); // $ExpectType void
@@ -75,6 +76,7 @@ owner.register('type:name', aFactory, { instantiate: false, singleton: true }); 
 owner.register('type:name', aFactory, { instantiate: false, singleton: false }); // $ExpectType void
 // @ts-expect-error
 owner.register('non-namespace-string', aFactory);
+owner.register('namespace@type:name', aFactory); // $ExpectType void
 
 owner.factoryFor('type:name'); // $ExpectType FactoryManager<unknown, object> | undefined
 owner.factoryFor('type:name')?.class; // $ExpectType Factory<unknown, object> | undefined
@@ -83,6 +85,7 @@ owner.factoryFor('type:name')?.create({}); // $ExpectType unknown
 owner.factoryFor('type:name')?.create({ anythingGoes: true }); // $ExpectType unknown
 // @ts-expect-error
 owner.factoryFor('non-namespace-string');
+owner.factoryFor('namespace@type:name'); // $ExpectType FactoryManager<unknown, object> | undefined
 
 // Tests deal with the fact that string literals are a special case! `let`
 // bindings will accordingly not "just work" as a result. The separate

--- a/types/ember__owner/ember__owner-tests.ts
+++ b/types/ember__owner/ember__owner-tests.ts
@@ -12,9 +12,8 @@ regOptionsA.singleton; // $ExpectType boolean | undefined
 
 // ----- Factory ----- //
 // This gives us coverage for the cases where you are *casting*.
-declare let aFactory: Factory<ConstructThis, typeof ConstructThis>;
-aFactory.class; // $ExpectType typeof ConstructThis
-new aFactory.class(); // $ExpectType ConstructThis
+declare let aFactory: Factory<ConstructThis>;
+
 aFactory.create();
 aFactory.create({});
 aFactory.create({
@@ -40,8 +39,8 @@ const badPojo = { hasProps: 'huzzah', unrelatedNonsense: 'also true' };
 aFactory.create(badPojo);
 
 // ----- FactoryManager ----- //
-declare let aFactoryManager: FactoryManager<ConstructThis, typeof ConstructThis>;
-aFactoryManager.class; // $ExpectType Factory<ConstructThis, typeof ConstructThis>
+declare let aFactoryManager: FactoryManager<ConstructThis>;
+aFactoryManager.class; // $ExpectType Factory<ConstructThis>
 aFactoryManager.create({}); // $ExpectType ConstructThis
 aFactoryManager.create({ hasProps: true }); // $ExpectType ConstructThis
 aFactoryManager.create({ hasProps: false }); // $ExpectType ConstructThis
@@ -78,14 +77,14 @@ owner.register('type:name', aFactory, { instantiate: false, singleton: false });
 owner.register('non-namespace-string', aFactory);
 owner.register('namespace@type:name', aFactory); // $ExpectType void
 
-owner.factoryFor('type:name'); // $ExpectType FactoryManager<unknown, object> | undefined
-owner.factoryFor('type:name')?.class; // $ExpectType Factory<unknown, object> | undefined
+owner.factoryFor('type:name'); // $ExpectType FactoryManager<unknown> | undefined
+owner.factoryFor('type:name')?.class; // $ExpectType Factory<unknown> | undefined
 owner.factoryFor('type:name')?.create(); // $ExpectType unknown
 owner.factoryFor('type:name')?.create({}); // $ExpectType unknown
 owner.factoryFor('type:name')?.create({ anythingGoes: true }); // $ExpectType unknown
 // @ts-expect-error
 owner.factoryFor('non-namespace-string');
-owner.factoryFor('namespace@type:name'); // $ExpectType FactoryManager<unknown, object> | undefined
+owner.factoryFor('namespace@type:name'); // $ExpectType FactoryManager<unknown> | undefined
 
 // Tests deal with the fact that string literals are a special case! `let`
 // bindings will accordingly not "just work" as a result. The separate
@@ -118,9 +117,8 @@ const Creatable = {
 };
 
 const pojoFactory: Factory<typeof Creatable> = {
-    class: Creatable,
     create(initialValues?) {
-        const instance = this.class as typeof Creatable;
+        const instance = Creatable;
         if (initialValues) {
             if (initialValues.hasProps) {
                 Object.defineProperty(instance, 'hasProps', {

--- a/types/ember__owner/index.d.ts
+++ b/types/ember__owner/index.d.ts
@@ -74,6 +74,12 @@ export interface RegisterOptions {
  * options to the {@linkcode Owner.register} method.
  */
 export interface Factory<T> {
+    /**
+     * A function that will create an instance of the class with any
+     * dependencies injected.
+     *
+     * @param initialValues Any values to set on an instance of the class
+     */
     create(initialValues?: Partial<T>): T;
 }
 
@@ -89,16 +95,9 @@ export interface Factory<T> {
  * @note `FactoryManager` is *not* user-constructible; the only legal way to get
  *   a `FactoryManager` is via {@linkcode Owner.factoryFor}.
  */
-export class FactoryManager<T> {
+export interface FactoryManager<T> extends Factory<T> {
     /** The registered or resolved class. */
     readonly class: Factory<T>;
-    /**
-     * A function that will create an instance of the class with any
-     * dependencies injected.
-     *
-     * @param initialValues Any values to set on an instance of the class
-     */
-    create(initialValues?: Partial<T>): T;
 }
 
 // Don't export things unless we *intend* to.

--- a/types/ember__owner/index.d.ts
+++ b/types/ember__owner/index.d.ts
@@ -73,8 +73,7 @@ export interface RegisterOptions {
  * However, that behavior can be modified with the `instantiate` and `singleton`
  * options to the {@linkcode Owner.register} method.
  */
-export interface Factory<T, C extends object = object> {
-    class: C;
+export interface Factory<T> {
     create(initialValues?: Partial<T>): T;
 }
 
@@ -90,9 +89,9 @@ export interface Factory<T, C extends object = object> {
  * @note `FactoryManager` is *not* user-constructible; the only legal way to get
  *   a `FactoryManager` is via {@linkcode Owner.factoryFor}.
  */
-export class FactoryManager<T, C extends object = object> {
+export class FactoryManager<T> {
     /** The registered or resolved class. */
-    readonly class: Factory<T, C>;
+    readonly class: Factory<T>;
     /**
      * A function that will create an instance of the class with any
      * dependencies injected.

--- a/types/ember__owner/index.d.ts
+++ b/types/ember__owner/index.d.ts
@@ -10,7 +10,7 @@
  * The name for a factory consists of a namespace and the name of a specific
  * type within that namespace, like `'service:session'`.
  */
-type FullName = `${string}:${string}`;
+export type FullName = `${string}:${string}`;
 
 // TODO: when migrating into Ember proper, evaluate whether we should introduce
 // a registry which users can provide to resolve known types, so e.g.

--- a/types/ember__owner/index.d.ts
+++ b/types/ember__owner/index.d.ts
@@ -65,10 +65,6 @@ export interface RegisterOptions {
     singleton?: boolean | undefined;
 }
 
-type InitialValues<T> = Partial<{
-    [K in keyof T]: T[K];
-}>;
-
 /**
  * Registered factories are instantiated by having create called on them.
  * Additionally they are singletons by default, so each time they are looked up
@@ -79,7 +75,7 @@ type InitialValues<T> = Partial<{
  */
 export interface Factory<T, C extends object = object> {
     class: C;
-    create(initialValues?: InitialValues<T>): T;
+    create(initialValues?: Partial<T>): T;
 }
 
 /**
@@ -103,7 +99,7 @@ export class FactoryManager<T, C extends object = object> {
      *
      * @param initialValues Any values to set on an instance of the class
      */
-    create(initialValues?: InitialValues<T>): T;
+    create(initialValues?: Partial<T>): T;
 }
 
 // Don't export things unless we *intend* to.

--- a/types/ember__owner/index.d.ts
+++ b/types/ember__owner/index.d.ts
@@ -1,0 +1,110 @@
+// Type definitions for non-npm package @ember/owner 4.0
+// Project: https://emberjs.com/api/ember/4.0/
+// Definitions by: Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.4
+
+/**
+ * The name for a factory consists of a namespace and the name of a specific
+ * type within that namespace, like `'service:session'`.
+ */
+type FullName = `${string}:${string}`;
+
+// TODO: when migrating into Ember proper, evaluate whether we should introduce
+// a registry which users can provide to resolve known types, so e.g.
+// `owner.lookup('service:session')` can return the right thing.
+/**
+ * Framework objects in an Ember application (components, services, routes,
+ * etc.) are created via a factory and dependency injection system. Each of
+ * these objects is the responsibility of an "owner", which handled its
+ * instantiation and manages its lifetime.
+ */
+export default interface Owner {
+    /**
+     * Given a {@linkcode FullName} return a corresponding instance.
+     */
+    lookup(fullName: FullName): unknown;
+
+    /**
+     * Registers a factory or value that can be used for dependency injection
+     * (with `inject`) or for service lookup. Each factory is registered with a
+     * full name including two parts: `'type:name'`.
+     *
+     * - To override the default of instantiating the class on the `Factory`,
+     *   pass the `{ instantiate: false }` option. This is useful when you have
+     *   already instantiated the class to use with this factory.
+     * - To override the default singleton behavior and instead create multiple
+     *   instances, pass the `{ singleton: false }` option.
+     */
+    // Dear future maintainer: yes, I know that `Factory<unknown> | object` is
+    // an exceedingly weird type here. This is how we type it internally in
+    // Ember itself. We actually allow more or less *anything* to be passed
+    // here. In the future, we may possibly be able to update this to actually
+    // take advantage of the `FullName` here to require that the registered
+    // factory and corresponding options do the right thing (passing an *actual*
+    // factory, not needing `create` if `options.instantiate` is `false`, etc.)
+    // but doing so will require rationalizing Ember's own internals and may
+    // need a full Ember RFC.
+    register(fullName: FullName, factory: Factory<unknown> | object, options?: RegisterOptions): void;
+
+    /**
+     * Given a fullName of the form `'type:name'`, like `'route:application'`,
+     * return a corresponding factory manager.
+     *
+     * Any instances created via the factory's `.create()` method must be
+     * destroyed manually by the caller of `.create()`. Typically, this is done
+     * during the creating objects own `destroy` or `willDestroy` methods.
+     */
+    factoryFor(fullName: FullName): FactoryManager<unknown> | undefined;
+}
+
+export interface RegisterOptions {
+    instantiate?: boolean | undefined;
+    singleton?: boolean | undefined;
+}
+
+type InitialValues<T> = Partial<{
+    [K in keyof T]: T[K];
+}>;
+
+/**
+ * Registered factories are instantiated by having create called on them.
+ * Additionally they are singletons by default, so each time they are looked up
+ * they return the same instance.
+ *
+ * However, that behavior can be modified with the `instantiate` and `singleton`
+ * options to the {@linkcode Owner.register} method.
+ */
+export interface Factory<T, C extends object = object> {
+    class: C;
+    create(initialValues?: InitialValues<T>): T;
+}
+
+/**
+ * A manager which can be used for introspection of the factory's class or for
+ * the creation of factory instances with initial properties. The manager is an
+ * object with the following properties:
+ *
+ * - `class` - The registered or resolved class.
+ * - `create` - A function that will create an instance of the class with any
+ *   dependencies injected.
+ *
+ * @note `FactoryManager` is *not* user-constructible; the only legal way to get
+ *   a `FactoryManager` is via {@linkcode Owner.factoryFor}.
+ */
+export class FactoryManager<T, C extends object = object> {
+    /** The registered or resolved class. */
+    readonly class: Factory<T, C>;
+    /**
+     * A function that will create an instance of the class with any
+     * dependencies injected.
+     *
+     * @param initialValues Any values to set on an instance of the class
+     */
+    create(initialValues?: InitialValues<T>): T;
+}
+
+// Don't export things unless we *intend* to.
+export {};

--- a/types/ember__owner/tsconfig.json
+++ b/types/ember__owner/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/*": [
+                "ember__*"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember__owner-tests.ts"
+    ]
+}

--- a/types/ember__owner/tslint.json
+++ b/types/ember__owner/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
These are new type-only imports for the newly-specified type-only `@ember/owner` package as specified in [Ember RFC 0821][RFC]. This PR makes the `Owner` type the source of truth for a couple elements which were previously available through the `Container` and `Registry` mixin types, resulting in their inheriting from `Owner` so they continue to have those tyeps. This is technically the inverse of the order these types are applied within Ember itself today. However, this is the only way to correctly preserve the *desired and intended* public API for `Owner` and for the things which Ember users typically actually *use* as owners, namely `EngineInstance` and `ApplicationInstance` instances.

[RFC]: https://rfcs.emberjs.com/id/0821-public-types

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
