### PR TITLE
[tabulator-tables] added support for headerMenuIcon

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1421,6 +1421,9 @@ export interface ColumnDefinition extends ColumnLayout, CellCallbacks {
     /** You can add a menu to any column by passing an array of menu items to the headerMenu option in that columns definition. */
     headerMenu?: Array<MenuObject<ColumnComponent> | MenuSeparator> | undefined;
 
+    /** The headerMenuIcon option will accept one of three types of value. You can pass in a string for the HTML contents of the button. Or you can pass the DOM node for the button. Though be careful not to pass the same node to multple columns or you may run into issues. Or you can define a function that is called when the column header is rendered that should return either an HTML string or the contents of the element. This funtion is passed the column component as its first argument. */
+    headerMenuIcon?: string | HTMLElement | ((component: ColumnComponent) => HTMLElement | string);
+
     /** You can add a right click context menu to any column by passing an array of menu items to the headerContextMenu option in that columns definition. */
     headerContextMenu?: Array<MenuObject<ColumnComponent> | MenuSeparator> | undefined;
 

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -1122,3 +1122,40 @@ table = new Tabulator('#test', {
         return new Blob([fileContents], { type: mimeType }); // must return a blob to proceed with the download, return false to abort download
     },
 });
+
+// 5.3 Testing ColumnDefinition.headerMenuIcon
+const headerMenuForIconTest: Array<MenuObject<ColumnComponent> | MenuSeparator> = [
+    {
+        label:"Hide Column",
+        action(e, column) {
+            column.hide();
+        }
+    },
+];
+let headerMenuIconElement = document.createElement("span");
+headerMenuIconElement.innerText = "Filter";
+
+table = new Tabulator('#testHeaderMenuIcon', {
+    columns: [
+        {
+            field: 'test_inline',
+            title: 'Test inline',
+            headerMenuIcon: "<i class='fas fa-filter'></i>",
+            headerMenu: headerMenuForIconTest
+        },
+        {
+            field: 'test_element',
+            title: 'Test DOM Element',
+            headerMenuIcon: headerMenuIconElement,
+            headerMenu: headerMenuForIconTest
+        },
+        {
+            field: 'test_function',
+            title: 'Test function',
+            headerMenuIcon(component) {
+                return "<i class='fas fa-filter'></i>";
+            },
+            headerMenu: headerMenuForIconTest
+        }
+    ]
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test tabulator-tables`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Tabulator Header Menu](http://tabulator.info/docs/5.3/menu#header-menu)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Added support for headerMenuIcon flag in the ColumnDefinition. Added a test/example of use as per documentation of the Tabulator project.()