### PR TITLE
refactor(styled-components-react-native)!: support for React Native >= 0.69

### DIFF
--- a/types/styled-components-react-native/index.d.ts
+++ b/types/styled-components-react-native/index.d.ts
@@ -5,9 +5,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // tslint:disable-next-line:no-single-declare-module
-declare module "styled-components/native" {
-    import * as ReactNative from "react-native";
-    import * as React from "react";
+declare module 'styled-components/native' {
+    import * as ReactNative from 'react-native';
+    import * as React from 'react';
 
     export {
         css,
@@ -19,7 +19,7 @@ declare module "styled-components/native" {
         ThemeProvider,
         withTheme,
         useTheme,
-    } from "styled-components";
+    } from 'styled-components';
 
     import {
         AnyStyledComponent,
@@ -32,14 +32,14 @@ declare module "styled-components/native" {
         ThemedStyledFunction,
         ThemeProviderComponent,
         WithThemeFnInterface,
-    } from "styled-components";
+    } from 'styled-components';
 
     type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
     export type ReactNativeThemedStyledFunction<
         C extends React.ComponentType<any>,
-        T extends object
-        > = ThemedStyledFunction<C, T>;
+        T extends object,
+    > = ThemedStyledFunction<C, T>;
 
     // Copied over from "ThemedBaseStyledInterface" in index.d.ts in order to remove DOM element typings
     interface ReactNativeThemedBaseStyledInterface<T extends object> {
@@ -52,7 +52,7 @@ declare module "styled-components/native" {
         <C extends React.ComponentType<any>>(
             // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
             // causes tests to fail in TS 3.1
-            component: C
+            component: C,
         ): ThemedStyledFunction<C, T>;
     }
 

--- a/types/styled-components-react-native/index.d.ts
+++ b/types/styled-components-react-native/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for styled-components-react-native 6.0
+// Type definitions for styled-components-react-native 5.3
 // Project: https://github.com/styled-components/styled-components
 // Definitions by: Nathan Bierema <https://github.com/Methuselah96>
 //                 Jérémy Barbet <https://github.com/jeremybarbet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.8
 
 // tslint:disable-next-line:no-single-declare-module
 declare module 'styled-components/native' {

--- a/types/styled-components-react-native/package.json
+++ b/types/styled-components-react-native/package.json
@@ -1,0 +1,6 @@
+{
+	"private": true,
+	"dependencies": {
+		"styled-components": "^5.3.5"
+	}
+}

--- a/types/styled-components-react-native/styled-components-react-native-tests.tsx
+++ b/types/styled-components-react-native/styled-components-react-native-tests.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactNative from "react-native";
+import * as React from 'react';
+import * as ReactNative from 'react-native';
 
 import styled, {
     css,
@@ -9,8 +9,8 @@ import styled, {
     withTheme,
     ThemeConsumer,
     ReactNativeThemedStyledComponentsModule,
-} from "styled-components/native";
-import {} from "styled-components/cssprop";
+} from 'styled-components/native';
+import {} from 'styled-components/cssprop';
 
 const StyledView = styled.View`
     background-color: papayawhip;
@@ -89,17 +89,20 @@ const tomatoElement = <TomatoButton name="needed" />;
 
 async function typedThemes() {
     const theme = {
-        color: "green",
+        color: 'green',
     };
 
     // abuse "await import(...)" to be able to reference the styled-components namespace
     // without actually doing a top level namespace import
-    const { default: styled, css, ThemeProvider, ThemeConsumer } = ((await import(
-        "styled-components/native"
-    )) as any) as ReactNativeThemedStyledComponentsModule<typeof theme>;
+    const {
+        default: styled,
+        css,
+        ThemeProvider,
+        ThemeConsumer,
+    } = (await import('styled-components/native')) as any as ReactNativeThemedStyledComponentsModule<typeof theme>;
 
     const ThemedView = styled.View`
-        background: ${(props) => {
+        background: ${props => {
             // $ExpectType string
             props.theme.color;
             // $ExpectType string | undefined
@@ -107,7 +110,7 @@ async function typedThemes() {
             return props.theme.color;
         }};
     `;
-    const ThemedView2 = styled.View((props) => {
+    const ThemedView2 = styled.View(props => {
         // $ExpectType string
         props.theme.color;
         // $ExpectType string | undefined
@@ -117,7 +120,7 @@ async function typedThemes() {
             background: props.theme.color,
         };
     });
-    const ThemedView3 = styled.View((props) => {
+    const ThemedView3 = styled.View(props => {
         // $ExpectType string
         props.theme.color;
         // $ExpectType string | undefined
@@ -128,7 +131,7 @@ async function typedThemes() {
         `;
     });
     const themedCss = css`
-        background: ${(props) => {
+        background: ${props => {
             // $ExpectType string
             props.theme.color;
             // $ExpectType "theme"
@@ -140,10 +143,10 @@ async function typedThemes() {
     // @ts-expect-error
     const ThemedView4 = styled.View(themedCss);
 
-    const themedCssWithNesting = css((props) => ({
+    const themedCssWithNesting = css(props => ({
         color: props.theme.color,
         [ThemedView3]: {
-            color: "green",
+            color: 'green',
         },
     }));
 
@@ -154,7 +157,7 @@ async function typedThemes() {
                 <ThemedView2 />
                 <ThemedView3 />
                 <ThemeConsumer>
-                    {(theme) => {
+                    {theme => {
                         // $ExpectType string
                         theme.color;
                         return theme.color;
@@ -166,7 +169,7 @@ async function typedThemes() {
 }
 
 async function reexportCompatibility() {
-    const sc = await import("styled-components/native");
+    const sc = await import('styled-components/native');
     const themed = sc as ReactNativeThemedStyledComponentsModule<any>;
 
     let { ...scExports } = sc;
@@ -187,10 +190,10 @@ async function themeAugmentation() {
         accent: string;
     }
 
-    const base = ((await import(
-        "styled-components/native"
-    )) as any) as ReactNativeThemedStyledComponentsModule<BaseTheme>;
-    const extra = ((await import("styled-components/native")) as any) as ReactNativeThemedStyledComponentsModule<
+    const base = (await import(
+        'styled-components/native'
+    )) as any as ReactNativeThemedStyledComponentsModule<BaseTheme>;
+    const extra = (await import('styled-components/native')) as any as ReactNativeThemedStyledComponentsModule<
         ExtraTheme,
         BaseTheme
     >;
@@ -198,20 +201,20 @@ async function themeAugmentation() {
     return (
         <base.ThemeProvider
             theme={{
-                background: "black",
+                background: 'black',
             }}
         >
             <>
                 <extra.ThemeProvider
                     // @ts-expect-error
-                    theme={(base) => base}
+                    theme={base => base}
                 >
                     <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
                 </extra.ThemeProvider>
                 <extra.ThemeProvider
-                    theme={(base) => ({
+                    theme={base => ({
                         ...base,
-                        accent: "blue",
+                        accent: 'blue',
                     })}
                 >
                     <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>

--- a/types/styled-components-react-native/v5.1/index.d.ts
+++ b/types/styled-components-react-native/v5.1/index.d.ts
@@ -5,9 +5,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // tslint:disable-next-line:no-single-declare-module
-declare module "styled-components/native" {
-    import * as ReactNative from "react-native";
-    import * as React from "react";
+declare module 'styled-components/native' {
+    import * as ReactNative from 'react-native';
+    import * as React from 'react';
 
     export {
         css,
@@ -19,7 +19,7 @@ declare module "styled-components/native" {
         ThemeProvider,
         withTheme,
         useTheme,
-    } from "styled-components";
+    } from 'styled-components';
 
     import {
         AnyStyledComponent,
@@ -32,14 +32,14 @@ declare module "styled-components/native" {
         ThemedStyledFunction,
         ThemeProviderComponent,
         WithThemeFnInterface,
-    } from "styled-components";
+    } from 'styled-components';
 
     type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
     export type ReactNativeThemedStyledFunction<
         C extends React.ComponentType<any>,
-        T extends object
-        > = ThemedStyledFunction<C, T>;
+        T extends object,
+    > = ThemedStyledFunction<C, T>;
 
     // Copied over from "ThemedBaseStyledInterface" in index.d.ts in order to remove DOM element typings
     interface ReactNativeThemedBaseStyledInterface<T extends object> {
@@ -52,7 +52,7 @@ declare module "styled-components/native" {
         <C extends React.ComponentType<any>>(
             // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
             // causes tests to fail in TS 3.1
-            component: C
+            component: C,
         ): ThemedStyledFunction<C, T>;
     }
 

--- a/types/styled-components-react-native/v5.1/index.d.ts
+++ b/types/styled-components-react-native/v5.1/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Nathan Bierema <https://github.com/Methuselah96>
 //                 Jérémy Barbet <https://github.com/jeremybarbet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 4.8
 
 // tslint:disable-next-line:no-single-declare-module
 declare module 'styled-components/native' {

--- a/types/styled-components-react-native/v5.1/index.d.ts
+++ b/types/styled-components-react-native/v5.1/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for styled-components-react-native 6.0
+// Type definitions for styled-components-react-native 5.1
 // Project: https://github.com/styled-components/styled-components
 // Definitions by: Nathan Bierema <https://github.com/Methuselah96>
 //                 Jérémy Barbet <https://github.com/jeremybarbet>
@@ -62,25 +62,22 @@ declare module "styled-components/native" {
         ActivityIndicator: ReactNativeThemedStyledFunction<typeof ReactNative.ActivityIndicator, T>;
         ActivityIndicatorIOS: ReactNativeThemedStyledFunction<typeof ReactNative.ActivityIndicator, T>;
         Button: ReactNativeThemedStyledFunction<typeof ReactNative.Button, T>;
-        /** @deprecated */
         DatePickerIOS: ReactNativeThemedStyledFunction<typeof ReactNative.DatePickerIOS, T>;
         DrawerLayoutAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.DrawerLayoutAndroid, T>;
         Image: ReactNativeThemedStyledFunction<typeof ReactNative.Image, T>;
         ImageBackground: ReactNativeThemedStyledFunction<typeof ReactNative.ImageBackground, T>;
         KeyboardAvoidingView: ReactNativeThemedStyledFunction<typeof ReactNative.KeyboardAvoidingView, T>;
-        /** @deprecated */
         ListView: ReactNativeThemedStyledFunction<typeof ReactNative.ListView, T>;
         Modal: ReactNativeThemedStyledFunction<typeof ReactNative.Modal, T>;
         NavigatorIOS: ReactNativeThemedStyledFunction<typeof ReactNative.NavigatorIOS, T>;
+        Picker: ReactNativeThemedStyledFunction<typeof ReactNative.Picker, T>;
+        PickerIOS: ReactNativeThemedStyledFunction<typeof ReactNative.PickerIOS, T>;
         Pressable: ReactNativeThemedStyledFunction<typeof ReactNative.Pressable, T>;
-        /** @deprecated */
         ProgressBarAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressBarAndroid, T>;
-        /** @deprecated */
         ProgressViewIOS: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressViewIOS, T>;
         ScrollView: ReactNativeThemedStyledFunction<typeof ReactNative.ScrollView, T>;
-        /** @deprecated */
+        SegmentedControlIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SegmentedControlIOS, T>;
         Slider: ReactNativeThemedStyledFunction<typeof ReactNative.Slider, T>;
-        /** @deprecated */
         SliderIOS: ReactNativeThemedStyledFunction<typeof ReactNative.Slider, T>;
         SnapshotViewIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SnapshotViewIOS, T>;
         Switch: ReactNativeThemedStyledFunction<typeof ReactNative.Switch, T>;
@@ -91,12 +88,9 @@ declare module "styled-components/native" {
         RefreshControl: ReactNativeThemedStyledFunction<typeof ReactNative.RefreshControl, T>;
         SafeAreaView: ReactNativeThemedStyledFunction<typeof ReactNative.SafeAreaView, T>;
         StatusBar: ReactNativeThemedStyledFunction<typeof ReactNative.StatusBar, T>;
-        /** @deprecated */
         SwipeableListView: ReactNativeThemedStyledFunction<typeof ReactNative.SwipeableListView, T>;
         SwitchAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.Switch, T>;
-        /** @deprecated */
         SwitchIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SwitchIOS, T>;
-        /** @deprecated */
         TabBarIOS: ReactNativeThemedStyledFunction<typeof ReactNative.TabBarIOS, T>;
         Text: ReactNativeThemedStyledFunction<typeof ReactNative.Text, T>;
         TextInput: ReactNativeThemedStyledFunction<typeof ReactNative.TextInput, T>;
@@ -105,7 +99,6 @@ declare module "styled-components/native" {
         TouchableOpacity: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableOpacity, T>;
         TouchableWithoutFeedback: ReactNativeThemedStyledFunction<typeof ReactNative.TouchableWithoutFeedback, T>;
         View: ReactNativeThemedStyledFunction<typeof ReactNative.View, T>;
-        /** @deprecated */
         ViewPagerAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ViewPagerAndroid, T>;
         FlatList: ReactNativeThemedStyledFunction<typeof ReactNative.FlatList, T>;
         SectionList: ReactNativeThemedStyledFunction<typeof ReactNative.SectionList, T>;

--- a/types/styled-components-react-native/v5.1/styled-components-react-native-tests.tsx
+++ b/types/styled-components-react-native/v5.1/styled-components-react-native-tests.tsx
@@ -16,14 +16,6 @@ const StyledView = styled.View`
     background-color: papayawhip;
 `;
 
-const StyledViewWrapped = styled(ReactNative.View)`
-    background-color: red;
-`;
-
-const StyledViewAsObject = styled(ReactNative.View)({
-    backgroundColor: 'red',
-});
-
 const StyledText = styled(ReactNative.Text)`
     color: palevioletred;
 `;
@@ -31,28 +23,9 @@ const StyledText = styled(ReactNative.Text)`
 class MyReactNativeComponent extends React.Component {
     render() {
         return (
-            <>
-                <StyledView
-                    // just any react-native props to make sure is available through styled-components
-                    accessibilityRole="text"
-                >
-                    <StyledText>Hello World!</StyledText>
-                </StyledView>
-
-                <StyledViewWrapped
-                    // just any react-native props to make sure is available through styled-components
-                    accessibilityRole="text"
-                >
-                    <StyledText>Hello World!</StyledText>
-                </StyledViewWrapped>
-
-                <StyledViewAsObject
-                    // just any react-native props to make sure is available through styled-components
-                    accessibilityRole="text"
-                >
-                    <StyledText>Hello World!</StyledText>
-                </StyledViewAsObject>
-            </>
+            <StyledView>
+                <StyledText>Hello World!</StyledText>
+            </StyledView>
         );
     }
 }

--- a/types/styled-components-react-native/v5.1/styled-components-react-native-tests.tsx
+++ b/types/styled-components-react-native/v5.1/styled-components-react-native-tests.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactNative from "react-native";
+import * as React from 'react';
+import * as ReactNative from 'react-native';
 
 import styled, {
     css,
@@ -9,8 +9,8 @@ import styled, {
     withTheme,
     ThemeConsumer,
     ReactNativeThemedStyledComponentsModule,
-} from "styled-components/native";
-import {} from "styled-components/cssprop";
+} from 'styled-components/native';
+import {} from 'styled-components/cssprop';
 
 const StyledView = styled.View`
     background-color: papayawhip;
@@ -62,17 +62,20 @@ const tomatoElement = <TomatoButton name="needed" />;
 
 async function typedThemes() {
     const theme = {
-        color: "green",
+        color: 'green',
     };
 
     // abuse "await import(...)" to be able to reference the styled-components namespace
     // without actually doing a top level namespace import
-    const { default: styled, css, ThemeProvider, ThemeConsumer } = ((await import(
-        "styled-components/native"
-    )) as any) as ReactNativeThemedStyledComponentsModule<typeof theme>;
+    const {
+        default: styled,
+        css,
+        ThemeProvider,
+        ThemeConsumer,
+    } = (await import('styled-components/native')) as any as ReactNativeThemedStyledComponentsModule<typeof theme>;
 
     const ThemedView = styled.View`
-        background: ${(props) => {
+        background: ${props => {
             // $ExpectType string
             props.theme.color;
             // $ExpectType string | undefined
@@ -80,7 +83,7 @@ async function typedThemes() {
             return props.theme.color;
         }};
     `;
-    const ThemedView2 = styled.View((props) => {
+    const ThemedView2 = styled.View(props => {
         // $ExpectType string
         props.theme.color;
         // $ExpectType string | undefined
@@ -90,7 +93,7 @@ async function typedThemes() {
             background: props.theme.color,
         };
     });
-    const ThemedView3 = styled.View((props) => {
+    const ThemedView3 = styled.View(props => {
         // $ExpectType string
         props.theme.color;
         // $ExpectType string | undefined
@@ -101,7 +104,7 @@ async function typedThemes() {
         `;
     });
     const themedCss = css`
-        background: ${(props) => {
+        background: ${props => {
             // $ExpectType string
             props.theme.color;
             // $ExpectType "theme"
@@ -113,10 +116,10 @@ async function typedThemes() {
     // @ts-expect-error
     const ThemedView4 = styled.View(themedCss);
 
-    const themedCssWithNesting = css((props) => ({
+    const themedCssWithNesting = css(props => ({
         color: props.theme.color,
         [ThemedView3]: {
-            color: "green",
+            color: 'green',
         },
     }));
 
@@ -127,7 +130,7 @@ async function typedThemes() {
                 <ThemedView2 />
                 <ThemedView3 />
                 <ThemeConsumer>
-                    {(theme) => {
+                    {theme => {
                         // $ExpectType string
                         theme.color;
                         return theme.color;
@@ -139,7 +142,7 @@ async function typedThemes() {
 }
 
 async function reexportCompatibility() {
-    const sc = await import("styled-components/native");
+    const sc = await import('styled-components/native');
     const themed = sc as ReactNativeThemedStyledComponentsModule<any>;
 
     let { ...scExports } = sc;
@@ -160,10 +163,10 @@ async function themeAugmentation() {
         accent: string;
     }
 
-    const base = ((await import(
-        "styled-components/native"
-    )) as any) as ReactNativeThemedStyledComponentsModule<BaseTheme>;
-    const extra = ((await import("styled-components/native")) as any) as ReactNativeThemedStyledComponentsModule<
+    const base = (await import(
+        'styled-components/native'
+    )) as any as ReactNativeThemedStyledComponentsModule<BaseTheme>;
+    const extra = (await import('styled-components/native')) as any as ReactNativeThemedStyledComponentsModule<
         ExtraTheme,
         BaseTheme
     >;
@@ -171,20 +174,20 @@ async function themeAugmentation() {
     return (
         <base.ThemeProvider
             theme={{
-                background: "black",
+                background: 'black',
             }}
         >
             <>
                 <extra.ThemeProvider
                     // @ts-expect-error
-                    theme={(base) => base}
+                    theme={base => base}
                 >
                     <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>
                 </extra.ThemeProvider>
                 <extra.ThemeProvider
-                    theme={(base) => ({
+                    theme={base => ({
                         ...base,
-                        accent: "blue",
+                        accent: 'blue',
                     })}
                 >
                     <extra.ThemeConsumer>{() => null}</extra.ThemeConsumer>

--- a/types/styled-components-react-native/v5.1/tsconfig.json
+++ b/types/styled-components-react-native/v5.1/tsconfig.json
@@ -9,10 +9,24 @@
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
-        "baseUrl": "../",
+        "baseUrl": "../../",
         "typeRoots": [
-            "../"
+            "../../"
         ],
+        "paths": {
+            "react-native": [
+                "react-native/v0.65"
+            ],
+            "react-native/*": [
+                "react-native/v0.65/*"
+            ],
+            "react": [
+                "react/v17"
+            ],
+            "react/*": [
+                "react/v17/*"
+            ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/styled-components-react-native/v5.1/tsconfig.json
+++ b/types/styled-components-react-native/v5.1/tsconfig.json
@@ -17,14 +17,11 @@
             "react-native": [
                 "react-native/v0.65"
             ],
-            "react-native/*": [
-                "react-native/v0.65/*"
-            ],
             "react": [
                 "react/v17"
             ],
-            "react/*": [
-                "react/v17/*"
+            "styled-components-react-native": [
+                "styled-components-react-native/v5.1"
             ]
         },
         "types": [],

--- a/types/styled-components-react-native/v5.1/tslint.json
+++ b/types/styled-components-react-native/v5.1/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Changes summary:
- Moved the old definition to a versioned directory, same setup as the one used in `react-native` for example.
- Change new version as major release
- Changes can be seen easily in this [commit](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61999/commits/d4809f0d5f40ae7116ce9a6bfac7ffdc063e9f99)
- I wish there was a way to pass down comment from JSDoc.

Let's take the following examples:

```tsx
import { Slider } from 'react-native';
import { styled } from 'styled-components/native';

const StyledSlider = styled(Slider)``;
// ^ This will throw a warning on the `Slider` import, because it has been deprecated within `@types/react-native`
```

However, when doing:

```tsx
import { Slider } from 'react-native';
import { styled } from 'styled-components/native';

const StyledSlider = styled.Slider``;
// That doesn't throw a warning, because the comment created in `@types/react-native` is not pass down to the `styled` function
```

I honestly have no idea if TypeScript is able to do that and if so, how to do it.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
