### PR TITLE
Update jquery.colorpicker for TS 4.9

### DIFF
--- a/types/jquery.colorpicker/index.d.ts
+++ b/types/jquery.colorpicker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/vanderlee/colorpicker
 // Definitions by: Jeffery Grajkowski <https://github.com/pushplay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 4.9
 
 /// <reference types="jquery" />
 

--- a/types/jquery.colorpicker/jquery.colorpicker-tests.ts
+++ b/types/jquery.colorpicker/jquery.colorpicker-tests.ts
@@ -105,7 +105,7 @@ $.colorpicker.parts["memory"] = function (inst) {
             container.append($node);
         },
         getMemory = function () {
-            return (<string>(document.cookie.match(/\bcolorpicker-memory=([^;]*)/) || [0, ''])[1]).split(',');
+            return ((document.cookie.match(/\bcolorpicker-memory=([^;]*)/) || [0, ''])[1]).split(',');
         },
         setMemory = function () {
             var colors = [];


### PR DESCRIPTION
TS 4.9 has better types for RegExp.match, so it's no longer necessary to cast in one of jquery.colorpicker's tests.
