### PR TITLE
[clean-css] makes Output.sourceMap optional

### DIFF
--- a/types/clean-css/clean-css-tests.ts
+++ b/types/clean-css/clean-css-tests.ts
@@ -17,9 +17,9 @@ new CleanCSS({ sourceMap: true, rebaseTo: pathToOutputDirectory })
   .minify(source, (error: any, minified: CleanCSS.Output): void => {
     // access minified.sourceMap for SourceMapGenerator object
     // see https://github.com/mozilla/source-map/#sourcemapgenerator for more details
-    // see https://github.com/jakubpawlowicz/clean-css/blob/master/bin/cleancss#L114 on how it's used in clean-css' CLI
+    // see https://github.com/clean-css/clean-css-cli/blob/8fc585e99d7bf4e812a5d4444ccbaf9967f24f10/index.js#L372-L374 on how it's used in clean-css' CLI
     console.log(minified.sourceMap);
-    minified.sourceMap.setSourceContent("bar.css", "");
+    minified.sourceMap?.setSourceContent("bar.css", "");
 });
 
 const inputSourceMap = { version: '3', sources: ['foo.css'], names: [], mappings: 'AAAA' };

--- a/types/clean-css/index.d.ts
+++ b/types/clean-css/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for clean-css 4.2
-// Project: https://github.com/jakubpawlowicz/clean-css
+// Project: https://github.com/clean-css/clean-css
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Andrew Potter <https://github.com/GolaWaya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -94,7 +94,7 @@ declare namespace CleanCSS {
         /**
          * Output source map if requested with `sourceMap` option
          */
-        sourceMap: SourceMapGenerator;
+        sourceMap?: SourceMapGenerator;
 
         /**
          * A list of errors raised


### PR DESCRIPTION
* [clean-css] Makes `Output.sourceMap` optional as it is only included in the result of a call to `new CleanCSS(options).minify` if `options.sourceMap` was `true`. Updates an unguarded access in the associated test file accordingly.

* [clean-css] Updates URL references to the CleanCSS repository to the current URL (the repository got transferred at one point).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). **Fail**: `npm test clean-css` fails with “File node_modules/source-map/source-map.d.ts comes from a `node_modules` but is not declared in this type's `package.json`.”. This is a pre-existing problem and I’m not sure what to do to avoid it.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [clean-css/lib/writer/simple.js](https://github.com/clean-css/clean-css/blob/73ef43f678194f26d5b1e543288cfc8ffbc1cf32/lib/writer/simple.js#L45) only contains `styles` while [clean-css/lib/writer/source-maps.js](https://github.com/clean-css/clean-css/blob/73ef43f678194f26d5b1e543288cfc8ffbc1cf32/lib/writer/source-maps.js#L98-L101) contains both `styles` and `sourceMap`.