### PR TITLE
feat: improve the return type of `GraphPointer#isList`

### DIFF
--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -290,8 +290,13 @@ function testList() {
 }
 
 function testIsList() {
-    const cf: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
-    const listNodes: boolean = cf.isList();
+    const anyPtr: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
+    const isList: boolean = anyPtr.isList();
+
+    if (anyPtr.isList()) {
+        const graphPtr: clownface.GraphPointer<NamedNode, Dataset> = anyPtr;
+        const listNodes: Iterable<clownface.AnyPointer<NamedNode, Dataset>> = anyPtr.list();
+    }
 }
 
 function testLiteral() {

--- a/types/clownface/clownface-tests.ts
+++ b/types/clownface/clownface-tests.ts
@@ -286,7 +286,7 @@ function testIn() {
 
 function testList() {
     const cf: clownface.AnyPointer<NamedNode, Dataset> = <any> {};
-    const listNodes: Iterable<clownface.AnyPointer<NamedNode, Dataset>> | null = cf.list();
+    const listNodes: Iterable<clownface.AnyPointer<Term, Dataset>> | null = cf.list();
 }
 
 function testIsList() {
@@ -295,7 +295,7 @@ function testIsList() {
 
     if (anyPtr.isList()) {
         const graphPtr: clownface.GraphPointer<NamedNode, Dataset> = anyPtr;
-        const listNodes: Iterable<clownface.AnyPointer<NamedNode, Dataset>> = anyPtr.list();
+        const listNodes: Iterable<clownface.AnyPointer<Term, Dataset>> = anyPtr.list();
     }
 }
 

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -62,8 +62,8 @@ declare namespace clownface {
     readonly datasets: D[];
     readonly _context: Array<Context<D, Term>>;
     any(): AnyPointer<AnyContext, D>;
-    list(): Iterable<Iteratee<T, D>> | null;
-    isList(): this is ListPointer<T, D>;
+    list(): Iterable<Iteratee<Term, D>> | null;
+    isList(): this is T extends BlankNode | NamedNode ? ListPointer<T, D> : never;
     toArray(): Array<AnyPointer<ExtractContext<T>, D>>;
     filter<S extends T>(cb: FilterCallback<T, D, S>): AnyPointer<S, D>;
     filter(cb: (ptr: Iteratee<T, D>, index: number, pointers: Array<GraphPointer<ExtractContext<T>>>) => boolean): AnyPointer<T, D>;
@@ -117,7 +117,7 @@ declare namespace clownface {
   }
 
   interface ListPointer<T extends Term = Term, D extends DatasetCore = DatasetCore> extends GraphPointer<T, D> {
-    list(): Iterable<Iteratee<T, D>>
+    list(): Iterable<Iteratee<Term, D>>;
   }
 
   type MultiPointer<T extends Term = Term, D extends DatasetCore = DatasetCore> = AnyPointer<T | T[], D>;

--- a/types/clownface/index.d.ts
+++ b/types/clownface/index.d.ts
@@ -63,7 +63,7 @@ declare namespace clownface {
     readonly _context: Array<Context<D, Term>>;
     any(): AnyPointer<AnyContext, D>;
     list(): Iterable<Iteratee<T, D>> | null;
-    isList(): boolean;
+    isList(): this is ListPointer<T, D>;
     toArray(): Array<AnyPointer<ExtractContext<T>, D>>;
     filter<S extends T>(cb: FilterCallback<T, D, S>): AnyPointer<S, D>;
     filter(cb: (ptr: Iteratee<T, D>, index: number, pointers: Array<GraphPointer<ExtractContext<T>>>) => boolean): AnyPointer<T, D>;
@@ -114,6 +114,10 @@ declare namespace clownface {
     deleteIn(predicates?: SingleOrArrayOfTerms<Term>, subjects?: SingleOrArrayOfTerms<Term>): AnyPointer<T, D>;
     deleteOut(predicates?: SingleOrArrayOfTerms<Term>, objects?: SingleOrArrayOfTerms<Term>): AnyPointer<T, D>;
     deleteList(predicates: SingleOrArrayOfTerms<Term>): AnyPointer<T, D>;
+  }
+
+  interface ListPointer<T extends Term = Term, D extends DatasetCore = DatasetCore> extends GraphPointer<T, D> {
+    list(): Iterable<Iteratee<T, D>>
   }
 
   type MultiPointer<T extends Term = Term, D extends DatasetCore = DatasetCore> = AnyPointer<T | T[], D>;


### PR DESCRIPTION
By making the return type a guard, having called `isList()` in a conditional will ensure that `list()` will not return null that it could

```js
// this can be null
const iterator = ptr.list()

if (ptr.isList()) {
  // this will not be null
  const iterator = ptr.list()
}
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
