### PR TITLE
Expose feature flags and functions to be able to use Relay Resolvers

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -209,11 +209,14 @@ export { default as isPromise } from './lib/util/isPromise';
 
 import * as fetchQueryInternal from './lib/query/fetchQueryInternal';
 
+import * as RelayResolverFragments from './lib/store/ResolverFragments';
+
 interface Internal {
     fetchQuery: typeof fetchQueryInternal.fetchQuery;
     fetchQueryDeduped: typeof fetchQueryInternal.fetchQueryDeduped;
     getPromiseForActiveRequest: typeof fetchQueryInternal.getPromiseForActiveRequest;
     getObservableForActiveRequest: typeof fetchQueryInternal.getObservableForActiveRequest;
+    RelayResolverFragments: typeof RelayResolverFragments;
 }
 
 export const __internal: Internal;

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -216,7 +216,7 @@ interface Internal {
     fetchQueryDeduped: typeof fetchQueryInternal.fetchQueryDeduped;
     getPromiseForActiveRequest: typeof fetchQueryInternal.getPromiseForActiveRequest;
     getObservableForActiveRequest: typeof fetchQueryInternal.getObservableForActiveRequest;
-    RelayResolverFragments: typeof RelayResolverFragments;
+    ResolverFragments: typeof RelayResolverFragments;
 }
 
 export const __internal: Internal;

--- a/types/relay-runtime/lib/store/ResolverFragments.d.ts
+++ b/types/relay-runtime/lib/store/ResolverFragments.d.ts
@@ -1,0 +1,48 @@
+import type { GraphQLTaggedNode } from '../query/RelayModernGraphQLTag';
+import type { FragmentType, SingularReaderSelector } from './RelayStoreTypes';
+
+export type KeyType<TData = unknown> = Readonly<{
+    ' $data'?: TData | undefined;
+    ' $fragmentSpreads': FragmentType;
+}>;
+
+export type KeyTypeData<TKey extends KeyType<TData>, TData = unknown> = Required<TKey>[' $data'];
+
+export type ArrayKeyType<TData = unknown> = ReadonlyArray<KeyType<ReadonlyArray<TData>> | null>;
+export type ArrayKeyTypeData<TKey extends ArrayKeyType<TData>, TData = unknown> = KeyTypeData<
+    NonNullable<TKey[number]>
+>;
+
+export interface ResolverContext {
+    getDataForResolverFragment: (
+        arg0: SingularReaderSelector,
+        arg1: FragmentType,
+    ) => {
+        data: unknown;
+        isMissingData: boolean;
+    };
+}
+
+export const RESOLVER_FRAGMENT_MISSING_DATA_SENTINEL: unknown;
+
+export function withResolverContext<T>(context: ResolverContext, cb: () => T): T;
+
+export function readFragment<TKey extends KeyType>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey,
+): KeyTypeData<TKey>;
+
+export function readFragment<TKey extends KeyType>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+): KeyTypeData<TKey> | null;
+
+export function readFragment<TKey extends ArrayKeyType>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey,
+): ArrayKeyTypeData<TKey>;
+
+export function readFragment<TKey extends ArrayKeyType>(
+    fragmentInput: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+): ArrayKeyTypeData<TKey> | null;

--- a/types/relay-runtime/lib/util/RelayFeatureFlags.d.ts
+++ b/types/relay-runtime/lib/util/RelayFeatureFlags.d.ts
@@ -3,6 +3,8 @@ export interface FeatureFlags {
     ENABLE_RELAY_CONTAINERS_SUSPENSE: boolean;
     ENABLE_PARTIAL_RENDERING_DEFAULT: boolean;
     ENABLE_UNIQUE_MUTATION_ROOT: boolean;
+    ENABLE_RELAY_RESOLVERS: boolean;
+    ENABLE_CLIENT_EDGES: boolean;
 }
 
 export const RelayFeatureFlags: FeatureFlags;

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -523,7 +523,7 @@ function multiActors() {
 // Relay Resolvers
 // ~~~~~~~~~~~~~~~~~~~~~~~
 
-const {readFragment, RESOLVER_FRAGMENT_MISSING_DATA_SENTINEL, withResolverContext} = __internal.RelayResolverFragments;
+const {readFragment} = __internal.ResolverFragments;
 
 // Regular fragment.
 interface UserComponent_user {

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -518,3 +518,121 @@ function multiActors() {
         operation
     }).toPromise();
 }
