### PR TITLE
Remove optional typing for teardown callback

### DIFF
--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -266,7 +266,7 @@ export interface HostedFields {
     on<EventType extends HostedFieldEventType>(event: EventType, handler: (event: HostedFieldsEventTypeMap[EventType]) => void): void;
     off<EventType extends HostedFieldEventType>(event: EventType, handler: (event: HostedFieldsEventTypeMap[EventType]) => void): void;
 
-    teardown(callback?: callback): void;
+    teardown(callback: callback): void;
     teardown(): Promise<void>;
 
     /**

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -228,6 +228,10 @@ braintree.client.create(
                         console.info('Hosted Fields has been torn down!');
                     }
                 });
+                
+                hostedFieldsInstance.teardown()
+                   .then(console.info('Hosted Fields has been torn down!');)
+                   .catch( (teardownErr) => console.error('Could not tear down Hosted Fields!'); )
 
                 hostedFieldsInstance.tokenize(
                     {

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -229,9 +229,10 @@ braintree.client.create(
                     }
                 });
                 
-                hostedFieldsInstance.teardown()
-                   .then(console.info('Hosted Fields has been torn down!');)
-                   .catch( (teardownErr) => console.error('Could not tear down Hosted Fields!'); )
+                hostedFieldsInstance
+                    .teardown()
+                    .then(() => console.info('Hosted Fields has been torn down!'))
+                    .catch(teardownErr => console.error('Could not tear down Hosted Fields!')); )
 
                 hostedFieldsInstance.tokenize(
                     {


### PR DESCRIPTION
With the current implementation, teardown returning a Promise is never reachable due to the callback param being optional.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://braintree.github.io/braintree-web/current/HostedFields.html#teardown>>
