### PR TITLE
fix(ckeditor4): add missing pluginDefinition properties

### DIFF
--- a/types/ckeditor4/ckeditor4-tests.ts
+++ b/types/ckeditor4/ckeditor4-tests.ts
@@ -883,6 +883,10 @@ function test_plugins() {
     });
 
     console.log(CKEDITOR.plugins.registered['abbr']);
+
+    CKEDITOR.plugins.add('myPlugin', {
+        icons: 'my-plugin-icon',
+    });
 }
 
 function test_resourceManager() {

--- a/types/ckeditor4/index.d.ts
+++ b/types/ckeditor4/index.d.ts
@@ -1669,10 +1669,12 @@ declare namespace CKEDITOR {
         hidpi?: boolean | undefined;
         lang?: string | string[] | undefined;
         requires?: string | string[] | undefined;
+        icons?: string | undefined;
 
         afterInit?(editor: editor): any;
         beforeInit?(editor: editor): any;
         init?(editor: editor): void;
+        isSupportedEnvironment?(editor: editor): boolean;
         onLoad?(): any;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_pluginDefinition.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This adds the missing `icons` property to the pluginDefinition. I think it shouldn't require a new version number in the header as that property was always supported by ckeditor4.