### PR TITLE
Make return type of `marked/TokenizerExtension.start` optional

### DIFF
--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -464,7 +464,7 @@ export namespace marked {
     interface TokenizerExtension {
         name: string;
         level: 'block' | 'inline';
-        start?: ((this: TokenizerThis, src: string) => number) | undefined;
+        start?: ((this: TokenizerThis, src: string) => number | void) | undefined;
         tokenizer: (this: TokenizerThis, src: string, tokens: Token[] | TokensList) => Tokens.Generic | void;
         childTokens?: string[] | undefined;
     }

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -192,7 +192,7 @@ interface NameToken {
 const tokenizerExtension: marked.TokenizerExtension = {
     name: 'name',
     level: 'block',
-    start: (src: string) => src.indexOf('name'),
+    start: (src: string) => src.match(/name/)?.index,
     tokenizer(src: string): NameToken | void {
         if (src === 'name') {
             const token: NameToken = {


### PR DESCRIPTION
According to the current documented example, the return type of an
extension's `start` can be a number *or* undefined.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation with usage in example][documentation], [source code]
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

[source code]: https://github.com/markedjs/marked/blob/f307df70e4a472b9fb9420ac0ee740702d2d3d45/src/Lexer.js#L466
[documentation]: https://marked.js.org/using_pro#extensions