### PR TITLE
Tooling: migrated no-bad-reference to ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
     ],
     "rules": {
       "dt-header": "error",
+      "no-bad-reference": "error",
       "no-dead-reference": "error",
       "no-const-enum": "error",
       "no-useless-files": "error"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Uses the script from #61793.

Sibling PR to: https://github.com/microsoft/DefinitelyTyped-tools/pull/521. ~Builds will fail until those changes are available.~ Well, builds _in this PR_ aren't failing because no packages disable the rule. 