### PR TITLE
[jmuxer] add missing 'OnError' option declaration

### DIFF
--- a/types/jmuxer/index.d.ts
+++ b/types/jmuxer/index.d.ts
@@ -15,6 +15,7 @@ declare namespace JMuxer {
         fps?: number | undefined;
         debug?: boolean | undefined;
         onReady?: (() => void) | undefined;
+        onError?: ((data: any) => void) | undefined;
     }
 
     interface Feeder {


### PR DESCRIPTION
Added missing 'OnError' declaration, which causes a build error when called.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
