### PR TITLE
Add new type to MissingFieldHandler union for when a Relay Resolver throws an error.

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -70,6 +70,7 @@ export {
     HasUpdatableSpread,
     InvalidationState,
     MissingFieldHandler,
+    RequiredFieldLogger,
     ModuleImportPointer,
     MutableRecordSource,
     NormalizationSelector,

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -913,8 +913,8 @@ export type MissingFieldHandler =
       };
 
 /**
- * A handler for events related to @required fields. Currently reports missing
- * fields with either `action: LOG` or `action: THROW`.
+ * A handler for events related to @required fields or Relay Resolvers. Currently reports missing
+ * fields with either `action: LOG` or `action: THROW` or when a Relay Resolver throws.
  */
 export type RequiredFieldLogger = (
     arg:
@@ -927,6 +927,12 @@ export type RequiredFieldLogger = (
               kind: 'missing_field.throw';
               owner: string;
               fieldPath: string;
+          }>
+        | Readonly<{
+              kind: 'relay_resolver.error';
+              owner: string;
+              fieldPath: string;
+              error: Error;
           }>,
 ) => void;
 

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -133,9 +133,11 @@ const environment = new Environment({
     requiredFieldLogger: arg => {
         if (arg.kind === 'missing_field.log') {
             console.log(arg.fieldPath, arg.owner);
-        } else {
-            arg.kind; // $ExpectType "missing_field.throw"
+        } else if (arg.kind === 'missing_field.throw') {
             console.log(arg.fieldPath, arg.owner);
+        } else {
+            arg.kind; // $ExpectType "relay_resolver.error"
+            console.log(arg.fieldPath, arg.owner, arg.error);
         }
     },
 });


### PR DESCRIPTION
This also exports the `MissingFieldHandler` in the index file. Not sure if that was omitted on purpose, but figured we should export it like all other types defined in the `RelayStoreTypes` file.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/2768c3ea12668c5bf23d47d51515bd3939f9543f/packages/relay-runtime/util/handlePotentialSnapshotErrors.js#L26
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
