### PR TITLE
[finalhandler] support real-world use case with `serve-static`

### DIFF
--- a/types/finalhandler/finalhandler-tests.ts
+++ b/types/finalhandler/finalhandler-tests.ts
@@ -14,6 +14,6 @@ result = finalhandler(req, res);
 result = finalhandler(req, res, options);
 
 // serve-static-like request handler
-declare function requestHandler (request: IncomingMessage, response: ServerResponse, next: () => void): any
+declare function requestHandler(request: IncomingMessage, response: ServerResponse, next: () => void): any;
 
 requestHandler(req, res, result);

--- a/types/finalhandler/finalhandler-tests.ts
+++ b/types/finalhandler/finalhandler-tests.ts
@@ -8,7 +8,12 @@ const options = {
     onerror: (err: any, req: IncomingMessage, res: ServerResponse): any => { return; }
 };
 
-let result: (err: any) => void;
+let result: (err?: any) => void;
 
 result = finalhandler(req, res);
 result = finalhandler(req, res, options);
+
+// serve-static-like request handler
+declare function requestHandler (request: IncomingMessage, response: ServerResponse, next: () => void): any
+
+requestHandler(req, res, result);

--- a/types/finalhandler/index.d.ts
+++ b/types/finalhandler/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/pillarjs/finalhandler
 // Definitions by: Ilya Mochalov <https://github.com/chrootsu>
 //                 Mark Veronda <https://github.com/hbomark>
-//                 Tomek Łaziuk <https://github.com/tlaziuk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/finalhandler/index.d.ts
+++ b/types/finalhandler/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for finalhandler 1.1
+// Type definitions for finalhandler 1.2
 // Project: https://github.com/pillarjs/finalhandler
 // Definitions by: Ilya Mochalov <https://github.com/chrootsu>
 //                 Mark Veronda <https://github.com/hbomark>
+//                 Tomek Łaziuk <https://github.com/tlaziuk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -9,7 +10,7 @@
 import { IncomingMessage, ServerResponse } from 'http';
 
 declare function finalhandler(req: IncomingMessage, res: ServerResponse,
-                              options?: finalhandler.Options): (err: any) => void;
+                              options?: finalhandler.Options): (err?: any) => void;
 
 declare namespace finalhandler {
     interface Options {


### PR DESCRIPTION
This PR introduces compatibility with the express-like `next` function type:
- https://github.com/tlaziuk/DefinitelyTyped/blob/507e9d3c8e48b2db81d3e071d270a2a297eed151/types/express-serve-static-core/index.d.ts#L22-L25
- https://github.com/tlaziuk/DefinitelyTyped/blob/ce1ed037489fce43cde23af1e82e88f4d1760c1e/types/serve-static/index.d.ts#L98-L100
- ![image](https://user-images.githubusercontent.com/7622070/183846853-35eab5d0-41f5-4eec-8b2a-90eac8a585de.png)
- `err` param is validated for falsely values https://github.com/pillarjs/finalhandler/blob/5ceb3e3e2482404cb71e9810bd10a422fe748f20/index.js#L86-L134


formalities:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pillarjs/finalhandler/blob/master/HISTORY.md#120--2022-03-22
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.