### PR TITLE
Fix tar package's list function types

### DIFF
--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -553,7 +553,7 @@ export interface ListOptions {
      * filter. This is important for when both file and sync are set, because
      * it will be called synchronously.
      */
-    onentry?(entry: FileStat): void;
+    onentry?(entry: ReadEntry): void;
 
     /**
      * The maximum buffer size for fs.read() operations. Defaults to 16 MB.
@@ -671,6 +671,18 @@ export interface FileOptions {
     f?: string | undefined;
 }
 
+export type RequiredFileOptions = {
+    /**
+     * Uses the given file as the input or output of this function.
+     */
+    file: string;
+} | {
+    /**
+     * Alias for file.
+     */
+    f: string;
+}
+
 /**
  * Create a tarball archive. The fileList is an array of paths to add to the
  * tarball. Adding a directory also adds its children recursively. An entry in
@@ -750,23 +762,13 @@ export const x: typeof extract;
  * to list from the tarball. If no paths are provided, then all the entries
  * are listed. If the archive is gzipped, then tar will detect this and unzip
  * it.
- *
- * Archive data should be written to the returned stream.
- */
-export function list(
-    options?: ListOptions & FileOptions,
-    fileList?: ReadonlyArray<string>,
-    callback?: (err?: Error) => void,
-): stream.Writable;
-
-/**
- * List the contents of a tarball archive. The fileList is an array of paths
- * to list from the tarball. If no paths are provided, then all the entries
- * are listed. If the archive is gzipped, then tar will detect this and unzip
- * it.
  */
 export function list(options: ListOptions & FileOptions, fileList?: ReadonlyArray<string>): Promise<void>;
-export function list(options: ListOptions & FileOptions & { sync: true }, fileList?: ReadonlyArray<string>): void;
+export function list(options: ListOptions & RequiredFileOptions & { sync: true }, fileList?: ReadonlyArray<string>): void;
+export function list(callback: (err?: Error) => void): Parse;
+export function list(fileList: ReadonlyArray<string>, callback: (err?: Error) => void): Parse;
+export function list(options: ListOptions, callback: (err?: Error) => void): Parse;
+export function list(options: ListOptions, fileList: ReadonlyArray<string>, callback: (err?: Error) => void): Parse;
 
 /**
  * Alias for list

--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -249,7 +249,7 @@ export interface FileStat extends stream.Readable, Fields {
     size: number;
 }
 
-export interface ReadEntry extends MiniPass, HeaderProperties {
+export interface ReadEntry extends MiniPass.default, HeaderProperties {
     /** The extended metadata object provided to the constructor. */
     extended: any;
     /** The global extended metadata object provided to the constructor. */
@@ -681,7 +681,7 @@ export type RequiredFileOptions = {
      * Alias for file.
      */
     f: string;
-}
+};
 
 /**
  * Create a tarball archive. The fileList is an array of paths to add to the
@@ -763,12 +763,11 @@ export const x: typeof extract;
  * are listed. If the archive is gzipped, then tar will detect this and unzip
  * it.
  */
-export function list(options: ListOptions & FileOptions, fileList?: ReadonlyArray<string>): Promise<void>;
+export function list(options: ListOptions & RequiredFileOptions, fileList?: ReadonlyArray<string>): Promise<void>;
 export function list(options: ListOptions & RequiredFileOptions & { sync: true }, fileList?: ReadonlyArray<string>): void;
-export function list(callback: (err?: Error) => void): Parse;
-export function list(fileList: ReadonlyArray<string>, callback: (err?: Error) => void): Parse;
-export function list(options: ListOptions, callback: (err?: Error) => void): Parse;
-export function list(options: ListOptions, fileList: ReadonlyArray<string>, callback: (err?: Error) => void): Parse;
+export function list(callback?: (err?: Error) => void): Parse;
+export function list(optionsOrFileList: ListOptions | ReadonlyArray<string>, callback?: (err?: Error) => void): Parse;
+export function list(options: ListOptions, fileList: ReadonlyArray<string>, callback?: (err?: Error) => void): Parse;
 
 /**
  * Alias for list

--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -249,7 +249,7 @@ export interface FileStat extends stream.Readable, Fields {
     size: number;
 }
 
-export interface ReadEntry extends MiniPass.default, HeaderProperties {
+export interface ReadEntry extends MiniPass, HeaderProperties {
     /** The extended metadata object provided to the constructor. */
     extended: any;
     /** The global extended metadata object provided to the constructor. */

--- a/types/tar/tar-tests.ts
+++ b/types/tar/tar-tests.ts
@@ -77,3 +77,8 @@ fs.createReadStream('my-tarball.tgz')
 fs.createReadStream('my-tarball.tgz')
     .pipe(new tar.Parse())
     .on('entry', entry => entry.on('data', data => console.log(data)));
+
+tar.list({
+    file: "my-tarball.tgz",
+    onentry: (entry) => entry.path.slice(1),
+}).then(() => console.log("after listing"));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/npm/node-tar/blob/main/lib/list.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Looking at the code there are two things that stand out to me:
- the `onentry` callback always is given a `ReadEntry` and not a `FileStat`
- The previous ordering and specifics of `list()` meant that typing `tar.list([ file: filePath, onentry })` was not typed as `Promise<void>`