### PR TITLE
ember-data: fix store.query resolve value

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -1136,8 +1136,7 @@ export namespace DS {
             modelName: K,
             query: object,
             options?: { adapterOptions?: object | undefined }
-        ): AdapterPopulatedRecordArray<ModelRegistry[K]> &
-            PromiseArray<ModelRegistry[K], Ember.ArrayProxy<ModelRegistry[K]>>;
+        ): PromiseArray<ModelRegistry[K], AdapterPopulatedRecordArray<ModelRegistry[K]>>;
         /**
          * This method makes a request for one record, where the `id` is not known
          * beforehand (if the `id` is known, use [`findRecord`](#method_findRecord)

--- a/types/ember-data/test/store.ts
+++ b/types/ember-data/test/store.ts
@@ -155,15 +155,22 @@ const tom = store
     });
 
 // GET /users?isAdmin=true
-const admins = store.query('user', { isAdmin: true });
-assertType<DS.AdapterPopulatedRecordArray<User> & DS.PromiseArray<User, Ember.ArrayProxy<User>>>(admins);
+const adminsQuery = store.query('user', { isAdmin: true });
+assertType<DS.PromiseArray<User, DS.AdapterPopulatedRecordArray<User>>>(adminsQuery);
 
-admins.then(function () {
-    console.log(admins.get('length')); // 42
-});
-admins.update().then(function () {
-    admins.get('isUpdating'); // false
-    console.log(admins.get('length')); // 123
+adminsQuery.then(function (admins) {
+    console.log(admins.get("length")); // 42
+
+    // somewhere later in the app code, when new admins have been created
+    // in the meantime
+    //
+    // GET /users?isAdmin=true
+    admins.update().then(function() {
+        admins.get('isUpdating'); // false
+        console.log(admins.get("length")); // 123
+    });
+
+    admins.get('isUpdating'); // true
 });
 
 store.push({

--- a/types/ember-data/v3/index.d.ts
+++ b/types/ember-data/v3/index.d.ts
@@ -1138,8 +1138,7 @@ export namespace DS {
             modelName: K,
             query: object,
             options?: { adapterOptions?: object | undefined }
-        ): AdapterPopulatedRecordArray<ModelRegistry[K]> &
-            PromiseArray<ModelRegistry[K], Ember.ArrayProxy<ModelRegistry[K]>>;
+        ): PromiseArray<ModelRegistry[K], AdapterPopulatedRecordArray<ModelRegistry[K]>>;
         /**
          * This method makes a request for one record, where the `id` is not known
          * beforehand (if the `id` is known, use [`findRecord`](#method_findRecord)

--- a/types/ember-data/v3/test/store.ts
+++ b/types/ember-data/v3/test/store.ts
@@ -155,15 +155,22 @@ const tom = store
     });
 
 // GET /users?isAdmin=true
-const admins = store.query('user', { isAdmin: true });
-assertType<DS.AdapterPopulatedRecordArray<User> & DS.PromiseArray<User, Ember.ArrayProxy<User>>>(admins);
+const adminsQuery = store.query('user', { isAdmin: true });
+assertType<DS.PromiseArray<User, DS.AdapterPopulatedRecordArray<User>>>(adminsQuery);
 
-admins.then(function () {
-    console.log(admins.get('length')); // 42
-});
-admins.update().then(function () {
-    admins.get('isUpdating'); // false
-    console.log(admins.get('length')); // 123
+adminsQuery.then(function (admins) {
+    console.log(admins.get("length")); // 42
+
+    // somewhere later in the app code, when new admins have been created
+    // in the meantime
+    //
+    // GET /users?isAdmin=true
+    admins.update().then(function() {
+        admins.get('isUpdating'); // false
+        console.log(admins.get("length")); // 123
+    });
+
+    admins.get('isUpdating'); // true
 });
 
 store.push({


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.emberjs.com/ember-data/release/classes/AdapterPopulatedRecordArray
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I've always found the return type for `store.query()` confusing. With the changes in #61873 it looks like I was relying on `any` due to `ArrayProxy` extending `EmberObject.extend()`

The docs in [`Store.query`](https://api.emberjs.com/ember-data/3.28/classes/Store/methods/query?anchor=query) state that..

> This method returns a promise, which is resolved with an [AdapterPopulatedRecordArray](https://api.emberjs.com/ember-data/release/classes/AdapterPopulatedRecordArray) once the server returns.

..and from the source I can see that `Store.query` does return a `PromiseArray`..

https://github.com/emberjs/data/blob/fbbff3dabdfcc4ced3d2ecfe8ffe8a4714fbaecb/packages/store/addon/-private/system/core-store.ts#L2037

..which does resolve with a `RecordArray`..

https://github.com/emberjs/data/blob/fbbff3dabdfcc4ced3d2ecfe8ffe8a4714fbaecb/packages/store/addon/-private/system/store/finders.js#L405-L441

I can also see this is the case while running the code in a browser console