### PR TITLE
[node] Fix missing callback argument for http2session.settings

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -780,7 +780,7 @@ declare module 'http2' {
          * @since v8.4.0
          * @param callback Callback that is called once the session is connected or right away if the session is already connected.
          */
-        settings(settings: Settings): void;
+        settings(settings: Settings, callback?: (err: Error | null, settings: Settings, duration: number) => void): void;
         /**
          * Calls `unref()` on this `Http2Session`instance's underlying `net.Socket`.
          * @since v9.4.0

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -122,6 +122,7 @@ import { URL } from 'node:url';
     };
 
     http2Session.settings(settings);
+    http2Session.settings(settings, (err: Error | null, newSettings: Settings, duration: number) => {});
 
     http2Session.ping((err: Error | null, duration: number, payload: Buffer) => {});
     http2Session.ping(Buffer.from(''), (err: Error | null, duration: number, payload: Buffer) => {});

--- a/types/node/v14/http2.d.ts
+++ b/types/node/v14/http2.d.ts
@@ -289,7 +289,7 @@ declare module 'http2' {
         ref(): void;
         setLocalWindowSize(windowSize: number): void;
         setTimeout(msecs: number, callback?: () => void): void;
-        settings(settings: Settings): void;
+        settings(settings: Settings, callback?: (err: Error | null, settings: Settings, duration: number) => void): void;
         unref(): void;
 
         addListener(event: "close", listener: () => void): this;

--- a/types/node/v14/test/http2.ts
+++ b/types/node/v14/test/http2.ts
@@ -121,6 +121,7 @@ import { URL } from 'node:url';
     };
 
     http2Session.settings(settings);
+    http2Session.settings(settings, (err: Error | null, newSettings: Settings, duration: number) => {});
 
     http2Session.ping((err: Error | null, duration: number, payload: Buffer) => {});
     http2Session.ping(Buffer.from(''), (err: Error | null, duration: number, payload: Buffer) => {});

--- a/types/node/v16/http2.d.ts
+++ b/types/node/v16/http2.d.ts
@@ -780,7 +780,7 @@ declare module 'http2' {
          * @since v8.4.0
          * @param callback Callback that is called once the session is connected or right away if the session is already connected.
          */
-        settings(settings: Settings): void;
+        settings(settings: Settings, callback?: (err: Error | null, settings: Settings, duration: number) => void): void;
         /**
          * Calls `unref()` on this `Http2Session`instance's underlying `net.Socket`.
          * @since v9.4.0

--- a/types/node/v16/test/http2.ts
+++ b/types/node/v16/test/http2.ts
@@ -121,6 +121,7 @@ import { URL } from 'node:url';
     };
 
     http2Session.settings(settings);
+    http2Session.settings(settings, (err: Error | null, newSettings: Settings, duration: number) => {});
 
     http2Session.ping((err: Error | null, duration: number, payload: Buffer) => {});
     http2Session.ping(Buffer.from(''), (err: Error | null, duration: number, payload: Buffer) => {});


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v12.x/api/http2.html#http2_http2session_settings_settings_callback - the callback has been in the API since the beginning, I think; this is a type fix
