### PR TITLE
[hellojs] Update .init definition to be more permissive

### DIFF
--- a/types/hellojs/hellojs-tests.ts
+++ b/types/hellojs/hellojs-tests.ts
@@ -5,7 +5,7 @@ hello.init({
             version: 2,
             auth: '',
             grant: '',
-            response_type: 'id_token token'
+            response_type: 'id_token token',
         },
         refresh: true,
         scope_delim: ' ',
@@ -13,7 +13,7 @@ hello.init({
             const id_token = hello('networkName').getAuthResponse().id_token;
             hello.utils.store('networkName', null);
         },
-        xhr: (p) => {
+        xhr: p => {
             const token = p.query.access_token;
             delete p.query.access_token;
             if (token) {
@@ -25,11 +25,11 @@ hello.init({
             switch (p.method) {
                 case 'post':
                 case 'put':
-                    if (typeof (p.data) === 'object') {
+                    if (typeof p.data === 'object') {
                         try {
                             p.data = JSON.stringify(p.data);
                             p.headers['content-type'] = 'application/json';
-                        } catch (e) { }
+                        } catch (e) {}
                     }
                     break;
                 case 'patch':
@@ -39,8 +39,8 @@ hello.init({
             }
             return true;
         },
-        form: false
-    }
+        form: false,
+    },
 });
 
 // Test code copied from hello.js built-in modules at
@@ -51,7 +51,7 @@ hello.init({
         oauth: {
             version: 2,
             auth: '',
-            grant: ''
+            grant: '',
         },
         refresh: false,
         scope: {
@@ -67,10 +67,10 @@ hello.init({
             publish_files: '',
             files: '',
             videos: '',
-            offline_access: ''
+            offline_access: '',
         },
         scope_delim: ' ',
-        login: (p) => {
+        login: p => {
             p.options.popup.width = 400;
             p.options.popup.height = 700;
         },
@@ -78,7 +78,7 @@ hello.init({
         get: {
             me: 'user',
             meetings: 'meetings',
-            'meetings/info': 'meetings/@{id}'
+            'meetings/info': 'meetings/@{id}',
         },
         post: {
             'meetings/start/adhoc': (p, callback) => {
@@ -88,10 +88,10 @@ hello.init({
         patch: {
             'meetings/update': (p, callback) => {
                 callback('meetings/' + p.data.meetingId);
-            }
+            },
         },
         del: {
-            'meetings/delete': 'meetings/@{id}'
+            'meetings/delete': 'meetings/@{id}',
         },
         wrap: {
             me: (o, headers) => {
@@ -108,37 +108,72 @@ hello.init({
             },
             default: (o, headers) => {
                 return o;
-            }
+            },
         },
         xhr: (p, qs) => {
             const token = qs.access_token;
             delete qs.access_token;
             p.headers.Authorization = 'Bearer ' + token;
-        }
-    }
+        },
+    },
 });
 
-hello.init({
-    facebook: '<app key>',
-}, {
-    redirect_uri: 'hello.html',
-    display: 'page',
-});
+hello.init(
+    {
+        facebook: '<app key>',
+    },
+    {
+        redirect_uri: 'hello.html',
+        display: 'page',
+    },
+);
+
+// handle a mix of service definitions (linkedin) and clientIds (facebook), with an options argument
+hello.init(
+    {
+        linkedin: {
+            id: '<linkedin app key>',
+            oauth: {
+                version: 2,
+                response_type: 'code',
+                auth: 'https://www.linkedin.com/oauth/v2/authorization',
+                grant: 'https://www.linkedin.com/oauth/v2/accessToken',
+            },
+            scope: {
+                basic: 'r_liteprofile',
+                email: 'r_emailaddress',
+            },
+            base: 'https://api.linkedin.com/v2/',
+
+            get: {
+                me: 'me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))',
+                email: 'emailAddress?q=members&projection=(elements*(handle~))',
+            },
+        },
+        facebook: '<facebook app key>',
+    },
+    {
+        redirect_uri: 'hello.html',
+        display: 'page',
+    },
+);
 
 hello.init({
     facebook: '359288236870',
-    windows: '000000004403AD10'
+    windows: '000000004403AD10',
 });
 
 hello('facebook').login();
 
 hello('facebook').logout();
 
-hello.on('auth.login', auth => {
-    alert('log to ' + auth.network);
-}).on('auth.logout', auth => {
-    alert('unlog from ' + auth.network);
-});
+hello
+    .on('auth.login', auth => {
+        alert('log to ' + auth.network);
+    })
+    .on('auth.logout', auth => {
+        alert('unlog from ' + auth.network);
+    });
 
 hello.getAuthResponse('facebook');
 
@@ -148,17 +183,22 @@ hello.login('facebook', null, () => {
 
 hello.logout('facebook');
 
-hello("facebook").api("me").then((json) => {
-    alert("Your name is " + json.name);
-}, () => {
-    alert("Whoops!");
-});
+hello('facebook')
+    .api('me')
+    .then(
+        json => {
+            alert('Your name is ' + json.name);
+        },
+        () => {
+            alert('Whoops!');
+        },
+    );
 
 const sessionstart = () => {
-    alert("Session has started");
+    alert('Session has started');
 };
-hello.on("auth.login", sessionstart);
+hello.on('auth.login', sessionstart);
 
-hello.off("auth.login", sessionstart);
+hello.off('auth.login', sessionstart);
 
-hello("facebook").login({ scope: "friends,photos,publish" });
+hello('facebook').login({ scope: 'friends,photos,publish' });

--- a/types/hellojs/index.d.ts
+++ b/types/hellojs/index.d.ts
@@ -1,11 +1,10 @@
-// Type definitions for hello.js 1.16
+// Type definitions for hello.js 1.19
 // Project: https://adodson.com/hello.js
 // Definitions by: Pavel Zika <https://github.com/PavelPZ>
 //                 Mikko Vuorinen <https://github.com/vuorinem>
 //                 Vincent Biret <https://github.com/baywet>
 //                 Batuhan Wilhelm <https://github.com/batuhanw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 export = hello;
 export as namespace hello;
@@ -125,8 +124,7 @@ declare namespace hello {
     }
 
     interface HelloJSStatic extends HelloJSEvent {
-        init(serviceAppIds: { [id: string]: string; }, options?: HelloJSLoginOptions): void;
-        init(servicesDef: { [id: string]: HelloJSServiceDef; }): void;
+        init(serviceAppIds: { [id: string]: string | HelloJSServiceDef; }, options?: HelloJSLoginOptions): void;
         login(callback: () => void): PromiseLike<HelloJSLoginEventArguement>;
         login(options?: HelloJSLoginOptions, callback?: () => void): PromiseLike<HelloJSLoginEventArguement>;
         login(network?: string, options?: HelloJSLoginOptions, callback?: () => void): PromiseLike<HelloJSLoginEventArguement>;
@@ -160,6 +158,7 @@ declare namespace hello {
     type HelloJSUrlMappingFunction = (p: any, callback: (url: string) => void) => void;
 
     interface HelloJSServiceDef {
+        id?: string | undefined;
         name?: string | undefined;
         oauth: HelloJSOAuth2Def | HelloJSOAuth1Def;
         scope?: { [id: string]: string; } | undefined;

--- a/types/hellojs/index.d.ts
+++ b/types/hellojs/index.d.ts
@@ -124,7 +124,7 @@ declare namespace hello {
     }
 
     interface HelloJSStatic extends HelloJSEvent {
-        init(serviceAppIds: { [id: string]: string | HelloJSServiceDef; }, options?: HelloJSLoginOptions): void;
+        init(serviceAppIdsOrDefs: { [id: string]: string | HelloJSServiceDef; }, options?: HelloJSLoginOptions): void;
         login(callback: () => void): PromiseLike<HelloJSLoginEventArguement>;
         login(options?: HelloJSLoginOptions, callback?: () => void): PromiseLike<HelloJSLoginEventArguement>;
         login(network?: string, options?: HelloJSLoginOptions, callback?: () => void): PromiseLike<HelloJSLoginEventArguement>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Here](https://github.com/MrSwitch/hello.js/blob/db93ed744be652cf6a72f2a7311a488c4df8af13/src/hello.js#L138) is the function definition for `init` in the latest released version.
  There is an overload in `index.d.ts` for the `init` method to allow a pattern that is not documented in the source repo but is useful for consumers: Passing a map of services => HelloJSServiceDefs, instead of a map of services => clientIds.
  This PR makes the service-map argument more flexible, to permit the workaround in [this comment](https://github.com/MrSwitch/hello.js/issues/585#issuecomment-849492078), and to permit `options` as the second argument.
  - Added id as an optional property to`HelloJSServiceDef`. When the service has a `clientId` in `init`, [hello adds an id to the service definition](https://github.com/MrSwitch/hello.js/blob/db93ed744be652cf6a72f2a7311a488c4df8af13/src/hello.js#L150). It also works to add the id as part of a partial service definition.

  
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - there were no notable API changes since the version in the header in DefinitelyTyped, [1.16](https://github.com/MrSwitch/hello.js/compare/v1.16.0...v1.19.5). I bumped the version to reflect that it's up to date.
  
  
## Summary:
* update `HelloJSStatic#init` definition to be more permissive
* add optional `id` to HelloJSServiceDef
* update version to latest minor version of hello.js
* remove typescript 2.3 from header (happy to roll this back, just a bit of housekeeping)
