### PR TITLE
human-format: add typing information for human-format

### DIFF
--- a/types/human-format/human-format-tests.ts
+++ b/types/human-format/human-format-tests.ts
@@ -1,0 +1,53 @@
+import humanFormat = require("human-format");
+
+// $ExpectType string
+humanFormat(1337);
+
+// $ExpectType string
+humanFormat(1337, {
+    maxDecimals: 1,
+});
+
+// $ExpectType string
+humanFormat(13337, {
+    maxDecimals: 'auto',
+});
+
+// $ExpectType string
+humanFormat(1337, {
+    decimals: 4,
+});
+
+// $ExpectType string
+humanFormat.bytes(65536);
+
+// $ExpectType string
+humanFormat(1337, {
+    separator: ' - ',
+});
+
+const timeScale = new humanFormat.Scale({
+    seconds: 1,
+    minutes: 60,
+    hours: 3600,
+    days: 86400,
+    months: 2592000,
+});
+// $ExpectType string
+humanFormat(26729235, { scale: timeScale });
+// $ExpectType ScaleOptions
+timeScale.findPrefix(100);
+// $ExpectType ParseResult
+timeScale.parse('10 months');
+
+// $ExpectType string
+humanFormat.raw(100, { prefix: 'k' });
+
+// $ExpectType string
+humanFormat(100, { unit: 'm', prefix: 'k' });
+
+// $ExpectType number
+humanFormat.parse('1.34 kiB', { scale: 'binary' });
+
+// $ExpectType ParseResult
+humanFormat.parse.raw('1.34 kB');

--- a/types/human-format/index.d.ts
+++ b/types/human-format/index.d.ts
@@ -1,0 +1,73 @@
+// Type definitions for human-format 1.0
+// Project: https://github.com/JsCommunity/human-format
+// Definitions by: liushuyu <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Options for formatting and parsing
+ */
+interface FormatOptions {
+    maxDecimals?: number | 'auto';
+    separator?: string;
+    unit?: string;
+    scale?: 'SI' | 'binary' | humanFormat.Scale;
+    strict?: boolean;
+    decimals?: number;
+    prefix?: string;
+}
+
+/**
+ * Scale map for defining prefixes and their corresponding factors
+ */
+interface ScaleMap {
+    [index: string]: number;
+}
+
+/**
+ * Scale options
+ */
+interface ScaleOptions {
+    factor: number;
+    prefix: string;
+}
+
+/**
+ * Parsing result
+ */
+interface ParseResult extends ScaleOptions {
+    unit: string;
+    value: number;
+}
+
+/**
+ * Converts a number to/from a human readable string
+ */
+declare function humanFormat(value: number, opts?: FormatOptions): string;
+
+/**
+ * Converts a number to/from a human readable string: 1337 ↔ 1.34kB
+ */
+declare namespace humanFormat {
+    /**
+     * Format the given numeric value into human-readable format
+     */
+    function bytes(value: number, opts?: FormatOptions): string;
+    function raw(value: number, opts?: FormatOptions): string;
+    /**
+     * Parse the given human-readable string into numeric value
+     */
+    function parse(value: string, opts?: FormatOptions): number;
+    namespace parse {
+        function raw(value: string, opts?: FormatOptions): ParseResult;
+    }
+    class Scale {
+        constructor(options: ScaleMap);
+        static create(options: string[], base: number, initExp: number): Scale;
+        findPrefix(value: number): ScaleOptions;
+        parse(str: string, strict?: boolean): ParseResult;
+    }
+}
+
+export as namespace humanFormat;
+
+export = humanFormat;

--- a/types/human-format/tsconfig.json
+++ b/types/human-format/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "human-format-tests.ts"
+    ]
+}

--- a/types/human-format/tslint.json
+++ b/types/human-format/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [X] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [X] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

