### PR TITLE
[data-api-client] fix typings for .rollback

### DIFF
--- a/types/data-api-client/data-api-client-tests.ts
+++ b/types/data-api-client/data-api-client-tests.ts
@@ -36,4 +36,7 @@ client
     .transaction()
     .query('INSERT INTO Users VALUES(:id, :name)', { id: 'id', name: 'name' })
     .query(prev => ['UPDATE Users SET name = :name WHERE id = :id', { id: prev.insertId, name: 'newName' }])
+    .rollback((err, status) => {
+        // console.error(err, status)
+    })
     .commit();

--- a/types/data-api-client/index.d.ts
+++ b/types/data-api-client/index.d.ts
@@ -43,7 +43,7 @@ declare namespace Client {
                 | ((prevResult: { insertId?: any }) => any),
         ): Transaction;
 
-        rollback: (error: Error, status: any) => void;
+        rollback(cb: ((error: Error, status: any) => void)): Transaction;
         commit: () => Promise<void>;
     }
 


### PR DESCRIPTION
The suggested usage of `rollback` in the data-api-client is this:
```
.rollback((e,status) => { /* do something with the error */ }) // optional
```
so it expects a callback function as a param, but it still returns a `Transaction` object (so you'd be able to call the `commit()`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [data-api-client](https://github.com/jeremydaly/data-api-client)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.