### PR TITLE
[sharedb] add `Connection` event emitter types

### DIFF
--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -2,7 +2,7 @@
 import * as ShareDB from './sharedb';
 import Agent = require('./agent');
 
-export class Connection {
+export class Connection extends ShareDB.TypedEmitter<ShareDB.ConnectionEventMap> {
     constructor(ws: ShareDB.Socket);
 
     // This direct reference from connection to agent is not used internal to

--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -138,6 +138,22 @@ export class Doc<T = any> extends TypedEmitter<DocEventMap<T>> {
     flush(): void;
 }
 
+export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'stopped' | 'closed';
+export type ConnectionStateEventMap = {
+    [state in ConnectionState]: (reason: string) => void;
+};
+export interface ConnectionReceiveRequest {
+    data: any;
+}
+export type ConnectionEventMap = ConnectionStateEventMap & {
+    'connection error': (error: Error) => void;
+    'doc': (doc: Doc) => void;
+    'error': (error: Error) => void;
+    'receive': (request: ConnectionReceiveRequest) => void;
+    'send': (message: any) => void;
+    'state': (newState: ConnectionState, reason: string) => void;
+};
+
 export interface DocEventMap<T> {
     'load': () => void;
     'no write pending': () => void;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -223,6 +223,13 @@ const connectionHasPending: boolean = connection.hasPending();
 connection.whenNothingPending(() => console.log('whenNothingPending resolved'));
 connection.send({ a: 'nonExistentAction', some: 'data' });
 
+connection.on('doc', (doc) => {
+    console.log(doc.data);
+});
+connection.on('connected', (reason) => {
+    if (reason === 'foo') console.log(reason);
+});
+
 const doc = connection.get('examples', 'counter');
 
 doc.fetch((err) => {


### PR DESCRIPTION
The `sharedb` `Connection` class can emit the following events:

 - [`receive`](https://github.com/share/sharedb/blob/8b531bedf19860ffe0b37a3e1c8da7a32b5005bd/lib/client/connection.js#L139)
 - [`error`](https://github.com/share/sharedb/blob/8b531bedf19860ffe0b37a3e1c8da7a32b5005bd/lib/client/connection.js#L146)
 - [`connection error`](https://github.com/share/sharedb/blob/8b531bedf19860ffe0b37a3e1c8da7a32b5005bd/lib/client/connection.js#L165)
 - [`state`](https://github.com/share/sharedb/blob/8b531bedf19860ffe0b37a3e1c8da7a32b5005bd/lib/client/connection.js#L371)
 - [state value](https://github.com/share/sharedb/blob/8b531bedf19860ffe0b37a3e1c8da7a32b5005bd/lib/client/connection.js#L370)
 - [`send`](https://github.com/share/sharedb/blob/8b531bedf19860ffe0b37a3e1c8da7a32b5005bd/lib/client/connection.js#L475)
 - [`doc`](https://github.com/share/sharedb/blob/8b531bedf19860ffe0b37a3e1c8da7a32b5005bd/lib/client/connection.js#L506)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
