### PR TITLE
[trusted-types] Properly augment global to prevent conflicts with lib.dom.d.ts et al.

### DIFF
--- a/types/trusted-types/index.d.ts
+++ b/types/trusted-types/index.d.ts
@@ -4,6 +4,7 @@
 //                 Damien Engels <https://github.com/engelsdamien>
 //                 Emanuel Tesar <https://github.com/siegrift>
 //                 Bjarki <https://github.com/bjarkler>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.1
 
@@ -11,23 +12,24 @@ import * as lib from './lib';
 
 // Re-export the type definitions globally.
 declare global {
-    const TrustedHTML: typeof lib.TrustedHTML;
-    type TrustedHTML = lib.TrustedHTML;
-    const TrustedScript: typeof lib.TrustedScript;
-    type TrustedScript = lib.TrustedScript;
-    const TrustedScriptURL: typeof lib.TrustedScriptURL;
-    type TrustedScriptURL = lib.TrustedScriptURL;
+    // tslint:disable-next-line no-empty-interface -- interface to allow module augmentation
+    interface TrustedHTML extends lib.TrustedHTML {}
+    // tslint:disable-next-line no-empty-interface -- interface to allow module augmentation
+    interface TrustedScript extends lib.TrustedScript {}
+    // tslint:disable-next-line no-empty-interface -- interface to allow module augmentation
+    interface TrustedScriptURL extends lib.TrustedScriptURL {}
 
-    const TrustedTypePolicy: typeof lib.TrustedTypePolicy;
-    type TrustedTypePolicy = lib.TrustedTypePolicy;
+    // tslint:disable-next-line no-empty-interface -- interface to allow module augmentation
+    interface TrustedTypePolicy extends lib.TrustedTypePolicy {}
 
-    const TrustedTypePolicyFactory: typeof lib.TrustedTypePolicyFactory;
-    type TrustedTypePolicyFactory = lib.TrustedTypePolicyFactory;
+    // tslint:disable-next-line no-empty-interface -- interface to allow module augmentation
+    interface TrustedTypePolicyFactory extends lib.TrustedTypePolicyFactory {}
 
-    type TrustedTypePolicyOptions = lib.TrustedTypePolicyOptions;
+    // tslint:disable-next-line no-empty-interface -- interface to allow module augmentation
+    interface TrustedTypePolicyOptions extends lib.TrustedTypePolicyOptions {}
 
     // Attach the relevant Trusted Types properties to the Window object.
-    // tslint:disable-next-line no-empty-interface
+    // tslint:disable-next-line no-empty-interface -- interface to allow module augmentation
     interface Window extends lib.TrustedTypesWindow {}
 }
 

--- a/types/trusted-types/test/browser.ts
+++ b/types/trusted-types/test/browser.ts
@@ -104,11 +104,11 @@ trustedHTML = trustedScript;
 // @ts-expect-error
 new TrustedHTML();
 
-// $ExpectType typeof TrustedHTML
+// $ExpectError
 TrustedHTML;
-// $ExpectType typeof TrustedScript
+// $ExpectError
 TrustedScript;
-// $ExpectType typeof TrustedScriptURL
+// $ExpectError
 TrustedScriptURL;
 
 // $ExpectType typeof TrustedHTML

--- a/types/trusted-types/test/browser.ts
+++ b/types/trusted-types/test/browser.ts
@@ -104,11 +104,11 @@ trustedHTML = trustedScript;
 // @ts-expect-error
 new TrustedHTML();
 
-// $ExpectError
+// @ts-expect-error
 TrustedHTML;
-// $ExpectError
+// @ts-expect-error
 TrustedScript;
-// $ExpectError
+// @ts-expect-error
 TrustedScriptURL;
 
 // $ExpectType typeof TrustedHTML


### PR DESCRIPTION
This is the proper patern to augment global interfaces that are defined by the runtime (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60837#pullrequestreview-1009631323)

The previous approach would break once `lib.dom.d.ts` declares these interfaces.

The previous approach also made it impossible for other libraries to use these types.
For example, https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60691/ had to be reverted.
With proper module augmentation we can land https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60691/ again.

Verified that the new approach will allow landing https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60691/: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61166

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://developer.mozilla.org/en-US/docs/Web/API/TrustedHTML
   - https://developer.mozilla.org/en-US/docs/Web/API/TrustedScript
   - https://developer.mozilla.org/en-US/docs/Web/API/TrustedScriptURL
   - https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicy
   - https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicyFactory
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

