### PR TITLE
fix(plotly.js): remove d3 references

### DIFF
--- a/types/plotly.js-basic-dist-min/tsconfig.json
+++ b/types/plotly.js-basic-dist-min/tsconfig.json
@@ -13,11 +13,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "d3": [
-                "d3/v3"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/plotly.js-basic-dist/tsconfig.json
+++ b/types/plotly.js-basic-dist/tsconfig.json
@@ -13,11 +13,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "d3": [
-                "d3/v3"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/plotly.js-dist-min/tsconfig.json
+++ b/types/plotly.js-dist-min/tsconfig.json
@@ -13,11 +13,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "d3": [
-                "d3/v3"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -21,7 +21,6 @@
 //                 Jeffrey van Gogh <https://github.com/jvgogh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as _d3 from 'd3';
 import { BoxPlotData, BoxPlotMarker } from './lib/traces/box';
 import { ViolinData } from './lib/traces/violin';
 import { OhclData } from './lib/traces/ohcl';

--- a/types/plotly.js/tsconfig.json
+++ b/types/plotly.js/tsconfig.json
@@ -13,11 +13,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "d3": [
-                "d3/v3"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/react-plotly.js/tsconfig.json
+++ b/types/react-plotly.js/tsconfig.json
@@ -13,11 +13,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "d3": [
-                "d3/v3"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This commit removes reference to regular d3 instance types, left probably by omission: related:
#62305
https://community.plotly.com/t/plotly-js-2-0-is-coming-soon/50055

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).