### PR TITLE
[jasmine] Add type definition for "spyOnGlobalErrorsAsync" method

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jasmine 4.0
+// Type definitions for Jasmine 4.3
 // Project: http://jasmine.github.io
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
 //                 Theodore Brown <https://github.com/theodorejb>
@@ -353,6 +353,7 @@ declare namespace jasmine {
     function setContaining<T>(sample: Set<T>): AsymmetricMatcher<Set<T>>;
 
     function setDefaultSpyStrategy<Fn extends Func = Func>(fn?: (and: SpyAnd<Fn>) => void): void;
+    function spyOnGlobalErrorsAsync(fn?: (globalErrorSpy: Error) => Promise<void>): Promise<void>;
     function addSpyStrategy<Fn extends Func = Func>(name: string, factory: Fn): void;
     function createSpy<Fn extends Func>(name?: string, originalFn?: Fn): Spy<Fn>;
     function createSpyObj(baseName: string, methodNames: SpyObjMethodNames, propertyNames?: SpyObjPropertyNames): any;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -2435,6 +2435,21 @@ describe("setDefaultSpyStrategy", () => {
     });
 });
 
+describe("spyOnGlobalErrorsAsync", () => {
+    it('demonstrates global error spies', async function() {
+        await jasmine.spyOnGlobalErrorsAsync(async function(globalErrorSpy) {
+            setTimeout(function() {
+                throw new Error('the expected error');
+            });
+            await new Promise(function(resolve) {
+                setTimeout(resolve);
+            });
+            const expected = new Error('the expected error');
+            expect(globalErrorSpy).toHaveBeenCalledWith(expected);
+        });
+    });
+});
+
 describe("version", () => {
     it("get version", () => {
         console.log(jasmine.version);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test jasmine`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://jasmine.github.io/api/edge/jasmine.html#.spyOnGlobalErrorsAsync>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.