### PR TITLE
fix(node): add missing Node 18.7 properties to TestOptions

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -158,11 +158,25 @@ declare module 'node:test' {
         only?: boolean;
 
         /**
+         * Allows aborting an in-progress test.
+         * @since 8.7.0
+         */
+        signal?: AbortSignal;
+
+        /**
          * If truthy, the test is skipped. If a string is provided, that string is displayed in the
          * test results as the reason for skipping the test.
          * @default false
          */
         skip?: boolean | string;
+
+        /**
+         * A number of milliseconds the test will fail after. If unspecified, subtests inherit this
+         * value from their parent.
+         * @default Infinity
+         * @since 8.7.0
+         */
+        timeout?: number;
 
         /**
          * If truthy, the test marked as `TODO`. If a string is provided, that string is displayed in

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -10,7 +10,9 @@ test('blank options', {});
 test('options with values', {
     concurrency: 1,
     only: true,
+    signal: new AbortController().signal,
     skip: 'reason for skip',
+    timeout: Infinity,
     todo: 'reason for todo',
 });
 
@@ -74,14 +76,18 @@ it('blank options', {});
 describe('options with values', {
     concurrency: 1,
     only: true,
+    signal: new AbortController().signal,
     skip: 'reason for skip',
+    timeout: Infinity,
     todo: 'reason for todo',
 });
 
 it('options with values', {
     concurrency: 1,
     only: true,
+    signal: new AbortController().signal,
     skip: 'reason for skip',
+    timeout: Infinity,
     todo: 'reason for todo',
 });
 


### PR DESCRIPTION
See https://nodejs.org/api/test.html#testname-options-fn

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/test.html#testname-options-fn
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~