### PR TITLE
[@types/facebook-js-sdk] add data_access_expiration_time property to AuthResponse

### DIFF
--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -475,6 +475,7 @@ declare namespace facebook {
     ////////////////////////
     interface AuthResponse {
         accessToken: string;
+        data_access_expiration_time: number;
         expiresIn: number;
         signedRequest: string;
         userID: string;


### PR DESCRIPTION
The property that is due to access user data was not defined and has been changed.

see https://developers.facebook.com/docs/facebook-login/auth-vs-data/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.facebook.com/docs/facebook-login/auth-vs-data/>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

