### PR TITLE
feat(react): Add utility types for `Component` and `FunctionComponent` with `children`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -539,6 +539,11 @@ declare namespace React {
         defaultProps?: Partial<P> | undefined;
         displayName?: string | undefined;
     }
+    class ComponentWithChildren<P = {}, S = {}, SS = any> extends Component<
+        P & { children?: ReactNode | undefined },
+        S,
+        SS
+    > {}
 
     type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
 
@@ -555,6 +560,14 @@ declare namespace React {
          * propTypes are not supported on render functions
          */
         propTypes?: never | undefined;
+    }
+
+    interface FunctionComponentWithChildren<P = {}> {
+        (props: P & { children?: ReactNode | undefined }, context?: unknown): ReactElement<unknown, any> | null;
+        propTypes?: WeakValidationMap<P> | undefined;
+        contextTypes?: ValidationMap<unknown> | undefined;
+        defaultProps?: Partial<P> | undefined;
+        displayName?: string | undefined;
     }
 
     interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -217,6 +217,16 @@ FunctionComponent2.defaultProps = {
     foo: 42
 };
 
+// utility types for components with children
+const FooFunctionComponentWithChildren: React.FunctionComponentWithChildren = props =>
+    React.createElement('div', props.children);
+
+class FooComponentWithChildren extends React.ComponentWithChildren {
+    render() {
+        return React.createElement('div', this.props.children);
+    }
+}
+
 // allows null as props
 const FunctionComponent4: React.FunctionComponent = props => null;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [no-implicit-children](https://solverfox.dev/writing/no-implicit-children/)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

--- 

This PR adds two utility classes to primarily ease the transition from React 17 types to React 18 types and the removal of implicit `children` from the type definitions. This provides an alternative to `React.PropsWithChildren`, which it uses under the hood, for easier migration of a code base.

Example of conversion from `npx types-react-codemod preset-18 .`:
```diff
- const Foo: FunctionComponent = ({ children }) => {…}
+ const Foo: FunctionComponent<React.PropsWithChildren<unknown>> = ({ children }) => {…}
```

Example with utility types:
```diff
- const Foo: FunctionComponent = ({ children }) => {…}
+ const Foo: FunctionComponentWithChildren = ({ children }) => {…}
```

Prior art
- https://github.com/zieka/bonsai-components/blob/main/packages/react-global-keys/src/helpers/utility-types.ts