### PR TITLE
Remove tregagnon (myself) from `@types/chrome` Definition owners

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5,7 +5,6 @@
 //                 sreimer15 <https://github.com/sreimer15>
 //                 MatCarlson <https://github.com/MatCarlson>
 //                 ekinsol <https://github.com/ekinsol>
-//                 Thierry Régagnon <https://github.com/tregagnon>
 //                 Brian Wilson <https://github.com/echoabstract>
 //                 Sebastiaan Pasma <https://github.com/spasma>
 //                 bdbai <https://github.com/bdbai>


### PR DESCRIPTION
I am removing myself from the list of Definition owners for `@types/chrome`. I have stopped developing Chrome extensions for almost a year, and I am not following changes made to those APIs. 

The package has many other owners that can review changes more efficiently than me.