### PR TITLE
Add missing properties for PlaybackRestrictions and activateElement() for Player

### DIFF
--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -50,6 +50,9 @@ declare namespace Spotify {
         seeking: boolean;
         skipping_next: boolean;
         skipping_prev: boolean;
+        toggling_repeat_context: boolean;
+        toggling_repeat_track: boolean;
+        toggling_shuffle: boolean;
     }
 
     interface PlaybackRestrictions {
@@ -60,6 +63,9 @@ declare namespace Spotify {
         disallow_seeking_reasons: string[];
         disallow_skipping_next_reasons: string[];
         disallow_skipping_prev_reasons: string[];
+        disallow_toggling_shuffle_reasons: string[];
+        disallow_toggling_repeat_track_reasons: string[];
+        disallow_toggling_repeat_context_reasons: string[];
     }
 
     interface PlaybackState {
@@ -128,6 +134,7 @@ declare namespace Spotify {
         setName(name: string): Promise<void>;
         setVolume(volume: number): Promise<void>;
         togglePlay(): Promise<void>;
+        activateElement(): Promise<void>;
     }
 
     interface Track {


### PR DESCRIPTION
The missing properties including:
PlaybackDisallows
PlaybackRestrictions
activateElement()

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[Spotify Web SDK Guide](https://developer.spotify.com/documentation/web-playback-sdk/reference/)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

