### PR TITLE
[react-native-vector-icons]: Fixed FontAwesome5 Icon.Button type to include light/solid/brand props

### DIFF
--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -1,5 +1,5 @@
 import { Component } from "react";
-import { Icon, IconProps, ImageSource } from "./Icon";
+import { Icon, IconButtonProps, IconProps, ImageSource } from "./Icon";
 
 export const FA5Style: {
     regular: 0;
@@ -17,6 +17,8 @@ export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, "regular">;
 
 export type FontAwesome5IconProps = { [K in FontAwesome5IconVariants]?: boolean } & IconProps;
+
+export type FontAwesome5IconButtonProps = { [K in FontAwesome5IconVariants]?: boolean } & IconButtonProps;
 
 export default class FontAwesome5Icon extends Component<
     FontAwesome5IconProps,
@@ -38,5 +40,5 @@ export default class FontAwesome5Icon extends Component<
     static hasIcon(name: string): boolean;
     static TabBarItem: typeof Icon.TabBarItem;
     static TabBarItemIOS: typeof Icon.TabBarItemIOS;
-    static Button: typeof Icon.Button;
+    static Button: typeof Component<FontAwesome5IconButtonProps, any>;
 }

--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -18,7 +18,10 @@ export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, "regular">;
 
 export type FontAwesome5IconProps = { [K in FontAwesome5IconVariants]?: boolean } & IconProps;
 
-export type FontAwesome5IconButtonProps = { [K in FontAwesome5IconVariants]?: boolean } & IconButtonProps;
+export class FontAwesome5IconButton extends Component<
+    { [K in FontAwesome5IconVariants]?: boolean } & IconButtonProps,
+    any
+> {}
 
 export default class FontAwesome5Icon extends Component<
     FontAwesome5IconProps,
@@ -40,5 +43,5 @@ export default class FontAwesome5Icon extends Component<
     static hasIcon(name: string): boolean;
     static TabBarItem: typeof Icon.TabBarItem;
     static TabBarItemIOS: typeof Icon.TabBarItemIOS;
-    static Button: typeof Component<FontAwesome5IconButtonProps, any>;
+    static Button: typeof FontAwesome5IconButton;
 }

--- a/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
+++ b/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
@@ -47,6 +47,18 @@ class Example extends React.Component {
             Login with Facebook
           </Text>
         </FontAwesomeIcon.Button>
+
+        {/* FA5 Icon button with solid  */}
+        <FontAwesome5Icon.Button
+          backgroundColor="#3b5998"
+          name="facebook"
+          onPress={() => this.handleButton()}
+          solid
+        >
+          <Text style={{ fontFamily: 'Arial', fontSize: 15 }}>
+            Login with Facebook
+          </Text>
+        </FontAwesome5Icon.Button>
       </View>
     );
   }


### PR DESCRIPTION
Changing an existing definition:

I updated the react-native-vector-icons FontAwesome5 Icon.Button type to include the light/solid/brand props.

