### PR TITLE
Add new postcss-preset-env 7.3.0 options

### DIFF
--- a/types/postcss-preset-env/index.d.ts
+++ b/types/postcss-preset-env/index.d.ts
@@ -24,6 +24,19 @@ declare namespace postcssPresetEnv {
          * **Stage 2** features.
          */
         stage?: number | undefined;
+        
+        /**
+         * The `minimumVendorImplementations` option determines which CSS
+         * features to polyfill, based their implementation status.
+         * This can be used to enable plugins that are available in browsers
+         * regardless of the {@linkplain pluginOptions.stage|spec status}.
+         *
+         * `minimumVendorImplementations` can be `0` (no vendor has implemented
+         * it) through `3` (all major vendors).
+         *
+         * @default 0
+         */
+        minimumVendorImplementations?: number | undefined;
 
         /**
          * The features option enables or disables specific polyfills by ID.
@@ -104,6 +117,22 @@ declare namespace postcssPresetEnv {
          * CSS, JS, and JSON files, functions, and directly passed objects.
          */
         exportTo?: string | any[] | undefined;
+        
+        /**
+         * The `debug` option enables debugging messages to stdout which
+         * should be useful to help you debug which features have been
+         * enabled/disabled and why.
+         */
+        debug?: boolean | undefined;
+
+        /**
+         * The `enableClientSidePolyfills` option enables any feature that
+         * would need an extra browser library to be loaded into the page
+         * for it to work.
+         *
+         * @default true
+         */
+        enableClientSidePolyfills?: boolean | undefined;
     }
 
     namespace pluginOptions {


### PR DESCRIPTION
minimumVendorImplementations, debug, enableClientSidePolyfills.

Source of the when: https://github.com/csstools/postcss-plugins/blob/934795303a2aa795699375c00edcba0fc6f92225/plugin-packs/postcss-preset-env/CHANGELOG.md#730-january-31-2022

Source of the texts: https://raw.githubusercontent.com/csstools/postcss-plugins/934795303a2aa795699375c00edcba0fc6f92225/plugin-packs/postcss-preset-env/README.md with very minor tweaks.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

*(No, I haven’t run tests and such, because that takes more effort and probably network bandwidth than I’m willing to put into this—I’m not invested here, just submitting a simple patch since I happened to observe these missing and figured why not. Decide for yourselves what to do with it.)*

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [changelog](https://github.com/csstools/postcss-plugins/blob/934795303a2aa795699375c00edcba0fc6f92225/plugin-packs/postcss-preset-env/CHANGELOG.md#730-january-31-2022), [readme](https://raw.githubusercontent.com/csstools/postcss-plugins/934795303a2aa795699375c00edcba0fc6f92225/plugin-packs/postcss-preset-env/README.md)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. *(Not applicable, it’s already past 7.3, these options were just missed.)*