### PR TITLE
types: export Cache class from @types/cached

### DIFF
--- a/types/cached/index.d.ts
+++ b/types/cached/index.d.ts
@@ -6,7 +6,7 @@
 
 import Memcached = require('memcached');
 
-export = cached;
+export default cached;
 
 interface CacheOptions {
     defaults?: CacheDefaults;
@@ -79,7 +79,7 @@ declare namespace cached {
     function deferred<T>(func: (callback: (err: any, result?: T) => void) => void): Promise<T>;
 }
 
-declare class Cache<T> {
+export declare class Cache<T> {
     constructor(options: {
         name: string;
         defaults: CacheDefaults;


### PR DESCRIPTION
allows products of cached to be named
but also removes ability to `import * as cached from 'cached';`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

