### PR TITLE
[@types/chrome] Fix chrome.tabs.sendMessage()

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9565,7 +9565,7 @@ declare namespace chrome.tabs {
      * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The runtime.onMessage event is fired in each content script running in the specified tab for the current extension.
      * @since Chrome 20.
      */
-    export function sendMessage<M = any, R = any>(tabId: number, message: M, responseCallback?: (response: R) => void): void;
+    export function sendMessage<M = any, R = any>(tabId: number, message: M, responseCallback: (response: R) => void): void;
     /**
      * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The runtime.onMessage event is fired in each content script running in the specified tab for the current extension.
      * @since Chrome 41.
@@ -9576,8 +9576,22 @@ declare namespace chrome.tabs {
         tabId: number,
         message: M,
         options: MessageSendOptions,
-        responseCallback?: (response: R) => void,
+        responseCallback: (response: R) => void,
     ): void;
+    /**
+     * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The runtime.onMessage event is fired in each content script running in the specified tab for the current extension.
+     * @since Chrome 99
+     */
+    export function sendMessage<M = any, R = any>(tabId: number, message: M): Promise<R>;
+    /**
+     * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The runtime.onMessage event is fired in each content script running in the specified tab for the current extension.
+     * @since Chrome 99
+     */
+    export function sendMessage<M = any, R = any>(
+        tabId: number,
+        message: M,
+        options: MessageSendOptions
+    ): Promise<R>;
     /**
      * Sends a single request to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The extension.onRequest event is fired in each content script running in the specified tab for the current extension.
      * @deprecated since Chrome 33. Please use runtime.sendMessage.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1241,14 +1241,16 @@ function testRuntimeSendNativeMessage() {
 
 function testTabsSendMessage() {
     chrome.tabs.sendMessage(1, "Hello World!");
-    chrome.tabs.sendMessage(2, "Hello World!", console.log);
-    chrome.tabs.sendMessage(3, "Hello World!", { }, console.log);
-    chrome.tabs.sendMessage<string>(4, "Hello World!", console.log);
-    chrome.tabs.sendMessage<string, number>(5, "Hello World!", console.log);
+    chrome.tabs.sendMessage(2, "Hello World!").then(() => {});
+    chrome.tabs.sendMessage(3, "Hello World!", console.log);
+    chrome.tabs.sendMessage(4, "Hello World!", { }).then(() => {});
+    chrome.tabs.sendMessage(5, "Hello World!", { }, console.log);
+    chrome.tabs.sendMessage<string>(6, "Hello World!", console.log);
+    chrome.tabs.sendMessage<string, number>(7, "Hello World!", console.log);
     // @ts-expect-error
-    chrome.tabs.sendMessage<number>(6, "Hello World!", console.log);
+    chrome.tabs.sendMessage<number>(8, "Hello World!", console.log);
     // @ts-expect-error
-    chrome.tabs.sendMessage<string, string>(7, "Hello World!", (num: number) => alert(num+1));
+    chrome.tabs.sendMessage<string, string>(9, "Hello World!", (num: number) => alert(num+1));
 }
 
 function testTabsSendRequest() {


### PR DESCRIPTION
Reflect that `chrome.tabs.sendMessage()` returns a Promise if the optional callback parameter is not set.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/tabs/#method-sendMessage
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
