### PR TITLE
d3-transition: Fix element generic assumptions

### DIFF
--- a/types/d3-transition/d3-transition-tests.ts
+++ b/types/d3-transition/d3-transition-tests.ts
@@ -8,6 +8,7 @@
 
 import {
     ArrayLike,
+    BaseType,
     selection,
     select,
     selectAll,
@@ -520,7 +521,7 @@ exitTransition = exitTransition
 
 // transition(...) ----------------------------------------------------------
 
-let topTransition: d3Transition.Transition<HTMLElement, any, null, undefined>;
+let topTransition: d3Transition.Transition<BaseType, any, null, undefined>;
 topTransition = d3Transition.transition('top');
 
 // test creation from existing transition
@@ -530,7 +531,7 @@ topTransition = d3Transition.transition(enterTransition);
 // tests with pre-existing datum (typed as string)
 // set datum with a type of string
 select('html').datum('test');
-let topTransition2: d3Transition.Transition<HTMLElement, string, null, undefined>;
+let topTransition2: d3Transition.Transition<BaseType, string, null, undefined>;
 topTransition2 = d3Transition.transition<string>('top');
 topTransition2 = d3Transition.transition<string>(enterTransition);
 

--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -623,21 +623,23 @@ export type SelectionOrTransition<GElement extends BaseType, Datum, PElement ext
  * Returns a new transition with the specified name. If a name is not specified, null is used.
  * The new transition is only exclusive with other transitions of the same name.
  *
- * The generic "OldDatum" refers to the type of a previously-set datum of the selected HTML element in the Transition.
+ * The generic "GElement" refers to the type of the selected element(s) in the transition.
+ * The generic "OldDatum" refers to the type of a previously-set datum of the selected element in the Transition.
  *
  * @param name Name of the transition.
  */
 // tslint:disable-next-line:no-unnecessary-generics
-export function transition<OldDatum>(name?: string): Transition<HTMLElement, OldDatum, null, undefined>;
+export function transition<GElement extends BaseType, OldDatum>(name?: string): Transition<GElement, OldDatum, null, undefined>;
 
 /**
  * Returns a new transition from an existing transition.
  *
  * When using a transition instance, the returned transition has the same id and name as the specified transition.
  *
- * The generic "OldDatum" refers to the type of a previously-set datum of the selected HTML element in the Transition.
+ * The generic "GElement" refers to the type of the selected element(s) in the transition.
+ * The generic "OldDatum" refers to the type of a previously-set datum of the selected element in the Transition.
  *
  * @param transition A transition instance.
  */
 // tslint:disable-next-line:no-unnecessary-generics
-export function transition<OldDatum>(transition: Transition<BaseType, any, BaseType, any>): Transition<HTMLElement, OldDatum, null, undefined>;
+export function transition<GElement extends BaseType, OldDatum>(transition: Transition<BaseType, any, BaseType, any>): Transition<GElement, OldDatum, null, undefined>;

--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -56,7 +56,7 @@ declare module 'd3-selection' {
          *
          * @param transition A transition instance.
          */
-        transition(transition: Transition<BaseType, any, any, any>): Transition<GElement, Datum, PElement, PDatum>;
+        transition(transition: Transition<GElement, any, any, any>): Transition<GElement, Datum, PElement, PDatum>;
     }
 }
 
@@ -629,7 +629,7 @@ export type SelectionOrTransition<GElement extends BaseType, Datum, PElement ext
  * @param name Name of the transition.
  */
 // tslint:disable-next-line:no-unnecessary-generics
-export function transition<GElement extends BaseType, OldDatum>(name?: string): Transition<GElement, OldDatum, null, undefined>;
+export function transition<GElement extends BaseType, OldDatum = any>(name?: string): Transition<GElement, OldDatum, null, undefined>;
 
 /**
  * Returns a new transition from an existing transition.
@@ -642,4 +642,4 @@ export function transition<GElement extends BaseType, OldDatum>(name?: string): 
  * @param transition A transition instance.
  */
 // tslint:disable-next-line:no-unnecessary-generics
