### PR TITLE
[@types/braintree-web-drop-in] Type threeDSecureInfo correctly

### DIFF
--- a/types/braintree-web-drop-in/index.d.ts
+++ b/types/braintree-web-drop-in/index.d.ts
@@ -19,7 +19,7 @@ https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-
 
 import { ApplePayPaymentRequest } from 'braintree-web/modules/apple-pay';
 import { HostedFieldsField } from 'braintree-web/modules/hosted-fields';
-import { ThreeDSecureVerifyPayload } from 'braintree-web/modules/three-d-secure';
+import { ThreeDSecureInfo } from 'braintree-web/modules/three-d-secure';
 import { ButtonStyle } from 'paypal-checkout-components';
 
 /**
@@ -207,7 +207,7 @@ export interface cardPaymentMethodPayload {
     deviceData?: string | undefined;
     liabilityShifted?: boolean | undefined;
     liabilityShiftPossible?: boolean | undefined;
-    threeDSecureInfo?: ThreeDSecureVerifyPayload | undefined;
+    threeDSecureInfo?: ThreeDSecureInfo | undefined;
 }
 
 export interface googlePayPaymentMethodPayload {


### PR DESCRIPTION
`cardPaymentMethodPayload.threeDSecureInfo` is currently typed as an entire payload, but it actually only contains 3DS information.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://braintree.github.io/braintree-web-drop-in/docs/current/Dropin.html#~cardPaymentMethodPayload
https://braintree.github.io/braintree-web/3.86.0/ThreeDSecure.html#~verifyPayload
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

