### PR TITLE
Define import.meta.jest in jest types

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1568,3 +1568,7 @@ declare namespace jasmine {
         [n: number]: T;
     }
 }
+
+interface ImportMeta {
+    jest: typeof jest;
+}

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -46,47 +46,55 @@ declare var xtest: jest.It;
 declare const expect: jest.Expect;
 
 type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
-    1: [T[0]],
-    2: [T[0], T[1]],
-    3: [T[0], T[1], T[2]],
-    4: [T[0], T[1], T[2], T[3]],
-    5: [T[0], T[1], T[2], T[3], T[4]],
-    6: [T[0], T[1], T[2], T[3], T[4], T[5]],
-    7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]],
-    8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]],
-    9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]],
-    10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]],
-    'fallback': Array<(T extends ReadonlyArray<infer U>? U: any)>
-}[
-    T extends Readonly<[any]> ? 1
-        : T extends Readonly<[any, any]> ? 2
-        : T extends Readonly<[any, any, any]> ? 3
-        : T extends Readonly<[any, any, any, any]> ? 4
-        : T extends Readonly<[any, any, any, any, any]> ? 5
-        : T extends Readonly<[any, any, any, any, any, any]> ? 6
-        : T extends Readonly<[any, any, any, any, any, any, any]> ? 7
-        : T extends Readonly<[any, any, any, any, any, any, any, any]> ? 8
-        : T extends Readonly<[any, any, any, any, any, any, any, any, any]> ? 9
-        : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]> ? 10
-        : 'fallback'
-];
+    1: [T[0]];
+    2: [T[0], T[1]];
+    3: [T[0], T[1], T[2]];
+    4: [T[0], T[1], T[2], T[3]];
+    5: [T[0], T[1], T[2], T[3], T[4]];
+    6: [T[0], T[1], T[2], T[3], T[4], T[5]];
+    7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]];
+    8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]];
+    9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]];
+    10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]];
+    fallback: Array<T extends ReadonlyArray<infer U> ? U : any>;
+}[T extends Readonly<[any]>
+    ? 1
+    : T extends Readonly<[any, any]>
+    ? 2
+    : T extends Readonly<[any, any, any]>
+    ? 3
+    : T extends Readonly<[any, any, any, any]>
+    ? 4
+    : T extends Readonly<[any, any, any, any, any]>
+    ? 5
+    : T extends Readonly<[any, any, any, any, any, any]>
+    ? 6
+    : T extends Readonly<[any, any, any, any, any, any, any]>
+    ? 7
+    : T extends Readonly<[any, any, any, any, any, any, any, any]>
+    ? 8
+    : T extends Readonly<[any, any, any, any, any, any, any, any, any]>
+    ? 9
+    : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]>
+    ? 10
+    : 'fallback'];
 
 type FakeableAPI =
-  | 'Date'
-  | 'hrtime'
-  | 'nextTick'
-  | 'performance'
-  | 'queueMicrotask'
-  | 'requestAnimationFrame'
-  | 'cancelAnimationFrame'
-  | 'requestIdleCallback'
-  | 'cancelIdleCallback'
-  | 'setImmediate'
-  | 'clearImmediate'
-  | 'setInterval'
-  | 'clearInterval'
-  | 'setTimeout'
-  | 'clearTimeout';
+    | 'Date'
+    | 'hrtime'
+    | 'nextTick'
+    | 'performance'
+    | 'queueMicrotask'
+    | 'requestAnimationFrame'
+    | 'cancelAnimationFrame'
+    | 'requestIdleCallback'
+    | 'cancelIdleCallback'
+    | 'setImmediate'
+    | 'clearImmediate'
+    | 'setInterval'
+    | 'clearInterval'
+    | 'setTimeout'
+    | 'clearTimeout';
 
 interface FakeTimersConfig {
     /**
@@ -228,7 +236,7 @@ declare namespace jest {
      *
      * Note: while it needs to be a function so that input type is changed, the helper itself does nothing else than returning the given input value.
      */
-     function mocked<T>(item: T, deep?: false): MaybeMocked<T>;
+    function mocked<T>(item: T, deep?: false): MaybeMocked<T>;
     /**
      * The mocked test helper provides typings on your mocked modules and even
      * their deep methods, based on the typing of its source. It makes use of
@@ -237,7 +245,7 @@ declare namespace jest {
      *
      * Note: while it needs to be a function so that input type is changed, the helper itself does nothing else than returning the given input value.
      */
-     function mocked<T>(item: T, deep: true): MaybeMockedDeep<T>;
+    function mocked<T>(item: T, deep: true): MaybeMockedDeep<T>;
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
      * whether the module should receive a mock implementation or not.
@@ -341,21 +349,24 @@ declare namespace jest {
         object: T,
         method: Key,
         accessType: A,
-    ):
-      A extends SetAccessor ? SpyInstance<void, [Value]>
-    : A extends GetAccessor ? SpyInstance<Value, []>
-    : Value extends Constructor ? SpyInstance<InstanceType<Value>, ConstructorArgsType<Value>>
-    : Value extends Func ? SpyInstance<ReturnType<Value>, ArgsType<Value>>
-    : never;
+    ): A extends SetAccessor
+        ? SpyInstance<void, [Value]>
+        : A extends GetAccessor
+        ? SpyInstance<Value, []>
+        : Value extends Constructor
+        ? SpyInstance<InstanceType<Value>, ConstructorArgsType<Value>>
+        : Value extends Func
+        ? SpyInstance<ReturnType<Value>, ArgsType<Value>>
+        : never;
     function spyOn<T extends {}, M extends FunctionPropertyNames<Required<T>>>(
         object: T,
-        method: M
+        method: M,
     ): FunctionProperties<Required<T>>[M] extends Func
         ? SpyInstance<ReturnType<FunctionProperties<Required<T>>[M]>, ArgsType<FunctionProperties<Required<T>>[M]>>
         : never;
     function spyOn<T extends {}, M extends ConstructorPropertyNames<Required<T>>>(
         object: T,
-        method: M
+        method: M,
     ): Required<T>[M] extends new (...args: any[]) => any
         ? SpyInstance<InstanceType<Required<T>[M]>, ConstructorArgsType<Required<T>[M]>>
         : never;
