### PR TITLE
prompt: Add before function to RevalidatorSchema

### DIFF
--- a/types/prompt/index.d.ts
+++ b/types/prompt/index.d.ts
@@ -13,9 +13,11 @@ declare namespace prompt {
     type GetCallback<T> = (err: Error | null, result: T) => void;
     type AddCallback = (err: Error | null) => void;
     type AskFunction = () => boolean;
+    type BeforeFunction = (line: string) => string;
 
     type RevalidatorSchema = Partial<Revalidator.ISchema<any>> & {
         ask?: AskFunction | undefined;
+        before?: BeforeFunction | undefined;
         name?: string | undefined;
         raw?: [string, string] | undefined;
     };

--- a/types/prompt/prompt-tests.ts
+++ b/types/prompt/prompt-tests.ts
@@ -49,6 +49,7 @@ prompt.get(
             type: 'string',
             required: true,
             message: 'Please dont use the demo credentials',
+            before: line => line.trim(),
             conform: surname => {
                 const name = prompt.history('name')!.value;
                 return name !== 'John' || surname !== 'Smith';


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/flatiron/prompt/blob/caa988ee15ec6cfbf61e3e8fccae5f4c0e640e99/lib/prompt.js#L642
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **(n/a, this `before` function was available 10 years ago and is not specific to a new version)**