### PR TITLE
[responselike] Restore types

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -4507,10 +4507,6 @@
             "libraryName": "resolve-pkg",
             "asOfVersion": "2.0.0"
         },
-        "responselike": {
-            "libraryName": "responselike",
-            "asOfVersion": "3.0.0"
-        },
         "rest-io": {
             "libraryName": "rest-io",
             "asOfVersion": "4.1.0"

--- a/types/responselike/index.d.ts
+++ b/types/responselike/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for responselike 1.0
+// Project: https://github.com/lukechilds/responselike#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { IncomingMessage } from 'http';
+import { Stream } from 'stream';
+
+export = ResponseLike;
+
+/**
+ * Returns a streamable response object similar to a [Node.js HTTP response stream](https://nodejs.org/api/http.html#http_class_http_incomingmessage).
+ */
+declare class ResponseLike extends Stream.Readable {
+    statusCode: number;
+    headers: { [header: string]: string | string[] | undefined };
+    body: Buffer;
+    url: string;
+
+    /**
+     * @param statusCode HTTP response status code.
+     * @param headers HTTP headers object. Keys will be automatically lowercased.
+     * @param body A Buffer containing the response body. The Buffer contents will be streamable but is also exposed directly as `response.body`.
+     * @param url Request URL string.
+     */
+    constructor(
+        statusCode: number,
+        headers: { [header: string]: string | string[] | undefined },
+        body: Buffer,
+        url: string
+    );
+}

--- a/types/responselike/responselike-tests.ts
+++ b/types/responselike/responselike-tests.ts
@@ -1,0 +1,10 @@
+import Response = require('responselike');
+
+const response = new Response(200, { foo: 'bar' }, Buffer.from('Hi!'), 'https://example.com');
+
+response.statusCode; // $ExpectType number
+response.headers; // $ExpectType { [header: string]: string | string[] | undefined; }
+response.body; // $ExpectType Buffer
+response.url; // $ExpectType string
+
+response.pipe(process.stdout);

--- a/types/responselike/tsconfig.json
+++ b/types/responselike/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "responselike-tests.ts"
+    ]
+}

--- a/types/responselike/tslint.json
+++ b/types/responselike/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Restoring types because of https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/62099 and discussions in https://github.com/sindresorhus/got/issues/2129.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.