### PR TITLE
Update marv definitions for 6.0.0

### DIFF
--- a/types/marv/api/callback.d.ts
+++ b/types/marv/api/callback.d.ts
@@ -12,11 +12,6 @@ export function migrate(
 
 export function migrate(migrations: ReadonlyArray<ParsedMigration>, driver: Driver, cb: ErrorOnlyCallback): void;
 
-/**
- * @deprecated no-op since 3.1.0
- */
-export function parseDirectives(): EmptyObject;
-
 export function scan(
     directory: PathLike,
     options: ScanOptions,

--- a/types/marv/api/promise.d.ts
+++ b/types/marv/api/promise.d.ts
@@ -9,9 +9,4 @@ export function migrate(
     options?: { quiet?: boolean },
 ): Promise<void>;
 
-/**
- * @deprecated no-op since 3.1.0
- */
-export function parseDirectives(): EmptyObject;
-
 export function scan(directory: PathLike, options?: ScanOptions): Promise<ParsedMigration[]>;

--- a/types/marv/index.d.ts
+++ b/types/marv/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for marv 5.0
+// Type definitions for marv 6.0
 // Project: https://github.com/guidesmiths/marv
 // Definitions by: Joonas Rouhiainen <https://github.com/rjoonas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -26,7 +26,6 @@ export interface ParsedMigration {
     script: string;
     directives: Record<string, string>;
     namespace: string;
-    audit?: string;
 }
 
 export interface Driver {


### PR DESCRIPTION
These deprecated features were removed from marv in https://github.com/guidesmiths/marv/commit/1f43204df1275005cc4853f07e3a03dbb08d7542

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/guidesmiths/marv/commit/1f43204df1275005cc4853f07e3a03dbb08d7542
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.