### PR TITLE
fix(jsoneditor): upgrade to v9.9, add back missing types

### DIFF
--- a/types/jsoneditor/index.d.ts
+++ b/types/jsoneditor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jsoneditor 9.5
+// Type definitions for jsoneditor 9.9
 // Project: https://github.com/josdejong/jsoneditor
 // Definitions by: Alejandro Sánchez <https://github.com/alejo90>
 //                 Errietta Kostala <https://github.com/errietta>
@@ -23,12 +23,6 @@ export type NodeType = 'object' | 'array' | 'string' | 'auto';
 
 export type JSONEditorMode = 'tree' | 'view' | 'form' | 'code' | 'text' | 'preview';
 
-export interface NodeName {
-    path: ReadonlyArray<string>;
-    type: NodeType;
-    size: number;
-}
-
 export interface ValidationError {
     path: JSONPath;
     message: string;
@@ -41,7 +35,7 @@ export interface FieldEditable {
 
 export interface BaseNode {
     editor: JSONEditor;
-    dom: { [key: string]: HTMLElement };
+    dom: Record<string, HTMLElement>;
     editable?: FieldEditable | undefined;
     parent: Node | null;
 }
@@ -100,21 +94,24 @@ export type AutoCompleteTrigger = 'keydown' | 'focus';
 
 export type AutoCompleteElementType = 'field' | 'value';
 
+export type AutoCompleteGetOptions = (
+    text: string,
+    path: JSONPath,
+    input: AutoCompleteElementType,
+    editor: JSONEditor,
+) => AutoCompleteCompletion | Promise<AutoCompleteCompletion>;
+
 export interface AutoCompleteOptions {
     /**
      * Pick one of the two strategies, or define a custom filter function.
-     *
-     * 'start': Match your input from the start, e.g. 'ap' matches 'apple' but 'pl' does not.
-     *
-     * 'contain': Contains the user's input or not, e.g. 'pl' matches 'apple' too.
+     * - 'start': Match your input from the start, e.g. 'ap' matches 'apple' but 'pl' does not.
+     * - 'contain': Contains the user's input or not, e.g. 'pl' matches 'apple' too.
      */
     filter?: AutoCompleteMatchingStrategy | ((query: string) => boolean) | undefined;
     /**
      * Indicate the way to trigger autocomplete menu.
-     *
-     * 'keydown': When you type something in the field or value, it will trigger autocomplete immediately.
-     *
-     * 'focus': When you focus in the field or value, it will trigger the autocomplete.
+     * - 'keydown': When you type something in the field or value, it will trigger autocomplete immediately.
+     * - 'focus': When you focus in the field or value, it will trigger the autocomplete.
      * @default 'keydown'
      */
     trigger?: AutoCompleteTrigger | undefined;
@@ -135,12 +132,7 @@ export interface AutoCompleteOptions {
      * @param input Can be 'field' or 'value' depending if the user is editing a field name or a value of a node.
      * @param editor The editor instance object that is being edited.
      */
-    getOptions?: ((
-        text: string,
-        path: JSONPath,
-        input: AutoCompleteElementType,
-        editor: JSONEditor,
-    ) => AutoCompleteCompletion | Promise<AutoCompleteCompletion>) | undefined;
+    getOptions?: AutoCompleteGetOptions | undefined;
 }
 
 export interface SelectionPosition {
@@ -174,7 +166,7 @@ export interface MenuItem {
     click?: (() => void) | undefined;
 }
 
-export type MenuItemNodeType = 'single' | 'append';
+export type MenuItemNodeType = 'single' | 'multiple' | 'append';
 
 export interface MenuItemNode {
     type: MenuItemNodeType;
@@ -188,24 +180,143 @@ export interface TimestampNode {
     path: ReadonlyArray<string>;
 }
 
-export interface QueryOptions {
-    filter?: {
-        field: string | '@';
-        relation: '==' | '!=' | '<' | '<=' | '>' | '>=';
-        value: string;
-    } | undefined;
-    sort?: {
-        field: string | '@';
-        direction: 'asc' | 'desc';
-    } | undefined;
-    projection?: {
-        fields: string[];
-    } | undefined;
+export interface QueryFilter {
+    field: string | '@';
+    relation: '==' | '!=' | '<' | '<=' | '>' | '>=';
+    value: string;
 }
+
+export interface QuerySort {
+    field: string | '@';
+    direction: 'asc' | 'desc';
+}
+
+export interface QueryProjection {
+    fields: string[];
+}
+
+export interface QueryOptions {
+    filter?: QueryFilter | undefined;
+    sort?: QuerySort | undefined;
+    projection?: QueryProjection | undefined;
+}
+
+export interface OnClassNameParams {
+    path: ReadonlyArray<string>;
+    field: string;
+    value: string;
+}
+
+export interface ExpandOptions {
+    path: ReadonlyArray<string>;
+    isExpand: boolean;
+    recursive: boolean;
+}
+
+export interface OnNodeNameParams {
+    path: ReadonlyArray<string>;
+    type: NodeType;
+    size: number;
+    value: any;
+}
+
+/** Obtained from master/src/js/i18n.js */
+export type TranslationKey =
+    | 'actionsMenu'
+    | 'appendSubmenuTitle'
+    | 'appendText'
+    | 'appendTitle'
+    | 'appendTitleAuto'
+    | 'array'
+    | 'arrayType'
+    | 'ascending'
+    | 'ascendingTitle'
+    | 'auto'
+    | 'autoType'
+    | 'cannotParseFieldError'
+    | 'cannotParseValueError'
+    | 'collapseAll'
+    | 'compactTitle'
+    | 'containsInvalidItems'
+    | 'containsInvalidProperties'
+    | 'default'
+    | 'descending'
+    | 'descendingTitle'
+    | 'drag'
+    | 'duplicateField'
+    | 'duplicateFieldError'
+    | 'duplicateKey'
+    | 'duplicateText'
+    | 'duplicateTitle'
+    | 'empty'
+    | 'examples'
+    | 'expandAll'
+    | 'expandTitle'
+    | 'extract'
+    | 'extractTitle'
+    | 'formatTitle'
+    | 'insert'
+    | 'insertSub'
+    | 'insertTitle'
+    | 'modeCodeText'
+    | 'modeCodeTitle'
+    | 'modeEditorTitle'
+    | 'modeFormText'
+    | 'modeFormTitle'
+    | 'modePreviewText'
+    | 'modePreviewTitle'
+    | 'modeTextText'
+    | 'modeTextTitle'
+    | 'modeTreeText'
+    | 'modeTreeTitle'
+    | 'modeViewText'
+    | 'modeViewTitle'
+    | 'object'
+    | 'objectType'
+    | 'ok'
+    | 'openUrl'
+    | 'redo'
+    | 'removeField'
+    | 'removeText'
+    | 'removeTitle'
+    | 'repairTitle'
+    | 'searchNextResultTitle'
+    | 'searchPreviousResultTitle'
+    | 'searchTitle'
+    | 'selectNode'
+    | 'showAll'
+    | 'showMore'
+    | 'showMoreStatus'
+    | 'sort'
+    | 'sortAscending'
+    | 'sortAscendingTitle'
+    | 'sortDescending'
+    | 'sortDescendingTitle'
+    | 'sortDirectionLabel'
+    | 'sortFieldLabel'
+    | 'sortFieldTitle'
+    | 'sortTitle'
+    | 'sortTitleShort'
+    | 'string'
+    | 'stringType'
+    | 'transform'
+    | 'transformPreviewLabel'
+    | 'transformQueryLabel'
+    | 'transformQueryTitle'
+    | 'transformTitle'
+    | 'transformTitleShort'
+    | 'transformWizardFilter'
+    | 'transformWizardLabel'
+    | 'transformWizardSelectFields'
+    | 'transformWizardSortBy'
+    | 'type'
+    | 'typeTitle'
+    | 'undo'
+    | 'validationCannotMove';
 
 export interface JSONEditorOptions {
     /**
-     * Provide a custom version of the Ace editor and use this instead of the version that comes embedded with JSONEditor. Only applicable when mode is 'code'.
+     * Provide a custom version of the Ace editor and use this instead of the version that comes embedded with JSONEditor. Only applicable when mode is `code`.
      *
      * Note that when using the minimalist version of JSONEditor (which has Ace excluded), JSONEditor will try to load the Ace plugins `ace/mode/json` and `ace/ext/searchbox`.
      * These plugins must be loaded beforehand or be available in the folder of the Ace editor.
@@ -219,50 +330,51 @@ export interface JSONEditorOptions {
     /**
      * Set a callback function triggered when the contents of the JSONEditor change.
      * This callback does not pass the changed contents, use `get()` or `getText()` for that.
-     * Note that `get()` can throw an exception in mode 'text', 'code', or 'preview', when the editor contains invalid JSON.
+     * Note that `get()` can throw an exception in mode `text`, `code`, or `preview`, when the editor contains invalid JSON.
      * Will only be triggered on changes made by the user, not in case of programmatic changes via the functions `set`, `setText`, `update`, or `updateText`.
      * See also callback functions `onChangeJSON(json)` and `onChangeText(jsonString)`.
      */
     onChange?: (() => void) | undefined;
     /**
      * Set a callback function triggered when the contents of the JSONEditor change.
-     * Passes the changed JSON document. Only applicable when option mode is 'tree', 'form', or 'view'.
+     * Passes the changed JSON document. Only applicable when option mode is `tree`, `form`, or `view`.
      * The callback will only be triggered on changes made by the user, not in case of programmatic changes via the functions `set`, `setText`, `update`, or `updateText`.
-     * Also see the callback function `onChangeText(jsonString)`.
+     * @see onChangeText for more details
      */
     onChangeJSON?: ((json: any) => void) | undefined;
     /**
      * Set a callback function triggered when the contents of the JSONEditor change.
      * Passes the changed JSON document as a string.
      * The callback will only be triggered on changes made by the user, not in case of programmatic changes via the functions `set`, `setText`, `update`, or `updateText`.
-     * Also see the callback function `onChangeJSON(json)`.
+     * @see onChangeJSON for more details
      */
     onChangeText?: ((jsonString: string) => void) | undefined;
     /**
      * Set a callback function to add custom CSS classes to the rendered nodes.
-     * Only applicable when option mode is 'tree', 'form', or 'view'.
+     * Only applicable when option mode is `tree`, `form`, or `view`.
      * The function must either return a string containing CSS class names, or return undefined in order to do nothing for a specific node.
      * In order to update css classes when they depend on external state, you can call `editor.refresh()`.
      */
-    onClassName?: ((classNameParams: {
-        path: ReadonlyArray<string>;
-        field: string;
-        value: string;
-    }) => string | undefined) | undefined;
+    onClassName?: ((classNameParams: OnClassNameParams) => string | undefined) | undefined;
+    /**
+     * Set a callback function to be invoked when a node is expanded/collapsed (not programtically via APIs).
+     * Only applicable when option mode is `tree`, `form`, or `view`.
+     */
+    onExpand?: (expandParams: ExpandOptions) => void | undefined;
     /**
      * Set a callback function to determine whether individual nodes are editable or readonly.
-     * Only applicable when option mode is 'tree', 'text', or 'code'.
-     * In case of mode 'tree', the callback is invoked as `editable(node)`, where the first parameter is a `Node`.
+     * Only applicable when option mode is `tree`, `text`, or `code`.
+     * In case of mode `tree`, the callback is invoked as `editable(node)`, where the first parameter is a `Node`.
      * The function must either return a boolean value to set both the nodes field and value editable or readonly,
      * or return `{ field: boolean; value: boolean }` to set the readonly attribute for field and value individually.
-     * In modes 'text' and 'code', the callback is invoked as `editable(node)` where node is an empty object (no field, value, or path).
+     * In modes `text` and `code`, the callback is invoked as `editable(node)` where node is an empty object (no field, value, or path).
      * In that case the function can return false to make the text or code editor completely readonly.
      */
     onEditable?: ((node: EditableNode | object) => boolean | FieldEditable) | undefined;
     /**
      * Set a callback function triggered when an error occurs.
      * Invoked with the error as first argument. The callback is only invoked
-     * for errors triggered by a users action, like switching from 'code' mode to 'tree' mode
+     * for errors triggered by a users action, like switching from `code` mode to `tree` mode
      * or clicking the Format button whilst the editor doesn't contain valid JSON.
      */
     onError?: ((error: Error) => void) | undefined;
@@ -276,19 +388,20 @@ export interface JSONEditorOptions {
      * The number inside can be customized. using onNodeName. The onNodeName function should return a string containing the name for the node.
      * If nothing is returned, the size (number of children) will be displayed.
      */
-    onNodeName?: ((nodeName: NodeName) => string | undefined) | undefined;
+    onNodeName?: ((nodeName: OnNodeNameParams) => string | undefined) | undefined;
     /**
      * Set a callback function for custom validation. Available in all modes.
      * On a change of the JSON, the callback function is invoked with the changed data.
      * The function should return an array with errors or null if there are no errors.
      * The function can also return a Promise resolving with the errors retrieved via an asynchronous validation (like sending a request to a server for validation).
-     * Also see the option `schema` for JSON schema validation.
+     * @see schema for JSON schema validation.
      */
     onValidate?: ((json: any) => ValidationError[] | Promise<ValidationError[]>) | undefined;
     /**
      * Set a callback function for validation and parse errors. Available in all modes.
      * On validation of the json, if errors of any kind were found this callback is invoked with the errors data.
      * On change, the callback will be invoked only if errors were changed.
+     * @param errors validation errors
      */
     onValidationError?: ((errors: ReadonlyArray<SchemaValidationError | ParseError>) => void) | undefined;
     /**
@@ -304,37 +417,42 @@ export interface JSONEditorOptions {
      */
     escapeUnicode?: boolean | undefined;
     /**
-     * If true, object keys in 'tree', 'view' or 'form' mode will be listed alphabetically instead by their insertion order.
+     * If true, object keys in `tree`, `view` or `form` mode will be listed alphabetically instead by their insertion order.
      * Sorting is performed using a natural sort algorithm, which makes it easier to see objects that have string numbers as keys.
      * @default false
      */
     sortObjectKeys?: boolean | undefined;
     /**
-     * Enables history, adds a button Undo and Redo to the menu of the JSONEditor. Only applicable when mode is 'tree', 'form', or 'preview'.
+     * If false, nodes can be dragged from any parent node to any other parent node. If true, nodes can only be dragged inside the same parent node, which effectively only allows reordering of nodes.
+     * By default, limitDragging is true when no JSON schema is defined, and false otherwise.
+     */
+    limitDragging?: boolean;
+    /**
+     * Enables history, adds a button Undo and Redo to the menu of the JSONEditor. Only applicable when mode is `tree`, `form`, or `preview`.
      * @default true
      */
     history?: boolean | undefined;
     /**
-     * Set the editor mode. Available values: 'tree', 'view', 'form', 'code', 'text', 'preview'.
-     * In 'view' mode, the data and datastructure is readonly. In 'form' mode, only the value can be changed, the data structure is readonly.
-     * Mode 'code' requires the Ace editor to be loaded on the page. Mode 'text' shows the data as plain text.
-     * The 'preview' mode can handle large JSON documents up to 500 MiB. It shows a preview of the data, and allows to transform, sort, filter, format, or compact the data.
+     * Set the editor mode. Available values: `tree`, `view`, `form`, `code`, `text`, `preview`.
+     * In `view` mode, the data and datastructure is readonly. In `form` mode, only the value can be changed, the data structure is readonly.
+     * Mode `code` requires the Ace editor to be loaded on the page. Mode `text` shows the data as plain text.
+     * The `preview` mode can handle large JSON documents up to 500 MiB. It shows a preview of the data, and allows to transform, sort, filter, format, or compact the data.
      * @default 'tree'
      */
     mode?: JSONEditorMode | undefined;
     /**
      * Create a box in the editor menu where the user can switch between the specified modes.
-     * @see mode.
+     * @see mode for configuration
      */
     modes?: JSONEditorMode[] | undefined;
     /**
-     * Initial field name for the root node. Can also be set using `setName(name)`. Only applicable when mode is 'tree', 'view', or 'form'.
+     * Initial field name for the root node. Can also be set using `setName(name)`. Only applicable when mode is `tree`, `view`, or `form`.
      * @default undefined
      */
     name?: string | undefined;
     /**
      * Validate the JSON object against a JSON schema. A JSON schema describes the structure that a JSON object must have, like required properties or the type that a value must have.
-     * Also see the option `onValidate` for custom validation.
+     * @see onValidate for custom validation.
      * @see http://json-schema.org/
      */
     schema?: object | undefined;
@@ -343,12 +461,19 @@ export interface JSONEditorOptions {
      */
     schemaRefs?: object | undefined;
     /**
-     * Enables a search box in the upper right corner of the JSONEditor. Only applicable when mode is 'tree', 'view', or 'form'.
+     * When enabled and schema is configured, the editor will suggest text completions based on the schema properties, examples and enums.
+     * - Limitation: the completions will be presented only for a valid json.
+     * - Only applicable when mode is `code`.
+     * @default false
+     */
+    allowSchemaSuggestions?: boolean | undefined;
+    /**
+     * Enables a search box in the upper right corner of the JSONEditor. Only applicable when mode is `tree`, `view`, or `form`.
      * @default true
      */
     search?: boolean | undefined;
     /**
-     * Number of indentation spaces. Only applicable when mode is 'code', 'text', or 'preview'.
+     * Number of indentation spaces. Only applicable when mode is `code`, `text`, or `preview`.
      * @default 2
      */
     indentation?: number | undefined;
@@ -362,7 +487,7 @@ export interface JSONEditorOptions {
      */
     templates?: Template[] | undefined;
     /**
-     * Providing this will enable this feature in your editor in 'tree' mode.
+     * Providing this will enable this feature in your editor in `tree` mode.
      */
     autocomplete?: AutoCompleteOptions | undefined;
     /**
@@ -372,28 +497,46 @@ export interface JSONEditorOptions {
     mainMenuBar?: boolean | undefined;
     /**
      * Adds navigation bar to the menu. The navigation bar visualizes the current position on the tree structure as well as allows breadcrumbs navigation.
-     * Only applicable when mode is 'tree', 'form' or 'view'.
+     * Only applicable when mode is `tree`, `form` or `view`.
      * @default true
      */
     navigationBar?: boolean | undefined;
     /**
      * Adds status bar to the bottom of the editor. The status bar shows the cursor position and a count of the selected characters.
-     * Only applicable when mode is 'code', 'text', or 'preview'.
+     * Only applicable when mode is `code`, `text`, or `preview`.
      * @default true
      */
     statusBar?: boolean | undefined;
     /**
-     * Set a callback function triggered when a text is selected in the JSONEditor. Only applicable when mode is 'code' or 'text'.
+     * Set a callback function triggered when a text is selected in the JSONEditor.
+     * Only applicable when mode is `code` or `text`.
+     * @param start Selection start position
+     * @param end Selected end position
+     * @param text selected text
      */
     onTextSelectionChange?: ((start: SelectionPosition, end: SelectionPosition, text: string) => void) | undefined;
     /**
-     * Set a callback function triggered when Nodes are selected in the JSONEditor. Only applicable when mode is 'tree'.
+     * Set a callback function triggered when Nodes are selected in the JSONEditor.
+     * Only applicable when mode is `tree`.
+     * @param start
+     * @param end
      */
     onSelectionChange?: ((start: SerializableNode, end: SerializableNode) => void) | undefined;
     /**
-     * Set a callback function that will be triggered when an event will occur in a JSON field or value. Only applicable when mode is 'form', 'tree' or 'view'.
+     * Set a callback function that will be triggered when an event will occur in a JSON field or value.
+     * Only applicable when mode is `form`, `tree` or `view`.
+     * @param node the Node where event has been triggered
+     * @param event the event fired
      */
-    onEvent?: ((node: EditableNode, event: string) => void) | undefined;
+    onEvent?: ((node: EditableNode, event: Event) => void) | undefined;
+    /**
+     * Callback method, triggered when the editor comes into focus
+     */
+    onFocus?: (event: Event) => void | undefined;
+    /**
+     * Callback method, triggered when the editor goes out of focus
+     */
+    onBlur?: (event: Event) => void | undefined;
     /**
      * When true, values containing a color name or color code will have a color picker rendered on their left side.
      * @default true
@@ -414,14 +557,14 @@ export interface JSONEditorOptions {
      * When the function returns a non-boolean value like null or undefined, JSONEditor will fallback on the built-in rules to determine whether or not to show a timestamp.
      * Whether a value is a timestamp can be determined implicitly based on the value, or explicitly based on field or path.
      * You can for example test whether a field name contains a string like: 'date' or 'time'.
-     * Only applicable for modes 'tree', 'form', and 'view'.
+     * Only applicable for modes `tree`, `form`, and `view`.
      * @default true
      * @example ({ field, value, path }) => field === 'dateCreated'
      */
     timestampTag?: boolean | ((node: TimestampNode) => boolean) | undefined;
     /**
      * Customizing the way formating the timestamp. Called when a value is timestamp after timestampTag. If it returns null, the timestamp would be formatted with default setting.
-     * Only applicable for modes 'tree', 'form', and 'view'.
+     * Only applicable for modes `tree`, `form`, and `view`.
      * @default value => new Date(value).toISOString()
      */
     timestampFormat?: ((node: TimestampNode) => string | null) | undefined;
@@ -435,11 +578,7 @@ export interface JSONEditorOptions {
      * All available fields for translation can be found in the source file `src/js/i18n.js`.
      * @example { 'pt-BR': { 'auto': 'Automático testing' }, 'en': { 'auto': 'Auto testing' } }
      */
-    languages?: {
-        [lang: string]: {
-            [key: string]: string;
-        };
-    } | undefined;
+    languages?: Record<string, Partial<Record<TranslationKey, string>>> | undefined;
     /**
      * The container element where modals (like for sorting and filtering) are attached:
      * an overlay will be created on top of this container, and the modal will be created in the center of this container.
@@ -453,17 +592,17 @@ export interface JSONEditorOptions {
      */
     popupAnchor?: HTMLElement | undefined;
     /**
-     * Enable sorting of arrays and object properties. Only applicable for mode 'tree'.
+     * Enable sorting of arrays and object properties. Only applicable for mode `tree`.
      * @default true
      */
     enableSort?: boolean | undefined;
     /**
-     * Enable filtering, sorting, and transforming JSON using a {@link https://jmespath.org/|JMESPath} query. Only applicable for mode 'tree'.
+     * Enable filtering, sorting, and transforming JSON using a {@link https://jmespath.org/|JMESPath} query. Only applicable for mode `tree`.
      * @default true
      */
     enableTransform?: boolean | undefined;
     /**
-     * Number of children allowed for a given node before the 'show more/show all' message appears (in 'tree', 'view', or 'form' modes).
+     * Number of children allowed for a given node before the 'show more/show all' message appears (in `tree`, `view`, or `form` modes).
      * @default 100
      */
     maxVisibleChilds?: number | undefined;
@@ -484,11 +623,6 @@ export interface JSONEditorOptions {
      * The text can contain HTML code like a link to a web page.
      */
     queryDescription?: string | undefined;
-    /**
-     * If false, nodes can be dragged from any parent node to any other parent node. If true, nodes can only be dragged inside the same parent node, which effectively only allows reordering of nodes.
-     * By default, limitDragging is true when no JSON schema is defined, and false otherwise.
-     */
-    limitDragging?: boolean;
 }
 
 export default class JSONEditor {
@@ -501,7 +635,7 @@ export default class JSONEditor {
      */
     constructor(container: HTMLElement, options?: JSONEditorOptions, json?: any);
     /**
-     * Collapse all fields. Only applicable for mode 'tree', 'view', and 'form'.
+     * Collapse all fields. Only applicable for mode `tree`, `view`, and `form`.
      */
     collapseAll(): void;
     /**
@@ -509,15 +643,22 @@ export default class JSONEditor {
      */
     destroy(): void;
     /**
-     * Expand all fields. Only applicable for mode 'tree', 'view', and 'form'.
+     * Expand all fields. Only applicable for mode `tree`, `view`, and `form`.
      */
     expandAll(): void;
+    /**
+     * Expand/collapse a given JSON node. Only applicable for mode 'tree', 'view' and 'form'.
+     * @param expandParams.path Path for the node to expand / collapse
+     * @param expandParams.isExpand Whether to expand the node (else collapse)
+     * @param expandParams.recursive Whether to expand/collapse child nodes recursively
+     */
+    expand(options: ExpandOptions): void;
     /**
      * Set focus to the JSONEditor.
      */
     focus(): void;
     /**
-     * Get JSON data. This method throws an exception when the editor does not contain valid JSON, which can be the case when the editor is in mode 'code', 'text', or 'preview'.
+     * Get JSON data. This method throws an exception when the editor does not contain valid JSON, which can be the case when the editor is in mode `code`, `text`, or `preview`.
      */
     get(): any;
     /**
@@ -536,16 +677,16 @@ export default class JSONEditor {
      */
     getNodesByRange(start: { path: JSONPath }, end: { path: JSONPath }): SerializableNode[];
     /**
-     * Get the current selected nodes. Only applicable for mode 'tree'.
+     * Get the current selected nodes. Only applicable for mode `tree`.
      */
     getSelection(): { start: SerializableNode; end: SerializableNode };
     /**
-     * Get JSON data as string. Returns the contents of the editor as string. When the editor is in mode 'text', 'code' or 'preview', the returned text is returned as-is.
+     * Get JSON data as string. Returns the contents of the editor as string. When the editor is in mode `text`, `code` or `preview`, the returned text is returned as-is.
      * For the other modes, the returned text is a compacted string. In order to get the JSON formatted with a certain number of spaces, use `JSON.stringify(JSONEditor.get(), null, 2)`.
      */
     getText(): string;
     /**
-     * Get the current selected text with the selection range. Only applicable for mode 'text' and 'code'.
+     * Get the current selected text with the selection range. Only applicable for mode `text` and `code`.
      */
     getTextSelection(): { start: SelectionPosition; end: SelectionPosition; text: string };
     /**
@@ -554,51 +695,67 @@ export default class JSONEditor {
     refresh(): void;
     /**
      * Set JSON data. Resets the state of the editor (expanded nodes, search, selection).
-     * @see update()
+     * @see update for more details
      * @param json JSON data to be displayed in the JSONEditor
      */
     set(json: any): void;
     /**
-     * Switch mode. Mode 'code' requires the Ace editor.
+     * Switch mode. Mode `code` requires the Ace editor.
      */
     setMode(mode: JSONEditorMode): void;
     /**
      * Set a field name for the root node.
+     * @param name Field name of the root node. If undefined, the current name will be removed.
      */
     setName(name?: string): void;
     /**
      * Set a JSON schema for validation of the JSON object. See also option `schema`. See http://json-schema.org/ for more information on the JSON schema definition.
+     * @param schema A JSON schema.
+     * @param schemaRefs Schemas that are referenced using the `$ref` property from the JSON schema, the object structure in the form of `{ reference_key: schemaObject }`
      */
     setSchema(schema: object, schemaRefs?: object): void;
     /**
-     * Set selection for a range of nodes, Only applicable for mode 'tree'.
-     * If no parameters sent - the current selection will be removed, if exists.
-     * For single node selection send only the start parameter.
-     * If the nodes are not from the same level the first common parent will be selected.
+     * Set selection for a range of nodes. Only applicable for mode `tree`.
+     * - If no parameters sent - the current selection will be removed, if exists.
+     * - For single node selection send only the start parameter.
+     * - If the nodes are not from the same level the first common parent will be selected.
+     * @param start Path for the start node
+     * @param end Path for the end node
      */
     setSelection(start: { path: JSONPath }, end: { path: JSONPath }): void;
     /**
-     * Set text data in the editor. This method throws an exception when the provided jsonString does not contain valid JSON and the editor is in mode 'tree', 'view', or 'form'.
+     * Set text data in the editor. This method throws an exception when the provided jsonString does not contain valid JSON and the editor is in mode `tree`, `view`, or `form`.
+     * @param jsonString Contents of the editor as string.
      */
     setText(jsonString: string): void;
     /**
-     * Set text selection for a range, Only applicable for mode 'text' and 'code'.
+     * Set text selection for a range, Only applicable for mode `text` and `code`.
+     * @param start Position for selection start
+     * @param end Position for selection end
      */
     setTextSelection(start: SelectionPosition, end: SelectionPosition): void;
     /**
-     * Replace JSON data when the new data contains changes. In modes 'tree', 'form', and 'view', the state of the editor will be maintained (expanded nodes, search, selection). See also `set`.
+     * Replace JSON data when the new data contains changes. In modes `tree`, `form`, and `view`, the state of the editor will be maintained (expanded nodes, search, selection). See also `set`.
+     * @param json JSON data to be displayed in the JSONEditor.
      */
     update(json: any): void;
     /**
-     * Replace text data when the new data contains changes. In modes 'tree', 'form', and 'view', the state of the editor will be maintained (expanded nodes, search, selection).
-     * Also see `setText()`. This method throws an exception when the provided jsonString does not contain valid JSON and the editor is in mode 'tree', 'view', or 'form'.
+     * Replace text data when the new data contains changes. In modes `tree`, `form`, and `view`, the state of the editor will be maintained (expanded nodes, search, selection).
+     * @see setText for more details
+     * @param jsonString Contents of the editor as string.
      */
     updateText(jsonString: string): void;
     /**
      * Validate the JSON document against the configured JSON schema or custom validator. See also the `onValidationError` callback.
-     * Returns a promise which resolves with the current validation errors, or an empty list when there are no errors.
+     * @returns a promise which resolves with the current validation errors, or an empty list when there are no errors.
      */
     validate(): Promise<ReadonlyArray<SchemaValidationError | ParseError>>;
+
+    /**
+     * (UNDOCUMENTED)
+     * Points to the AceEditor instance for the current JsonEditor instance
+     */
+    aceEditor: AceAjax.Editor;
 
     /**
      * An array with the names of all known options.

--- a/types/jsoneditor/jsoneditor-tests.ts
+++ b/types/jsoneditor/jsoneditor-tests.ts
@@ -1,50 +1,362 @@
 import * as Ajv from 'ajv';
-import JSONEditor, { JSONEditorMode, EditableNode, JSONEditorOptions, AutoCompleteOptions } from 'jsoneditor';
+import JSONEditor, { AutoCompleteOptions, EditableNode, JSONEditorMode, JSONEditorOptions } from 'jsoneditor';
 
-const autocomplete: AutoCompleteOptions = {
-    caseSensitive: true,
-    confirmKeys: [0],
-    filter: 'start',
-    getOptions: (text, path, type, editor) => [],
-    trigger: 'keydown',
-};
+const autocomplete: AutoCompleteOptions = {};
+
+autocomplete.caseSensitive = undefined;
+autocomplete.caseSensitive = true;
+
+autocomplete.confirmKeys = undefined;
+autocomplete.confirmKeys = [0];
+
+autocomplete.filter = undefined;
+autocomplete.filter = 'start';
+autocomplete.filter = 'contain';
 autocomplete.filter = input => true;
 
-let options: JSONEditorOptions;
-options = {};
-options = {
-    ace,
-    ajv: new Ajv({ allErrors: true, verbose: true }),
-    onChange() {},
-    autocomplete,
-    colorPicker: false,
-    onEditable(node: EditableNode | {}) {
-        return true;
-    },
-    limitDragging: true,
-    onError(error: Error) {},
-    onModeChange(newMode: JSONEditorMode, oldMode: JSONEditorMode) {},
-    onValidate: json => [],
-    onValidationError: errors => {
-        return;
-    },
-    escapeUnicode: false,
-    sortObjectKeys: true,
-    history: true,
-    mode: 'tree',
-    modes: ['tree', 'view', 'form', 'code', 'text'],
-    name: 'foo',
-    schema: {},
-    schemaRefs: { otherSchema: {} },
-    search: false,
-    indentation: 2,
-    theme: 'default',
+autocomplete.getOptions = undefined;
+autocomplete.getOptions = (text, path, type, editor) => [];
+
+autocomplete.trigger = undefined;
+autocomplete.trigger = 'keydown';
+autocomplete.trigger = 'focus';
+
+const options: JSONEditorOptions = {};
+
+options.ace = undefined;
+options.ace = ace;
+
+options.ajv = undefined;
+options.ajv = new Ajv({ allErrors: true, verbose: true });
+
+options.onChange = undefined;
+options.onChange = () => {};
+
+options.onChangeJSON = undefined;
+options.onChangeJSON = json => {};
+
+options.onChangeText = undefined;
+options.onChangeText = (json: string) => {};
+
+options.onClassName = undefined;
+options.onClassName = obj => {
+    // $ExpectType ReadonlyArray<string>
+    obj.path;
+    // $ExpectType string
+    obj.field;
+    // $ExpectType string
+    obj.value;
+    return '';
 };
-options = {
-    onEditable(node: EditableNode | {}) {
-        return { field: true, value: false };
-    },
+options.onClassName = obj => {
+    // $ExpectType ReadonlyArray<string>
+    obj.path;
+    // $ExpectType string
+    obj.field;
+    // $ExpectType string
+    obj.value;
+    return undefined;
 };
+
+options.onExpand = undefined;
+options.onExpand = obj => {
+    // $ExpectType ReadonlyArray<string>
+    obj.path;
+    // $ExpectType boolean
+    obj.isExpand;
+    // $ExpectType boolean
+    obj.recursive;
+};
+
+options.onEditable = undefined;
+options.onEditable = (node: EditableNode | {}) => {
+    return true;
+};
+options.onEditable = (node: EditableNode | {}) => {
+    return { field: true, value: false };
+};
+
+options.onError = undefined;
+options.onError = (error: Error) => {};
+
+options.onModeChange = undefined;
+options.onModeChange = (newMode: JSONEditorMode, oldMode: JSONEditorMode) => {};
+
+options.onNodeName = undefined;
+options.onNodeName = obj => {
+    // $ExpectType ReadonlyArray<string>
+    obj.path;
+    // $ExpectType NodeType
+    obj.type;
+    // $ExpectType number
+    obj.size;
+    // $ExpectType any
+    obj.value;
+    return '';
+};
+options.onNodeName = obj => {
+    // $ExpectType ReadonlyArray<string>
+    obj.path;
+    // $ExpectType NodeType
+    obj.type;
+    // $ExpectType number
+    obj.size;
+    // $ExpectType any
+    obj.value;
+    return undefined;
+};
+
+options.onValidate = undefined;
+options.onValidate = json => [];
+options.onValidate = json => new Promise(() => []);
+
+options.onValidationError = undefined;
+options.onValidationError = errors => {
+    return;
+};
+
+options.onCreateMenu = undefined;
+options.onCreateMenu = (menuItems, node) => {
+    const menuItem = menuItems[0];
+    // $ExpectType string
+    menuItem.text;
+    // $ExpectType string
+    menuItem.title;
+    // $ExpectType "separator" | undefined
+    menuItem.type;
+    // $ExpectType string
+    menuItem.className;
+    // $ExpectType MenuItem[] | undefined
+    menuItem.submenu;
+    // $ExpectType string | undefined
+    menuItem.submenuTitle;
+    // $ExpectType (() => void) | undefined
+    menuItem.click;
+
+    // $ExpectType MenuItemNodeType
+    node.type;
+    // $ExpectType ReadonlyArray<string>
+    node.path;
+    // $ExpectType readonly (readonly string[])[]
+    node.paths;
+
+    return menuItems;
+};
+
+options.escapeUnicode = undefined;
+options.escapeUnicode = false;
+
+options.sortObjectKeys = undefined;
+options.sortObjectKeys = true;
+
+options.limitDragging = undefined;
+options.limitDragging = true;
+
+options.history = undefined;
+options.history = true;
+
+options.mode = undefined;
+options.mode = 'tree';
+
+options.modes = undefined;
+options.modes = ['tree', 'view', 'form', 'code', 'text'];
+
+options.name = undefined;
+options.name = 'foo';
+
+options.schema = undefined;
+options.schema = {};
+
+options.schemaRefs = undefined;
+options.schemaRefs = { otherSchema: {} };
+
+options.allowSchemaSuggestions = undefined;
+options.allowSchemaSuggestions = true;
+
+options.search = undefined;
+options.search = false;
+
+options.indentation = undefined;
+options.indentation = 2;
+
+options.theme = undefined;
+options.theme = 'default';
+
+options.templates = undefined;
+options.templates = [];
+options.templates = [{ text: '', title: '', field: '', value: {} }];
+
+options.autocomplete = undefined;
+options.autocomplete = autocomplete;
+
+options.mainMenuBar = undefined;
+options.mainMenuBar = false;
+
+options.navigationBar = undefined;
+options.navigationBar = false;
+
+options.statusBar = undefined;
+options.statusBar = false;
+
+options.onTextSelectionChange = undefined;
+options.onTextSelectionChange = (start, end, text) => {
+    // $ExpectType number
+    start.row;
+    // $ExpectType number
+    start.column;
+    // $ExpectType number
+    end.row;
+    // $ExpectType number
+    end.column;
+    // $ExpectType string
+    text;
+};
+
+options.onSelectionChange = undefined;
+options.onSelectionChange = (start, end) => {
+    // $ExpectType JSONPath
+    start.path;
+    // $ExpectType any
+    start.value;
+    // $ExpectType JSONPath
+    end.path;
+    // $ExpectType any
+    end.value;
+};
+
+options.onEvent = undefined;
+options.onEvent = (node, event) => {
+    // $ExpectType string
+    node.field;
+    // $ExpectType string | undefined
+    node.value;
+    // $ExpectType JSONPath
+    node.path;
+    // $ExpectType Event
+    event;
+};
+
+options.onFocus = undefined;
+options.onFocus = event => {
+    // $ExpectType Event
+    event;
+};
+
+options.onBlur = undefined;
+options.onBlur = event => {
+    // $ExpectType Event
+    event;
+};
+
+options.colorPicker = undefined;
+options.colorPicker = false;
+
+options.onColorPicker = undefined;
+options.onColorPicker = (parent, color, onChange) => {
+    // $ExpectType HTMLElement
+    parent;
+    // $ExpectType string
+    color;
+    // $ExpectType (color: Color) => void
+    onChange;
+};
+
+options.timestampTag = undefined;
+options.timestampTag = false;
+options.timestampTag = node => {
+    // $ExpectType string
+    node.field;
+    // $ExpectType string
+    node.value;
+    // $ExpectType ReadonlyArray<string>
+    node.path;
+
+    return true;
+};
+
+options.timestampFormat = undefined;
+options.timestampFormat = node => {
+    // $ExpectType string
+    node.field;
+    // $ExpectType string
+    node.value;
+    // $ExpectType ReadonlyArray<string>
+    node.path;
+
+    return '';
+};
+options.timestampFormat = node => {
+    // $ExpectType string
+    node.field;
+    // $ExpectType string
+    node.value;
+    // $ExpectType ReadonlyArray<string>
+    node.path;
+
+    return null;
+};
+
+options.language = undefined;
+options.language = 'en';
+
+options.languages = undefined;
+options.languages = { 'pt-BR': { auto: 'Automático testing' }, en: { auto: 'Auto testing' } };
+
+options.modalAnchor = undefined;
+options.modalAnchor = new HTMLElement();
+
+options.popupAnchor = undefined;
+options.popupAnchor = new HTMLElement();
+
+options.enableSort = undefined;
+options.enableSort = false;
+
+options.enableTransform = undefined;
+options.enableTransform = false;
+
+options.maxVisibleChilds = undefined;
+options.maxVisibleChilds = 3;
+
+options.createQuery = undefined;
+options.createQuery = (json, queryOptions) => {
+    // $ExpectType any
+    json;
+
+    if (queryOptions.filter) {
+        // $ExpectType string
+        queryOptions.filter.field;
+        // $ExpectType "==" | "!=" | "<" | "<=" | ">" | ">="
+        queryOptions.filter.relation;
+        // $ExpectType string
+        queryOptions.filter.value;
+    }
+
+    if (queryOptions.sort) {
+        // $ExpectType string
+        queryOptions.sort.field;
+
+        queryOptions.sort.direction = 'asc';
+        queryOptions.sort.direction = 'desc';
+    }
+
+    if (queryOptions.projection) {
+        // $ExpectType string[]
+        queryOptions.projection.fields;
+    }
+
+    return '';
+};
+
+options.executeQuery = undefined;
+options.executeQuery = (json, query) => {
+    // $ExpectType any
+    json;
+    // $ExpectType string
+    query;
+};
+
+options.queryDescription = undefined;
+options.queryDescription = '';
 
 let jsonEditor: JSONEditor;
 jsonEditor = new JSONEditor(document.body);
@@ -53,41 +365,99 @@ jsonEditor = new JSONEditor(document.body, options, { foo: 'bar' });
 
 // $ExpectType void
 jsonEditor.collapseAll();
+
 // $ExpectType void
 jsonEditor.destroy();
+
 // $ExpectType void
 jsonEditor.expandAll();
+
+// $ExpectType void
+jsonEditor.expand({ path: [], isExpand: false, recursive: false });
+
 // $ExpectType void
 jsonEditor.focus();
-// $ExpectType void
-jsonEditor.set({ foo: 'bar' });
-// $ExpectType void
-jsonEditor.setMode('text');
-// $ExpectType void
-jsonEditor.setName('foo');
-// $ExpectType void
-jsonEditor.setName();
-// $ExpectType void
-jsonEditor.setSchema({});
-// $ExpectType void
-jsonEditor.setText('{foo: 1}');
+
 // $ExpectType any
 jsonEditor.get();
+
 // $ExpectType JSONEditorMode
 jsonEditor.getMode();
+
+// $ExpectType string | undefined
+jsonEditor.getName();
+
 // $ExpectType SerializableNode[]
 jsonEditor.getNodesByRange({ path: ['a', 'b'] }, { path: [1] });
-// $ExpectType { start: SerializableNode; end: SerializableNode; }
-jsonEditor.getSelection();
+
+// $ExpectType SerializableNode
+jsonEditor.getSelection().start;
+// $ExpectType SerializableNode
+jsonEditor.getSelection().end;
+
 // $ExpectType string
 jsonEditor.getText();
-// $ExpectType { start: SelectionPosition; end: SelectionPosition; text: string; }
-jsonEditor.getTextSelection();
+
+// $ExpectType number
+jsonEditor.getTextSelection().start.row;
+// $ExpectType number
+jsonEditor.getTextSelection().start.column;
+// $ExpectType number
+jsonEditor.getTextSelection().end.row;
+// $ExpectType number
+jsonEditor.getTextSelection().end.column;
+// $ExpectType string
+jsonEditor.getTextSelection().text;
+
 // $ExpectType void
 jsonEditor.refresh();
+
+// $ExpectType void
+jsonEditor.set({ foo: 'bar' });
+
+// $ExpectType void
+jsonEditor.setMode('text');
+
+// $ExpectType void
+jsonEditor.setName('foo');
+
+// $ExpectType void
+jsonEditor.setName();
+
+// $ExpectType void
+jsonEditor.setSchema({});
+
+// $ExpectType void
+jsonEditor.setSelection({ path: ['a', 'b'] }, { path: [1] });
+
+// $ExpectType void
+jsonEditor.setText('{foo: 1}');
+
+// $ExpectType void
+jsonEditor.setTextSelection({ row: 0, column: 0 }, { row: 1, column: 1 });
+
 // $ExpectType void
 jsonEditor.update(null);
+
 // $ExpectType void
 jsonEditor.updateText('');
-// $ExpectType Promise<readonly (SchemaValidationError | ParseError)[]>
-jsonEditor.validate();
+
+jsonEditor.validate().then(result => {
+    // $ExpectType readonly (SchemaValidationError | ParseError)[]
+    result;
+});
+
+// $ExpectType Editor
+jsonEditor.aceEditor;
+
+// $ExpectType string[]
+JSONEditor.VALID_OPTIONS;
+
+// $ExpectType Ace
+JSONEditor.ace;
+
+// $ExpectType Ajv
+JSONEditor.Ajv;
+
+// $ExpectType any
+JSONEditor.VanillaPicker;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Further Details
- Add back missing `"multiple"` to `MenuItemNodeType`.
    - See `{function} onCreateMenu(items, node)` in [API config options][config-options].
- Add back missing `onExpand` to `JSONEditorOptions`.
    - See `{function} onExpand({ path, isExpand, recursive })` in [API config options][config-options].
- Add back missing `allowSchemaSuggestions` to `JSONEditorOptions`.
    - See `{boolean} allowSchemaSuggestions` in [API config options][config-options].
- Add back missing `onFocus` to `JSONEditorOptions`.
    - See `{function} onFocus({ type: 'focus', target })` in [API config options][config-options].
- Add back missing `onBlur` to `{function} onBlur({ type: 'blur', target })`.
    - See `{boolean} allowSchemaSuggestions` in [API config options][config-options].
- Add back missing `expand` to `JsonEditor`.
    - See `JSONEditor.expand(options)` in [its Documentation][expand-options].
- Add **UNDOCUMENTED** `aceEditor` to `JsonEditor`.
    - See [this block of source codes][ace-editor-code].
    - And also see [this issue][ace-editor-type-issue].    
- Add strict `TranslationKey` to `JSONEditorOptions.languages`.
    - See `{Object} languages` in [API config options][config-options].
    - Also see [src/js/i18n.js][i18n] for a complete set of available keys.
- Apply `Record` type to simplify typing.
- Extract explicit interface from existing interface and function parameters.
    - This is done to 
        - `AutoCompleteOptions.getOptions`
        - `QueryOptions`
        - `JSONEditorOptions.onClassName`
    - Reason: A single `AutoCompleteGetOptions` is much more handy than `NonNullable<AutoCompleteOptions['getOptions']>` when explicitly typing callback outside the function call.
- Minor modification in tsdoc comment.
    - Changing things like `'code'` to  `` `code` `` to make things more explicit.
    - Add some more `@see` and `@param` according to [API Documentation][API].
- Rename `NodeName` to `OnNodeNameParams`.
- Sort interface property according to the order in [API Documentation][API].
    - Move `limitDragging` a bit upward.

[API]: https://github.com/josdejong/jsoneditor/blob/master/docs/api.md
[config-options]: https://github.com/josdejong/jsoneditor/blob/master/docs/api.md#configuration-options
[i18n]: https://github.com/josdejong/jsoneditor/blob/master/src/js/i18n.js
[expand-options]: https://github.com/josdejong/jsoneditor/blob/master/docs/api.md#jsoneditorexpandoptions
[ace-editor-code]: https://github.com/josdejong/jsoneditor/blob/07239a7501c32f68358495816b6eb87f7f600eff/src/js/textmode.js#L272-L300
[ace-editor-type-issue]: https://github.com/josdejong/jsoneditor/issues/1202