### PR TITLE
@types/yadda: allow parsed values to be any type, allowing converters

### DIFF
--- a/types/yadda/lib/Library.d.ts
+++ b/types/yadda/lib/Library.d.ts
@@ -8,19 +8,19 @@ declare class Library implements localisation.Language.Library {
     constructor(dictionary?: Dictionary);
     define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn) => void, macro_context?: Context, options?: Macro.Options): this;
     define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
-    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, ...args: string[]) => Promise<void>, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: string) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: string) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: string) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: string) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: any, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: any, arg6: string) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: any, arg6: any, next: (err?: Error) => void) => void, macro_context?: Context, options?: Macro.Options): this;
+    define(signatures: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, ...args: any[]) => Promise<void>, macro_context?: Context, options?: Macro.Options): this;
 }
 
 export = Library;

--- a/types/yadda/lib/localisation/English.d.ts
+++ b/types/yadda/lib/localisation/English.d.ts
@@ -20,30 +20,30 @@ declare namespace English {
     }
 
     interface Library extends Language.Library {
-        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, ...args: string[]) => Promise<void>): this;
+        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, ...args: any[]) => Promise<void>): this;
         given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, next: (err?: Error) => void) => void): this;
-        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, next: (err?: Error) => void) => void): this;
-        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, next: (err?: Error) => void) => void): this;
-        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, next: (err?: Error) => void) => void): this;
-        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, next: (err?: Error) => void) => void): this;
-        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, next: (err?: Error) => void) => void): this;
-        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string, next: (err?: Error) => void) => void): this;
-        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, ...args: string[]) => Promise<void>): this;
+        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, next: (err?: Error) => void) => void): this;
+        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, next: (err?: Error) => void) => void): this;
+        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, next: (err?: Error) => void) => void): this;
+        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, next: (err?: Error) => void) => void): this;
+        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: any, next: (err?: Error) => void) => void): this;
+        given(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: any, arg6: any, next: (err?: Error) => void) => void): this;
+        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, ...args: any[]) => Promise<void>): this;
         when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, next: (err?: Error) => void) => void): this;
-        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, next: (err?: Error) => void) => void): this;
-        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, next: (err?: Error) => void) => void): this;
-        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, next: (err?: Error) => void) => void): this;
-        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, next: (err?: Error) => void) => void): this;
-        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, next: (err?: Error) => void) => void): this;
-        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string, next: (err?: Error) => void) => void): this;
-        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, ...args: string[]) => Promise<void>): this;
+        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, next: (err?: Error) => void) => void): this;
+        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, next: (err?: Error) => void) => void): this;
+        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, next: (err?: Error) => void) => void): this;
+        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, next: (err?: Error) => void) => void): this;
+        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: any, next: (err?: Error) => void) => void): this;
+        when(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: any, arg6: any, next: (err?: Error) => void) => void): this;
+        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, ...args: any[]) => Promise<void>): this;
         then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, next: (err?: Error) => void) => void): this;
-        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, next: (err?: Error) => void) => void): this;
-        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, next: (err?: Error) => void) => void): this;
-        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, next: (err?: Error) => void) => void): this;
-        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, next: (err?: Error) => void) => void): this;
-        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, next: (err?: Error) => void) => void): this;
-        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string, next: (err?: Error) => void) => void): this;
+        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, next: (err?: Error) => void) => void): this;
+        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, next: (err?: Error) => void) => void): this;
+        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, next: (err?: Error) => void) => void): this;
+        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, next: (err?: Error) => void) => void): this;
+        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: any, next: (err?: Error) => void) => void): this;
+        then(step: string | string[] | RegExp | RegExp[], fn?: (this: StepFn, arg1: any, arg2: any, arg3: any, arg4: any, arg5: any, arg6: any, next: (err?: Error) => void) => void): this;
     }
 }
 

--- a/types/yadda/yadda-tests.ts
+++ b/types/yadda/yadda-tests.ts
@@ -147,7 +147,7 @@ const English = Yadda.localisation.English;
 }
 
 function quantity_converter(amount: string, units: string, cb: (err: Error | null, quantity: { amount: number, units: string }) => void) {
-    cb(null, { amount: parseInt(amount), units });
+    cb(null, { amount: parseInt(amount, 10), units });
 }
 
 {

--- a/types/yadda/yadda-tests.ts
+++ b/types/yadda/yadda-tests.ts
@@ -139,15 +139,15 @@ const English = Yadda.localisation.English;
         .define("num", /(\d+)/, Yadda.converters.integer);
 
     const library = Yadda.localisation.English.library(dictionary)
-        .given("A whole number $num", (number: string) => {
+        .given("A whole number $num", (number: number) => {
             // Number will be an integer rather than a string
         });
 
     Yadda.createInstance(library);
 }
 
-function quantity_converter(amount: string, units: string, cb: (err: Error | null, quantity: { amount: string, units: string }) => void) {
-    cb(null, { amount, units });
+function quantity_converter(amount: string, units: string, cb: (err: Error | null, quantity: { amount: number, units: string }) => void) {
+    cb(null, { amount: parseInt(amount), units });
 }
 
 {
@@ -155,7 +155,7 @@ function quantity_converter(amount: string, units: string, cb: (err: Error | nul
         .define("quantity", /(\d+) (\w+)/, quantity_converter);
 
     const library = Yadda.localisation.English.library(dictionary)
-        .given("a delay of $quantity", (quantity: string) => {
+        .given("a delay of $quantity", (quantity: {amount: number, units: string}) => {
             // quantity will be an object with two fields "amount" and "units"
         });
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Allow parsed values to have types other than string](https://github.com/silver-curve/DefinitelyTyped/blob/yadda-typing/types/yadda/yadda-tests.ts#L158)

# Changes

Using converters you can provide parsed data to the test from the yadda step definition. This parsed data can be of any type depending on the converter used. This PR changes the data type from `string` to `any` so that this is possible.

This change is backwards compatible.