### PR TITLE
Update more export just namespace exemptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "remark-cli": "^11.0.0",
         "remark-gfm": "^3.0.0",
         "remark-validate-links": "^12.0.0",
+        "shelljs": "^0.8.5",
         "source-map-support": "^0.5.21",
         "typescript": "next",
         "w3c-xmlserializer": "^2.0.0",

--- a/scripts/addbars.js
+++ b/scripts/addbars.js
@@ -1,0 +1,56 @@
+const fs = require('fs')
+const lines = fs.readFileSync('../dterrors.txt', 'utf8').split('\n')
+/** @type {{ [s: string]: { replacements: [string, number][], filename: string } }} */
+const projects = {}
+/** @type {{ replacements: [string, number][], filename: string }} */
+let project = { replacements: [], filename: '' }
+lines.forEach((line, i) => {
+    // '/home/vsts/work/1/s/types/'
+    if (line.startsWith('Error in ')) {
+        const match = line.match('Error in (.+)')
+        // new project
+        if (match) {
+            project = { replacements: [], filename: `../types/${match[1]}/${match[1]}-tests.ts` }
+            projects[match[1]] = project
+        }
+        else {
+            console.log('skipping', line)
+        }
+    }
+    else if (line.match(/^Error: .+\d+:\d+$/)) {
+        const match = line.match(/(types\/.+):\d+:\d+$/)
+        if (match) {
+            project.filename = `../${match[1]}`
+        }
+    }
+    else if (line.endsWith('expected type to be:')) {
+        const match = line.match(/^ERROR: (\d+):/)
+        if (match) {
+            project.replacements.push([lines[i + 3].slice(2), +match[1]])
+        }
+    }
+})
+for (const k of Object.keys(projects)) {
+    // 1. open types/${k}/${k}-tests.ts
+    // 2. split to lines
+    if (!fs.existsSync(projects[k].filename)) {
+        console.log("could not find normal test file for", k)
+        continue
+    }
+    const lines = fs.readFileSync(projects[k].filename, 'utf8').split('\n')
+    // 3. add to end of line at v[1]
+    for (const replacement of projects[k].replacements) {
+        const [newt, i] = replacement
+        if (lines[i + 1] == null) console.log ('no matching line for', newt, i + 1, 'in', k, '; total length was', lines.length)
+        if (lines[i + 1] == null) console.log ([lines[i - 1], lines[i], lines[i + 1]])
+        if (lines[i - 1].includes('ExpectType'))
+            lines[i - 1] += " || " + newt
+        else if (lines[i - 2].includes('ExpectType'))
+            lines[i - 2] += " || " + newt
+        else
+            console.log('Could not find replacement for line', i, 'in', k, lines[i], lines[i+1])
+    }
+    fs.writeFileSync(projects[k].filename, lines.join('\n'))
+}
+
+console.log(Object.keys(projects).length)

--- a/scripts/tslint-rule-to-eslint.js
+++ b/scripts/tslint-rule-to-eslint.js
@@ -1,6 +1,7 @@
 import { parse } from 'comment-json';
-import { promises as fs } from 'fs';
+import fs from 'fs';
 import { format } from 'prettier';
+import sh from 'shelljs';
 import * as path from 'path';
 
 /** @type {any} */
@@ -8,78 +9,76 @@ const emptyObject = {};
 
 /**
  * @param {string} filePath
- * @returns {Promise<any>}
+ * @returns {any}
  */
