### PR TITLE
[webfontloader] Fixing type definition for Config.context. This shoul…

### DIFF
--- a/types/webfontloader/index.d.ts
+++ b/types/webfontloader/index.d.ts
@@ -7,56 +7,55 @@ export = WebFont;
 export as namespace WebFont;
 
 declare namespace WebFont {
-    export function load(config:WebFont.Config):void;
+    export function load(config: WebFont.Config): void;
     export interface Config {
         /** Setting this to false will disable html classes (defaults to true) */
-        classes?:boolean | undefined;
+        classes?: boolean | undefined;
         /** Settings this to false will disable callbacks/events (defaults to true) */
-        events?:boolean | undefined;
+        events?: boolean | undefined;
         /** Time (in ms) until the fontinactive callback will be triggered (defaults to 5000) */
-        timeout?:number | undefined;
+        timeout?: number | undefined;
         /** This event is triggered when all fonts have been requested. */
-        loading?():void;
+        loading?(): void;
         /** This event is triggered when the fonts have rendered. */
-        active?():void;
+        active?(): void;
         /** This event is triggered when the browser does not support linked fonts or if none of the fonts could be loaded. */
-        inactive?():void;
+        inactive?(): void;
         /** This event is triggered once for each font that's loaded. */
-        fontloading?(familyName:string, fvd:string):void;
+        fontloading?(familyName: string, fvd: string): void;
         /** This event is triggered once for each font that renders. */
-        fontactive?(familyName:string, fvd:string):void;
+        fontactive?(familyName: string, fvd: string): void;
         /** This event is triggered if the font can't be loaded. */
-        fontinactive?(familyName:string, fvd:string):void;
+        fontinactive?(familyName: string, fvd: string): void;
 
-        /** Child window or iframes to manage fonts for */
-        context?:Array<string> | undefined;
+        /** Child window or iframe to manage fonts for */
+        context?: Window | undefined;
 
-        custom?:Custom | undefined;
-        google?:Google | undefined;
-        typekit?:Typekit | undefined;
-        fontdeck?:Fontdeck | undefined;
-        monotype?:Monotype | undefined;
+        custom?: Custom | undefined;
+        google?: Google | undefined;
+        typekit?: Typekit | undefined;
+        fontdeck?: Fontdeck | undefined;
+        monotype?: Monotype | undefined;
     }
     export interface Google {
         api?: string | undefined;
-        families:Array<string>;
+        families: Array<string>;
         text?: string | undefined;
     }
     export interface Typekit {
-        id?:string | undefined;
+        id?: string | undefined;
     }
     export interface Custom {
-        families?:Array<string> | undefined;
-        urls?:Array<string> | undefined;
-        testStrings?:{[fontFamily:string]:string} | undefined;
+        families?: Array<string> | undefined;
+        urls?: Array<string> | undefined;
+        testStrings?: { [fontFamily: string]: string } | undefined;
     }
     export interface Fontdeck {
-        id?:string | undefined;
+        id?: string | undefined;
     }
     export interface Monotype {
-        projectId?:string | undefined;
-        version?:number | undefined;
-        loadAllFonts?:boolean | undefined;
+        projectId?: string | undefined;
+        version?: number | undefined;
+        loadAllFonts?: boolean | undefined;
     }
-
 }

--- a/types/webfontloader/tsconfig.json
+++ b/types/webfontloader/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/webfontloader/webfontloader-tests.ts
+++ b/types/webfontloader/webfontloader-tests.ts
@@ -1,31 +1,31 @@
-
-import webfontloader = require("webfontloader");
+import webfontloader = require('webfontloader');
 
 var config: webfontloader.Config = {
+    context: window,
     classes: false,
     events: false,
     loading: function() {},
-      active: function() {},
-      inactive: function() {},
-      fontloading: function(familyName:string, fvd:string) {},
-      fontactive: function(familyName:string, fvd:string) {},
-      fontinactive: function(familyName:string, fvd:string) {},
-      google: {
+    active: function() {},
+    inactive: function() {},
+    fontloading: function(familyName: string, fvd: string) {},
+    fontactive: function(familyName: string, fvd: string) {},
+    fontinactive: function(familyName: string, fvd: string) {},
+    google: {
         families: ['Droid Sans', 'Droid Serif:bold'],
-        text: 'abcdedfghijklmopqrstuvwxyz!'
-      },
-      custom: {
+        text: 'abcdedfghijklmopqrstuvwxyz!',
+    },
+    custom: {
         families: ['My Font', 'My Other Font:n4,i4,n7'],
-        urls: ['/fonts.css']
-      },
-      fontdeck: {
-        id: 'xxxx'
-      },
-      monotype: {
+        urls: ['/fonts.css'],
+    },
+    fontdeck: {
+        id: 'xxxx',
+    },
+    monotype: {
         projectId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
         version: 12345,
-        loadAllFonts: true
-      },
-      timeout: 2000
-}
+        loadAllFonts: true,
+    },
+    timeout: 2000,
+};
 webfontloader.load(config);


### PR DESCRIPTION
The config's "context" property is currently set as Array<string>. I assume this came from a misinterpretation of the example of "context: frames['my-child']". The documentation says this should be a reference to a window, and I also checked the code for webfontloader to verify that it accepts exactly one Window object. I also updated the comment in index.d.ts that said "Child window or iframes" to now say "iframe" singular, as only one is supported.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/typekit/webfontloader#iframes
(Documentation stating "context" should be a reference to a window.)
https://github.com/typekit/webfontloader/blob/117e48d521d6408f78cbfe4d23923cc828fdf576/src/core/webfont.js#L39
(Code where the "context" is used.)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (Fixing typings for a current version.)
