### PR TITLE
plotly.js: Add modebar to layout in plotly js

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -859,11 +859,11 @@ export interface Margin {
 
 export interface ModeBar {
     activecolor: Color;
-    add: ModeBarDefaultButtons[];
+    add: ModeBarDefaultButtons | ModeBarDefaultButtons[];
     bgcolor: Color;
     color: Color;
     orientation: 'v' | 'h';
-    remove: ModeBarDefaultButtons[];
+    remove: ModeBarDefaultButtons | ModeBarDefaultButtons[];
     uirevision: number | string;
 }
 

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -481,6 +481,7 @@ export interface Layout {
     datarevision: number | string;
     editrevision: number | string;
     selectionrevision: number | string;
+    modebar: Partial<ModeBar>;
 }
 
 export interface Legend extends Label {
@@ -854,6 +855,16 @@ export interface Margin {
     l: number;
     r: number;
     pad: number;
+}
+
+export interface ModeBar {
+    activecolor: Color;
+    add: ModeBarDefaultButtons[];
+    bgcolor: Color;
+    color: Color;
+    orientation: 'v' | 'h';
+    remove: ModeBarDefaultButtons[];
+    uirevision: number | string;
 }
 
 export type ModeBarDefaultButtons =


### PR DESCRIPTION
Added modebar according to https://plotly.com/javascript/reference/#layout-modebar