### PR TITLE
Add `style` prop to `ResizableBox` in react-resizable package

### DIFF
--- a/types/react-resizable/index.d.ts
+++ b/types/react-resizable/index.d.ts
@@ -72,6 +72,6 @@ export interface ResizableBoxState {
     width: number;
 }
 
-export type ResizableBoxProps = ResizableProps;
+export type ResizableBoxProps = ResizableProps & { style?: React.CSSProperties };
 
 export class ResizableBox extends React.Component<ResizableBoxProps, ResizableBoxState> {}

--- a/types/react-resizable/react-resizable-tests.tsx
+++ b/types/react-resizable/react-resizable-tests.tsx
@@ -48,6 +48,16 @@ class TestResizableBoxComponent extends React.Component<{ children?: React.React
     }
 }
 
+class TestStyledResizableBoxComponent extends React.Component<{ children?: React.ReactNode }> {
+    render() {
+        return (
+            <ResizableBox width={10} height={20} style={{ color: 'pink' }}>
+                <div>{this.props.children}</div>
+            </ResizableBox>
+        );
+    }
+}
+
 class TestXResizableComponent extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return (


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Description of the missing style prop](https://github.com/react-grid-layout/react-resizable/blob/master/lib/ResizableBox.js#L13)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.