### PR TITLE
Add type definitions for @pkgjs/parseargs

### DIFF
--- a/types/pkgjs__parseargs/index.d.ts
+++ b/types/pkgjs__parseargs/index.d.ts
@@ -1,0 +1,182 @@
+// Type definitions for @pkgjs/parseargs 0.10
+// Project: https://github.com/pkgjs/parseargs
+// Definitions by: Remco Haszing <https://github.com/remcohaszing>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Provides a high-level API for command-line argument parsing. Takes a
+ * specification for the expected arguments and returns a structured object
+ * with the parsed values and positionals.
+ *
+ * `config` provides arguments for parsing and configures the parser. It
+ * supports the following properties:
+ *
+ *   - `args` The array of argument strings. **Default:** `process.argv` with
+ *     `execPath` and `filename` removed.
+ *   - `options` Arguments known to the parser. Keys of `options` are the long
+ *     names of options and values are objects accepting the following properties:
+ *
+ *     - `type` Type of argument, which must be either `boolean` (for options
+ *        which do not take values) or `string` (for options which do).
+ *     - `multiple` Whether this option can be provided multiple
+ *       times. If `true`, all values will be collected in an array. If
+ *       `false`, values for the option are last-wins. **Default:** `false`.
+ *     - `short` A single character alias for the option.
+ *
+ *   - `strict`: Whether an error should be thrown when unknown arguments
+ *     are encountered, or when arguments are passed that do not match the
+ *     `type` configured in `options`. **Default:** `true`.
+ *   - `allowPositionals`: Whether this command accepts positional arguments.
+ *     **Default:** `false` if `strict` is `true`, otherwise `true`.
+ *   - `tokens`: Whether tokens {boolean} Return the parsed tokens. This is useful
+ *     for extending the built-in behavior, from adding additional checks through
+ *     to reprocessing the tokens in different ways.
+ *     **Default:** `false`.
+ *
+ * @returns The parsed command line arguments:
+ *
+ *   - `values` A mapping of parsed option names with their string
+ *     or boolean values.
+ *   - `positionals` Positional arguments.
+ *   - `tokens` Detailed parse information (only if `tokens` was specified).
+ *
+ */
+export function parseArgs<T extends ParseArgsConfig>(config: T): ParsedResults<T>;
+
+interface ParseArgsOptionConfig {
+    type: 'string' | 'boolean';
+    short?: string;
+    multiple?: boolean;
+}
+
+interface ParseArgsOptionsConfig {
+    [longOption: string]: ParseArgsOptionConfig;
+}
+
+export interface ParseArgsConfig {
+    strict?: boolean;
+    allowPositionals?: boolean;
+    tokens?: boolean;
+    options?: ParseArgsOptionsConfig;
+    args?: string[];
+}
+
+/*
+IfDefaultsTrue and IfDefaultsFalse are helpers to handle default values for missing boolean properties.
+TypeScript does not have exact types for objects: https://github.com/microsoft/TypeScript/issues/12936
+This means it is impossible to distinguish between "field X is definitely not present" and "field X may or may not be present".
+But we expect users to generally provide their config inline or `as const`, which means TS will always know whether a given field is present.
+So this helper treats "not definitely present" (i.e., not `extends boolean`) as being "definitely not present", i.e. it should have its default value.
+This is technically incorrect but is a much nicer UX for the common case.
+The IfDefaultsTrue version is for things which default to true; the IfDefaultsFalse version is for things which default to false.
+*/
+type IfDefaultsTrue<T, IfTrue, IfFalse> = T extends true ? IfTrue : T extends false ? IfFalse : IfTrue;
+
+// we put the `extends false` condition first here because `undefined` compares like `any` when `strictNullChecks: false`
+type IfDefaultsFalse<T, IfTrue, IfFalse> = T extends false ? IfFalse : T extends true ? IfTrue : IfFalse;
+
+type ExtractOptionValue<T extends ParseArgsConfig, O extends ParseArgsOptionConfig> = IfDefaultsTrue<
+    T['strict'],
+    O['type'] extends 'string' ? string : O['type'] extends 'boolean' ? boolean : string | boolean,
+    string | boolean
+>;
+
+type ParsedValues<T extends ParseArgsConfig> = IfDefaultsTrue<
+    T['strict'],
+    unknown,
+    { [longOption: string]: undefined | string | boolean }
+> &
+    (T['options'] extends ParseArgsOptionsConfig
+        ? {
+              -readonly [LongOption in keyof T['options']]: IfDefaultsFalse<
+                  T['options'][LongOption]['multiple'],
+                  undefined | Array<ExtractOptionValue<T, T['options'][LongOption]>>,
+                  undefined | ExtractOptionValue<T, T['options'][LongOption]>
+              >;
+          }
+        : {});
+
+type ParsedPositionals<T extends ParseArgsConfig> = IfDefaultsTrue<
+    T['strict'],
+    IfDefaultsFalse<T['allowPositionals'], string[], []>,
+    IfDefaultsTrue<T['allowPositionals'], string[], []>
+>;
+
+type PreciseTokenForOptions<K extends string, O extends ParseArgsOptionConfig> = O['type'] extends 'string'
+    ? {
+          kind: 'option';
+          index: number;
+          name: K;
+          rawName: string;
+          value: string;
+          inlineValue: boolean;
+      }
+    : O['type'] extends 'boolean'
+    ? {
+          kind: 'option';
+          index: number;
+          name: K;
+          rawName: string;
+          value: undefined;
+          inlineValue: undefined;
+      }
+    : OptionToken & { name: K };
+
+type TokenForOptions<T extends ParseArgsConfig, K extends keyof T['options'] = keyof T['options']> = K extends unknown
+    ? T['options'] extends ParseArgsOptionsConfig
+        ? PreciseTokenForOptions<K & string, T['options'][K]>
+        : OptionToken
+    : never;
+
+type ParsedOptionToken<T extends ParseArgsConfig> = IfDefaultsTrue<T['strict'], TokenForOptions<T>, OptionToken>;
+
+type ParsedPositionalToken<T extends ParseArgsConfig> = IfDefaultsTrue<
+    T['strict'],
+    IfDefaultsFalse<T['allowPositionals'], { kind: 'positional'; index: number; value: string }, never>,
+    IfDefaultsTrue<T['allowPositionals'], { kind: 'positional'; index: number; value: string }, never>
+>;
+
+type ParsedTokens<T extends ParseArgsConfig> = Array<
+    ParsedOptionToken<T> | ParsedPositionalToken<T> | { kind: 'option-terminator'; index: number }
+>;
+
+type PreciseParsedResults<T extends ParseArgsConfig> = IfDefaultsFalse<
+    T['tokens'],
+    {
+        values: ParsedValues<T>;
+        positionals: ParsedPositionals<T>;
+        tokens: ParsedTokens<T>;
+    },
+    {
+        values: ParsedValues<T>;
+        positionals: ParsedPositionals<T>;
+    }
+>;
+
+type OptionToken =
+    | { kind: 'option'; index: number; name: string; rawName: string; value: string; inlineValue: boolean }
+    | {
+          kind: 'option';
+          index: number;
+          name: string;
+          rawName: string;
+          value: undefined;
+          inlineValue: undefined;
+      };
+
+type Token =
+    | OptionToken
+    | { kind: 'positional'; index: number; value: string }
+    | { kind: 'option-terminator'; index: number };
+
+// If ParseArgsConfig extends T, then the user passed config constructed elsewhere.
+// So we can't rely on the `"not definitely present" implies "definitely not present"` assumption mentioned above.
+type ParsedResults<T extends ParseArgsConfig> = ParseArgsConfig extends T
+    ? {
+          values: { [longOption: string]: undefined | string | boolean | Array<string | boolean> };
+          positionals: string[];
+          tokens?: Token[];
+      }
+    : PreciseParsedResults<T>;
+
+export {};

