### PR TITLE
Create types for react-google-picker

### DIFF
--- a/types/react-google-picker/index.d.ts
+++ b/types/react-google-picker/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for react-google-picker 0.1
+// Project: https://github.com/sdoomz/react-google-picker
+// Definitions by: Evan Broder <https://github.com/ebroder>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="gapi" />
+/// <reference types="google.picker" />
+
+import * as React from 'react';
+
+export interface GooglePickerProps {
+    clientId: string;
+    developerKey: string;
+    scope?: ReadonlyArray<string>;
+    viewId?: keyof typeof google.picker.ViewId;
+    mimeTypes?: ReadonlyArray<string>;
+    query?: string;
+    authImmediate?: boolean;
+    origin?: string;
+    onChange?: (result: google.picker.ResponseObject) => void;
+    onAuthenticate?: (oauthToken: string) => void;
+    onAuthFailed?: (response: GoogleApiOAuth2TokenObject) => void;
+    createPicker?: (google: typeof self.google, oauthToken: string) => void;
+    multiselect?: boolean;
+    navHidden?: boolean;
+    disabled?: boolean;
+}
+
+export default class GooglePicker extends React.Component<React.PropsWithChildren<GooglePickerProps>> {}

--- a/types/react-google-picker/react-google-picker-tests.tsx
+++ b/types/react-google-picker/react-google-picker-tests.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import GooglePicker from 'react-google-picker';
+
+const ReactGooglePickerTest = () => {
+    /* All code samples taken from project README */
+    return (
+        <>
+            <GooglePicker
+                clientId={'your-client-id'}
+                developerKey={'your-developer-key'}
+                scope={['https://www.googleapis.com/auth/drive.readonly']}
+                onChange={data => console.log('on change:', data)}
+                onAuthFailed={data => console.log('on auth failed:', data)}
+                multiselect={true}
+                navHidden={true}
+                authImmediate={false}
+                mimeTypes={['image/png', 'image/jpeg', 'image/jpg']}
+                query={'a query string like .txt or fileName'}
+                viewId={'DOCS'}
+            >
+                <button>Pick a file</button>
+            </GooglePicker>
+
+            <GooglePicker
+                clientId={'your-client-id'}
+                developerKey={'your-developer-key'}
+                scope={['https://www.googleapis.com/auth/drive.readonly']}
+                onChange={data => console.log('on change:', data)}
+                onAuthenticate={token => console.log('oauth token:', token)}
+                onAuthFailed={data => console.log('on auth failed:', data)}
+                multiselect={true}
+                navHidden={true}
+                authImmediate={false}
+                mimeTypes={['image/png', 'image/jpeg', 'image/jpg']}
+                viewId={'DOCS'}
+            >
+                <button>Pick a file</button>
+            </GooglePicker>
+
+            <GooglePicker
+                clientId={'your-client-id'}
+                developerKey={'your-developer-key'}
+                scope={['https://www.googleapis.com/auth/drive.readonly']}
+                onChange={data => console.log('on change:', data)}
+                onAuthFailed={data => console.log('on auth failed:', data)}
+                multiselect={true}
+                navHidden={true}
+                authImmediate={false}
+                viewId={'FOLDERS'}
+                createPicker={(google, oauthToken) => {
+                    const googleViewId = google.picker.ViewId.FOLDERS;
+                    const docsView = new google.picker.DocsView(googleViewId)
+                        .setIncludeFolders(true)
+                        .setMimeTypes('application/vnd.google-apps.folder')
+                        .setSelectFolderEnabled(true);
+
+                    const picker = new window.google.picker.PickerBuilder()
+                        .addView(docsView)
+                        .setOAuthToken(oauthToken)
+                        .setDeveloperKey('your-developer-key')
+                        .setCallback(() => {
+                            console.log('Custom picker is ready!');
+                        });
+
+                    picker.build().setVisible(true);
+                }}
+            >
+                <span>Click</span>
+                <div className="google"></div>
+            </GooglePicker>
+        </>
+    );
+};

--- a/types/react-google-picker/tsconfig.json
+++ b/types/react-google-picker/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "jsx": "preserve",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-google-picker-tests.tsx"
+    ]
+}

--- a/types/react-google-picker/tslint.json
+++ b/types/react-google-picker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
I've written up a type declaration for the [`react-google-picker` package](https://www.npmjs.com/package/react-google-picker). The tests are taken from the example code, as was the type declaration (except for when the documentation wasn't sufficiently clear, in which case I went to the source code behavior)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
