### PR TITLE
prepper type definitions (new package)

### DIFF
--- a/types/prepper/index.d.ts
+++ b/types/prepper/index.d.ts
@@ -1,3 +1,7 @@
+// Type definitions for prepper 1.2.1
+// Project: https://github.com/guidesmiths/prepper
+// Definitions by: Teun Mooij <https://github.com/teunmooij>
+
 import { EventEmitter } from 'events';
 
 export interface LogFn {

--- a/types/prepper/index.d.ts
+++ b/types/prepper/index.d.ts
@@ -1,21 +1,21 @@
 import { EventEmitter } from 'events';
 
-type LogFn = {
+export interface LogFn {
   (message: string, error: Error, context?: any): void;
   (message: string, context?: any): void;
   (error: Error, context?: any): void;
   (context: any): void;
-};
+}
 
-type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
-export type LoggerOptions = {
+export interface LoggerOptions {
   sequence?: handlers.Handler;
   handlers?: handlers.Handler[];
   message?: string;
   level?: LogLevel;
   maxListeners?: number;
-};
+}
 
 export interface Logger {
   trace: LogFn;
@@ -32,51 +32,50 @@ export class Logger extends EventEmitter implements Logger {
   constructor(options?: LoggerOptions);
 }
 
-declare namespace handlers {
+export namespace handlers {
   type PropertyName = string | number | symbol;
 
-  export type Event = {
+  type Event = {
     message?: string;
     level: LogLevel;
     error?: { message: string; level: string; error: any };
-  } & Record<string, any>
+  } & Record<string, any>;
 
-  export interface Handler extends EventEmitter {
+  interface Handler extends EventEmitter {
     /**
      * handles the event
-     * @param event 
      * @remarks handle must emit 'message' event, passing on the altered event
      */
     handle(event: Event): void;
   }
 
-  export class Merge extends EventEmitter implements Handler {
+  class Merge extends EventEmitter implements Handler {
     constructor(other: Record<string, any>, options?: { key?: PropertyName | PropertyName[]; invert?: boolean });
     handle(event: Event): void;
   }
 
-  export class KeyFilter extends EventEmitter implements Handler {
+  class KeyFilter extends EventEmitter implements Handler {
     constructor(other: { include?: string[]; exclude?: string[] });
     handle(event: Event): void;
   }
 
-  export class Oversized extends EventEmitter implements Handler {
+  class Oversized extends EventEmitter implements Handler {
     constructor(options: { size: number });
     handle(event: Event): void;
   }
 
-  export class Sequence extends EventEmitter implements Handler {
+  class Sequence extends EventEmitter implements Handler {
     constructor(handlers?: Handler[]);
     handle(event: Event): void;
   }
 
-  export class Env extends EventEmitter implements Handler { handle(event: Event): void; }
-  export class Noop extends EventEmitter implements Handler { handle(event: Event): void; }
-  export class Repo extends EventEmitter implements Handler { handle(event: Event): void; }
-  export class Tracer extends EventEmitter implements Handler { handle(event: Event): void; }
-  export class Process extends EventEmitter implements Handler { handle(event: Event): void; }
-  export class System extends EventEmitter implements Handler { handle(event: Event): void; }
-  export class Timestamp extends EventEmitter implements Handler { handle(event: Event): void; }
-  export class Flatten extends EventEmitter implements Handler { handle(event: Event): void; }
-  export class Unflatten extends EventEmitter implements Handler { handle(event: Event): void; }
+  class Env extends EventEmitter implements Handler { handle(event: Event): void; }
+  class Noop extends EventEmitter implements Handler { handle(event: Event): void; }
+  class Repo extends EventEmitter implements Handler { handle(event: Event): void; }
+  class Tracer extends EventEmitter implements Handler { handle(event: Event): void; }
+  class Process extends EventEmitter implements Handler { handle(event: Event): void; }
+  class System extends EventEmitter implements Handler { handle(event: Event): void; }
+  class Timestamp extends EventEmitter implements Handler { handle(event: Event): void; }
+  class Flatten extends EventEmitter implements Handler { handle(event: Event): void; }
+  class Unflatten extends EventEmitter implements Handler { handle(event: Event): void; }
 }

--- a/types/prepper/index.d.ts
+++ b/types/prepper/index.d.ts
@@ -1,0 +1,82 @@
+import { EventEmitter } from 'events';
+
+type LogFn = {
+  (message: string, error: Error, context?: any): void;
+  (message: string, context?: any): void;
+  (error: Error, context?: any): void;
+  (context: any): void;
+};
+
+type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+export type LoggerOptions = {
+  sequence?: handlers.Handler;
+  handlers?: handlers.Handler[];
+  message?: string;
+  level?: LogLevel;
+  maxListeners?: number;
+};
+
+export interface Logger {
+  trace: LogFn;
+  debug: LogFn;
+  info: LogFn;
+  warn: LogFn;
+  error: LogFn;
+  fatal: LogFn;
+  log: LogFn;
+  child: (options: LoggerOptions) => Logger;
+}
+
+export class Logger extends EventEmitter implements Logger {
+  constructor(options?: LoggerOptions);
+}
+
+declare namespace handlers {
+  type PropertyName = string | number | symbol;
+
+  export type Event = {
+    message?: string;
+    level: LogLevel;
+    error?: { message: string; level: string; error: any };
+  } & Record<string, any>
+
+  export interface Handler extends EventEmitter {
+    /**
+     * handles the event
+     * @param event 
+     * @remarks handle must emit 'message' event, passing on the altered event
+     */
+    handle(event: Event): void;
+  }
+
+  export class Merge extends EventEmitter implements Handler {
+    constructor(other: Record<string, any>, options?: { key?: PropertyName | PropertyName[]; invert?: boolean });
+    handle(event: Event): void;
+  }
+
+  export class KeyFilter extends EventEmitter implements Handler {
+    constructor(other: { include?: string[]; exclude?: string[] });
+    handle(event: Event): void;
+  }
+
+  export class Oversized extends EventEmitter implements Handler {
+    constructor(options: { size: number });
+    handle(event: Event): void;
+  }
+
+  export class Sequence extends EventEmitter implements Handler {
+    constructor(handlers?: Handler[]);
+    handle(event: Event): void;
+  }
+
+  export class Env extends EventEmitter implements Handler { handle(event: Event): void; }
+  export class Noop extends EventEmitter implements Handler { handle(event: Event): void; }
+  export class Repo extends EventEmitter implements Handler { handle(event: Event): void; }
+  export class Tracer extends EventEmitter implements Handler { handle(event: Event): void; }
+  export class Process extends EventEmitter implements Handler { handle(event: Event): void; }
+  export class System extends EventEmitter implements Handler { handle(event: Event): void; }
+  export class Timestamp extends EventEmitter implements Handler { handle(event: Event): void; }
+  export class Flatten extends EventEmitter implements Handler { handle(event: Event): void; }
+  export class Unflatten extends EventEmitter implements Handler { handle(event: Event): void; }
+}

--- a/types/prepper/index.d.ts
+++ b/types/prepper/index.d.ts
@@ -1,13 +1,13 @@
-// Type definitions for prepper 1.2.1
+// Type definitions for prepper 1.2
 // Project: https://github.com/guidesmiths/prepper
 // Definitions by: Teun Mooij <https://github.com/teunmooij>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { EventEmitter } from 'events';
 
 export interface LogFn {
   (message: string, error: Error, context?: any): void;
-  (message: string, context?: any): void;
-  (error: Error, context?: any): void;
+  (message_or_error: string | Error, context?: any): void;
   (context: any): void;
 }
 

--- a/types/prepper/prepper-tests.ts
+++ b/types/prepper/prepper-tests.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from 'events';
+import { Logger, handlers } from 'prepper';
+
+const logger: Logger = new Logger({
+  handlers: [
+    new handlers.Merge({ foo: 'bar' }, { invert: true }),
+    new handlers.Oversized({ size: 100_000 }),
+    new handlers.Env(),
+    new handlers.Noop(),
+    new handlers.Repo(),
+    new handlers.Tracer(),
+    new handlers.Process(),
+    new handlers.System(),
+    new handlers.Flatten(),
+    new handlers.KeyFilter({ include: ['a', 'b'], exclude: ['a.b'] }),
+    new handlers.Unflatten(),
+  ],
+  message: 'Some default message',
+  level: 'warn',
+  maxListeners: 15,
+});
+
+const otherLogger = new Logger({
+  sequence: new handlers.Sequence([new handlers.Noop()])
+}).on('message', logger.log);
+
+class CustomHandler extends EventEmitter implements handlers.Handler {
+  handle(event: handlers.Event): void {
+    const extendedEvent = {
+      ...event,
+      foo: 'bar'
+    };
+
+    this.emit('message', extendedEvent);
+  }
+}
+
+const childLogger = otherLogger.child({
+  handlers: [
+    new handlers.Merge({ correlationId: '123' }),
+    new CustomHandler(),
+  ],
+});
+
+childLogger.trace('message');
+childLogger.debug('message', { foo: 'bar' });
+childLogger.info({ message: 'message', foo: 'bar' });
+childLogger.warn('oops');
+childLogger.error(new Error('oops'), { dump: '...' });
+childLogger.fatal('message', new Error('very oops'), { dump: '...' });

--- a/types/prepper/tsconfig.json
+++ b/types/prepper/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "prepper-tests.ts"
+    ]
+}

--- a/types/prepper/tslint.json
+++ b/types/prepper/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/prepper/tslint.json
+++ b/types/prepper/tslint.json
@@ -1,6 +1,1 @@
-{
-  "extends": "@definitelytyped/dtslint/dtslint.json",
-  "rules": {
-    "unified-signatures": false
-  }
-}
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/prepper/tslint.json
+++ b/types/prepper/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+  "extends": "@definitelytyped/dtslint/dtslint.json",
+  "rules": {
+    "unified-signatures": false
+  }
+}


### PR DESCRIPTION
Type definitions for [prepper](https://github.com/guidesmiths/prepper#readme) 

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

I did add 1 rule. I set unified-signatures to false, because the overloaded function has multiple overloads and merging them would make the usage confusing because the parameters have a different meaning. => But had to remove it. :'(