### PR TITLE
Update vue@2.7.9 dependents

### DIFF
--- a/types/vue-feather-icons/index.d.ts
+++ b/types/vue-feather-icons/index.d.ts
@@ -15,8 +15,7 @@ export type FeatherIconComponent = ExtendedVue<
   {},
   {},
   {},
-  FeatherIconProps,
-  {}
+  FeatherIconProps
   >;
 export const ActivityIcon: FeatherIconComponent;
 export const AirplayIcon: FeatherIconComponent;

--- a/types/vue-select/index.d.ts
+++ b/types/vue-select/index.d.ts
@@ -238,7 +238,7 @@ type ComputedValues = {
     [K in keyof VueSelectComputed]: ReturnType<VueSelectComputed[K]>;
 };
 
-export type VueSelectInstance = InstanceType<ExtendedVue<Vue, VueSelectData, VueSelectMethods, ComputedValues, VueSelectProps, {}>> & {
+export type VueSelectInstance = InstanceType<ExtendedVue<Vue, VueSelectData, VueSelectMethods, ComputedValues, VueSelectProps>> & {
     $refs: {
         search: HTMLInputElement;
         toggle: HTMLDivElement;


### PR DESCRIPTION
The sixth parameter of ExtendedVue now has a default, so lint rules forbid passing the default type to it.
