### PR TITLE
[mapbox-gl]: extend allowed types for data sources of type 'geojson'

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -9,6 +9,7 @@
 //                 makspetrov <https://github.com/Nosfit>
 //                 Michael Bullington <https://github.com/mbullington>
 //                 Olivier Pascal <https://github.com/pascaloliv>
+//                 Marko Schilde <https://github.com/mschilde>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -1421,7 +1422,7 @@ declare namespace mapboxgl {
     }
 
     export interface GeoJSONSourceOptions {
-        data?: GeoJSON.Feature<GeoJSON.Geometry> | GeoJSON.FeatureCollection<GeoJSON.Geometry> | string | undefined;
+        data?: GeoJSON.Feature<GeoJSON.Geometry> | GeoJSON.FeatureCollection<GeoJSON.Geometry> | GeoJSON.Geometry | string | undefined;
 
         maxzoom?: number | undefined;
 


### PR DESCRIPTION
Mapbox data sources of type `geojson` also allows inline Geometry (e.g. `LineString`). It is not limited to `Feature` or `FeatureCollection`.

Example: https://codepen.io/mschilde/pen/zYjrdxb (mapbox token needs to be provided)

```
map.addSource('maine', {
            'type': 'geojson',
            'data': {
                    'type': 'MultiPolygon',
                    'coordinates': [[
                        [
                            [-67.13734, 45.13745],
                            [-66.96466, 44.8097],
                             ...
                        ]
                    ]]
                }
        });
```

The data doesn't have to be wrapped into a GeoJSON `Feature`, all geometries are valid too.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [MapBox](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#geojson)