### PR TITLE
[greasemonkey]: add generics to `GM.getValue(string)` overload to avoid breaking change at 4.0.4

### DIFF
--- a/types/greasemonkey/greasemonkey-tests.ts
+++ b/types/greasemonkey/greasemonkey-tests.ts
@@ -32,6 +32,11 @@ GM.setValue('x', new Date());
 
 // GM.getValue
 
+async function getStringValueWithoutDefault() {
+    const a: string | undefined = await GM.getValue<string>('a');
+    return a;
+}
+
 async function getStringValueWithDefault() {
     const a: string = await GM.getValue('a', 'foobar');
     return a;

--- a/types/greasemonkey/greasemonkey-tests.ts
+++ b/types/greasemonkey/greasemonkey-tests.ts
@@ -32,11 +32,6 @@ GM.setValue('x', new Date());
 
 // GM.getValue
 
-async function getStringValueWithoutDefault() {
-    const a: string | undefined = await GM.getValue<string>('a');
-    return a;
-}
-
 async function getStringValueWithDefault() {
     const a: string = await GM.getValue('a', 'foobar');
     return a;
@@ -45,7 +40,7 @@ async function getStringValueWithDefault() {
 async function getNumberValueWithDefault() {
     const b: number = await GM.getValue('b', 123);
     // @ts-expect-error
-    const x: string  = GM.getValue('x', 123);
+    const x: string = GM.getValue('x', 123);
     return b;
 }
 
@@ -55,17 +50,17 @@ async function getBooleanWithDefault() {
 }
 
 async function getStringValue() {
-    const e = await GM.getValue('e') as string | undefined;
+    const e: string | undefined = await GM.getValue<string>('e');
     return e;
 }
 
 async function getNumberValue() {
-    const f = await GM.getValue('f') as number | undefined;
+    const f: number | undefined = await GM.getValue<number>('f');
     return f;
 }
 
 async function getBooleanValue() {
-    const g = await GM.getValue('g') as boolean | undefined;
+    const g: boolean | undefined = await GM.getValue<boolean>('g');
     return g;
 }
 

--- a/types/greasemonkey/index.d.ts
+++ b/types/greasemonkey/index.d.ts
@@ -216,13 +216,9 @@ declare var GM: {
      * // For structured data used `JSON.stringify()` to place an object into storage and then `JSON.parse()` to convert it back
      * const storedObject = JSON.parse(await GM.getValue('foo', '{}'));
      */
-    getValue<TValue = GM.Value>(
-        name: string,
-    ): Promise<TValue | undefined>
-    getValue<TValue = GM.Value>(
-        name: string,
-        defaultValue: TValue
-    ): Promise<TValue>
+    // tslint:disable-next-line no-unnecessary-generics
+    getValue<TValue = GM.Value>(name: string): Promise<TValue | undefined>
+    getValue<TValue = GM.Value>(name: string, defaultValue: TValue): Promise<TValue>
 
     /**
      * Deletes an existing name / value pair from storage.

--- a/types/greasemonkey/index.d.ts
+++ b/types/greasemonkey/index.d.ts
@@ -216,9 +216,9 @@ declare var GM: {
      * // For structured data used `JSON.stringify()` to place an object into storage and then `JSON.parse()` to convert it back
      * const storedObject = JSON.parse(await GM.getValue('foo', '{}'));
      */
-    getValue(
+    getValue<TValue = GM.Value>(
         name: string,
-    ): Promise<GM.Value | undefined>
+    ): Promise<TValue | undefined>
     getValue<TValue = GM.Value>(
         name: string,
         defaultValue: TValue


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Neither, this fix a breaking change added at 4.0.4

previous PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61907 says due to `no-unnecessary-generics` rule that `GM.getValue` without default value should be `GM.getValue(name: string): Promise<GM.Value | undefined>`, but this will break old working code:

```typescript
  type Type = 'enum 1' | 'enum 2' | 'enum 3' | ...;
  let v: Type | undefined = await GM.getValue<Type>(key);
  if (!v) {
    init_or_set_v_value()
  }
```

it raise ` Type 'Value | undefined' is not assignable to type 'Type | undefined'.   Type 'string' is not assignable to type 'Type | undefined'.` 

or 
```typescript
  let v = await GM.getValue<Type>(key);
```

raise `error TS2554: Expected 2 arguments, but got 1.`

User can call it like `GM.getValue(key) as Type | undefined` but it still a breaking change when upgrading `@types/greasemonkey` from 4.0.3 to 4.0.4.
