### PR TITLE
Remove WebRTC types that were removed with TS 4.9

### DIFF
--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -74,7 +74,6 @@ interface RTCAnswerOptions extends RTCOfferAnswerOptions {
 // https://www.w3.org/TR/webrtc/#idl-def-rtciceserver
 interface RTCIceServer {
     credential?: string | undefined;
-    credentialType?: RTCIceCredentialType | undefined;
     urls: string | string[];
     username?: string | undefined;
 }

--- a/types/webrtc/test/RTCPeerConnection.ts
+++ b/types/webrtc/test/RTCPeerConnection.ts
@@ -8,7 +8,6 @@ let ice1: RTCIceServer = {
     urls: 'stun:stun.l.google.com:19302',
     username: 'john',
     credential: '1234',
-    credentialType: 'password',
 };
 let ice2: RTCIceServer = { urls: ['stun:stunserver.org', 'stun:stun.example.com'] };
 let pc: RTCPeerConnection = new RTCPeerConnection({});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

As of TS 4.9, `credentialType` has been removed from the `RTCIceServer` type: https://github.com/microsoft/TypeScript/blob/549b5429d4837344e8c99657109bb6538fd2dbb5/lib/lib.dom.d.ts#L1328-L1332 .

It is now deprecated in most major browsers:  https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer/credentialType

This PR updates declarations and tests to conform to the latest shape of `RTCIceServer` and make the `webrtc` tests pass with the `typescript@next` pipeline, which are currently failing, see https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=140254&view=logs&j=6399d89d-3d30-5fff-3e92-07bbaf7ebe2f&t=482eae7c-85d2-5e8a-ea70-a5ab41e9bc13&l=13019