### PR TITLE
fix(@types/node): ecdh getPublicKey can return compressed Buffer

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -2309,11 +2309,11 @@ declare module 'crypto' {
          * If `encoding` is specified, a string is returned; otherwise a `Buffer` is
          * returned.
          * @since v0.11.14
-         * @param encoding The `encoding` of the return value.
+         * @param [encoding] The `encoding` of the return value.
          * @param [format='uncompressed']
          * @return The EC Diffie-Hellman public key in the specified `encoding` and `format`.
          */
-        getPublicKey(): Buffer;
+        getPublicKey(encoding?: null, format?: ECDHKeyFormat): Buffer;
         getPublicKey(encoding: BinaryToTextEncoding, format?: ECDHKeyFormat): string;
         /**
          * Sets the EC Diffie-Hellman private key.

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -1337,6 +1337,32 @@ import { promisify } from 'node:util';
 }
 
 {
+    const alice = crypto.createECDH('prime256v1');
+    const bob = crypto.createECDH('prime256v1');
+
+    alice.setPrivateKey('abcd', 'hex');
+    bob.setPrivateKey(Buffer.from('abcd', 'hex'));
+
+    alice.generateKeys();
+
+    let alicePublicKey = alice.getPublicKey(); // $ExpectType Buffer
+    alicePublicKey = alice.getPublicKey(null);
+    alicePublicKey = alice.getPublicKey(null, 'compressed');
+    alicePublicKey = alice.getPublicKey(undefined, 'hybrid');
+
+    let bobPublicKey = bob.getPublicKey('hex'); // $ExpectType string
+    bobPublicKey = bob.getPublicKey('hex', 'compressed');
+
+    let aliceSecret = alice.computeSecret(bobPublicKey, 'hex'); // $ExpectType Buffer
+    aliceSecret = alice.computeSecret(Buffer.from(bobPublicKey, 'hex'));
+
+    let bobSecret = bob.computeSecret(alicePublicKey, 'hex'); // $ExpectType string
+    bobSecret = bob.computeSecret(alicePublicKey.toString('hex'), 'hex', 'hex');
+
+    aliceSecret.toString('hex') === bobSecret;
+}
+
+{
     crypto.setFips(false);
     crypto.setEngine('dynamic');
     crypto.setEngine('dynamic', crypto.constants.ENGINE_METHOD_RSA);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#ecdhgetpublickeyencoding-format
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (NOT APPLICABLE)
