### PR TITLE
[node] Add missing `ReadonlyArray.at()`

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -87,6 +87,7 @@ interface RelativeIndexable<T> {
 }
 interface String extends RelativeIndexable<string> {}
 interface Array<T> extends RelativeIndexable<T> {}
+interface ReadonlyArray<T> extends RelativeIndexable<T> {}
 interface Int8Array extends RelativeIndexable<number> {}
 interface Uint8Array extends RelativeIndexable<number> {}
 interface Uint8ClampedArray extends RelativeIndexable<number> {}

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -37,3 +37,11 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     const arrayBuffer = new ArrayBuffer(0);
     structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
 }
+
+// Array.prototype.at()
+{
+    const mutableArray = ['a'];
+    mutableArray.at(-1);
+    const readonlyArray: ReadonlyArray<string> = ['b'];
+    readonlyArray.at(-1);
+}

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -87,6 +87,7 @@ interface RelativeIndexable<T> {
 }
 interface String extends RelativeIndexable<string> {}
 interface Array<T> extends RelativeIndexable<T> {}
+interface ReadonlyArray<T> extends RelativeIndexable<T> {}
 interface Int8Array extends RelativeIndexable<number> {}
 interface Uint8Array extends RelativeIndexable<number> {}
 interface Uint8ClampedArray extends RelativeIndexable<number> {}

--- a/types/node/v16/test/globals.ts
+++ b/types/node/v16/test/globals.ts
@@ -26,3 +26,11 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
         gc();
     }
 }
+
+// Array.prototype.at()
+{
+    const mutableArray = ['a'];
+    mutableArray.at(-1);
+    const readonlyArray: ReadonlyArray<string> = ['b'];
+    readonlyArray.at(-1);
+}


### PR DESCRIPTION
The core TypeScript types [already support this](https://github.com/microsoft/TypeScript/blob/4d91204c9d9f27756785f62fade44d93824d47f4/src/lib/es2022.array.d.ts#L9-L15), so it was really confusing me when I ran into this inconsistency.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: `.at()` doesn't mutate anything, and the core TypeScript types [already support `ReadonlyArray.at()`](https://github.com/microsoft/TypeScript/blob/4d91204c9d9f27756785f62fade44d93824d47f4/src/lib/es2022.array.d.ts#L9-L15).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.