### PR TITLE
[@types/inquirer] Fix broken ESModule imports

### DIFF
--- a/types/inquirer-npm-name/index.d.ts
+++ b/types/inquirer-npm-name/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.2
 
-import inquirer, { Question } from "inquirer";
+import inquirer = require("inquirer");
 
 type Inquirer = typeof inquirer;
-declare function askName(name: string | Question, inquirer: Inquirer): Promise<{ [key: string]: string }>;
+declare function askName(name: string | inquirer.Question, inquirer: Inquirer): Promise<{ [key: string]: string }>;
 export = askName;

--- a/types/inquirer-npm-name/index.d.ts
+++ b/types/inquirer-npm-name/index.d.ts
@@ -4,8 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.2
 
-import inquirer = require("inquirer");
+import { Question, PromptFunction } from "inquirer";
 
-type Inquirer = typeof inquirer;
-declare function askName(name: string | inquirer.Question, inquirer: Inquirer): Promise<{ [key: string]: string }>;
+declare function askName(name: string | Question, inquirer: { prompt: PromptFunction }): Promise<{ [key: string]: string }>;
 export = askName;

--- a/types/inquirer-npm-name/inquirer-npm-name-tests.ts
+++ b/types/inquirer-npm-name/inquirer-npm-name-tests.ts
@@ -8,7 +8,7 @@ askName("moduleName", inquirer);
 askName(
     {
         name: "moduleName",
-        message: "Whar's the name of your module?"
+        message: "What's the name of your module?"
     },
     inquirer);
 

--- a/types/inquirer-npm-name/inquirer-npm-name-tests.ts
+++ b/types/inquirer-npm-name/inquirer-npm-name-tests.ts
@@ -1,4 +1,4 @@
-import inquirer from "inquirer";
+import inquirer = require("inquirer");
 import askName = require("inquirer-npm-name");
 
 // $ExpectType Promise<{ [key: string]: string; }>

--- a/types/inquirer-npm-name/inquirer-npm-name-tests.ts
+++ b/types/inquirer-npm-name/inquirer-npm-name-tests.ts
@@ -11,3 +11,10 @@ askName(
         message: "Whar's the name of your module?"
     },
     inquirer);
+
+askName(
+    "", {
+    prompt<T extends inquirer.Answers>(questions: inquirer.QuestionCollection<T>): Promise<T> {
+        return null as any;
+    }
+});

--- a/types/inquirer-npm-name/tsconfig.json
+++ b/types/inquirer-npm-name/tsconfig.json
@@ -9,6 +9,14 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
+        "paths": {
+            "inquirer": [
+                "inquirer/v8"
+            ],
+            "inquirer/*": [
+                "inquirer/v8/*"
+            ]
+        },
         "typeRoots": [
             "../"
         ],

--- a/types/inquirer/OTHER_FILES.txt
+++ b/types/inquirer/OTHER_FILES.txt
@@ -1,0 +1,15 @@
+lib/objects/choice.d.ts
+lib/objects/separator.d.ts
+lib/prompts/base.d.ts
+lib/prompts/checkbox.d.ts
+lib/prompts/confirm.d.ts
+lib/prompts/editor.d.ts
+lib/prompts/expand.d.ts
+lib/prompts/list.d.ts
+lib/prompts/number.d.ts
+lib/prompts/password.d.ts
+lib/prompts/rawlist.d.ts
+lib/ui/baseUI.d.ts
+lib/ui/prompt.d.ts
+lib/utils/events.d.ts
+lib/utils/readline.d.ts

--- a/types/inquirer/OTHER_FILES.txt
+++ b/types/inquirer/OTHER_FILES.txt
@@ -1,10 +1,12 @@
 lib/objects/choice.d.ts
+lib/objects/choices.d.ts
 lib/objects/separator.d.ts
 lib/prompts/base.d.ts
 lib/prompts/checkbox.d.ts
 lib/prompts/confirm.d.ts
 lib/prompts/editor.d.ts
 lib/prompts/expand.d.ts
