### PR TITLE
[semver] Fix `options` type for range functions

### DIFF
--- a/types/semver/functions/satisfies.d.ts
+++ b/types/semver/functions/satisfies.d.ts
@@ -8,7 +8,7 @@ import semver = require('../index');
 declare function satisfies(
     version: string | SemVer,
     range: string | Range,
-    optionsOrLoose?: boolean | semver.Options,
+    optionsOrLoose?: boolean | semver.RangeOptions,
 ): boolean;
 
 export = satisfies;

--- a/types/semver/ranges/gtr.d.ts
+++ b/types/semver/ranges/gtr.d.ts
@@ -8,7 +8,7 @@ import semver = require('../index');
 declare function gtr(
     version: string | SemVer,
     range: string | Range,
-    optionsOrLoose?: boolean | semver.Options,
+    optionsOrLoose?: boolean | semver.RangeOptions,
 ): boolean;
 
 export = gtr;

--- a/types/semver/ranges/intersects.d.ts
+++ b/types/semver/ranges/intersects.d.ts
@@ -7,7 +7,7 @@ import semver = require('../index');
 declare function intersects(
     range1: string | Range,
     range2: string | Range,
-    optionsOrLoose?: boolean | semver.Options,
+    optionsOrLoose?: boolean | semver.RangeOptions,
 ): boolean;
 
 export = intersects;

--- a/types/semver/ranges/ltr.d.ts
+++ b/types/semver/ranges/ltr.d.ts
@@ -8,7 +8,7 @@ import semver = require('../index');
 declare function ltr(
     version: string | SemVer,
     range: string | Range,
-    optionsOrLoose?: boolean | semver.Options,
+    optionsOrLoose?: boolean | semver.RangeOptions,
 ): boolean;
 
 export = ltr;

--- a/types/semver/ranges/max-satisfying.d.ts
+++ b/types/semver/ranges/max-satisfying.d.ts
@@ -8,7 +8,7 @@ import semver = require('../index');
 declare function maxSatisfying<T extends string | SemVer>(
     versions: ReadonlyArray<T>,
     range: string | Range,
-    optionsOrLoose?: boolean | semver.Options,
+    optionsOrLoose?: boolean | semver.RangeOptions,
 ): T | null;
 
 export = maxSatisfying;

--- a/types/semver/ranges/min-satisfying.d.ts
+++ b/types/semver/ranges/min-satisfying.d.ts
@@ -8,7 +8,7 @@ import semver = require('../index');
 declare function minSatisfying<T extends string | SemVer>(
     versions: ReadonlyArray<T>,
     range: string | Range,
-    optionsOrLoose?: boolean | semver.Options,
+    optionsOrLoose?: boolean | semver.RangeOptions,
 ): T | null;
 
 export = minSatisfying;

--- a/types/semver/ranges/outside.d.ts
+++ b/types/semver/ranges/outside.d.ts
@@ -10,6 +10,6 @@ declare function outside(
     version: string | SemVer,
     range: string | Range,
     hilo: '>' | '<',
-    optionsOrLoose?: boolean | semver.Options,
+    optionsOrLoose?: boolean | semver.RangeOptions,
 ): boolean;
 export = outside;

--- a/types/semver/ranges/valid.d.ts
+++ b/types/semver/ranges/valid.d.ts
@@ -6,7 +6,7 @@ import semver = require('../index');
  */
 declare function validRange(
     range: string | Range | null | undefined,
-    optionsOrLoose?: boolean | semver.Options,
+    optionsOrLoose?: boolean | semver.RangeOptions,
 ): string | null;
 
 export = validRange;

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -234,13 +234,29 @@ diff = semver.diff(v1, v2, loose);
 
 // Ranges
 strn = semver.validRange(str, loose);
+strn = semver.validRange(str, { loose: false });
+strn = semver.validRange(str, { includePrerelease: false });
 bool = semver.satisfies(version, str, loose);
+bool = semver.satisfies(version, str, { loose: false });
+bool = semver.satisfies(version, str, { includePrerelease: false });
 strn = semver.maxSatisfying(versions, str, loose);
+strn = semver.maxSatisfying(versions, str, { loose: false });
+strn = semver.maxSatisfying(versions, str, { includePrerelease: false });
 strn = semver.minSatisfying(versions, str, loose);
+strn = semver.minSatisfying(versions, str, { loose: false });
+strn = semver.minSatisfying(versions, str, { includePrerelease: false });
 bool = semver.gtr(version, str, loose);
+bool = semver.gtr(version, str, { loose: false });
+bool = semver.gtr(version, str, { includePrerelease: false });
 bool = semver.ltr(version, str, loose);
+bool = semver.ltr(version, str, { loose: false });
+bool = semver.ltr(version, str, { includePrerelease: false });
 bool = semver.outside(version, str, '<', loose);
+bool = semver.outside(version, str, '<', { loose: false });
+bool = semver.outside(version, str, '<', { includePrerelease: false });
 bool = semver.intersects(str, str, loose);
+bool = semver.intersects(str, str, { loose: false });
+bool = semver.intersects(str, str, { includePrerelease: false });
 sem = semver.minVersion(str, loose);
 semver.simplifyRange(versions, '1.x'); // $ExpectType string | Range
 semver.simplifyRange(versions, '1.0.0 || 1.0.1 || 1.0.2 || 1.0.3 || 1.0.4'); // $ExpectType string | Range


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  The last paragraph [here](https://github.com/npm/node-semver/tree/v7.3.7#prerelease-tags) contains the following:
  > by setting the `includePrerelease` flag on the options object to any [functions](https://github.com/npm/node-semver#functions) **that do range matching**.

  Functions can be found here: https://github.com/npm/node-semver/tree/v7.3.7/ranges
  Tests and their fixtures can be found here: https://github.com/npm/node-semver/tree/v7.3.7/test/ranges
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Fixes the issues introduced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61586.
