### PR TITLE
Apply prettier formatting to relay-runtime

### DIFF
--- a/types/relay-runtime/lib/handlers/connection/ConnectionHandler.d.ts
+++ b/types/relay-runtime/lib/handlers/connection/ConnectionHandler.d.ts
@@ -35,11 +35,7 @@ export function getConnection(
     filters?: Variables | null,
 ): RecordProxy | null | undefined;
 
-export function getConnectionID(
-    recordID: DataID,
-    key: string,
-    filters?: Variables | null,
-): DataID;
+export function getConnectionID(recordID: DataID, key: string, filters?: Variables | null): DataID;
 
 export function insertEdgeAfter(record: RecordProxy, newEdge: RecordProxy, cursor?: string | null): void;
 

--- a/types/relay-runtime/lib/multi-actor-environment/ActorIdentifier.d.ts
+++ b/types/relay-runtime/lib/multi-actor-environment/ActorIdentifier.d.ts
@@ -3,9 +3,7 @@
  */
 export type ActorIdentifier = string;
 
-export function assertInternalActorIndentifier(
-    actorIdentifier: ActorIdentifier,
-): void;
+export function assertInternalActorIndentifier(actorIdentifier: ActorIdentifier): void;
 
 export function getActorIdentifier(actorID: string): ActorIdentifier;
 

