### PR TITLE
webpack-bundle-analyzer - Better Webpack types and cover plugin methods and members

### DIFF
--- a/types/customize-cra/tsconfig.json
+++ b/types/customize-cra/tsconfig.json
@@ -12,6 +12,9 @@
             "webpack": [
                 "webpack/v4"
             ],
+            "webpack-bundle-analyzer": [
+                "webpack-bundle-analyzer/v3"
+            ],
             "tapable": [
                 "tapable/v1"
             ],

--- a/types/webpack-bundle-analyzer/index.d.ts
+++ b/types/webpack-bundle-analyzer/index.d.ts
@@ -150,9 +150,12 @@ export class BundleAnalyzerPlugin implements WebpackPluginInstance {
     constructor(options?: BundleAnalyzerPlugin.Options);
 
     apply(compiler: Compiler): void;
+    /** @async */
     startAnalyzerServer: (stats: WebpackStats) => Promise<void>;
+    /** @async */
     generateJSONReport: (stats: WebpackStats) => Promise<void>;
     generateStatsFile: (stats: WebpackStats) => Promise<void>;
+    /** @async */
     generateStaticReport: (stats: WebpackStats) => Promise<void>;
     getBundleDirFromCompiler: () => null | string;
 }

--- a/types/webpack-bundle-analyzer/index.d.ts
+++ b/types/webpack-bundle-analyzer/index.d.ts
@@ -17,20 +17,19 @@ export namespace BundleAnalyzerPlugin {
     // Copied from @types/webpack@4 as webpack@5 only has `any` defined at the moment.
     // See https://github.com/webpack/webpack/issues/11630
     namespace Stats {
-        type Preset
-            = boolean
-            | 'errors-only'
-            | 'errors-warnings'
-            | 'minimal'
-            | 'none'
-            | 'normal'
-            | 'verbose';
+        type Preset = boolean | 'errors-only' | 'errors-warnings' | 'minimal' | 'none' | 'normal' | 'verbose';
 
         type ToJsonOptionsObject = StatsOptions;
 
         type ToJsonOptions = Preset | ToJsonOptionsObject;
 
-        type StatsExcludeFilter = string | string[] | RegExp | RegExp[] | ((assetName: string) => boolean) | Array<(assetName: string) => boolean>;
+        type StatsExcludeFilter =
+            | string
+            | string[]
+            | RegExp
+            | RegExp[]
+            | ((assetName: string) => boolean)
+            | Array<(assetName: string) => boolean>;
     }
 
     type ExcludeAssetsPatternFn = (assetName: string) => boolean;

--- a/types/webpack-bundle-analyzer/index.d.ts
+++ b/types/webpack-bundle-analyzer/index.d.ts
@@ -11,7 +11,7 @@
 /// <reference types="node" />
 
 import { Server } from 'http';
-import { WebpackPluginInstance, Compiler, StatsOptions, Stats } from 'webpack';
+import { WebpackPluginInstance, Compiler, StatsOptions, Stats as WebpackStats } from 'webpack';
 
 export namespace BundleAnalyzerPlugin {
     // Copied from @types/webpack@4 as webpack@5 only has `any` defined at the moment.
@@ -103,7 +103,7 @@ export namespace BundleAnalyzerPlugin {
          * For example you can exclude sources of your modules from stats file with "source: false" option.
          * @default null
          */
-        statsOptions?: null | Stats.ToJsonOptionsObject | undefined;
+        statsOptions?: null | Stats.ToJsonOptions | undefined;
 
         /**
          * Patterns that will be used to match against asset names to exclude them from the report.
@@ -151,9 +151,9 @@ export class BundleAnalyzerPlugin implements WebpackPluginInstance {
     constructor(options?: BundleAnalyzerPlugin.Options);
 
     apply(compiler: Compiler): void;
-    startAnalyzerServer: (stats: Stats) => Promise<void>;
-    generateJSONReport: (stats: Stats) => Promise<void>;
-    generateStatsFile: (stats: Stats) => Promise<void>;
-    generateStaticReport: (stats: Stats) => Promise<void>;
+    startAnalyzerServer: (stats: WebpackStats) => Promise<void>;
+    generateJSONReport: (stats: WebpackStats) => Promise<void>;
+    generateStatsFile: (stats: WebpackStats) => Promise<void>;
+    generateStaticReport: (stats: WebpackStats) => Promise<void>;
     getBundleDirFromCompiler: () => null | string;
 }

--- a/types/webpack-bundle-analyzer/index.d.ts
+++ b/types/webpack-bundle-analyzer/index.d.ts
@@ -10,7 +10,8 @@
 
 /// <reference types="node" />
 
-import { WebpackPluginInstance, Compiler } from 'webpack';
+import { Server } from 'http';
+import { WebpackPluginInstance, Compiler, StatsOptions, Stats } from 'webpack';
 
 export namespace BundleAnalyzerPlugin {
     // Copied from @types/webpack@4 as webpack@5 only has `any` defined at the moment.
@@ -25,80 +26,7 @@ export namespace BundleAnalyzerPlugin {
             | 'normal'
             | 'verbose';
 
-        interface ToJsonOptionsObject {
-            /** fallback value for stats options when an option is not defined (has precedence over local webpack defaults) */
-            all?: boolean | undefined;
-            /** Add asset Information */
-            assets?: boolean | undefined;
-            /** Sort assets by a field */
-            assetsSort?: string | undefined;
-            /** Add built at time information */
-            builtAt?: boolean | undefined;
-            /** Add information about cached (not built) modules */
-            cached?: boolean | undefined;
-            /** Show cached assets (setting this to `false` only shows emitted files) */
-            cachedAssets?: boolean | undefined;
-            /** Add children information */
-            children?: boolean | undefined;
-            /** Add information about the `namedChunkGroups` */
-            chunkGroups?: boolean | undefined;
-            /** Add built modules information to chunk information */
-            chunkModules?: boolean | undefined;
-            /** Add the origins of chunks and chunk merging info */
-            chunkOrigins?: boolean | undefined;
-            /** Add chunk information (setting this to `false` allows for a less verbose output) */
-            chunks?: boolean | undefined;
-            /** Sort the chunks by a field */
-            chunksSort?: string | undefined;
-            /** Context directory for request shortening */
-            context?: string | undefined;
-            /** Display the distance from the entry point for each module */
-            depth?: boolean | undefined;
-            /** Display the entry points with the corresponding bundles */
-            entrypoints?: boolean | undefined;
-            /** Add --env information */
-            env?: boolean | undefined;
-            /** Add errors */
-            errors?: boolean | undefined;
-            /** Add details to errors (like resolving log) */
-            errorDetails?: boolean | undefined;
-            /** Exclude assets from being displayed in stats */
-            excludeAssets?: StatsExcludeFilter | undefined;
-            /** Exclude modules from being displayed in stats */
-            excludeModules?: StatsExcludeFilter | undefined;
-            /** See excludeModules */
-            exclude?: StatsExcludeFilter | undefined;
-            /** Add the hash of the compilation */
-            hash?: boolean | undefined;
-            /** Set the maximum number of modules to be shown */
-            maxModules?: number | undefined;
-            /** Add built modules information */
-            modules?: boolean | undefined;
-            /** Sort the modules by a field */
-            modulesSort?: string | undefined;
-            /** Show dependencies and origin of warnings/errors */
-            moduleTrace?: boolean | undefined;
-            /** Add public path information */
-            publicPath?: boolean | undefined;
-            /** Add information about the reasons why modules are included */
-            reasons?: boolean | undefined;
-            /** Add the source code of modules */
-            source?: boolean | undefined;
-            /** Add timing information */
-            timings?: boolean | undefined;
-            /** Add webpack version information */
-            version?: boolean | undefined;
-            /** Add warnings */
-            warnings?: boolean | undefined;
-            /** Show which exports of a module are used */
-            usedExports?: boolean | undefined;
-            /** Filter warnings to be shown */
-            warningsFilter?: string | RegExp | Array<string | RegExp> | ((warning: string) => boolean) | undefined;
-            /** Show performance hint when file size exceeds `performance.maxAssetSize` */
-            performance?: boolean | undefined;
-            /** Show the exports of the modules */
-            providedExports?: boolean | undefined;
-        }
+        type ToJsonOptionsObject = StatsOptions;
 
         type ToJsonOptions = Preset | ToJsonOptionsObject;
 
@@ -216,7 +144,16 @@ export namespace BundleAnalyzerPlugin {
 }
 
 export class BundleAnalyzerPlugin implements WebpackPluginInstance {
+    opts: BundleAnalyzerPlugin.Options;
+    compiler?: Compiler;
+    server: null | Server;
+
     constructor(options?: BundleAnalyzerPlugin.Options);
 
     apply(compiler: Compiler): void;
+    startAnalyzerServer: (stats: Stats) => Promise<void>;
+    generateJSONReport: (stats: Stats) => Promise<void>;
+    generateStatsFile: (stats: Stats) => Promise<void>;
+    generateStaticReport: (stats: Stats) => Promise<void>;
+    getBundleDirFromCompiler: () => null | string;
 }

--- a/types/webpack-bundle-analyzer/tsconfig.json
+++ b/types/webpack-bundle-analyzer/tsconfig.json
@@ -16,9 +16,6 @@
             "webpack": [
                 "./node_modules/webpack"
             ],
-            "buffer": [
-                "./node_modules/@types/node/buffer"
-            ],
             "tapable": [
                 "./node_modules/tapable"
             ]

--- a/types/webpack-bundle-analyzer/tsconfig.json
+++ b/types/webpack-bundle-analyzer/tsconfig.json
@@ -16,6 +16,9 @@
             "webpack": [
                 "./node_modules/webpack"
             ],
+            "buffer": [
+                "./node_modules/@types/node/buffer"
+            ],
             "tapable": [
                 "./node_modules/tapable"
             ]

--- a/types/webpack-bundle-analyzer/tslint.json
+++ b/types/webpack-bundle-analyzer/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "no-outside-dependencies": false
+    }
+}

