### PR TITLE
three: Fix ConstructorUnion's distributivity

### DIFF
--- a/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
@@ -82,10 +82,10 @@ type FilterConstructorsByScope<T extends AnyConstructors, S> = {
  * "flattens" the tuple into an union type
  */
 type ConstructorUnion<T extends AnyConstructors> =
-    | (T['a'] extends undefined ? never : T['a'])
-    | (T['b'] extends undefined ? never : T['b'])
-    | (T['c'] extends undefined ? never : T['c'])
-    | (T['d'] extends undefined ? never : T['d']);
+    | Exclude<T['a'], undefined>
+    | Exclude<T['b'], undefined>
+    | Exclude<T['c'], undefined>
+    | Exclude<T['d'], undefined>;
 
 /**
  * Extract list of possible scopes - union of the first paramter


### PR DESCRIPTION
Typescript 4.9 [optimises substitution types](https://github.com/microsoft/TypeScript/pull/50397a), but this exposes that ConstructorUnion isn't correctly distributive.

I used the [fix suggested by @ahejlsberg](https://github.com/microsoft/TypeScript/pull/50397#issuecomment-1227746792) on the same PR.