### PR TITLE
[react-native] Add hover props to PressableProps

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -42,6 +42,7 @@
 //                 Lorenzo Sciandra <https://github.com/kelset>
 //                 Mateusz Wit <https://github.com/MateWW>
 //                 Luna Wei <https://github.com/lunaleaps>
+//                 Saad Najmi <https://github.com/saadnajmi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -546,6 +546,8 @@ export type PointerEvent = NativeSyntheticEvent<NativePointerEvent>;
 
 export interface GestureResponderEvent extends NativeSyntheticEvent<NativeTouchEvent> {}
 
+export interface MouseEvent extends NativeSyntheticEvent<NativeMouseEvent> {}
+
 // See https://reactnative.dev/docs/scrollview#contentoffset
 export interface PointProp {
     x: number;
@@ -572,6 +574,16 @@ export interface PressableAndroidRippleConfig {
 
 export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'children' | 'style' | 'hitSlop'> {
     /**
+     * Called when the hover is activated to provide visual feedback.
+     */
+    onHoverIn?: null | ((event: MouseEvent) => void) | undefined,
+
+    /**
+     * Called when the hover is deactivated to undo visual feedback.
+     */
+    onHoverOut?: null | ((event: MouseEvent) => void) | undefined,
+
+    /**
      * Called when a single tap gesture is detected.
      */
     onPress?: null | ((event: GestureResponderEvent) => void) | undefined;
@@ -593,13 +605,13 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'chi
 
     /**
      * Called after the element loses focus.
-     * @platform windows
+     * @platform macos windows
      */
     onBlur?: null | ((event: NativeSyntheticEvent<TargetedEvent>) => void) | undefined;
 
     /**
      * Called after the element is focused.
-     * @platform windows
+     * @platform macos windows
      */
     onFocus?: null | ((event: NativeSyntheticEvent<TargetedEvent>) => void) | undefined;
 
@@ -614,6 +626,18 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'chi
      * scroll event. Defaults to true.
      */
     cancelable?: null | boolean | undefined;
+
+    /**
+     * Duration to wait after hover in before calling `onHoverIn`.
+     * @platform macos windows
+     */
+    delayHoverIn?: number | null | undefined;
+
+    /**
+     * Duration to wait after hover out before calling `onHoverOut`.
+     * @platform macos windows
+     */
+    delayHoverOut?: number | null | undefined;
 
     /**
      * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -57,6 +57,7 @@ import {
     LogBox,
     MaskedViewIOS,
     Modal,
+    MouseEvent,
     NativeEventEmitter,
     NativeModule, // Not actually exported, not sure why
     NativeModules,
@@ -438,6 +439,12 @@ export class PressableTest extends React.Component<{}> {
         e.isDefaultPrevented();
     };
 
+    onHoverButton = (e: MouseEvent) => {
+        e.persist();
+        e.isPropagationStopped();
+        e.isDefaultPrevented();
+    };
+
     render() {
         return (
             <>
@@ -487,6 +494,12 @@ export class PressableTest extends React.Component<{}> {
                     onPress={this.onPressButton}
                     style={{ backgroundColor: 'blue' }}
                 >
+                    <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
+                        <Text style={{ margin: 30 }}>Button</Text>
+                    </View>
+                </Pressable>
+                {/* onHoverIn */}
+                <Pressable ref={this.myRef} onHoverIn={this.onHoverButton} style={{ backgroundColor: 'blue' }}>
                     <View style={{ width: 150, height: 100, backgroundColor: 'red' }}>
                         <Text style={{ margin: 30 }}>Button</Text>
                     </View>

--- a/types/react-native/v0.68/index.d.ts
+++ b/types/react-native/v0.68/index.d.ts
@@ -39,6 +39,7 @@
 //                 Pedro Hernández <https://github.com/phvillegas>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Zihan Chen <https://github.com/ZihanChen-MSFT>
+//                 Saad Najmi <https://github.com/saadnajmi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -424,7 +425,17 @@ export interface NativeTouchEvent {
     force?: number | undefined;
 }
 
+export interface NativeMouseEvent {
+    clientX: number,
+    clientY: number,
+    pageX: number,
+    pageY: number,
+    timestamp: number,
+}
+
 export interface GestureResponderEvent extends NativeSyntheticEvent<NativeTouchEvent> {}
+
+export interface MouseEvent extends NativeSyntheticEvent<NativeMouseEvent> {}
 
 // See https://reactnative.dev/docs/scrollview#contentoffset
 export interface PointPropType {
@@ -452,6 +463,16 @@ export interface PressableAndroidRippleConfig {
 
 export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'children' | 'style' | 'hitSlop'> {
     /**
+     * Called when the hover is activated to provide visual feedback.
+     */
+    onHoverIn?: null | ((event: MouseEvent) => void) | undefined,
+
+    /**
+     * Called when the hover is deactivated to undo visual feedback.
+     */
+    onHoverOut?: null | ((event: MouseEvent) => void) | undefined,
+
+    /**
      * Called when a single tap gesture is detected.
      */
     onPress?: null | ((event: GestureResponderEvent) => void) | undefined;
@@ -473,13 +494,13 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'chi
 
     /**
      * Called after the element loses focus.
-     * @platform windows
+     * @platform macos windows
      */
     onBlur?: null | ((event: NativeSyntheticEvent<TargetedEvent>) => void) | undefined;
 
     /**
      * Called after the element is focused.
-     * @platform windows
+     * @platform macos windows
      */
     onFocus?: null | ((event: NativeSyntheticEvent<TargetedEvent>) => void) | undefined;
 
@@ -494,6 +515,16 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'chi
      * scroll event. Defaults to true.
      */
     cancelable?: null | boolean | undefined;
+
+    /**
+     * Duration to wait after hover in before calling `onHoverIn`.
+     */
+    delayHoverIn?: number | null | undefined;
+
+    /**
+     * Duration to wait after hover out before calling `onHoverOut`.
+     */
+    delayHoverOut?: number | null | undefined;
 
     /**
      * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.

--- a/types/react-native/v0.69/index.d.ts
+++ b/types/react-native/v0.69/index.d.ts
@@ -41,6 +41,7 @@
 //                 Zihan Chen <https://github.com/ZihanChen-MSFT>
 //                 Lorenzo Sciandra <https://github.com/kelset>
 //                 Mateusz Wit <https://github.com/MateWW>
+//                 Saad Najmi <https://github.com/saadnajmi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
@@ -427,7 +428,17 @@ export interface NativeTouchEvent {
     force?: number | undefined;
 }
 
+export interface NativeMouseEvent {
+    clientX: number,
+    clientY: number,
+    pageX: number,
+    pageY: number,
+    timestamp: number,
+}
+
 export interface GestureResponderEvent extends NativeSyntheticEvent<NativeTouchEvent> {}
+
+export interface MouseEvent extends NativeSyntheticEvent<NativeMouseEvent> {}
 
 // See https://reactnative.dev/docs/scrollview#contentoffset
 export interface PointProp {
@@ -455,6 +466,16 @@ export interface PressableAndroidRippleConfig {
 
 export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'children' | 'style' | 'hitSlop'> {
     /**
+     * Called when the hover is activated to provide visual feedback.
+     */
+    onHoverIn?: null | ((event: MouseEvent) => void) | undefined,
+
+    /**
+     * Called when the hover is deactivated to undo visual feedback.
+     */
+    onHoverOut?: null | ((event: MouseEvent) => void) | undefined,
+
+    /**
      * Called when a single tap gesture is detected.
      */
     onPress?: null | ((event: GestureResponderEvent) => void) | undefined;
@@ -476,13 +497,13 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'chi
 
     /**
      * Called after the element loses focus.
-     * @platform windows
+     * @platform macos windows
      */
     onBlur?: null | ((event: NativeSyntheticEvent<TargetedEvent>) => void) | undefined;
 
     /**
      * Called after the element is focused.
-     * @platform windows
+     * @platform macos windows
      */
     onFocus?: null | ((event: NativeSyntheticEvent<TargetedEvent>) => void) | undefined;
 
@@ -498,6 +519,16 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'chi
      */
     cancelable?: null | boolean | undefined;
 
+   /**
+    * Duration to wait after hover in before calling `onHoverIn`.
+    */
+    delayHoverIn?: number | null | undefined;
+
+    /**
+     * Duration to wait after hover out before calling `onHoverOut`.
+     */
+    delayHoverOut?: number | null | undefined;
+ 
     /**
      * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
      */

--- a/types/react-native/v0.69/index.d.ts
+++ b/types/react-native/v0.69/index.d.ts
@@ -528,7 +528,7 @@ export interface PressableProps extends AccessibilityProps, Omit<ViewProps, 'chi
      * Duration to wait after hover out before calling `onHoverOut`.
      */
     delayHoverOut?: number | null | undefined;
- 
+
     /**
      * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
      */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested 

====

This is a followup to my now (ancient feeling) change that exposed new props on the Pressable component in React Native. This adds it to the types.

My change won't make it to React Native till RN 0.68, but I've backported it to older React Native macOS and React Native Windows releases. 
Relevant PRs:

RN Core change (0.68+): https://github.com/facebook/react-native/pull/32405

RN macOS and Windows changes + back ports: 

(RN macOS - 0.64) - https://github.com/microsoft/react-native-macos/pull/923
(macOS skipped RN 0.65, and went straight to 0.66)
(RN macOS - 0.66) - https://github.com/microsoft/react-native-macos/pull/884

(RN Windows - 0.64) - https://github.com/microsoft/react-native-windows/pull/9350
(RN Windows - 0.65) - https://github.com/microsoft/react-native-windows/pull/9349
(RN Windows - 0.66) - https://github.com/microsoft/react-native-windows/pull/9348
(RN Windows - 0.67) - https://github.com/microsoft/react-native-windows/pull/9347