### PR TITLE
eslint-utils: add parent node to node in `ReferenceTracker` class functions

### DIFF
--- a/types/eslint-utils/referenceTracker.d.ts
+++ b/types/eslint-utils/referenceTracker.d.ts
@@ -1,5 +1,4 @@
-import { Scope } from 'eslint';
-import { Node } from 'estree';
+import { Scope, Rule } from 'eslint';
 
 export interface ReferenceTrackerOptions {
     /**
@@ -32,7 +31,7 @@ export const READ: unique symbol;
 
 export interface TrackedReferences<T> {
     info: T;
-    node: Node;
+    node: Rule.Node;
     path: string[];
     type: symbol;
 }

--- a/types/eslint-utils/test/reference-tracker.ts
+++ b/types/eslint-utils/test/reference-tracker.ts
@@ -2,7 +2,10 @@ import { Scope } from 'eslint';
 import * as utils from 'eslint-utils';
 
 declare const scope: Scope.Scope;
-declare const traceMap: utils.TraceMap;
+
+const traceMap = {
+    find: { [utils.ReferenceTracker.CALL]: true }, // Simulate searching for call to find().
+};
 
 utils.ReferenceTracker.CALL;
 utils.ReferenceTracker.CONSTRUCT;
@@ -15,13 +18,13 @@ new utils.ReferenceTracker(scope, { mode: Math.random() ? 'legacy' : 'strict' })
 
 const referenceTracker = new utils.ReferenceTracker(scope);
 
-// $ExpectType IterableIterator<TrackedReferences<unknown>>
+// $ExpectType IterableIterator<TrackedReferences<boolean>>
 referenceTracker.iterateCjsReferences(traceMap);
 
-// $ExpectType IterableIterator<TrackedReferences<unknown>>
+// $ExpectType IterableIterator<TrackedReferences<boolean>>
 referenceTracker.iterateEsmReferences(traceMap);
 
-// $ExpectType IterableIterator<TrackedReferences<unknown>>
+// $ExpectType IterableIterator<TrackedReferences<boolean>>
 referenceTracker.iterateGlobalReferences(traceMap);
 
 // $ExpectType IterableIterator<TrackedReferences<{ type: string; }>>
@@ -30,6 +33,12 @@ referenceTracker.iterateCjsReferences({ test: { [utils.ReferenceTracker.READ]: {
 // $ExpectType IterableIterator<TrackedReferences<{ type: string; } | { type: number; }>>
 referenceTracker.iterateGlobalReferences({ test: { [utils.ReferenceTracker.READ]: { type: 'string' }, [utils.ReferenceTracker.CALL]: { type: 6 } } });
 
-function *getTrackedReferences() {
-    const { info, node, path, type } = yield referenceTracker.iterateCjsReferences(traceMap);
+for (const { info, node, path, type } of referenceTracker.iterateCjsReferences(traceMap)) {
+    info; // $ExpectType boolean
+    node; // $ExpectType Node
+    path; // $ExpectType string[]
+    type; // $ExpectType symbol
+
+    // Ensure node has its parent node (which is added to it by ESLint).
+    node.parent; // $ExpectType Node
 }

--- a/types/eslint-utils/tsconfig.json
+++ b/types/eslint-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "target": "ES6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

ESLint has long added a `parent` node to each node for the convenience of lint rules to use in their implementation, as mentioned in this [doc](https://eslint.org/docs/latest/developer-guide/working-with-custom-parsers#all-nodes).

> ESLint sets each node’s parent property to its parent node while traversing, before any rules have access to the AST.

The `Node` type from `estree` just has the bare node without a `parent` property. So ESLint has its own [type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9dc27eddf926981d53b4aede5386e4b7bc082cb4/types/eslint/index.d.ts#L513) for `Node` that adds the `parent`:

```ts
interface NodeParentExtension {
  parent: Node;
}
type Node = ESTree.Node & NodeParentExtension;
```

When someone is using any of the eslint-utils [ReferenceTracker](https://eslint-utils.mysticatea.dev/api/scope-utils.html#referencetracker-class) functions like [tracker.iterateGlobalReferences(traceMap)](https://eslint-utils.mysticatea.dev/api/scope-utils.html#tracker-iterateglobalreferences), the return type should include the `Node` with the `parent`.

[Here](https://github.com/square/eslint-plugin-square/pull/723#discussion_r951598354) is where I ran into this issue. And I tested to ensure this PR fixes the issue for me.

I also updated the unit tests here to be more realistic and actually test the return values while iterating over `referenceTracker.iterateCjsReferences(traceMap)`.

This is a backwards-compatible bug fix.