### PR TITLE
[minio] Add support for minio new way of marshaling Metadata in listObjectsV2WithMetadata 

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -90,7 +90,7 @@ export interface BucketItem {
 }
 
 export interface BucketItemWithMetadata extends BucketItem {
-    metadata: ItemBucketMetadata;
+    metadata: ItemBucketMetadata | ItemBucketMetadataList;
 }
 
 export interface BucketItemStat {
@@ -118,6 +118,15 @@ export interface PostPolicyResult {
     formData: {
         [key: string]: any;
     };
+}
+
+export interface MetadataItem {
+    Key: string;
+    Value: string;
+}
+
+export interface ItemBucketMetadataList {
+    Items: MetadataItem[];
 }
 
 export interface ItemBucketMetadata {


### PR DESCRIPTION
Since https://github.com/minio/minio/pull/15511 metadata marshal has been changed. This is not treated as a breaking change since it only affects listObjectsV2WithMetadata which is an extension.
For minio servers newer than 25 August 2022, the new List type should be used

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/minio/minio/pull/15511)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
