### PR TITLE
[@mapbox/mapbox-gl-draw] Fix some issues.

### DIFF
--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -1,4 +1,4 @@
-import MapboxDraw, { DrawMode, DrawUpdateEvent, DrawCustomMode } from '@mapbox/mapbox-gl-draw';
+import MapboxDraw, { DrawCustomMode, DrawFeature, DrawMode, DrawUpdateEvent } from '@mapbox/mapbox-gl-draw';
 
 const draw = new MapboxDraw({});
 
@@ -20,17 +20,32 @@ draw.delete(['1', '2']);
 draw.getSelectedIds();
 
 // $ExpectType MapboxDraw
-draw.changeMode('direct_select', { featureId: '1' });
-
-// @ts-expect-error
-draw.changeMode('direct_select');
+draw.changeMode('simple_select');
 
 // $ExpectType MapboxDraw
-draw.changeMode('simple_select');
+draw.changeMode('direct_select', { featureId: '1' });
+
+// $ExpectType MapboxDraw
+draw.changeMode('some_custom_mode');
+
+// $ExpectType MapboxDraw
+draw.changeMode('some_custom_mode', { withSome: 'options' });
 
 const drawLineSelect: DrawMode = 'draw_line_string';
 // $ExpectType MapboxDraw
 draw.changeMode(drawLineSelect, { featureId: '1', from: [1] });
+
+if (draw.getMode() === 'draw_line_string') {
+}
+
+if (draw.getMode() === 'some_custom_mode') {
+}
+
+// $ExpectType "direct_select"
+draw.modes.DIRECT_SELECT;
+
+// $ExpectType DrawCustomMode<any, any>
+MapboxDraw.modes.direct_select;
 
 function callback(event: DrawUpdateEvent) {
     // $ExpectType "draw.update"
@@ -38,13 +53,91 @@ function callback(event: DrawUpdateEvent) {
 }
 
 const CustomMode: DrawCustomMode<{}, {}> = {
-  onClick(state, e) {
-    // $ExpectType LngLat
-    e.lngLat;
-  },
+    onClick(state, e) {
+        // $ExpectType LngLat
+        e.lngLat;
 
-  toDisplayFeatures(state, geojson, display) {}
+        // $ExpectType Map
+        this.map;
+
+        // $ExpectType void
+        this.changeMode('simple_select');
+
+        // $ExpectType void
+        this.changeMode('some_custom_mode');
+    },
+
+    toDisplayFeatures(state, geojson, display) {},
 };
 
 // @ts-expect-error
 const CustomModeMissingDisplayFeatures: DrawCustomMode<{}, {}> = {};
+
+// @ts-expect-error
+const feature: DrawFeature = {};
+
+// $ExpectType void
+feature.changed();
+
+// $ExpectType boolean
+feature.isValid();
+
+// $ExpectType Position
+feature.getCoordinate('');
+
+// $ExpectType void
+feature.updateCoordinate('', 0, 0);
+
+// $ExpectType void
+feature.setProperty('', 0);
+
+// $ExpectType GeoJSON
+feature.toGeoJSON();
+
+if (feature.type === 'Point') {
+    // $ExpectType Position
+    feature.coordinates;
+
+    // $ExpectType Position
+    feature.getCoordinate();
+
+    // $ExpectType void
+    feature.updateCoordinate(0, 0);
+}
+
+if (feature.type === 'LineString') {
+    // $ExpectType Position[]
+    feature.coordinates;
+
+    // $ExpectType void
+    feature.addCoordinate('', 0, 0);
+
+    // $ExpectType void
+    feature.removeCoordinate('');
+}
+
+if (feature.type === 'Polygon') {
+    // $ExpectType Position[][]
+    feature.coordinates;
+
+    // $ExpectType void
+    feature.addCoordinate('', 0, 0);
+
+    // $ExpectType void
+    feature.removeCoordinate('');
+}
+
+if (feature.type === 'MultiPoint') {
+    // $ExpectType DrawPoint[]
+    feature.features;
+}
+
+if (feature.type === 'MultiLineString') {
+    // $ExpectType DrawLineString[]
+    feature.features;
+}
+
+if (feature.type === 'MultiPolygon') {
+    // $ExpectType DrawPolygon[]
+    feature.features;
+}


### PR DESCRIPTION
- Add the exact interfaces of different `DrawFeature` sub-types.
- `DrawCustomModeThis` was missing the `map` property.
- `changeMode` and `getMode` did not accept/return the correct type when using custom modes.
- Definition of `MapboxDraw.modes` was incorrect. In fact, the defined property is not static, and the actual static property contains the mode objects as values.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/mapbox/mapbox-gl-draw> (I read through most of the relevant parts of the source code.)