### PR TITLE
Apply prettier formatting to react-relay

### DIFF
--- a/types/react-relay/ReactRelayTypes.d.ts
+++ b/types/react-relay/ReactRelayTypes.d.ts
@@ -1,13 +1,6 @@
 import * as React from 'react';
 
-import {
-    Disposable,
-    Environment,
-    Observer,
-    Variables,
-    _FragmentRefs,
-    _RefType
-} from 'relay-runtime';
+import { Disposable, Environment, Observer, Variables, _FragmentRefs, _RefType } from 'relay-runtime';
 
 export { FragmentRef } from 'relay-runtime';
 

--- a/types/react-relay/hooks.d.ts
+++ b/types/react-relay/hooks.d.ts
@@ -1,52 +1,45 @@
 export {
-  VariablesOf,
-  JSResourceReference,
-  PreloadFetchPolicy,
-  PreloadOptions,
-  LoadQueryOptions,
-  PreloadableConcreteRequest,
-  EnvironmentProviderOptions,
-  PreloadedQuery,
-  PreloadQueryStatus,
-  PreloadProps,
-  EntryPointProps,
-  EntryPointComponent,
-  PreloadedEntryPoint,
-  ThinQueryParams,
-  ThinNestedEntryPointParams,
-  EntryPoint,
-  IEnvironmentProvider
+    VariablesOf,
+    JSResourceReference,
+    PreloadFetchPolicy,
+    PreloadOptions,
+    LoadQueryOptions,
+    PreloadableConcreteRequest,
+    EnvironmentProviderOptions,
+    PreloadedQuery,
+    PreloadQueryStatus,
+    PreloadProps,
+    EntryPointProps,
+    EntryPointComponent,
+    PreloadedEntryPoint,
+    ThinQueryParams,
+    ThinNestedEntryPointParams,
+    EntryPoint,
+    IEnvironmentProvider,
 } from './relay-hooks/EntryPointTypes';
 
-export {
-  MatchContainerProps,
-  MatchPointer,
-} from './relay-hooks/MatchContainer';
+export { MatchContainerProps, MatchPointer } from './relay-hooks/MatchContainer';
 export { ProfilerContextType } from './relay-hooks/ProfilerContext';
 export { Direction, LoadMoreFn } from './relay-hooks/useLoadMoreFunction';
 export { UseMutationConfig } from './relay-hooks/useMutation';
 export { UseQueryLoaderLoadQueryOptions } from './relay-hooks/useQueryLoader';
+export { RefetchFn, RefetchFnDynamic, Options as RefetchOptions } from './relay-hooks/useRefetchableFragmentNode';
 export {
-  RefetchFn,
-  RefetchFnDynamic,
-  Options as RefetchOptions,
-} from './relay-hooks/useRefetchableFragmentNode';
-export {
-  DataID,
-  DeclarativeMutationConfig,
-  Disposable,
-  // RelayRuntime has two environment exports: one interface, one concrete.
-  IEnvironment as Environment,
-  GraphQLTaggedNode,
-  MutationType,
-  NormalizationSelector,
-  OperationDescriptor,
-  RangeOperation,
-  ReaderSelector,
-  RelayContext,
-  Snapshot,
-  Variables,
-  FetchPolicy,
+    DataID,
+    DeclarativeMutationConfig,
+    Disposable,
+    // RelayRuntime has two environment exports: one interface, one concrete.
+    IEnvironment as Environment,
+    GraphQLTaggedNode,
+    MutationType,
+    NormalizationSelector,
+    OperationDescriptor,
+    RangeOperation,
+    ReaderSelector,
+    RelayContext,
+    Snapshot,
+    Variables,
+    FetchPolicy,
 } from 'relay-runtime';
 
 // /**

--- a/types/react-relay/relay-hooks/EntryPointTypes.d.ts
+++ b/types/react-relay/relay-hooks/EntryPointTypes.d.ts
@@ -49,7 +49,7 @@ export type EnvironmentProviderOptions<T extends Record<string, unknown> = Recor
 
 export interface PreloadedQuery<
     TQuery extends OperationType,
