### PR TITLE
plotly.js Allow grouping of default and custom modebar buttons

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1609,7 +1609,7 @@ export interface Config {
      * buttons config objects or names of default buttons
      * (see ./components/modebar/buttons.js for more info)
      */
-    modeBarButtons: Array<ModeBarDefaultButtons[] | ModeBarButton[]> | false;
+    modeBarButtons: Array<Array<ModeBarDefaultButtons | ModeBarButton>> | false;
 
     /** add the plotly logo on the end of the mode bar */
     displaylogo: boolean;

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -263,7 +263,17 @@ const graphDiv = '#test';
         },
         layout: { barmode: 'stack', showlegend: false, xaxis: { tickangle: -45 } },
     };
-    const layout: Partial<Layout> = { showlegend: true, title: 'January 2013 Sales Report', template };
+
+    // Test the modebar with practical types.
+    // https://plotly.com/javascript/reference/layout/#layout-modebar
+    const modebar = {
+        color: '#ff0000',
+        bgcolor: 'rgba(0,0,0,0)',
+        activecolor: '#00ff00',
+        orientation: 'h' as 'h' | 'v',
+    };
+
+    const layout: Partial<Layout> = { showlegend: true, title: 'January 2013 Sales Report', template, modebar };
     const config: Partial<Config> = {
         modeBarButtons: [
             [
@@ -282,6 +292,8 @@ const graphDiv = '#test';
                     },
                     click: (gd, ev) => console.log('Download data'),
                 },
+                'pan2d',
+                'zoom2d',
             ],
             ['toImage'],
         ],


### PR DESCRIPTION
This change allows grouping of default and custom modebar buttons. See this example: https://codepen.io/etpinard/pen/gWEOWR
