### PR TITLE
Make mouseConstraint use correct type [@types/matter-js]

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -2328,7 +2328,7 @@ declare namespace Matter {
          * The `Constraint` object that is used to move the body during interaction.
          *
          * @property constraint
-         * @type constraint
+         * @type {IConstraintDefinition}
          */
         constraint?: IConstraintDefinition | undefined;
 

--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -2330,7 +2330,7 @@ declare namespace Matter {
          * @property constraint
          * @type constraint
          */
-        constraint?: Constraint | undefined;
+        constraint?: IConstraintDefinition | undefined;
 
         /**
          * An `Object` that specifies the collision filter properties.


### PR DESCRIPTION
Use the IConstraintDefinition interface instead of the regular Constraint class on the constraint field in IMouseConstraintDefinition. This removes the obsolete error when creating a MouseConstraint and not having entered all parameters.