### PR TITLE
[passport] add message object to fail signature

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -119,7 +119,7 @@ declare namespace passport {
          *
          * Strategies should call this function to fail an authentication attempt.
          */
-        fail(challenge?: string | number, status?: number): void;
+        fail(challenge?: {message?: string, [key: string]: any } | string | number, status?: number): void;
         /**
          * Redirect to `url` with optional `status`, defaulting to 302.
          *

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -24,6 +24,10 @@ class TestStrategy extends passport.Strategy {
         const user: Express.User = { username: 'abc' };
         if (Math.random() > 0.5) {
             this.fail();
+            this.fail(403);
+            this.fail('challenge string', 403);
+            this.fail({message: 'hello'}, 403);
+            this.fail({message: 'hello', other: 123}, 123);
         } else {
             this.success(user);
         }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:


## Context + Documentation
This matches the definition of `fail` described in the the existing [passport-strategy](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/14ffce947e2da5c203b405cd2db2e05348f7a1b9/types/passport-strategy/index.d.ts#L50-L59) type definitions.

There are also a number of [examples](https://cs.github.com/?scopeName=All+repos&scope=&q=org%3Ajaredhanson+fail%28%7B) from the author of `passport-strategy` using it this way.

`passport-strategy` has an [open issue](https://github.com/jaredhanson/passport-strategy/issues/11) from 2016 and `passport` has a [similar one](https://github.com/jaredhanson/passport/issues/531) from the same reporter to address the ambiguity but there hasn't been much activity.