--- a/types/pkgjs__parseargs/pkgjs__parseargs-tests.ts
+++ b/types/pkgjs__parseargs/pkgjs__parseargs-tests.ts
@@ -1,0 +1,79 @@
+import { parseArgs } from '@pkgjs/parseargs';
+
+{
+    // util.parseArgs: happy path
+    // tslint:disable-next-line:no-object-literal-type-assertion
+    const config = {
+        allowPositionals: true,
+        options: {
+            foo: { type: 'string' },
+            bar: { type: 'boolean', multiple: true },
+        },
+    } as const;
+
+    // $ExpectType { values: { foo: string | undefined; bar: boolean[] | undefined; }; positionals: string[]; }
+    parseArgs(config);
+}
+
+{
+    // util.parseArgs: positionals not enabled
+    // tslint:disable-next-line:no-object-literal-type-assertion
+    const config = {
+        options: {
+            foo: { type: 'string' },
+            bar: { type: 'boolean', multiple: true },
+        },
+    } as const;
+
+    // @ts-expect-error
+    parseArgs(config).positionals[0];
+}
+
+{
+    // util.parseArgs: tokens
+    // tslint:disable-next-line:no-object-literal-type-assertion
+    const config = {
+        tokens: true,
+        allowPositionals: true,
+        options: {
+            foo: { type: 'string' },
+            bar: { type: 'boolean' },
+        },
+    } as const;
+
+    // tslint:disable-next-line:max-line-length
+    // $ExpectType { kind: "positional"; index: number; value: string; } | { kind: "option-terminator"; index: number; } | { kind: "option"; index: number; name: "foo"; rawName: string; value: string; inlineValue: boolean; } | { kind: "option"; index: number; name: "bar"; rawName: string; value: undefined; inlineValue: undefined; }
+    parseArgs(config).tokens[0];
+}
+
+{
+    // util.parseArgs: strict: false
+
+    // $ExpectType { values: { [longOption: string]: string | boolean | undefined; }; positionals: string[]; }
+    const result = parseArgs({
+        strict: false,
+    });
+}
+
+{
+    // util.parseArgs: strict: false
+
+    const result = parseArgs({
+        strict: false,
+        options: {
+            x: { type: 'string', multiple: true },
+        },
+    });
+    // $ExpectType (string | boolean)[] | undefined
+    result.values.x;
+    // $ExpectType string | boolean | undefined
+    result.values.y;
+}
+
+{
+    // util.parseArgs: config not inferred precisely
+    const config = {};
+
+    // $ExpectType { values: { [longOption: string]: string | boolean | (string | boolean)[] | undefined; }; positionals: string[]; tokens?: Token[] | undefined; }
+    const result = parseArgs(config);
+}

--- a/types/pkgjs__parseargs/tsconfig.json
+++ b/types/pkgjs__parseargs/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@pkgjs/parseargs": ["pkgjs__parseargs"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "pkgjs__parseargs-tests.ts"
+    ]
+}

--- a/types/pkgjs__parseargs/tslint.json
+++ b/types/pkgjs__parseargs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Since this is a polyfill from Node.js util#parseArgs, both type definitions and tests have been literally copied from
there.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
