### PR TITLE
[google-apps-script] Added missing `.build()` definitions to the validation builders

### DIFF
--- a/types/google-apps-script/google-apps-script.forms.d.ts
+++ b/types/google-apps-script/google-apps-script.forms.d.ts
@@ -85,6 +85,7 @@ declare namespace GoogleAppsScript {
      */
     interface CheckboxGridValidationBuilder {
       requireLimitOneResponsePerColumn(): CheckboxGridValidationBuilder;
+      build(): CheckboxGridValidation;
     }
     /**
      * A question item that allows the respondent to select one or more checkboxes, as well as an
@@ -173,6 +174,7 @@ declare namespace GoogleAppsScript {
       requireSelectAtLeast(number: Integer): CheckboxValidationBuilder;
       requireSelectAtMost(number: Integer): CheckboxValidationBuilder;
       requireSelectExactly(number: Integer): CheckboxValidationBuilder;
+      build(): CheckboxValidation;
     }
     /**
      * A single choice associated with a type of Item that supports choices, like CheckboxItem, ListItem, or MultipleChoiceItem.
@@ -534,6 +536,7 @@ declare namespace GoogleAppsScript {
      */
     interface GridValidationBuilder {
       requireLimitOneResponsePerColumn(): GridValidationBuilder;
+      build(): GridValidation;
     }
     /**
      * A layout item that displays an image. Items can be accessed or created from a Form.
@@ -837,7 +840,8 @@ declare namespace GoogleAppsScript {
      *     var paragraphTextItem = form.addParagraphTextItem().setTitle('Describe yourself:');
      *     var paragraphtextValidation = FormApp.createParagraphTextValidation()
      *       .setHelpText(“Answer must be more than 100 characters.”)
-     *       .requireTextLengthGreatherThan(100);
+     *       .requireTextLengthLessThanOrEqualTo(100)
+     *       .build();
      *     paragraphTextItem.setValidation(paragraphtextValidation);
      */
     interface ParagraphTextValidationBuilder {
@@ -847,6 +851,7 @@ declare namespace GoogleAppsScript {
       requireTextLengthGreaterThanOrEqualTo(number: Integer): ParagraphTextValidationBuilder;
       requireTextLengthLessThanOrEqualTo(number: Integer): ParagraphTextValidationBuilder;
       requireTextMatchesPattern(pattern: string): ParagraphTextValidationBuilder;
+      build(): ParagraphTextValidation;
     }
     /**
      * The bean implementation of a Feedback, which contains properties common to all feedback, such as
@@ -1012,6 +1017,7 @@ declare namespace GoogleAppsScript {
       requireTextLengthLessThanOrEqualTo(number: Integer): TextValidationBuilder;
       requireTextMatchesPattern(pattern: string): TextValidationBuilder;
       requireWholeNumber(): TextValidationBuilder;
+      build(): TextValidation;
     }
     /**
      * A question item that allows the respondent to indicate a time of day. Items can be accessed or

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -641,3 +641,30 @@ const onItemSelected = () => {
 };
 
 SlidesApp.getActivePresentation().getSlides()[0].setSkipped(true);
+
+// Examples for form app validation builders:
+
+// Example of building a text validation
+const formAppTextValidation = FormApp.createTextValidation()
+    .requireNumberBetween(1, 100)
+    .build();
+
+// Example of building a grid validation
+const formAppGridValidation = FormApp.createGridValidation()
+    .requireLimitOneResponsePerColumn()
+    .build();
+
+// Example of building a grid validation
+const formAppCheckboxGridValidation = FormApp.createCheckboxGridValidation()
+    .requireLimitOneResponsePerColumn()
+    .build();
+
+// Example of building a checkbox validation
+const formAppCheckboxValidation = FormApp.createCheckboxValidation()
+    .requireSelectAtLeast(1)
+    .build();
+
+// Example of building a paragraph text validation
+const formAppParagraphTextValidation = FormApp.createParagraphTextValidation()
+    .requireTextDoesNotContainPattern('string')
+    .build();


### PR DESCRIPTION
* Added missing `.build()` definitions to the validation builders.
    * `CheckboxGridValidationBuilder`
    * `CheckboxValidationBuilder` 
    * `GridValidationBuilder`
    * `ParagraphTextValidationBuilder`
    * `TextValidationBuilder`
    * The `build` method was already on the `QuizFeedbackBuilder`
* Fixed a typo in the `ParagraphTextValidationBuilder` comment doc.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Documentation](https://developers.google.com/apps-script/reference/forms/text-validation-builder)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
