### PR TITLE
Add types for getComponentTemplate

### DIFF
--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -114,15 +114,14 @@ export function setComponentManager<T>(managerFactory: (owner: unknown) => Compo
 /**
  * Takes a component class and returns the template associated with the given component class,
  * if any, or one of its superclasses, if any, or undefined if no template association was found.
- * 
+ *
  * Prescribed in the Component Templates Co-location RFC
  * https://rfcs.emberjs.com/id/0481-component-templates-co-location/#low-level-primitives
- * 
+ *
  * @param object the component object
  * @return the template factory of the given component
  */
  export function getComponentTemplate(obj: object): TemplateFactory | undefined;
-
 
 // In normal TypeScript, these built-in components are essentially opaque tokens
 // that just need to be importable. Declaring them with unique interfaces

--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -111,6 +111,19 @@ export default class Component<S = unknown> extends CoreView {
  */
 export function setComponentManager<T>(managerFactory: (owner: unknown) => ComponentManager<unknown>, object: T): T;
 
+/**
+ * Takes a component class and returns the template associated with the given component class,
+ * if any, or one of its superclasses, if any, or undefined if no template association was found.
+ * 
+ * Prescribed in the Component Templates Co-location RFC
+ * https://rfcs.emberjs.com/id/0481-component-templates-co-location/#low-level-primitives
+ * 
+ * @param object the component object
+ * @return the template factory of the given component
+ */
+ export function getComponentTemplate(obj: object): TemplateFactory | undefined;
+
+
 // In normal TypeScript, these built-in components are essentially opaque tokens
 // that just need to be importable. Declaring them with unique interfaces
 // like this, however, gives tools like Glint (that DO have a richer

--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -115,9 +115,6 @@ export function setComponentManager<T>(managerFactory: (owner: unknown) => Compo
  * Takes a component class and returns the template associated with the given component class,
  * if any, or one of its superclasses, if any, or undefined if no template association was found.
  *
- * Prescribed in the Component Templates Co-location RFC
- * https://rfcs.emberjs.com/id/0481-component-templates-co-location/#low-level-primitives
- *
  * @param object the component object
  * @return the template factory of the given component
  */

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -156,8 +156,8 @@ class SigExample extends Component<MySig> {
     }
 }
 
-const templateFactory = getComponentTemplate(component1);
-assertExtendsType<object | undefined>(templateFactory);
+// $ExpectType object | undefined
+getComponentTemplate(component1);
 
 // @ts-expect-error
 getComponentTemplate('foo');

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -1,7 +1,7 @@
-import Component from '@ember/component';
+import Component, { getComponentTemplate } from '@ember/component';
 import Object, { computed, get } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
-import { assertType } from './lib/assert';
+import { assertExtendsType, assertType } from './lib/assert';
 
 Component.extend({
     layout: hbs`
@@ -155,3 +155,7 @@ class SigExample extends Component<MySig> {
         return `${name} is ${age} years old`;
     }
 }
+
+
+const templateFactory = getComponentTemplate(component1);
+assertExtendsType<object | undefined>(templateFactory)

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -1,7 +1,7 @@
 import Component, { getComponentTemplate } from '@ember/component';
 import Object, { computed, get } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
-import { assertExtendsType, assertType } from './lib/assert';
+import { assertType } from './lib/assert';
 
 Component.extend({
     layout: hbs`

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -156,6 +156,8 @@ class SigExample extends Component<MySig> {
     }
 }
 
-
 const templateFactory = getComponentTemplate(component1);
-assertExtendsType<object | undefined>(templateFactory)
+assertExtendsType<object | undefined>(templateFactory);
+
+// @ts-expect-error
+getComponentTemplate('foo');

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -156,7 +156,7 @@ class SigExample extends Component<MySig> {
     }
 }
 
-// $ExpectType object | undefined
+// $ExpectType TemplateFactory | undefined
 getComponentTemplate(component1);
 
 // @ts-expect-error

--- a/types/ember__component/test/lib/assert.ts
+++ b/types/ember__component/test/lib/assert.ts
@@ -1,5 +1,2 @@
 /** Static assertion that `value` has type `T` */
 export declare function assertType<T>(value: T): T;
-
-// tslint:disable-next-line:no-unnecessary-generics
-export declare function assertExtendsType<P, T extends P = P>(value: T): T;

--- a/types/ember__component/test/lib/assert.ts
+++ b/types/ember__component/test/lib/assert.ts
@@ -1,4 +1,5 @@
 /** Static assertion that `value` has type `T` */
 export declare function assertType<T>(value: T): T;
 
+// tslint:disable-next-line:no-unnecessary-generics
 export declare function assertExtendsType<P, T extends P = P>(value: T): T;

--- a/types/ember__component/test/lib/assert.ts
+++ b/types/ember__component/test/lib/assert.ts
@@ -1,2 +1,4 @@
 /** Static assertion that `value` has type `T` */
 export declare function assertType<T>(value: T): T;
+
+export declare function assertExtendsType<P, T extends P = P>(value: T): T;


### PR DESCRIPTION
Add types for: https://github.com/emberjs/ember.js/blob/032bdc446e83a3348e62be89c10a5dfe9a8ad474/packages/%40ember/component/index.ts#L1

Which is ultimately defined here:
https://github.com/glimmerjs/glimmer-vm/blob/4f1bef0d9a8a3c3ebd934c5b6e09de4c5f6e4468/packages/%40glimmer/manager/lib/public/template.ts

And described here:
https://rfcs.emberjs.com/id/0481-component-templates-co-location/#low-level-primitives

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
