### PR TITLE
fix(yargs): add error parameter to getCompletion callback

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -339,6 +339,7 @@ declare namespace yargs {
          * @param done The callback to be called with the resulting completions.
          */
         getCompletion(args: ReadonlyArray<string>, done: (err: Error|null, completions: ReadonlyArray<string>) => void): Argv<T>;
+        getCompletion(args: ReadonlyArray<string>, done?: never): Promise<ReadonlyArray<string>>;
 
         /**
          * Returns a promise which resolves to a string containing the help text.

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -338,7 +338,7 @@ declare namespace yargs {
          * @param args An array of the words in the command line to complete.
          * @param done The callback to be called with the resulting completions.
          */
-        getCompletion(args: ReadonlyArray<string>, done: (completions: ReadonlyArray<string>) => void): Argv<T>;
+        getCompletion(args: ReadonlyArray<string>, done: (err: Error|null, completions: ReadonlyArray<string>) => void): Argv<T>;
 
         /**
          * Returns a promise which resolves to a string containing the help text.

--- a/types/yargs/ts4.1/index.d.ts
+++ b/types/yargs/ts4.1/index.d.ts
@@ -325,7 +325,7 @@ declare namespace yargs {
          * @param args An array of the words in the command line to complete.
          * @param done The callback to be called with the resulting completions.
          */
-        getCompletion(args: ReadonlyArray<string>, done: (completions: ReadonlyArray<string>) => void): Argv<T>;
+         getCompletion(args: ReadonlyArray<string>, done: (err: Error|null, completions: ReadonlyArray<string>) => void): Argv<T>;
 
         /**
          * Returns a promise which resolves to a string containing the help text.

--- a/types/yargs/ts4.1/index.d.ts
+++ b/types/yargs/ts4.1/index.d.ts
@@ -325,7 +325,8 @@ declare namespace yargs {
          * @param args An array of the words in the command line to complete.
          * @param done The callback to be called with the resulting completions.
          */
-         getCompletion(args: ReadonlyArray<string>, done: (err: Error|null, completions: ReadonlyArray<string>) => void): Argv<T>;
+        getCompletion(args: ReadonlyArray<string>, done: (err: Error|null, completions: ReadonlyArray<string>) => void): Argv<T>;
+        getCompletion(args: ReadonlyArray<string>, done?: never): Promise<ReadonlyArray<string>>;
 
         /**
          * Returns a promise which resolves to a string containing the help text.

--- a/types/yargs/ts4.1/yargs-tests.ts
+++ b/types/yargs/ts4.1/yargs-tests.ts
@@ -745,8 +745,11 @@ function Argv$getCompletion() {
         .option('foobar', {})
         .option('foobaz', {})
         .completion()
-        .getCompletion(['./test.js', '--foo'], (completions) => {
-            console.log(completions);
+        .getCompletion(['./test.js', '--foo'], (err, completions) => {
+          if (err !== null) {
+            console.error(err.message);
+          }
+          console.log(completions.length);
         })
         .argv;
 }

--- a/types/yargs/ts4.1/yargs-tests.ts
+++ b/types/yargs/ts4.1/yargs-tests.ts
@@ -754,6 +754,17 @@ function Argv$getCompletion() {
         .argv;
 }
 
+function Argv$getCompletionPromise() {
+    const ya = yargs
+        .option('foobar', {})
+        .option('foobaz', {})
+        .completion()
+        .getCompletion(['./test.js', '--foo'])
+        .then(completions => {
+          console.log(completions.length);
+        });
+}
+
 function Argv$getHelp() {
 	const ya = yargs.getHelp().then((help: string) => {
             console.log(help);

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -786,6 +786,17 @@ function Argv$getCompletion() {
         .argv;
 }
 
+function Argv$getCompletionPromise() {
+    const ya = yargs
+        .option('foobar', {})
+        .option('foobaz', {})
+        .completion()
+        .getCompletion(['./test.js', '--foo'])
+        .then(completions => {
+          console.log(completions.length);
+        });
+}
+
 function Argv$getHelp() {
 	const ya = yargs.getHelp().then((help: string) => {
             console.log(help);

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -777,8 +777,11 @@ function Argv$getCompletion() {
         .option('foobar', {})
         .option('foobaz', {})
         .completion()
-        .getCompletion(['./test.js', '--foo'], (completions) => {
-            console.log(completions);
+        .getCompletion(['./test.js', '--foo'], (err, completions) => {
+          if (err !== null) {
+            console.error(err.message);
+          }
+          console.log(completions.length);
         })
         .argv;
 }


### PR DESCRIPTION
The type of the callback for `getCompletion` has changed since v17 and the type declarations are outdated.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/yargs/yargs/commit/6ad2be0cb564cbcf01f5148db05e8cf999057caf#diff-a6b47d9a7a59d2fffb8a85bce2005db20344af8fc1b70a8dddd6400633ba1862>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
