### PR TITLE
[minimatch] Fix matchOne types (again)

### DIFF
--- a/types/minimatch/index.d.ts
+++ b/types/minimatch/index.d.ts
@@ -268,7 +268,7 @@ declare namespace minimatch {
          * This method is mainly for internal use, but is exposed so that it can be used
          * by a glob-walker that needs to avoid excessive filesystem calls.
          */
-        matchOne(file: readonly string[], pattern: readonly (string | RegExp)[], partial: boolean): boolean;
+        matchOne(file: readonly string[], pattern: ReadonlyArray<string | RegExp>, partial: boolean): boolean;
 
         /**
          * @deprecated. For internal use.

--- a/types/minimatch/index.d.ts
+++ b/types/minimatch/index.d.ts
@@ -268,7 +268,7 @@ declare namespace minimatch {
          * This method is mainly for internal use, but is exposed so that it can be used
          * by a glob-walker that needs to avoid excessive filesystem calls.
          */
-        matchOne(file: readonly string[], pattern: readonly string[], partial: boolean): boolean;
+        matchOne(file: readonly string[], pattern: readonly (string | RegExp)[], partial: boolean): boolean;
 
         /**
          * @deprecated. For internal use.

--- a/types/minimatch/minimatch-tests.ts
+++ b/types/minimatch/minimatch-tests.ts
@@ -50,6 +50,7 @@ const res2: false = mmInst.makeRe();
 mmInst.match(pattern); // $ExpectType boolean
 mmInst.match(pattern, true); // $ExpectType boolean
 mmInst.matchOne([pattern], files, true); // $ExpectType boolean
+mmInst.matchOne([pattern], [/a/], true); // $ExpectType boolean
 mmInst.debug(); // $ExpectType void
 mmInst.make(); // $ExpectType void
 mmInst.parseNegate(); // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

I missed this when preparing #61956. `Minimatch#set` is defined as `Array<Array<RegExp | string>>`. Not entirely sure how my code worked with old versions of the types, but...

```js
const set = this.set
...
for (let i = 0; i < set.length; i++) {
  const pattern = set[i]
...
  const hit = this.matchOne(file, pattern, partial)
```

https://github.com/isaacs/minimatch/blob/6410ef32f59e4842121ca13eefacdf0b3da8533c/minimatch.js#L872
https://github.com/isaacs/minimatch/blob/6410ef32f59e4842121ca13eefacdf0b3da8533c/minimatch.js#L882-L883
https://github.com/isaacs/minimatch/blob/6410ef32f59e4842121ca13eefacdf0b3da8533c/minimatch.js#L888