### PR TITLE
Correct minimatch matchOne types

### DIFF
--- a/types/minimatch/index.d.ts
+++ b/types/minimatch/index.d.ts
@@ -268,7 +268,7 @@ declare namespace minimatch {
          * This method is mainly for internal use, but is exposed so that it can be used
          * by a glob-walker that needs to avoid excessive filesystem calls.
          */
-        matchOne(file: string, pattern: readonly string[], partial: boolean): boolean;
+        matchOne(file: readonly string[], pattern: readonly string[], partial: boolean): boolean;
 
         /**
          * @deprecated. For internal use.

--- a/types/minimatch/minimatch-tests.ts
+++ b/types/minimatch/minimatch-tests.ts
@@ -49,7 +49,7 @@ const res1: RegExp = mmInst.makeRe();
 const res2: false = mmInst.makeRe();
 mmInst.match(pattern); // $ExpectType boolean
 mmInst.match(pattern, true); // $ExpectType boolean
-mmInst.matchOne(pattern, files, true); // $ExpectType boolean
+mmInst.matchOne([pattern], files, true); // $ExpectType boolean
 mmInst.debug(); // $ExpectType void
 mmInst.make(); // $ExpectType void
 mmInst.parseNegate(); // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

  * [x]  Use a meaningful title for the pull request. Include the name of the package modified.
  * [x]  Test the change in your own code. (Compile and run.)
  * [x]  [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
  * [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
  * [x]  Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
  * [x]  [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:

  * [x]  Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/isaacs/minimatch

The version of `@types/minimatch` published two days ago due to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61699 introduced a bug in the types. Minimatch expects the `file` parameter of `matchOne` to be an array of strings, not a single string.

Evidence:

https://github.com/isaacs/minimatch/blob/6410ef32f59e4842121ca13eefacdf0b3da8533c/minimatch.js#L864

https://github.com/isaacs/minimatch/blob/6410ef32f59e4842121ca13eefacdf0b3da8533c/minimatch.js#L884-L888