+lib/prompts/input.d.ts
 lib/prompts/list.d.ts
 lib/prompts/number.d.ts
 lib/prompts/password.d.ts
@@ -12,4 +14,8 @@ lib/prompts/rawlist.d.ts
 lib/ui/baseUI.d.ts
 lib/ui/prompt.d.ts
 lib/utils/events.d.ts
+lib/utils/incrementListIndex.d.ts
+lib/utils/paginator.d.ts
 lib/utils/readline.d.ts
+lib/utils/screen-manager.d.ts
+lib/utils/utils.d.ts

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -16,26 +16,26 @@
 import { Interface as ReadlineInterface } from 'readline';
 import { Observable } from 'rxjs';
 import { ThroughStream } from 'through';
-import Choice from './lib/objects/choice';
-import Choices from './lib/objects/choices';
-import Separator from './lib/objects/separator';
-import './lib/prompts/base';
-import CheckboxPrompt from './lib/prompts/checkbox';
-import ConfirmPrompt from './lib/prompts/confirm';
-import EditorPrompt from './lib/prompts/editor';
-import ExpandPrompt from './lib/prompts/expand';
-import InputPrompt from './lib/prompts/input';
-import ListPrompt from './lib/prompts/list';
-import NumberPrompt from './lib/prompts/number';
-import PasswordPrompt from './lib/prompts/password';
-import RawListPrompt from './lib/prompts/rawlist';
-import UI from './lib/ui/baseUI';
-import './lib/ui/bottom-bar';
-import './lib/ui/prompt';
-import './lib/utils/events';
-import './lib/utils/paginator';
-import './lib/utils/readline';
-import './lib/utils/screen-manager';
+import Choice from './lib/objects/choice.js';
+import Choices from './lib/objects/choices.js';
+import Separator from './lib/objects/separator.js';
+import './lib/prompts/base.js';
+import CheckboxPrompt from './lib/prompts/checkbox.js';
+import ConfirmPrompt from './lib/prompts/confirm.js';
+import EditorPrompt from './lib/prompts/editor.js';
+import ExpandPrompt from './lib/prompts/expand.js';
+import InputPrompt from './lib/prompts/input.js';
+import ListPrompt from './lib/prompts/list.js';
+import NumberPrompt from './lib/prompts/number.js';
+import PasswordPrompt from './lib/prompts/password.js';
+import RawListPrompt from './lib/prompts/rawlist.js';
+import UI from './lib/ui/baseUI.js';
+import './lib/ui/bottom-bar.js';
+import './lib/ui/prompt.js';
+import './lib/utils/events.js';
+import './lib/utils/paginator.js';
+import './lib/utils/readline.js';
+import './lib/utils/screen-manager.js';
 
 /**
  * Represents a union which preserves autocompletion.

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -48,6 +48,9 @@ import './lib/utils/screen-manager.js';
  */
 type LiteralUnion<T extends F, F = string> = T | (F & {});
 
