### PR TITLE
mapbox-gl-draw: Amend function signatures, object properties

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -3,8 +3,12 @@
 // Definitions by: Tudor Gergely <https://github.com/tudorgergely>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Feature, GeoJSON, FeatureCollection, Geometry, Point, Position, BBox } from 'geojson';
-import { IControl, Map, MapMouseEvent, MapTouchEvent } from 'mapbox-gl';
+import { Feature, GeoJSON, FeatureCollection, Geometry, Point, Position, BBox, GeoJsonProperties } from 'geojson';
+import {
+    IControl, Map,
+    MapMouseEvent as MapboxMapMouseEvent,
+    MapTouchEvent as MapboxMapTouchEvent,
+} from 'mapbox-gl';
 
 export = MapboxDraw;
 export as namespace MapboxDraw;
@@ -48,6 +52,9 @@ declare namespace MapboxDraw {
     }
 
     interface DrawFeature {
+        properties: GeoJsonProperties;
+        coordinates: Position;
+
         changed(): void;
 
         incomingCoords(coords: Position): void;
@@ -59,6 +66,13 @@ declare namespace MapboxDraw {
         setProperty(property: string, value: any): void;
 
         toGeoJSON(): GeoJSON;
+    }
+
+    interface MapMouseEvent extends MapboxMapMouseEvent {
+        featureTarget: DrawFeature;
+    }
+    interface MapTouchEvent extends MapboxMapTouchEvent {
+        featureTarget: DrawFeature;
     }
 
     interface DrawEvent {
@@ -117,9 +131,9 @@ declare namespace MapboxDraw {
     }
 
     interface DrawCustomModeThis {
-        setSelected(features: DrawFeature[]): void;
+        setSelected(features?: string | string[]): void;
 
-        setSelectedCoordinates(coords: { coord_path: string; feature_id: string }): void;
+        setSelectedCoordinates(coords: Array<{ coord_path: string; feature_id: string }>): void;
 
         getSelected(): DrawFeature[];
 

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -57,6 +57,21 @@ const customMode: CustomMode = {
     onClick(state, e) {
         // $ExpectType LngLat
         e.lngLat;
+        // $ExpectType DrawFeature
+        e.featureTarget;
+
+        this.setSelectedCoordinates([{
+            coord_path: '0',
+            feature_id: '1',
+        }]);
+
+        this.setSelected();
+        this.setSelected('1');
+        this.setSelected(['1', '2']);
+
+        // $ExpectType DrawFeature
+        const feat = this.getFeature('1');
+        feat.setCoordinates(feat.coordinates);
 
         // $ExpectType number
         this.customMethod();


### PR DESCRIPTION
A random smattering of functions (like `setSelected`) and objects (like
`DrawFeature`) did not match source reality. Some are through no fault of any
type writers; their documentation also don't match reality.

- [DrawFeature properties](https://github.com/mapbox/mapbox-gl-draw/blob/0efdb4d14a0ecae37cfe467334aaa5b2e501f702/src/feature_types/feature.js#L6-L7)
- [MapMouse and MapTouch events](https://github.com/mapbox/mapbox-gl-draw/blob/2b9ce3e58e3695c018a48b6fca78ed1a9d1b67c2/src/events.js#L48) (among others)
- `setSelected`: [Mode definition](https://github.com/mapbox/mapbox-gl-draw/blob/2b9ce3e58e3695c018a48b6fca78ed1a9d1b67c2/src/modes/mode_interface_accessors.js#L14-L19) verbatim calls [the store function](https://github.com/mapbox/mapbox-gl-draw/blob/2b9ce3e58e3695c018a48b6fca78ed1a9d1b67c2/src/store.js#L204-L212); the former is mistyped
- [`setSelectedCoordinates`](https://github.com/mapbox/mapbox-gl-draw/blob/2b9ce3e58e3695c018a48b6fca78ed1a9d1b67c2/src/modes/mode_interface_accessors.js#L23-L28) receives an array

This commit addresses multiple unrelated points. I'm unsure what's accepted practice here; if there's any preference or need I can split the commit without a problem.

Thanks for your time.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (urls in the commit message)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.