### PR TITLE
fix: `@types/react-dom/test-utils` - corrects `act` signature

### DIFF
--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -281,23 +281,16 @@ export function createRenderer(): ShallowRenderer;
  * Wrap any code rendering and triggering updates to your components into `act()` calls.
  *
  * Ensures that the behavior in your tests matches what happens in the browser
- * more closely by executing pending `useEffect`s before returning. This also
- * reduces the amount of re-renders done.
+ * more closely by executing pending `useEffect`s before returning.
+ * 
+ * All `useEffect`s scheduled by the actions within the callback will be condensed into
+ * a single action, with only the latest values returned, to improve the efficiency of the test.
  *
- * @param callback A synchronous, void callback that will execute as a single, complete React commit.
+ * @param callback A synchronous or asyncronous callback that will execute as a single, complete React commit.
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
  */
-// NOTES
-// - the order of these signatures matters - typescript will check the signatures in source order.
-//   If the `() => VoidOrUndefinedOnly` signature is first, it'll erroneously match a Promise returning function for users with
-//   `strictNullChecks: false`.
-// - VoidOrUndefinedOnly is there to forbid any non-void return values for users with `strictNullChecks: true`
-declare const UNDEFINED_VOID_ONLY: unique symbol;
-// tslint:disable-next-line: void-return
-type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
-export function act(callback: () => Promise<void>): Promise<undefined>;
-export function act(callback: () => VoidOrUndefinedOnly): void;
+export function act<T>(callback: () => Promise<T> | T): Promise<T>;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.


### PR DESCRIPTION
1. Corrects for the addition of returned values from the act function: https://github.com/facebook/react/pull/21759
2. Simultaneously corrects that all calls to that method will return a Thenable, and never a synchronous value.

### Proof

1. `react-dom` exports `act` [here](https://github.com/facebook/react/blob/3d443cad74bdd8f3d617c39756afe02d51f8d636/packages/react-dom/src/test-utils/ReactTestUtils.js#L732)
2. This act is a direct import of `react`'s `unstable_act`, [here](https://github.com/facebook/react/blob/3d443cad74bdd8f3d617c39756afe02d51f8d636/packages/react-dom/src/test-utils/ReactTestUtils.js#L37)
3. `react` exports `unstable_act` [here](https://github.com/facebook/react/blob/3d443cad74bdd8f3d617c39756afe02d51f8d636/packages/react/index.js#L36)
4. Following this through, `unstable_act` (renamed from `act`) is implemented [here](https://github.com/facebook/react/blob/3d443cad74bdd8f3d617c39756afe02d51f8d636/packages/react/src/ReactAct.js#L17)
5. This method **always** returns a Thenable, and the value returned by input callback

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/facebook/react/pull/21759>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
