### PR TITLE
[`@wordpress/editor`] Export definition for `store`

### DIFF
--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -15,3 +15,4 @@ declare module '@wordpress/data' {
 
 export * from './components';
 export * from './utils';
+export * from './store';

--- a/types/wordpress__editor/package.json
+++ b/types/wordpress__editor/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^4.0.0"
+        "@wordpress/element": "^4.0.0",
+        "@wordpress/data/": "^6.14.0"
     }
 }

--- a/types/wordpress__editor/store/index.ts
+++ b/types/wordpress__editor/store/index.ts
@@ -1,0 +1,2 @@
+import { StoreDescriptor } from '@wordpress/data';
+export let store: StoreDescriptor;

--- a/types/wordpress__editor/store/index.ts
+++ b/types/wordpress__editor/store/index.ts
@@ -1,2 +1,5 @@
-import { StoreDescriptor } from '@wordpress/data';
-export let store: StoreDescriptor;
+import type { StoreDescriptor } from '@wordpress/data';
+interface EditorStoreDescriptor extends StoreDescriptor {
+    name: 'core/editor',
+}
+export let store: EditorStoreDescriptor;

--- a/types/wordpress__editor/wordpress__editor-tests.tsx
+++ b/types/wordpress__editor/wordpress__editor-tests.tsx
@@ -324,6 +324,9 @@ declare const BLOCK_INSTANCE: import('@wordpress/blocks').BlockInstance;
 // Store
 // ============================================================================
 
+// $ExpectType StoreDescriptor
+e.store;
+
 // $ExpectType IterableIterator<void>
 dispatch('core/editor').autosave();
 // $ExpectType IterableIterator<void>

--- a/types/wordpress__editor/wordpress__editor-tests.tsx
+++ b/types/wordpress__editor/wordpress__editor-tests.tsx
@@ -324,7 +324,7 @@ declare const BLOCK_INSTANCE: import('@wordpress/blocks').BlockInstance;
 // Store
 // ============================================================================
 
-// $ExpectType StoreDescriptor
+// $ExpectType EditorStoreDescriptor
 e.store;
 
 // $ExpectType IterableIterator<void>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/index.js#L6 `store` is exported here but trying to import it elsewhere gives an error saying `@wordpress/editor` has no exported member.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.