### PR TITLE
Add optional property of title attribute

### DIFF
--- a/types/mui-image/index.d.ts
+++ b/types/mui-image/index.d.ts
@@ -29,6 +29,7 @@ interface MuiImageProps {
     width?: React.CSSProperties['width'] | number | undefined;
     wrapperClassName?: string | undefined;
     wrapperStyle?: React.CSSProperties | undefined;
+    title?: string;
 }
 
 declare const Image: React.FC<MuiImageProps>;

--- a/types/mui-image/mui-image-tests.tsx
+++ b/types/mui-image/mui-image-tests.tsx
@@ -6,5 +6,5 @@ import Image from 'mui-image';
         console.log('loaded!');
     }
 
-    return <Image src="https://picsum.photos/id/674/2000" width="50vw" onLoad={onLoad} />;
+    return <Image src="https://picsum.photos/id/674/2000" width="50vw" onLoad={onLoad} title="Image Title" />;
 })();


### PR DESCRIPTION
I need to add a title attribute to `mui-image` in my project. The title itself works, but TypeScript throws an error. So I need this addition to the type definition. Since the `{...rest}` is being used and is being applied to an `HTMLElement` it exists.

Best regards

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test mui-image`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/benmneb/mui-image/blob/master/src/Image.js#L129
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

