### PR TITLE
[jest] add types of `jest.now` and `withImplementation`

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 29.0
+// Type definitions for Jest 29.1
 // Project: https://jestjs.io/
 // Definitions by: Asana (https://asana.com)
 //                 Ivo Stratev <https://github.com/NoHomey>
@@ -182,8 +182,12 @@ declare namespace jest {
      */
     function getRealSystemTime(): number;
     /**
+     * Returns the current time in ms of the fake timer clock.
+     */
+    function now(): number;
+    /**
      * Indicates that the module system should never return a mocked version
-     * of the specified module, including all of the specificied module's dependencies.
+     * of the specified module, including all of the specified module's dependencies.
      */
     function deepUnmock(moduleName: string): typeof jest;
     /**
@@ -1249,7 +1253,21 @@ declare namespace jest {
          * myMockFn((err, val) => console.log(val)); // false
          */
         mockImplementationOnce(fn: (...args: Y) => T): this;
-        /** Sets the name of the mock`. */
+        /**
+         * Temporarily overrides the default mock implementation within the callback,
+         * then restores its previous implementation.
+         *
+         * @remarks
+         * If the callback is async or returns a `thenable`, `withImplementation` will return a promise.
+         * Awaiting the promise will await the callback and reset the implementation.
+         */
+        withImplementation(fn: (...args: Y) => T, callback: () => Promise<unknown>): Promise<void>;
+        /**
+         * Temporarily overrides the default mock implementation within the callback,
+         * then restores its previous implementation.
+         */
+        withImplementation(fn: (...args: Y) => T, callback: () => void): void;
+        /** Sets the name of the mock. */
         mockName(name: string): this;
         /**
          * Just a simple sugar function for:

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -408,6 +408,11 @@ const realSystemTime1: number = jest.getRealSystemTime();
 // @ts-expect-error
 const realSystemTime2: number = jest.getRealSystemTime('foo');
 
+// $ExpectType number
+jest.now();
+// @ts-expect-error
+jest.now('1995-12-17T03:24:00');
+
 // https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename
 // $ExpectType any
 jest.requireActual('./thisReturnsTheActualModule');
@@ -572,6 +577,18 @@ const spy3Mock = spy3
     .mockReturnThis()
     .mockReturnValue('value')
     .mockReturnValueOnce('value');
+
+// $ExpectType void
+spy3.withImplementation(
+    () => 'mocked value',
+    () => {},
+);
+
+// $ExpectType Promise<void>
+spy3.withImplementation(
+    () => 'mocked value',
+    async () => {},
+);
 
 const spiedPromiseTarget = {
     resolvesString() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: `jest.now()` was added in https://github.com/facebook/jest/pull/13244; withImplementation was add in https://github.com/facebook/jest/pull/13281
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

## Summary

Jest v29.1 shipped earlier today ([release notes](https://github.com/facebook/jest/releases/tag/v29.1.0)) with two new features: `jest.now` and `withImplementation`. This PR adds typings for these features.