### PR TITLE
[react-swipeable-views-utils] Make `index` and `onChangeIndex` optional

### DIFF
--- a/types/react-swipeable-views-utils/index.d.ts
+++ b/types/react-swipeable-views-utils/index.d.ts
@@ -9,28 +9,25 @@ import * as React from 'react';
 import { ConsistentWith, Omit, PropInjector } from '@material-ui/types';
 import { OnChangeIndexCallback, OnSwitchingCallback, OnTransitionEndCallback } from 'react-swipeable-views';
 
-export interface WithAutoPlay {
-    index: number;
-    onChangeIndex: OnChangeIndexCallback;
+export interface WithIndex {
+    index?: number;
+    onChangeIndex?: OnChangeIndexCallback;
+}
+
+export interface WithAutoPlay extends WithIndex {
     onSwitching?: OnSwitchingCallback | undefined;
 }
-export interface WithAutoPlayProps {
+export interface WithAutoPlayProps extends WithIndex {
     autoplay?: boolean | undefined;
     direction?: 'incremental' | 'decremental' | undefined;
-    index: number;
     interval?: number | undefined;
-    onChangeIndex: OnChangeIndexCallback;
     slideCount?: number | undefined;
 }
 
-export interface WithVirtualize {
-    index: number;
-    onChangeIndex: OnChangeIndexCallback;
+export interface WithVirtualize extends WithIndex {
     slideRenderer: (render: SlideRendererCallback) => React.ReactNode;
 }
-export interface WithVirtualizeProps {
-    index: number;
-    onChangeIndex: OnChangeIndexCallback;
+export interface WithVirtualizeProps extends WithIndex {
     onTransitionEnd?: OnTransitionEndCallback | undefined;
     overscanSlideAfter?: number | undefined;
     overscanSlideBefore?: number | undefined;
@@ -43,14 +40,10 @@ export interface SlideRenderProps {
     key: number;
 }
 
-export interface WithBindKeyboard {
-    index: number;
-    onChangeIndex: OnChangeIndexCallback;
-}
-export interface WithBindKeyboardProps {
+export type WithBindKeyboard = WithIndex;
+
+export interface WithBindKeyboardProps extends WithIndex {
     axis?: "x" | "x-reverse" | "y" | "y-reverse" | undefined;
-    index: number;
-    onChangeIndex: OnChangeIndexCallback;
     slidecount?: number | undefined;
 }
 

--- a/types/react-swipeable-views-utils/index.d.ts
+++ b/types/react-swipeable-views-utils/index.d.ts
@@ -6,7 +6,7 @@
 // TypeScript Version: 3.0
 
 import * as React from 'react';
-import { ConsistentWith, Omit, PropInjector } from '@material-ui/types';
+import { PropInjector } from '@material-ui/types';
 import { OnChangeIndexCallback, OnSwitchingCallback, OnTransitionEndCallback } from 'react-swipeable-views';
 
 export interface WithIndex {

--- a/types/react-swipeable-views-utils/react-swipeable-views-utils-tests.tsx
+++ b/types/react-swipeable-views-utils/react-swipeable-views-utils-tests.tsx
@@ -7,8 +7,6 @@ const VirtualizeSwipeableViews = virtualize(SwipeableViews);
 const BindKeyboardSwipeableViews = bindKeyboard(SwipeableViews);
 
 function autoPlayTest() {
-    // @ts-expect-error
-    <AutoPlaySwipeableViews />;
     <AutoPlaySwipeableViews
         index={1}
         onChangeIndex={(index: number) => {
@@ -22,6 +20,12 @@ function virtualizeTest() {
     // @ts-expect-error
     <VirtualizeSwipeableViews />;
     <VirtualizeSwipeableViews
+        slideRenderer={(renderer: SlideRenderProps) => {
+            return <div>Slide {renderer.index}</div>;
+        }}
+        enableMouseEvents
+    />;
+    <VirtualizeSwipeableViews
         index={1}
         onChangeIndex={(index: number) => {
             index;
@@ -33,7 +37,6 @@ function virtualizeTest() {
 }
 
 function bindKeyboardTest() {
-    // @ts-expect-error
     <BindKeyboardSwipeableViews />;
     <BindKeyboardSwipeableViews
         index={1}


### PR DESCRIPTION
These props are not mandatory, as per the demo code example: https://github.com/oliviertassinari/react-swipeable-views/blob/f0f114ce514b46168daa8ed68d9fad29ba1bfc0f/docs/src/pages/demos/DemoCircular.js#L56

Also took the opportunity to DRY a bit by making a common `WithIndex` interface that the other utils interfaces extend from.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/oliviertassinari/react-swipeable-views/blob/f0f114ce514b46168daa8ed68d9fad29ba1bfc0f/docs/src/pages/demos/DemoCircular.js#L56
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.