### PR TITLE
Exempt 3 packages from npm-naming

### DIFF
--- a/types/sketchapp/tslint.json
+++ b/types/sketchapp/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
 }

--- a/types/vscode-webview/tslint.json
+++ b/types/vscode-webview/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}

--- a/types/xast/tslint.json
+++ b/types/xast/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
+}


### PR DESCRIPTION
These packages conflict with unrelated packages on npm, but they're not widely used enough to justify renaming them.

Also, `xast` at least publishes its own types, so `@types/xast` won't load its types even if they're mistakenly installed.
