### PR TITLE
video.js: fix deprecation of getComponent

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -1980,11 +1980,6 @@ declare namespace videojs {
          *        The Name of the component to get.
          *
          * @return The `Component` that got registered under the given name.
-         *
-         * @deprecated In `videojs` 6 this will not return `Component`s that were not
-         *             registered using {@link Component.registerComponent}. Currently we
-         *             check the global `videojs` object for a `Component` name and
-         *             return that if it exists.
          */
         getComponent(name: 'Button' | 'button'): typeof Button;
         getComponent(name: 'ClickableComponent' | 'clickablecomponent'): typeof ClickableComponent;


### PR DESCRIPTION
Since Video.js 7.15.5, videojs has removed the deprecated functionality, but @types/video.js still exist the deprecation warning.

Follow-up of [7410](https://github.com/videojs/video.js/pull/7410)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/videojs/video.js/blob/main/src/js/component.js#1727>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