--- a/types/relay-runtime/lib/multi-actor-environment/MultiActorEnvironment.d.ts
+++ b/types/relay-runtime/lib/multi-actor-environment/MultiActorEnvironment.d.ts
@@ -29,20 +29,20 @@ import {
 } from './MultiActorEnvironmentTypes';
 
 export type MultiActorEnvironmentConfig = Readonly<{
-    createConfigNameForActor?: ((actorIdentifier: ActorIdentifier) => string) | null,
-    createNetworkForActor: (actorIdentifier: ActorIdentifier) => Network,
-    createStoreForActor?: ((actorIdentifier: ActorIdentifier) => Store) | null,
-    defaultRenderPolicy?: RenderPolicy | null,
-    getDataID?: GetDataID,
-    handlerProvider?: HandlerProvider,
-    isServer?: boolean | null,
-    logFn?: LogFunction | null,
-    missingFieldHandlers?: ReadonlyArray<MissingFieldHandler> | null,
-    operationLoader?: OperationLoader | null,
-    requiredFieldLogger?: RequiredFieldLogger | null,
-    scheduler?: TaskScheduler | null,
-    shouldProcessClientComponents?: boolean | null,
-    treatMissingFieldsAsNull?: boolean,
+    createConfigNameForActor?: ((actorIdentifier: ActorIdentifier) => string) | null;
+    createNetworkForActor: (actorIdentifier: ActorIdentifier) => Network;
+    createStoreForActor?: ((actorIdentifier: ActorIdentifier) => Store) | null;
+    defaultRenderPolicy?: RenderPolicy | null;
+    getDataID?: GetDataID;
+    handlerProvider?: HandlerProvider;
+    isServer?: boolean | null;
+    logFn?: LogFunction | null;
+    missingFieldHandlers?: ReadonlyArray<MissingFieldHandler> | null;
+    operationLoader?: OperationLoader | null;
+    requiredFieldLogger?: RequiredFieldLogger | null;
+    scheduler?: TaskScheduler | null;
+    shouldProcessClientComponents?: boolean | null;
+    treatMissingFieldsAsNull?: boolean;
 }>;
 
 export class MultiActorEnvironment implements IMultiActorEnvironment {
@@ -52,7 +52,11 @@ export class MultiActorEnvironment implements IMultiActorEnvironment {
 
     check(actorEnvironment: ActorEnvironment, operation: OperationDescriptor): OperationAvailability;
 
-    subscribe(actorEnvironment: ActorEnvironment, snapshot: Snapshot, callback: (snapshot: Snapshot) => void): Disposable;
+    subscribe(
+        actorEnvironment: ActorEnvironment,
+        snapshot: Snapshot,
+        callback: (snapshot: Snapshot) => void,
+    ): Disposable;
 
     retain(actorEnvironment: ActorEnvironment, operation: OperationDescriptor): Disposable;
 
@@ -60,28 +64,51 @@ export class MultiActorEnvironment implements IMultiActorEnvironment {
 
     revertUpdate(actorEnvironment: ActorEnvironment, update: OptimisticUpdateFunction): void;
 
-    replaceUpdate(actorEnvironment: ActorEnvironment, update: OptimisticUpdateFunction, replacement: OptimisticUpdateFunction): void;
+    replaceUpdate(
+        actorEnvironment: ActorEnvironment,
+        update: OptimisticUpdateFunction,
+        replacement: OptimisticUpdateFunction,
+    ): void;
 
-    applyMutation(actorEnvironment: ActorEnvironment, optimisticConfig: OptimisticResponseConfig<MutationParameters>): Disposable;
+    applyMutation(
+        actorEnvironment: ActorEnvironment,
+        optimisticConfig: OptimisticResponseConfig<MutationParameters>,
+    ): Disposable;
 
     commitUpdate(actorEnvironment: ActorEnvironment, updater: StoreUpdater): void;
 
     commitMultiActorUpdate(updater: MultiActorStoreUpdater): void;
 
-    commitPayload(actorEnvironment: ActorEnvironment, operationDescriptor: OperationDescriptor, payload: PayloadData): void;
+    commitPayload(
+        actorEnvironment: ActorEnvironment,
+        operationDescriptor: OperationDescriptor,
+        payload: PayloadData,
+    ): void;
 
     lookup(actorEnvironment: ActorEnvironment, selector: SingularReaderSelector): Snapshot;
 
-    execute(actorEnvironment: ActorEnvironment, config: { operation: OperationDescriptor; }): Observable<GraphQLResponse>;
+    execute(
+        actorEnvironment: ActorEnvironment,
+        config: { operation: OperationDescriptor },
+    ): Observable<GraphQLResponse>;
 
     executeSubscription(
         actorEnvironment: ActorEnvironment,
-        config: { operation: OperationDescriptor; updater?: SelectorStoreUpdater<MutationParameters['response']> | null | undefined; },
+        config: {
+            operation: OperationDescriptor;
+            updater?: SelectorStoreUpdater<MutationParameters['response']> | null | undefined;
+        },
     ): Observable<GraphQLResponse>;
 
-    executeMutation(actorEnvironment: ActorEnvironment, config: ExecuteMutationConfig<MutationParameters>): Observable<GraphQLResponse>;
+    executeMutation(
+        actorEnvironment: ActorEnvironment,
+        config: ExecuteMutationConfig<MutationParameters>,
+    ): Observable<GraphQLResponse>;
 
-    executeWithSource(actorEnvironment: ActorEnvironment, arg: { operation: OperationDescriptor; source: Observable<GraphQLResponse>; }): Observable<GraphQLResponse>;
+    executeWithSource(
+        actorEnvironment: ActorEnvironment,
+        arg: { operation: OperationDescriptor; source: Observable<GraphQLResponse> },
+    ): Observable<GraphQLResponse>;
 
     isRequestActive(actorEnvironment: ActorEnvironment, requestIdentifier: string): boolean;
 

--- a/types/relay-runtime/lib/multi-actor-environment/MultiActorEnvironmentTypes.d.ts
+++ b/types/relay-runtime/lib/multi-actor-environment/MultiActorEnvironmentTypes.d.ts
@@ -61,10 +61,7 @@ export interface MultiActorEnvironment {
      * cache and therefore takes time proportional to the size/complexity of the
      * selector.
      */
-    check(
-        actorEnvironment: ActorEnvironment,
-        operation: OperationDescriptor,
-    ): OperationAvailability;
+    check(actorEnvironment: ActorEnvironment, operation: OperationDescriptor): OperationAvailability;
 
     /**
      * Subscribe to changes to the results of a selector. The callback is called
@@ -82,27 +79,18 @@ export interface MultiActorEnvironment {
      * retained in-memory. The records will not be eligible for garbage collection
      * until the returned reference is disposed.
      */
-    retain(
-        actorEnvironment: ActorEnvironment,
-        operation: OperationDescriptor,
-    ): Disposable;
+    retain(actorEnvironment: ActorEnvironment, operation: OperationDescriptor): Disposable;
 
     /**
      * Apply an optimistic update to the environment. The mutation can be reverted
      * by calling `dispose()` on the returned value.
      */
-    applyUpdate(
-        actorEnvironment: ActorEnvironment,
-        optimisticUpdate: OptimisticUpdateFunction,
-    ): Disposable;
+    applyUpdate(actorEnvironment: ActorEnvironment, optimisticUpdate: OptimisticUpdateFunction): Disposable;
 
     /**
      * Revert updates for the `update` function.
      */
-    revertUpdate(
-        actorEnvironment: ActorEnvironment,
-        update: OptimisticUpdateFunction,
-    ): void;
+    revertUpdate(actorEnvironment: ActorEnvironment, update: OptimisticUpdateFunction): void;
 
     /**
      * Revert updates for the `update` function, and apply the `replacement` update.
@@ -127,10 +115,7 @@ export interface MultiActorEnvironment {
      * should therefore not be used for optimistic updates. This is mainly
      * intended for updating fields from client schema extensions.
      */
-    commitUpdate(
-        actorEnvironment: ActorEnvironment,
-        updater: StoreUpdater,
-    ): void;
+    commitUpdate(actorEnvironment: ActorEnvironment, updater: StoreUpdater): void;
 
     /**
      * Commit store updates for each actor-specific environment known to MultActorEnvironment
@@ -149,10 +134,7 @@ export interface MultiActorEnvironment {
     /**
      * Read the results of a selector from in-memory records in the store.
      */
-    lookup(
-        actorEnvironment: ActorEnvironment,
-        selector: SingularReaderSelector,
-    ): Snapshot;
+    lookup(actorEnvironment: ActorEnvironment, selector: SingularReaderSelector): Snapshot;
 
     /**
      * Send a query to the server with Observer semantics: one or more
@@ -165,7 +147,7 @@ export interface MultiActorEnvironment {
     execute(
         actorEnvironment: ActorEnvironment,
         config: {
-            operation: OperationDescriptor,
+            operation: OperationDescriptor;
         },
     ): RelayObservable<GraphQLResponse>;
 
@@ -183,8 +165,8 @@ export interface MultiActorEnvironment {
     executeSubscription(
         actorEnvironment: ActorEnvironment,
         config: {
-            operation: OperationDescriptor,
-            updater?: SelectorStoreUpdater<MutationParameters['response']> | null,
+            operation: OperationDescriptor;
+            updater?: SelectorStoreUpdater<MutationParameters['response']> | null;
         },
     ): RelayObservable<GraphQLResponse>;
 
@@ -215,8 +197,8 @@ export interface MultiActorEnvironment {
     executeWithSource(
         actorEnvironment: ActorEnvironment,
         arg: {
-            operation: OperationDescriptor,
-            source: RelayObservable<GraphQLResponse>,
+            operation: OperationDescriptor;
+            source: RelayObservable<GraphQLResponse>;
         },
     ): RelayObservable<GraphQLResponse>;
 
@@ -227,10 +209,7 @@ export interface MultiActorEnvironment {
      * without actively receiving payload, for example a live query or an
      * active GraphQL subscription
      */
-    isRequestActive(
-        actorEnvironment: ActorEnvironment,
-        requestIdentifier: string,
-    ): boolean;
+    isRequestActive(actorEnvironment: ActorEnvironment, requestIdentifier: string): boolean;
 
     /**
      * Returns `true` if execute in the server environment

--- a/types/relay-runtime/lib/multi-actor-environment/index.d.ts
+++ b/types/relay-runtime/lib/multi-actor-environment/index.d.ts
@@ -1,10 +1,7 @@
-export {
-    ActorIdentifier,
-    getActorIdentifier
-} from './ActorIdentifier';
+export { ActorIdentifier, getActorIdentifier } from './ActorIdentifier';
 
 export { MultiActorEnvironment } from './MultiActorEnvironment';
 export {
     ActorEnvironment as IActorEnvironment,
-    MultiActorEnvironment as IMultiActorEnvironment
+    MultiActorEnvironment as IMultiActorEnvironment,
 } from './MultiActorEnvironmentTypes';

--- a/types/relay-runtime/lib/mutations/RelayDeclarativeMutationConfig.d.ts
+++ b/types/relay-runtime/lib/mutations/RelayDeclarativeMutationConfig.d.ts
@@ -15,11 +15,13 @@ export interface RangeAddConfig {
     type: 'RANGE_ADD';
     parentName?: string | undefined;
     parentID?: string | undefined;
-    connectionInfo?: ReadonlyArray<{
-        key: string;
-        filters?: Variables | undefined;
-        rangeBehavior: string;
-    }> | undefined;
+    connectionInfo?:
+        | ReadonlyArray<{
+              key: string;
+              filters?: Variables | undefined;
+              rangeBehavior: string;
+          }>
+        | undefined;
     connectionName?: string | undefined;
     edgeName: string;
     rangeBehaviors?: RangeBehaviors | undefined;
@@ -29,10 +31,12 @@ export interface RangeDeleteConfig {
     type: 'RANGE_DELETE';
     parentName?: string | undefined;
     parentID?: string | undefined;
-    connectionKeys?: ReadonlyArray<{
-        key: string;
-        filters?: Variables | undefined;
-    }> | undefined;
+    connectionKeys?:
+        | ReadonlyArray<{
+              key: string;
+              filters?: Variables | undefined;
+          }>
+        | undefined;
     connectionName?: string | undefined;
     deletedIDFieldName: string | ReadonlyArray<string>;
     pathToConnection: ReadonlyArray<string>;

--- a/types/relay-runtime/lib/mutations/commitMutation.d.ts
+++ b/types/relay-runtime/lib/mutations/commitMutation.d.ts
@@ -17,7 +17,8 @@ export interface MutationConfig<TOperation extends MutationParameters> {
     onError?: ((error: Error) => void) | null | undefined;
     onCompleted?:
         | ((response: TOperation['response'], errors: ReadonlyArray<PayloadError> | null | undefined) => void)
-        | null | undefined;
+        | null
+        | undefined;
     onUnsubscribe?: (() => void | null | undefined) | undefined;
     /**
      * An object whose type matches the raw response type of the mutation. Make sure you decorate

--- a/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
+++ b/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
@@ -17,10 +17,12 @@ export interface PayloadData {
 
 export interface PayloadError {
     message: string;
-    locations?: Array<{
-        line: number;
-        column: number;
-    }> | undefined;
+    locations?:
+        | Array<{
+              line: number;
+              column: number;
+          }>
+        | undefined;
     severity?: 'CRITICAL' | 'ERROR' | 'WARNING' | undefined; // Not officially part of the spec, but used at Facebook
 }
 

--- a/types/relay-runtime/lib/query/fetchQuery.d.ts
+++ b/types/relay-runtime/lib/query/fetchQuery.d.ts
@@ -7,5 +7,8 @@ export function fetchQuery<T extends OperationType>(
     environment: Environment,
     taggedNode: GraphQLTaggedNode,
     variables: T['variables'],
-    cacheConfig?: { networkCacheConfig?: CacheConfig | null | undefined, fetchPolicy?: FetchQueryFetchPolicy | null | undefined } | null,
+    cacheConfig?: {
+        networkCacheConfig?: CacheConfig | null | undefined;
+        fetchPolicy?: FetchQueryFetchPolicy | null | undefined;
+    } | null,
 ): RelayObservable<T['response']>;

--- a/types/relay-runtime/lib/store/RelayOperationTracker.d.ts
+++ b/types/relay-runtime/lib/store/RelayOperationTracker.d.ts
@@ -15,9 +15,7 @@ export class RelayOperationTracker {
 
     _resolveOwnerResolvers(owner: RequestDescriptor): void;
 
-    getPendingOperationsAffectingOwner(
-        owner: RequestDescriptor,
-    ): {
+    getPendingOperationsAffectingOwner(owner: RequestDescriptor): {
         promise: Promise<void>;
         pendingOperations: ReadonlyArray<RequestDescriptor>;
     } | null;

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -419,141 +419,141 @@ interface OperationDescriptor {
 
 export type LogEvent =
     | Readonly<{
-        name: 'suspense.fragment',
-        data: unknown,
-        fragment: ReaderFragment,
-        isRelayHooks: boolean,
-        isMissingData: boolean,
-        isPromiseCached: boolean,
-        pendingOperations: ReadonlyArray<RequestDescriptor>,
-    }>
+          name: 'suspense.fragment';
+          data: unknown;
+          fragment: ReaderFragment;
+          isRelayHooks: boolean;
+          isMissingData: boolean;
+          isPromiseCached: boolean;
+          pendingOperations: ReadonlyArray<RequestDescriptor>;
+      }>
     | Readonly<{
-        name: 'suspense.query',
-        fetchPolicy: string,
-        isPromiseCached: boolean,
-        operation: OperationDescriptor,
-        queryAvailability?: OperationAvailability | undefined,
-        renderPolicy: RenderPolicy,
-    }>
+          name: 'suspense.query';
+          fetchPolicy: string;
+          isPromiseCached: boolean;
+          operation: OperationDescriptor;
+          queryAvailability?: OperationAvailability | undefined;
+          renderPolicy: RenderPolicy;
+      }>
     | Readonly<{
-        name: 'queryresource.fetch';
-        /**
-         * ID of this query resource request and will be the same if there is an associated queryresource.retain event.
-         */
-        resourceID: number;
-        operation: OperationDescriptor;
-        profilerContext: unknown;
-        fetchPolicy: FetchPolicy;
-        renderPolicy: RenderPolicy;
-        queryAvailability: OperationAvailability;
-        shouldFetch: boolean;
-    }>
+          name: 'queryresource.fetch';
+          /**
+           * ID of this query resource request and will be the same if there is an associated queryresource.retain event.
+           */
+          resourceID: number;
+          operation: OperationDescriptor;
+          profilerContext: unknown;
+          fetchPolicy: FetchPolicy;
+          renderPolicy: RenderPolicy;
+          queryAvailability: OperationAvailability;
+          shouldFetch: boolean;
+      }>
     | Readonly<{
-        name: 'queryresource.retain';
-        resourceID: number;
-        // value from ProfilerContext
-        profilerContext: unknown;
-    }>
+          name: 'queryresource.retain';
+          resourceID: number;
+          // value from ProfilerContext
+          profilerContext: unknown;
+      }>
     | Readonly<{
-        name: 'network.info';
-        networkRequestId: number;
-        info: unknown;
-    }>
+          name: 'network.info';
+          networkRequestId: number;
+          info: unknown;
+      }>
     | Readonly<{
-        name: 'network.start';
-        networkRequestId: number;
-        params: RequestParameters;
-        variables: Variables;
-        cacheConfig: CacheConfig;
-    }>
+          name: 'network.start';
+          networkRequestId: number;
+          params: RequestParameters;
+          variables: Variables;
+          cacheConfig: CacheConfig;
+      }>
     | Readonly<{
-        name: 'network.next';
-        networkRequestId: number;
-        response: GraphQLResponse;
-    }>
+          name: 'network.next';
+          networkRequestId: number;
+          response: GraphQLResponse;
+      }>
     | Readonly<{
-        name: 'network.error';
-        networkRequestId: number;
-        error: Error;
-    }>
+          name: 'network.error';
+          networkRequestId: number;
+          error: Error;
+      }>
     | Readonly<{
-        name: 'network.complete';
-        networkRequestId: number;
-    }>
+          name: 'network.complete';
+          networkRequestId: number;
+      }>
     | Readonly<{
-        name: 'network.unsubscribe';
-        networkRequestId: number;
-    }>
+          name: 'network.unsubscribe';
+          networkRequestId: number;
+      }>
     | Readonly<{
-        name: 'execute.start';
-        executeId: number;
-        params: RequestParameters;
-        variables: Variables;
-        cacheConfig: CacheConfig;
-    }>
+          name: 'execute.start';
+          executeId: number;
+          params: RequestParameters;
+          variables: Variables;
+          cacheConfig: CacheConfig;
+      }>
     | Readonly<{
-        name: "execute.next";
-        executeId: number;
-        response: GraphQLResponse;
-        duration: number;
-    }>
+          name: 'execute.next';
+          executeId: number;
+          response: GraphQLResponse;
+          duration: number;
+      }>
     | Readonly<{
-        name: 'execute.async.module';
-        executeId: number;
-        operationName: string;
-        duration: number;
-    }>
+          name: 'execute.async.module';
+          executeId: number;
+          operationName: string;
+          duration: number;
+      }>
     | Readonly<{
-        name: 'execute.flight.payload_deserialize';
-        executeId: number;
-        operationName: string;
-        duration: number;
-    }>
+          name: 'execute.flight.payload_deserialize';
+          executeId: number;
+          operationName: string;
+          duration: number;
+      }>
     | Readonly<{
-        name: 'execute.error';
-        executeId: number;
-        error: Error;
-    }>
+          name: 'execute.error';
+          executeId: number;
+          error: Error;
+      }>
     | Readonly<{
-        name: 'execute.complete';
-        executeId: number;
-    }>
+          name: 'execute.complete';
+          executeId: number;
+      }>
     | Readonly<{
-        name: 'store.publish';
-        source: RecordSource;
-        optimistic: boolean;
-    }>
+          name: 'store.publish';
+          source: RecordSource;
+          optimistic: boolean;
+      }>
     | Readonly<{
-        name: 'store.snapshot';
-    }>
+          name: 'store.snapshot';
+      }>
     | Readonly<{
-        name: 'store.restore';
-    }>
+          name: 'store.restore';
+      }>
     | Readonly<{
-        name: 'store.gc';
-        references: DataIDSet;
-    }>
+          name: 'store.gc';
+          references: DataIDSet;
+      }>
     | Readonly<{
-        name: 'store.notify.start';
-        sourceOperation?: OperationDescriptor | undefined;
-    }>
+          name: 'store.notify.start';
+          sourceOperation?: OperationDescriptor | undefined;
+      }>
     | Readonly<{
-        name: 'store.notify.complete';
-        sourceOperation?: OperationDescriptor | undefined;
-        updatedRecordIDs: DataIDSet;
-        invalidatedRecordIDs: DataIDSet;
-    }>
+          name: 'store.notify.complete';
+          sourceOperation?: OperationDescriptor | undefined;
+          updatedRecordIDs: DataIDSet;
+          invalidatedRecordIDs: DataIDSet;
+      }>
     | Readonly<{
-        name: 'store.notify.subscription';
-        sourceOperation?: OperationDescriptor | undefined;
-        snapshot: Snapshot;
-        nextSnapshot: Snapshot;
-    }>
+          name: 'store.notify.subscription';
+          sourceOperation?: OperationDescriptor | undefined;
+          snapshot: Snapshot;
+          nextSnapshot: Snapshot;
+      }>
     | Readonly<{
-        name: 'entrypoint.root.consume';
-        profilerContext: unknown;
-        rootModuleID: string;
-    }>;
+          name: 'entrypoint.root.consume';
+          profilerContext: unknown;
+          rootModuleID: string;
+      }>;
 
 export type LogFunction = (logEvent: LogEvent) => void;
 

