### PR TITLE
Update Server type in @node-red/registry test

### DIFF
--- a/types/node-red__registry/node-red__registry-tests.ts
+++ b/types/node-red__registry/node-red__registry-tests.ts
@@ -169,7 +169,7 @@ function registryTests() {
             RED.httpNode;
             // $ExpectType Express
             RED.httpAdmin;
-            // $ExpectType Server
+            // $ExpectType Server<typeof IncomingMessage, typeof ServerResponse>
             RED.server;
 
             // $ExpectType string


### PR DESCRIPTION
Node types updated, so `Server` is now generic. The dependency tracker failed to run node-red__registry as part of the tests for that change.
