### PR TITLE
Package "webextension-polyfill" type for "notifications.d.ts"

### DIFF
--- a/types/webextension-polyfill/namespaces/notifications.d.ts
+++ b/types/webextension-polyfill/namespaces/notifications.d.ts
@@ -28,6 +28,19 @@ export namespace Notifications {
         message: string;
     }
 
+    interface NotificationButton {
+        /**
+         * Title of one button of a list notification.
+         */
+        title: string;
+
+        /**
+         * @Deprecated since Chrome 59
+         * URL pointing to an icon for the button.
+         */
+        iconUrl?: string;
+    }
+
     interface CreateNotificationOptions {
         /**
          * Which type of notification to display.
@@ -85,6 +98,13 @@ export namespace Notifications {
          * Optional.
          */
         items?: NotificationItem[];
+
+        /**
+         * An array of up to 2 buttons to include in the notification.
+         * Maximum: 2
+         * Optional.
+         */
+        buttons?: NotificationButton[];
 
         /**
          * Current progress ranges from 0 to 100.
@@ -159,6 +179,13 @@ export namespace Notifications {
          * Optional.
          */
         items?: NotificationItem[];
+
+        /**
+         * An array of up to 2 buttons to include in the notification.
+         * Maximum: 2
+         * Optional.
+         */
+        buttons?: NotificationButton[];
 
         /**
          * Current progress ranges from 0 to 100.


### PR DESCRIPTION
Missing buttons in notifications.d.ts

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

- https://developer.chrome.com/docs/extensions/reference/notifications/#type-NotificationButton
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
