### PR TITLE
migrate inquirer-autocomplete-prompt to esm

### DIFF
--- a/types/inquirer-autocomplete-prompt/index.d.ts
+++ b/types/inquirer-autocomplete-prompt/index.d.ts
@@ -1,13 +1,13 @@
-// Type definitions for inquirer-autocomplete-prompt 1.3
+// Type definitions for inquirer-autocomplete-prompt 3.0.0
 // Project: https://www.npmjs.com/package/inquirer-autocomplete-prompt
 // Definitions by: Jason Catel <https://github.com/jayeeson/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.2
+// TypeScript Version: 4.4
 
 import { Answers, KeyUnion, Question, QuestionCollection } from "inquirer";
-import Choices = require("inquirer/lib/objects/choices");
-import Base = require("inquirer/lib/prompts/base");
-import Paginator = require("inquirer/lib/utils/paginator");
+import Choices from "inquirer/lib/objects/choices";
+import Base from "inquirer/lib/prompts/base";
+import Paginator from "inquirer/lib/utils/paginator";
 import { Interface as ReadlineInterface } from "readline";
 
 export = AutocompletePrompt;

--- a/types/inquirer-autocomplete-prompt/index.d.ts
+++ b/types/inquirer-autocomplete-prompt/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inquirer-autocomplete-prompt 3.0.0
+// Type definitions for inquirer-autocomplete-prompt 3.0
 // Project: https://www.npmjs.com/package/inquirer-autocomplete-prompt
 // Definitions by: Jason Catel <https://github.com/jayeeson/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/inquirer-autocomplete-prompt/index.d.ts
+++ b/types/inquirer-autocomplete-prompt/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/inquirer-autocomplete-prompt
 // Definitions by: Jason Catel <https://github.com/jayeeson/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.4
+// TypeScript Version: 4.2
 
 import { Answers, KeyUnion, Question, QuestionCollection } from "inquirer";
 import Choices from "inquirer/lib/objects/choices";

--- a/types/inquirer-autocomplete-prompt/index.d.ts
+++ b/types/inquirer-autocomplete-prompt/index.d.ts
@@ -5,9 +5,9 @@
 // TypeScript Version: 4.2
 
 import { Answers, KeyUnion, Question, QuestionCollection } from "inquirer";
-import Choices from "inquirer/lib/objects/choices";
-import Base from "inquirer/lib/prompts/base";
-import Paginator from "inquirer/lib/utils/paginator";
+import Choices from "inquirer/lib/objects/choices.js";
+import Base from "inquirer/lib/prompts/base.js";
+import Paginator from "inquirer/lib/utils/paginator.js";
 import { Interface as ReadlineInterface } from "readline";
 
 export default AutocompletePrompt;

--- a/types/inquirer-autocomplete-prompt/inquirer-autocomplete-prompt-tests.ts
+++ b/types/inquirer-autocomplete-prompt/inquirer-autocomplete-prompt-tests.ts
@@ -1,5 +1,5 @@
 import AutocompletePrompt from "inquirer-autocomplete-prompt";
-import inquirer from "inquirer";
+import inquirer, { Answers } from "inquirer";
 
 inquirer.registerPrompt("autocomplete", AutocompletePrompt);
 
@@ -27,6 +27,6 @@ inquirer.prompt([
         type: "autocomplete",
         name: "test autocomplete",
         message: "Test question",
-        source: (answersSoFar: inquirer.Answers, input: string | undefined) => search(input, choices),
+        source: (answersSoFar: Answers, input: string | undefined) => search(input, choices),
     },
 ]);

--- a/types/inquirer-autocomplete-prompt/package.json
+++ b/types/inquirer-autocomplete-prompt/package.json
@@ -1,0 +1,4 @@
+{
+    "private": true,
+    "type": "module"
+}

