### PR TITLE
[prettier] Add getSupportInfo to standalone API

### DIFF
--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -72,7 +72,7 @@ const configFilePathInSpecificPath = prettier.resolveConfigFile.sync('/path');
 
 prettier.clearConfigCache();
 
-const currentSupportInfo = prettier.getSupportInfo();
+prettier.getSupportInfo(); // $ExpectType SupportInfo
 
 prettierStandalone.formatWithCursor(' 1', { cursorOffset: 2, parser: 'babel' });
 // @ts-expect-error
@@ -82,6 +82,7 @@ prettierStandalone.formatWithCursor(' 1', { cursorOffset: 2, parser: 'babel', ra
 
 prettierStandalone.format(' 1', { parser: 'babel' });
 prettierStandalone.check(' console.log(b)');
+prettierStandalone.getSupportInfo(); // $ExpectType SupportInfo
 
 angularParser.parsers.__ng_action.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser<any>; }, options: ParserOptions<any>) => any
 babelParser.parsers.babel.parse; // $ExpectType (text: string, parsers: { [parserName: string]: Parser<any>; }, options: ParserOptions<any>) => any

--- a/types/prettier/standalone.d.ts
+++ b/types/prettier/standalone.d.ts
@@ -1,4 +1,4 @@
-import { CursorOptions, CursorResult, Options, Plugin } from './';
+import { CursorOptions, CursorResult, Options, SupportInfo } from './';
 
 /**
  * formatWithCursor both formats the code, and translates a cursor position from unformatted code to formatted code.
@@ -23,5 +23,10 @@ export function format(source: string, options?: Options): string;
  * This is similar to the `--list-different` parameter in the CLI and is useful for running Prettier in CI scenarios.
  */
 export function check(source: string, options?: Options): boolean;
+
+/**
+ * Returns an object representing the parsers, languages and file types Prettier supports for the current version.
+ */
+export function getSupportInfo(): SupportInfo;
 
 export as namespace prettier;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/prettier/prettier/blob/c51d509560b713fdef9590fc60a55329c8660671/src/standalone.js#L47
