### PR TITLE
[aws-lambda]: Add missing types for Cognito Custom Messages Trigger

### DIFF
--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -242,11 +242,12 @@ const customMessage: CustomMessageTriggerHandler = async (event, _, callback) =>
     obj = request.userAttributes;
     str = request.userAttributes.email;
     str = request.codeParameter;
-    str = request.usernameParameter;
+    str = request.linkParameter;
+    strOrNull = request.usernameParameter;
 
-    str = response.smsMessage;
-    str = response.emailMessage;
-    str = response.emailSubject;
+    strOrNull = response.smsMessage;
+    strOrNull = response.emailMessage;
+    strOrNull = response.emailSubject;
 
     triggerSource === 'CustomMessage_AdminCreateUser';
     triggerSource === 'CustomMessage_Authentication';

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/custom-message.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/custom-message.d.ts
@@ -6,6 +6,9 @@ export interface BaseCustomMessageTriggerEvent<T extends string> extends BaseTri
       userAttributes: StringMap;
       codeParameter: string;
       linkParameter: string;
+        /**
+         * This is null for all events other than the AdminCreateUser action.
+         */
       usernameParameter: string | null;
       clientMetadata?: StringMap | undefined;
   };

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/custom-message.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/custom-message.d.ts
@@ -5,13 +5,14 @@ export interface BaseCustomMessageTriggerEvent<T extends string> extends BaseTri
   request: {
       userAttributes: StringMap;
       codeParameter: string;
-      usernameParameter: string;
+      linkParameter: string;
+      usernameParameter: string | null;
       clientMetadata?: StringMap | undefined;
   };
   response: {
-      smsMessage: string;
-      emailMessage: string;
-      emailSubject: string;
+      smsMessage: string | null;
+      emailMessage: string | null;
+      emailSubject: string | null;
   };
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
AWS hasn't updated their examples yet (https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html#aws-lambda-triggers-custom-message-example).
I retrieved the definitions by logging the received event in Lambda:

```json
{
  "version": "1",
  "region": "eu-central-1",
  "userPoolId": "eu-central-1_XXXXX",
  "userName": "AAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEE",
  "callerContext": {
    "awsSdkVersion": "aws-sdk-unknown-unknown",
    "clientId": "abcdefghijkl"
  },
  "triggerSource": "CustomMessage_SignUp",
  "request": {
    "userAttributes": {
      "sub": "AAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEE",
      "cognito:email_alias": "me@example.com",
      "email_verified": "false",
      "cognito:user_status": "UNCONFIRMED",
      "phone_number_verified": "false",
      "phone_number": "+XXXYYYYYYY",
      "given_name": "John",
      "family_name": "Doe",
      "email": "me@example.com"
    },
    "codeParameter": "{####}",
    "linkParameter": "{##Click Here##}",
    "usernameParameter": null
  },
  "response": {
    "smsMessage": null,
    "emailMessage": null,
    "emailSubject": null
  }
}
```