### PR TITLE
Fix types for mapbox-gl-leaflet

### DIFF
--- a/types/mapbox-gl-leaflet/index.d.ts
+++ b/types/mapbox-gl-leaflet/index.d.ts
@@ -8,13 +8,8 @@ import * as L from 'leaflet';
 
 declare module 'leaflet' {
   class MapboxGL extends Layer {
-    constructor(options: MapboxGLOptions);
+    constructor(options: any);
   }
 
-  function mapboxGL(options: MapboxGLOptions): MapboxGL;
-
-  interface MapboxGLOptions {
-    accessToken: string;
-    style: string;
-  }
+  function mapboxGL(options: any): MapboxGL;
 }

--- a/types/mapbox-gl-leaflet/mapbox-gl-leaflet-tests.ts
+++ b/types/mapbox-gl-leaflet/mapbox-gl-leaflet-tests.ts
@@ -10,5 +10,6 @@ L.marker([38.912753, -77.032194])
 
 const gl = L.mapboxGL({
     accessToken: token,
-    style: 'mapbox://styles/mapbox/bright-v8'
+    style: 'mapbox://styles/mapbox/bright-v8',
+    attribution: 'John Doe'
 }).addTo(map);


### PR DESCRIPTION
Make options `any` to mimic the way it is used inside leaflet

The options are used here : https://github.com/mapbox/mapbox-gl-leaflet/blob/85cc938a0d4aa7af0e6859a09982c0714ed5491b/leaflet-mapbox-gl.js#L27

And as we can see here, it takes `any` : 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ed9298deca5192811c5152eae29f91e5adeda8c9/types/leaflet/index.d.ts#L2570

I realised the issue when trying to set an attribution 

Thanks !

-----
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
