### PR TITLE
[validator] Allow any range type in isInt/isFloat options

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -487,19 +487,19 @@ declare namespace validator {
         /**
          * less or equal
          */
-        min?: number | undefined;
+        min?: any;
         /**
          * greater or equal
          */
-        max?: number | undefined;
+        max?: any;
         /**
          * greater than
          */
-        gt?: number | undefined;
+        gt?: any;
         /**
          * less than
          */
-        lt?: number | undefined;
+        lt?: any;
         /**
          * FloatLocale
          */
@@ -591,11 +591,11 @@ declare namespace validator {
         /**
          * to check the integer min boundary
          */
-        min?: number | undefined;
+        min?: any;
         /**
          * to check the integer max boundary
          */
-        max?: number | undefined;
+        max?: any;
         /**
          * if `false`, will disallow integer values with leading zeroes
          * @default true
@@ -604,11 +604,11 @@ declare namespace validator {
         /**
          * enforce integers being greater than the value provided
          */
-        lt?: number | undefined;
+        lt?: any;
         /**
          * enforce integers being less than the value provided
          */
-        gt?: number | undefined;
+        gt?: any;
     }
 
     /**

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -637,7 +637,7 @@ const any: any = null;
     result = validator.isFQDN('sample');
     result = validator.isFQDN('sample', isFQDNOptions);
 
-    const isFloatOptions: validator.IsFloatOptions = {};
+    const isFloatOptions: validator.IsFloatOptions = { gt: 0, lt: '100' };
     result = validator.isFloat('sample');
     result = validator.isFloat('sample', isFloatOptions);
 
@@ -701,7 +701,7 @@ const any: any = null;
 
     result = validator.isIn('sample', []);
 
-    const isIntOptions: validator.IsIntOptions = {};
+    const isIntOptions: validator.IsIntOptions = { min: '0', max: 100 };
     result = validator.isInt('sample');
     result = validator.isInt('sample', isIntOptions);
 


### PR DESCRIPTION
The `min`, `max`, `gt` and `lt` options of `isInt` / `isFloat` can be passed not just as numbers, but also string, bigint or actually any type that is comparable to a numeric string, e.g. a bignumber.js object.

I would like therefore to type these options to `any`.

As an alternative, I could also use generics in the function type and the options type.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/validatorjs/validator.js/blob/468a35f/src/lib/isInt.js#L18
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
