### PR TITLE
[@types/meteor] update react-meteor-data definitions for v2.3.1

### DIFF
--- a/types/meteor/react-meteor-data.d.ts
+++ b/types/meteor/react-meteor-data.d.ts
@@ -11,7 +11,7 @@ export function withTracker<TDataProps, TOwnProps>(
  * Hooks (React 16.8 or later) version of tracker.
  * Requires react-meteor-data 2.0.0 or later
  */
-export function useTracker<TDataProps>(getMeteorData: () => TDataProps, deps?: React.DependencyList): TDataProps;
+export function useTracker<TDataProps>(getMeteorData: () => TDataProps, deps?: React.DependencyList, skipUpdate: (prev: TDataProps, next: TDataProps): boolean): TDataProps;
 
 /**
  * Requires react-meteor-data 2.4.0 or later

--- a/types/meteor/react-meteor-data.d.ts
+++ b/types/meteor/react-meteor-data.d.ts
@@ -11,7 +11,7 @@ export function withTracker<TDataProps, TOwnProps>(
  * Hooks (React 16.8 or later) version of tracker.
  * Requires react-meteor-data 2.0.0 or later
  */
-export function useTracker<TDataProps>(getMeteorData: () => TDataProps, deps?: React.DependencyList, skipUpdate?: (prev: TDataProps, next: TDataProps) => boolean): TDataProps;
+export function useTracker<TDataProps>(getMeteorData: () => TDataProps, deps?: React.DependencyList, skipUpdate?: (prev: TDataProps, next: TDataProps) => boolean) => TDataProps;
 
 /**
  * Requires react-meteor-data 2.4.0 or later

--- a/types/meteor/react-meteor-data.d.ts
+++ b/types/meteor/react-meteor-data.d.ts
@@ -11,7 +11,7 @@ export function withTracker<TDataProps, TOwnProps>(
  * Hooks (React 16.8 or later) version of tracker.
  * Requires react-meteor-data 2.0.0 or later
  */
-export function useTracker<TDataProps>(getMeteorData: () => TDataProps, deps?: React.DependencyList, skipUpdate: (prev: TDataProps, next: TDataProps): boolean): TDataProps;
+export function useTracker<TDataProps>(getMeteorData: () => TDataProps, deps?: React.DependencyList, skipUpdate?: (prev: TDataProps, next: TDataProps): boolean): TDataProps;
 
 /**
  * Requires react-meteor-data 2.4.0 or later

--- a/types/meteor/react-meteor-data.d.ts
+++ b/types/meteor/react-meteor-data.d.ts
@@ -11,7 +11,7 @@ export function withTracker<TDataProps, TOwnProps>(
  * Hooks (React 16.8 or later) version of tracker.
  * Requires react-meteor-data 2.0.0 or later
  */
-export function useTracker<TDataProps>(getMeteorData: () => TDataProps, deps?: React.DependencyList, skipUpdate?: (prev: TDataProps, next: TDataProps): boolean): TDataProps;
+export function useTracker<TDataProps>(getMeteorData: () => TDataProps, deps?: React.DependencyList, skipUpdate?: (prev: TDataProps, next: TDataProps) => boolean): TDataProps;
 
 /**
  * Requires react-meteor-data 2.4.0 or later


### PR DESCRIPTION
The current type definitions seem to be outdated. In v2.3.1 react-meteor-data added a third parameter `skipUpdate` to the `userTracker` hook.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
https://github.com/meteor/react-packages/blob/master/packages/react-meteor-data/useTracker.ts
