### PR TITLE
@ember/routing: include back-compat shim private types

### DIFF
--- a/types/ember__routing/-private/route-info-with-attributes.d.ts
+++ b/types/ember__routing/-private/route-info-with-attributes.d.ts
@@ -1,0 +1,1 @@
+export { RouteInfoWithAttributes as default } from '../route-info';

--- a/types/ember__routing/-private/route-info.d.ts
+++ b/types/ember__routing/-private/route-info.d.ts
@@ -1,0 +1,1 @@
+export { default as default } from '../route-info';

--- a/types/ember__routing/-private/transition.d.ts
+++ b/types/ember__routing/-private/transition.d.ts
@@ -1,0 +1,1 @@
+export { default as default } from '../transition';

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -3,6 +3,7 @@ import Array from '@ember/array';
 import EmberObject from '@ember/object';
 import Controller from '@ember/controller';
 import Transition from '@ember/routing/transition';
+import RouteInfo, { RouteInfoWithAttributes } from '@ember/routing/route-info';
 
 class Post extends EmberObject {}
 
@@ -203,3 +204,24 @@ class WithImplicitParams extends Route {
 
 // $ExpectType RouteParams
 type ImplicitParams = WithImplicitParams extends Route<any, infer T> ? T : never;
+
+// back-compat for existing users of these
+// NOTE: we will *not* migrate the private import locations when moving to
+// publish from Ember itself.
+import PrivateTransition from '@ember/routing/-private/transition';
+declare let publicTransition: Transition;
+declare let oldPrivateTransition: PrivateTransition;
+publicTransition = oldPrivateTransition;
+oldPrivateTransition = publicTransition;
+
+import PrivateRouteInfo from '@ember/routing/-private/route-info';
+declare let publicRouteInfo: RouteInfo;
+declare let privateRouteInfo: PrivateRouteInfo;
+publicRouteInfo = privateRouteInfo;
+privateRouteInfo = publicRouteInfo;
+
+import PrivateRouteInfoWithAttributes from '@ember/routing/-private/route-info-with-attributes';
+declare let publicRouteInfoWithAttributes: RouteInfoWithAttributes;
+declare let privateRouteInfoWithAttributes: PrivateRouteInfoWithAttributes;
+publicRouteInfoWithAttributes = privateRouteInfoWithAttributes;
+privateRouteInfoWithAttributes = publicRouteInfoWithAttributes;


### PR DESCRIPTION
In #61510, we introduced new public API import locations for these types. However, removing the `-private` locations to import from meant this was effectively a breaking change for existing libraries which had little choice *other* than to use the private APIs. Providing them here makes for a non-breaking change instead.

When we migrate these types to Ember itself, we will *not* include these backwards-compatibility `-private` import paths, but *will* document that it is part of the migration. A blog post announcing the publication of these types (probably next week) will also nudge people to start migrating.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A – see comments above!
