### PR TITLE
[jest] Fix options type of `jest.mocked()` helper method

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -229,23 +229,15 @@ declare namespace jest {
     function mock<T = unknown>(moduleName: string, factory?: () => T, options?: MockOptions): typeof jest;
 
     /**
-     * The mocked test helper provides typings on your mocked modules and even
-     * their deep methods, based on the typing of its source. It makes use of
-     * the latest TypeScript feature, so you even have argument types
-     * completion in the IDE (as opposed to jest.MockInstance).
-     *
-     * Note: while it needs to be a function so that input type is changed, the helper itself does nothing else than returning the given input value.
+     * Wraps types of the `source` object and its deep members with type definitions
+     * of Jest mock function. Pass `{shallow: true}` option to disable the deeply
+     * mocked behavior.
      */
-    function mocked<T>(item: T, deep?: false): MaybeMocked<T>;
+    function mocked<T>(source: T, options?: { shallow: false }): MaybeMockedDeep<T>;
     /**
-     * The mocked test helper provides typings on your mocked modules and even
-     * their deep methods, based on the typing of its source. It makes use of
-     * the latest TypeScript feature, so you even have argument types
-     * completion in the IDE (as opposed to jest.MockInstance).
-     *
-     * Note: while it needs to be a function so that input type is changed, the helper itself does nothing else than returning the given input value.
+     * Wraps types of the `source` object with type definitions of Jest mock function.
      */
-    function mocked<T>(item: T, deep: true): MaybeMockedDeep<T>;
+    function mocked<T>(source: T, options: { shallow: true }): MaybeMocked<T>;
     /**
      * Returns the actual module instead of a mock, bypassing all checks on
      * whether the module should receive a mock implementation or not.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -649,7 +649,7 @@ jest.spyOn(spyWithIndexSignatureImpl, 'prop', 'get');
 
 // $ExpectType MockedObjectDeep<{}>
 jest.mocked({});
-// $ExpectType MockedObject<{}>
+// $ExpectType MockedObjectDeep<{}>
 jest.mocked({}, { shallow: false });
 // $ExpectType MockedObject<{}>
 jest.mocked({}, { shallow: true });

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -647,8 +647,12 @@ jest.spyOn(spyWithIndexSignatureImpl, 'prop');
 // $ExpectType SpyInstance<{ some: string; }, []>
 jest.spyOn(spyWithIndexSignatureImpl, 'prop', 'get');
 
-// $ExpectType MockedObject<{}>
+// $ExpectType MockedObjectDeep<{}>
 jest.mocked({});
+// $ExpectType MockedObject<{}>
+jest.mocked({}, { shallow: false });
+// $ExpectType MockedObject<{}>
+jest.mocked({}, { shallow: true });
 // @ts-expect-error
 jest.mocked();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation](https://jestjs.io/docs/mock-function-api/#jestmockedsource-options), [Upgrade Guide](https://jestjs.io/docs/upgrading-to-jest29#jestmocked)

## Summary

Jest 29 shipped with reworked implementation `jest.mocked()` helper method. The second argument is now a [bag of options](https://jestjs.io/docs/upgrading-to-jest29#jestmocked) instead of a boolean. The API is [documented](https://jestjs.io/docs/mock-function-api/#jestmockedsource-options) and I think it makes sense to keep the implementation in `@types/jest` aligned. First, users can follow the documentation of Jest. Second, currently this is one of the reasons of the error described in https://github.com/facebook/jest/issues/13199.

Probably it is also a good idea to align the types in order to prevent similar issues in the future.