--- a/types/webpack-bundle-analyzer/tslint.json
+++ b/types/webpack-bundle-analyzer/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "no-outside-dependencies": false
+    }
 }

--- a/types/webpack-bundle-analyzer/tslint.json
+++ b/types/webpack-bundle-analyzer/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json",
-    "rules": {
-        "no-outside-dependencies": false
-    }
+    "extends": "@definitelytyped/dtslint/dt.json"
 }

--- a/types/webpack-bundle-analyzer/webpack-bundle-analyzer-tests.ts
+++ b/types/webpack-bundle-analyzer/webpack-bundle-analyzer-tests.ts
@@ -28,6 +28,12 @@ const config: webpack.Configuration = {
             excludeAssets: ['foo', /foo/, assetName => assetName.indexOf('foo') !== -1],
             logLevel: 'info',
         }),
+        new BundleAnalyzerPlugin({
+            analyzerMode: 'static',
+            statsOptions: {
+                ids: true
+            }
+        }),
     ],
 };
 
@@ -100,3 +106,13 @@ const report: BundleAnalyzerPlugin.JsonReport = [
         ],
     },
 ];
+
+const plugin = new BundleAnalyzerPlugin();
+
+plugin.apply;
+plugin.server;
+plugin.startAnalyzerServer;
+plugin.generateJSONReport;
+plugin.generateStatsFile;
+plugin.generateStaticReport;
+plugin.getBundleDirFromCompiler;


### PR DESCRIPTION
This PR does 2 things:
1. Replace the hard-coded Webpack stats options with the type provided by Webpack.
2. Adds types for plugin methods and members.

I also had to ignore the `no-outside-dependencies` dtslint rule, since Webpack relies on node's `buffer` module.

