### PR TITLE
update to graphql 16.6.0

### DIFF
--- a/types/graphql-fields/package.json
+++ b/types/graphql-fields/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^16.6.0"
   }
 }


### PR DESCRIPTION
Bumping GQL version since V16 introduced a breaking change from past versions by changing the field 'value' on FieldNode type from mandatory to optional.
It now creates a conflict when using @types/graphql-fields together with the latest graphql package

```
Argument of type 'import("node_modules/graphql/type/definition").GraphQLResolveInfo' is not assignable to parameter of type 'import("node_modules/@types/graphql-fields/node_modules/graphql/type/definition").GraphQLResolveInfo'.
             Types of property 'fieldNodes' are incompatible.
               Type 'readonly import("node_modules/graphql/language/ast").FieldNode[]' is not assignable to type 'readonly import("node_modules/@types/graphql-fields/node_modules/graphql/language/ast").FieldNode[]'.
                 Type 'import("node_modules/graphql/language/ast").FieldNode' is not assignable to type 'import("node_modules/@types/graphql-fields/node_modules/graphql/language/ast").FieldNode'.
                   The types returned by 'loc.startToken.toJSON()' are incompatible between these types.
                     Type '{ kind: TokenKind; value?: string; line: number; column: number; }' is not assignable to type '{ kind: TokenKindEnum; value: string; line: number; column: number; }'.
                       Property 'value' is optional in type '{ kind: TokenKind; value?: string; line: number; column: number; }' but required in type '{ kind: TokenKindEnum; value: string; line: number; column: number; }'.
```