### PR TITLE
feat(node): expose `OptionToken`, `PositionalToken`, `OptionTerminatorToken` and `Token` types of `util.parseArgs()`

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -275,6 +275,6 @@ access('file/that/does/not/exist', (err) => {
     // util.parseArgs: config not inferred precisely
     const config = {};
 
-    // $ExpectType { values: { [longOption: string]: string | boolean | (string | boolean)[] | undefined; }; positionals: string[]; tokens?: Token[] | undefined; }
+    // $ExpectType { values: { [longOption: string]: string | boolean | (string | boolean)[] | undefined; }; positionals: string[]; tokens?: ParseArgsToken[] | undefined; }
     const result = util.parseArgs(config);
 }

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1231,7 +1231,7 @@ declare module 'util' {
               value: undefined;
               inlineValue: undefined;
           }
-        : OptionToken & { name: K };
+        : ParseArgsOptionToken & { name: K };
 
     type TokenForOptions<
         T extends ParseArgsConfig,
@@ -1239,10 +1239,10 @@ declare module 'util' {
     > = K extends unknown
         ? T['options'] extends ParseArgsOptionsConfig
             ? PreciseTokenForOptions<K & string, T['options'][K]>
-            : OptionToken
+            : ParseArgsOptionToken
         : never;
 
-    type ParsedOptionToken<T extends ParseArgsConfig> = IfDefaultsTrue<T['strict'], TokenForOptions<T>, OptionToken>;
+    type ParsedOptionToken<T extends ParseArgsConfig> = IfDefaultsTrue<T['strict'], TokenForOptions<T>, ParseArgsOptionToken>;
 
     type ParsedPositionalToken<T extends ParseArgsConfig> = IfDefaultsTrue<
         T['strict'],
@@ -1267,7 +1267,7 @@ declare module 'util' {
         }
     >;
 
-    export type OptionToken =
+    export type ParseArgsOptionToken =
         | { kind: 'option'; index: number; name: string; rawName: string; value: string; inlineValue: boolean }
         | {
               kind: 'option';
@@ -1278,11 +1278,11 @@ declare module 'util' {
               inlineValue: undefined;
           };
 
-    export interface PositionalToken { kind: 'positional'; index: number; value: string; }
+    export interface ParseArgsPositionalToken { kind: 'positional'; index: number; value: string; }
 
-    export interface OptionTerminatorToken { kind: 'option-terminator'; index: number; }
+    export interface ParseArgsOptionTerminatorToken { kind: 'option-terminator'; index: number; }
 
-    export type Token = OptionToken | PositionalToken | OptionTerminatorToken;
+    export type ParseArgsToken = ParseArgsOptionToken | ParseArgsPositionalToken | ParseArgsOptionTerminatorToken;
 
     // If ParseArgsConfig extends T, then the user passed config constructed elsewhere.
     // So we can't rely on the `"not definitely present" implies "definitely not present"` assumption mentioned above.
@@ -1290,7 +1290,7 @@ declare module 'util' {
         ? {
               values: { [longOption: string]: undefined | string | boolean | Array<string | boolean> };
               positionals: string[];
-              tokens?: Token[];
+              tokens?: ParseArgsToken[];
           }
         : PreciseParsedResults<T>;
 }

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1267,7 +1267,7 @@ declare module 'util' {
         }
     >;
 
-    type OptionToken =
+    export type OptionToken =
         | { kind: 'option'; index: number; name: string; rawName: string; value: string; inlineValue: boolean }
         | {
               kind: 'option';
@@ -1278,10 +1278,11 @@ declare module 'util' {
               inlineValue: undefined;
           };
 
-    type Token =
-        | OptionToken
-        | { kind: 'positional'; index: number; value: string }
-        | { kind: 'option-terminator'; index: number };
+    export interface PositionalToken { kind: 'positional'; index: number; value: string; }
+
+    export interface OptionTerminatorToken { kind: 'option-terminator'; index: number; }
+
+    export type Token = OptionToken | PositionalToken | OptionTerminatorToken;
 
     // If ParseArgsConfig extends T, then the user passed config constructed elsewhere.
     // So we can't rely on the `"not definitely present" implies "definitely not present"` assumption mentioned above.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Following up https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61512

It would be useful to expose recently added `OptionToken`, `PositionalToken`, `OptionTerminatorToken` and `Token` types of `util.parseArgs()`. My use case:

```ts
import { parseArgs, type OptionToken } from "node:util";

const parsedArgs = parseArgs({
  options,
  allowPositionals: true,
  strict: false,
  tokens: true,
});

// In real life `validateOptions()` has much more logic. Without `OptionToken` type
// being exposed I am forced to keep the logic inline or to copy types from `@types/node`
function validateOptionToken(
  token: OptionToken,
  validationErrors: Array<ValidationError>
) {
  if (!Object.hasOwn(options, token.name)) {
    validationErrors.push({ message: `Unknown option '${token.rawName}'` });
  }
}

for (const token of parsedArgs.tokens) {
  if (token.kind === "option") {
    validateOptionToken(token, validationErrors);
  }
}
```