### PR TITLE
fix(jwt): strong type for SigningKeyCallback error

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -96,12 +96,13 @@ export type VerifyErrors =
     | NotBeforeError
     | TokenExpiredError;
 export type VerifyCallback<T = Jwt | JwtPayload | string> = (
-    err: VerifyErrors | null,
+    error: VerifyErrors | null,
     decoded: T | undefined,
 ) => void;
 
 export type SignCallback = (
-    err: Error | null, encoded: string | undefined
+    error: Error | null,
+    encoded: string | undefined,
 ) => void;
 
 // standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
@@ -145,8 +146,8 @@ export type Algorithm =
     "none";
 
 export type SigningKeyCallback = (
-    err: any,
-    signingKey?: Secret,
+    error: Error | null,
+    signingKey?: Secret
 ) => void;
 
 export type GetPublicKeyOrSecret = (

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -98,16 +98,24 @@ jwt.verify(token, cert, (err, decoded) => {
 });
 
 // verify a token assymetric with async key fetch function
-function getKey(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
-    cert = fs.readFileSync("public.pem");
+function getKeySuccess(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
+    cert = fs.readFileSync('public.pem');
 
     callback(null, cert);
 }
-
-jwt.verify(token, getKey, (err, decoded) => {
+jwt.verify(token, getKeySuccess, (err, decoded) => {
     const result = decoded as TestObject;
 
     console.log(result.foo); // bar
+});
+
+function getKeyFailed(header: jwt.JwtHeader, callback: jwt.SigningKeyCallback) {
+    cert = fs.readFileSync('public.pem');
+
+    callback(new Error('FAILED_KEY_RETRIEVAL'), cert);
+}
+jwt.verify(token, getKeyFailed, (err, decoded) => {
+    console.error(err); // new JsonWebTokenError('error in secret or public key callback: FAILED_KEY_RETRIEVAL')
 });
 
 // verify audience


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - `SigningKeyCallback` should only accept `Error` type or `null` type `error` argument.
    - See [here](https://github.com/auth0/node-jsonwebtoken/blob/74d5719bd03993fcf71e3b176621f133eb6138c0/verify.js#L95-L97) for the original source code.