### PR TITLE
Add aws-lambda kinesis tumbling window handler types

### DIFF
--- a/types/aws-lambda/test/kinesis-tests.ts
+++ b/types/aws-lambda/test/kinesis-tests.ts
@@ -43,6 +43,14 @@ const tumblingWindowHandler: KinesisStreamTumblingWindowHandler = async (event, 
 
     callback();
     callback(new Error());
+
+    if (str == str) {
+        // return with state...
+        return { state: { one: 'two' } };
+    } else {
+        // or void
+        return;
+    }
 };
 
 const handlerWithResponse: KinesisStreamHandler = async (event, context, callback) => {

--- a/types/aws-lambda/test/kinesis-tests.ts
+++ b/types/aws-lambda/test/kinesis-tests.ts
@@ -5,6 +5,7 @@ import {
     KinesisStreamHandler,
     KinesisStreamRecord,
     KinesisStreamRecordPayload,
+    KinesisStreamTumblingWindowHandler,
 } from "aws-lambda";
 
 const handler: KinesisStreamHandler = async (event, context, callback) => {
@@ -27,6 +28,18 @@ const handler: KinesisStreamHandler = async (event, context, callback) => {
     str = kinesisStreamRecordPayload.kinesisSchemaVersion;
     str = kinesisStreamRecordPayload.partitionKey;
     str = kinesisStreamRecordPayload.sequenceNumber;
+
+    callback();
+    callback(new Error());
+};
+
+const tumblingWindowHandler: KinesisStreamTumblingWindowHandler = async (event, context, callback) => {
+    bool = event.isFinalInvokeForWindow;
+    bool = event.isWindowTerminatedEarly;
+    str = event.window.start;
+    str = event.window.end;
+
+    anyObj = event.state;
 
     callback();
     callback(new Error());

--- a/types/aws-lambda/test/kinesis-tests.ts
+++ b/types/aws-lambda/test/kinesis-tests.ts
@@ -44,7 +44,7 @@ const tumblingWindowHandler: KinesisStreamTumblingWindowHandler = async (event, 
     callback();
     callback(new Error());
 
-    if (str == str) {
+    if (str === str) {
         // return with state...
         return { state: { one: 'two' } };
     } else {

--- a/types/aws-lambda/trigger/kinesis-stream.d.ts
+++ b/types/aws-lambda/trigger/kinesis-stream.d.ts
@@ -3,6 +3,9 @@ import { Handler } from "../handler";
 // tslint:disable-next-line:void-return
 export type KinesisStreamHandler = Handler<KinesisStreamEvent, KinesisStreamBatchResponse | void>;
 
+// tslint:disable-next-line:void-return
+export type KinesisStreamTumblingWindowHandler = Handler<KinesisStreamTumblingWindowEvent, KinesisStreamStateResponse | void>;
+
 // Kinesis Streams
 // https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-kinesis-streams
 export interface KinesisStreamRecordPayload {
@@ -35,6 +38,10 @@ export interface KinesisStreamTumblingWindowEvent {
     isFinalInvokeForWindow: boolean;
     isWindowTerminatedEarly: boolean;
     Records: KinesisStreamRecord[];
+}
+
+export interface KinesisStreamStateResponse {
+    state?: { [key: string]: any };
 }
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-batchfailurereporting

--- a/types/aws-lambda/trigger/kinesis-stream.d.ts
+++ b/types/aws-lambda/trigger/kinesis-stream.d.ts
@@ -32,12 +32,11 @@ export interface KinesisStreamEvent {
 }
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows
-export interface KinesisStreamTumblingWindowEvent {
+export interface KinesisStreamTumblingWindowEvent extends KinesisStreamEvent {
     window: { start: string; end: string };
     state?: { [key: string]: any };
     isFinalInvokeForWindow: boolean;
     isWindowTerminatedEarly: boolean;
-    Records: KinesisStreamRecord[];
 }
 
 export interface KinesisStreamStateResponse {

--- a/types/aws-lambda/trigger/kinesis-stream.d.ts
+++ b/types/aws-lambda/trigger/kinesis-stream.d.ts
@@ -41,7 +41,7 @@ export interface KinesisStreamTumblingWindowEvent {
 }
 
 export interface KinesisStreamStateResponse {
-    state?: { [key: string]: any };
+    state: { [key: string]: any };
 }
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-batchfailurereporting

--- a/types/aws-lambda/trigger/kinesis-stream.d.ts
+++ b/types/aws-lambda/trigger/kinesis-stream.d.ts
@@ -28,7 +28,16 @@ export interface KinesisStreamEvent {
     Records: KinesisStreamRecord[];
 }
 
-// https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html
+// https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows
+export interface KinesisStreamTumblingWindowEvent {
+    window: { start: string; end: string };
+    state?: { [key: string]: any };
+    isFinalInvokeForWindow: boolean;
+    isWindowTerminatedEarly: boolean;
+    Records: KinesisStreamRecord[];
+}
+
+// https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-batchfailurereporting
 export interface KinesisStreamBatchResponse {
     batchItemFailures: KinesisStreamBatchItemFailure[];
 }

--- a/types/aws-lambda/trigger/kinesis-stream.d.ts
+++ b/types/aws-lambda/trigger/kinesis-stream.d.ts
@@ -39,7 +39,7 @@ export interface KinesisStreamTumblingWindowEvent extends KinesisStreamEvent {
     isWindowTerminatedEarly: boolean;
 }
 
-export interface KinesisStreamStateResponse {
+export interface KinesisStreamStateResponse extends Partial<KinesisStreamBatchResponse> {
     state: { [key: string]: any };
 }
 


### PR DESCRIPTION
With aws-lambda, there is a feature to use tumbling windows; when executing in this mode, the event has additional properties and a different return type. This PR provides these values along with dedicated types.

See the documentation at:
https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows