### PR TITLE
[@types/node] use explicit strings for path.sep and path.delimiter

### DIFF
--- a/types/node/path.d.ts
+++ b/types/node/path.d.ts
@@ -137,11 +137,11 @@ declare module 'path' {
             /**
              * The platform-specific file separator. '\\' or '/'.
              */
-            readonly sep: string;
+            readonly sep: '\\' | '/';
             /**
              * The platform-specific file delimiter. ';' or ':'.
              */
-            readonly delimiter: string;
+            readonly delimiter: ';' | ':';
             /**
              * Returns an object from a path string - the opposite of format().
              *

--- a/types/node/test/path.ts
+++ b/types/node/test/path.ts
@@ -87,7 +87,10 @@ path.extname('index');
 // returns
 //        ['foo', 'bar', 'baz']
 
-process.env["PATH"]; // $ExpectType string | undefined
+// $ExpectType "folder\\file.png" | "folder/file.png"
+const string = `folder${path.sep}file.png` as const; // tslint:disable-line:no-unnecessary-type-assertion
+
+process.env['PATH']; // $ExpectType string | undefined
 
 path.parse('/home/user/dir/file.txt');
 // returns

--- a/types/node/v14/path.d.ts
+++ b/types/node/v14/path.d.ts
@@ -122,11 +122,11 @@ declare module 'path' {
             /**
              * The platform-specific file separator. '\\' or '/'.
              */
-            readonly sep: string;
+            readonly sep: '\\' | '/';
             /**
              * The platform-specific file delimiter. ';' or ':'.
              */
-            readonly delimiter: string;
+            readonly delimiter: ';' | ':';
             /**
              * Returns an object from a path string - the opposite of format().
              *

--- a/types/node/v14/test/path.ts
+++ b/types/node/v14/test/path.ts
@@ -85,7 +85,10 @@ path.extname('index');
 // returns
 //        ['foo', 'bar', 'baz']
 
-process.env["PATH"]; // $ExpectType string | undefined
+// $ExpectType "folder\\file.png" | "folder/file.png"
+const string = `folder${path.sep}file.png` as const; // tslint:disable-line:no-unnecessary-type-assertion
+
+process.env['PATH']; // $ExpectType string | undefined
 
 path.parse('/home/user/dir/file.txt');
 // returns

--- a/types/node/v16/path.d.ts
+++ b/types/node/v16/path.d.ts
@@ -137,11 +137,11 @@ declare module 'path' {
             /**
              * The platform-specific file separator. '\\' or '/'.
              */
-            readonly sep: string;
+            readonly sep: '\\' | '/';
             /**
              * The platform-specific file delimiter. ';' or ':'.
              */
-            readonly delimiter: string;
+            readonly delimiter: ';' | ':';
             /**
              * Returns an object from a path string - the opposite of format().
              *

--- a/types/node/v16/test/path.ts
+++ b/types/node/v16/test/path.ts
@@ -87,7 +87,10 @@ path.extname('index');
 // returns
 //        ['foo', 'bar', 'baz']
 
-process.env["PATH"]; // $ExpectType string | undefined
+// $ExpectType "folder\\file.png" | "folder/file.png"
+const string = `folder${path.sep}file.png` as const; // tslint:disable-line:no-unnecessary-type-assertion
+
+process.env['PATH']; // $ExpectType string | undefined
 
 path.parse('/home/user/dir/file.txt');
 // returns


### PR DESCRIPTION
rationale: This improves type safety when using `switch...case` statements with either of these attributes, and allows for more precise [Template Literal Types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: *not applicable*
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
