### PR TITLE
change(passport-local): Strongly type user as Express.User in done callback

### DIFF
--- a/types/passport-local/index.d.ts
+++ b/types/passport-local/index.d.ts
@@ -6,8 +6,8 @@
 
 /// <reference types="passport"/>
 
-import { Strategy as PassportStrategy } from "passport-strategy";
-import express = require("express");
+import { Strategy as PassportStrategy } from 'passport-strategy';
+import express = require('express');
 
 interface IStrategyOptions {
     usernameField?: string | undefined;
@@ -32,7 +32,7 @@ interface VerifyFunctionWithRequest {
         req: express.Request,
         username: string,
         password: string,
-        done: (error: any, user?: any, options?: IVerifyOptions) => void
+        done: (error: any, user?: Express.User | false, options?: IVerifyOptions) => void,
     ): void;
 }
 
@@ -40,15 +40,12 @@ interface VerifyFunction {
     (
         username: string,
         password: string,
-        done: (error: any, user?: any, options?: IVerifyOptions) => void
+        done: (error: any, user?: Express.User | false, options?: IVerifyOptions) => void,
     ): void;
 }
 
 declare class Strategy extends PassportStrategy {
-    constructor(
-        options: IStrategyOptionsWithRequest,
-        verify: VerifyFunctionWithRequest
-    );
+    constructor(options: IStrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
     constructor(options: IStrategyOptions, verify: VerifyFunction);
     constructor(verify: VerifyFunction);
 

--- a/types/passport-local/passport-local-tests.ts
+++ b/types/passport-local/passport-local-tests.ts
@@ -1,9 +1,8 @@
-
 /**
  * Created by Maxime LUCE <https://github.com/SomaticIT>.
  */
 
-import express = require("express");
+import express = require('express');
 import passport = require('passport');
 import local = require('passport-local');
 
@@ -12,67 +11,79 @@ interface IUser {
     username: string;
 }
 
-const testingLocalStrategy = new local.Strategy(()=>{});
+const testingLocalStrategy = new local.Strategy(() => {});
 testingLocalStrategy.success = () => {};
 testingLocalStrategy.fail = () => {};
 
-class User implements IUser {
+class UserModel implements IUser {
     public username: string;
     public password: string;
 
-    static findOne(user: IUser, callback: (err: Error, user: User) => void): void {
-        callback(null, new User());
+    static findOne(user: IUser, callback: (err: Error, user: UserModel) => void): void {
+        callback(null, new UserModel());
     }
 
     verifyPassword(password: string): boolean {
         return true;
     }
 }
+
+declare global {
+    namespace Express {
+        // tslint:disable-next-line:no-empty-interface
+        interface User extends UserModel {}
+    }
+}
 //#endregion
 
 // Sample from https://github.com/jaredhanson/passport-local#configure-strategy
-passport.use(new local.Strategy((username: any, password: any, done: any) => {
-    User.findOne({ username: username }, function (err, user) {
-        if (err) {
-            return done(err);
-        }
+passport.use(
+    new local.Strategy((username: any, password: any, done: any) => {
+        UserModel.findOne({ username: username }, function (err, user) {
+            if (err) {
+                return done(err);
+            }
 
-        if (!user) {
-            return done(null, false);
-        }
+            if (!user) {
+                return done(null, false);
+            }
 
-        if (!user.verifyPassword(password)) {
-            return done(null, false);
-        }
+            if (!user.verifyPassword(password)) {
+                return done(null, false);
+            }
 
-        return done(null, user);
-    });
-}));
+            return done(null, user);
+        });
+    }),
+);
 
-passport.use(new local.Strategy({
-    passReqToCallback: true
-}, function (req, username, password, done) {
-    User.findOne({ username: username }, function (err, user) {
-        if (err) {
-            return done(err);
-        }
+passport.use(
+    new local.Strategy(
+        {
+            passReqToCallback: true,
+        },
+        function (req, username, password, done) {
+            UserModel.findOne({ username: username }, function (err, user) {
+                if (err) {
+                    return done(err);
+                }
 
-        if (!user) {
-            return done(null, false);
-        }
+                if (!user) {
+                    return done(null, false);
+                }
 
-        if (!user.verifyPassword(password)) {
-            return done(null, false);
-        }
+                if (!user.verifyPassword(password)) {
+                    return done(null, false);
+                }
 
-        return done(null, user);
-    });
-}));
+                return done(null, user);
+            });
+        },
+    ),
+);
 
 // Sample from https://github.com/jaredhanson/passport-local#authenticate-requests
 var app = express();
-app.post('/login',
-    passport.authenticate('local', { failureRedirect: '/login' }),
-    function (req, res) {
-        res.redirect('/');
-    });
+app.post('/login', passport.authenticate('local', { failureRedirect: '/login' }), function (req, res) {
+    res.redirect('/');
+});


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Changes the type of the user passed to the callback to be `Express.User`. This is in line with several other passport packages, updated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49723. The strategy also supports passing `false` to the callback, to show that no user was found, [here](https://github.com/jaredhanson/passport-local/blob/master/lib/strategy.js#L82). This is already reflected in the tests for the types [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/passport-local/passport-local-tests.ts#L61)