--- a/types/relay-runtime/lib/util/NormalizationNode.d.ts
+++ b/types/relay-runtime/lib/util/NormalizationNode.d.ts
@@ -1,4 +1,4 @@
-import type { ConcreteRequest } from "./RelayConcreteNode";
+import type { ConcreteRequest } from './RelayConcreteNode';
 
 /**
  * Represents a single operation used to processing and normalize runtime
@@ -11,9 +11,7 @@ export interface NormalizationOperation {
     readonly selections: ReadonlyArray<NormalizationSelection>;
 }
 
-export type NormalizationHandle =
-    | NormalizationScalarHandle
-    | NormalizationLinkedHandle;
+export type NormalizationHandle = NormalizationScalarHandle | NormalizationLinkedHandle;
 
 export interface NormalizationLinkedHandle {
     readonly kind: string; // "LinkedHandle";
@@ -59,10 +57,7 @@ export interface NormalizationClientExtension {
     readonly selections: ReadonlyArray<NormalizationSelection>;
 }
 
-export type NormalizationField =
-    | NormalizationFlightField
-    | NormalizationScalarField
-    | NormalizationLinkedField;
+export type NormalizationField = NormalizationFlightField | NormalizationScalarField | NormalizationLinkedField;
 
 export interface NormalizationInlineFragment {
     readonly kind: string; // "InlineFragment";
@@ -214,6 +209,4 @@ export type NormalizationSelectableNode =
     | NormalizationSplitOperation
     | NormalizationStream;
 
-export type NormalizationRootNode =
-    | ConcreteRequest
-    | NormalizationSplitOperation;
+export type NormalizationRootNode = ConcreteRequest | NormalizationSplitOperation;

--- a/types/relay-runtime/lib/util/ReaderNode.d.ts
+++ b/types/relay-runtime/lib/util/ReaderNode.d.ts
@@ -1,5 +1,5 @@
-import type { ConnectionMetadata } from "../handlers/connection/ConnectionHandler";
-import type { ConcreteRequest } from "./RelayConcreteNode";
+import type { ConnectionMetadata } from '../handlers/connection/ConnectionHandler';
+import type { ConcreteRequest } from './RelayConcreteNode';
 
 export interface ReaderFragmentSpread {
     readonly kind: string; // 'FragmentSpread';
@@ -18,12 +18,15 @@ export interface ReaderFragment {
     readonly name: string;
     readonly type: string;
     readonly abstractKey?: string | null | undefined;
-    readonly metadata?: {
-        readonly connection?: ReadonlyArray<ConnectionMetadata>;
-        readonly mask?: boolean;
-        readonly plural?: boolean;
-        readonly refetch?: ReaderRefetchMetadata;
-    } | null | undefined;
+    readonly metadata?:
+        | {
+              readonly connection?: ReadonlyArray<ConnectionMetadata>;
+              readonly mask?: boolean;
+              readonly plural?: boolean;
+              readonly refetch?: ReaderRefetchMetadata;
+          }
+        | null
+        | undefined;
     readonly argumentDefinitions: ReadonlyArray<ReaderArgumentDefinition>;
     readonly selections: ReadonlyArray<ReaderSelection>;
 }
@@ -42,7 +45,7 @@ export interface ReaderPaginationFragment extends ReaderFragment {
         readonly connection: [ConnectionMetadata];
         readonly refetch: ReaderRefetchMetadata & {
             connection: ReaderPaginationMetadata;
-        }
+        };
     };
 }
 
@@ -77,9 +80,7 @@ export type ReaderArgument =
     | ReaderObjectValueArgument
     | ReaderVariableArgument;
 
-export type ReaderArgumentDefinition =
-    | ReaderLocalArgument
-    | ReaderRootArgument;
+export type ReaderArgumentDefinition = ReaderLocalArgument | ReaderRootArgument;
 
 export interface ReaderCondition {
     readonly kind: string; // 'Condition';
@@ -93,10 +94,7 @@ export interface ReaderClientExtension {
     readonly selections: ReadonlyArray<ReaderSelection>;
 }
 
-export type ReaderField =
-    | ReaderScalarField
-    | ReaderLinkedField
-    | ReaderRelayResolver;
+export type ReaderField = ReaderScalarField | ReaderLinkedField | ReaderRelayResolver;
 
 export interface ReaderRootArgument {
     readonly kind: string; // 'RootArgument';
@@ -163,11 +161,7 @@ export interface ReaderObjectValueArgument {
     readonly fields: ReadonlyArray<ReaderArgument>;
 }
 
-export type ReaderNode =
-    | ReaderCondition
-    | ReaderLinkedField
-    | ReaderFragment
-    | ReaderInlineFragment;
+export type ReaderNode = ReaderCondition | ReaderLinkedField | ReaderFragment | ReaderInlineFragment;
 
 export interface ReaderScalarField {
     readonly kind: string; // 'ScalarField';
@@ -195,7 +189,7 @@ export interface ReaderStream {
     readonly selections: ReadonlyArray<ReaderSelection>;
 }
 
-export type RequiredFieldAction = "NONE" | "LOG" | "THROW";
+export type RequiredFieldAction = 'NONE' | 'LOG' | 'THROW';
 
 export interface ReaderRequiredField {
     readonly kind: string; // 'RequiredField';

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -130,14 +130,14 @@ const environment = new Environment({
                 break;
         }
     },
-    requiredFieldLogger: (arg) => {
+    requiredFieldLogger: arg => {
         if (arg.kind === 'missing_field.log') {
             console.log(arg.fieldPath, arg.owner);
         } else {
             arg.kind; // $ExpectType "missing_field.throw"
             console.log(arg.fieldPath, arg.owner);
         }
-    }
+    },
 });
 
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -219,9 +219,9 @@ function connectionHandlerWithoutStore() {
 // ~~~~~~~~~~~~~~~~~~~~~
 
 store.publish(source);
-const get_store_recorditem = store.getSource().get("someDataId");
+const get_store_recorditem = store.getSource().get('someDataId');
 // $ExpectType Record<TConversation> | null | undefined
-const get_store_recorditem_typed = store.getSource().get<TConversation>("someDataId");
+const get_store_recorditem_typed = store.getSource().get<TConversation>('someDataId');
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // commitLocalUpdate
@@ -438,32 +438,28 @@ interface Module_data$key {
     readonly ' $fragmentSpreads': FragmentRefs<'Module_data'>;
 }
 
-function readData(
-  dataRef: Module_data$key,
-) {
-  // $ExpectType Module_data
-  readInlineData(
-    graphql`
-      fragment Module_data on Data @inline {
-        id
-      }
-    `,
-    dataRef,
-  );
+function readData(dataRef: Module_data$key) {
+    // $ExpectType Module_data
+    readInlineData(
+        graphql`
+            fragment Module_data on Data @inline {
+                id
+            }
+        `,
+        dataRef,
+    );
 }
 
-function readNullableData(
-  dataRef: Module_data$key | null,
-) {
-  // $ExpectType Module_data | null
-  readInlineData(
-    graphql`
-      fragment Module_data on Data @inline {
-        id
-      }
-    `,
-    dataRef,
-  );
+function readNullableData(dataRef: Module_data$key | null) {
+    // $ExpectType Module_data | null
+    readInlineData(
+        graphql`
+            fragment Module_data on Data @inline {
+                id
+            }
+        `,
+        dataRef,
+    );
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -480,14 +476,14 @@ const gqlQuery = graphql`
         page(id: $pageID) {
             name
         }
-   }
+    }
 `;
 
 const pageID = '110798995619330';
-const cacheConfig: CacheConfig = { force: true};
+const cacheConfig: CacheConfig = { force: true };
 const request = getRequest(gqlQuery);
-const variables: Variables = {pageID};
-const dataID: DataID = "dataID";
+const variables: Variables = { pageID };
+const dataID: DataID = 'dataID';
 const operation = createOperationDescriptor(request, variables);
 const operationWithCacheConfig = createOperationDescriptor(request, variables, cacheConfig);
 const operationWithDataID = createOperationDescriptor(request, variables, undefined, dataID);
@@ -499,47 +495,49 @@ const operationWithAll = createOperationDescriptor(request, variables, cacheConf
 
 function multiActors() {
     const environment = new multiActorEnvironment.MultiActorEnvironment({
-       createNetworkForActor(
-           id // $ExpectType string
-       ) {
-           return network;
-       },
-        createStoreForActor(
-            id // $ExpectType string
+        createNetworkForActor(
+            id, // $ExpectType string
         ) {
-           return store;
+            return network;
+        },
+        createStoreForActor(
+            id, // $ExpectType string
+        ) {
+            return store;
         },
     });
 
     // $ExpectType ActorEnvironment
-    const actor = environment.forActor("test");
+    const actor = environment.forActor('test');
 
-    environment.execute(actor, {
-        operation
-    }).toPromise();
+    environment
+        .execute(actor, {
+            operation,
+        })
+        .toPromise();
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~
 // Relay Resolvers
 // ~~~~~~~~~~~~~~~~~~~~~~~
 
-const {readFragment} = __internal.ResolverFragments;
+const { readFragment } = __internal.ResolverFragments;
 
 // Regular fragment.
 interface UserComponent_user {
-  readonly id: string;
-  readonly name: string;
-  readonly profile_picture: {
-      readonly uri: string;
-  };
-  readonly ' $fragmentType': 'UserComponent_user';
+    readonly id: string;
+    readonly name: string;
+    readonly profile_picture: {
+        readonly uri: string;
+    };
+    readonly ' $fragmentType': 'UserComponent_user';
 }
 
 type UserComponent_user$data = UserComponent_user;
 
 interface UserComponent_user$key {
-  readonly ' $data'?: UserComponent_user$data | undefined;
-  readonly ' $fragmentSpreads': FragmentRefs<'UserComponent_user'>;
+    readonly ' $data'?: UserComponent_user$data | undefined;
+    readonly ' $fragmentSpreads': FragmentRefs<'UserComponent_user'>;
 }
 
 function NonNullableFragmentResolver(userKey: UserComponent_user$key) {
@@ -576,17 +574,17 @@ function NullableFragmentResolver(userKey: UserComponent_user$key | null) {
 
 // Plural fragment @relay(plural: true)
 type UserComponent_users = ReadonlyArray<{
-  readonly id: string;
-  readonly name: string;
-  readonly profile_picture: {
-      readonly uri: string;
-  };
-  readonly ' $fragmentType': 'UserComponent_users';
+    readonly id: string;
+    readonly name: string;
+    readonly profile_picture: {
+        readonly uri: string;
+    };
+    readonly ' $fragmentType': 'UserComponent_users';
 }>;
 type UserComponent_users$data = UserComponent_users;
 type UserComponent_users$key = ReadonlyArray<{
-  readonly ' $data'?: UserComponent_users$data | undefined;
-  readonly ' $fragmentSpreads': FragmentRefs<'UserComponent_users'>;
+    readonly ' $data'?: UserComponent_users$data | undefined;
+    readonly ' $fragmentSpreads': FragmentRefs<'UserComponent_users'>;
 }>;
 
 function NonNullableArrayFragmentResolver(usersKey: UserComponent_users$key) {
@@ -602,7 +600,7 @@ function NonNullableArrayFragmentResolver(usersKey: UserComponent_users$key) {
         usersKey,
     );
 
-    return data.map((thing) => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
+    return data.map(thing => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
 }
 
 function NullableArrayFragmentResolver(usersKey: UserComponent_users$key | null) {
@@ -618,7 +616,7 @@ function NullableArrayFragmentResolver(usersKey: UserComponent_users$key | null)
         usersKey,
     );
 
-    return data?.map((thing) => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
+    return data?.map(thing => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
 }
 
 function ArrayOfNullableFragmentResolver(usersKey: ReadonlyArray<UserComponent_users$key[0] | null>) {
@@ -634,5 +632,5 @@ function ArrayOfNullableFragmentResolver(usersKey: ReadonlyArray<UserComponent_u
         usersKey,
     );
 
-    return data?.map((thing) => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
+    return data?.map(thing => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
 }


### PR DESCRIPTION
Many of the files in `relay-runtime` hasn't been auto-formatted by prettier. This PR applies the repo formatting rules to easy any diffs in future contributions.

`npm run prettier -- --write types/relay-runtime/**/*.ts`

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] ~Test the change in your own code. (Compile and run.)~
- [ ] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
