### PR TITLE
@ember/utils: make `typeOf()` smarter

### DIFF
--- a/types/ember__utils/-private/types.d.ts
+++ b/types/ember__utils/-private/types.d.ts
@@ -11,10 +11,14 @@ type _KeysOfType<Key extends keyof TypeLookup, Type> =
 type KeysOfType<Type> =
     { [Key in keyof TypeLookup]: _KeysOfType<Key, Type> }[keyof TypeLookup];
 
-// Since `TypeLookup` resolves all *other* types, including `null` and
-// `undefined`, we can assume that if the type does *not* resolve from
-// `KeysOfType`, it is safe to treat it as 'object'.
 export type TypeOf<T> =
+    // Start by handling the case where `T` is no specific type, i.e. it is
+    // `unknown`. In that case, it will be *one of* the type names, but which
+    // one we cannot know statically.
+    unknown extends T ? AllTypeNames :
+    // Otherwise, since `TypeLookup` resolves all *other* types, including
+    // `null` and `undefined`, we can assume that if the type does *not* resolve
+    // from `KeysOfType`, it is safe to treat it as 'object'.
     KeysOfType<T> extends never ? 'object' : KeysOfType<T>;
 
 export interface TypeLookup {
@@ -30,6 +34,8 @@ export interface TypeLookup {
     null: null;
     undefined: undefined;
 }
+
+type AllTypeNames = 'object' | keyof TypeLookup;
 
 // Don't export anything but the required type util
 export {};

--- a/types/ember__utils/ember__utils-tests.ts
+++ b/types/ember__utils/ember__utils-tests.ts
@@ -38,6 +38,9 @@ import { compare, isBlank, isEmpty, isEqual, isNone, isPresent, typeOf } from '@
 
 (function() {
     /** typeOf */
+    let x = "something" as unknown;
+    typeOf(x); // $ExpectType AllTypeNames
+    if (typeOf(x) === 'object') {}
     typeOf(null); // $ExpectType "null"
     typeOf(undefined); // $ExpectType "undefined"
     typeOf('michael'); // $ExpectType "string"

--- a/types/ember__utils/index.d.ts
+++ b/types/ember__utils/index.d.ts
@@ -6,7 +6,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.4
 
-import { TypeLookup, TypeOf } from './-private/types';
+import { TypeOf } from './-private/types';
 
 /**
  * Compares two javascript values and returns:
@@ -46,4 +46,3 @@ export function isPresent(obj?: unknown): boolean;
  */
 export function typeOf<T>(value: T): TypeOf<T>;
 export function typeOf(): 'undefined';
-export function typeOf(item: unknown): string;


### PR DESCRIPTION
Users have long noticed that given `unknown`, this would fail to type check when compared to `'object'`. Introduce handling for `unknown` specifically, which addresses this by falling back to a union of all the string types which `typeOf` may return.

Notably, since an unconstrained generic `typeOf<T>(t: T)` will always fall back to `unknown`, we were never actually hitting the dedicated overload for `unknown`, which is what ultimately surfaced this today.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[<url here>](https://api.emberjs.com/ember/4.6/functions/@ember%2Futils/typeOf)>
