### PR TITLE
use new @ember/owner type in @ember/application

### DIFF
--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -7,6 +7,7 @@
 // Minimum TypeScript Version: 4.4
 
 import Engine from '@ember/engine';
+import Owner from '@ember/owner';
 import ApplicationInstance from '@ember/application/instance';
 import EventDispatcher from '@ember/application/-private/event-dispatcher';
 import { EventDispatcherEvents } from '@ember/application/types';
@@ -119,12 +120,12 @@ export default class Application extends Engine {
  * objects is the responsibility of an "owner", which handled its
  * instantiation and manages its lifetime.
  */
-export function getOwner(object: unknown): unknown;
+export function getOwner(object: unknown): Owner;
 /**
  * `setOwner` forces a new owner on a given object instance. This is primarily
  * useful in some testing cases.
  */
-export function setOwner(object: unknown, owner: unknown): void;
+export function setOwner(object: unknown, owner: Owner): void;
 
 /**
  * Detects when a specific package of Ember (e.g. 'Ember.Application')

--- a/types/ember__application/test/owner.ts
+++ b/types/ember__application/test/owner.ts
@@ -1,0 +1,11 @@
+import Owner from '@ember/owner';
+import { getOwner, setOwner } from '@ember/application';
+import EmberObject from '@ember/object';
+
+declare let owner: Owner;
+
+class MyClass extends EmberObject {}
+const classInstance = new MyClass();
+
+setOwner(classInstance, owner);
+getOwner({}); // $ExpectType Owner

--- a/types/ember__application/tsconfig.json
+++ b/types/ember__application/tsconfig.json
@@ -25,6 +25,7 @@
         "index.d.ts",
         "test/application.ts",
         "test/deprecations.ts",
+        "test/owner.ts",
         "test/application-instance.ts"
     ]
 }


### PR DESCRIPTION
Updates the `@ember/applications` exports `getOwner` / `setOwner` to use the newly added `Owner` type from `@ember/owner`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/blob/16136bfcb6a0242d9c55ca7023ab8ea317167c71/packages/%40ember/application/index.ts#L1
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

