### PR TITLE
Revert "feat(node): Error.cause property support"

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -1,28 +1,5 @@
-// Error extensions
-interface Error {
-    /**
-     * If present, the `error.cause` property is the underlying cause of the `Error`.
-     * It is used when catching an error and throwing a new one with a different message or code in order to still have access to the original error.
-     * @added v16.9.0
-     */
-    cause?: unknown;
-}
-
-/**
- * @added v16.9.0
- */
-interface ErrorOptions {
-    /**
-     * The error that caused the newly created error.
-     * @added v16.9.0
-     */
-    cause?: unknown;
-}
-
 // Declare "static" methods in Error
 interface ErrorConstructor {
-    new(message?: string, options?: ErrorOptions): Error;
-    (message?: string, options?: ErrorOptions): Error;
     /** Create .stack property on a target object */
     captureStackTrace(targetObject: object, constructorOpt?: Function): void;
 

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -37,10 +37,3 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     const arrayBuffer = new ArrayBuffer(0);
     structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
 }
-
-{
-    // Error extensions
-    const cause = new Error('The remote HTTP server responded with a 500 status');
-    const symptom = new Error('The message failed to send', { cause });
-    symptom.cause; // $ExpectType unknown
-}

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -1,28 +1,5 @@
-// Error extensions
-interface Error {
-    /**
-     * If present, the `error.cause` property is the underlying cause of the `Error`.
-     * It is used when catching an error and throwing a new one with a different message or code in order to still have access to the original error.
-     * @added v16.9.0
-     */
-    cause?: unknown;
-}
-
-/**
- * @added v16.9.0
- */
-interface ErrorOptions {
-    /**
-     * The error that caused the newly created error.
-     * @added v16.9.0
-     */
-    cause?: unknown;
-}
-
 // Declare "static" methods in Error
 interface ErrorConstructor {
-    new(message?: string, options?: ErrorOptions): Error;
-    (message?: string, options?: ErrorOptions): Error;
     /** Create .stack property on a target object */
     captureStackTrace(targetObject: object, constructorOpt?: Function): void;
 

--- a/types/node/v16/test/globals.ts
+++ b/types/node/v16/test/globals.ts
@@ -26,10 +26,3 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
         gc();
     }
 }
-
-{
-    // Error extensions
-    const cause = new Error('The remote HTTP server responded with a 500 status');
-    const symptom = new Error('The message failed to send', { cause });
-    symptom.cause; // $ExpectType unknown
-}


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#61790

It's better to not have this unstable implementation yet:
microsoft/TypeScript#49639
preferring not breaking existing code usage (it passed all tests here, broke stuff in the wild):
#61824

Thanks!