### PR TITLE
[jest] Fix return types of fake timers APIs

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -278,30 +278,30 @@ declare namespace jest {
      * > Note: This function is only available when using modern fake timers
      * > implementation
      */
-    function runAllImmediates(): typeof jest;
+    function runAllImmediates(): void;
     /**
      * Exhausts the micro-task queue (usually interfaced in node via process.nextTick).
      */
-    function runAllTicks(): typeof jest;
+    function runAllTicks(): void;
     /**
      * Exhausts both the macro-task queue (i.e., all tasks queued by setTimeout(),
      * setInterval(), and setImmediate()) and the micro-task queue (usually interfaced
      * in node via process.nextTick).
      */
-    function runAllTimers(): typeof jest;
+    function runAllTimers(): void;
     /**
      * Executes only the macro-tasks that are currently pending (i.e., only the
      * tasks that have been queued by setTimeout() or setInterval() up to this point).
      * If any of the currently pending macro-tasks schedule new macro-tasks,
      * those new tasks will not be executed by this call.
      */
-    function runOnlyPendingTimers(): typeof jest;
+    function runOnlyPendingTimers(): void;
     /**
      * Advances all timers by msToRun milliseconds. All pending "macro-tasks" that have been
      * queued via setTimeout() or setInterval(), and would be executed within this timeframe
      * will be executed.
      */
-    function advanceTimersByTime(msToRun: number): typeof jest;
+    function advanceTimersByTime(msToRun: number): void;
     /**
      * Advances all timers by the needed milliseconds so that only the next
      * timeouts/intervals will run. Optionally, you can provide steps, so it

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -156,7 +156,7 @@ declare namespace jest {
      * been scheduled, they will be cleared and will never have the opportunity
      * to execute in the future.
      */
-    function clearAllTimers(): typeof jest;
+    function clearAllTimers(): void;
     /**
      * Returns the number of fake timers still left to run.
      */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -355,11 +355,6 @@ jest.autoMockOff()
     .resetModules()
     .isolateModules(() => {})
     .retryTimes(3, { logErrorsBeforeRetry: true })
-    .runAllImmediates()
-    .runAllTicks()
-    .runAllTimers()
-    .runOnlyPendingTimers()
-    .advanceTimersByTime(9001)
     .setMock('moduleName', {})
     .setMock<{}>('moduleName', {})
     .setMock<{ a: 'b' }>('moduleName', { a: 'b' })
@@ -368,11 +363,27 @@ jest.autoMockOff()
     .useFakeTimers()
     .useRealTimers();
 
+// $ExpectType void
+jest.advanceTimersByTime(9001);
+
+// $ExpectType void
 jest.advanceTimersToNextTimer();
 jest.advanceTimersToNextTimer(2);
 
 // $ExpectType void
 jest.clearAllTimers();
+
+// $ExpectType void
+jest.runAllImmediates();
+
+// $ExpectType void
+jest.runAllTicks();
+
+// $ExpectType void
+jest.runAllTimers();
+
+// $ExpectType void
+jest.runOnlyPendingTimers();
 
 // https://jestjs.io/docs/configuration#faketimers-object
 jest.useFakeTimers();

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -332,10 +332,8 @@ const customMatcherFactories: jasmine.CustomMatcherFactories = {};
 jest.autoMockOff()
     .autoMockOn()
     .clearAllMocks()
-    .clearAllTimers()
     .resetAllMocks()
     .restoreAllMocks()
-    .clearAllTimers()
     .deepUnmock('moduleName')
     .disableAutomock()
     .doMock('moduleName')
@@ -372,6 +370,9 @@ jest.autoMockOff()
 
 jest.advanceTimersToNextTimer();
 jest.advanceTimersToNextTimer(2);
+
+// $ExpectType void
+jest.clearAllTimers();
 
 // https://jestjs.io/docs/configuration#faketimers-object
 jest.useFakeTimers();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see documentation of [fake timers](https://jestjs.io/docs/jest-object#fake-timers)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Summary

The correct return type of `jest.clearAllTimers()`, `jest. runAllImmediates()`, `jest. runAllTicks()`, `jest.runAllTimers()`, `jest.runOnlyPendingTimers()`, `jest.advanceTimersByTime()` should be `void` instead of `typeof jest`.  See [source code](https://github.com/facebook/jest/blob/05cd93bc0bfdd91e2e0b42e51b569ba9f073801f/packages/jest-fake-timers/src/legacyFakeTimers.ts#L119-L262) for reference.