-export function transition<GElement extends BaseType, OldDatum>(transition: Transition<BaseType, any, BaseType, any>): Transition<GElement, OldDatum, null, undefined>;
+export function transition<GElement extends BaseType, OldDatum = any>(transition: Transition<BaseType, any, BaseType, any>): Transition<GElement, OldDatum, null, undefined>;

--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -56,7 +56,7 @@ declare module 'd3-selection' {
          *
          * @param transition A transition instance.
          */
-        transition(transition: Transition<GElement, any, any, any>): Transition<GElement, Datum, PElement, PDatum>;
+        transition(transition: Transition<BaseType, any, any, any>): Transition<GElement, Datum, PElement, PDatum>;
     }
 }
 

--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -623,23 +623,21 @@ export type SelectionOrTransition<GElement extends BaseType, Datum, PElement ext
  * Returns a new transition with the specified name. If a name is not specified, null is used.
  * The new transition is only exclusive with other transitions of the same name.
  *
- * The generic "GElement" refers to the type of the selected element(s) in the transition.
  * The generic "OldDatum" refers to the type of a previously-set datum of the selected element in the Transition.
  *
  * @param name Name of the transition.
  */
 // tslint:disable-next-line:no-unnecessary-generics
-export function transition<GElement extends BaseType, OldDatum = any>(name?: string): Transition<GElement, OldDatum, null, undefined>;
+export function transition<OldDatum>(name?: string): Transition<BaseType, OldDatum, null, undefined>;
 
 /**
  * Returns a new transition from an existing transition.
  *
  * When using a transition instance, the returned transition has the same id and name as the specified transition.
  *
- * The generic "GElement" refers to the type of the selected element(s) in the transition.
  * The generic "OldDatum" refers to the type of a previously-set datum of the selected element in the Transition.
  *
  * @param transition A transition instance.
  */
 // tslint:disable-next-line:no-unnecessary-generics
-export function transition<GElement extends BaseType, OldDatum = any>(transition: Transition<BaseType, any, BaseType, any>): Transition<GElement, OldDatum, null, undefined>;
+export function transition<OldDatum>(transition: Transition<BaseType, any, BaseType, any>): Transition<BaseType, OldDatum, null, undefined>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: not needed
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Changes
- Remove `HTMLElement` type assumption on selected element


Consider the following

```ts
const myTransition = transition();
select<SVGPathElement, any>(el)
  .transition(myTransition)
  // ...
```

Prior to this change, the following error would be encountered due to defaulting to `HTMLElement` as the selected element

>  Error type Transition<HTMLElement ...> is not assignable  to type Transition<SVGPathElement ...>

With this change, this error no longer occurs.  See [playground example here](https://www.typescriptlang.org/play?&dtPR=61740&install-plugin=playground-dt-review#code/JYWwDg9gTgLgBAbzjKBDAdgZ2DYF0A0cAKmljnunAL5wBmUEIcARACYDMAtChtrvhYAoUJFiI4mAKYAbKQGN4tBk1acu0uYsrCh8-JngQZbACJS6qAK4z4AXmRl+lABQBKOKkxwr6ANboEADuVF4kThT4ADwAEsQAsgAyAKJyIFLoMEQYAJ7Z6HmeBQB8ANx6BvDoUkHmljb2jnyR6O7lFVjwmgoCVA7dilEAygBqAOIACqgwABapUumZ+TnFLiyYAG4A5nDFcGDTMyxuQkIDvQB0vOS9LsZmFta2HnCvbwD073AAQox+GXA2FYpMgIHA4kl5ot4GxHg0zrIepQrhFbtVanDnm9sZ84AB1aB+YDoHZAkEwMEAI0YqFhUEBmJgpyAA)