+
+// ~~~~~~~~~~~~~~~~~~~~~~~
+// Relay Resolvers
+// ~~~~~~~~~~~~~~~~~~~~~~~
+
+const {readFragment, RESOLVER_FRAGMENT_MISSING_DATA_SENTINEL, withResolverContext} = __internal.RelayResolverFragments;
+
+// Regular fragment.
+interface UserComponent_user {
+  readonly id: string;
+  readonly name: string;
+  readonly profile_picture: {
+      readonly uri: string;
+  };
+  readonly ' $fragmentType': 'UserComponent_user';
+}
+
+type UserComponent_user$data = UserComponent_user;
+
+interface UserComponent_user$key {
+  readonly ' $data'?: UserComponent_user$data | undefined;
+  readonly ' $fragmentSpreads': FragmentRefs<'UserComponent_user'>;
+}
+
+function NonNullableFragmentResolver(userKey: UserComponent_user$key) {
+    // $ExpectType UserComponent_user
+    const data = readFragment(
+        graphql`
+            fragment UserComponent_user on User {
+                name
+                profile_picture(scale: 2) {
+                    uri
+                }
+            }
+        `,
+        userKey,
+    );
+
+    return `${data.name}, ${data.profile_picture.uri}`;
+}
+
+function NullableFragmentResolver(userKey: UserComponent_user$key | null) {
+    // $ExpectType UserComponent_user | null
+    readFragment(
+        graphql`
+            fragment UserComponent_user on User {
+                name
+                profile_picture(scale: 2) {
+                    uri
+                }
+            }
+        `,
+        userKey,
+    );
+}
+
+// Plural fragment @relay(plural: true)
+type UserComponent_users = ReadonlyArray<{
+  readonly id: string;
+  readonly name: string;
+  readonly profile_picture: {
+      readonly uri: string;
+  };
+  readonly ' $fragmentType': 'UserComponent_users';
+}>;
+type UserComponent_users$data = UserComponent_users;
+type UserComponent_users$key = ReadonlyArray<{
+  readonly ' $data'?: UserComponent_users$data | undefined;
+  readonly ' $fragmentSpreads': FragmentRefs<'UserComponent_users'>;
+}>;
+
+function NonNullableArrayFragmentResolver(usersKey: UserComponent_users$key) {
+    const data = readFragment(
+        graphql`
+            fragment UserComponent_users on User @relay(plural: true) {
+                name
+                profile_picture(scale: 2) {
+                    uri
+                }
+            }
+        `,
+        usersKey,
+    );
+
+    return data.map((thing) => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
+}
+
+function NullableArrayFragmentResolver(usersKey: UserComponent_users$key | null) {
+    const data = readFragment(
+        graphql`
+            fragment UserComponent_users on User @relay(plural: true) {
+                name
+                profile_picture(scale: 2) {
+                    uri
+                }
+            }
+        `,
+        usersKey,
+    );
+
+    return data?.map((thing) => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
+}
+
+function ArrayOfNullableFragmentResolver(usersKey: ReadonlyArray<UserComponent_users$key[0] | null>) {
+    const data = readFragment(
+        graphql`
+            fragment UserComponent_users on User @relay(plural: true) {
+                name
+                profile_picture(scale: 2) {
+                    uri
+                }
+            }
+        `,
+        usersKey,
+    );
+
+    return data?.map((thing) => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
+}


### PR DESCRIPTION
When attempting to consume [Relay Resolvers](https://relay.dev/docs/guides/relay-resolvers/) I noticed that a number of internal functions and feature flags were not exposed in the types. This PR adds types to be able to use Relay Resolvers. Note that there are a number of other feature flags exposed in the source, but I didn't expose them all since I'm unsure whether they're even supported. 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
	https://github.com/facebook/relay/blob/main/packages/relay-runtime/util/RelayFeatureFlags.js#L20
	https://github.com/facebook/relay/blob/main/packages/relay-runtime/store/ResolverFragments.js
