### PR TITLE
Fix Showdown typing for browser 

### DIFF
--- a/types/showdown/index.d.ts
+++ b/types/showdown/index.d.ts
@@ -946,13 +946,21 @@ declare namespace Showdown {
         makeHtml(text: string): string;
 
         /**
-         * Converts an HTML string into a markdown string.
+         * Node : Converts an HTML string into a markdown string.
          *
          * @param src - The input text (HTML)
          * @param [HTMLParser] A WHATWG DOM and HTML parser, such as JSDOM. If none is supplied, window.document will be used.
          * @returns The output markdown.
          */
         makeMarkdown(src: string, HTMLParser?: HTMLDocument): string;
+        /**
+         * Browser : Converts an HTML string into a markdown string.
+         *
+         * @param src - The input text (HTML)
+         * @param [HTMLParser] A WHATWG DOM and HTML parser, such as JSDOM. If none is supplied, window.document will be used.
+         * @returns The output markdown.
+         */
+        makeMd(src: string, HTMLParser?: HTMLDocument): string;
 
         /**
          * Setting a "local" option only affects the specified Converter object.


### PR DESCRIPTION
<img width="797" alt="image" src="https://user-images.githubusercontent.com/20707343/186696229-393fc66c-3ccc-493a-8f76-ca7e747a5b7b.png">



[https://www.npmjs.com/package/showdown](https://www.npmjs.com/package/showdown)