### PR TITLE
@ember/routing: remove wrong exports

### DIFF
--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -10,7 +10,7 @@ import Engine from '@ember/engine';
 import ApplicationInstance from '@ember/application/instance';
 import EventDispatcher from '@ember/application/-private/event-dispatcher';
 import { EventDispatcherEvents } from '@ember/application/types';
-import { Router } from '@ember/routing';
+import Router from '@ember/routing/router';
 import Registry from '@ember/application/-private/registry';
 import Resolver from 'ember-resolver';
 import { AnyFn } from 'ember/-private/type-utils';
@@ -60,7 +60,11 @@ export default class Application extends Engine {
      * @param fullName type:name (e.g., 'model:user')
      * @param factory (e.g., App.Person)
      */
-    register(fullName: string, factory: unknown, options?: { singleton?: boolean | undefined; instantiate?: boolean | undefined }): void;
+    register(
+        fullName: string,
+        factory: unknown,
+        options?: { singleton?: boolean | undefined; instantiate?: boolean | undefined },
+    ): void;
     /**
      * This removes all helpers that have been registered, and resets and functions
      * that were overridden by the helpers.

--- a/types/ember__routing/index.d.ts
+++ b/types/ember__routing/index.d.ts
@@ -6,9 +6,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.4
 
-export { default as Route } from '@ember/routing/route';
-export { default as Router } from '@ember/routing/router';
-
 import { Opaque } from 'ember/-private/type-utils';
 
 // In normal TypeScript, this component is essentially an opaque token


### PR DESCRIPTION
These exports have been present for a very long time, but do not actually exist. This change aligns the type exports with the actual public API.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/emberjs/ember.js/pull/20212>

---

Note for maintainers: this literally *cannot* have tests because the whole problem here is that this wasn't supposed to be present in the first place and so we *didn't* test it. 🙃

Same fix on Ember official preview types: https://github.com/emberjs/ember.js/pull/20212