### PR TITLE
[tabulator-tables] - Export TabulatorOptions from Tabulator.Options

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -5,6 +5,8 @@
 // TypeScript Version: 3.2
 // tslint:disable:max-line-length
 // tslint:disable:no-unnecessary-class
+// tslint:disable:no-empty-interface
+
 declare namespace Tabulator {
     interface Options
         extends OptionsGeneral,

--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -6,26 +6,26 @@
 // tslint:disable:max-line-length
 // tslint:disable:no-unnecessary-class
 declare namespace Tabulator {
-    interface Options extends
-        OptionsGeneral,
-        OptionsMenu,
-        OptionsHistory,
-        OptionsLocale,
-        OptionsDownload,
-        OptionsColumns,
-        OptionsRows,
-        OptionsData,
-        OptionsSorting,
-        OptionsFiltering,
-        OptionsRowGrouping,
-        OptionsPagination,
-        OptionsPersistentConfiguration,
-        OptionsClipboard,
-        OptionsDataTree,
-        OptionsCell,
-        OptionsCells,
-        OptionsDebug,
-        OptionsHTML { }
+    interface Options
+        extends OptionsGeneral,
+            OptionsMenu,
+            OptionsHistory,
+            OptionsLocale,
+            OptionsDownload,
+            OptionsColumns,
+            OptionsRows,
+            OptionsData,
+            OptionsSorting,
+            OptionsFiltering,
+            OptionsRowGrouping,
+            OptionsPagination,
+            OptionsPersistentConfiguration,
+            OptionsClipboard,
+            OptionsDataTree,
+            OptionsCell,
+            OptionsCells,
+            OptionsDebug,
+            OptionsHTML {}
 
     interface OptionsDebug {
         invalidOptionWarning?: boolean;
@@ -977,7 +977,7 @@ declare namespace Tabulator {
 
     type DownloadType = 'csv' | 'json' | 'xlsx' | 'pdf' | 'html';
 
-    interface DownloadOptions extends DownloadCSV, DownloadXLXS, DownloadPDF, DownloadHTML { }
+    interface DownloadOptions extends DownloadCSV, DownloadXLXS, DownloadPDF, DownloadHTML {}
 
     interface DownloadCSV {
         /** By default CSV files are created using a comma (,) delimiter. If you need to change this for any reason the you can pass the options object with a delimiter property to the download function which will then use this delimiter instead of the comma. */
@@ -1186,25 +1186,25 @@ declare namespace Tabulator {
          * You can pass an optional additional property with sorter, sorterParams that should contain an object with additional information for configuring the sorter
          */
         sorter?:
-        | 'string'
-        | 'number'
-        | 'alphanum'
-        | 'boolean'
-        | 'exists'
-        | 'date'
-        | 'time'
-        | 'datetime'
-        | 'array'
-        | ((
-            a: any,
-            b: any,
-            aRow: RowComponent,
-            bRow: RowComponent,
-            column: ColumnComponent,
-            dir: SortDirection,
-            sorterParams: {},
-        ) => number)
-        | undefined;
+            | 'string'
+            | 'number'
+            | 'alphanum'
+            | 'boolean'
+            | 'exists'
+            | 'date'
+            | 'time'
+            | 'datetime'
+            | 'array'
+            | ((
+                  a: any,
+                  b: any,
+                  aRow: RowComponent,
+                  bRow: RowComponent,
+                  column: ColumnComponent,
+                  dir: SortDirection,
+                  sorterParams: {},
+              ) => number)
+            | undefined;
 
         /** If you want to dynamically generate the sorterParams at the time the sort is called you can pass a function into the property that should return the params object. */
         sorterParams?: ColumnDefinitionSorterParams | ColumnSorterParamLookupFunction | undefined;
@@ -1390,9 +1390,9 @@ declare namespace Tabulator {
          * If you want to specify the type of filter used you can pass it to the headerFilterFunc option in the column definition object. This will take any of the standard filters outlined above or a custom function
          */
         headerFilterFunc?:
-        | FilterType
-        | ((headerValue: any, rowValue: any, rowdata: any, filterparams: any) => boolean)
-        | undefined;
+            | FilterType
+            | ((headerValue: any, rowValue: any, rowdata: any, filterparams: any) => boolean)
+            | undefined;
 
         /** additional parameters object passed to the headerFilterFunc function. */
         headerFilterFuncParams?: any;
@@ -1508,7 +1508,7 @@ declare namespace Tabulator {
 
     type TextDirection = 'auto' | 'ltr' | 'rtl';
 
-    type GlobalTooltipOption = boolean | ((event: MouseEvent, cell: CellComponent, onRender: (() => void)) => string);
+    type GlobalTooltipOption = boolean | ((event: MouseEvent, cell: CellComponent, onRender: () => void) => string);
 
     type CustomMutator = (
         value: any,
@@ -1532,12 +1532,12 @@ declare namespace Tabulator {
     type CustomAccessorParams =
         | {}
         | ((
-            value: any,
-            data: any,
-            type: 'data' | 'download' | 'clipboard',
-            column?: ColumnComponent,
-            row?: RowComponent,
-        ) => any);
+              value: any,
+              data: any,
+              type: 'data' | 'download' | 'clipboard',
+              column?: ColumnComponent,
+              row?: RowComponent,
+          ) => any);
 
     type ColumnCalc =
         | 'avg'
@@ -1599,12 +1599,12 @@ declare namespace Tabulator {
         | 'autocomplete'
         | 'list'
         | ((
-            cell: CellComponent,
-            onRendered: EmptyCallback,
-            success: ValueBooleanCallback,
-            cancel: ValueVoidCallback,
-            editorParams: {},
-        ) => HTMLElement | false);
+              cell: CellComponent,
+              onRendered: EmptyCallback,
+              success: ValueBooleanCallback,
+              cancel: ValueVoidCallback,
+              editorParams: {},
+          ) => HTMLElement | false);
 
     type EditorParams =
         | NumberParams
@@ -2272,7 +2272,7 @@ interface EventCallBackMethods {
 }
 
 declare class Tabulator {
-    static defaultOptions: Tabulator.Options;
+    static defaultOptions: TabulatorOptions;
 
     /**
      * A lot of the modules come with a range of default settings to make setting up your table easier, for example the sorters, formatters and editors that ship with Tabulator as standard.
@@ -2289,14 +2289,14 @@ declare class Tabulator {
     static findTable: (query: string) => Tabulator[];
     static registerModule: (module: Module) => void;
     static bindModules: ([]) => void;
-    constructor(selector: string | HTMLElement, options?: Tabulator.Options);
+    constructor(selector: string | HTMLElement, options?: TabulatorOptions);
     columnManager: any;
     rowManager: any;
     footerManager: any;
     browser: string;
     browserSlow: boolean;
     modules: any;
-    options: Tabulator.Options;
+    options: TabulatorOptions;
     element: HTMLElement;
 
     /**
@@ -2713,7 +2713,7 @@ declare class Tabulator {
     /** You can use the setGroupHeader function to change the header generation function for each group. This function has one argument and takes the same values as passed to the groupHeader setup option. */
     setGroupHeader: (
         values:
-            ((value: any, count: number, data: any, group: Tabulator.GroupComponent) => string)
+            | ((value: any, count: number, data: any, group: Tabulator.GroupComponent) => string)
             | Array<(value: any, count: number, data: any) => string>,
     ) => void;
 
@@ -2806,42 +2806,42 @@ declare class Module {
     static moduleName: string;
     constructor(table: Tabulator);
 }
-declare class AccessorModule { }
-declare class AjaxModule { }
-declare class ClipboardModule { }
-declare class ColumnCalcsModule { }
-declare class DataTreeModule { }
-declare class DownloadModule { }
-declare class EditModule { }
-declare class ExportModule { }
-declare class FilterModule { }
-declare class FormatModule { }
-declare class FrozenColumnsModule { }
-declare class FrozenRowsModule { }
-declare class GroupRowsModule { }
-declare class HistoryModule { }
-declare class HtmlTableImportModule { }
-declare class InteractionModule { }
-declare class KeybindingsModule { }
-declare class MenuModule { }
-declare class MoveColumnsModule { }
-declare class MoveRowsModule { }
-declare class MutatorModule { }
-declare class PageModule { }
-declare class PersistenceModule { }
-declare class PrintModule { }
-declare class PseudoRow { }
-declare class ReactiveDataModule { }
-declare class Renderer { }
-declare class ResizeColumnsModule { }
-declare class ResizeRowsModule { }
-declare class ResizeTableModule { }
-declare class ResponsiveLayoutModule { }
-declare class SelectRowModule { }
-declare class SortModule { }
-declare class TabulatorFull extends Tabulator { }
+declare class AccessorModule {}
+declare class AjaxModule {}
+declare class ClipboardModule {}
+declare class ColumnCalcsModule {}
+declare class DataTreeModule {}
+declare class DownloadModule {}
+declare class EditModule {}
+declare class ExportModule {}
+declare class FilterModule {}
+declare class FormatModule {}
+declare class FrozenColumnsModule {}
+declare class FrozenRowsModule {}
+declare class GroupRowsModule {}
+declare class HistoryModule {}
+declare class HtmlTableImportModule {}
+declare class InteractionModule {}
+declare class KeybindingsModule {}
+declare class MenuModule {}
+declare class MoveColumnsModule {}
+declare class MoveRowsModule {}
+declare class MutatorModule {}
+declare class PageModule {}
+declare class PersistenceModule {}
+declare class PrintModule {}
+declare class PseudoRow {}
+declare class ReactiveDataModule {}
+declare class Renderer {}
+declare class ResizeColumnsModule {}
+declare class ResizeRowsModule {}
+declare class ResizeTableModule {}
+declare class ResponsiveLayoutModule {}
+declare class SelectRowModule {}
+declare class SortModule {}
+declare class TabulatorFull extends Tabulator {}
 declare class TooltipModule {}
-declare class ValidateModule { }
+declare class ValidateModule {}
 
 export {
     Module,
@@ -2883,3 +2883,5 @@ export {
     TooltipModule,
     ValidateModule,
 };
+
+export interface TabulatorOptions extends Tabulator.Options {}

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -1,4 +1,12 @@
-import { Tabulator, Renderer, Module, DataTreeModule, TabulatorFull, TooltipModule } from 'tabulator-tables';
+import {
+    Tabulator,
+    Renderer,
+    Module,
+    DataTreeModule,
+    TabulatorFull,
+    TooltipModule,
+    TabulatorOptions,
+} from 'tabulator-tables';
 
 // tslint:disable:no-object-literal-type-assertion
 // tslint:disable:whitespace
@@ -338,10 +346,10 @@ colDef.bottomCalcFormatter = (cell, formatterParams, onRendered) => {
 
 colDef.tooltip = (event: MouseEvent, cell: Tabulator.CellComponent, onRendered: (callback: () => void) => void) => {
     onRendered(() => {
-      console.log('rendering occured');
+        console.log('rendering occured');
     });
     return cell.getValue();
-  };
+};
 
 // Cell Component
 
@@ -361,7 +369,7 @@ row.delete()
     });
 
 // Options
-let options = <Tabulator.Options>{};
+let options = <TabulatorOptions>{};
 options.keybindings = {
     navPrev: 'ctrl + 1',
     navNext: false,
@@ -1059,9 +1067,9 @@ table = new Tabulator('#test', {
     // test editor of type 'list' supported.
     columns: [
         {
-            field: "test_editor",
-            title: "Test Editor",
-            editor: "list"
-        }
-    ]
+            field: 'test_editor',
+            title: 'Test Editor',
+            editor: 'list',
+        },
+    ],
 });


### PR DESCRIPTION
This allows us to now access the Tabulator options as it was hidden under the namespace before.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] This is a pure TS improvement to allow Options be accessible