### PR TITLE
[wordpress__blocks] Change `InnerBlockTemplate` tuple members from possibly `undefined` to optional

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -507,7 +507,7 @@ export type Transform<T extends Record<string, any> = Record<string, any>> =
 
 export type BlockAttributes = Record<string, any>;
 
-export type InnerBlockTemplate = [string, BlockAttributes | undefined, InnerBlockTemplate[] | undefined];
+export type InnerBlockTemplate = [string, BlockAttributes?, InnerBlockTemplate[]?];
 
 export type BlockVariationScope = 'block' | 'inserter' | 'transform';
 

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -514,6 +514,14 @@ blocks.getBlockVariations('core/columns');
 blocks.registerBlockVariation('core/columns', {
     name: 'core/columns/variation',
     title: 'Core Column Variation',
+    innerBlocks: [
+        [ 'core/paragraph' ],
+        [
+            'core/paragraph',
+            { placeholder: 'Enter side content...' },
+            [ [ 'core/paragraph' ] ]
+        ],
+    ],
 });
 
 // $ExpectType void


### PR DESCRIPTION
Currently, the `InnerBlockTemplate` tuple is defined as to accept “something” or `undefined` as the second and third member.

The original intention of this, is however that they are optional. For example in [this docs](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inner-blocks/README.md):

```
const TEMPLATE = [ [ 'core/columns', {}, [
    [ 'core/column', {}, [
        [ 'core/image' ],
    ] ],
    [ 'core/column', {}, [
        [ 'core/paragraph', { placeholder: 'Enter side content...' } ],
    ] ],
] ] ];
```

We can see that while the first string member of the tuple is required, the other two coming from the type are optional. There should be no need to define an `InnerBlockTemplate` as: `[ 'core/block', undefined, undefined]`.

Under loose TypeScript rules, saying `MyType | undefined` might seem synonymous with saying “optional”. However, something being `undefined` is strictly not the same as not being defined (😅), and, as such, under [stricter TypeScript rules](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes), this signature would throw a type error.

I've also modified the tests to reflect the expected signature.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inner-blocks/README.md