### PR TITLE
Ember: no more `.extend()` calls

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -892,11 +892,8 @@ export namespace DS {
      * A `ManyArray` is a `MutableArray` that represents the contents of a has-many
      * relationship.
      */
-    interface ManyArray<T> extends Ember.MutableArray<T> {}
-    class ManyArray<T> extends Ember.Object.extend(
-        Ember.MutableArray as {},
-        Ember.Evented
-    ) {
+    interface ManyArray<T> extends Ember.MutableArray<T>, Evented {}
+    class ManyArray<T> extends Ember.Object {
         /**
          * The loading state of this array
          */

--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -892,6 +892,7 @@ export namespace DS {
      * A `ManyArray` is a `MutableArray` that represents the contents of a has-many
      * relationship.
      */
+    // tslint:disable-next-line:no-empty-interface -- used for declaration merge
     interface ManyArray<T> extends Ember.MutableArray<T>, Evented {}
     class ManyArray<T> extends Ember.Object {
         /**

--- a/types/ember__array/proxy.d.ts
+++ b/types/ember__array/proxy.d.ts
@@ -19,6 +19,7 @@ interface EmberArrayLike<T> {
  * behave as expected. [`Ember.A`](https://api.emberjs.com/ember/release/functions/@ember%2Farray/A)
  * may be used in this case.
  */
+// tslint:disable-next-line:no-empty-interface -- used for declaration merge
 interface ArrayProxy<T> extends MutableArray<T> {}
 declare class ArrayProxy<T> extends EmberObject {
     content: T[] | EmberArrayLike<T>;

--- a/types/ember__array/proxy.d.ts
+++ b/types/ember__array/proxy.d.ts
@@ -20,7 +20,7 @@ interface EmberArrayLike<T> {
  * may be used in this case.
  */
 interface ArrayProxy<T> extends MutableArray<T> {}
-declare class ArrayProxy<T> extends EmberObject.extend(MutableArray as {}) {
+declare class ArrayProxy<T> extends EmberObject {
     content: T[] | EmberArrayLike<T>;
 
     /**

--- a/types/ember__component/-private/core-view.d.ts
+++ b/types/ember__component/-private/core-view.d.ts
@@ -8,4 +8,5 @@ import ActionHandler from '@ember/object/-private/action-handler';
  *
  * Unless you have specific needs for CoreView, you will use Ember.Component in your applications.
  */
-export default class CoreView extends EmberObject.extend(Evented, ActionHandler) {}
+export default class CoreView extends EmberObject {}
+export default interface CoreView extends Evented, ActionHandler {}

--- a/types/ember__component/-private/core-view.d.ts
+++ b/types/ember__component/-private/core-view.d.ts
@@ -9,4 +9,5 @@ import ActionHandler from '@ember/object/-private/action-handler';
  * Unless you have specific needs for CoreView, you will use Ember.Component in your applications.
  */
 export default class CoreView extends EmberObject {}
+// tslint:disable-next-line:no-empty-interface -- used for declaration merge
 export default interface CoreView extends Evented, ActionHandler {}

--- a/types/ember__controller/index.d.ts
+++ b/types/ember__controller/index.d.ts
@@ -44,11 +44,10 @@ export interface ControllerMixin extends ActionHandler {
     target: object;
 }
 export const ControllerMixin: Mixin<ControllerMixin>;
-export default class Controller extends EmberObject.extend(ControllerMixin) {}
+export default class Controller extends EmberObject {}
+export default interface Controller extends ControllerMixin {}
 export function inject(): ComputedProperty<Controller>;
-export function inject<K extends keyof Registry>(
-    name: K
-): ComputedProperty<Registry[K]>;
+export function inject<K extends keyof Registry>(name: K): ComputedProperty<Registry[K]>;
 export function inject(target: object, propertyKey: string | symbol): void;
 
 // A type registry for Ember `Controller`s. Meant to be declaration-merged

--- a/types/ember__controller/index.d.ts
+++ b/types/ember__controller/index.d.ts
@@ -45,9 +45,12 @@ export interface ControllerMixin extends ActionHandler {
 }
 export const ControllerMixin: Mixin<ControllerMixin>;
 export default class Controller extends EmberObject {}
+// tslint:disable-next-line:no-empty-interface -- used for declaration merge
 export default interface Controller extends ControllerMixin {}
 export function inject(): ComputedProperty<Controller>;
-export function inject<K extends keyof Registry>(name: K): ComputedProperty<Registry[K]>;
+export function inject<K extends keyof Registry>(
+    name: K
+): ComputedProperty<Registry[K]>;
 export function inject(target: object, propertyKey: string | symbol): void;
 
 // A type registry for Ember `Controller`s. Meant to be declaration-merged

--- a/types/ember__engine/index.d.ts
+++ b/types/ember__engine/index.d.ts
@@ -45,6 +45,7 @@ export default class Engine extends EmberObject {
     buildInstance(options?: object): EngineInstance;
 }
 
+// tslint:disable-next-line:no-empty-interface -- used for declaration merge
 export default interface Engine extends RegistryProxyMixin {}
 
 /**

--- a/types/ember__engine/index.d.ts
+++ b/types/ember__engine/index.d.ts
@@ -17,7 +17,8 @@ import Resolver from 'ember-resolver';
  * The `Engine` class contains core functionality for both applications and
  * engines.
  */
-export default class Engine extends EmberObject.extend(RegistryProxyMixin) {
+
+export default class Engine extends EmberObject {
     /**
      * The goal of initializers should be to register dependencies and injections.
      * This phase runs once. Because these initializers may load code, they are
@@ -43,6 +44,8 @@ export default class Engine extends EmberObject.extend(RegistryProxyMixin) {
      */
     buildInstance(options?: object): EngineInstance;
 }
+
+export default interface Engine extends RegistryProxyMixin {}
 
 /**
  * `getEngineParent` retrieves an engine instance's parent instance.

--- a/types/ember__object/index.d.ts
+++ b/types/ember__object/index.d.ts
@@ -23,6 +23,7 @@ import ComputedProperty from '@ember/object/computed';
  * see the documentation for each of these.
  */
 export default class EmberObject extends CoreObject {}
+// tslint:disable-next-line:no-empty-interface -- used for declaration merge
 export default interface EmberObject extends Observable {}
 
 /**

--- a/types/ember__object/index.d.ts
+++ b/types/ember__object/index.d.ts
@@ -22,7 +22,8 @@ import ComputedProperty from '@ember/object/computed';
  * of `Ember.CoreObject` with the `Ember.Observable` mixin applied. For details,
  * see the documentation for each of these.
  */
-export default class EmberObject extends CoreObject.extend(Observable) {}
+export default class EmberObject extends CoreObject {}
+export default interface EmberObject extends Observable {}
 
 /**
  * This helper returns a new property descriptor that wraps the passed computed

--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -523,4 +523,5 @@ export default class Route<Model = unknown, Params extends object = object> exte
     buildRouteInfoMetadata(): unknown;
 }
 
+// tslint:disable-next-line:no-empty-interface -- used for declaration merge
 export default interface Route<Model = unknown, Params extends object = object> extends ActionHandler, Evented {}

--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import ActionHandler from '@ember/object/-private/action-handler';
 import Transition from '@ember/routing/transition';
 import Evented from '@ember/object/evented';
-import { RenderOptions, RouteQueryParam } from '@ember/routing/types';
+import { RouteQueryParam } from '@ember/routing/types';
 import Controller from '@ember/controller';
 
 // tslint:disable-next-line:strict-export-declare-modifiers
@@ -12,8 +12,7 @@ type RouteModel = object | string | number;
  * The `Ember.Route` class is used to define individual routes. Refer to
  * the [routing guide](http://emberjs.com/guides/routing/) for documentation.
  */
-export default class Route<Model = unknown, Params extends object = object>
-    extends EmberObject.extend(ActionHandler, Evented) {
+export default class Route<Model = unknown, Params extends object = object> extends EmberObject {
     // methods
     /**
      * This hook is called after this route's model has resolved. It follows
@@ -523,3 +522,5 @@ export default class Route<Model = unknown, Params extends object = object>
      */
     buildRouteInfoMetadata(): unknown;
 }
+
+export default interface Route<Model = unknown, Params extends object = object> extends ActionHandler, Evented {}

--- a/types/ember__routing/router.d.ts
+++ b/types/ember__routing/router.d.ts
@@ -8,7 +8,7 @@ import RouterService from "@ember/routing/router-service";
  * The `Ember.Router` class manages the application state and URLs. Refer to
  * the [routing guide](http://emberjs.com/guides/routing/) for documentation.
  */
-export default class Router extends EmberObject.extend(Evented) {
+export default class Router extends EmberObject {
     /**
      * The `Router.map` function allows you to define mappings from URLs to routes
      * in your application. These mappings are defined within the
@@ -35,6 +35,8 @@ export default class Router extends EmberObject.extend(Evented) {
     transitionTo(name: string, ...models: any[]): Transition;
     transitionTo(name: string, options: {}): Transition;
 }
+
+export default interface Router extends Evented {}
 
 declare module '@ember/service' {
     interface Registry {

--- a/types/ember__routing/router.d.ts
+++ b/types/ember__routing/router.d.ts
@@ -36,6 +36,7 @@ export default class Router extends EmberObject {
     transitionTo(name: string, options: {}): Transition;
 }
 
+// tslint:disable-next-line:no-empty-interface -- used for declaration merge
 export default interface Router extends Evented {}
 
 declare module '@ember/service' {


### PR DESCRIPTION
These shouldn't actually be legal in TS definition files, and they *definitely* don't do what people think/want them to: it's bizarre that this works at all. Remove them in favor of interface merging!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. **N/A, annoyingly enough: everything works as it did before.**
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition: **N/A**
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