--- a/types/inquirer-autocomplete-prompt/tsconfig.json
+++ b/types/inquirer-autocomplete-prompt/tsconfig.json
@@ -12,14 +12,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "inquirer": [
-                "inquirer/v8"
-            ],
-            "inquirer/*": [
-                "inquirer/v8/*"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/inquirer-autocomplete-prompt/v2/index.d.ts
+++ b/types/inquirer-autocomplete-prompt/v2/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for inquirer-autocomplete-prompt 3.0
+// Type definitions for inquirer-autocomplete-prompt 2.0
 // Project: https://www.npmjs.com/package/inquirer-autocomplete-prompt
 // Definitions by: Jason Catel <https://github.com/jayeeson/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/inquirer-autocomplete-prompt/v2/index.d.ts
+++ b/types/inquirer-autocomplete-prompt/v2/index.d.ts
@@ -5,12 +5,12 @@
 // TypeScript Version: 4.2
 
 import { Answers, KeyUnion, Question, QuestionCollection } from "inquirer";
-import Choices from "inquirer/lib/objects/choices";
-import Base from "inquirer/lib/prompts/base";
-import Paginator from "inquirer/lib/utils/paginator";
+import Choices = require("inquirer/lib/objects/choices");
+import Base = require("inquirer/lib/prompts/base");
+import Paginator = require("inquirer/lib/utils/paginator");
 import { Interface as ReadlineInterface } from "readline";
 
-export default AutocompletePrompt;
+export = AutocompletePrompt;
 
 /**
  * Provides the functionality to create a new Inquirer plugin

--- a/types/inquirer-autocomplete-prompt/v2/inquirer-autocomplete-prompt-tests.ts
+++ b/types/inquirer-autocomplete-prompt/v2/inquirer-autocomplete-prompt-tests.ts
@@ -1,5 +1,5 @@
-import AutocompletePrompt from "inquirer-autocomplete-prompt";
-import inquirer from "inquirer";
+import AutocompletePrompt = require("inquirer-autocomplete-prompt");
+import inquirer = require("inquirer");
 
 inquirer.registerPrompt("autocomplete", AutocompletePrompt);
 

--- a/types/inquirer-autocomplete-prompt/v2/tsconfig.json
+++ b/types/inquirer-autocomplete-prompt/v2/tsconfig.json
@@ -18,6 +18,12 @@
             ],
             "inquirer/*": [
                 "inquirer/v8/*"
+            ],
+            "inquirer-autocomplete-prompt": [
+                "inquirer-autocomplete-prompt"
+            ],
+            "inquirer-autocomplete-prompt/*": [
+                "inquirer-autocomplete-prompt/*"
             ]
         },
         "types": [],

--- a/types/inquirer-autocomplete-prompt/v2/tsconfig.json
+++ b/types/inquirer-autocomplete-prompt/v2/tsconfig.json
@@ -8,7 +8,7 @@
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
-        "baseUrl": "../",
+        "baseUrl": "../../",
         "typeRoots": [
             "../"
         ],

--- a/types/inquirer-autocomplete-prompt/v2/tsconfig.json
+++ b/types/inquirer-autocomplete-prompt/v2/tsconfig.json
@@ -20,10 +20,10 @@
                 "inquirer/v8/*"
             ],
             "inquirer-autocomplete-prompt": [
-                "inquirer-autocomplete-prompt"
+                "inquirer-autocomplete-prompt/v2"
             ],
             "inquirer-autocomplete-prompt/*": [
-                "inquirer-autocomplete-prompt/*"
+                "inquirer-autocomplete-prompt/v2/*"
             ]
         },
         "types": [],

--- a/types/inquirer-autocomplete-prompt/v2/tsconfig.json
+++ b/types/inquirer-autocomplete-prompt/v2/tsconfig.json
@@ -10,7 +10,7 @@
         "strictNullChecks": true,
         "baseUrl": "../../",
         "typeRoots": [
-            "../"
+            "../../"
         ],
         "paths": {
             "inquirer": [

--- a/types/inquirer-autocomplete-prompt/v2/tsconfig.json
+++ b/types/inquirer-autocomplete-prompt/v2/tsconfig.json
@@ -18,12 +18,6 @@
             ],
             "inquirer/*": [
                 "inquirer/v8/*"
-            ],
-            "inquirer-autocomplete-prompt": [
-                "inquirer-autocomplete-prompt"
-            ],
-            "inquirer-autocomplete-prompt/*": [
-                "inquirer-autocomplete-prompt/*"
             ]
         },
         "types": [],
@@ -32,6 +26,6 @@
     },
     "files": [
         "index.d.ts",
-        "inquirer-fuzzy-path-tests.ts"
+        "inquirer-autocomplete-prompt-tests.ts"
     ]
 }

--- a/types/inquirer-autocomplete-prompt/v2/tslint.json
+++ b/types/inquirer-autocomplete-prompt/v2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/inquirer-fuzzy-path/tsconfig.json
+++ b/types/inquirer-fuzzy-path/tsconfig.json
@@ -20,10 +20,10 @@
                 "inquirer/v8/*"
             ],
             "inquirer-autocomplete-prompt": [
-                "inquirer-autocomplete-prompt"
+                "inquirer-autocomplete-prompt/v2"
             ],
             "inquirer-autocomplete-prompt/*": [
-                "inquirer-autocomplete-prompt/*"
+                "inquirer-autocomplete-prompt/v2/*"
             ]
         },
         "types": [],


### PR DESCRIPTION
`inquirer-autocomplete-prompt` v3.0.0 and `inquirer` v9 was migrated to esm,
so the import statement should be updated.

see: https://github.com/mokkabonna/inquirer-autocomplete-prompt/releases/tag/v3.0.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/mokkabonna/inquirer-autocomplete-prompt/releases/tag/v3.0.0>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

