### PR TITLE
Allow number data type in scrollY

### DIFF
--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1288,7 +1288,7 @@ declare namespace DataTables {
         /**
          * Vertical scrolling. Since: 1.10 Exp: "200px"
          */
-        scrollY?: string | undefined;
+        scrollY?: number | string | undefined;
 
         /**
          * Feature control search (filtering) abilities Since: 1.10


### PR DESCRIPTION
When using the plugin scroller with serverSide and ajax options, setting scrollY as "300px" or "300" gives incorrect scrolling experience. If I set 200 as a number, it works as expected. Example link: https://datatables.net/extensions/scroller/examples/initialisation/server-side_processing.html

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [] Test the change in your own code. (Compile and run.)
- [] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatables.net/extensions/scroller/examples/initialisation/server-side_processing.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.