### PR TITLE
Ember: more use of @ember/owner types

### DIFF
--- a/types/ember/test/ember-module-tests.ts
+++ b/types/ember/test/ember-module-tests.ts
@@ -106,7 +106,8 @@ Ember.set(o2.create(), 'age', 4); // $ExpectType number
 // @ts-expect-error
 Ember.set(o2.create(), 'nam', 'bar');
 // setOwner
-Ember.setOwner(o2.create(), {});
+declare let app: Ember.ApplicationInstance;
+Ember.setOwner(o2.create(), app);
 // setProperties
 Ember.setProperties(o2.create(), { name: 'bar' }).name; // $ExpectType string
 // trySet

--- a/types/ember/test/ember-module-tests.ts
+++ b/types/ember/test/ember-module-tests.ts
@@ -43,7 +43,7 @@ Ember.get({ z: 23 }, 'zz'); // $ExpectType unknown
 // getEngineParent
 Ember.getEngineParent(new Ember.EngineInstance()); // $ExpectType EngineInstance
 // getOwner
-Ember.getOwner(new Ember.Component());
+Ember.getOwner(new Ember.Component()); // $ExpectType Owner
 // getProperties
 Ember.getProperties({ z: 23 }, 'z').z; // $ExpectType number
 Ember.getProperties({ z: 23 }, 'z', 'z').z; // $ExpectType number

--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -15,6 +15,8 @@ import Registry from '@ember/application/-private/registry';
 import Resolver from 'ember-resolver';
 import { AnyFn } from 'ember/-private/type-utils';
 import Owner from '@ember/owner';
+import type GlimmerComponent from '@glimmer/component';
+import EmberObject from '@ember/object';
 
 /**
  * An instance of Ember.Application is the starting point for every Ember application. It helps to
@@ -114,12 +116,21 @@ export default class Application extends Engine {
     buildInstance(options?: object): ApplicationInstance;
 }
 
+// Known framework objects, so that `getOwner` can always, accurately, return
+// `Owner` when working with one of these classes, which the framework *does*
+// guarantee will always have an `Owner`. NOTE: this must be kept up to date
+// whenever we add new base classes to the framework. For example, if we
+// introduce a standalone `Service` or `Route` base class which *does not*
+// extend from `EmberObject`, it will need to be added here.
+type FrameworkObject = EmberObject | GlimmerComponent;
+
 /**
  * Framework objects in an Ember application (components, services, routes, etc.)
  * are created via a factory and dependency injection system. Each of these
  * objects is the responsibility of an "owner", which handled its
  * instantiation and manages its lifetime.
  */
+export function getOwner(object: FrameworkObject): Owner;
 export function getOwner(object: unknown): Owner | undefined;
 /**
  * `setOwner` forces a new owner on a given object instance. This is primarily

--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -18,6 +18,10 @@ import Owner from '@ember/owner';
 import type GlimmerComponent from '@glimmer/component';
 import EmberObject from '@ember/object';
 
+// Shut off default exporting; we don't want anything but the *intended*
+// public API present.
+export {};
+
 /**
  * An instance of Ember.Application is the starting point for every Ember application. It helps to
  * instantiate, initialize and coordinate the many objects that make up your app.

--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -14,6 +14,7 @@ import { Router } from '@ember/routing';
 import Registry from '@ember/application/-private/registry';
 import Resolver from 'ember-resolver';
 import { AnyFn } from 'ember/-private/type-utils';
+import Owner from '@ember/owner';
 
 /**
  * An instance of Ember.Application is the starting point for every Ember application. It helps to
@@ -119,12 +120,12 @@ export default class Application extends Engine {
  * objects is the responsibility of an "owner", which handled its
  * instantiation and manages its lifetime.
  */
-export function getOwner(object: unknown): unknown;
+export function getOwner(object: unknown): Owner;
 /**
  * `setOwner` forces a new owner on a given object instance. This is primarily
  * useful in some testing cases.
  */
