### PR TITLE
[react, rax, babel-plugin-react-html-attrs] Fix code formatting in ElementRef type docs

### DIFF
--- a/types/babel-plugin-react-html-attrs/index.d.ts
+++ b/types/babel-plugin-react-html-attrs/index.d.ts
@@ -77,7 +77,7 @@ declare namespace React {
      * - React stateless functional components that forward a `ref` will give you the `ElementRef` of the forwarded
      *   to component.
      *
-     * `C` must be the type _of_ a React component so you need to use typeof as in React.ElementRef<typeof MyComponent>.
+     * `C` must be the type _of_ a React component so you need to use typeof as in `React.ElementRef<typeof MyComponent>`.
      *
      * @todo In Flow, this works a little different with forwarded refs and the `AbstractComponent` that
      *       `React.forwardRef()` returns.

--- a/types/rax/index.d.ts
+++ b/types/rax/index.d.ts
@@ -88,7 +88,7 @@ declare namespace Rax {
    * - Rax stateless functional components that forward a `ref` will give you the `ElementRef` of the forwarded
    *   to component.
    *
-   * `C` must be the type _of_ a Rax component so you need to use typeof as in ElementRef<typeof MyComponent>.
+   * `C` must be the type _of_ a Rax component so you need to use typeof as in `ElementRef<typeof MyComponent>`.
    */
   type ElementRef<
       C extends

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -97,7 +97,7 @@ declare namespace React {
      * - React stateless functional components that forward a `ref` will give you the `ElementRef` of the forwarded
      *   to component.
      *
-     * `C` must be the type _of_ a React component so you need to use typeof as in React.ElementRef<typeof MyComponent>.
+     * `C` must be the type _of_ a React component so you need to use typeof as in `React.ElementRef<typeof MyComponent>`.
      *
      * @todo In Flow, this works a little different with forwarded refs and the `AbstractComponent` that
      *       `React.forwardRef()` returns.

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -99,7 +99,7 @@ declare namespace React {
      * - React stateless functional components that forward a `ref` will give you the `ElementRef` of the forwarded
      *   to component.
      *
-     * `C` must be the type _of_ a React component so you need to use typeof as in React.ElementRef<typeof MyComponent>.
+     * `C` must be the type _of_ a React component so you need to use typeof as in `React.ElementRef<typeof MyComponent>`.
      *
      * @todo In Flow, this works a little different with forwarded refs and the `AbstractComponent` that
      *       `React.forwardRef()` returns.

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -96,7 +96,7 @@ declare namespace React {
      * - React stateless functional components that forward a `ref` will give you the `ElementRef` of the forwarded
      *   to component.
      *
-     * `C` must be the type _of_ a React component so you need to use typeof as in React.ElementRef<typeof MyComponent>.
+     * `C` must be the type _of_ a React component so you need to use typeof as in `React.ElementRef<typeof MyComponent>`.
      *
      * @todo In Flow, this works a little different with forwarded refs and the `AbstractComponent` that
      *       `React.forwardRef()` returns.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

The JSDoc for the ElementRef type originally in `react` and also found in `rax`, and `babel-plugin-react-html-attrs` is missing backticks in its final remark, which causes it to render incorrectly in (at least) vscode:
<img width="591" alt="Screenshot of vscode documentation tooltip for the ElementRef type" src="https://user-images.githubusercontent.com/1508774/187326714-731bc444-9b69-421d-8bf1-5022ea8e5bbc.png">

In the above screenshot, the tooltip *should* say "`as in ElementRef<typeof MyComponent>`", but the `<typeof MyComponent>` portion gets parsed as a tag instead and doesn't appear.

I read over the PR template, but I think this change doesn't apply to many of these points since only a type comment is edited...? Please let me know if there's something I've overlooked. Thanks!