### PR TITLE
[@types/chrome] Fix chrome.devtools.inspectedWindow.reload()

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2469,7 +2469,7 @@ declare namespace chrome.devtools.inspectedWindow {
     export var tabId: number;
 
     /** Reloads the inspected page. */
-    export function reload(reloadOptions: ReloadOptions): void;
+    export function reload(reloadOptions?: ReloadOptions): void;
     /**
      * Evaluates a JavaScript expression in the context of the main frame of the inspected page. The expression must evaluate to a JSON-compliant object, otherwise an exception is thrown. The eval function can report either a DevTools-side error or a JavaScript exception that occurs during evaluation. In either case, the result parameter of the callback is undefined. In the case of a DevTools-side error, the isException parameter is non-null and has isError set to true and code set to an error code. In the case of a JavaScript error, isException is set to true and value is set to the string value of thrown object.
      * @param expression An expression to evaluate.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -798,6 +798,14 @@ function testDevtools() {
     chrome.devtools.inspectedWindow.eval('1+1', undefined, result => {
         console.log(result);
     });
+
+    chrome.devtools.inspectedWindow.reload();
+    chrome.devtools.inspectedWindow.reload({});
+    chrome.devtools.inspectedWindow.reload({
+        userAgent: 'Best Browser',
+        ignoreCache: true,
+        injectedScript: 'console.log("Hello World!")',
+    });
 }
 
 function testAssistiveWindow() {


### PR DESCRIPTION
Reflect that `chrome.devtools.inspectedWindow.reload()` takes an optional argument.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Chrome Developer documentation:
https://developer.chrome.com/docs/extensions/reference/devtools_inspectedWindow/#method-reload
  - MDN Documentation:
 https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/reload#parameters
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.