### PR TITLE
fix: merge-images remove unnecessary undefined declaration that can b…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4568,7 +4568,7 @@
 /types/merge-deep/                                      @forivall
 /types/merge-descriptors/                               @danny8002
 /types/merge-env/                                       @BendingBender
-/types/merge-images/                                    @BendingBender @mdnm @k-yle
+/types/merge-images/                                    @BendingBender @mdnm @k-yle @ChanhyukPark-Tech
 /types/merge-img/                                       @peterblazejewicz
 /types/merge-objects/                                   @Richienb
 /types/merge-ranges/                                    @BERENGENITA

--- a/types/merge-images/index.d.ts
+++ b/types/merge-images/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for merge-images 1.2
+// Type definitions for merge-images 2.0.0
 // Project: https://github.com/lukechilds/merge-images
 // Definitions by: BendingBender <https://github.com/BendingBender>
 //                 Mateus Nardo <https://github.com/mdnm>
 //                 Kyle Hensel <https://github.com/k-yle>
+//                 Chanhyuk Park <https://github.com/ChanhyukPark-Tech>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -26,7 +27,7 @@ declare function mergeImages(sources: mergeImages.ImageSource[], options?: merge
 declare namespace mergeImages {
     type Image = string | Buffer;
 
-    type ImageSource = Image | { src: Image; x?: number | undefined; y?: number | undefined; opacity?: number | undefined };
+    type ImageSource = Image | { src: Image; x?: number; y?: number; opacity?: number; };
 
     interface Options {
         /**
@@ -34,14 +35,14 @@ declare namespace mergeImages {
          *
          * @default 'image/png'
          */
-        format?: string | undefined;
+        format?: string;
 
         /**
          * A number between `0` and `1` indicating image quality if the requested format is `'image/jpeg'` or `'image/webp'`.
          *
          * @default 0.92
          */
-        quality?: number | undefined;
+        quality?: number;
 
         /**
          * The width in pixels the rendered image should be. Defaults to the width of the widest source image.
@@ -55,7 +56,7 @@ declare namespace mergeImages {
          *   .then(b64 => ...);
          *   // data:image/png;base64,iVBORw0KGgoAA...
          */
-        width?: number | undefined;
+        width?: number;
 
         /**
          * The height in pixels the rendered image should be. Defaults to the height of the tallest source image.
@@ -69,7 +70,7 @@ declare namespace mergeImages {
          *   .then(b64 => ...);
          *   // data:image/png;base64,iVBORw0KGgoAA...
          */
-        height?: number | undefined;
+        height?: number;
 
         /**
          * `Canvas` implementation to be used to allow usage outside of the browser. e.g Node.js with [node-canvas](https://github.com/Automattic/node-canvas).
@@ -114,6 +115,6 @@ declare namespace mergeImages {
          *
          * @default undefined
          */
-        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "";
     }
 }


### PR DESCRIPTION
 merge-images remove unnecessary undefined declaration that can be referenced by typescript automatically

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
