### PR TITLE
Added Buffer type as the other accepted type for the Database constructor of better-sqlite3 for v7.6.2

### DIFF
--- a/types/better-sqlite3/better-sqlite3-tests.ts
+++ b/types/better-sqlite3/better-sqlite3-tests.ts
@@ -122,3 +122,9 @@ db.backup('backup-today.db', {
         return paused ? 0 : 200;
     },
 });
+
+const newDb = new Sqlite(db.serialize());
+db.close();
+
+const stmtWithNamedBindForNewDb = newDb.prepare<NamedBindParameters>('INSERT INTO test VALUES (@name, @age, @id)');
+stmtWithNamedBindForNewDb.run({ name: 'bob1', age: 201, id: BigInt(1234) });

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for better-sqlite3 7.5
+// Type definitions for better-sqlite3 7.6.2
 // Project: https://github.com/JoshuaWise/better-sqlite3
 // Definitions by: Ben Davies <https://github.com/Morfent>
 //                 Mathew Rumsey <https://github.com/matrumz>

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for better-sqlite3 7.6.2
+// Type definitions for better-sqlite3 7.6
 // Project: https://github.com/JoshuaWise/better-sqlite3
 // Definitions by: Ben Davies <https://github.com/Morfent>
 //                 Mathew Rumsey <https://github.com/matrumz>

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -84,7 +84,7 @@ declare namespace BetterSqlite3 {
     }
 
     interface DatabaseConstructor {
-        new (filename: string, options?: Database.Options): Database;
+        new (filename: string | Buffer, options?: Database.Options): Database;
         (filename: string, options?: Database.Options): Database;
         prototype: Database;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/WiseLibs/better-sqlite3/blob/master/lib/database.js)>> && <<https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md#serializeoptions---buffer>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **There might be other changes needed but I've not noticed any yet for my use of the library**.