-export function setOwner(object: unknown, owner: unknown): void;
+export function setOwner(object: unknown, owner: Owner): void;
 
 /**
  * Detects when a specific package of Ember (e.g. 'Ember.Application')

--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -120,7 +120,7 @@ export default class Application extends Engine {
  * objects is the responsibility of an "owner", which handled its
  * instantiation and manages its lifetime.
  */
-export function getOwner(object: unknown): Owner;
+export function getOwner(object: unknown): Owner | undefined;
 /**
  * `setOwner` forces a new owner on a given object instance. This is primarily
  * useful in some testing cases.

--- a/types/ember__application/package.json
+++ b/types/ember__application/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@glimmer/component": "^1.1.0"
+    }
+}

--- a/types/ember__application/test/index.ts
+++ b/types/ember__application/test/index.ts
@@ -2,9 +2,18 @@ import { getOwner, setOwner } from '@ember/application';
 import EngineInstance from '@ember/engine/instance';
 import Owner from '@ember/owner';
 import ApplicationInstance from '@ember/application/instance';
+import Service from '@ember/service';
 
 // $ExpectType Owner | undefined
 getOwner({});
+
+// Confirm that random subclasses work as expected.
+declare class MyService extends Service {
+    withStuff: true;
+}
+declare let myService: MyService;
+// $ExpectType Owner
+getOwner(myService);
 
 // @ts-expect-error
 getOwner();

--- a/types/ember__application/test/index.ts
+++ b/types/ember__application/test/index.ts
@@ -1,0 +1,19 @@
+import { getOwner, setOwner } from '@ember/application';
+import EngineInstance from '@ember/engine/instance';
+import Owner from '@ember/owner';
+import ApplicationInstance from '@ember/application/instance';
+
+// $ExpectType Owner | undefined
+getOwner({});
+
+// @ts-expect-error
+getOwner();
+
+declare let baseOwner: Owner;
+setOwner({}, baseOwner);
+
+declare let engine: EngineInstance;
+setOwner({}, engine);
+
+declare let application: ApplicationInstance;
+setOwner({}, application);

--- a/types/ember__application/tsconfig.json
+++ b/types/ember__application/tsconfig.json
@@ -25,6 +25,7 @@
         "index.d.ts",
         "test/application.ts",
         "test/deprecations.ts",
-        "test/application-instance.ts"
+        "test/application-instance.ts",
+        "test/index.ts"
     ]
 }

--- a/types/ember__test-helpers/ember__test-helpers-tests.ts
+++ b/types/ember__test-helpers/ember__test-helpers-tests.ts
@@ -58,6 +58,7 @@ module('proper module', function (hooks) {
         const { owner } = this;
         assert.ok(owner, 'owner was setup');
         assert.equal(typeof owner.lookup, 'function', 'has expected lookup interface');
+        owner; // $ExpectType Owner
     });
 
     test('can pauseTest to be resumed "later"', async function(assert) {

--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.4
 
-import ApplicationInstance from '@ember/application/instance';
+import Owner from '@ember/owner';
 import { TemplateFactory } from 'htmlbars-inline-precompile';
 
 export interface TestContext {
@@ -17,12 +17,7 @@ export interface TestContext {
     render(template?: string | string[] | TemplateFactory): Promise<void>;
     clearRender(): void;
     factory(fullName: string): unknown;
-    // NOTE: this uses an intersection instead of something more normal because
-    // it is intentionally causing a collision between the two `factoryFor`
-    // definitions.
-    owner: ApplicationInstance & {
-        factoryFor(fullName: string, options?: {}): unknown;
-    };
+    owner: Owner;
     pauseTest(): Promise<void>;
     resumeTest(): void;
     element: Element | Document;


### PR DESCRIPTION
This is a follow-on to #61533, carrying the new `Owner` type into a few places missed in the previous pass.

- in the `this.owner` declaration on `TestContext` in `@ember/test-helpers`
- in `getOwner` and `setOwner` in `@ember/application`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://rfcs.emberjs.com/id/0821-public-types>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
