### PR TITLE
change(passport-jwt): Strongly type user as Express.User in done call…

### DIFF
--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -10,7 +10,7 @@
 // TypeScript Version: 2.3
 
 import { Strategy as PassportStrategy } from 'passport-strategy';
-import { Request } from 'express';
+import * as express from 'express';
 import { VerifyOptions } from 'jsonwebtoken';
 
 export declare class Strategy extends PassportStrategy {
@@ -36,19 +36,19 @@ export interface VerifyCallback {
 }
 
 export interface VerifyCallbackWithRequest {
-    (req: Request, payload: any, done: VerifiedCallback): void;
+    (req: express.Request, payload: any, done: VerifiedCallback): void;
 }
 
 export interface VerifiedCallback {
-    (error: any, user?: any, info?: any): void;
+    (error: any, user?: Express.User | false, info?: any): void;
 }
 
 export interface JwtFromRequestFunction {
-    (req: Request): string | null;
+    (req: express.Request): string | null;
 }
 
 export interface SecretOrKeyProvider {
-    (request: Request, rawJwtToken: any, done: (err: any, secretOrKey?: string | Buffer) => void): void;
+    (request: express.Request, rawJwtToken: any, done: (err: any, secretOrKey?: string | Buffer) => void): void;
 }
 
 export declare namespace ExtractJwt {

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -14,8 +14,8 @@ let opts: StrategyOptions = {
 
 passport.use(
     JwtStrategy.name,
-    new JwtStrategy(opts, function (jwt_payload, done) {
-        findUser({ id: jwt_payload.sub }, function (err, user) {
+    new JwtStrategy(opts, function(jwt_payload, done) {
+        findUser({ id: jwt_payload.sub }, function(err, user) {
             if (err) {
                 return done(err, false);
             }

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -14,8 +14,8 @@ let opts: StrategyOptions = {
 
 passport.use(
     JwtStrategy.name,
-    new JwtStrategy(opts, function(jwt_payload, done) {
-        findUser({ id: jwt_payload.sub }, function(err, user) {
+    new JwtStrategy(opts, function (jwt_payload, done) {
+        findUser({ id: jwt_payload.sub }, function (err, user) {
             if (err) {
                 return done(err, false);
             }
@@ -45,4 +45,12 @@ opts.jwtFromRequest = (req: Request) => {
 opts.secretOrKey = new Buffer('secret');
 opts.secretOrKeyProvider = (request, rawJwtToken, done) => done(null, new Buffer('secret'));
 
-declare function findUser(condition: { id: string }, callback: (error: any, user: any) => void): void;
+class UserModel {}
+
+declare global {
+    namespace Express {
+        // tslint:disable-next-line:no-empty-interface
+        interface User extends UserModel {}
+    }
+}
+declare function findUser(condition: { id: string }, callback: (error: any, user: UserModel) => void): void;


### PR DESCRIPTION
…back

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Changes the type of the user passed to `VerifiedCallback` to be `Express.User`. This is in line with several other passport packages, updated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49723. The strategy also supports passing `false` to the callback, to show that no user was found, [here](https://github.com/mikenicholson/passport-jwt/blob/master/lib/strategy.js#L112). This is already reflected in the tests for the types [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/passport-jwt/passport-jwt-tests.ts#L25)

