### PR TITLE
[eslint] propagate config Rules to `overrides` property

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -789,7 +789,15 @@ eslintConfig = {
     rules: {
         'capitalized-comments': [2, 'always', { ignorePattern: 'const|let' }],
     },
+    overrides: [{
+        files: '*.json',
+        rules: {
+            'max-len': 0,
+        },
+    }],
 };
+
+eslintConfig.overrides?.[0].rules; // $ExpectType Partial<ESLintRules> | undefined
 
 //#endregion
 

--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -794,10 +794,34 @@ eslintConfig = {
         rules: {
             'max-len': 0,
         },
+    },
+    {
+        files: '*.ts',
+        rules: {
+            '@typescript-eslint/no-invalid-void-type': [2, {allowAsThisParameter: true}],
+        },
     }],
 };
 
+eslintConfig.rules; // $ExpectType Partial<ESLintRules> | undefined
 eslintConfig.overrides?.[0].rules; // $ExpectType Partial<ESLintRules> | undefined
+
+interface TSLinterRules {
+    '@typescript-eslint/no-invalid-void-type'?: Linter.RuleEntry<[Partial<{
+        allowInGenericTypeArguments: boolean | string[];
+        allowAsThisParameter: boolean;
+    }>]>;
+}
+
+const eslintConfig2: Linter.Config<ESLintRules, ESLintRules & TSLinterRules> = eslintConfig;
+
+eslintConfig2.rules; // $ExpectType Partial<ESLintRules> | undefined
+eslintConfig2.overrides?.[1].rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
+
+const eslintConfig3: Linter.Config<ESLintRules & TSLinterRules> = eslintConfig2;
+
+eslintConfig3.rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
+eslintConfig3.overrides?.[1].rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
 
 //#endregion
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -719,13 +719,13 @@ export namespace Linter {
         rules?: Partial<Rules> | undefined;
     }
 
-    interface BaseConfig<Rules extends RulesRecord = RulesRecord> extends HasRules<Rules> {
+    interface BaseConfig<Rules extends RulesRecord = RulesRecord, OverrideRules extends RulesRecord = Rules> extends HasRules<Rules> {
         $schema?: string | undefined;
         env?: { [name: string]: boolean } | undefined;
         extends?: string | string[] | undefined;
         globals?: { [name: string]: boolean | "readonly" | "readable" | "writable" | "writeable" } | undefined;
         noInlineConfig?: boolean | undefined;
-        overrides?: Array<ConfigOverride<Rules>> | undefined;
+        overrides?: Array<ConfigOverride<OverrideRules>> | undefined;
         parser?: string | undefined;
         parserOptions?: ParserOptions | undefined;
         plugins?: string[] | undefined;
@@ -740,7 +740,7 @@ export namespace Linter {
     }
 
     // https://github.com/eslint/eslint/blob/v6.8.0/conf/config-schema.js
-    interface Config<Rules extends RulesRecord = RulesRecord> extends BaseConfig<Rules> {
+    interface Config<Rules extends RulesRecord = RulesRecord, OverrideRules extends RulesRecord = Rules> extends BaseConfig<Rules, OverrideRules> {
         ignorePatterns?: string | string[] | undefined;
         root?: boolean | undefined;
     }

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -725,7 +725,7 @@ export namespace Linter {
         extends?: string | string[] | undefined;
         globals?: { [name: string]: boolean | "readonly" | "readable" | "writable" | "writeable" } | undefined;
         noInlineConfig?: boolean | undefined;
-        overrides?: ConfigOverride[] | undefined;
+        overrides?: Array<ConfigOverride<Rules>> | undefined;
         parser?: string | undefined;
         parserOptions?: ParserOptions | undefined;
         plugins?: string[] | undefined;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://eslint.org/docs/latest/user-guide/configuring/configuration-files#how-do-overrides-work "Override blocks can contain any configuration options that are valid in a regular config, ..." 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This change enables ESLint rules documentation on mouse hover for the rules in the `overrides` property.