### PR TITLE
Added missing maskPattern option to QRCodeOptions 

### DIFF
--- a/types/qrcode/index.d.ts
+++ b/types/qrcode/index.d.ts
@@ -12,6 +12,8 @@ import * as stream from 'stream';
 
 export type QRCodeErrorCorrectionLevel = 'low' | 'medium' | 'quartile' | 'high' | 'L' | 'M' | 'Q' | 'H';
 
+export type QRCodeMAskPattern = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | '1' | '2' | '3' | '4' | '5' | '6' | '7';
+
 export interface QRCodeOptions {
     /**
      * QR Code version. If not specified the more suitable value will be calculated.
@@ -23,6 +25,12 @@ export interface QRCodeOptions {
      * Default: M
      */
     errorCorrectionLevel?: QRCodeErrorCorrectionLevel | undefined;
+    /**
+     * maskPattern.
+     * Possible values are numbers 0 to 7 or strings representing numbers 0 to 7.
+     * Default: undefined - most suitable value will be calculated.
+     */
+    maskPattern?: QRCodeMAskPattern;
     /**
      * Helper function used internally to convert a kanji to its Shift JIS value.
      * Provide this function if you need support for Kanji mode.
@@ -164,7 +172,7 @@ export interface QRCode {
     /**
      * Calculated Mask pattern
      */
-    maskPattern: any;
+    maskPattern: QRCodeMAskPattern;
     /**
      * Generated segments
      */

--- a/types/qrcode/qrcode-tests.ts
+++ b/types/qrcode/qrcode-tests.ts
@@ -27,6 +27,24 @@ QRCode.toDataURL([{ data: new Uint8ClampedArray([253, 254, 255]), mode: 'byte' }
     console.log(url);
 });
 
+QRCode.toCanvas(canvas, 'sample text', { maskPattern: 0 }, error => {
+    if (error) console.error(error);
+    console.log('success!');
+});
+
+QRCode.toDataURL('I am a pony!', { maskPattern: 1 }, (err, url) => {
+    console.log(url);
+});
+
+QRCode.toString('some text', { errorCorrectionLevel: 'H', maskPattern: '2' }, (err, str) => {
+    console.log(str);
+});
+
+QRCode.toBuffer('some text', { errorCorrectionLevel: 'H', maskPattern: 3} , (err, buffer) => {
+    if (err) throw err;
+    console.log(buffer);
+});
+
 QRCode.toDataURL(
     [
         { data: 'ABCDEFG', mode: 'alphanumeric' },


### PR DESCRIPTION
The option was partly implemented for the QRCode interface but could also be set when creating a QRCode (introduced with: https://github.com/soldair/node-qrcode/commit/1f1487b58159c00022e2c72b25d9df4fd10ed0fb) 
this fixes the issue [61735](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/61735)

Please fill in this template.

- [/ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ /] Test the change in your own code. (Compile and run.)
- [/ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [/] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ /] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ /] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- 
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
  -  https://github.com/soldair/node-qrcode/commit/1f1487b58159c00022e2c72b25d9df4fd10ed0fb
  -  https://github.com/soldair/node-qrcode/blob/master/lib/core/qrcode.js#L487