@@ -413,14 +424,15 @@ declare namespace jest {
     type RejectedValue<T> = T extends PromiseLike<any> ? any : never;
     type ResolvedValue<T> = T extends PromiseLike<infer U> ? U | T : never;
     // see https://github.com/Microsoft/TypeScript/issues/25215
-    type NonFunctionPropertyNames<T> = keyof { [K in keyof T as T[K] extends Func ? never : K]: T[K]; };
+    type NonFunctionPropertyNames<T> = keyof { [K in keyof T as T[K] extends Func ? never : K]: T[K] };
     type GetAccessor = 'get';
     type SetAccessor = 'set';
-    type PropertyAccessors<M extends keyof T, T extends {}> = M extends NonFunctionPropertyNames<Required<T>> ? GetAccessor | SetAccessor : never;
+    type PropertyAccessors<M extends keyof T, T extends {}> = M extends NonFunctionPropertyNames<Required<T>>
+        ? GetAccessor | SetAccessor
+        : never;
     type FunctionProperties<T> = { [K in keyof T as T[K] extends (...args: any[]) => any ? K : never]: T[K] };
     type FunctionPropertyNames<T> = keyof FunctionProperties<T>;
-    type ConstructorPropertyNames<T> = { [K in keyof T]: T[K] extends Constructor ? K : never }[keyof T] &
-        string;
+    type ConstructorPropertyNames<T> = { [K in keyof T]: T[K] extends Constructor ? K : never }[keyof T] & string;
 
     interface DoneCallback {
         (...args: any[]): any;
@@ -438,19 +450,27 @@ declare namespace jest {
 
     interface Each {
         // Exclusively arrays.
-        <T extends any[] | [any]>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T) => any, timeout?: number) => void;
-        <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (name: string, fn: (...args: ExtractEachCallbackArgs<T>) => any, timeout?: number) => void;
+        <T extends any[] | [any]>(cases: ReadonlyArray<T>): (
+            name: string,
+            fn: (...args: T) => any,
+            timeout?: number,
+        ) => void;
+        <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (
+            name: string,
+            fn: (...args: ExtractEachCallbackArgs<T>) => any,
+            timeout?: number,
+        ) => void;
         // Not arrays.
         <T>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T[]) => any, timeout?: number) => void;
         (cases: ReadonlyArray<ReadonlyArray<any>>): (
             name: string,
             fn: (...args: any[]) => any,
-            timeout?: number
+            timeout?: number,
         ) => void;
         (strings: TemplateStringsArray, ...placeholders: any[]): (
             name: string,
             fn: (arg: any) => any,
-            timeout?: number
+            timeout?: number,
         ) => void;
     }
 
