### PR TITLE
chore: replace jest's MatcherUtils and MatcherState with upstream types from expect

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -543,27 +543,21 @@ declare namespace jest {
 
     type EqualityTester = (a: any, b: any) => boolean | undefined;
 
-    interface MatcherUtils {
-        readonly isNot: boolean;
-        readonly dontThrow: () => void;
-        readonly promise: string;
-        readonly assertionCalls: number;
-        readonly expectedAssertionsNumber: number | null;
-        readonly isExpectingAssertions: boolean;
-        readonly suppressedErrors: any[];
-        readonly expand: boolean;
-        readonly testPath: string;
-        readonly currentTestName: string;
-        utils: typeof import('jest-matcher-utils') & {
-            iterableEquality: EqualityTester;
-            subsetEquality: EqualityTester;
-        };
-        /**
-         *  This is a deep-equality function that will return true if two objects have the same values (recursively).
-         */
-        equals(a: any, b: any, customTesters?: EqualityTester[], strictCheck?: boolean): boolean;
-        [other: string]: any;
-    }
+    type MatcherUtils = Pick<
+        import('expect').MatcherState,
+        | 'isNot'
+        | 'dontThrow'
+        | 'promise'
+        | 'assertionCalls'
+        | 'expectedAssertionsNumber'
+        | 'isExpectingAssertions'
+        | 'suppressedErrors'
+        | 'expand'
+        | 'testPath'
+        | 'currentTestName'
+        | 'utils'
+        | 'equals'
+    > & { [other: string]: any; };
 
     interface ExpectExtendMap {
         [key: string]: CustomMatcher;
@@ -619,15 +613,16 @@ declare namespace jest {
          */
         stringContaining(str: string): any;
     }
-    interface MatcherState {
-        assertionCalls: number;
-        currentTestName: string;
-        expand: boolean;
-        expectedAssertionsNumber: number;
-        isExpectingAssertions?: boolean | undefined;
-        suppressedErrors: Error[];
-        testPath: string;
-    }
+    type MatcherState = Pick<
+        import('expect').MatcherState,
+        | 'assertionCalls'
+        | 'currentTestName'
+        | 'expand'
+        | 'expectedAssertionsNumber'
+        | 'isExpectingAssertions'
+        | 'suppressedErrors'
+        | 'testPath'
+    >;
     /**
      * The `expect` function is used every time you want to test a value.
      * You will rarely call `expect` by itself.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -782,15 +782,15 @@ switch (mockResult.type) {
 expect.setState(true);
 expect.setState({for: 'state'});
 const expectState = expect.getState();
-// $ExpectType string
+// $ExpectType string | undefined
 expectState.currentTestName;
-// $ExpectType string
+// $ExpectType string | undefined
 expectState.testPath;
-// $ExpectType boolean
+// $ExpectType boolean | undefined
 expectState.expand;
 // $ExpectType number
 expectState.assertionCalls;
-// $ExpectType number
+// $ExpectType number | null | undefined
 expectState.expectedAssertionsNumber;
 // $ExpectType boolean | undefined
 expectState.isExpectingAssertions;
@@ -910,7 +910,7 @@ expect.extend({
 expect.extend({
     foo(this: jest.MatcherContext) {
         const isNot: boolean = this.isNot;
-        const expand: boolean = this.expand;
+        const expand: boolean | undefined = this.expand;
 
         const expectedColor = this.utils.EXPECTED_COLOR('blue');
         const receivedColor = this.utils.EXPECTED_COLOR('red');
@@ -953,10 +953,10 @@ expect.extend({
 
         const equals: boolean = this.equals({}, {});
 
-        this.dontThrow();
+        this.dontThrow!();
         this.fromState;
-        const currentTestName: string = this.currentTestName;
-        const testPath: string = this.testPath;
+        const currentTestName: string | undefined = this.currentTestName;
+        const testPath: string | undefined = this.testPath;
 
         return {
             message: () => `Can use ${this.promise} for failure message`,

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "jest-matcher-utils": "^28.0.0",
+        "expect": "^28.0.0",
         "pretty-format": "^28.0.0"
     },
     "exports": {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/blob/2f4340cb1da435a9b147e238f7034f99653b8070/packages/expect/src/types.ts#L44-L63
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Chipping away at #44365 🙂 