### PR TITLE
braintree: removed deprecated connect function & update error types

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -294,7 +294,7 @@ braintree.Subscription.Status.All;
 /**
  * Gateway function helper
  */
-const gateway2: BraintreeGateway = braintree.connect({
+const gateway2: BraintreeGateway = new braintree.BraintreeGateway({
     environment: braintree.Environment.Sandbox,
     merchantId: 'abc123',
     publicKey: 'def456',

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -2289,13 +2289,14 @@ declare namespace braintree {
 
     export interface AuthenticationError extends Error {}
     export interface AuthorizationError extends Error {}
-    export interface DownForMaintenanceError extends Error {}
+    export interface GatewayTimeoutError extends Error {}
     export interface InvalidChallengeError extends Error {}
     export interface InvalidKeysError extends Error {}
     export interface InvalidSignatureError extends Error {}
-    export interface InvalidTransparentRedirectHashError extends Error {}
     export interface NotFoundError extends Error {}
+    export interface RequestTimeoutError extends Error {}
     export interface ServerError extends Error {}
+    export interface ServiceUnavailableError extends Error {}
     export interface TestOperationPerformedInProductionError extends Error {}
     export interface TooManyRequestsError extends Error {}
     export interface UnexpectedError extends Error {}

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -178,8 +178,6 @@ declare namespace braintree {
         webhookTesting: WebhookTestingGateway;
     }
 
-    export function connect(config: GatewayConfig): BraintreeGateway;
-
     interface ValidatedResponse<T> {
         success: boolean;
         errors: ValidationErrorsCollection;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/braintree/braintree_node/blob/master/CHANGELOG.md#300
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The version notated in the header is 3.3; my changes bring the types up to date with 3.0.0.