@@ -557,7 +577,7 @@ declare namespace jest {
         | 'currentTestName'
         | 'utils'
         | 'equals'
-    > & { [other: string]: any; };
+    > & { [other: string]: any };
 
     interface ExpectExtendMap {
         [key: string]: CustomMatcher;
@@ -734,15 +754,15 @@ declare namespace jest {
          * Use resolves to unwrap the value of a fulfilled promise so any other
          * matcher can be chained. If the promise is rejected the assertion fails.
          */
-        resolves: AndNot<TPromise>,
+        resolves: AndNot<TPromise>;
         /**
          * Unwraps the reason of a rejected promise so any other matcher can be chained.
          * If the promise is fulfilled the assertion fails.
          */
-        rejects: AndNot<TPromise>
+        rejects: AndNot<TPromise>;
     } & AndNot<TNonPromise>;
     type AndNot<T> = T & {
-        not: T
+        not: T;
     };
 
     // should be R extends void|Promise<void> but getting dtslint error
@@ -1075,38 +1095,53 @@ declare namespace jest {
         toThrowErrorMatchingInlineSnapshot(snapshot?: string): R;
     }
 
-    type RemoveFirstFromTuple<T extends any[]> =
-    T['length'] extends 0 ? [] :
-        (((...b: T) => void) extends (a: any, ...b: infer I) => void ? I : []);
+    type RemoveFirstFromTuple<T extends any[]> = T['length'] extends 0
+        ? []
+        : ((...b: T) => void) extends (a: any, ...b: infer I) => void
+        ? I
+        : [];
 
     interface AsymmetricMatcher {
         asymmetricMatch(other: unknown): boolean;
     }
     type NonAsyncMatchers<TMatchers extends ExpectExtendMap> = {
-        [K in keyof TMatchers]: ReturnType<TMatchers[K]> extends Promise<CustomMatcherResult>? never: K
+        [K in keyof TMatchers]: ReturnType<TMatchers[K]> extends Promise<CustomMatcherResult> ? never : K;
     }[keyof TMatchers];
-    type CustomAsyncMatchers<TMatchers extends ExpectExtendMap> = {[K in NonAsyncMatchers<TMatchers>]: CustomAsymmetricMatcher<TMatchers[K]>};
-    type CustomAsymmetricMatcher<TMatcher extends (...args: any[]) => any> = (...args: RemoveFirstFromTuple<Parameters<TMatcher>>) => AsymmetricMatcher;
+    type CustomAsyncMatchers<TMatchers extends ExpectExtendMap> = {
+        [K in NonAsyncMatchers<TMatchers>]: CustomAsymmetricMatcher<TMatchers[K]>;
+    };
+    type CustomAsymmetricMatcher<TMatcher extends (...args: any[]) => any> = (
+        ...args: RemoveFirstFromTuple<Parameters<TMatcher>>
+    ) => AsymmetricMatcher;
 
     // should be TMatcherReturn extends void|Promise<void> but getting dtslint error
-    type CustomJestMatcher<TMatcher extends (...args: any[]) => any, TMatcherReturn> = (...args: RemoveFirstFromTuple<Parameters<TMatcher>>) => TMatcherReturn;
+    type CustomJestMatcher<TMatcher extends (...args: any[]) => any, TMatcherReturn> = (
+        ...args: RemoveFirstFromTuple<Parameters<TMatcher>>
+    ) => TMatcherReturn;
 
-    type ExpectProperties= {
-        [K in keyof Expect]: Expect[K]
+    type ExpectProperties = {
+        [K in keyof Expect]: Expect[K];
     };
     // should be TMatcherReturn extends void|Promise<void> but getting dtslint error
     // Use the `void` type for return types only. Otherwise, use `undefined`. See: https://github.com/Microsoft/dtslint/blob/master/docs/void-return.md
     // have added issue https://github.com/microsoft/dtslint/issues/256 - Cannot have type union containing void ( to be used as return type only
-    type ExtendedMatchers<TMatchers extends ExpectExtendMap, TMatcherReturn, TActual> = Matchers<TMatcherReturn, TActual> & {[K in keyof TMatchers]: CustomJestMatcher<TMatchers[K], TMatcherReturn>};
-    type JestExtendedMatchers<TMatchers extends ExpectExtendMap, TActual> = JestMatchersShape<ExtendedMatchers<TMatchers, void, TActual>, ExtendedMatchers<TMatchers, Promise<void>, TActual>>;
+    type ExtendedMatchers<TMatchers extends ExpectExtendMap, TMatcherReturn, TActual> = Matchers<
+        TMatcherReturn,
+        TActual
+    > & { [K in keyof TMatchers]: CustomJestMatcher<TMatchers[K], TMatcherReturn> };
+    type JestExtendedMatchers<TMatchers extends ExpectExtendMap, TActual> = JestMatchersShape<
+        ExtendedMatchers<TMatchers, void, TActual>,
+        ExtendedMatchers<TMatchers, Promise<void>, TActual>
+    >;
 
     // when have called expect.extend
-    type ExtendedExpectFunction<TMatchers extends ExpectExtendMap> = <TActual>(actual: TActual) => JestExtendedMatchers<TMatchers, TActual>;
+    type ExtendedExpectFunction<TMatchers extends ExpectExtendMap> = <TActual>(
+        actual: TActual,
+    ) => JestExtendedMatchers<TMatchers, TActual>;
 
-    type ExtendedExpect<TMatchers extends ExpectExtendMap>=
-    ExpectProperties &
-    AndNot<CustomAsyncMatchers<TMatchers>> &
-    ExtendedExpectFunction<TMatchers>;
+    type ExtendedExpect<TMatchers extends ExpectExtendMap> = ExpectProperties &
+        AndNot<CustomAsyncMatchers<TMatchers>> &
+        ExtendedExpectFunction<TMatchers>;
 
     type NonPromiseMatchers<T extends JestMatchersShape<any>> = Omit<T, 'resolves' | 'rejects' | 'not'>;
     type PromiseMatchers<T extends JestMatchersShape> = Omit<T['resolves'], 'not'>;
@@ -1177,9 +1212,8 @@ declare namespace jest {
             ? MockInstance<ReturnType<T[P]>, ArgsType<T[P]>>
             : T[P] extends Constructable
             ? MockedClass<T[P]>
-            : T[P]
-    } &
-        T;
+            : T[P];
+    } & T;
 
     interface MockInstance<T, Y extends any[]> {
         /** Returns the mock name string set by calling `mockFn.mockName(value)`. */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1371,6 +1371,18 @@ describe('', () => {
 
         fail();
     });
+
+    it('', () => {
+        fail('error');
+    });
+
+    it('', () => {
+        fail(new Error('reason'));
+    });
+
+    it('', () => {
+        fail({});
+    });
 });
 
 /* Jasmine clocks and timing */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -50,47 +50,74 @@ afterEach((done: jest.DoneCallback) => Promise.resolve());
 
 describe(0, () => {});
 describe('name', () => {});
-describe(() => {}, () => {});
+describe(
+    () => {},
+    () => {},
+);
 describe({ name: 'name' }, () => {});
 
 describe.only(0, () => {});
 describe.only('name', () => {});
-describe.only(() => {}, () => {});
+describe.only(
+    () => {},
+    () => {},
+);
 describe.only({ name: 'name' }, () => {});
 
 describe.skip(0, () => {});
 describe.skip('name', () => {});
-describe.skip(() => {}, () => {});
+describe.skip(
+    () => {},
+    () => {},
+);
 describe.skip({ name: 'name' }, () => {});
 
 fdescribe(0, () => {});
 fdescribe('name', () => {});
-fdescribe(() => {}, () => {});
+fdescribe(
+    () => {},
+    () => {},
+);
 fdescribe({ name: 'name' }, () => {});
 
 fdescribe.only(0, () => {});
 fdescribe.only('name', () => {});
-fdescribe.only(() => {}, () => {});
+fdescribe.only(
+    () => {},
+    () => {},
+);
 fdescribe.only({ name: 'name' }, () => {});
 
 fdescribe.skip(0, () => {});
 fdescribe.skip('name', () => {});
-fdescribe.skip(() => {}, () => {});
+fdescribe.skip(
+    () => {},
+    () => {},
+);
 fdescribe.skip({ name: 'name' }, () => {});
 
 xdescribe(0, () => {});
 xdescribe('name', () => {});
-xdescribe(() => {}, () => {});
+xdescribe(
+    () => {},
+    () => {},
+);
 xdescribe({ name: 'name' }, () => {});
 
 xdescribe.only(0, () => {});
 xdescribe.only('name', () => {});
-xdescribe.only(() => {}, () => {});
+xdescribe.only(
+    () => {},
+    () => {},
+);
 xdescribe.only({ name: 'name' }, () => {});
 
 xdescribe.skip(0, () => {});
 xdescribe.skip('name', () => {});
-xdescribe.skip(() => {}, () => {});
+xdescribe.skip(
+    () => {},
+    () => {},
+);
 xdescribe.skip({ name: 'name' }, () => {});
 
 /* it */
@@ -315,18 +342,18 @@ jest.autoMockOff()
     .doMock('moduleName', jest.fn())
     .doMock('moduleName', jest.fn(), {})
     .doMock('moduleName', jest.fn(), { virtual: true })
-    .doMock<{animal: string}>('moduleName', () => ({animal: 'cat'}))
+    .doMock<{ animal: string }>('moduleName', () => ({ animal: 'cat' }))
     // @ts-expect-error
-    .doMock<{animal: string}>('moduleName', () => ({name: 'tom'}))
+    .doMock<{ animal: string }>('moduleName', () => ({ name: 'tom' }))
     .dontMock('moduleName')
     .enableAutomock()
     .mock('moduleName')
     .mock('moduleName', jest.fn())
     .mock('moduleName', jest.fn(), {})
     .mock('moduleName', jest.fn(), { virtual: true })
-    .mock<{animal: string}>('moduleName', () => ({animal: 'cat'}))
+    .mock<{ animal: string }>('moduleName', () => ({ animal: 'cat' }))
     // @ts-expect-error
-    .mock<{animal: string}>('moduleName', () => ({name: 'tom'}))
+    .mock<{ animal: string }>('moduleName', () => ({ name: 'tom' }))
     .resetModules()
     .isolateModules(() => {})
     .retryTimes(3, { logErrorsBeforeRetry: true })
@@ -383,7 +410,7 @@ jest.requireActual('./thisReturnsTheActualModule').default;
 
 // https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename
 // $ExpectType any
-const spreadRequireActual = {...jest.requireActual('./thisReturnsTheActualModule')};
+const spreadRequireActual = { ...jest.requireActual('./thisReturnsTheActualModule') };
 
 // https://jestjs.io/docs/en/jest-object#jestrequiremockmodulename
 // $ExpectType any
@@ -399,7 +426,7 @@ jest.requireMock('./thisAlwaysReturnsTheMock').default;
 
 // https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename
 // $ExpectType any
-const spreadRequireMock = {...jest.requireMock('./thisAlwaysReturnsTheMock')};
+const spreadRequireMock = { ...jest.requireMock('./thisAlwaysReturnsTheMock') };
 
 /* Mocks and spies */
 
@@ -421,7 +448,7 @@ const mock7 = jest.fn((arg: number) => arg);
 const mock8: jest.Mock = jest.fn((arg: number) => arg);
 // $ExpectType Mock<Promise<boolean>, [number, string, {}, [], boolean]> || Mock<Promise<boolean>, [a: number, _b: string, _c: {}, _iReallyDontCare: [], _makeItStop: boolean]>
 const mock9 = jest.fn((a: number, _b: string, _c: {}, _iReallyDontCare: [], _makeItStop: boolean) =>
-    Promise.resolve(_makeItStop)
+    Promise.resolve(_makeItStop),
 );
 // $ExpectType Mock<never, []>
 const mock10 = jest.fn(() => {
@@ -537,7 +564,7 @@ const spy3Mock = spy3
 const spiedPromiseTarget = {
     resolvesString() {
         return Promise.resolve('string');
-    }
+    },
 };
 jest.spyOn(spiedPromiseTarget, 'resolvesString')
     .mockResolvedValue('value')
@@ -567,7 +594,7 @@ spy6.mockReturnValue('5');
 // $ExpectType SpyInstance<void, [number]>
 jest.spyOn(spiedTarget2, 'value', 'set');
 
-let spyInterfaceImpl: SpyInterface = {};
+const spyInterfaceImpl: SpyInterface = {};
 // @ts-expect-error
 jest.spyOn(spyInterfaceImpl, 'method', 'get');
 // @ts-expect-error
@@ -582,7 +609,7 @@ class SpyableClass {
     foo() {}
 }
 // $ExpectType SpyInstance<SpyableClass, [number, string]> || SpyInstance<SpyableClass, [a: number, b: string]>
-jest.spyOn({ SpyableClass }, "SpyableClass");
+jest.spyOn({ SpyableClass }, 'SpyableClass');
 
 interface SpyableWithIndexSignature {
     [index: string]: {
@@ -592,19 +619,19 @@ interface SpyableWithIndexSignature {
     methodOne: () => void;
     methodTwo: (s: string, b: boolean) => { b: boolean; n: number };
 }
-let spyWithIndexSignatureImpl: SpyableWithIndexSignature = {
+const spyWithIndexSignatureImpl: SpyableWithIndexSignature = {
     methodOne: () => {},
     methodTwo: (s, b) => ({ b, n: Number(s) }),
     prop: { some: 'thing' },
 };
 // $ExpectType SpyInstance<void, []>
-jest.spyOn(spyWithIndexSignatureImpl, "methodOne");
+jest.spyOn(spyWithIndexSignatureImpl, 'methodOne');
 // $ExpectType SpyInstance<{ b: boolean; n: number; }, [s: string, b: boolean]>
-jest.spyOn(spyWithIndexSignatureImpl, "methodTwo");
+jest.spyOn(spyWithIndexSignatureImpl, 'methodTwo');
 // @ts-expect-error
-jest.spyOn(spyWithIndexSignatureImpl, "nonExistentMethod");
+jest.spyOn(spyWithIndexSignatureImpl, 'nonExistentMethod');
 // @ts-expect-error
-jest.spyOn(spyWithIndexSignatureImpl, "prop");
+jest.spyOn(spyWithIndexSignatureImpl, 'prop');
 // $ExpectType SpyInstance<{ some: string; }, []>
 jest.spyOn(spyWithIndexSignatureImpl, 'prop', 'get');
 
@@ -780,7 +807,7 @@ switch (mockResult.type) {
 /* getState and setState */
 // @ts-expect-error
 expect.setState(true);
-expect.setState({for: 'state'});
+expect.setState({ for: 'state' });
 const expectState = expect.getState();
 // $ExpectType string | undefined
 expectState.currentTestName;
@@ -946,7 +973,7 @@ expect.extend({
 
         const receivedPrinted: string = this.utils.printReceived({});
 
-        const printedWithType: string = this.utils.printWithType('name', {}, (value) => '');
+        const printedWithType: string = this.utils.printWithType('name', {}, value => '');
 
         const stringified: string = this.utils.stringify({});
         const stringifiedWithMaxDepth: string = this.utils.stringify({}, 3);
@@ -1007,7 +1034,7 @@ describe('', () => {
         // @ts-expect-error
         expect(jest.fn()).toBeCalledWith<[string, number]>(1, 'two');
         // @ts-expect-error
-        expect({}).toEqual<{ p1: string, p2: number }>({ p1: 'hello' });
+        expect({}).toEqual<{ p1: string; p2: number }>({ p1: 'hello' });
 
         expect(0).toBeCloseTo(1);
         expect(0).toBeCloseTo(1, 2);
@@ -1192,11 +1219,19 @@ describe('', () => {
 
         /* Promise matchers */
 
-        expect(Promise.reject('jest')).rejects.toEqual('jest').then(() => {});
-        expect(Promise.reject('jest')).rejects.not.toEqual('other').then(() => {});
+        expect(Promise.reject('jest'))
+            .rejects.toEqual('jest')
+            .then(() => {});
+        expect(Promise.reject('jest'))
+            .rejects.not.toEqual('other')
+            .then(() => {});
 
-        expect(Promise.resolve('jest')).resolves.toEqual('jest').then(() => {});
-        expect(Promise.resolve('jest')).resolves.not.toEqual('other').then(() => {});
+        expect(Promise.resolve('jest'))
+            .resolves.toEqual('jest')
+            .then(() => {});
+        expect(Promise.resolve('jest'))
+            .resolves.not.toEqual('other')
+            .then(() => {});
         /* type matchers */
 
         expect({}).toBe(expect.anything());
@@ -1220,7 +1255,7 @@ describe('', () => {
                     foo: 'bar',
                 }),
                 ghi: expect.stringMatching('foo'),
-            })
+            }),
         );
 
         /* Inverse type matchers */
@@ -1241,73 +1276,89 @@ describe('', () => {
 /* Custom matchers and CustomExpect */
 describe('', () => {
     it('', () => {
-        const customMatcher = (expected: any, actual: {prop: string}, option1: boolean) => {
-            return {pass: true, message: () => ''};
+        const customMatcher = (expected: any, actual: { prop: string }, option1: boolean) => {
+            return { pass: true, message: () => '' };
         };
         const asyncMatcher = () => {
-            return Promise.resolve({pass: true, message: () => ''});
+            return Promise.resolve({ pass: true, message: () => '' });
         };
 
-        const customMatchers = {customMatcher, asyncMatcher};
+        const customMatchers = { customMatcher, asyncMatcher };
         expect.extend(customMatchers);
         const extendedExpect: jest.ExtendedExpect<typeof customMatchers> = expect as any;
 
         // extracting matcher types
-        const matchers = extendedExpect({thing: true});
+        const matchers = extendedExpect({ thing: true });
         let nonPromiseMatchers: jest.NonPromiseMatchers<typeof matchers> = matchers;
         const isNot = true;
         if (isNot) {
             nonPromiseMatchers = matchers.not;
         }
         // retains U from <U>(actual: U) => JestExtendedMatchers<T, U>; - BUT CANNOT DO THAT WITH CUSTOM...
-        nonPromiseMatchers.toMatchInlineSnapshot({thing: extendedExpect.any(Boolean)});
+        nonPromiseMatchers.toMatchInlineSnapshot({ thing: extendedExpect.any(Boolean) });
         // @ts-expect-error
-        nonPromiseMatchers.toMatchInlineSnapshot({notthing: extendedExpect.any(Boolean)});
+        nonPromiseMatchers.toMatchInlineSnapshot({ notthing: extendedExpect.any(Boolean) });
 
         let promiseMatchers: jest.PromiseMatchers<typeof matchers> = matchers.rejects;
         if (isNot) {
             promiseMatchers = matchers.rejects.not;
         }
         // $ExpectType Promise<void>
-        promiseMatchers.customMatcher({prop: ''}, true);
+        promiseMatchers.customMatcher({ prop: '' }, true);
 
         // retains built in asymmetric matcher
         extendedExpect.not.arrayContaining;
 
-        extendedExpect.customMatcher({prop: 'good'}, false).asymmetricMatch({}).valueOf();
+        extendedExpect.customMatcher({ prop: 'good' }, false).asymmetricMatch({}).valueOf();
         // @ts-expect-error
-        extendedExpect.customMatcher({prop: {not: 'good'}}, false);
+        extendedExpect.customMatcher({ prop: { not: 'good' } }, false);
 
-        extendedExpect.not.customMatcher({prop: 'good'}, false).asymmetricMatch({}).valueOf();
+        extendedExpect.not.customMatcher({ prop: 'good' }, false).asymmetricMatch({}).valueOf();
         // @ts-expect-error
-        extendedExpect.not.customMatcher({prop: 'good'}, 'bad').asymmetricMatch({}).valueOf();
+        extendedExpect.not.customMatcher({ prop: 'good' }, 'bad').asymmetricMatch({}).valueOf();
 
         // @ts-expect-error
         const asynMatcherExcluded = extendedExpect.asyncMatcher;
 
-        extendedExpect('').customMatcher({prop: 'good'}, true);
+        extendedExpect('').customMatcher({ prop: 'good' }, true);
         // @ts-expect-error
-        extendedExpect('').customMatcher({prop: 'good'}, 'bad');
+        extendedExpect('').customMatcher({ prop: 'good' }, 'bad');
 
-        extendedExpect('').not.customMatcher({prop: 'good'}, true);
+        extendedExpect('').not.customMatcher({ prop: 'good' }, true);
         // @ts-expect-error
-        extendedExpect('').not.customMatcher({prop: 'good'}, 'bad');
+        extendedExpect('').not.customMatcher({ prop: 'good' }, 'bad');
 
-        extendedExpect(Promise.resolve('')).resolves.customMatcher({prop: 'good'}, true).then(() => {});
-        // @ts-expect-error
-        extendedExpect(Promise.resolve('')).resolves.customMatcher({prop: 'good'}, 'bad').then(() => {});
+        extendedExpect(Promise.resolve(''))
+            .resolves.customMatcher({ prop: 'good' }, true)
+            .then(() => {});
+        extendedExpect(Promise.resolve(''))
+            // @ts-expect-error
+            .resolves.customMatcher({ prop: 'good' }, 'bad')
+            .then(() => {});
 
-        extendedExpect(Promise.resolve('')).resolves.not.customMatcher({prop: 'good'}, true).then(() => {});
-        // @ts-expect-error
-        extendedExpect(Promise.resolve('')).resolves.not.customMatcher({prop: 'good'}, 'bad').then(() => {});
+        extendedExpect(Promise.resolve(''))
+            .resolves.not.customMatcher({ prop: 'good' }, true)
+            .then(() => {});
+        extendedExpect(Promise.resolve(''))
+            // @ts-expect-error
+            .resolves.not.customMatcher({ prop: 'good' }, 'bad')
+            .then(() => {});
 
-        extendedExpect(Promise.reject('')).rejects.customMatcher({prop: 'good'}, true).then(() => {});
-        // @ts-expect-error
-        extendedExpect(Promise.reject('')).rejects.customMatcher({prop: 'good'}, 'bad').then(() => {});
+        extendedExpect(Promise.reject(''))
+            .rejects.customMatcher({ prop: 'good' }, true)
+            .then(() => {});
+        extendedExpect(Promise.reject(''))
+            // @ts-expect-error
+            .rejects.customMatcher({ prop: 'good' }, 'bad')
+            .then(() => {});
 
-        extendedExpect(Promise.reject('')).rejects.not.customMatcher({prop: 'good'}, true).then(() => {});
-        // @ts-expect-error
-        extendedExpect(Promise.reject('')).rejects.not.customMatcher({prop: 'good'}, 'bad').then(() => {});
+        extendedExpect(Promise.reject(''))
+            .rejects.not.customMatcher({ prop: 'good' }, true)
+            .then(() => {});
+        extendedExpect(Promise.reject(''))
+            // @ts-expect-error
+            .rejects.not.customMatcher({ prop: 'good' }, 'bad')
+            .then(() => {});
     });
 });
 
@@ -1319,9 +1370,6 @@ describe('', () => {
         pending('reason');
 
         fail();
-        fail('error');
-        fail(new Error('reason'));
-        fail({});
     });
 });
 
@@ -1374,7 +1422,7 @@ expect({ abc: 'def' }).toBe(
             foo: 'bar',
         }),
         ghi: jasmine.stringMatching('foo'),
-    })
+    }),
 );
 
 /* Jasmine spies */
@@ -1478,7 +1526,7 @@ const matchersUtil1 = {
     equals: (a: {}, b: {}) => false,
 };
 
-let matchersUtil2: jasmine.MatchersUtil = {
+const matchersUtil2: jasmine.MatchersUtil = {
     buildFailureMessage(matcherName: string, isNot: boolean, actual: any, ...expected: any[]): string {
         return `${matcherName}${isNot ? '1' : '0'}${actual}${expected.join('')}`;
     },
@@ -1490,7 +1538,11 @@ let matchersUtil2: jasmine.MatchersUtil = {
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26368
 
-describe.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])('.add(%i, %i)', (a: number, b: number, expected: number) => {
+describe.each([
+    [1, 1, 2],
+    [1, 2, 3],
+    [2, 1, 3],
+])('.add(%i, %i)', (a: number, b: number, expected: number) => {
     test(`returns ${expected}`, () => {
         expect(a + b).toBe(expected);
     });
@@ -1513,7 +1565,11 @@ describe.each`
     });
 });
 
-describe.only.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])('.add(%i, %i)', (a, b, expected) => {
+describe.only.each([
+    [1, 1, 2],
+    [1, 2, 3],
+    [2, 1, 3],
+])('.add(%i, %i)', (a, b, expected) => {
     test(`returns ${expected}`, () => {
         expect(a + b).toBe(expected);
     });
@@ -1530,7 +1586,11 @@ describe.only.each`
     });
 });
 
-describe.skip.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])('.add(%i, %i)', (a, b, expected) => {
+describe.skip.each([
+    [1, 1, 2],
+    [1, 2, 3],
+    [2, 1, 3],
+])('.add(%i, %i)', (a, b, expected) => {
     test(`returns ${expected}`, () => {
         expect(a + b).toBe(expected);
     });
@@ -1547,16 +1607,24 @@ describe.skip.each`
     });
 });
 
-test.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])('.add(%i, %i)', (a, b, expected) => {
+test.each([
+    [1, 1, 2],
+    [1, 2, 3],
+    [2, 1, 3],
+])('.add(%i, %i)', (a, b, expected) => {
     expect(a + b).toBe(expected);
 });
 
-test.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])(
+test.each([
+    [1, 1, 2],
+    [1, 2, 3],
+    [2, 1, 3],
+])(
     '.add(%i, %i)',
     (a, b, expected) => {
         expect(a + b).toBe(expected);
     },
-    5000
+    5000,
 );
 
 declare const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']];
@@ -1568,7 +1636,7 @@ test.each(constCases)('%s + %s', (...args) => {
 
 declare const constCasesWithMoreThanTen: [
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-    [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
+    [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911],
 ];
 
 test.each(constCasesWithMoreThanTen)('should fall back with more than 10 args', (...args) => {
@@ -1596,18 +1664,22 @@ test.each`
     ({ a, b, expected }: Case) => {
         expect(a + b).toBe(expected);
     },
-    5000
+    5000,
 );
 
 test.each([
-    [1, "1"],
-    [2, "2"]
-])("", (a, b) => {
+    [1, '1'],
+    [2, '2'],
+])('', (a, b) => {
     a; // $ExpectType number
     b; // $ExpectType string
 });
 
-test.only.each([[1, 1, 2], [1, 2, 3], [2, 1, 3]])('.add(%i, %i)', (a, b, expected) => {
+test.only.each([
+    [1, 1, 2],
+    [1, 2, 3],
+    [2, 1, 3],
+])('.add(%i, %i)', (a, b, expected) => {
     expect(a + b).toBe(expected);
 });
 
@@ -1639,7 +1711,7 @@ test(`returns a Promise<any>`, () => {
 
 /* Test function can take and call the done callback function */
 
-test(`uses done`, (done) => {
+test(`uses done`, done => {
     done();
 });
 
@@ -1664,36 +1736,38 @@ test(`returns a number`, () => {
 // @ts-expect-error
 test(`returns an object`, () => {
     return {
-        isAnObject: true
+        isAnObject: true,
     };
 });
 
 /* Test function should not return promise and takes done callback function */
 
 // @ts-expect-error
-test(`returns a Promise<boolean> and takes done`, (done) => {
+test(`returns a Promise<boolean> and takes done`, done => {
     return Promise.resolve(true);
 });
 
 // @ts-expect-error
-test(`returns a Promise<{ isAnObject: boolean }> and takes done`, (done) => {
+test(`returns a Promise<{ isAnObject: boolean }> and takes done`, done => {
     return Promise.resolve({ isAnObject: true });
 });
 
 // @ts-expect-error
-test(`returns a Promise<any> and takes done`, (done) => {
+test(`returns a Promise<any> and takes done`, done => {
     return Promise.resolve('any' as any);
 });
 
 // @ts-expect-error
-test(`async function takes done`, async (done) => {
+test(`async function takes done`, async done => {
     done();
 });
 
 test('import.meta.jest replaces the global jest in ESM', () => {
     // @ts-expect-error
     // ts(1343): The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
-    const importMetaJest = import .meta.jest;
+
+    // tslint:disable-next-line: whitespace
+    const importMetaJest = import.meta.jest;
 
     importMetaJest.fn();
 });

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1689,3 +1689,11 @@ test(`returns a Promise<any> and takes done`, (done) => {
 test(`async function takes done`, async (done) => {
     done();
 });
+
+test('import.meta.jest replaces the global jest in ESM', () => {
+    // @ts-expect-error
+    // ts(1343): The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+    const importMetaJest = import .meta.jest;
+
+    importMetaJest.fn();
+});


### PR DESCRIPTION
`import.meta.jest` can be used instead of the global `jest` object in ESM.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jestjs.io/docs/28.0/ecmascript-modules#differences-between-esm-and-commonjs
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
