### PR TITLE
Update Pinterest/Gestalt: Fixing typo in Datapoint Trend prop

### DIFF
--- a/types/gestalt/index.d.ts
+++ b/types/gestalt/index.d.ts
@@ -485,7 +485,7 @@ export interface DatapointProps {
     value: string;
     size?: 'md' | 'lg' | undefined;
     tooltipText?: string | undefined;
-    trend?: { accesibilityLabel: string; value: number } | undefined;
+    trend?: { accessibilityLabel: string; value: number } | undefined;
     trendSentiment?: 'good' | 'bad' | 'neutral' | 'auto' | undefined;
     badge?: BadgeObject | undefined;
     tooltipZIndex?: Indexable | undefined;


### PR DESCRIPTION
The `accesibilityLabel` property was spelled incorrectly

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Source](https://gestalt.pinterest.systems/web/datapoint#Trend)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

