### PR TITLE
fix(selenium-webdriver): typo in window.fullscreen method

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -1301,7 +1301,7 @@ export class Window {
    *     has completed.
    * @see <https://fullscreen.spec.whatwg.org/#fullscreen-an-element>
    */
-  fullsceen(): Promise<void>;
+  fullscreen(): Promise<void>;
 
   // endregion
 }

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -381,7 +381,7 @@ function TestWebDriverWindow() {
     sizePromise = window.getSize();
     voidPromise = window.maximize();
     voidPromise = window.minimize();
-    voidPromise = window.fullsceen();
+    voidPromise = window.fullscreen();
     voidPromise = window.setPosition(12, 34);
     voidPromise = window.setSize(12, 34);
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
According to the original implementation the method is called "fullscreen" and not "fullsceen"
https://github.com/SeleniumHQ/selenium/blob/c06370910c804e7de0cbdc3c1eae131bd634f55f/javascript/node/selenium-webdriver/lib/webdriver.js#L2141

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
