### PR TITLE
Update types for relay-runtime 14.1.0

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for relay-runtime 13.0
+// Type definitions for relay-runtime 14.1
 // Project: https://github.com/facebook/relay, https://facebook.github.io/relay
 // Definitions by: Eloy Durán <https://github.com/alloy>
 //                 Marais Rossouw <https://github.com/maraisr>
@@ -46,9 +46,13 @@ export {
     graphql,
     getFragment,
     getInlineDataFragment,
+    getNode,
     getPaginationFragment,
     getRefetchableFragment,
     getRequest,
+    isFragment,
+    isInlineDataFragment,
+    isRequest,
 } from './lib/query/RelayModernGraphQLTag';
 export { isClientID, generateClientID, generateUniqueClientID } from './lib/store/ClientID';
 export { TaskScheduler } from './lib/store/RelayModernQueryExecutor';
@@ -57,14 +61,16 @@ export {
     Environment as IEnvironment,
     FragmentMap,
     FragmentPointer,
-    // DEPRECATED: use FragmentType instead of FragmentReference
+    /** @deprecated use FragmentType instead of FragmentReference */
     FragmentType as FragmentReference,
     FragmentType,
     FragmentSpecResolver,
     HandleFieldPayload,
+    HasUpdatableSpread,
     InvalidationState,
     MissingFieldHandler,
     ModuleImportPointer,
+    MutableRecordSource,
     NormalizationSelector,
     OperationAvailability,
     OperationDescriptor,
@@ -92,6 +98,7 @@ export {
     StoreUpdater,
     LogEvent,
     LogFunction,
+    UpdatableData,
 } from './lib/store/RelayStoreTypes';
 export { GraphQLSubscriptionConfig } from './lib/subscription/requestSubscription';
 export {
@@ -103,6 +110,7 @@ export {
     NormalizationLinkedHandle,
     NormalizationLocalArgumentDefinition,
     NormalizationModuleImport,
+    NormalizationRootNode,
     NormalizationScalarField,
     NormalizationSelection,
     NormalizationSplitOperation,
@@ -129,6 +137,7 @@ export {
     RequiredFieldAction,
 } from './lib/util/ReaderNode';
 export { ConcreteRequest, GeneratedNode, RequestParameters } from './lib/util/RelayConcreteNode';
+export { RelayReplaySubject as ReplaySubject } from './lib/util/RelayReplaySubject';
 export * from './lib/util/RelayRuntimeTypes';
 
 // Core API
@@ -180,6 +189,8 @@ import getDefaultMissingFieldHandlers from './lib/handlers/getRelayDefaultMissin
 export { getDefaultMissingFieldHandlers };
 import * as ConnectionHandler from './lib/handlers/connection/ConnectionHandler';
 export { ConnectionHandler };
+export { MutationHandlers } from './lib/handlers/connection/MutationHandlers';
+export { VIEWER_ID, VIEWER_TYPE } from './lib/store/ViewerPattern';
 
 // Helpers (can be implemented via the above API)
 export { applyOptimisticMutation } from './lib/mutations/applyOptimisticMutation';
@@ -192,6 +203,7 @@ export { requestSubscription } from './lib/subscription/requestSubscription';
 
 // Utilities
 export { RelayProfiler } from './lib/util/RelayProfiler';
+export { default as createPayloadFor3DField } from './lib/util/createPayloadFor3DField';
 export { default as getRelayHandleKey } from './lib/util/getRelayHandleKey';
 export { default as getRequestIdentifier } from './lib/util/getRequestIdentifier';
 export { default as getFragmentIdentifier } from './lib/util/getFragmentIdentifier';
@@ -200,14 +212,23 @@ export { default as getPaginationVariables } from './lib/util/getPaginationVaria
 export { default as getRefetchMetadata } from './lib/util/getRefetchMetadata';
 export { default as getValueAtPath } from './lib/util/getValueAtPath';
 export { Direction } from './lib/util/getPaginationVariables';
+export { default as handlePotentialSnapshotErrors } from './lib/util/handlePotentialSnapshotErrors';
+export { default as PreloadableQueryRegistry } from './lib/util/PreloadableQueryRegistry';
 
 // INTERNAL-ONLY
 export { RelayConcreteNode } from './lib/util/RelayConcreteNode';
+export { default as RelayError } from './lib/util/RelayError';
 export { RelayFeatureFlags } from './lib/util/RelayFeatureFlags';
+export const DEFAULT_HANDLE_KEY = '';
 export { default as deepFreeze } from './lib/util/deepFreeze';
 export { default as isPromise } from './lib/util/isPromise';
+export { default as isScalarAndEqual } from './lib/util/isScalarAndEqual';
+export { default as recycleNodesInto } from './lib/util/recycleNodesInto';
+export { default as stableCopy } from './lib/util/stableCopy';
+export { default as getPendingOperationsForFragment } from './lib/util/getPendingOperationsForFragment';
 
 import * as fetchQueryInternal from './lib/query/fetchQueryInternal';
+import withProvidedVariables from './lib/util/withProvidedVariables';
 
 import * as RelayResolverFragments from './lib/store/ResolverFragments';
 
@@ -217,6 +238,7 @@ interface Internal {
     getPromiseForActiveRequest: typeof fetchQueryInternal.getPromiseForActiveRequest;
     getObservableForActiveRequest: typeof fetchQueryInternal.getObservableForActiveRequest;
     ResolverFragments: typeof RelayResolverFragments;
+    withProvidedVariables: typeof withProvidedVariables;
 }
 
 export const __internal: Internal;

--- a/types/relay-runtime/lib/handlers/connection/MutationHandlers.d.ts
+++ b/types/relay-runtime/lib/handlers/connection/MutationHandlers.d.ts
@@ -1,0 +1,10 @@
+import type { Handler } from '../../store/RelayStoreTypes';
+
+export const MutationHandlers: {
+    DeleteRecordHandler: Handler;
+    DeleteEdgeHandler: Handler;
+    AppendEdgeHandler: Handler;
+    PrependEdgeHandler: Handler;
+    AppendNodeHandler: Handler;
+    PrependNodeHandler: Handler;
+};

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -1014,3 +1014,36 @@ export interface ReactFlightReachableQuery {
 }
 
 export type ReactFlightPayloadDeserializer = (tree: ReactFlightServerTree) => ReactFlightClientResponse;
+
+interface FieldLocation {
+    path: string;
+    owner: string;
+}
+
+export type MissingRequiredFields =
+    | Readonly<{ action: 'THROW'; field: FieldLocation }>
+    | Readonly<{ action: 'LOG'; fields: FieldLocation[] }>;
+
+export interface RelayResolverError {
+    field: FieldLocation;
+    error: Error;
+}
+
+export type RelayResolverErrors = RelayResolverError[];
+
+/**
+ * The return type of calls to readUpdatableQuery_EXPERIMENTAL and
+ * readUpdatableFragment_EXPERIMENTAL.
+ */
+export interface UpdatableData<TData> {
+    readonly updatableData: TData;
+}
+
+/**
+ * A linked field where an updatable fragment is spread has the type
+ * HasUpdatableSpread.
+ * This type is expected by store.readUpdatableFragment_EXPERIMENTAL.
+ */
+export interface HasUpdatableSpread<TFragmentType> {
+    readonly $updatableFragmentSpreads: TFragmentType;
+}

--- a/types/relay-runtime/lib/store/ViewerPattern.d.ts
+++ b/types/relay-runtime/lib/store/ViewerPattern.d.ts
@@ -1,0 +1,4 @@
+import type { DataID } from '../util/RelayRuntimeTypes';
+
+export const VIEWER_ID: DataID;
+export const VIEWER_TYPE = 'Viewer';

--- a/types/relay-runtime/lib/util/JSResourceReference.d.ts
+++ b/types/relay-runtime/lib/util/JSResourceReference.d.ts
@@ -1,0 +1,5 @@
+export interface JSResourceReference<TModule> {
+    getModuleId(): string;
+    getModuleIfRequired(): TModule | null | undefined;
+    load(): Promise<TModule>;
+}

--- a/types/relay-runtime/lib/util/NormalizationNode.d.ts
+++ b/types/relay-runtime/lib/util/NormalizationNode.d.ts
@@ -1,4 +1,5 @@
 import type { ConcreteRequest } from './RelayConcreteNode';
+import type { JSResourceReference } from './JSResourceReference';
 
 /**
  * Represents a single operation used to processing and normalize runtime
@@ -9,6 +10,9 @@ export interface NormalizationOperation {
     readonly name: string;
     readonly argumentDefinitions: ReadonlyArray<NormalizationLocalArgumentDefinition>;
     readonly selections: ReadonlyArray<NormalizationSelection>;
+    readonly clientAbstractTypes?: {
+        readonly [key: string]: ReadonlyArray<string>;
+    };
 }
 
 export type NormalizationHandle = NormalizationScalarHandle | NormalizationLinkedHandle;
@@ -94,6 +98,11 @@ export interface NormalizationModuleImport {
     readonly documentName: string;
     readonly fragmentPropName: string;
     readonly fragmentName: string;
+    readonly componentModuleProvider?: () => unknown | Promise<unknown> | JSResourceReference<unknown>;
+    readonly operationModuleProvider?: () =>
+        | NormalizationRootNode
+        | Promise<NormalizationRootNode>
+        | JSResourceReference<NormalizationRootNode>;
 }
 
 export interface NormalizationListValueArgument {

--- a/types/relay-runtime/lib/util/PreloadableQueryRegistry.d.ts
+++ b/types/relay-runtime/lib/util/PreloadableQueryRegistry.d.ts
@@ -1,0 +1,9 @@
+import type { ConcreteRequest } from '../util/RelayConcreteNode';
+import type { Disposable } from '../util/RelayRuntimeTypes';
+
+export default class PreloadableQueryRegistry {
+    set(key: string, value: ConcreteRequest): void;
+    get(key: string): ConcreteRequest | null | undefined;
+    onLoad(key: string, callback: (concreteRequest: ConcreteRequest) => void): Disposable;
+    clear(): void;
+}

--- a/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
+++ b/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
@@ -14,28 +14,55 @@ export interface ConcreteRequest {
     readonly params: RequestParameters;
 }
 
+export interface ConcreteUpdatableQuery {
+    readonly kind: string; // 'UpdatableQuery';
+    readonly fragment: ReaderFragment;
+}
+
 /**
  * Contains the parameters required for executing a GraphQL request.
  * The operation can either be provided as a persisted `id` or `text`. If given
  * in `text` format, a `cacheID` as a hash of the text should be set to be used
  * for local caching.
  */
-export interface RequestParameters {
-    readonly cacheID?: string | null | undefined;
-    readonly name: string;
-    readonly operationKind: string; // 'mutation' | 'query' | 'subscription';
-    readonly id: string | null | undefined;
-    readonly text: string | null | undefined;
-    readonly metadata: { [key: string]: unknown };
-}
+export type RequestParameters =
+    | {
+          readonly id: string;
+          readonly text: null;
+          // common fields
+          readonly name: string;
+          readonly operationKind: string; // 'mutation' | 'query' | 'subscription';
+          readonly providedVariables?: ProvidedVariablesType;
+          readonly metadata: { [key: string]: unknown };
+      }
+    | {
+          readonly cacheID: string;
+          readonly id: null;
+          readonly text: string | null;
+          // common fields
+          readonly name: string;
+          readonly operationKind: string; // 'mutation' | 'query' | 'subscription';
+          readonly providedVariables?: ProvidedVariablesType;
+          readonly metadata: { [key: string]: unknown };
+      };
 
-export type GeneratedNode = ConcreteRequest | ReaderFragment | ReaderInlineDataFragment | NormalizationSplitOperation;
+export type GeneratedNode =
+    | ConcreteRequest
+    | ReaderFragment
+    | ReaderInlineDataFragment
+    | NormalizationSplitOperation
+    | ConcreteUpdatableQuery;
 
 export const RelayConcreteNode: {
+    ACTOR_CHANGE: 'ActorChange';
     CONDITION: 'Condition';
+    CLIENT_COMPONENT: 'ClientComponent';
+    CLIENT_EDGE_TO_SERVER_OBJECT: 'ClientEdgeToServerObject';
+    CLIENT_EDGE_TO_CLIENT_OBJECT: 'ClientEdgeToClientObject';
     CLIENT_EXTENSION: 'ClientExtension';
     DEFER: 'Defer';
     CONNECTION: 'Connection';
+    FLIGHT_FIELD: 'FlightField';
     FRAGMENT: 'Fragment';
     FRAGMENT_SPREAD: 'FragmentSpread';
     INLINE_DATA_FRAGMENT_SPREAD: 'InlineDataFragmentSpread';
@@ -47,6 +74,11 @@ export const RelayConcreteNode: {
     LIST_VALUE: 'ListValue';
     LOCAL_ARGUMENT: 'LocalArgument';
     MODULE_IMPORT: 'ModuleImport';
+    ALIASED_FRAGMENT_SPREAD: 'AliasedFragmentSpread';
+    ALIASED_INLINE_FRAGMENT_SPREAD: 'AliasedInlineFragmentSpread';
+    RELAY_RESOLVER: 'RelayResolver';
+    RELAY_LIVE_RESOLVER: 'RelayLiveResolver';
+    REQUIRED_FIELD: 'RequiredField';
     OBJECT_VALUE: 'ObjectValue';
     OPERATION: 'Operation';
     REQUEST: 'Request';
@@ -56,5 +88,10 @@ export const RelayConcreteNode: {
     SPLIT_OPERATION: 'SplitOperation';
     STREAM: 'Stream';
     TYPE_DISCRIMINATOR: 'TypeDiscriminator';
+    UPDATABLE_QUERY: 'UpdatableQuery';
     VARIABLE: 'Variable';
 };
+
+export interface ProvidedVariablesType {
+    readonly [key: string]: { get(): unknown };
+}

--- a/types/relay-runtime/lib/util/RelayError.d.ts
+++ b/types/relay-runtime/lib/util/RelayError.d.ts
@@ -1,0 +1,6 @@
+declare const RelayError: {
+    create(name: string, messageFormat: string, ...messageParams: Array<string | number | boolean>): Error;
+    createWarning(name: string, messageFormat: string, ...messageParams: Array<string | number | boolean>): Error;
+};
+
+export default RelayError;

--- a/types/relay-runtime/lib/util/RelayFeatureFlags.d.ts
+++ b/types/relay-runtime/lib/util/RelayFeatureFlags.d.ts
@@ -1,10 +1,22 @@
+import { Disposable } from './RelayRuntimeTypes';
+
 export interface FeatureFlags {
-    ENABLE_VARIABLE_CONNECTION_KEY: boolean;
-    ENABLE_RELAY_CONTAINERS_SUSPENSE: boolean;
-    ENABLE_PARTIAL_RENDERING_DEFAULT: boolean;
-    ENABLE_UNIQUE_MUTATION_ROOT: boolean;
-    ENABLE_RELAY_RESOLVERS: boolean;
     ENABLE_CLIENT_EDGES: boolean;
+    ENABLE_VARIABLE_CONNECTION_KEY: boolean;
+    ENABLE_PARTIAL_RENDERING_DEFAULT: boolean;
+    ENABLE_REACT_FLIGHT_COMPONENT_FIELD: boolean;
+    ENABLE_RELAY_RESOLVERS: boolean;
+    ENABLE_GETFRAGMENTIDENTIFIER_OPTIMIZATION: boolean;
+    ENABLE_FRIENDLY_QUERY_NAME_GQL_URL: boolean;
+    ENABLE_LOAD_QUERY_REQUEST_DEDUPING: boolean;
+    ENABLE_DO_NOT_WRAP_LIVE_QUERY: boolean;
+    ENABLE_NOTIFY_SUBSCRIPTION: boolean;
+    BATCH_ASYNC_MODULE_UPDATES_FN: null | undefined | ((arg: () => void) => Disposable);
+    ENABLE_CONTAINERS_SUBSCRIBE_ON_COMMIT: boolean;
+    MAX_DATA_ID_LENGTH: number | null | undefined;
+    STRING_INTERN_LEVEL: number;
+    USE_REACT_CACHE: boolean;
+    USE_REACT_CACHE_LEGACY_TIMEOUTS: boolean;
 }
 
 export const RelayFeatureFlags: FeatureFlags;

--- a/types/relay-runtime/lib/util/RelayReplaySubject.d.ts
+++ b/types/relay-runtime/lib/util/RelayReplaySubject.d.ts
@@ -1,0 +1,18 @@
+import type { Observer, Sink, Subscription, RelayObservable } from '../network/RelayObservable';
+
+export type Event<T> = { kind: 'next'; data: T } | { kind: 'error'; error: Error } | { kind: 'complete' };
+
+/**
+ * An implementation of a `ReplaySubject` for Relay Observables.
+ *
+ * Records events provided and synchronously plays them back to new subscribers,
+ * as well as forwarding new asynchronous events.
+ */
+export class RelayReplaySubject<T> {
+    complete(): void;
+    error(error: Error): void;
+    next(data: T): void;
+    subscribe(observer: Observer<T> | Sink<T>): Subscription;
+    unsubscribe(): void;
+    getObserverCount(): number;
+}

--- a/types/relay-runtime/lib/util/createPayloadFor3DField.d.ts
+++ b/types/relay-runtime/lib/util/createPayloadFor3DField.d.ts
@@ -1,0 +1,11 @@
+import type { JSResourceReference } from './JSResourceReference';
+import type { NormalizationSplitOperation } from './NormalizationNode';
+
+export type Local3DPayload<DocumentName extends string, Response extends {}> = Response;
+
+export default function createPayloadFor3DField<DocumentName extends string, Response extends {}>(
+    name: DocumentName,
+    operation: JSResourceReference<NormalizationSplitOperation>,
+    component: JSResourceReference<unknown>,
+    response: Response,
+): Local3DPayload<DocumentName, Response>;

--- a/types/relay-runtime/lib/util/getPendingOperationsForFragment.d.ts
+++ b/types/relay-runtime/lib/util/getPendingOperationsForFragment.d.ts
@@ -1,0 +1,11 @@
+import type { Environment, RequestDescriptor } from '../store/RelayStoreTypes';
+import type { ReaderFragment } from './ReaderNode';
+
+export default function getPendingOperationsForFragment(
+    environment: Environment,
+    fragmentNode: ReaderFragment,
+    fragmentOwner: RequestDescriptor,
+): {
+    promise: Promise<void>;
+    pendingOperations: ReadonlyArray<RequestDescriptor>;
+} | null;

--- a/types/relay-runtime/lib/util/handlePotentialSnapshotErrors.d.ts
+++ b/types/relay-runtime/lib/util/handlePotentialSnapshotErrors.d.ts
@@ -1,0 +1,7 @@
+import { Environment, MissingRequiredFields, RelayResolverErrors } from '../store/RelayStoreTypes';
+
+export default function handlePotentialSnapshotErrors(
+    environment: Environment,
+    missingRequiredFields: MissingRequiredFields | null | undefined,
+    relayResolverErrors: RelayResolverErrors,
+): void;

--- a/types/relay-runtime/lib/util/isScalarAndEqual.d.ts
+++ b/types/relay-runtime/lib/util/isScalarAndEqual.d.ts
@@ -1,0 +1,1 @@
+export default function isScalarAndEqual(valueA: unknown, valueB: unknown): boolean;

--- a/types/relay-runtime/lib/util/recycleNodesInto.d.ts
+++ b/types/relay-runtime/lib/util/recycleNodesInto.d.ts
@@ -1,0 +1,1 @@
+export default function recycleNodesInto<T>(prevData: T, nextData: T): T;

--- a/types/relay-runtime/lib/util/stableCopy.d.ts
+++ b/types/relay-runtime/lib/util/stableCopy.d.ts
@@ -1,0 +1,1 @@
+export default function stableCopy<T extends unknown>(value: T): T;

--- a/types/relay-runtime/lib/util/withProvidedVariables.d.ts
+++ b/types/relay-runtime/lib/util/withProvidedVariables.d.ts
@@ -1,0 +1,7 @@
+import { ProvidedVariablesType } from './RelayConcreteNode';
+import { Variables } from './RelayRuntimeTypes';
+
+export default function withProvidedVariables(
+    userSuppliedVariables: Variables,
+    providedVariables: ProvidedVariablesType | null | undefined,
+): Variables;

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -302,7 +302,7 @@ const node: ConcreteRequest = (function () {
             operationKind: 'query',
             name: 'FooQuery',
             id: null,
-            cacheID: null,
+            cacheID: '2e5967148a8303de3c58059c0eaa87c6',
             text: 'query FooQuery {\n  __typename\n}\n',
             metadata: {},
         },


### PR DESCRIPTION
Updates the types for `relay-runtime` to match the new APIs exposed in 14.1.0

Major changes:
 * Updated feature flags
 * A few extra types exported from `RelayStoreTypes` in `relay-runtime`
 * Exported all of the valid missing types reported by [DangerBotOSS](https://github.com/DangerBotOSS)

Other tasks:

 * Updated tests from `$ExpectError` to `@ts-expect-error`
 * Formatted all existing files using the correct prettier rules

Best reviewed with whitespace turned off to ignore the indentation changes from running prettier.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/compare/v13.0.0...v14.1.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
