### PR TITLE
fix(node): add named export for `constants`

### DIFF
--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -13,29 +13,31 @@ declare module 'fs/promises' {
     import { Stream } from 'node:stream';
     import { ReadableStream } from 'node:stream/web';
     import {
-        Stats,
         BigIntStats,
-        StatOptions,
-        WriteVResult,
-        ReadVResult,
+        BufferEncodingOption,
+        constants as fsConstants,
+        CopyOptions,
+        Dir,
+        Dirent,
+        MakeDirectoryOptions,
+        Mode,
+        ObjectEncodingOptions,
+        OpenDirOptions,
+        OpenMode,
         PathLike,
+        ReadStream,
+        ReadVResult,
         RmDirOptions,
         RmOptions,
-        MakeDirectoryOptions,
-        Dirent,
-        OpenDirOptions,
-        Dir,
-        ObjectEncodingOptions,
-        BufferEncodingOption,
-        OpenMode,
-        Mode,
-        WatchOptions,
-        WatchEventType,
-        CopyOptions,
-        ReadStream,
+        StatOptions,
+        Stats,
         TimeLike,
+        WatchEventType,
+        WatchOptions,
         WriteStream,
+        WriteVResult,
     } from 'node:fs';
+
     interface FileChangeInfo<T extends string | Buffer> {
         eventType: WatchEventType;
         filename: T;
@@ -427,6 +429,9 @@ declare module 'fs/promises' {
          */
         close(): Promise<void>;
     }
+
+    const constants: typeof fsConstants;
+
     /**
      * Tests a user's permissions for the file or directory specified by `path`.
      * The `mode` argument is an optional integer that specifies the accessibility

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -1,4 +1,13 @@
-import { FileHandle, open as openAsync, writeFile as writeFileAsync, watch as watchAsync, cp as cpAsync } from 'node:fs/promises';
+import {
+    FileHandle,
+    open as openAsync,
+    writeFile as writeFileAsync,
+    watch as watchAsync,
+    cp as cpAsync,
+    constants,
+    access,
+    copyFile,
+} from 'node:fs/promises';
 import * as fs from 'node:fs';
 import * as util from 'node:util';
 import { URL } from 'node:url';
@@ -740,3 +749,9 @@ const anyStats: fs.Stats | fs.BigIntStats = fs.statSync('.', { bigint: Math.rand
         stream.close();
     });
 }
+
+// constants
+async () => {
+    await copyFile('source.txt', 'destination.txt', constants.COPYFILE_EXCL);
+    await access('/etc/passwd', constants.R_OK | constants.W_OK);
+};

--- a/types/node/v14/fs/promises.d.ts
+++ b/types/node/v14/fs/promises.d.ts
@@ -1,21 +1,22 @@
 declare module 'fs/promises' {
     import {
-        Stats,
+        BaseEncodingOptions,
         BigIntStats,
-        StatOptions,
-        WriteVResult,
-        ReadVResult,
+        BufferEncodingOption,
+        constants as fsConstants,
+        Dir,
+        Dirent,
+        MakeDirectoryOptions,
+        Mode,
+        OpenDirOptions,
+        OpenMode,
         PathLike,
+        ReadVResult,
         RmDirOptions,
         RmOptions,
-        MakeDirectoryOptions,
-        Dirent,
-        OpenDirOptions,
-        Dir,
-        BaseEncodingOptions,
-        BufferEncodingOption,
-        OpenMode,
-        Mode,
+        StatOptions,
+        Stats,
+        WriteVResult,
     } from 'fs';
 
     interface FileHandle {
@@ -160,6 +161,8 @@ declare module 'fs/promises' {
          */
         close(): Promise<void>;
     }
+
+    const constants: typeof fsConstants;
 
     /**
      * Asynchronously tests a user's permissions for the file specified by path.

--- a/types/node/v14/test/fs.ts
+++ b/types/node/v14/test/fs.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import assert = require('node:assert');
 import * as util from 'node:util';
 import * as url from 'node:url';
+import { access, constants, copyFile } from 'node:fs/promises';
 
 {
     fs.writeFile("thebible.txt",
@@ -615,3 +616,9 @@ async function testStat(
     fs.promises.lstat(path, opts); // $ExpectType Promise<Stats | BigIntStats>
     fh.stat(opts); // $ExpectType Promise<Stats | BigIntStats>
 }
+
+// constants
+async () => {
+    await copyFile('source.txt', 'destination.txt', constants.COPYFILE_EXCL);
+    await access('/etc/passwd', constants.R_OK | constants.W_OK);
+};

--- a/types/node/v16/fs/promises.d.ts
+++ b/types/node/v16/fs/promises.d.ts
@@ -12,27 +12,28 @@ declare module 'fs/promises' {
     import { Abortable } from 'node:events';
     import { Stream } from 'node:stream';
     import {
-        Stats,
         BigIntStats,
-        StatOptions,
-        WriteVResult,
-        ReadVResult,
+        BufferEncodingOption,
+        constants as fsConstants,
+        CopyOptions,
+        Dir,
+        Dirent,
+        MakeDirectoryOptions,
+        Mode,
+        ObjectEncodingOptions,
+        OpenDirOptions,
+        OpenMode,
         PathLike,
+        ReadStream,
+        ReadVResult,
         RmDirOptions,
         RmOptions,
-        MakeDirectoryOptions,
-        Dirent,
-        OpenDirOptions,
-        Dir,
-        ObjectEncodingOptions,
-        BufferEncodingOption,
-        OpenMode,
-        Mode,
-        WatchOptions,
+        StatOptions,
+        Stats,
         WatchEventType,
-        CopyOptions,
-        ReadStream,
+        WatchOptions,
         WriteStream,
+        WriteVResult,
     } from 'node:fs';
     interface FileChangeInfo<T extends string | Buffer> {
         eventType: WatchEventType;
@@ -405,6 +406,8 @@ declare module 'fs/promises' {
          */
         close(): Promise<void>;
     }
+
+    const constants: typeof fsConstants;
     /**
      * Tests a user's permissions for the file or directory specified by `path`.
      * The `mode` argument is an optional integer that specifies the accessibility

--- a/types/node/v16/test/fs.ts
+++ b/types/node/v16/test/fs.ts
@@ -1,4 +1,13 @@
-import { FileHandle, open as openAsync, writeFile as writeFileAsync, watch as watchAsync, cp as cpAsync } from 'node:fs/promises';
+import {
+    FileHandle,
+    open as openAsync,
+    writeFile as writeFileAsync,
+    watch as watchAsync,
+    cp as cpAsync,
+    copyFile,
+    constants,
+    access,
+} from 'node:fs/promises';
 import * as fs from 'node:fs';
 import * as util from 'node:util';
 import { URL } from 'node:url';
@@ -722,3 +731,9 @@ const anyStats: fs.Stats | fs.BigIntStats = fs.statSync('.', { bigint: Math.rand
         stream.close();
     });
 }
+
+// constants
+async () => {
+    await copyFile('source.txt', 'destination.txt', constants.COPYFILE_EXCL);
+    await access('/etc/passwd', constants.R_OK | constants.W_OK);
+};


### PR DESCRIPTION
This adds missing export in `node:fs/promises`

- exports
- tests
- sorted imports for readability

Thanks!

/cc @Himself65

Fixes #61676

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).