-    TEnvironmentProviderOptions = EnvironmentProviderOptions
+    TEnvironmentProviderOptions = EnvironmentProviderOptions,
 > extends Readonly<{
         kind: 'PreloadedQuery';
         environment: IEnvironment;
@@ -115,7 +115,7 @@ interface InternalEntryPointRepresentation<
      * a bag of extra props that you may define in `entrypoint` file and they will be passed to the EntryPointComponent
      * as `extraProps`
      */
-    TExtraProps extends {} | null
+    TExtraProps extends {} | null,
 > extends Readonly<{
         root: JSResourceReference<
             EntryPointComponent<TPreloadedQueries, TPreloadedEntryPoints, TRuntimeProps, TExtraProps>
@@ -130,7 +130,7 @@ type ThinQueryParamsObject<TPreloadedQueries extends Record<string, OperationTyp
 };
 
 type ThinNestedEntryPointParamsObject<
-    TPreloadedEntryPoints extends Record<string, EntryPoint<any, any> | undefined> = {}
+    TPreloadedEntryPoints extends Record<string, EntryPoint<any, any> | undefined> = {},
 > = {
     [K in keyof TPreloadedEntryPoints]: ThinNestedEntryPointParams<TPreloadedEntryPoints[K]>;
 };
@@ -157,7 +157,7 @@ export interface PreloadProps<
     TPreloadParams extends {},
     TPreloadedQueries extends Record<string, OperationType>,
     TPreloadedEntryPoints extends Record<string, EntryPoint<any, any> | undefined>,
-    TExtraProps extends {} | null
+    TExtraProps extends {} | null,
 > extends Readonly<{
         entryPoints?: ThinNestedEntryPointParamsObject<TPreloadedEntryPoints> | undefined;
         extraProps?: TExtraProps | undefined;
@@ -178,7 +178,7 @@ export type EntryPointComponent<
     TPreloadedQueries extends Record<string, OperationType>,
     TPreloadedEntryPoints extends Record<string, EntryPoint<any, any> | undefined>,
     TRuntimeProps extends {} = {},
-    TExtraProps extends {} | null = {}
+    TExtraProps extends {} | null = {},
 > = ComponentType<EntryPointProps<TPreloadedQueries, TPreloadedEntryPoints, TRuntimeProps, TExtraProps>>;
 
 // Return type of `loadEntryPoint(...)`
@@ -201,7 +201,7 @@ export type PreloadedEntryPoint<TEntryPointComponent> = TEntryPointComponent ext
 
 export interface ThinQueryParams<
     TQuery extends OperationType,
-    TEnvironmentProviderOptions extends EnvironmentProviderOptions = EnvironmentProviderOptions
+    TEnvironmentProviderOptions extends EnvironmentProviderOptions = EnvironmentProviderOptions,
 > extends Readonly<{
         /**
          * A reference to the $Parameters file that matches the type param provided to preloadQuery type.

--- a/types/react-relay/relay-hooks/loadQuery.d.ts
+++ b/types/react-relay/relay-hooks/loadQuery.d.ts
@@ -8,7 +8,7 @@ import {
 
 export function loadQuery<
     TQuery extends OperationType,
-    TEnvironmentProviderOptions extends EnvironmentProviderOptions = {}
+    TEnvironmentProviderOptions extends EnvironmentProviderOptions = {},
 >(
     environment: IEnvironment,
     preloadableRequest: GraphQLTaggedNode | PreloadableConcreteRequest<TQuery>,

--- a/types/react-relay/relay-hooks/usePaginationFragment.d.ts
+++ b/types/react-relay/relay-hooks/usePaginationFragment.d.ts
@@ -3,7 +3,11 @@ import { KeyType, KeyTypeData } from './helpers';
 import { LoadMoreFn } from './useLoadMoreFunction';
 import { RefetchFnDynamic } from './useRefetchableFragmentNode';
 
-export interface usePaginationFragmentHookType<TQuery extends OperationType, TKey extends KeyType | null, TFragmentData> {
+export interface usePaginationFragmentHookType<
+    TQuery extends OperationType,
+    TKey extends KeyType | null,
+    TFragmentData,
+> {
     data: TFragmentData;
     loadNext: LoadMoreFn<TQuery>;
     loadPrevious: LoadMoreFn<TQuery>;

--- a/types/react-relay/relay-hooks/useQueryLoader.d.ts
+++ b/types/react-relay/relay-hooks/useQueryLoader.d.ts
@@ -7,9 +7,10 @@ export type useQueryLoaderHookType<TQuery extends OperationType> = [
     DisposeFn,
 ];
 
-export type UseQueryLoaderLoadQueryOptions = LoadQueryOptions & Readonly<{
-    __environment?: IEnvironment | null | undefined,
-}>;
+export type UseQueryLoaderLoadQueryOptions = LoadQueryOptions &
+    Readonly<{
+        __environment?: IEnvironment | null | undefined;
+    }>;
 
 export function useQueryLoader<TQuery extends OperationType>(
     preloadableRequest: GraphQLTaggedNode | PreloadableConcreteRequest<TQuery>,

--- a/types/react-relay/relay-hooks/useRefetchableFragmentNode.d.ts
+++ b/types/react-relay/relay-hooks/useRefetchableFragmentNode.d.ts
@@ -21,7 +21,7 @@ export type RefetchFn<TQuery extends OperationType, TOptions = Options> = Refetc
 export type RefetchFnDynamic<
     TQuery extends OperationType,
     TKey extends KeyType | null,
-    TOptions = Options
+    TOptions = Options,
 > = RefetchInexactDynamicResponse<TQuery, TOptions> & RefetchExactDynamicResponse<TQuery, TOptions>;
 
 export type RefetchInexact<TQuery extends OperationType, TOptions> = (

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -717,12 +717,13 @@ requestSubscription(
 ReactRelayContext.Consumer.prototype;
 ReactRelayContext.Provider.prototype;
 
-const MyRelayContextProvider: React.FunctionComponent<{ children?: React.ReactNode }> = ({children}) => {
+const MyRelayContextProvider: React.FunctionComponent<{ children?: React.ReactNode }> = ({ children }) => {
     return (
         <ReactRelayContext.Provider
             value={{
                 environment: modernEnvironment,
-            }}>
+            }}
+        >
             {children}
         </ReactRelayContext.Provider>
     );

--- a/types/react-relay/test/relay-hooks-tests.tsx
+++ b/types/react-relay/test/relay-hooks-tests.tsx
@@ -20,7 +20,7 @@ import {
     useQueryLoader,
     useRefetchableFragment,
     useRelayEnvironment,
-    useSubscription
+    useSubscription,
 } from 'react-relay/hooks';
 
 import {

--- a/types/react-relay/v7/index.d.ts
+++ b/types/react-relay/v7/index.d.ts
@@ -133,7 +133,9 @@ export const ReactRelayContext: React.Context<RelayContext | null>;
 
 export type ContainerProps<Props> = MappedFragmentProps<Pick<Props, Exclude<keyof Props, 'relay'>>>;
 
-export type Container<Props> = React.ComponentType<ContainerProps<Props> & { componentRef?: ((ref: any) => void) | undefined }>;
+export type Container<Props> = React.ComponentType<
+    ContainerProps<Props> & { componentRef?: ((ref: any) => void) | undefined }
+>;
 
 export function createFragmentContainer<Props>(
     Component: React.ComponentType<Props & { relay?: RelayProp | undefined }>,

--- a/types/react-relay/v7/lib/relay-experimental/EntryPointTypes.d.ts
+++ b/types/react-relay/v7/lib/relay-experimental/EntryPointTypes.d.ts
@@ -48,7 +48,7 @@ export type EnvironmentProviderOptions<T extends Record<string, unknown> = Recor
 
 export interface PreloadedQuery<
     TQuery extends OperationType,
-    TEnvironmentProviderOptions = EnvironmentProviderOptions
+    TEnvironmentProviderOptions = EnvironmentProviderOptions,
 > extends Readonly<{
         kind: 'PreloadedQuery';
         environment: IEnvironment;
@@ -114,7 +114,7 @@ interface InternalEntryPointRepresentation<
      * a bag of extra props that you may define in `entrypoint` file and they will be passed to the EntryPointComponent
      * as `extraProps`
      */
-    TExtraProps extends {} | null
+    TExtraProps extends {} | null,
 > extends Readonly<{
         root: JSResourceReference<
             EntryPointComponent<TPreloadedQueries, TPreloadedEntryPoints, TRuntimeProps, TExtraProps>
@@ -129,7 +129,7 @@ type ThinQueryParamsObject<TPreloadedQueries extends Record<string, OperationTyp
 };
 
 type ThinNestedEntryPointParamsObject<
-    TPreloadedEntryPoints extends Record<string, EntryPoint<any, any> | undefined> = {}
+    TPreloadedEntryPoints extends Record<string, EntryPoint<any, any> | undefined> = {},
 > = {
     [K in keyof TPreloadedEntryPoints]: ThinNestedEntryPointParams<TPreloadedEntryPoints[K]>;
 };
@@ -156,7 +156,7 @@ export interface PreloadProps<
     TPreloadParams extends {},
     TPreloadedQueries extends Record<string, OperationType>,
     TPreloadedEntryPoints extends Record<string, EntryPoint<any, any> | undefined>,
-    TExtraProps extends {} | null
+    TExtraProps extends {} | null,
 > extends Readonly<{
         entryPoints?: ThinNestedEntryPointParamsObject<TPreloadedEntryPoints> | undefined;
         extraProps?: TExtraProps | undefined;
@@ -177,7 +177,7 @@ export type EntryPointComponent<
     TPreloadedQueries extends Record<string, OperationType>,
     TPreloadedEntryPoints extends Record<string, EntryPoint<any, any> | undefined>,
     TRuntimeProps extends {} = {},
-    TExtraProps extends {} | null = {}
+    TExtraProps extends {} | null = {},
 > = ComponentType<EntryPointProps<TPreloadedQueries, TPreloadedEntryPoints, TRuntimeProps, TExtraProps>>;
 
 // Return type of `loadEntryPoint(...)`
@@ -200,7 +200,7 @@ export type PreloadedEntryPoint<TEntryPointComponent> = TEntryPointComponent ext
 
 export interface ThinQueryParams<
     TQuery extends OperationType,
-    TEnvironmentProviderOptions extends EnvironmentProviderOptions = EnvironmentProviderOptions
+    TEnvironmentProviderOptions extends EnvironmentProviderOptions = EnvironmentProviderOptions,
 > extends Readonly<{
         /**
          * A reference to the $Parameters file that matches the type param provided to preloadQuery type.

--- a/types/react-relay/v7/lib/relay-experimental/loadQuery.d.ts
+++ b/types/react-relay/v7/lib/relay-experimental/loadQuery.d.ts
@@ -8,7 +8,7 @@ import {
 
 export function loadQuery<
     TQuery extends OperationType,
-    TEnvironmentProviderOptions extends EnvironmentProviderOptions = {}
+    TEnvironmentProviderOptions extends EnvironmentProviderOptions = {},
 >(
     environment: IEnvironment,
     preloadableRequest: GraphQLTaggedNode | PreloadableConcreteRequest<TQuery>,

--- a/types/react-relay/v7/lib/relay-experimental/useRefetchableFragmentNode.d.ts
+++ b/types/react-relay/v7/lib/relay-experimental/useRefetchableFragmentNode.d.ts
@@ -21,7 +21,7 @@ export type RefetchFn<TQuery extends OperationType, TOptions = Options> = Refetc
 export type RefetchFnDynamic<
     TQuery extends OperationType,
     TKey extends KeyType | null,
-    TOptions = Options
+    TOptions = Options,
 > = RefetchInexactDynamicResponse<TQuery, TOptions> & RefetchExactDynamicResponse<TQuery, TOptions>;
 
 export type RefetchInexact<TQuery extends OperationType, TOptions> = (


### PR DESCRIPTION
Many of the files in `react-relay` hasn't been auto-formatted by prettier. This PR applies the repo formatting rules to reduce any diffs in future contributions.

`npm run prettier -- --write types/react-relay/**/*.ts`

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] ~Test the change in your own code. (Compile and run.)~
- [ ] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
