### PR TITLE
Update ember-qunit tests for changes in @ember/owner

### DIFF
--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -77,7 +77,7 @@ module('misc and async', function (hooks) {
             result: string;
         }
 
-        const subject = this.owner.lookup('foo') as Foo;
+        const subject = this.owner.lookup('foo:bar') as Foo;
 
         subject.set('value', 'foo');
         assert.equal(subject.get('result'), 'bar');


### PR DESCRIPTION
The test previously passed a string of the wrong format. I don't know how this got missed in CI during the recent ember changes.
