### PR TITLE
[sharedb] add `Connection.canSend`

### DIFF
--- a/types/sharedb/lib/client.d.ts
+++ b/types/sharedb/lib/client.d.ts
@@ -19,6 +19,7 @@ export class Connection extends ShareDB.TypedEmitter<ShareDB.ConnectionEventMap>
     nextSnapshotRequestId: number;
 
     state: string;
+    readonly canSend: boolean;
     debug: boolean;
 
     close(): void;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -231,7 +231,7 @@ connection.on('connected', (reason) => {
 });
 
 connection.on('pong', () => {});
-connection.ping();
+if (connection.canSend) connection.ping();
 
 const doc = connection.get('examples', 'counter');
 


### PR DESCRIPTION
Adds [`Connection.canSend`][1] as a `readonly` variable, since the `canSend` flag shouldn't be manually toggled.

[1]: https://github.com/share/sharedb/blob/5176283e2d1c9dc263f1fa3c2bc6a93c1afe2ad3/lib/client/connection.js#L121-L123

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
