### PR TITLE
papaparse: Update ParseError code field type

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -432,7 +432,7 @@ export interface ParseError {
     /** A generalization of the error */
     type: 'Quotes' | 'Delimiter' | 'FieldMismatch';
     /** Standardized error code */
-    code: 'MissingQuotes' | 'UndetectableDelimiter' | 'TooFewFields' | 'TooManyFields';
+    code: 'MissingQuotes' | 'UndetectableDelimiter' | 'TooFewFields' | 'TooManyFields' | 'InvalidQuotes';
     /** Human-readable details */
     message: string;
     /** Row index of parsed data where error is */


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/mholt/PapaParse/blob/07724570a111dc3439975a924dbc3ce6b3bd2235/papaparse.js#L1604)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
