### PR TITLE
[sharp] Add affine, interpolators, SharpenOptions and failOn

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -776,7 +776,6 @@ declare namespace sharp {
          * By default halt processing and raise an error when loading invalid images.
          * Set this flag to false if you'd rather apply a "best effort" to decode images,
          * even if the data is corrupt or invalid. (optional, default true)
-         * (optional, default true)
          *
          * @deprecated Use `failOn` instead
          */

--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -79,6 +79,7 @@ declare namespace sharp {
         installed: string[];
     };
 
+    /** An Object containing the available interpolators and their proper values */
     const interpolators: Interpolators;
 
     /** An EventEmitter that emits a change event when a task is either queued, waiting for libuv to provide a worker thread, complete */
@@ -777,7 +778,7 @@ declare namespace sharp {
          * even if the data is corrupt or invalid. (optional, default true)
          * (optional, default true)
          *
-         * @deprecated
+         * @deprecated Use `failOn` instead
          */
         failOnError?: boolean | undefined;
         /**

--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -79,6 +79,8 @@ declare namespace sharp {
         installed: string[];
     };
 
+    const interpolators: Interpolators;
+
     /** An EventEmitter that emits a change event when a task is either queued, waiting for libuv to provide a worker thread, complete */
     const queue: NodeJS.EventEmitter;
 
@@ -332,6 +334,40 @@ declare namespace sharp {
         flop(flop?: boolean): Sharp;
 
         /**
+         * Perform an affine transform on an image. This operation will always occur after resizing, extraction and rotation, if any.
+         * You must provide an array of length 4 or a 2x2 affine transformation matrix.
+         * By default, new pixels are filled with a black background. You can provide a background color with the `background` option.
+         * A particular interpolator may also be specified. Set the `interpolator` option to an attribute of the `sharp.interpolator` Object e.g. `sharp.interpolator.nohalo`.
+         *
+         * In the case of a 2x2 matrix, the transform is:
+         * X = matrix[0, 0] * (x + idx) + matrix[0, 1] * (y + idy) + odx
+         * Y = matrix[1, 0] * (x + idx) + matrix[1, 1] * (y + idy) + ody
+         *
+         * where:
+         *
+         * x and y are the coordinates in input image.
+         * X and Y are the coordinates in output image.
+         * (0,0) is the upper left corner.
+         *
+         * @param matrix Affine transformation matrix, may either by a array of length four or a 2x2 matrix array
+         * @param options if present, is an Object with optional attributes.
+         *
+         * @returns A sharp instance that can be used to chain operations
+         */
+        affine(matrix: [number, number, number, number] | Matrix2x2, options?: AffineOptions): Sharp;
+
+        /**
+         * Sharpen the image.
+         * When used without parameters, performs a fast, mild sharpen of the output image.
+         * When a sigma is provided, performs a slower, more accurate sharpen of the L channel in the LAB colour space.
+         * Separate control over the level of sharpening in "flat" and "jagged" areas is available.
+         * @param options if present, is an Object with optional attributes
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        sharpen(options?: SharpenOptions): Sharp;
+
+        /**
          * Sharpen the image.
          * When used without parameters, performs a fast, mild sharpen of the output image.
          * When a sigma is provided, performs a slower, more accurate sharpen of the L channel in the LAB colour space.
@@ -341,6 +377,8 @@ declare namespace sharp {
          * @param jagged the level of sharpening to apply to "jagged" areas. (optional, default 2.0)
          * @throws {Error} Invalid parameters
          * @returns A sharp instance that can be used to chain operations
+         *
+         * @deprecated Use the object parameter `sharpen({sigma, m1, m2, x1, y2, y3})` instead
          */
         sharpen(sigma?: number, flat?: number, jagged?: number): Sharp;
 
@@ -729,10 +767,17 @@ declare namespace sharp {
 
     interface SharpOptions {
         /**
+         *  Level of sensitivity to invalid images, one of (in order of sensitivity):
+         *  'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels. (optional, default 'warning')
+         */
+        failOn?: FailOnOptions | undefined;
+        /**
          * By default halt processing and raise an error when loading invalid images.
          * Set this flag to false if you'd rather apply a "best effort" to decode images,
          * even if the data is corrupt or invalid. (optional, default true)
          * (optional, default true)
+         *
+         * @deprecated
          */
         failOnError?: boolean | undefined;
         /**
@@ -1230,6 +1275,36 @@ declare namespace sharp {
         delay?: number | number[] | undefined;
     }
 
+    interface SharpenOptions {
+        /** The sigma of the Gaussian mask, where sigma = 1 + radius / 2. */
+        sigma: number;
+        /** The level of sharpening to apply to "flat" areas. (optional, default 1.0) */
+        m1?: number | undefined;
+        /** The level of sharpening to apply to "jagged" areas. (optional, default 2.0) */
+        m2?: number | undefined;
+        /** Threshold between "flat" and "jagged" (optional, default 2.0) */
+        x1?: number | undefined;
+        /** Maximum amount of brightening. (optional, default 10.0) */
+        y2?: number | undefined;
+        /** Maximum amount of darkening. (optional, default 20.0) */
+        y3?: number | undefined;
+    }
+
+    interface AffineOptions {
+        /** Parsed by the color module to extract values for red, green, blue and alpha. (optional, default "#000000") */
+        background?: string | object | undefined;
+        /** Input horizontal offset (optional, default 0) */
+        idx?: number | undefined;
+        /** Input vertical offset (optional, default 0) */
+        idy?: number | undefined;
+        /** Output horizontal offset (optional, default 0) */
+        odx?: number | undefined;
+        /** Output horizontal offset (optional, default 0) */
+        ody?: number | undefined;
+        /** Interpolator (optional, default sharp.interpolators.bicubic) */
+        interpolator?: Interpolators[keyof Interpolators] | undefined;
+    }
+
     interface OutputInfo {
         format: string;
         size: number;
@@ -1283,6 +1358,8 @@ declare namespace sharp {
         cmyk: string;
         srgb: string;
     }
+
+    type FailOnOptions = 'none' | 'truncated' | 'error' | 'warning';
 
     type TileLayout = 'dz' | 'iiif' | 'iiif3' | 'zoomify' | 'google';
 
@@ -1363,6 +1440,25 @@ declare namespace sharp {
         items: { current: number; max: number };
     }
 
+    interface Interpolators {
+        /** [Nearest neighbour interpolation](http://en.wikipedia.org/wiki/Nearest-neighbor_interpolation). Suitable for image enlargement only. */
+        nearest: 'nearest';
+        /** [Bilinear interpolation](http://en.wikipedia.org/wiki/Bilinear_interpolation). Faster than bicubic but with less smooth results. */
+        bilinear: 'bilinear';
+        /** [Bicubic interpolation](http://en.wikipedia.org/wiki/Bicubic_interpolation) (the default). */
+        bicubic: 'bicubic';
+        /**
+         * [LBB interpolation](https://github.com/libvips/libvips/blob/master/libvips/resample/lbb.cpp#L100).
+         * Prevents some "[acutance](http://en.wikipedia.org/wiki/Acutance)" but typically reduces performance by a factor of 2.
+         */
+        locallyBoundedBicubic: 'lbb';
+        /** [Nohalo interpolation](http://eprints.soton.ac.uk/268086/). Prevents acutance but typically reduces performance by a factor of 3. */
+        nohalo: 'nohalo';
+        /** [VSQBS interpolation](https://github.com/libvips/libvips/blob/master/libvips/resample/vsqbs.cpp#L48). Prevents "staircasing" when enlarging. */
+        vertexSplitQuadraticBasisSpline: 'vsqbs';
+    }
+
+    type Matrix2x2 = [[number, number], [number, number]];
     type Matrix3x3 = [[number, number, number], [number, number, number], [number, number, number]];
 }
 

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -488,3 +488,46 @@ sharp('input.tiff').jp2({ quality: 50 }).toFile('out.jp2');
 sharp('input.tiff').jp2({ lossless: true }).toFile('out.jp2');
 sharp('input.tiff').jp2({ tileWidth: 128, tileHeight: 128 }).toFile('out.jp2');
 sharp('input.tiff').jp2({ chromaSubsampling: '4:2:0' }).toFile('out.jp2');
+
+// 'failOn' input param
+sharp('input.tiff', { failOn: 'none' });
+sharp('input.tiff', { failOn: 'truncated' });
+sharp('input.tiff', { failOn: 'error' });
+sharp('input.tiff', { failOn: 'warning' });
+
+// Sharpen operation taking an object instead of three params
+sharp('input.tiff').sharpen().toBuffer();
+sharp('input.tiff').sharpen({ sigma: 2 }).toBuffer();
+sharp('input.tiff')
+  .sharpen({
+    sigma: 2,
+    m1: 0,
+    m2: 3,
+    x1: 3,
+    y2: 15,
+    y3: 15,
+  })
+  .toBuffer();
+
+// Affine operator + interpolator hash
+sharp()
+  .affine([[1, 0.3], [0.1, 0.7]], {
+     background: 'white',
+     interpolator: sharp.interpolators.nohalo
+  });
+
+sharp()
+  .affine([1, 1, 1, 1], {
+     background: 'white',
+     idx: 0,
+     idy: 0,
+     odx: 0,
+     ody: 0
+  });
+
+const bicubic: string = sharp.interpolators.bicubic;
+const bilinear: string = sharp.interpolators.bilinear;
+const locallyBoundedBicubic: string = sharp.interpolators.locallyBoundedBicubic;
+const nearest: string = sharp.interpolators.nearest;
+const nohalo: string = sharp.interpolators.nohalo;
+const vertexSplitQuadraticBasisSpline: string = sharp.interpolators.vertexSplitQuadraticBasisSpline;


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/61141

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - New operation types: affine: https://sharp.pixelplumbing.com/api-operation#affine
  - Change options for sharpen to be an object: https://sharp.pixelplumbing.com/api-operation#sharpen
  - Add interpolators object: https://sharp.pixelplumbing.com/api-utility#interpolators
  - Deprecate `failOnError` and add `failOn`: https://sharp.pixelplumbing.com/api-constructor

