### PR TITLE
Adding cancelButtonTintColor property to React Native ActionSheetIOS

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6864,6 +6864,7 @@ export interface ActionSheetIOSOptions {
     message?: string | undefined;
     anchor?: number | undefined;
     tintColor?: ColorValue | ProcessedColorValue | undefined;
+    cancelButtonTintColor?: ColorValue | ProcessedColorValue | undefined;
     userInterfaceStyle?: 'light' | 'dark' | undefined;
     disabledButtonIndices?: number[] | undefined;
 }

--- a/types/react-native/v0.67/index.d.ts
+++ b/types/react-native/v0.67/index.d.ts
@@ -6938,6 +6938,7 @@ export interface ActionSheetIOSOptions {
     message?: string | undefined;
     anchor?: number | undefined;
     tintColor?: ColorValue | ProcessedColorValue | undefined;
+    cancelButtonTintColor?: ColorValue | ProcessedColorValue | undefined;
     userInterfaceStyle?: 'light' | 'dark' | undefined;
     disabledButtonIndices?: number[] | undefined;
 }

--- a/types/react-native/v0.68/index.d.ts
+++ b/types/react-native/v0.68/index.d.ts
@@ -6943,6 +6943,7 @@ export interface ActionSheetIOSOptions {
     message?: string | undefined;
     anchor?: number | undefined;
     tintColor?: ColorValue | ProcessedColorValue | undefined;
+    cancelButtonTintColor?: ColorValue | ProcessedColorValue | undefined;
     userInterfaceStyle?: 'light' | 'dark' | undefined;
     disabledButtonIndices?: number[] | undefined;
 }


### PR DESCRIPTION
Hello guys, thank you for such a great job!

Since version 0.67, React Native (as shown in the official documentation) brought a new property: `cancelButtonTintColor`. So as soon as you pass this property to the options of `ActionSheetIOS.showActionSheetWithOptions(options, callback)` method, the code editor shows some red indicating that the property does not exist in the definition file.

About the unchecked options bellow, I do not know if the first one is needed and do not know exactly if and how the last one should be done.

**PS:** I closed this Pull Request because I had the wrong email set for my commits. So my commits got unverified signature. Consider [this Pull Request](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61993) please. I am sorry for that!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test react-native`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/0.67/actionsheetios
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.