### PR TITLE
[papaparse] Fix calling `parse` with `step` but no `complete`

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -18,6 +18,8 @@ import { Duplex } from "stream";
 
 export as namespace Papa;
 
+export {};   // Don't export all declarations!
+
 /**
  * Parse local files
  * @param file a File object obtained from the DOM.
@@ -130,7 +132,7 @@ export let RemoteChunkSize: number;
 export let DefaultDelimiter: string;
 
 /** File object */
-export type LocalFile = Blob | NodeJS.ReadableStream;
+export type LocalFile = File | NodeJS.ReadableStream;
 
 /**
  * On Papa there are actually more classes exposed
@@ -278,7 +280,8 @@ export interface ParseWorkerConfig<T = any> extends ParseConfig<T> {
     complete(results: ParseResult<T>): void;
 }
 
-export interface ParseAsyncConfig<T = any, TInput = undefined> extends ParseConfig<T, TInput> {
+// Base interface for all async parsing
+interface ParseAsyncConfigBase<T = any, TInput = undefined> extends ParseConfig<T, TInput> {
     /**
      * Whether or not to use a worker thread.
      * Using a worker will keep your page reactive, but may be slightly slower.
@@ -301,16 +304,28 @@ export interface ParseAsyncConfig<T = any, TInput = undefined> extends ParseConf
      * The function is passed two arguments: the error and the File.
      */
     error?(error: Error, file: TInput): void;
-    /** @inheritdoc */
-    complete(results: ParseResult<T>, file: TInput): void;
 }
 
-export interface ParseLocalConfig<T = any, TInput = undefined> extends ParseAsyncConfig<T, TInput> {
+// Async parsing local file can specify encoding
+interface ParseLocalConfigBase<T = any, TInput = undefined> extends ParseAsyncConfigBase<T, TInput> {
     /** The encoding to use when opening local files. If specified, it must be a value supported by the FileReader API. */
     encoding?: string | undefined;
 }
 
-export interface ParseRemoteConfig<T = any> extends ParseAsyncConfig<T, string> {
+interface ParseLocalConfigStep<T = any, TInput = undefined> extends ParseLocalConfigBase<T, TInput> {
+    /** @inheritdoc */
+    step(results: ParseStepResult<T>, parser: Parser): void;
+}
+interface ParseLocalConfigNoStep<T = any, TInput = undefined> extends ParseLocalConfigBase<T, TInput> {
+    /** @inheritdoc */
+    complete(results: ParseResult<T>, file: TInput): void;
+}
+
+// Local parsing is async and thus must specify either `step` or `complete` (but may specify both)
+export type ParseLocalConfig<T = any, TInput = undefined> = ParseLocalConfigStep<T, TInput> | ParseLocalConfigNoStep<T, TInput>;
+
+// Remote parsing has options for the backing web request
+interface ParseRemoteConfigBase<T = any> extends ParseAsyncConfigBase<T, string> {
     /**
      * This indicates that the string you passed as the first argument to `parse()`
      * is actually a URL from which to download a file and parse its contents.
@@ -333,6 +348,18 @@ export interface ParseRemoteConfig<T = any> extends ParseAsyncConfig<T, string> 
      */
     withCredentials?: boolean | undefined;
 }
+
+interface ParseRemoteConfigStep<T = any> extends ParseRemoteConfigBase<T> {
+    /** @inheritdoc */
+    step(results: ParseStepResult<T>, parser: Parser): void;
+}
+interface ParseRemoteConfigNoStep<T = any> extends ParseRemoteConfigBase<T> {
+    /** @inheritdoc */
+    complete(results: ParseResult<T>, file: string): void;
+}
+
+// Remote parsing is async and thus must specify either `step` or `complete` (but may specify both)
+export type ParseRemoteConfig<T = any> = ParseRemoteConfigStep<T> | ParseRemoteConfigNoStep<T>;
 
 export interface UnparseConfig {
     /**

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -115,6 +115,48 @@ Papa.parse<[string]>(file, {
     },
 });
 
+// Async parsing is allowed to specify only step, only complete, or both
+Papa.parse<string[]>(file, {
+    step(results, parser) {
+        // $ExpectType string[]
+        results.data;
+        // $ExpectType ParseError[]
+        results.errors;
+        // $ExpectType Parser
+        parser;
+    },
+});
+
+Papa.parse<string[]>(file, {
+    complete(results, file) {
+        // $ExpectType string[][]
+        results.data;
+        // $ExpectType ParseError[]
+        results.errors;
+        // $ExpectType LocalFile
+        file;
+    },
+});
+
+Papa.parse<string[]>(file, {
+    step(results, parser) {
+        // $ExpectType string[]
+        results.data;
+        // $ExpectType ParseError[]
+        results.errors;
+        // $ExpectType Parser
+        parser;
+    },
+    complete(results, file) {
+        // $ExpectType string[][]
+        results.data;
+        // $ExpectType ParseError[]
+        results.errors;
+        // $ExpectType LocalFile
+        file;
+    },
+});
+
 // $ExpectType void
 Papa.parse('/resources/files/normal.csv', {
     download: true,
@@ -159,17 +201,17 @@ const papaStream: Duplex = Papa.parse(Papa.NODE_STREAM_INPUT);
 readable.pipe(papaStream);
 
 // generic
-Papa.parse<string>('a,b,c', {
+Papa.parse<string[]>('a,b,c', {
     step(a) {
-        a.data[0];
+        a.data[0].toLowerCase();
     },
 });
 
 // `chunk` Works only with local and remote files
 // @ts-expect-error
-Papa.parse<string>('a,b,c', {
+Papa.parse<string[]>('a,b,c', {
     chunk(a) {
-        a.data[0];
+        console.log(a);
     },
 });
 


### PR DESCRIPTION
Added tests

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.papaparse.com/docs


----

There is one additional change that should be made but is currently not possible.  The defs include a triple-slash reference to `@types/node`, and also specify `lib:['dom']` in the tsconfig.  This allows defs to be referenced from both node and browser environments, but also means that all consumers must include types from both platforms.

There are a number of efforts underway to address this issue (like https://github.com/microsoft/TypeScript/issues/31894 or https://github.com/microsoft/TypeScript/issues/3538) but in the interim the best fix I have found is abusing `ts-ignore` comments on import declarations -- if you put a `@ts-ignore` comment before `type NodeReadableStream = any extends NodeJS.ReadableStream ? never: NodeJS.ReadableStream;`, the type will be an alias to the real ReadableStream when `@types/node` has been included, or `never` if not.  Unfortunately, `dtslint` always flags `ts-ignore` comments so the PR will not merge cleanly with my workaround in place.  For now, I'm going to open an issue with dtslint.
