### PR TITLE
Update wicg-mediasession for TS 4.9

### DIFF
--- a/types/wicg-mediasession/index.d.ts
+++ b/types/wicg-mediasession/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Julien CROUZET <https://github.com/jucrouzet>
 //                 Eana Hufwe <https://github.com/blueset>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.4
+// Minimum TypeScript Version: 4.9
 
 interface Navigator {
     readonly mediaSession: MediaSession;
@@ -94,11 +94,11 @@ interface MediaSessionActionDetails {
     action: MediaSessionAction;
 
     // This MAY be provided when the action is seekbackward or seekforward. Stores number of seconds to move the playback time by.
-    seekOffset?: number | null | undefined;
+    seekOffset?: number | undefined;
 
     // MUST be provided when action is seekto. Stores the time in seconds to move the playback time to.
-    seekTime?: number | null | undefined;
+    seekTime?: number | undefined;
 
     // MAY be provided when action is seekto. Stores true if the action is being called multiple times as part of a sequence and this is not the last call in that sequence.
-    fastSeek?: boolean | null | undefined;
+    fastSeek?: boolean | undefined;
 }

--- a/types/wicg-mediasession/wicg-mediasession-tests.ts
+++ b/types/wicg-mediasession/wicg-mediasession-tests.ts
@@ -48,16 +48,6 @@ if ('mediaSession' in navigator && navigator.mediaSession) {
         updatePositionState();
     });
 
-    navigator.mediaSession.setActionHandler('hangup', event => {
-        if (navigator.mediaSession) {
-            navigator.mediaSession.playbackState = 'none';
-        }
-    });
-
-    navigator.mediaSession.setActionHandler('togglemicrophone', event => {});
-
-    navigator.mediaSession.setActionHandler('togglecamera', event => {});
-
     navigator.mediaSession.setCameraActive(true);
 
     navigator.mediaSession.setMicrophoneActive(true);


### PR DESCRIPTION
1. 3 MediaSessionActions are removed: "hangup", "togglecamera" and "togglemicrophone".
2. MediaSessionActionDetails optional properties no longer allow `null`, just `undefined`.
