### PR TITLE
update(siren-parser): v9 updates

### DIFF
--- a/types/siren-parser/Action.d.ts
+++ b/types/siren-parser/Action.d.ts
@@ -1,8 +1,6 @@
-import { Field } from './Field';
+import Field from './Field';
 
-export default function(action: object): Action;
-
-export interface Action {
+interface Action {
     name: string;
     href: string;
     class?: string[] | undefined;
@@ -27,4 +25,10 @@ export interface Action {
     getFieldsByType(fieldType: string | RegExp): Field[];
 }
 
-export { Field, FieldType } from './Field';
+declare var Action: {
+    prototype: Action;
+    new (action: object): Action;
+    (action: object): Action;
+};
+
+export default Action;

--- a/types/siren-parser/Field.d.ts
+++ b/types/siren-parser/Field.d.ts
@@ -1,6 +1,4 @@
-export default function(field: object): Field;
-
-export interface Field {
+interface Field {
     name: string;
     class?: string[] | undefined;
     type?: FieldType | undefined;
@@ -8,10 +6,16 @@ export interface Field {
     value?: any;
     min?: number | undefined;
     max?: number | undefined;
-
     hasClass(cls: string | RegExp): boolean;
 }
 
+declare var Field: {
+    prototype: Field;
+    new (field: object): Field;
+    (field: object): Field;
+};
+
+export default Field;
 export enum FieldType {
     Hidden = 'hidden',
     Text = 'text',
@@ -31,5 +35,5 @@ export enum FieldType {
     Color = 'color',
     Checkbox = 'checkbox',
     Radio = 'radio',
-    File = 'file'
+    File = 'file',
 }

--- a/types/siren-parser/Link.d.ts
+++ b/types/siren-parser/Link.d.ts
@@ -1,6 +1,4 @@
-export default function(link: object): Link;
-
-export interface Link {
+interface Link {
     rel: string[];
     class?: string[] | undefined;
     href: string;
@@ -9,3 +7,11 @@ export interface Link {
 
     hasClass(cls: string | RegExp): boolean;
 }
+
+declare var Link: {
+    prototype: Link;
+    new (link: object): Link;
+    (link: object): Link;
+};
+
+export default Link;

--- a/types/siren-parser/chai.d.ts
+++ b/types/siren-parser/chai.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="Chai" />
+/// <reference types="chai" />
 
 declare namespace Chai {
     interface Assertion {

--- a/types/siren-parser/index.d.ts
+++ b/types/siren-parser/index.d.ts
@@ -1,14 +1,12 @@
-// Type definitions for siren-parser 8.4
+// Type definitions for siren-parser 9.0
 // Project: https://github.com/Brightspace/node-siren-parser
 // Definitions by: Dillon Redding <https://github.com/dillonredding>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Link } from './Link';
-import { Action } from './Action';
+import Link from './Link';
+import Action from './Action';
 
-export default function(entity: string | object): Entity;
-
-export interface Entity {
+interface Entity {
     class?: string[] | undefined;
     properties?: object | undefined;
     entities?: Entity[] | undefined;
@@ -77,6 +75,12 @@ export interface Entity {
     getSubEntitiesByType(entityType: string | RegExp): Entity[];
 }
 
+declare var Entity: {
+    prototype: Entity;
+    new (entity: string | object): Entity;
+    (entity: string | object): Entity;
+};
+
 declare global {
     namespace D2L {
         namespace Hypermedia {
@@ -87,5 +91,5 @@ declare global {
     }
 }
 
-export { Link } from './Link';
-export { Action, Field, FieldType } from './Action';
+export default Entity;
+export { Entity, Action, Link };

--- a/types/siren-parser/siren-parser-tests.ts
+++ b/types/siren-parser/siren-parser-tests.ts
@@ -1,48 +1,59 @@
-import parseSiren from 'siren-parser';
+import SirenParse, { Action, Entity, Link } from 'siren-parser';
 import * as superagent from 'superagent';
 import * as sirenSuperagent from 'siren-parser/superagent';
 import * as chai from 'chai';
 import 'siren-parser/chai';
 
-parseSiren('{"class":["foo","bar"]}');
+SirenParse('{"class":["foo","bar"]}');
 
 const siren = {
     title: 'My title',
     class: ['outer'],
-    links: [{
-        rel: ['self', 'crazy'],
-        href: 'http://example.com'
-    }, {
-        rel: ['crazy'],
-        href: 'http://example2.com'
-    }],
-    actions: [{
-        name: 'fancy-action',
-        href: 'http://example.com',
-        title: 'A fancy action!',
-        method: 'GET',
-        fields: [{
-            name: 'max',
-            title: 'Maximum value'
-        }]
-    }],
-    entities: [{
-        class: ['inner', 'smaller'],
-        rel: ['child'],
-        links: [{
-            rel: ['self'],
-            href: 'http://example.com/child',
-            title: 'Child entity'
-        }]
-    }],
+    links: [
+        {
+            rel: ['self', 'crazy'],
+            href: 'http://example.com',
+        },
+        {
+            rel: ['crazy'],
+            href: 'http://example2.com',
+        },
+    ],
+    actions: [
+        {
+            name: 'fancy-action',
+            href: 'http://example.com',
+            title: 'A fancy action!',
+            method: 'GET',
+            fields: [
+                {
+                    name: 'max',
+                    title: 'Maximum value',
+                },
+            ],
+        },
+    ],
+    entities: [
+        {
+            class: ['inner', 'smaller'],
+            rel: ['child'],
+            links: [
+                {
+                    rel: ['self'],
+                    href: 'http://example.com/child',
+                    title: 'Child entity',
+                },
+            ],
+        },
+    ],
     properties: {
         one: 1,
         two: 2,
-        pi: 'is exactly three'
-    }
+        pi: 'is exactly three',
+    },
 };
 
-const entity = parseSiren(siren);
+const entity = SirenParse(siren);
 
 D2L.Hypermedia.Siren.Parse(siren);
 
@@ -52,8 +63,9 @@ chai.expect(entity).to.have.sirenLinks.with.classes('foo', 'bar');
 chai.expect(entity).to.have.sirenLinks.all.with.classes('foo', 'bar');
 chai.expect(entity).to.have.a.sirenEntity.with.a.sirenEntity.with.title('foo');
 
-sirenSuperagent.perform(superagent, entity.getAction('fancy-action')!)
-    .send({key: 'value'})
+sirenSuperagent
+    .perform(superagent, entity.getAction('fancy-action')!)
+    .send({ key: 'value' })
     .parse(sirenSuperagent.parse)
     .end((err, res) => {
         const resource = res.body;


### PR DESCRIPTION
v9 corrects exports in native JS module. That is excellent occasion to correct exports and limite exported symbols, to match native JS module.

https://github.com/Brightspace/node-siren-parser/releases/tag/v9.0.0

- exports only symbols found in native JS module
- exports aligned with JS module

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.