### PR TITLE
fix(matter-js): make index, body and isInternal optional in Vertex

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -2473,9 +2473,9 @@ declare namespace Matter {
     export interface Vertex {
         x: number;
         y: number;
-        index: number;
-        body: Body;
-        isInternal: boolean;
+        index?: number;
+        body?: Body;
+        isInternal?: boolean;
     }
 
     /**

--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -157,7 +157,7 @@ declare namespace Matter {
         static fromVertices(
             x: number,
             y: number,
-            vertexSets: Array<Array<Vertex>>,
+            vertexSets: Array<Array<{ x: number, y: number }>>,
             options?: IBodyDefinition,
             flagInternal?: boolean,
             removeCollinear?: number,

--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -157,7 +157,7 @@ declare namespace Matter {
         static fromVertices(
             x: number,
             y: number,
-            vertexSets: Array<Array<{ x: number, y: number }>>,
+            vertexSets: Array<Array<Vector>>,
             options?: IBodyDefinition,
             flagInternal?: boolean,
             removeCollinear?: number,
@@ -2470,12 +2470,10 @@ declare namespace Matter {
         static update(pairs: Pairs, collisions: Array<Collision>, timestamp: number): void;
     }
 
-    export interface Vertex {
-        x: number;
-        y: number;
-        index?: number;
-        body?: Body;
-        isInternal?: boolean;
+    export interface Vertex extends Vector {
+        index: number;
+        body: Body;
+        isInternal: boolean;
     }
 
     /**

--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Matter.js - 0.18.0
+// Type definitions for Matter.js - 0.18
 // Project: https://github.com/liabru/matter-js
 // Definitions by: Ivane Gegia <https://twitter.com/ivanegegia>
 //                 David Asmuth <https://github.com/piranha771>

--- a/types/matter-js/matter-js-tests.ts
+++ b/types/matter-js/matter-js-tests.ts
@@ -67,7 +67,7 @@ const vertex: Matter.Vertex = {
     isInternal: false,
 };
 // $ExpectType Body
-Bodies.fromVertices(1, 2, [[vertex]]);
+Bodies.fromVertices(1, 2, [[vertex, { x: 3, y: 4 }]]);
 
 const vector = Matter.Vector.create(10, 10);
 var radius = circle1.circleRadius;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/liabru/matter-js/blob/f1ba9b583ba92a56d307d63c850a0330d26bbd5e/src/geometry/Vertices.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

