### PR TITLE
ember-qunit: Update `test` return types to allow for returning non-empty Promises

### DIFF
--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -135,6 +135,16 @@ module('misc and async', function (hooks) {
 });
 // end tests ported from ember-test-helpers
 
+module('returning a promise', function () {
+    test('it can return Promise<void>', function (this: TestContext, assert) {
+        return Promise.resolve();
+    });
+
+    test('it can return a non-empty Promise', function (this: TestContext, assert) {
+        return Promise.resolve('foo');
+    });
+});
+
 // https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md#qunit-nested-modules-api
 QUnit.module('some description', function (hooks) {
     hooks.before(() => {});

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -176,7 +176,7 @@ declare global {
          * @param callback Function to close over assertions
          */
         // tslint:disable-next-line no-unnecessary-generics
-        test<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<void>): void;
+        test<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<unknown>): void;
 
         /**
          * Adds a test to exclusively run, preventing all other tests from running.
@@ -195,7 +195,7 @@ declare global {
          * @param callback Function to close over assertions
          */
         // tslint:disable-next-line no-unnecessary-generics
-        only<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<void>): void;
+        only<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<unknown>): void;
 
         /**
          * Use this method to test a unit of code which is still under development (in a “todo” state).
@@ -208,7 +208,7 @@ declare global {
          * @param callback Function to close over assertions
          */
         // tslint:disable-next-line no-unnecessary-generics
-        todo<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<void>): void;
+        todo<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<unknown>): void;
 
         /**
          * Adds a test like object to be skipped.
@@ -224,6 +224,6 @@ declare global {
          * @param callback Function to close over assertions
          */
         // tslint:disable-next-line no-unnecessary-generics
-        skip<TC extends TestContext>(name: string, callback?: (this: TC, assert: Assert) => void | Promise<void>): void;
+        skip<TC extends TestContext>(name: string, callback?: (this: TC, assert: Assert) => void | Promise<unknown>): void;
     }
 }

--- a/types/ember-qunit/v4/index.d.ts
+++ b/types/ember-qunit/v4/index.d.ts
@@ -204,7 +204,7 @@ declare global {
          * @param callback Function to close over assertions
          */
         // tslint:disable-next-line no-unnecessary-generics
-        test<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<void>): void;
+        test<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<unknown>): void;
 
         /**
          * Adds a test to exclusively run, preventing all other tests from running.
@@ -223,7 +223,7 @@ declare global {
          * @param callback Function to close over assertions
          */
         // tslint:disable-next-line no-unnecessary-generics
-        only<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<void>): void;
+        only<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<unknown>): void;
 
         /**
          * Use this method to test a unit of code which is still under development (in a “todo” state).
@@ -236,7 +236,7 @@ declare global {
          * @param callback Function to close over assertions
          */
         // tslint:disable-next-line no-unnecessary-generics
-        todo<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<void>): void;
+        todo<TC extends TestContext>(name: string, callback: (this: TC, assert: Assert) => void | Promise<unknown>): void;
 
         /**
          * Adds a test like object to be skipped.
@@ -252,6 +252,6 @@ declare global {
          * @param callback Function to close over assertions
          */
         // tslint:disable-next-line no-unnecessary-generics
-        skip<TC extends TestContext>(name: string, callback?: (this: TC, assert: Assert) => void | Promise<void>): void;
+        skip<TC extends TestContext>(name: string, callback?: (this: TC, assert: Assert) => void | Promise<unknown>): void;
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


This PR updates the return types of `test`, `todo`, `skip`, and `only` to allow for returning non-empty Promises. This change prevents a nasty bug that can occur when someone returns a non-empty Promise while also passing a `this` parameter as part of the test callback, e.g.:

```ts
test('it works', function(this: TestContext, assert) {
  return Promise.resolve('foo');
})
```

Since the `ember-qunit` types constrain the return type of the callback to `void | Promise<void>`, the type system sees the `Promise<string>` here and falls back to the [original Qunit `test` definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/qunit/index.d.ts#L755) (of which the `ember-qunit` version is an overload). At that point, TypeScript gives up because both versions specify `Promise<void>` and the original `qunit` type doesn't allow for a `this` parameter at all. An example of the type error can be found below:

```
No overload matches this call.
  Overload 1 of 2, '(name: string, callback: (this: Context, assert: Assert) => void | Promise<void>): void', gave the following error.
    Argument of type '(this: Context, assert: Assert) => Promise<LixTests>' is not assignable to parameter of type '(this: Context, assert: Assert) => void | Promise<void>'.
      Type 'Promise<string>' is not assignable to type 'void | Promise<void>'.
        Type 'Promise<string>' is not assignable to type 'Promise<void>'.
          Type 'string' is not assignable to type 'void'.
  Overload 2 of 2, '(name: string, callback: (assert: Assert) => void | Promise<void>): void', gave the following error.
    Argument of type '(this: Context, assert: Assert) => Promise<string>' is not assignable to parameter of type '(assert: Assert) => void | Promise<void>'.
      Type 'Promise<string>' is not assignable to type 'void | Promise<void>'
```

Since it doesn't actually matter what is contained in the Promise, we can avoid this behavior by simply changing the type return type to `Promise<unknown>` instead of `Promise<void>`, since all that really matters is that we're returning a Promise to signify when the test itself is actually done executing.