### PR TITLE
Update `mjml-react` to allow `letterSpacing` in buttons

### DIFF
--- a/types/mjml-react/index.d.ts
+++ b/types/mjml-react/index.d.ts
@@ -208,6 +208,7 @@ export interface MjmlButtonProps {
     textTransform?: string | undefined;
     align?: string | undefined;
     verticalAlign?: React.CSSProperties['verticalAlign'] | undefined;
+    letterSpacing?: string | number | undefined;
     lineHeight?: string | number | undefined;
     innerPadding?: string | undefined;
     width?: string | number | undefined;

--- a/types/mjml-react/mjml-react-tests.tsx
+++ b/types/mjml-react/mjml-react-tests.tsx
@@ -69,7 +69,7 @@ function renderOutTestEmail() {
                 </MjmlSection>
                 <MjmlSection>
                     <MjmlColumn>
-                        <MjmlButton padding="20px" backgroundColor="#346DB7" href="https://www.wix.com/" fontWeight="initial">
+                        <MjmlButton padding="20px" backgroundColor="#346DB7" href="https://www.wix.com/" fontWeight="initial" letterSpacing="normal">
                             I like it!
                         </MjmlButton>
                     </MjmlColumn>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See text below
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

`letter-spacing` support was added to `mjml` here: https://github.com/mjmlio/mjml/pull/1732

Looking at `mjml-react`, the button (https://github.com/wix-incubator/mjml-react/blob/261d996d9fb67492bd8168caaec50a11fd5f3a25/src/mjml-button.js) calls `handleMjmlProps` (https://github.com/wix-incubator/mjml-react/blob/261d996d9fb67492bd8168caaec50a11fd5f3a25/src/utils.js#L28) with all the props. That function just proxies all the props to `mjml` which leads me to believe no change is required in the `react-mjml` library. Furthermore, I tested locally and adding a `// @ts-ignore` and providing the `letterSpacing` prop works as expected
