### PR TITLE
[node] Add missing type definitions for net module

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -54,6 +54,9 @@ declare module 'net' {
         hints?: number | undefined;
         family?: number | undefined;
         lookup?: LookupFunction | undefined;
+        noDelay?: boolean | undefined;
+        keepAlive?: boolean | undefined;
+        keepAliveInitialDelay?: number | undefined;
     }
     interface IpcSocketConnectOpts extends ConnectOpts {
         path: string;
@@ -399,6 +402,21 @@ declare module 'net' {
          * @default false
          */
         pauseOnConnect?: boolean | undefined;
+        /**
+         * Indicates whether to use nagle's algorithm.
+         * @default false
+         */
+        noDelay?: boolean | undefined;
+        /**
+         * Indicates whether TCP keep-alive is enabled.
+         * @default false
+         */
+        keepAlive?: boolean | undefined;
+        /**
+         * Indicates the initial delay in seconds before keep-alive probes are sent.
+         * @default 0
+         */
+        keepAliveInitialDelay?: number | undefined;
     }
     /**
      * This class is used to create a TCP or `IPC` server.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
https://nodejs.org/docs/latest-v16.x/api/net.html#netcreateserveroptions-connectionlistener
https://nodejs.org/docs/latest-v16.x/api/net.html#socketconnectoptions-connectlistener
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

These seem to have been added in node v16