-const parseAndReadFileContents = async filePath => {
+const parseAndReadFileContents = filePath => {
     try {
-        return parse((await fs.readFile(filePath)).toString());
+        return parse(fs.readFileSync(filePath).toString());
     } catch {
         return undefined;
     }
 };
 
-(async () => {
-    const prettierConfig = await parseAndReadFileContents('.prettierrc.json');
+const prettierConfig = parseAndReadFileContents('.prettierrc.json');
 
-    /**
-     * @param {string} filePath
-     * @param {unknown} contents
-     */
-    const writeFileFormatted = async (filePath, contents) => {
-        await fs.writeFile(
-            filePath,
-            format(JSON.stringify(contents, null, 4), {
-                ...prettierConfig,
-                filepath: filePath,
-            }),
-        );
-    };
+/**
+ * @param {string} filePath
+ * @param {unknown} contents
+ */
+const writeFileFormatted = (filePath, contents) => {
+    fs.writeFileSync(
+        filePath,
+        format(JSON.stringify(contents, null, 4), {
+            ...prettierConfig,
+            filepath: filePath,
+        }),
+    );
+};
 
-    const [, , tslintRuleName, eslintRuleName = tslintRuleName] = process.argv;
+const [, , tslintRuleName, eslintRuleName = tslintRuleName] = process.argv;
 
-    const typeNames = await fs.readdir('types');
-    for (const typeName of typeNames) {
-        const typeDirectory = path.join('types', typeName);
+const typeNames = fs.readdirSync('types');
+for (const typeName of typeNames) {
+    const typeDirectory = path.join('types', typeName);
+    sh.exec(`find . -path '${typeDirectory}/node_modules' -prune -o -iname '${typeDirectory}/*.ts' -print | xargs sed -i '' 's/tslint:disable-next-line[: ]${tslintRuleName}/eslint-disable-next-line ${eslintRuleName}/'`);
+    typeNames.push(
+        ...(fs.readdirSync(typeDirectory))
+            .filter(childDirectory => /^(ts|v)(\d+|\.)+$/.test(childDirectory))
+            .map(childDirectory => path.join(typeName, childDirectory)),
+    );
 
-        typeNames.push(
-            ...(await fs.readdir(typeDirectory))
-                .filter(childDirectory => /^(ts|v)(\d+|\.)+$/.test(childDirectory))
-                .map(childDirectory => path.join(typeName, childDirectory)),
-        );
-
-        const tslintFilePath = path.join(typeDirectory, 'tslint.json');
-        /** @type {{ rules?: { [s:string]: boolean }}} */
-        const tslintData = await parseAndReadFileContents(tslintFilePath);
-        if (tslintData?.rules?.[tslintRuleName] !== false) {
-            continue;
-        }
-
-        console.log(`Converting ${typeName}...`);
-
-        delete tslintData.rules[tslintRuleName];
-        if (Object.keys(tslintData.rules).length === 0) {
-            console.log(`\t${tslintFilePath} has no remaining rules; deleting rules property.`);
-            delete tslintData.rules;
-        } else {
-            console.log(`\t${tslintFilePath} has remaining rules.`);
-        }
-        await writeFileFormatted(tslintFilePath, tslintData);
-
-        const eslintFilePath = path.join(typeDirectory, '.eslintrc.json');
-        const eslintData = (await parseAndReadFileContents(eslintFilePath)) ?? emptyObject;
-
-        if (eslintData === emptyObject) {
-            console.log(`\t${eslintFilePath} did not yet exist; creating.`);
-        } else {
-            console.log(`\t${eslintFilePath} already exists; modifying.`);
-        }
-
-        writeFileFormatted(eslintFilePath, {
-            ...eslintData,
-            rules: {
-                ...eslintData.rules,
-                [eslintRuleName]: 'off',
-            },
-        });
+    const tslintFilePath = path.join(typeDirectory, 'tslint.json');
+    /** @type {{ rules?: { [s:string]: boolean }}} */
+    const tslintData = parseAndReadFileContents(tslintFilePath);
+    if (tslintData?.rules?.[tslintRuleName] !== false) {
+        continue;
     }
-})();
+
+    console.log(`Converting ${typeName}...`);
+
+    delete tslintData.rules[tslintRuleName];
+    if (Object.keys(tslintData.rules).length === 0) {
+        console.log(`\t${tslintFilePath} has no remaining rules; deleting rules property.`);
+        delete tslintData.rules;
+    } else {
+        console.log(`\t${tslintFilePath} has remaining rules.`);
+    }
+    writeFileFormatted(tslintFilePath, tslintData);
+
+    const eslintFilePath = path.join(typeDirectory, '.eslintrc.json');
+    const eslintData = parseAndReadFileContents(eslintFilePath) ?? emptyObject;
+
+    if (eslintData === emptyObject) {
+        console.log(`\t${eslintFilePath} did not yet exist; creating.`);
+    } else {
+        console.log(`\t${eslintFilePath} already exists; modifying.`);
+    }
+
+    writeFileFormatted(eslintFilePath, {
+        ...eslintData,
+        rules: {
+            ...eslintData.rules,
+            [eslintRuleName]: 'off',
+        },
+    });
+}

--- a/scripts/tslint-rule-to-eslint.js
+++ b/scripts/tslint-rule-to-eslint.js
@@ -37,10 +37,11 @@ const writeFileFormatted = (filePath, contents) => {
 
 const [, , tslintRuleName, eslintRuleName = tslintRuleName] = process.argv;
 
+sh.exec(`find types -path '*/node_modules' -prune -o -iname '*.ts' -type f -print | xargs sed -i 's/tslint:disable-next-line[: ]${tslintRuleName}/eslint-disable-next-line ${eslintRuleName}/'`);
+
 const typeNames = fs.readdirSync('types');
 for (const typeName of typeNames) {
     const typeDirectory = path.join('types', typeName);
-    sh.exec(`find . -path '${typeDirectory}/node_modules' -prune -o -iname '${typeDirectory}/*.ts' -print | xargs sed -i '' 's/tslint:disable-next-line[: ]${tslintRuleName}/eslint-disable-next-line ${eslintRuleName}/'`);
     typeNames.push(
         ...(fs.readdirSync(typeDirectory))
             .filter(childDirectory => /^(ts|v)(\d+|\.)+$/.test(childDirectory))

--- a/types/fbjs/lib/BrowserSupportCore.d.ts
+++ b/types/fbjs/lib/BrowserSupportCore.d.ts
@@ -19,5 +19,5 @@ declare namespace BrowserSupportCore {
      */
     function hasCSSTransitions(): boolean;
 }
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = BrowserSupportCore;

--- a/types/fbjs/lib/CSSCore.d.ts
+++ b/types/fbjs/lib/CSSCore.d.ts
@@ -32,5 +32,5 @@ declare namespace CSSCore {
      */
     function matchesSelector(element: HTMLElement | DOMWindow, selector: string): boolean;
 }
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = CSSCore;

--- a/types/fbjs/lib/ErrorUtils.d.ts
+++ b/types/fbjs/lib/ErrorUtils.d.ts
@@ -2,5 +2,5 @@ declare namespace ErrorUtils {
     function guard(callback: any, name?: string): any;
     function applyWithGuard(callback: any, context?: any, args?: any, onError?: any, name?: string): any;
 }
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = ErrorUtils;

--- a/types/fbjs/lib/EventListener.d.ts
+++ b/types/fbjs/lib/EventListener.d.ts
@@ -15,5 +15,5 @@ declare namespace EventListener {
     function registerDefault(): void;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = EventListener;

--- a/types/fbjs/lib/ExecutionEnvironment.d.ts
+++ b/types/fbjs/lib/ExecutionEnvironment.d.ts
@@ -12,5 +12,5 @@ declare namespace ExecutionEnvironment {
     const isInWorker: boolean;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = ExecutionEnvironment;

--- a/types/fbjs/lib/Keys.d.ts
+++ b/types/fbjs/lib/Keys.d.ts
@@ -23,5 +23,5 @@ declare namespace Keys {
     const NUMPAD_9: 105;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = Keys;

--- a/types/fbjs/lib/Locale.d.ts
+++ b/types/fbjs/lib/Locale.d.ts
@@ -2,5 +2,5 @@ declare namespace Locale {
     function isRTL(): boolean;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = Locale;

--- a/types/fbjs/lib/PhotosMimeType.d.ts
+++ b/types/fbjs/lib/PhotosMimeType.d.ts
@@ -3,5 +3,5 @@ declare namespace PhotosMimeType {
     function isJpeg(mimeString: string): boolean;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = PhotosMimeType;

--- a/types/fbjs/lib/Scroll.d.ts
+++ b/types/fbjs/lib/Scroll.d.ts
@@ -17,5 +17,5 @@ declare namespace Scroll {
     function setLeft(element: HTMLElement, newLeft: number): void;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = Scroll;

--- a/types/fbjs/lib/SiteData.d.ts
+++ b/types/fbjs/lib/SiteData.d.ts
@@ -2,5 +2,5 @@ declare namespace SiteData {
     const is_rtl: false;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = SiteData;

--- a/types/fbjs/lib/Style.d.ts
+++ b/types/fbjs/lib/Style.d.ts
@@ -16,5 +16,5 @@ declare namespace Style {
     function getScrollParent(node: Node): HTMLElement | DOMWindow;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = Style;

--- a/types/fbjs/lib/TokenizeUtil.d.ts
+++ b/types/fbjs/lib/TokenizeUtil.d.ts
@@ -16,5 +16,5 @@ declare namespace TokenizeUtil {
     function getPunctuation(): string;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = TokenizeUtil;

--- a/types/fbjs/lib/TouchEventUtils.d.ts
+++ b/types/fbjs/lib/TouchEventUtils.d.ts
@@ -14,5 +14,5 @@ declare namespace TouchEventUtils {
     } | null;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = TouchEventUtils;

--- a/types/fbjs/lib/UnicodeBidi.d.ts
+++ b/types/fbjs/lib/UnicodeBidi.d.ts
@@ -51,5 +51,5 @@ declare namespace UnicodeBidi {
     function isDirectionRTL(str: string, strongFallback: BidiDirection | null): boolean;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = UnicodeBidi;

--- a/types/fbjs/lib/UnicodeBidiDirection.d.ts
+++ b/types/fbjs/lib/UnicodeBidiDirection.d.ts
@@ -53,5 +53,5 @@ declare namespace UnicodeBidiDirection {
     function getGlobalDir(): BidiDirection;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = UnicodeBidiDirection;

--- a/types/fbjs/lib/UnicodeCJK.d.ts
+++ b/types/fbjs/lib/UnicodeCJK.d.ts
@@ -40,5 +40,5 @@ declare namespace UnicodeCJK {
     function kanaRemoveTrailingLatin(str: string): string;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = UnicodeCJK;

--- a/types/fbjs/lib/UnicodeHangulKorean.d.ts
+++ b/types/fbjs/lib/UnicodeHangulKorean.d.ts
@@ -31,5 +31,5 @@ declare namespace UnicodeHangulKorean {
     function toConjoiningJamo(str: string): string;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = UnicodeHangulKorean;

--- a/types/fbjs/lib/UnicodeUtils.d.ts
+++ b/types/fbjs/lib/UnicodeUtils.d.ts
@@ -52,5 +52,5 @@ declare namespace UnicodeUtils {
     function substr(str: string, start?: number, length?: number): string;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = UnicodeUtils;

--- a/types/fbjs/lib/UnicodeUtilsExtra.d.ts
+++ b/types/fbjs/lib/UnicodeUtilsExtra.d.ts
@@ -38,5 +38,5 @@ declare namespace UnicodeUtilsExtra {
     function pyEscape(s: string): string;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = UnicodeUtilsExtra;

--- a/types/fbjs/lib/UserAgent.d.ts
+++ b/types/fbjs/lib/UserAgent.d.ts
@@ -138,5 +138,5 @@ declare namespace UserAgent {
     function isPlatformArchitecture(query: string): boolean;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = UserAgent;

--- a/types/fbjs/lib/UserAgentData.d.ts
+++ b/types/fbjs/lib/UserAgentData.d.ts
@@ -23,5 +23,5 @@ declare namespace uaData {
     const platformFullVersion: string;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = uaData;

--- a/types/fbjs/lib/VersionRange.d.ts
+++ b/types/fbjs/lib/VersionRange.d.ts
@@ -29,5 +29,5 @@ declare namespace VersionRange {
     function contains(range: string, version: string): boolean;
 }
 
-// tslint:disable-next-line export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = VersionRange;

--- a/types/lapo__asn1js/base64.d.ts
+++ b/types/lapo__asn1js/base64.d.ts
@@ -7,7 +7,7 @@ declare namespace Base64 {
     function unarmor(a: string): ReturnType<typeof decode>;
 }
 
-// tslint:disable-next-line:export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = Base64;
 
 export as namespace base64;

--- a/types/lapo__asn1js/hex.d.ts
+++ b/types/lapo__asn1js/hex.d.ts
@@ -4,7 +4,7 @@ declare namespace Hex {
     function decode(a: ASN1.Binary): Uint8Array;
 }
 
-// tslint:disable-next-line:export-just-namespace
+// eslint-disable-next-line export-just-namespace
 export = Hex;
 
 export as namespace hex;


### PR DESCRIPTION
Also add a sed command to the tslint-rule-to-eslint script.
*Also* switch it from async to sync IO. I don't like using monads, especially ones that I can't escape from, so one less is an improvement in my book.

Best viewed with whitespace ignored.