### PR TITLE
`@types/babel__traverse`: improve how `NodePath`s can be related

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -355,7 +355,7 @@ const objectTypeAnnotation: NodePath<t.ObjectTypeAnnotation> = new NodePath<t.Ob
     {} as any,
 );
 
-objectTypeAnnotation.get('indexers'); // $ExpectType NodePath<null | undefined> | NodePath<ObjectTypeIndexer>[]
+objectTypeAnnotation.get('indexers'); // $ExpectType NodePathResult<ObjectTypeIndexer[] | undefined>
 
 // Test that NodePath can be narrowed from union to single type
 const path: NodePath<t.ExportDefaultDeclaration | t.ExportNamedDeclaration> = new NodePath<t.ExportNamedDeclaration>(

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -555,16 +555,7 @@ export class NodePath<T = Node> {
     getAllPrevSiblings(): NodePath[];
     getAllNextSiblings(): NodePath[];
 
-    get<K extends keyof T>(
-        key: K,
-        context?: boolean | TraversalContext,
-    ): T[K] extends Array<Node | null | undefined>
-        ? Array<NodePath<T[K][number]>>
-        : T[K] extends Array<Node | null | undefined> | null | undefined
-        ? Array<NodePath<NonNullable<T[K]>[number]>> | NodePath<null | undefined>
-        : T[K] extends Node | null | undefined
-        ? NodePath<T[K]>
-        : never;
+    get<K extends keyof T>(key: K, context?: boolean | TraversalContext): NodePathResult<T[K]>;
     get(key: string, context?: boolean | TraversalContext): NodePath | NodePath[];
 
     getBindingIdentifiers(duplicates: true): Record<string, t.Identifier[]>;
@@ -1202,3 +1193,7 @@ export interface TraversalContext {
     state: any;
     opts: any;
 }
+
+export type NodePathResult<T> =
+    | (Extract<T, Node | null | undefined> extends never ? never : NodePath<Extract<T, Node | null | undefined>>)
+    | (T extends Array<Node | null | undefined> ? Array<NodePath<T[number]>> : never);


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/issues/50290#issuecomment-1221331939
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

`RangeError` could happen when relating NodePaths sometimes, it has been suggested by @ahejlsberg that this type [here](https://github.com/microsoft/TypeScript/issues/50290#issuecomment-1221331939) should be changed in this way to avoid the problem. It has also been mentioned that this actually increases correctness - so a new test case could be added. However, I'm not too familiar with this code so I'm not sure what that correctness improvement is.

cc @nstepien