### PR TITLE
add react-size-reporter to types

### DIFF
--- a/types/react-size-reporter/index.d.ts
+++ b/types/react-size-reporter/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for react-size-reporter 2.0
+// Project: https://github.com/berrtech/react-size-reporter
+// Definitions by: Mattias Martens <https://github.com/MattiasMartens>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import * as React from 'react';
+
+declare const ReactSizeReporter: React.FC<{
+    children: React.ReactNode;
+    onSizeChange: (newDimensions: { height: number; width: number }) => void;
+}>;
+
+export default ReactSizeReporter;

--- a/types/react-size-reporter/index.d.ts
+++ b/types/react-size-reporter/index.d.ts
@@ -2,11 +2,20 @@
 // Project: https://github.com/berrtech/react-size-reporter
 // Definitions by: Mattias Martens <https://github.com/MattiasMartens>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import * as React from 'react';
+import { FC, ReactNode, Ref } from 'react';
 
-declare const ReactSizeReporter: React.FC<{
-    children: React.ReactNode;
+export interface ReactSizeReporterRef {
+    // Use this if for any reason onSizeChange doesn't trigger anymore.
+    reattachResizeListener: () => void;
+}
+
+declare const ReactSizeReporter: FC<{
+    // Children with static or dynamic height or width
+    children: ReactNode;
+    ref?: Ref<ReactSizeReporterRef>;
+    // Callback called on mount and size changes.
     onSizeChange: (newDimensions: { height: number; width: number }) => void;
 }>;
 
+export type ReactSizeReporter = typeof ReactSizeReporter;
 export default ReactSizeReporter;

--- a/types/react-size-reporter/react-size-reporter-tests.tsx
+++ b/types/react-size-reporter/react-size-reporter-tests.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import SizeReporter from 'react-size-reporter';
+
+const TestComponent = () => (
+    <SizeReporter
+        onSizeChange={({
+            width, // $ExpectType number
+            height, // $ExpectType number
+        }) => {
+            throw new Error('DefinitelyTyped example code');
+        }}
+    >
+        <div style={{ width: '50vw', height: 'calc(100 + 7em)' }}></div>
+    </SizeReporter>
+);

--- a/types/react-size-reporter/react-size-reporter-tests.tsx
+++ b/types/react-size-reporter/react-size-reporter-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import SizeReporter from 'react-size-reporter';
+import SizeReporter, { ReactSizeReporterRef } from 'react-size-reporter';
 
 const TestComponent = () => (
     <SizeReporter
@@ -13,3 +13,19 @@ const TestComponent = () => (
         <div style={{ width: '50vw', height: 'calc(100 + 7em)' }}></div>
     </SizeReporter>
 );
+
+class TestConsumer {
+    reattach = () => this.sizeReporter?.reattachResizeListener();
+    sizeReporter?: ReactSizeReporterRef;
+    render() {
+        return (
+            <SizeReporter onSizeChange={() => {}} ref={ref => (ref ? (this.sizeReporter = ref) : undefined)}>
+                <div>CONTENT GOES HERE</div>
+                <div>AND HERE</div>
+                <button type="button" onClick={this.reattach}>
+                    Reattach!
+                </button>
+            </SizeReporter>
+        );
+    }
+}

--- a/types/react-size-reporter/tsconfig.json
+++ b/types/react-size-reporter/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "react-size-reporter-tests.tsx"
+    ]
+}

--- a/types/react-size-reporter/tslint.json
+++ b/types/react-size-reporter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules. (!!!! MAINTAINERS: this was **NOT** the default when i ran `npx dts-gen --dt --name react-size-reporter --template module`! instead i got as content `{ "extends": "dtslint/dt.json" }`. one of these is configured wrong! !!!!)
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.