### PR TITLE
Improve @wordpress/shortcode.fromMatch type

### DIFF
--- a/types/wordpress__shortcode/index.d.ts
+++ b/types/wordpress__shortcode/index.d.ts
@@ -62,7 +62,7 @@ export const attrs: {
  * by `regexp()`. `match` can also be set to the `arguments` from a callback
  * passed to `regexp.replace()`.
  */
-export function fromMatch(match: RegExpMatchArray): Shortcode;
+export function fromMatch(match: RegExpExecArray): Shortcode;
 
 /**
  * Find the next matching shortcode.


### PR DESCRIPTION
Previously it took a parameter of type RegExpMatchArray, even though the documentation says it should be RegExpExecArray. In TS 4.9 these types are different enough for the compiler to complain, which is how I noticed it.