+/**
+ * Represents a function for prompting questions to the user.
+ */
 export interface PromptFunction {
     /**
      * Prompts the questions to the user.

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -48,10 +48,17 @@ import './lib/utils/screen-manager.js';
  */
 type LiteralUnion<T extends F, F = string> = T | (F & {});
 
+export interface PromptFunction {
+    /**
+     * Prompts the questions to the user.
+     */
+    <T extends Answers = Answers>(questions: QuestionCollection<T>, initialAnswers?: Partial<T>): Promise<T>;
+}
+
 /**
  * Provides prompts for answering questions.
  */
-interface PromptModuleBase {
+export interface PromptModuleBase extends PromptFunction {
     /**
      * Registers a new prompt-type.
      *

--- a/types/inquirer/inquirer-tests.ts
+++ b/types/inquirer/inquirer-tests.ts
@@ -1,11 +1,11 @@
 import { createInterface } from 'readline';
 import inquirer, { Answers, DistinctChoice, DistinctQuestion, InputQuestionOptions } from 'inquirer';
-import InputPrompt from 'inquirer/lib/prompts/input';
-import { fetchAsyncQuestionProperty } from 'inquirer/lib/utils/utils';
-import incrementListIndex from 'inquirer/lib/utils/incrementListIndex';
-import Choices from 'inquirer/lib/objects/choices';
-import Paginator from 'inquirer/lib/utils/paginator';
-import ScreenManager from 'inquirer/lib/utils/screen-manager';
+import InputPrompt from 'inquirer/lib/prompts/input.js';
+import { fetchAsyncQuestionProperty } from 'inquirer/lib/utils/utils.js';
+import incrementListIndex from 'inquirer/lib/utils/incrementListIndex.js';
+import Choices from 'inquirer/lib/objects/choices.js';
+import Paginator from 'inquirer/lib/utils/paginator.js';
+import ScreenManager from 'inquirer/lib/utils/screen-manager.js';
 import { Subject } from 'rxjs';
 {
     new inquirer.Separator('');

--- a/types/inquirer/lib/objects/choice.d.ts
+++ b/types/inquirer/lib/objects/choice.d.ts
@@ -1,4 +1,4 @@
-import { Answers, CheckboxChoiceOptions, ExpandChoiceOptions, ListChoiceOptions } from '../..';
+import { Answers, CheckboxChoiceOptions, ExpandChoiceOptions, ListChoiceOptions } from '../../index.js';
 
 /**
  * Represents a choice for several question-types.

--- a/types/inquirer/lib/objects/choices.d.ts
+++ b/types/inquirer/lib/objects/choices.d.ts
@@ -1,6 +1,6 @@
-import { AllChoiceMap, Answers, KeyUnion, UnionToIntersection } from '../..';
-import Choice from './choice';
-import Separator from './separator';
+import { AllChoiceMap, Answers, KeyUnion, UnionToIntersection } from '../../index.js';
+import Choice from './choice.js';
+import Separator from './separator.js';
 
 /**
  * Represents a valid choice for the {@link Choices `Choices<T>`} class.

--- a/types/inquirer/lib/objects/separator.d.ts
+++ b/types/inquirer/lib/objects/separator.d.ts
@@ -1,3 +1,3 @@
-import inquirer from "../..";
+import inquirer from "../../index.js";
 
 export default inquirer.Separator;

--- a/types/inquirer/lib/prompts/base.d.ts
+++ b/types/inquirer/lib/prompts/base.d.ts
@@ -1,7 +1,7 @@
 import { Interface as ReadLineInterface } from 'readline';
 import { Observable } from 'rxjs';
-import inquirer, { Answers, Question } from '../..';
-import ScreenManager from '../utils/screen-manager';
+import inquirer, { Answers, Question } from '../../index.js';
+import ScreenManager from '../utils/screen-manager.js';
 
 /**
  * Represents a prompt.

--- a/types/inquirer/lib/prompts/checkbox.d.ts
+++ b/types/inquirer/lib/prompts/checkbox.d.ts
@@ -1,7 +1,7 @@
 import { Interface as ReadLineInterface } from 'readline';
-import inquirer, { Answers, CheckboxQuestionOptions } from '../..';
-import Paginator from '../utils/paginator';
-import Prompt from './base';
+import inquirer, { Answers, CheckboxQuestionOptions } from '../../index.js';
+import Paginator from '../utils/paginator.js';
+import Prompt from './base.js';
 
 /**
  * The question-options for the {@link CheckboxPrompt `CheckboxPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/confirm.d.ts
+++ b/types/inquirer/lib/prompts/confirm.d.ts
@@ -1,6 +1,6 @@
 import { Interface as ReadlineInterface } from 'readline';
-import { Answers, ConfirmQuestionOptions } from '../..';
-import Prompt from './base';
+import { Answers, ConfirmQuestionOptions } from '../../index.js';
+import Prompt from './base.js';
 
 /**
  * The question-options for the {@link ConfirmPrompt `ConfirmPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/editor.d.ts
+++ b/types/inquirer/lib/prompts/editor.d.ts
@@ -1,7 +1,7 @@
 import { Interface as ReadlineInterface } from 'readline';
 import { Subject, Subscription } from 'rxjs';
-import inquirer, { Answers, EditorQuestionOptions } from '../..';
-import Prompt from './base';
+import inquirer, { Answers, EditorQuestionOptions } from '../../index.js';
+import Prompt from './base.js';
 
 /**
  * The question-options for the {@link EditorPrompt `EditorPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/expand.d.ts
+++ b/types/inquirer/lib/prompts/expand.d.ts
@@ -1,7 +1,7 @@
 import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { Answers, ExpandQuestionOptions } from '../..';
-import Paginator from '../utils/paginator';
-import Prompt from './base';
+import inquirer, { Answers, ExpandQuestionOptions } from '../../index.js';
+import Paginator from '../utils/paginator.js';
+import Prompt from './base.js';
 
 /**
  * The question-options for the {@link ExpandPrompt `ExpandPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/input.d.ts
+++ b/types/inquirer/lib/prompts/input.d.ts
@@ -1,6 +1,6 @@
 import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { Answers, InputQuestionOptions } from '../..';
-import Prompt from './base';
+import inquirer, { Answers, InputQuestionOptions } from '../../index.js';
+import Prompt from './base.js';
 
 /**
  * The question-options for the {@link InputPrompt `InputPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/list.d.ts
+++ b/types/inquirer/lib/prompts/list.d.ts
@@ -1,7 +1,7 @@
 import { Interface as ReadlineInterface } from 'readline';
-import { Answers, ListQuestionOptions } from '../..';
-import Paginator from '../utils/paginator';
-import Prompt from './base';
+import { Answers, ListQuestionOptions } from '../../index.js';
+import Paginator from '../utils/paginator.js';
+import Prompt from './base.js';
 
 /**
  * The question-options for the {@link ListPrompt `ListPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/number.d.ts
+++ b/types/inquirer/lib/prompts/number.d.ts
@@ -1,6 +1,6 @@
 import { Interface as ReadlineInterface } from 'readline';
-import { Answers, NumberQuestionOptions } from '../..';
-import InputPrompt from './input';
+import { Answers, NumberQuestionOptions } from '../../index.js';
+import InputPrompt from './input.js';
 
 /**
  * The question for the {@link NumberPrompt `NumberPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/password.d.ts
+++ b/types/inquirer/lib/prompts/password.d.ts
@@ -1,6 +1,6 @@
 import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { Answers, PasswordQuestionOptions } from '../..';
-import Prompt from './base';
+import inquirer, { Answers, PasswordQuestionOptions } from '../../index.js';
+import Prompt from './base.js';
 
 /**
  * The question for the {@link PasswordPrompt `PasswordPrompt<TQuestion>`}.

--- a/types/inquirer/lib/prompts/rawlist.d.ts
+++ b/types/inquirer/lib/prompts/rawlist.d.ts
@@ -1,7 +1,7 @@
 import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { Answers, RawListQuestionOptions } from '../..';
-import Paginator from '../utils/paginator';
-import Prompt from './base';
+import inquirer, { Answers, RawListQuestionOptions } from '../../index.js';
+import Paginator from '../utils/paginator.js';
+import Prompt from './base.js';
 
 /**
  * The question for the {@link RawListPrompt `RawListPrompt<TQuestion>`}.

--- a/types/inquirer/lib/ui/baseUI.d.ts
+++ b/types/inquirer/lib/ui/baseUI.d.ts
@@ -1,5 +1,5 @@
 import { Interface as ReadlineInterface } from 'readline';
-import inquirer, { StreamOptions } from '../..';
+import inquirer, { StreamOptions } from '../../index.js';
 
 /**
  * Represents a ui.

--- a/types/inquirer/lib/ui/bottom-bar.d.ts
+++ b/types/inquirer/lib/ui/bottom-bar.d.ts
@@ -1,3 +1,3 @@
-import inquirer from '../..';
+import inquirer from '../../index.js';
 
 export default inquirer.ui.BottomBar;

--- a/types/inquirer/lib/ui/prompt.d.ts
+++ b/types/inquirer/lib/ui/prompt.d.ts
@@ -1,3 +1,3 @@
-import inquirer from '../..';
+import inquirer from '../../index.js';
 
 export default inquirer.ui.Prompt;

--- a/types/inquirer/lib/utils/incrementListIndex.d.ts
+++ b/types/inquirer/lib/utils/incrementListIndex.d.ts
@@ -1,4 +1,4 @@
-import Choices from '../objects/choices';
+import Choices from '../objects/choices.js';
 
 type Direction = 'up' | 'down';
 interface Options {

--- a/types/inquirer/lib/utils/paginator.d.ts
+++ b/types/inquirer/lib/utils/paginator.d.ts
@@ -1,4 +1,4 @@
-import ScreenManager from './screen-manager';
+import ScreenManager from './screen-manager.js';
 
 interface PaginatorOptions {
     /**

--- a/types/inquirer/lib/utils/utils.d.ts
+++ b/types/inquirer/lib/utils/utils.d.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import { Answers, DistinctQuestion, KeyUnion, UnionToIntersection } from '../..';
+import { Answers, DistinctQuestion, KeyUnion, UnionToIntersection } from '../../index.js';
 
 /**
  * Represents a property-name of any question-type.

--- a/types/inquirer/v8/index.d.ts
+++ b/types/inquirer/v8/index.d.ts
@@ -48,6 +48,9 @@ import './lib/utils/screen-manager';
  */
 type LiteralUnion<T extends F, F = string> = T | (F & {});
 
+/**
+ * Represents a function for prompting questions to the user.
+ */
 export interface PromptFunction {
     /**
      * Prompts the questions to the user.

--- a/types/inquirer/v8/index.d.ts
+++ b/types/inquirer/v8/index.d.ts
@@ -48,10 +48,17 @@ import './lib/utils/screen-manager';
  */
 type LiteralUnion<T extends F, F = string> = T | (F & {});
 
+export interface PromptFunction {
+    /**
+     * Prompts the questions to the user.
+     */
+    <T extends Answers = Answers>(questions: QuestionCollection<T>, initialAnswers?: Partial<T>): Promise<T>;
+}
+
 /**
  * Provides prompts for answering questions.
  */
-interface PromptModuleBase {
+export interface PromptModuleBase extends PromptFunction {
     /**
      * Registers a new prompt-type.
      *

--- a/types/yeoman-environment/tsconfig.json
+++ b/types/yeoman-environment/tsconfig.json
@@ -9,6 +9,14 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
+        "paths": {
+            "inquirer": [
+                "inquirer/v8"
+            ],
+            "inquirer/*": [
+                "inquirer/v8/*"
+            ]
+        },
         "typeRoots": [
             "../"
         ],

--- a/types/yeoman-generator/tsconfig.json
+++ b/types/yeoman-generator/tsconfig.json
@@ -9,6 +9,14 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
+        "paths": {
+            "inquirer": [
+                "inquirer/v8"
+            ],
+            "inquirer/*": [
+                "inquirer/v8/*"
+            ]
+        },
         "typeRoots": [
             "../"
         ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~


This is a follow-up to #61269 
As it looks, in ESModule `@types/`-packages too, import specifiers must contain the file extension in relative import paths.

Some files were reported as not being part of the project for a reason unknown to me. Therefore, I added the files which weren't being recognized properly to `OTHER_FILES.txt`.