### PR TITLE
update(html-minifier-terser): ESM module and v7 bump

### DIFF
--- a/types/html-minifier-terser/html-minifier-terser-tests.ts
+++ b/types/html-minifier-terser/html-minifier-terser-tests.ts
@@ -1,11 +1,11 @@
-import { minify } from 'html-minifier-terser';
+import HtmlMinifier, { minify } from 'html-minifier-terser';
 
 // $ExpectType Promise<string>
-minify('<p title="blah" id="moo">foo</p>');
+HtmlMinifier.minify('<p title="blah" id="moo">foo</p>');
 
 (async () => {
     // $ExpectType string
-    await minify('<p title="blah" id="moo">foo</p>');
+    await HtmlMinifier.minify('<p title="blah" id="moo">foo</p>');
 
     // $ExpectType string
     await minify('<p title="blah" id="moo">foo</p>', {});

--- a/types/html-minifier-terser/index.d.ts
+++ b/types/html-minifier-terser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for html-minifier-terser 6.1
+// Type definitions for html-minifier-terser 7.0
 // Project: https://github.com/terser/html-minifier-terser#readme
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -209,3 +209,9 @@ export interface Options {
      */
     useShortDoctype?: boolean | undefined;
 }
+
+declare const htmlminifier: {
+    minify: typeof minify;
+};
+
+export default htmlminifier;

--- a/types/html-minifier-terser/package.json
+++ b/types/html-minifier-terser/package.json
@@ -1,0 +1,4 @@
+{
+    "private": true,
+    "type": "module"
+}


### PR DESCRIPTION
The main change is migration in upstream to module with direct support
for both ESM/CJS

https://github.com/terser/html-minifier-terser/releases/tag/v7.0.0

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.