### PR TITLE
[fontkit]: add render method definition for glyph, fix export types

### DIFF
--- a/types/fontkit/fontkit-tests.ts
+++ b/types/fontkit/fontkit-tests.ts
@@ -1,4 +1,4 @@
-import fontkit from 'fontkit';
+import * as fontkit from 'fontkit';
 
 const f = fontkit.openSync('fonts/a-font.ttf');
 const { glyphs, positions } = f.layout('Hello World!');

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -197,6 +197,9 @@ export interface Glyph {
 
     /** is a ligature glyph (multiple character, spacing glyph) */
     isLigature: boolean;
+
+    /** Renders the glyph to the given graphics context, at the specified font size. */
+    render(ctx: CanvasRenderingContext2D, size: number): void;
 }
 
 /**
@@ -279,5 +282,5 @@ interface Fontkit {
     create(buffer: Buffer, postscriptName?: string): Font;
 }
 
-declare const defExp: Fontkit;
-export default defExp;
+declare const fontkit: Fontkit;
+export = fontkit;

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for fontkit 1.8
+// Type definitions for fontkit 2.0
 // Project: https://github.com/foliojs/fontkit#readme
 // Definitions by: Teoxoy <https://github.com/Teoxoy>
+//                 Stepan Mikhailiuk <https://github.com/stepancar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -259,28 +260,23 @@ export interface BBOX {
     maxY: number;
 }
 
-interface Fontkit {
-    /**
-     * Opens a font file asynchronously, and calls the callback with a font object.
-     * For collection fonts (such as TrueType collection files),
-     * you can pass a postscriptName to get that font out of the collection instead of a collection object.
-     */
-    open(filename: string, postscriptName: string, callback: (err: Error | null, font: Font) => void): void;
+/**
+ * Opens a font file asynchronously, and calls the callback with a font object.
+ * For collection fonts (such as TrueType collection files),
+ * you can pass a postscriptName to get that font out of the collection instead of a collection object.
+ */
+export function open(filename: string, postscriptName: string, callback: (err: Error | null, font: Font) => void): void;
 
-    /**
-     * Opens a font file synchronously, and returns a font object.
-     * For collection fonts (such as TrueType collection files),
-     * you can pass a postscriptName to get that font out of the collection instead of a collection object.
-     */
-    openSync(filename: string, postscriptName?: string): Font;
+/**
+ * Opens a font file synchronously, and returns a font object.
+ * For collection fonts (such as TrueType collection files),
+ * you can pass a postscriptName to get that font out of the collection instead of a collection object.
+ */
+export function openSync(filename: string, postscriptName?: string): Font;
 
-    /**
-     * Returns a font object for the given buffer.
-     * For collection fonts (such as TrueType collection files),
-     * you can pass a postscriptName to get that font out of the collection instead of a collection object.
-     */
-    create(buffer: Buffer, postscriptName?: string): Font;
-}
-
-declare const fontkit: Fontkit;
-export = fontkit;
+/**
+ * Returns a font object for the given buffer.
+ * For collection fonts (such as TrueType collection files),
+ * you can pass a postscriptName to get that font out of the collection instead of a collection object.
+ */
+export function create(buffer: Buffer, postscriptName?: string): Font;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/foliojs/fontkit/blob/master/test/index.js#L1
[This test](https://github.com/foliojs/fontkit/blob/master/test/index.js#L1]) describes a way how this package should be imported, 
[This code](https://github.com/foliojs/fontkit/blob/master/src/index.js) proves that package doesn't have default export
[Here](https://github.com/foliojs/fontkit/blob/master/src/glyph/Glyph.js#L200) you can find definition of `Glyph.render`

