### PR TITLE
[share-api-polyfill] Pinterest option support

### DIFF
--- a/types/share-api-polyfill/index.d.ts
+++ b/types/share-api-polyfill/index.d.ts
@@ -21,6 +21,7 @@ export interface ShareAPIPolyfillOptions {
     linkedin?: boolean | undefined;
     telegram?: boolean | undefined;
     skype?: boolean | undefined;
+    pinterest?: boolean | undefined;
     language?: string | undefined;
 }
 

--- a/types/share-api-polyfill/share-api-polyfill-tests.ts
+++ b/types/share-api-polyfill/share-api-polyfill-tests.ts
@@ -2,5 +2,5 @@ import { ShareAPIPolyfillOptions } from 'share-api-polyfill';
 
 navigator.share({ url: 'https://example.com' }); // $ExpectType Promise<void>
 navigator.share({ url: 'https://example.com', hashtags: 'example' }); // $ExpectType Promise<void>
-navigator.share({ title: 'Example' }, { sms: false, language: 'en' }); // $ExpectType Promise<void>
+navigator.share({ title: 'Example' }, { sms: false, language: 'en', pinterest: false }); // $ExpectType Promise<void>
 const options: ShareAPIPolyfillOptions = { copy: false };


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/on2-dev/share-api-polyfill/commit/10dafd5c5c29e6df996b54ec708d6ca8c734218e#diff-7ca1d05369990f8bfa7e35442ccbb8aba2c8a811241d3b7edebc1c4e8efa2a20)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
(header says 1.0, and pinterest option was added in 1.0.21, do i need to change it in the header anyway ?)
