### PR TITLE
use new public @ember/owner type in @ember/modifier

### DIFF
--- a/types/ember__modifier/ember__modifier-tests.ts
+++ b/types/ember__modifier/ember__modifier-tests.ts
@@ -1,5 +1,8 @@
 import { setModifierManager, capabilities, on } from '@ember/modifier';
+import Owner from '@ember/owner';
+
+declare let owner: Owner;
 
 on; // $ExpectType OnModifier
-setModifierManager(() => {}, {}); // $ExpectType {}
+setModifierManager((owner) => {}, {}); // $ExpectType {}
 capabilities('3.24'); // $ExpectType unknown

--- a/types/ember__modifier/index.d.ts
+++ b/types/ember__modifier/index.d.ts
@@ -6,6 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.4
 
+import Owner from '@ember/owner';
 import { Opaque } from 'ember/-private/type-utils';
 
 // In normal TypeScript, this modifier is essentially an opaque token
@@ -30,7 +31,7 @@ export const on: OnModifier;
  * @param modifier The modifier definition to associate with the manager.
  */
 export function setModifierManager<T>(
-  factory: (owner: unknown) => unknown,
+  factory: (owner: Owner) => unknown,
   modifier: T
 ): T;
 


### PR DESCRIPTION
building off of [this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61533) to add public types for Ember's `Owner` class, we now can type the input to `setModifierManager` with the correct `Owner` type instead of relying on `unknown`.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/glimmerjs/glimmer-vm/blob/4f1bef0d9a8a3c3ebd934c5b6e09de4c5f6e4468/packages/%40glimmer/manager/lib/public/index.ts#L23
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

