### PR TITLE
nova-editor-node: Add Process.stdio stream APIs

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -10,9 +10,7 @@
 
 /// <reference no-default-lib="true"/>
 /// <reference lib="es7" />
-
-type ReadableStream<T = any> = unknown;
-type WritableStream<T = any> = unknown;
+/// <reference lib="WebWorker" />
 
 /// https://docs.nova.app/api-reference/assistants-registry/
 
@@ -640,14 +638,14 @@ declare class Process {
     readonly env?: { [key: string]: string };
     readonly command: string;
     readonly pid: number;
-    readonly stdio?: [
-        ReadableStream | WritableStream | null,
-        ReadableStream | WritableStream | null,
-        ReadableStream | WritableStream | null,
+    readonly stdio: [
+        WritableStream | null,
+        ReadableStream | null,
+        ReadableStream | null,
     ];
-    readonly stdin?: ReadableStream | WritableStream | null;
-    readonly stdout?: ReadableStream | WritableStream | null;
-    readonly stderr?: ReadableStream | WritableStream | null;
+    readonly stdin:  WritableStream | null;
+    readonly stdout: ReadableStream | null;
+    readonly stderr: ReadableStream | null;
 
     onStdout(callback: (line: string) => void): Disposable;
     onStderr(callback: (line: string) => void): Disposable;
@@ -1074,8 +1072,6 @@ interface Workspace {
 
 declare function atob(data: string): string;
 declare function btoa(data: string): string;
-
-type TimerHandler = string | Function;
 
 declare function setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
 declare function clearTimeout(handle?: number): void;

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -269,6 +269,21 @@ process.onRequest('getCount', request => {
     });
 });
 
+// $ExpectType WritableStream<any> | null
+process.stdin;
+// $ExpectType WritableStreamDefaultWriter<any> | undefined
+process.stdin?.getWriter();
+
+// $ExpectType ReadableStream<any> | null
+process.stdout;
+// $ExpectType ReadableStreamDefaultReader<any> | undefined
+process.stdout?.getReader();
+
+// $ExpectType ReadableStream<any> | null
+process.stderr;
+// $ExpectType ReadableStreamDefaultReader<any> | undefined
+process.stderr?.getReader();
+
 /// https://novadocs.panic.com/api-reference/scanner/
 
 const scanner = new Scanner('Foobar abc 12.0');

--- a/types/nova-editor/index.d.ts
+++ b/types/nova-editor/index.d.ts
@@ -14,4 +14,7 @@ declare const module: { exports: any };
 declare const __filename: string;
 declare const __dirname: string;
 
-declare const console: Console;
+// WebWorker" library already declare's console, as `var` not `const`
+
+// declare const console: Console;
+declare var console: Console;

--- a/types/nova-editor/nova-editor-tests.ts
+++ b/types/nova-editor/nova-editor-tests.ts
@@ -2,3 +2,5 @@ console.log('activating...');
 console.error('deactivating...');
 console.warn('test', 1, 2, 3);
 console.assert(() => true, 'message', 1);
+console.time('quick');
+console.timeEnd('quick');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developer.mozilla.org/en-US/docs/Web/API/Streams_API>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

This PR expands (narrows?) the typings for the Process API to include the `WriteableStream`/`ReadableStream` typings (applicable on default stdio of `pipe`), as pulled from TypeScript's WebWorker lib. Also deleted a minor declaration made redundant by referencing that library.

Nova's docs on Process streams link to MDN's [Stream API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) section, so I assume their (or JSC's) interface isn't doing anything *too* unique behind the scenes.