### PR TITLE
[semver] Stricter `options` types

### DIFF
--- a/types/semver/classes/semver.d.ts
+++ b/types/semver/classes/semver.d.ts
@@ -1,7 +1,7 @@
 import semver = require('../index');
 
 declare class SemVer {
-    constructor(version: string | SemVer, optionsOrLoose?: boolean | semver.Options);
+    constructor(version: string | SemVer, optionsOrLoose?: boolean | semver.RangeOptions);
 
     raw: string;
     loose: boolean;

--- a/types/semver/functions/diff.d.ts
+++ b/types/semver/functions/diff.d.ts
@@ -4,10 +4,6 @@ import SemVer = require('../classes/semver');
 /**
  * Returns difference between two versions by the release type (major, premajor, minor, preminor, patch, prepatch, or prerelease), or null if the versions are the same.
  */
-declare function diff(
-    v1: string | SemVer,
-    v2: string | SemVer,
-    optionsOrLoose?: boolean | semver.Options,
-): semver.ReleaseType | null;
+declare function diff(v1: string | SemVer, v2: string | SemVer): semver.ReleaseType | null;
 
 export = diff;

--- a/types/semver/index.d.ts
+++ b/types/semver/index.d.ts
@@ -113,6 +113,9 @@ export type ReleaseType = 'major' | 'premajor' | 'minor' | 'preminor' | 'patch' 
 
 export interface Options {
     loose?: boolean | undefined;
+}
+
+export interface RangeOptions extends Options {
     includePrerelease?: boolean | undefined;
 }
 export interface CoerceOptions extends Options {

--- a/types/semver/ranges/subset.d.ts
+++ b/types/semver/ranges/subset.d.ts
@@ -4,10 +4,6 @@ import semver = require('../index');
 /**
  * Return true if the subRange range is entirely contained by the superRange range.
  */
-declare function subset(
-    sub: string | Range,
-    dom: string | Range,
-    options?: semver.Options,
-): boolean;
+declare function subset(sub: string | Range, dom: string | Range, options?: semver.RangeOptions): boolean;
 
 export = subset;

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -81,6 +81,10 @@ semverSatisfies('1.2.3', '1.x || >=2.5.0 || 5.0.0 - 7.2.3'); // $ExpectType bool
 semverGt('1.2.3', '9.8.7'); // $ExpectType boolean
 semverLt('1.2.3', '9.8.7'); // $ExpectType boolean
 semverMinVersion('>=1.0.0'); // $ExpectType SemVer | null
+semverMinVersion('>=1.0.0', true); // $ExpectType SemVer | null
+semverMinVersion('>=1.0.0', { loose: false }); // $ExpectType SemVer | null
+// @ts-expect-error
+semverMinVersion('>=1.0.0', { includePrerelease: false }); // $ExpectType SemVer | null
 semverValid(semverCoerce('v2')); // $ExpectType string | null
 semverValid(semverCoerce('42.6.7.9.3-alpha')); // $ExpectType string | null
 
@@ -122,36 +126,110 @@ strn = semver.valid(str);
 strn = semver.clean(str);
 
 strn = semver.valid(str, loose);
+strn = semver.valid(str, { loose: false });
+// @ts-expect-error
+strn = semver.valid(str, { includePrerelease: false });
 strn = semver.clean(str, loose);
+strn = semver.clean(str, { loose: false });
+// @ts-expect-error
+strn = semver.clean(str, { includePrerelease: false });
 strn = semver.inc(str, 'major', loose);
+strn = semver.inc(str, 'major', { loose: false });
+// @ts-expect-error
+strn = semver.inc(str, 'major', { includePrerelease: false });
 strn = semver.inc(str, 'premajor', loose);
+strn = semver.inc(str, 'premajor', { loose: false });
+// @ts-expect-error
+strn = semver.inc(str, 'premajor', { includePrerelease: false });
 strn = semver.inc(str, 'minor', loose);
+strn = semver.inc(str, 'minor', { loose: false });
+// @ts-expect-error
+strn = semver.inc(str, 'minor', { includePrerelease: false });
 strn = semver.inc(str, 'preminor', loose);
+strn = semver.inc(str, 'preminor', { loose: false });
+// @ts-expect-error
+strn = semver.inc(str, 'preminor', { includePrerelease: false });
 strn = semver.inc(str, 'patch', loose);
+strn = semver.inc(str, 'patch', { loose: false });
+// @ts-expect-error
+strn = semver.inc(str, 'patch', { includePrerelease: false });
 strn = semver.inc(str, 'prepatch', loose);
+strn = semver.inc(str, 'prepatch', { loose: false });
+// @ts-expect-error
+strn = semver.inc(str, 'prepatch', { includePrerelease: false });
 strn = semver.inc(str, 'prerelease', loose);
+strn = semver.inc(str, 'prerelease', { loose: false });
+// @ts-expect-error
+strn = semver.inc(str, 'prerelease', { includePrerelease: false });
 strn = semver.inc(str, 'prerelease', loose, 'alpha');
+strn = semver.inc(str, 'prerelease', { loose: false }, 'alpha');
+// @ts-expect-error
+strn = semver.inc(str, 'prerelease', { includePrerelease: false }, 'alpha');
 strn = semver.inc(str, 'prerelease', 'beta');
 num = semver.major(str, loose);
+num = semver.major(str, { loose: false });
+// @ts-expect-error
+num = semver.major(str, { includePrerelease: false });
 num = semver.minor(str, loose);
+num = semver.minor(str, { loose: false });
+// @ts-expect-error
+num = semver.minor(str, { includePrerelease: false });
 num = semver.patch(str, loose);
+num = semver.patch(str, { loose: false });
+// @ts-expect-error
+num = semver.patch(str, { includePrerelease: false });
 prereleaseIdAttr = semver.prerelease(str, loose);
+prereleaseIdAttr = semver.prerelease(str, { loose: false });
+// @ts-expect-error
+prereleaseIdAttr = semver.prerelease(str, { includePrerelease: false });
 
 // Comparison
 bool = semver.gt(v1, v2, loose);
+bool = semver.gt(v1, v2, { loose: false });
+// @ts-expect-error
+bool = semver.gt(v1, v2, { includePrerelease: false });
 bool = semver.gte(v1, v2, loose);
+bool = semver.gte(v1, v2, { loose: false });
+// @ts-expect-error
+bool = semver.gte(v1, v2, { includePrerelease: false });
 bool = semver.lt(v1, v2, loose);
+bool = semver.lt(v1, v2, { loose: false });
+// @ts-expect-error
+bool = semver.lt(v1, v2, { includePrerelease: false });
 bool = semver.lte(v1, v2, loose);
+bool = semver.lte(v1, v2, { loose: false });
+// @ts-expect-error
+bool = semver.lte(v1, v2, { includePrerelease: false });
 bool = semver.eq(v1, v2, loose);
+bool = semver.eq(v1, v2, { loose: false });
+// @ts-expect-error
+bool = semver.eq(v1, v2, { includePrerelease: false });
 bool = semver.neq(v1, v2, loose);
+bool = semver.neq(v1, v2, { loose: false });
+// @ts-expect-error
+bool = semver.neq(v1, v2, { includePrerelease: false });
 bool = semver.cmp(v1, op, v2, loose);
+bool = semver.cmp(v1, op, v2, { loose: false });
+// @ts-expect-error
+bool = semver.cmp(v1, op, v2, { includePrerelease: false });
 comparatorResult = semver.compare(v1, v2, loose);
+comparatorResult = semver.compare(v1, v2, { loose: false });
+// @ts-expect-error
+comparatorResult = semver.compare(v1, v2, { includePrerelease: false });
 comparatorResult = semver.compareBuild(v1, v2, loose);
+comparatorResult = semver.compareBuild(v1, v2, { loose: false });
+// @ts-expect-error
+comparatorResult = semver.compareBuild(v1, v2, { includePrerelease: false });
 comparatorResult = semver.rcompare(v1, v2, loose);
+comparatorResult = semver.rcompare(v1, v2, { loose: false });
+// @ts-expect-error
+comparatorResult = semver.rcompare(v1, v2, { includePrerelease: false });
 comparatorResult = semver.compareIdentifiers(str, str);
 comparatorResult = semver.rcompareIdentifiers(str, str);
 versionsArr = semver.sort(['', new semver.SemVer('')]);
 versionsArr = semver.rsort(['', new semver.SemVer('')]);
+diff = semver.diff(v1, v2);
+// @ts-expect-error
 diff = semver.diff(v1, v2, loose);
 
 // Ranges


### PR DESCRIPTION
Only functions that take ranges take a `includePrereleases` option.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  The last paragraph [here](https://github.com/npm/node-semver/tree/v7.3.7#prerelease-tags) contains the following:
  > by setting the `includePrerelease` flag on the options object to any [functions](https://github.com/npm/node-semver#functions) **that do range matching**.

  Functions can be found here: https://github.com/npm/node-semver/tree/v7.3.7/functions
  Tests and their fixtures can be found here: https://github.com/npm/node-semver/tree/v7.3.7/test/functions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
