### PR TITLE
fix: Added text getter and setter for node class.

### DIFF
--- a/types/libxmljs/index.d.ts
+++ b/types/libxmljs/index.d.ts
@@ -127,6 +127,8 @@ export class Node {
         whitespace: boolean;
         type: 'xml'|'html'|'xhtml'
     }): string;
+    text(): string;
+    text(newText: string): this;
 }
 
 export class Element extends Node {

--- a/types/libxmljs/libxmljs-tests.ts
+++ b/types/libxmljs/libxmljs-tests.ts
@@ -96,3 +96,13 @@ const gchilEldWithNs = childElWithNs.get('//a:grandchild', { a: 'http://test.com
 const validated: boolean = doc.validate(doc);
 doc.validationErrors[0].message; // inherited from Error
 doc.validationErrors[0].line;
+
+// text accessors on node.
+const element = libxmljs.parseXmlString('<root><child>Hello <name>user1</name></child></root>').get("//child");
+const node = element?.childNodes()?.at(0);
+if (node) {
+  console.log(node.text()); // prints "Hello"
+  
+  node.text('Welcome');
+  console.log(node.text()); // prints "Welcome"
+}

--- a/types/libxmljs/libxmljs-tests.ts
+++ b/types/libxmljs/libxmljs-tests.ts
@@ -102,7 +102,7 @@ const element = libxmljs.parseXmlString('<root><child>Hello <name>user1</name></
 const node = element?.childNodes()?.at(0);
 if (node) {
   console.log(node.text()); // prints "Hello"
-  
+
   node.text('Welcome');
   console.log(node.text()); // prints "Welcome"
 }


### PR DESCRIPTION
`textNode.text('newData')` is permitted by core and js library but existing type definitions don't allow for it. This PR aims to fix it.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/libxmljs/libxmljs/blob/23da4cf9eca569a37cc36a26977fa7ab0b53d875/src/xml_node.h#L71>
