### PR TITLE
marked - add async option to the MarkedExtension interface (new in version 4.1.0)

### DIFF
--- a/types/marked/index.d.mts
+++ b/types/marked/index.d.mts
@@ -1,1 +1,1 @@
-export * from "./index.js";
+export * from './index.js';

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -33,7 +33,7 @@ export function marked(src: string, options: marked.MarkedOptions & {async: true
 export function marked(src: string, options?: marked.MarkedOptions): string;
 
 /**
- * Compiles markdown to HTML asynchronously.
+ * Compiles markdown to HTML asynchronously with a callback.
  *
  * @param src String of markdown source to be compiled
  * @param callback Function called when the markdownString has been fully parsed when using async highlighting
@@ -41,7 +41,7 @@ export function marked(src: string, options?: marked.MarkedOptions): string;
 export function marked(src: string, callback: (error: any, parseResult: string) => void): void;
 
 /**
- * Compiles markdown to HTML asynchronously.
+ * Compiles markdown to HTML asynchronously with a callback.
  *
  * @param src String of markdown source to be compiled
  * @param options Hash of options
@@ -82,11 +82,19 @@ export namespace marked {
      * Compiles markdown to HTML asynchronously.
      *
      * @param src String of markdown source to be compiled
-     * @param Hash of options having async: true
-     * @param callback Function called when the markdownString has been fully parsed when using async highlighting
+     * @param options Hash of options having async: true
      * @return Promise of string of compiled HTML
      */
-    function parse(src: string, options: MarkedOptions & {async: true}, callback?: (error: any, parseResult: string) => void): Promise<string>;
+    function parse(src: string, options: MarkedOptions & {async: true}): Promise<string>;
+
+    /**
+     * Compiles markdown to HTML synchronously.
+     *
+     * @param src String of markdown source to be compiled
+     * @param options Optional hash of options
+     * @return String of compiled HTML
+     */
+    function parse(src: string, options?: MarkedOptions): string;
 
     /**
      * Compiles markdown to HTML synchronously.
@@ -96,7 +104,7 @@ export namespace marked {
      * @param callback Function called when the markdownString has been fully parsed when using async highlighting
      * @return String of compiled HTML
      */
-    function parse(src: string, options?: MarkedOptions, callback?: (error: any, parseResult: string) => void): string;
+    function parse(src: string, options: MarkedOptions, callback: (error: any, parseResult: string) => void): void;
 
     /**
      * @param src Tokenized source as array of tokens

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -480,6 +480,11 @@ export namespace marked {
 
     interface MarkedExtension {
         /**
+         * True will tell marked to await any walkTokens functions before parsing the tokens and returning an HTML string.
+         */
+        async?: boolean;
+
+        /**
          * A prefix URL for any relative link.
          */
         baseUrl?: string | undefined;

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -21,6 +21,7 @@
  * @param options Optional hash of options
  * @return String of compiled HTML
  */
+export function marked(src: string, options: marked.MarkedOptions & {async: true}): Promise<string>;
 export function marked(src: string, options?: marked.MarkedOptions): string;
 
 /**
@@ -67,7 +68,7 @@ export namespace marked {
      * @param callback Function called when the markdownString has been fully parsed when using async highlighting
      * @return String of compiled HTML
      */
-    function parse(src: string, callback: (error: any, parseResult: string) => void): string;
+    function parse(src: string, callback: (error: any, parseResult: string) => void): void;
 
     /**
      * Compiles markdown to HTML.
@@ -77,6 +78,7 @@ export namespace marked {
      * @param callback Function called when the markdownString has been fully parsed when using async highlighting
      * @return String of compiled HTML
      */
+    function parse(src: string, options: MarkedOptions & {async: true}, callback?: (error: any, parseResult: string) => void): Promise<string>;
     function parse(src: string, options?: MarkedOptions, callback?: (error: any, parseResult: string) => void): string;
 
     /**

--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -15,13 +15,21 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**
+ * Compiles markdown to HTML asynchronously.
+ *
+ * @param src String of markdown source to be compiled
+ * @param options Hash of options, having async: true
+ * @return Promise of string of compiled HTML
+ */
+export function marked(src: string, options: marked.MarkedOptions & {async: true}): Promise<string>;
+
+/**
  * Compiles markdown to HTML synchronously.
  *
  * @param src String of markdown source to be compiled
  * @param options Optional hash of options
  * @return String of compiled HTML
  */
-export function marked(src: string, options: marked.MarkedOptions & {async: true}): Promise<string>;
 export function marked(src: string, options?: marked.MarkedOptions): string;
 
 /**
@@ -71,14 +79,23 @@ export namespace marked {
     function parse(src: string, callback: (error: any, parseResult: string) => void): void;
 
     /**
-     * Compiles markdown to HTML.
+     * Compiles markdown to HTML asynchronously.
      *
      * @param src String of markdown source to be compiled
-     * @param options Hash of options
+     * @param Hash of options having async: true
+     * @param callback Function called when the markdownString has been fully parsed when using async highlighting
+     * @return Promise of string of compiled HTML
+     */
+    function parse(src: string, options: MarkedOptions & {async: true}, callback?: (error: any, parseResult: string) => void): Promise<string>;
+
+    /**
+     * Compiles markdown to HTML synchronously.
+     *
+     * @param src String of markdown source to be compiled
+     * @param options Optional hash of options
      * @param callback Function called when the markdownString has been fully parsed when using async highlighting
      * @return String of compiled HTML
      */
-    function parse(src: string, options: MarkedOptions & {async: true}, callback?: (error: any, parseResult: string) => void): Promise<string>;
     function parse(src: string, options?: MarkedOptions, callback?: (error: any, parseResult: string) => void): string;
 
     /**

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -260,11 +260,14 @@ marked.use(asyncExtension);
 (async () => {
     const a: string = await marked('# foobar', { async: true });
     const b: string = marked('# foobar', { async: false });
-    const d: string = marked('# foobar');
+    const c: string = marked('# foobar');
 
-    const e: string = await marked.parse('# foobar', { async: true });
-    const f: string = marked.parse('# foobar', { async: false });
-    const h: string = marked.parse('# foobar');
+    const d: string = await marked.parse('# foobar', { async: true });
+    const e: string = marked.parse('# foobar', { async: false });
+    const f: string = marked.parse('# foobar');
+
+    const g: Promise<string> = marked('md', {async: true});
+    const h: Promise<string> = marked.parse('md', {async: true, headerIds: false});
 })();
 
 // Tests for List and ListItem

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -263,17 +263,23 @@ marked.use(asyncExtension);
     const promiseMarked: Promise<string> = marked(md, {async: true});
     const notAsyncMarked: string = marked(md, {async: false});
     const defaultMarked: string = marked(md);
-    const callback: void = marked(md, (_: any, res: string) => { res; });
-    const asyncCallbackwithOpts: void = marked(md, {async: true}, (_: any, res: string) => { res; });
-    const notAsyncCallbackwithOpts: void = marked(md, {async: false}, (_: any, res: string) => { res; });
+    // $ExpectType void
+    marked(md, (_: any, res: string) => { res; });
+    // $ExpectType void
+    marked(md, {async: true}, (_: any, res: string) => { res; });
+    // $ExpectType void
+    marked(md, {async: false}, (_: any, res: string) => { res; });
 
     const asyncMarkedParse: string = await marked.parse(md, {async: true});
     const promiseMarkedParse: Promise<string> = marked.parse(md, {async: true, headerIds: false});
     const notAsyncMarkedParse: string = marked.parse(md, {async: false});
     const defaultMarkedParse: string = marked.parse(md);
-    const callbackParse: void = marked.parse(md, (_: any, res: string) => { res; });
-    const asyncCallbackwithOptsParse: void = marked(md, {async: true}, (_: any, res: string) => { res; });
-    const notAsyncCallbackwithOptsParse: void = marked(md, {async: false}, (_: any, res: string) => { res; });
+    // $ExpectType void
+    marked.parse(md, (_: any, res: string) => { res; });
+    // $ExpectType void
+    marked(md, {async: true}, (_: any, res: string) => { res; });
+    // $ExpectType void
+    marked(md, {async: false}, (_: any, res: string) => { res; });
 })();
 
 // Tests for List and ListItem

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -259,27 +259,27 @@ marked.use(asyncExtension);
 
 (async () => {
     const md = '# foobar';
-    const asyncMarked: string = await marked(md, {async: true});
-    const promiseMarked: Promise<string> = marked(md, {async: true});
-    const notAsyncMarked: string = marked(md, {async: false});
+    const asyncMarked: string = await marked(md, { async: true });
+    const promiseMarked: Promise<string> = marked(md, { async: true });
+    const notAsyncMarked: string = marked(md, { async: false });
     const defaultMarked: string = marked(md);
     // $ExpectType void
     marked(md, (_: any, res: string) => { res; });
     // $ExpectType void
-    marked(md, {async: true}, (_: any, res: string) => { res; });
+    marked(md, { async: true }, (_: any, res: string) => { res; });
     // $ExpectType void
-    marked(md, {async: false}, (_: any, res: string) => { res; });
+    marked(md, { async: false }, (_: any, res: string) => { res; });
 
-    const asyncMarkedParse: string = await marked.parse(md, {async: true});
-    const promiseMarkedParse: Promise<string> = marked.parse(md, {async: true, headerIds: false});
-    const notAsyncMarkedParse: string = marked.parse(md, {async: false});
+    const asyncMarkedParse: string = await marked.parse(md, { async: true });
+    const promiseMarkedParse: Promise<string> = marked.parse(md, { async: true, headerIds: false });
+    const notAsyncMarkedParse: string = marked.parse(md, { async: false });
     const defaultMarkedParse: string = marked.parse(md);
     // $ExpectType void
     marked.parse(md, (_: any, res: string) => { res; });
     // $ExpectType void
-    marked(md, {async: true}, (_: any, res: string) => { res; });
+    marked(md, { async: true }, (_: any, res: string) => { res; });
     // $ExpectType void
-    marked(md, {async: false}, (_: any, res: string) => { res; });
+    marked(md, { async: false }, (_: any, res: string) => { res; });
 })();
 
 // Tests for List and ListItem

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -258,16 +258,22 @@ const asyncExtension: marked.MarkedExtension = {
 marked.use(asyncExtension);
 
 (async () => {
-    const a: string = await marked('# foobar', { async: true });
-    const b: string = marked('# foobar', { async: false });
-    const c: string = marked('# foobar');
+    const md = '# foobar';
+    const asyncMarked: string = await marked(md, {async: true});
+    const promiseMarked: Promise<string> = marked(md, {async: true});
+    const notAsyncMarked: string = marked(md, {async: false});
+    const defaultMarked: string = marked(md);
+    const callback: void = marked(md, (_: any, res: string) => { res; });
+    const asyncCallbackwithOpts: void = marked(md, {async: true}, (_: any, res: string) => { res; });
+    const notAsyncCallbackwithOpts: void = marked(md, {async: false}, (_: any, res: string) => { res; });
 
-    const d: string = await marked.parse('# foobar', { async: true });
-    const e: string = marked.parse('# foobar', { async: false });
-    const f: string = marked.parse('# foobar');
-
-    const g: Promise<string> = marked('md', {async: true});
-    const h: Promise<string> = marked.parse('md', {async: true, headerIds: false});
+    const asyncMarkedParse: string = await marked.parse(md, {async: true});
+    const promiseMarkedParse: Promise<string> = marked.parse(md, {async: true, headerIds: false});
+    const notAsyncMarkedParse: string = marked.parse(md, {async: false});
+    const defaultMarkedParse: string = marked.parse(md);
+    const callbackParse: void = marked.parse(md, (_: any, res: string) => { res; });
+    const asyncCallbackwithOptsParse: void = marked(md, {async: true}, (_: any, res: string) => { res; });
+    const notAsyncCallbackwithOptsParse: void = marked(md, {async: false}, (_: any, res: string) => { res; });
 })();
 
 // Tests for List and ListItem

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -257,6 +257,16 @@ const asyncExtension: marked.MarkedExtension = {
 
 marked.use(asyncExtension);
 
+(async () => {
+    const a: string = await marked('# foobar', { async: true });
+    const b: string = marked('# foobar', { async: false });
+    const d: string = marked('# foobar');
+
+    const e: string = await marked.parse('# foobar', { async: true });
+    const f: string = marked.parse('# foobar', { async: false });
+    const h: string = marked.parse('# foobar');
+})();
+
 // Tests for List and ListItem
 // Dumped from markdown list parsed data
 

--- a/types/marked/marked-tests.ts
+++ b/types/marked/marked-tests.ts
@@ -112,7 +112,7 @@ class ExtendedRenderer extends marked.Renderer {
     paragraph = (text: string): string => super.paragraph(text);
     table = (header: string, body: string): string => super.table(header, body);
     tablerow = (content: string): string => super.tablerow(content);
-    tablecell = (content: string, flags: { header: boolean; align: 'center' | 'left' | 'right' | null; }): string => super.tablecell(content, flags);
+    tablecell = (content: string, flags: { header: boolean; align: 'center' | 'left' | 'right' | null }): string => super.tablecell(content, flags);
     strong = (text: string): string => super.strong(text);
     em = (text: string): string => super.em(text);
     codespan = (code: string): string => super.codespan(code);
@@ -158,11 +158,9 @@ marked.use({
             return false;
         },
         listitem(text, task, checked) {
-            if (task)
-                return `<li class="task-list-item ${checked ? "checked" : ""}">${text}</li>\n`;
-            else
-                return `<li>${text}</li>\n`;
-        }
+            if (task) return `<li class="task-list-item ${checked ? 'checked' : ''}">${text}</li>\n`;
+            else return `<li>${text}</li>\n`;
+        },
     },
     tokenizer: {
         codespan(src) {
@@ -247,6 +245,18 @@ marked.use({
     extensions: [tokenizerExtension, rendererExtension, tokenizerAndRendererExtension],
 });
 
+const asyncExtension: marked.MarkedExtension = {
+    async: true,
+    async walkTokens(token) {
+        if (token.type === 'code') {
+            await Promise.resolve(3);
+            token.text += 'foobar';
+        }
+    },
+};
+
+marked.use(asyncExtension);
+
 // Tests for List and ListItem
 // Dumped from markdown list parsed data
 
@@ -295,13 +305,13 @@ const listAndListItemText: marked.Tokens.List = {
 import { Lexer, Parser, Tokenizer, Renderer, TextRenderer, Slugger } from 'marked';
 
 const lexer2 = new Lexer();
-const tokens4 = lexer2.lex("# test");
+const tokens4 = lexer2.lex('# test');
 const parser2 = new Parser();
 console.log(parser2.parse(tokens4));
 
 const slugger2 = new Slugger();
 console.log(slugger2.slug('Test Slug'));
 
-marked.use({renderer: new Renderer()});
-marked.use({renderer: new TextRenderer()});
-marked.use({tokenizer: new Tokenizer()});
+marked.use({ renderer: new Renderer() });
+marked.use({ renderer: new TextRenderer() });
+marked.use({ tokenizer: new Tokenizer() });

--- a/types/marked/tslint.json
+++ b/types/marked/tslint.json
@@ -1,7 +1,3 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json",
-    "rules": {
-        "void-return": false,
-        "no-void-expression": false
-    }
+    "extends": "@definitelytyped/dtslint/dt.json"
 }

--- a/types/marked/tslint.json
+++ b/types/marked/tslint.json
@@ -1,3 +1,7 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "void-return": false,
+        "no-void-expression": false
+    }
 }

--- a/types/marked/v3/marked-tests.ts
+++ b/types/marked/v3/marked-tests.ts
@@ -124,11 +124,9 @@ marked.use({
             return false;
         },
         listitem(text, task, checked) {
-            if (task)
-                return `<li class="task-list-item ${checked ? "checked" : ""}">${text}</li>\n`;
-            else
-                return `<li>${text}</li>\n`;
-        }
+            if (task) return `<li class="task-list-item ${checked ? 'checked' : ''}">${text}</li>\n`;
+            else return `<li>${text}</li>\n`;
+        },
     },
     tokenizer: {
         codespan(src) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test marked`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
https://github.com/markedjs/marked/pull/2474
https://marked.js.org/using_pro#async

