### PR TITLE
Add types for react-native-markdown-view

### DIFF
--- a/types/react-native-markdown-view/index.d.ts
+++ b/types/react-native-markdown-view/index.d.ts
@@ -1,0 +1,102 @@
+// Type definitions for react-native-markdown-view 1.10
+// Project: https://github.com/Benjamin-Dobell/react-native-markdown-view
+// Definitions by: Fabio Nettis <https://github.com/fabio-nettis>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+import type { ViewStyle, ImageStyle, TextStyle } from 'react-native';
+
+export type ParseState = any;
+export type NodeKey = string;
+export type RenderStyle = object;
+export type RegexComponents = string[];
+export type OutputFunction = (node: Node, s: any) => any;
+export type NestedParseFunction = (x: string, s: any) => any;
+export class MarkdownView extends React.Component<MarkdownViewProps> {}
+
+export interface MarkdownStyles {
+    blockQuote?: TextStyle;
+    codeBlock?: TextStyle;
+    del?: TextStyle;
+    em?: TextStyle;
+    heading?: TextStyle;
+    heading1?: TextStyle;
+    heading2?: TextStyle;
+    heading3?: TextStyle;
+    heading4?: TextStyle;
+    heading5?: TextStyle;
+    heading6?: TextStyle;
+    hr?: TextStyle;
+    imageWrapper?: ViewStyle;
+    image?: ImageStyle;
+    inlineCode?: TextStyle;
+    link?: TextStyle;
+    list?: ViewStyle;
+    listItem?: ViewStyle;
+    listItemNumber?: TextStyle;
+    listItemBullet?: TextStyle;
+    listItemOrderedContent?: TextStyle;
+    listItemUnorderedContent?: TextStyle;
+    paragraph?: TextStyle;
+    strong?: TextStyle;
+    table?: ViewStyle;
+    tableHeaderCell?: ViewStyle;
+    tableHeaderCellContent?: ViewStyle;
+    tableCell?: ViewStyle;
+    tableCellOddRow?: ViewStyle;
+    tableCellEvenRow?: ViewStyle;
+    tableCellLastRow?: ViewStyle;
+    tableCellOddColumn?: ViewStyle;
+    tableCellEvenColumn?: ViewStyle;
+    tableCellLastColumn?: ViewStyle;
+    tableCellContent?: ViewStyle;
+    tableCellContentOddRow?: ViewStyle;
+    tableCellContentEvenRow?: ViewStyle;
+    tableCellContentLastRow?: ViewStyle;
+    tableCellContentOddColumn?: ViewStyle;
+    tableCellContentEvenColumn?: ViewStyle;
+    tableCellContentLastColumn?: ViewStyle;
+    u?: TextStyle;
+}
+
+export interface RenderState {
+    key: string;
+    onLinkPress?: (url: string) => void;
+}
+
+export interface RenderStyles {
+    [key: string]: RenderStyle;
+}
+
+export interface MarkdownRule {
+    match?: (x: string, state: RenderState, list: string[]) => RegExp | undefined | null;
+    parse?: (components: RegexComponents, parse: NestedParseFunction, state: ParseState) => any;
+    render: (node: Node, output: OutputFunction, state: RenderState, style: RenderStyle) => any;
+}
+
+export interface MarkdownRules {
+    [key: string]: MarkdownRule;
+}
+
+export interface MarkdownViewProps {
+    /**
+     *
+     */
+    rules?: MarkdownRules;
+
+    /**
+     * An object providing styles to be passed to a corresponding rule render method. Keys are
+     * rule/node names and values are React Native style objects. If a style is defined here and a
+     * default style exists, they will me merged, with style properties defined here taking
+     * precedence.
+     */
+    styles?: MarkdownStyles;
+
+    style?: ViewStyle | TextStyle | ImageStyle;
+
+    /**
+     * Callback function for when a link is pressed. The callback receives the URL of the link as a
+     * string (first and only argument).
+     */
+    onLinkPress?: (url: string) => void;
+}

--- a/types/react-native-markdown-view/index.d.ts
+++ b/types/react-native-markdown-view/index.d.ts
@@ -80,7 +80,19 @@ export interface MarkdownRules {
 
 export interface MarkdownViewProps {
     /**
+     * An object overriding or providing additional rules for parsing and rendering Markdown. Keys
+     * are rule names (you can define your own, or override existing rules), and values are an
+     * object. You can find additional information [here](https://github.com/Benjamin-Dobell/react-native-markdown-view#rules).
      *
+     * #### Example
+     *
+     * ```typescript
+     * {
+     *   match: (x: string, state: RenderState, list: string[]) => RegExp | undefined | null,
+     *   parse: (components: RegexComponents, parse: NestedParseFunction, state: ParseState) => any,
+     *   render: (node: Node, output: OutputFunction, state: RenderState, style: RenderStyle) => any
+     * }
+     * ```
      */
     rules?: MarkdownRules;
 
@@ -92,6 +104,10 @@ export interface MarkdownViewProps {
      */
     styles?: MarkdownStyles;
 
+    /**
+     * The style that is applied to the root view. This is the outermost view that wraps the
+     * rendered Markdown.
+     */
     style?: ViewStyle | TextStyle | ImageStyle;
 
     /**

--- a/types/react-native-markdown-view/index.d.ts
+++ b/types/react-native-markdown-view/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Fabio Nettis <https://github.com/fabio-nettis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import type { Component } from '@types/react';
-import type { ViewStyle, ImageStyle, TextStyle } from '@types/react-native';
+import type { Component } from 'react';
+import type { ViewStyle, ImageStyle, TextStyle } from 'react-native';
 
 export type ParseState = any;
 export type NodeKey = string;

--- a/types/react-native-markdown-view/index.d.ts
+++ b/types/react-native-markdown-view/index.d.ts
@@ -3,8 +3,8 @@
 // Definitions by: Fabio Nettis <https://github.com/fabio-nettis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as React from 'react';
-import type { ViewStyle, ImageStyle, TextStyle } from 'react-native';
+import type { Component } from '@types/react';
+import type { ViewStyle, ImageStyle, TextStyle } from '@types/react-native';
 
 export type ParseState = any;
 export type NodeKey = string;
@@ -12,7 +12,7 @@ export type RenderStyle = object;
 export type RegexComponents = string[];
 export type OutputFunction = (node: Node, s: any) => any;
 export type NestedParseFunction = (x: string, s: any) => any;
-export class MarkdownView extends React.Component<MarkdownViewProps> {}
+export class MarkdownView extends Component<MarkdownViewProps> {}
 
 export interface MarkdownStyles {
     blockQuote?: TextStyle;

--- a/types/react-native-markdown-view/react-native-markdown-view-tests.tsx
+++ b/types/react-native-markdown-view/react-native-markdown-view-tests.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { MarkdownView, MarkdownViewProps } from 'react-native-markdown-view';
+
+export default function Test(props: MarkdownViewProps): JSX.Element {
+    return <MarkdownView {...props} />;
+}

--- a/types/react-native-markdown-view/tsconfig.json
+++ b/types/react-native-markdown-view/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "preserve"
+    },
+    "files": ["index.d.ts", "react-native-markdown-view-tests.tsx"]
+}

--- a/types/react-native-markdown-view/tslint.json
+++ b/types/react-native-markdown-view/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Add type definitions for the `react-native-markdown-view` package. Maintainer seems to have abandoned the repository and the type definitions used in the package are not exported anywhere in it. I basically just copied the type definitions from [here](https://github.com/Benjamin-Dobell/react-native-markdown-view/blob/master/index.d.ts) and modified them a bit.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
