### PR TITLE
[marked] Optional params for Parser.parseInline and Lexter.inlineTokens

### DIFF
--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -223,7 +223,7 @@ export namespace marked {
         static parse(src: Token[] | TokensList, options?: MarkedOptions): string;
         static parseInline(src: Token[], options?: MarkedOptions): string;
         parse(src: Token[] | TokensList): string;
-        parseInline(src: Token[], renderer: Renderer): string;
+        parseInline(src: Token[], renderer?: Renderer): string;
         next(): Token;
     }
 
@@ -238,7 +238,7 @@ export namespace marked {
         lex(src: string): TokensList;
         blockTokens(src: string, tokens: Token[]): Token[];
         blockTokens(src: string, tokens: TokensList): TokensList;
-        inline(src: string, tokens: Token[]): void;
+        inline(src: string, tokens?: Token[]): void;
         inlineTokens(src: string, tokens: Token[]): Token[];
         state: {
             inLink: boolean;

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -77,11 +77,7 @@ export namespace marked {
      * @param callback Function called when the markdownString has been fully parsed when using async highlighting
      * @return String of compiled HTML
      */
-    function parse(
-        src: string,
-        options?: MarkedOptions,
-        callback?: (error: any, parseResult: string) => void,
-    ): string;
+    function parse(src: string, options?: MarkedOptions, callback?: (error: any, parseResult: string) => void): string;
 
     /**
      * @param src Tokenized source as array of tokens
@@ -149,7 +145,12 @@ export namespace marked {
             src: string,
             links: Tokens.Link[] | Tokens.Image[],
         ): Tokens.Link | Tokens.Image | Tokens.Text | T;
-        emStrong(this: Tokenizer & TokenizerThis, src: string, maskedSrc: string, prevChar: string): Tokens.Em | Tokens.Strong | T;
+        emStrong(
+            this: Tokenizer & TokenizerThis,
+            src: string,
+            maskedSrc: string,
+            prevChar: string,
+        ): Tokens.Em | Tokens.Strong | T;
         codespan(this: Tokenizer & TokenizerThis, src: string): Tokens.Codespan | T;
         br(this: Tokenizer & TokenizerThis, src: string): Tokens.Br | T;
         del(this: Tokenizer & TokenizerThis, src: string): Tokens.Del | T;
@@ -238,8 +239,8 @@ export namespace marked {
         lex(src: string): TokensList;
         blockTokens(src: string, tokens: Token[]): Token[];
         blockTokens(src: string, tokens: TokensList): TokensList;
-        inline(src: string, tokens?: Token[]): void;
-        inlineTokens(src: string, tokens: Token[]): Token[];
+        inline(src: string, tokens: Token[]): void;
+        inlineTokens(src: string, tokens?: Token[]): Token[];
         state: {
             inLink: boolean;
             inRawBlock: boolean;
@@ -516,11 +517,7 @@ export namespace marked {
          * with an error if any occurred during highlighting and a string
          * if highlighting was successful)
          */
-        highlight?(
-            code: string,
-            lang: string,
-            callback?: (error: any, code?: string) => void,
-        ): string | void;
+        highlight?(code: string, lang: string, callback?: (error: any, code?: string) => void): string | void;
 
         /**
          * Set the prefix for code block classes.

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -83,6 +83,9 @@ const tokens2 = lexer.lex(text);
 console.log(tokens2);
 const tokens3 = lexer.inlineTokens(text, tokens);
 console.log(tokens3);
+// verifying that the second param to inlineTokens can be ignored
+const tokens3a = lexer.inlineTokens(text);
+console.log(tokens3a);
 const re: RegExp | marked.Rules = marked.Lexer.rules['code'];
 const lexerOptions: marked.MarkedOptions = lexer.options;
 
@@ -212,6 +215,8 @@ const rendererExtension: marked.RendererExtension = {
     renderer(t) {
         const token = t as NameToken;
         if (token.text === 'name') {
+            // verifying that the second param to parseInline can be ignored
+            console.log(this.parser.parseInline(token.items));
             return this.parser.parse(token.items);
         }
         return false;


### PR DESCRIPTION
Following two changes:

* Makes the `renderer` param of `Parser.parseInline()` optional
* Makes the `tokens` param of `Lexer.inlineTokens()` optional

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: discussions on repos for **marked** and **definitleytyped** confirmed the params should be optional; see [here](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/61664#discussioncomment-3376571) and [here](https://github.com/markedjs/marked/issues/2551#issuecomment-1211576792).
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

