### PR TITLE
feat(node): Error.cause property support

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -1,5 +1,28 @@
+// Error extensions
+interface Error {
+    /**
+     * If present, the `error.cause` property is the underlying cause of the `Error`.
+     * It is used when catching an error and throwing a new one with a different message or code in order to still have access to the original error.
+     * @added v16.9.0
+     */
+    cause?: unknown;
+}
+
+/**
+ * @added v16.9.0
+ */
+interface ErrorOptions {
+    /**
+     * The error that caused the newly created error.
+     * @added v16.9.0
+     */
+    cause?: unknown;
+}
+
 // Declare "static" methods in Error
 interface ErrorConstructor {
+    new(message?: string, options?: ErrorOptions): Error;
+    (message?: string, options?: ErrorOptions): Error;
     /** Create .stack property on a target object */
     captureStackTrace(targetObject: object, constructorOpt?: Function): void;
 

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -37,3 +37,10 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     const arrayBuffer = new ArrayBuffer(0);
     structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
 }
+
+{
+    // Error extensions
+    const cause = new Error('The remote HTTP server responded with a 500 status');
+    const symptom = new Error('The message failed to send', { cause });
+    symptom.cause; // $ExpectType unknown
+}

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -1,5 +1,28 @@
+// Error extensions
+interface Error {
+    /**
+     * If present, the `error.cause` property is the underlying cause of the `Error`.
+     * It is used when catching an error and throwing a new one with a different message or code in order to still have access to the original error.
+     * @added v16.9.0
+     */
+    cause?: unknown;
+}
+
+/**
+ * @added v16.9.0
+ */
+interface ErrorOptions {
+    /**
+     * The error that caused the newly created error.
+     * @added v16.9.0
+     */
+    cause?: unknown;
+}
+
 // Declare "static" methods in Error
 interface ErrorConstructor {
+    new(message?: string, options?: ErrorOptions): Error;
+    (message?: string, options?: ErrorOptions): Error;
     /** Create .stack property on a target object */
     captureStackTrace(targetObject: object, constructorOpt?: Function): void;
 

--- a/types/node/v16/test/globals.ts
+++ b/types/node/v16/test/globals.ts
@@ -26,3 +26,10 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
         gc();
     }
 }
+
+{
+    // Error extensions
+    const cause = new Error('The remote HTTP server responded with a 500 status');
+    const symptom = new Error('The message failed to send', { cause });
+    symptom.cause; // $ExpectType unknown
+}


### PR DESCRIPTION
Added in 16.9.0 as reported in #61786

- global extensions
- tests

https://nodejs.org/dist/latest-v16.x/docs/api/errors.html#new-errormessage-options
https://nodejs.org/dist/latest-v16.x/docs/api/errors.html#errorcause

Thanks!

/cc @RobvH

Closes #61786

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).