### PR TITLE
fix(Video.JS): Support 'video.js/dist/video.min.js' import

### DIFF
--- a/types/video.js/OTHER_FILES.txt
+++ b/types/video.js/OTHER_FILES.txt
@@ -1,2 +1,3 @@
 dist/alt/video.core.novtt.d.ts
 dist/alt/video.core.d.ts
+dist/video.min.d.ts

--- a/types/video.js/dist/video.min.d.ts
+++ b/types/video.js/dist/video.min.d.ts
@@ -1,0 +1,8 @@
+/**
+ * This provides `video.min.js` alternative distribution typings :
+ * - `import videojs from 'video.js/dist/video.min.js';`
+ * - `import('video.js/dist/video.min.js').then((videoJSBundle) => {})`
+ */
+import videojs from '../index';
+export default videojs;
+export as namespace videojs;

--- a/types/video.js/test/videojs-alt-distributions-tests.ts
+++ b/types/video.js/test/videojs-alt-distributions-tests.ts
@@ -1,8 +1,10 @@
 import { default as videojsnovtt } from 'video.js/dist/alt/video.core.novtt.js';
 import { default as videojscore } from 'video.js/dist/alt/video.core.js';
+import { default as videojsmin } from 'video.js/dist/video.min.js';
 
 test(videojsnovtt);
 test(videojscore);
+test(videojsmin);
 
 function test(videojs: typeof videojsnovtt | typeof videojscore) {
     // support for inline player ready callback with proper `this`


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [Video.js distributions](https://videojs.com/getting-started/#distributions)
  - We need types for minified bundle of video.js such as `import videojs from 'video.js/dist/video.min.js';` or `import('video.js/dist/video.min.js').then((videoJSBundle) => {})`
- [x] No new version of the JS library

Thanks and happy coding everyone :octocat: 