### PR TITLE
[benchmark] Added Suite constructor type

### DIFF
--- a/types/benchmark/benchmark-tests.ts
+++ b/types/benchmark/benchmark-tests.ts
@@ -1,6 +1,16 @@
 import Benchmark = require("benchmark");
 
+// Constructor with no params
 var suite = new Benchmark.Suite;
+
+// Constructor with name param
+var suite = new Benchmark.Suite("just name");
+
+// Constructor with name and options
+var suite = new Benchmark.Suite("name and options", { async: true });
+
+// Constructor with just options
+var suite = new Benchmark.Suite({ name: "Just options" });
 
 // add tests
 suite.add('RegExp#test', function() {

--- a/types/benchmark/index.d.ts
+++ b/types/benchmark/index.d.ts
@@ -33,7 +33,7 @@ declare class Benchmark {
     constructor(options: Benchmark.Options);
 
     id: number;
-    name: string;
+    name?: string;
     count: number;
     cycles: number;
     hz: number;
@@ -168,10 +168,12 @@ declare namespace Benchmark {
         static options: { name: string };
 
         constructor(name?: string, options?: Options);
+        constructor(options?: Options);
 
         length: number;
         aborted: boolean;
         running: boolean;
+        name?: string;
 
         abort(): Suite;
         add(name: string, fn: Function | string, options?: Options): Suite;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The documentation doesn't mention it but the [Suite constructor](https://github.com/bestiejs/benchmark.js/blob/42f3b732bac3640eddb3ae5f50e445f3141016fd/benchmark.js#L467-L483) checks if the first parameter is an object and if it is the first parameter is used as the options object. 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I also added the `name` field to `Suite` definition since it has one similarly to `Benchmark`.

I changed `Benchmark`s `name` field to be optional since it will be undefined when `Benchmark` is constructed without a name. I'm unsure if this requires a major version update.