### PR TITLE
[ramda] Improved typings for assoc, chain, path, and pickAll

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3977,6 +3977,7 @@ export function pick<K extends string | number | symbol>(
  * R.pickAll(['a', 'e', 'f'], {a: 1, b: 2, c: 3, d: 4}); //=> {a: 1, e: undefined, f: undefined}
  * ```
  */
+export function pickAll<T, K extends keyof T>(names: readonly K[], obj: T): { [Key in K]: T[K]};
 export function pickAll<T, U>(names: readonly string[], obj: T): U;
 export function pickAll(names: readonly string[]): <T, U>(obj: T) => U;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -4317,8 +4317,10 @@ export function promap<A, B>(
  */
 export function prop<T>(__: Placeholder, obj: T): <P extends keyof T>(p: P) => T[P];
 export function prop<P extends keyof T, T>(p: P, obj: T): T[P];
-export function prop<P extends string>(p: P): <T>(obj: Record<P, T>) => T;
-export function prop<P extends string, T>(p: P): (obj: Record<P, T>) => T;
+export function prop<P extends string>(p: P): <R, T extends Record<P, R>>(obj: T) => T[P];
+export function prop<P extends string>(p: P): <R>(obj: Record<P, R>) => R;
+export function prop<P extends string, R, T extends Record<P, R>>(p: P): (obj: T) => T[P];
+export function prop<P extends string, R>(p: P): (obj: Record<P, R>) => R;
 
 // NOTE: `hair` property was added to `alois` to make example work.
 // A union of two types is a valid usecase but doesn't work with current types

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3854,14 +3854,14 @@ declare function path<
     K0 extends keyof S = keyof S,
     K1 extends keyof S[K0] = keyof S[K0],
     K2 extends keyof S[K0][K1] = keyof S[K0][K1]
->(path: [K0, K1, K2]): S[K0][K1][K2];
+>(path: [K0, K1, K2], obj: S): S[K0][K1][K2];
 declare function path<
     S,
     K0 extends keyof S = keyof S,
     K1 extends keyof S[K0] = keyof S[K0],
     K2 extends keyof S[K0][K1] = keyof S[K0][K1],
     K3 extends keyof S[K0][K1][K2] = keyof S[K0][K1][K2],
->(path: [K0, K1, K2, K3]): S[K0][K1][K2][K3];
+>(path: [K0, K1, K2, K3], obj: S): S[K0][K1][K2][K3];
 declare function path<
     S,
     K0 extends keyof S = keyof S,
@@ -3869,7 +3869,7 @@ declare function path<
     K2 extends keyof S[K0][K1] = keyof S[K0][K1],
     K3 extends keyof S[K0][K1][K2] = keyof S[K0][K1][K2],
     K4 extends keyof S[K0][K1][K2][K3] = keyof S[K0][K1][K2][K3],
->(path: [K0, K1, K2, K3, K4]): S[K0][K1][K2][K3][K4];
+>(path: [K0, K1, K2, K3, K4], obj: S): S[K0][K1][K2][K3][K4];
 declare function path<
     S,
     K0 extends keyof S = keyof S,
@@ -3878,7 +3878,7 @@ declare function path<
     K3 extends keyof S[K0][K1][K2] = keyof S[K0][K1][K2],
     K4 extends keyof S[K0][K1][K2][K3] = keyof S[K0][K1][K2][K3],
     K5 extends keyof S[K0][K1][K2][K3][K4] = keyof S[K0][K1][K2][K3][K4],
->(path: [K0, K1, K2, K3, K4, K5]): S[K0][K1][K2][K3][K4][K5];
+>(path: [K0, K1, K2, K3, K4, K5], obj: S): S[K0][K1][K2][K3][K4][K5];
 declare function path<T>(path: Path, obj: any): T | undefined;
 declare function path<T>(path: Path): (obj: any) => T | undefined;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -504,8 +504,10 @@ export function ascend<T>(fn: (obj: T) => Ord): (a: T, b: T) => Ordering;
  * R.assoc('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
  * ```
  */
-export function assoc<T, U>(__: Placeholder, val: T, obj: U): <K extends string>(prop: K) => Record<K, T> & Omit<U, K>;
+export function assoc<T, U>(__: Placeholder, val: T, obj: U): <K extends string>(prop: K) => K extends keyof U ? T extends U[K] ? U : Record<K, T> & Omit<U, K> : Record<K, T> & Omit<U, K>;
+export function assoc<U, K extends keyof U>(prop: K, __: Placeholder, obj: U): <T>(val: T) => T extends U[K] ? U : Record<K, T> & Omit<U, K>;
 export function assoc<U, K extends string>(prop: K, __: Placeholder, obj: U): <T>(val: T) => Record<K, T> & Omit<U, K>;
+export function assoc<K extends keyof U, U>(prop: K, val: U[K], obj: U): U;
 export function assoc<T, U, K extends string>(prop: K, val: T, obj: U): Record<K, T> & Omit<U, K>;
 export function assoc<T, K extends string>(prop: K, val: T): <U>(obj: U) => Record<K, T> & Omit<U, K>;
 export function assoc<K extends string>(prop: K): AssocPartialOne<K>;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3847,8 +3847,40 @@ export function partition(fn: (a: string) => boolean): (list: readonly string[])
  * R.path(['a', 'b', -2], {a: {b: [1, 2, 3]}}); //=> 2
  * ```
  */
-export function path<T>(path: Path, obj: any): T | undefined;
-export function path<T>(path: Path): (obj: any) => T | undefined;
+declare function path<S, K0 extends keyof S = keyof S>(path: [K0], obj: S): S[K0];
+declare function path<S, K0 extends keyof S = keyof S, K1 extends keyof S[K0] = keyof S[K0]>(path: [K0, K1], obj: S): S[K0][K1];
+declare function path<
+    S,
+    K0 extends keyof S = keyof S,
+    K1 extends keyof S[K0] = keyof S[K0],
+    K2 extends keyof S[K0][K1] = keyof S[K0][K1]
+>(path: [K0, K1, K2]): S[K0][K1][K2];
+declare function path<
+    S,
+    K0 extends keyof S = keyof S,
+    K1 extends keyof S[K0] = keyof S[K0],
+    K2 extends keyof S[K0][K1] = keyof S[K0][K1],
+    K3 extends keyof S[K0][K1][K2] = keyof S[K0][K1][K2],
+>(path: [K0, K1, K2, K3]): S[K0][K1][K2][K3];
+declare function path<
+    S,
+    K0 extends keyof S = keyof S,
+    K1 extends keyof S[K0] = keyof S[K0],
+    K2 extends keyof S[K0][K1] = keyof S[K0][K1],
+    K3 extends keyof S[K0][K1][K2] = keyof S[K0][K1][K2],
+    K4 extends keyof S[K0][K1][K2][K3] = keyof S[K0][K1][K2][K3],
+>(path: [K0, K1, K2, K3, K4]): S[K0][K1][K2][K3][K4];
+declare function path<
+    S,
+    K0 extends keyof S = keyof S,
+    K1 extends keyof S[K0] = keyof S[K0],
+    K2 extends keyof S[K0][K1] = keyof S[K0][K1],
+    K3 extends keyof S[K0][K1][K2] = keyof S[K0][K1][K2],
+    K4 extends keyof S[K0][K1][K2][K3] = keyof S[K0][K1][K2][K3],
+    K5 extends keyof S[K0][K1][K2][K3][K4] = keyof S[K0][K1][K2][K3][K4],
+>(path: [K0, K1, K2, K3, K4, K5]): S[K0][K1][K2][K3][K4][K5];
+declare function path<T>(path: Path, obj: any): T | undefined;
+declare function path<T>(path: Path): (obj: any) => T | undefined;
 
 /**
  * Determines whether a nested path on an object has a specific value,

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -646,6 +646,9 @@ export function call<T extends AnyFunction>(fn: T, ...args: Parameters<T>): Retu
 export function chain<A, B, T = never>(fn: (n: A) => readonly B[], list: readonly A[]): B[];
 export function chain<A, B, T = never>(fn: (n: A) => readonly B[]): (list: readonly A[]) => B[];
 
+export function chain<A, Ma extends { chain: (fn: (a: A) => Mb) => Mb }, Mb>(fn: (a: A) => Mb, monad: Ma): Mb;
+export function chain<A, Ma extends { chain: (fn: (a: A) => Mb) => Mb }, Mb>(fn: (a: A) => Mb): (monad: Ma) => Mb;
+
 export function chain<A, B, R>(aToMb: (a: A, r: R) => B, Ma: (r: R) => A): (r: R) => B;
 export function chain<A, B, R>(aToMb: (a: A, r: R) => B): (Ma: (r: R) => A) => (r: R) => B;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -4317,10 +4317,8 @@ export function promap<A, B>(
  */
 export function prop<T>(__: Placeholder, obj: T): <P extends keyof T>(p: P) => T[P];
 export function prop<P extends keyof T, T>(p: P, obj: T): T[P];
-export function prop<P extends string>(p: P): <R, T extends Record<P, R>>(obj: T) => T[P];
-export function prop<P extends string>(p: P): <R>(obj: Record<P, R>) => R;
-export function prop<P extends string, R, T extends Record<P, R>>(p: P): (obj: T) => T[P];
-export function prop<P extends string, R>(p: P): (obj: Record<P, R>) => R;
+export function prop<P extends string>(p: P): <T>(obj: Record<P, T>) => T;
+export function prop<P extends string, T>(p: P): (obj: Record<P, T>) => T;
 
 // NOTE: `hair` property was added to `alois` to make example work.
 // A union of two types is a valid usecase but doesn't work with current types

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3977,7 +3977,7 @@ export function pick<K extends string | number | symbol>(
  * R.pickAll(['a', 'e', 'f'], {a: 1, b: 2, c: 3, d: 4}); //=> {a: 1, e: undefined, f: undefined}
  * ```
  */
-export function pickAll<T, K extends keyof T>(names: readonly K[], obj: T): { [Key in K]: T[K]};
+export function pickAll<T, K extends keyof T>(names: readonly K[], obj: T): Pick<T, K>;
 export function pickAll<T, U>(names: readonly string[], obj: T): U;
 export function pickAll(names: readonly string[]): <T, U>(obj: T) => U;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3849,22 +3849,22 @@ export function partition(fn: (a: string) => boolean): (list: readonly string[])
  * R.path(['a', 'b', -2], {a: {b: [1, 2, 3]}}); //=> 2
  * ```
  */
-declare function path<S, K0 extends keyof S = keyof S>(path: [K0], obj: S): S[K0];
-declare function path<S, K0 extends keyof S = keyof S, K1 extends keyof S[K0] = keyof S[K0]>(path: [K0, K1], obj: S): S[K0][K1];
-declare function path<
+export function path<S, K0 extends keyof S = keyof S>(path: [K0], obj: S): S[K0];
+export function path<S, K0 extends keyof S = keyof S, K1 extends keyof S[K0] = keyof S[K0]>(path: [K0, K1], obj: S): S[K0][K1];
+export function path<
     S,
     K0 extends keyof S = keyof S,
     K1 extends keyof S[K0] = keyof S[K0],
     K2 extends keyof S[K0][K1] = keyof S[K0][K1]
 >(path: [K0, K1, K2], obj: S): S[K0][K1][K2];
-declare function path<
+export function path<
     S,
     K0 extends keyof S = keyof S,
     K1 extends keyof S[K0] = keyof S[K0],
     K2 extends keyof S[K0][K1] = keyof S[K0][K1],
     K3 extends keyof S[K0][K1][K2] = keyof S[K0][K1][K2],
 >(path: [K0, K1, K2, K3], obj: S): S[K0][K1][K2][K3];
-declare function path<
+export function path<
     S,
     K0 extends keyof S = keyof S,
     K1 extends keyof S[K0] = keyof S[K0],
@@ -3872,7 +3872,7 @@ declare function path<
     K3 extends keyof S[K0][K1][K2] = keyof S[K0][K1][K2],
     K4 extends keyof S[K0][K1][K2][K3] = keyof S[K0][K1][K2][K3],
 >(path: [K0, K1, K2, K3, K4], obj: S): S[K0][K1][K2][K3][K4];
-declare function path<
+export function path<
     S,
     K0 extends keyof S = keyof S,
     K1 extends keyof S[K0] = keyof S[K0],
@@ -3881,8 +3881,8 @@ declare function path<
     K4 extends keyof S[K0][K1][K2][K3] = keyof S[K0][K1][K2][K3],
     K5 extends keyof S[K0][K1][K2][K3][K4] = keyof S[K0][K1][K2][K3][K4],
 >(path: [K0, K1, K2, K3, K4, K5], obj: S): S[K0][K1][K2][K3][K4][K5];
-declare function path<T>(path: Path, obj: any): T | undefined;
-declare function path<T>(path: Path): (obj: any) => T | undefined;
+export function path<T>(path: Path, obj: any): T | undefined;
+export function path<T>(path: Path): (obj: any) => T | undefined;
 
 /**
  * Determines whether a nested path on an object has a specific value,

--- a/types/ramda/test/assoc-tests.ts
+++ b/types/ramda/test/assoc-tests.ts
@@ -6,12 +6,63 @@ import * as R from 'ramda';
         b: number;
         c: number;
     }
+
     const a: ABC = R.assoc('c', 3, { a: 1, b: 2 }); // => {a: 1, b: 2, c: 3}
     const b: ABC = R.assoc('c')(3, { a: 1, b: 2 }); // => {a: 1, b: 2, c: 3}
     const c: ABC = R.assoc('c', 3)({ a: 1, b: 2 }); // => {a: 1, b: 2, c: 3}
     const d: ABC = R.assoc(R.__, 3, { a: 1, b: 2 })('c'); // => {a: 1, b: 2, c: 3}
     const e: ABC = R.assoc('c', R.__, { a: 1, b: 2 })(3); // => {a: 1, b: 2, c: 3}
+};
 
+() => {
+    interface ABC {
+        a: number;
+        b: number;
+        c: number;
+    }
+
+    // $ExpectType ABC
+    R.assoc('c', R.__, { a: 1, b: 2, c: 3 } as ABC)(4); // => {a: 1, b: 2, c: 4}
+    // $ExpectType Record<"c", string> & Omit<ABC, "c">
+    R.assoc('c', R.__, { a: 1, b: 2, c: 3 } as ABC)('test'); // => {a: 1, b: 2, c: "test"}
+    // $ExpectType Record<"d", string> & Omit<ABC, "d">
+    R.assoc('d', R.__, { a: 1, b: 2, c: 3 } as ABC)('test'); // => {a: 1, b: 2, c: 3, d: "test"}
+    // $ExpectType { a: number; b: number; c: number; }
+    R.assoc('c', R.__, { a: 1, b: 2, c: 3 })(4); // => {a: 1, b: 2, c: 4}
+    // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
+    R.assoc('c', R.__, { a: 1, b: 2, c: 3 })('test'); // => {a: 1, b: 2, c: "test"}
+}
+
+() => {
+    interface ABC {
+        a: number;
+        b: number;
+        c: number;
+    }
+
+    // $ExpectType ABC
+    R.assoc(R.__, 4, { a: 1, b: 2, c: 3 } as ABC)('c'); // => {a: 1, b: 2, c: 4}
+    // $ExpectType Record<"c", string> & Omit<ABC, "c">
+    R.assoc(R.__, 'test', { a: 1, b: 2, c: 3 } as ABC)('c'); // => {a: 1, b: 2, c: "test"}
+    // $ExpectType Record<"d", string> & Omit<ABC, "d">
+    R.assoc(R.__, 'test', { a: 1, b: 2, c: 3 } as ABC)('d'); // => {a: 1, b: 2, c: 3, d: "test"}
+    // $ExpectType { a: number; b: number; c: number; }
+    R.assoc(R.__, 4, { a: 1, b: 2, c: 3 })('c'); // => {a: 1, b: 2, c: 4}
+    // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
+    R.assoc(R.__, 'test', { a: 1, b: 2, c: 3 })('c'); // => {a: 1, b: 2, c: "test"}
+}
+
+() => {
+    interface ABC {
+        a: number;
+        b: number;
+        c: number;
+    }
+
+    // $ExpectType ABC
+    R.assoc('c', 4, { a: 1, b: 2, c: 3 } as ABC); // => {a: 1, b: 2, c: 4}
+    // $ExpectType Record<"c", string> & Omit<ABC, "c">
+    R.assoc('c', 'test', { a: 1, b: 2, c: 3 } as ABC); // => {a: 1, b: 2, c: "test"}
     // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
     R.assoc('c', 'test', { a: 1, b: 2, c: 3 }); // => {a: 1, b: 2, c: "test"}
     // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">

--- a/types/ramda/test/assoc-tests.ts
+++ b/types/ramda/test/assoc-tests.ts
@@ -21,17 +21,19 @@ import * as R from 'ramda';
         c: number;
     }
 
+    const obj: ABC = { a: 1, b: 2, c: 3 };
+
     // $ExpectType ABC
-    R.assoc('c', R.__, { a: 1, b: 2, c: 3 } as ABC)(4); // => {a: 1, b: 2, c: 4}
+    R.assoc('c', R.__, obj)(4); // => {a: 1, b: 2, c: 4}
     // $ExpectType Record<"c", string> & Omit<ABC, "c">
-    R.assoc('c', R.__, { a: 1, b: 2, c: 3 } as ABC)('test'); // => {a: 1, b: 2, c: "test"}
+    R.assoc('c', R.__, obj)('test'); // => {a: 1, b: 2, c: "test"}
     // $ExpectType Record<"d", string> & Omit<ABC, "d">
-    R.assoc('d', R.__, { a: 1, b: 2, c: 3 } as ABC)('test'); // => {a: 1, b: 2, c: 3, d: "test"}
+    R.assoc('d', R.__, obj)('test'); // => {a: 1, b: 2, c: 3, d: "test"}
     // $ExpectType { a: number; b: number; c: number; }
     R.assoc('c', R.__, { a: 1, b: 2, c: 3 })(4); // => {a: 1, b: 2, c: 4}
     // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
     R.assoc('c', R.__, { a: 1, b: 2, c: 3 })('test'); // => {a: 1, b: 2, c: "test"}
-}
+};
 
 () => {
     interface ABC {
@@ -40,17 +42,19 @@ import * as R from 'ramda';
         c: number;
     }
 
+    const obj: ABC = { a: 1, b: 2, c: 3 };
+
     // $ExpectType ABC
-    R.assoc(R.__, 4, { a: 1, b: 2, c: 3 } as ABC)('c'); // => {a: 1, b: 2, c: 4}
+    R.assoc(R.__, 4, obj)('c'); // => {a: 1, b: 2, c: 4}
     // $ExpectType Record<"c", string> & Omit<ABC, "c">
-    R.assoc(R.__, 'test', { a: 1, b: 2, c: 3 } as ABC)('c'); // => {a: 1, b: 2, c: "test"}
+    R.assoc(R.__, 'test', obj)('c'); // => {a: 1, b: 2, c: "test"}
     // $ExpectType Record<"d", string> & Omit<ABC, "d">
-    R.assoc(R.__, 'test', { a: 1, b: 2, c: 3 } as ABC)('d'); // => {a: 1, b: 2, c: 3, d: "test"}
+    R.assoc(R.__, 'test', obj)('d'); // => {a: 1, b: 2, c: 3, d: "test"}
     // $ExpectType { a: number; b: number; c: number; }
     R.assoc(R.__, 4, { a: 1, b: 2, c: 3 })('c'); // => {a: 1, b: 2, c: 4}
     // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
     R.assoc(R.__, 'test', { a: 1, b: 2, c: 3 })('c'); // => {a: 1, b: 2, c: "test"}
-}
+};
 
 () => {
     interface ABC {
@@ -59,10 +63,12 @@ import * as R from 'ramda';
         c: number;
     }
 
+    const obj: ABC = { a: 1, b: 2, c: 3 };
+
     // $ExpectType ABC
-    R.assoc('c', 4, { a: 1, b: 2, c: 3 } as ABC); // => {a: 1, b: 2, c: 4}
+    R.assoc('c', 4, obj); // => {a: 1, b: 2, c: 4}
     // $ExpectType Record<"c", string> & Omit<ABC, "c">
-    R.assoc('c', 'test', { a: 1, b: 2, c: 3 } as ABC); // => {a: 1, b: 2, c: "test"}
+    R.assoc('c', 'test', obj); // => {a: 1, b: 2, c: "test"}
     // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">
     R.assoc('c', 'test', { a: 1, b: 2, c: 3 }); // => {a: 1, b: 2, c: "test"}
     // $ExpectType Record<"c", string> & Omit<{ a: number; b: number; c: number; }, "c">

--- a/types/ramda/test/chain-tests.ts
+++ b/types/ramda/test/chain-tests.ts
@@ -1,5 +1,6 @@
 import * as R from 'ramda';
 
+// array
 () => {
     function duplicate(n: number) {
         return [n, n];
@@ -30,7 +31,52 @@ import * as R from 'ramda';
     R.chain(duplicateReadonly, [1, 2, 3]); // => [1, 1, 2, 2, 3, 3]
     // $ExpectType number[]
     R.chain(duplicateReadonly)([1, 2, 3]); // => [1, 1, 2, 2, 3, 3]
+};
 
+// monad
+() => {
+    abstract class Maybe<A> {
+        constructor(public value: A) {}
+    }
+
+    class Just<A> extends Maybe<A> {
+        static of<T>(value: T) { return new Just<T>(value); }
+
+        chain<B>(fn: (a: A) => Maybe<B>) {
+            return fn(this.value);
+        }
+    }
+
+    class Nothing<A> extends Maybe<A> {
+        static of<T>() { return new Nothing<T>(); }
+
+        constructor() {
+            super(undefined as unknown as A);
+        }
+
+        chain<B>(fn: (a: A) => Maybe<B>) {
+            return this as unknown as Maybe<B>;
+        }
+    }
+
+    const findIndexMaybe = <A>(pred: (value: A) => boolean) => (arr: A[]): Maybe<number> => {
+        const index = arr.findIndex(pred);
+        return index === -1 ? Nothing.of<number>() : Just.of(index);
+    };
+
+    const sqrtMaybe = (value: number): Maybe<number> => {
+        const result = Math.sqrt(value);
+        return Number.isNaN(result) ? Nothing.of<number>() : Just.of(result);
+    };
+
+    // $ExpectType Maybe<number>
+    R.chain(findIndexMaybe<number>(x => x === 2), Just.of([1, 2, 3]));
+    // $ExpectType Maybe<number>
+    R.chain(sqrtMaybe, Just.of(4));
+};
+
+// transducer
+() => {
     interface Score {
         maths: number;
         physics: number;

--- a/types/ramda/test/path-tests.ts
+++ b/types/ramda/test/path-tests.ts
@@ -1,6 +1,24 @@
 import * as R from 'ramda';
 
 () => {
+    // $ExpectType number
+    R.path(['a'], { a: 1 });
+    // $ExpectType number
+    R.path(['a', 'b'], { a: { b: 1 } });
+    // $ExpectType number
+    R.path(['a', 'b', 'c'], { a: { b: { c: 1 } } });
+    // $ExpectType number
+    R.path(['a', 'b', 'c', 'd'], { a: { b: { c: { d: 1 } } } });
+    // $ExpectType number
+    R.path(['a', 'b', 'c', 'd', 'e'], { a: { b: { c: { d: { e: 1 } } } } });
+    // $ExpectType number
+    R.path(['a', 'b', 'c', 'd', 'e', 'f'], { a: { b: { c: { d: { e: { f: 1 } } } } } });
+
+    // $ExpectType unknown
+    R.path(['a', 'b', 'c', 'd', 'e', 'f', 'g'], { a: { b: { c: { d: { e: { f: { g: 1 } } } } } } });
+};
+
+() => {
     const testPath = ['x', 0, 'y'];
     const testObj = {
         x: [

--- a/types/ramda/test/pickAll-tests.ts
+++ b/types/ramda/test/pickAll-tests.ts
@@ -1,8 +1,21 @@
 import * as R from 'ramda';
 
 () => {
-    R.pickAll(['a', 'd'], { a: 1, b: 2, c: 3, d: 4 }); // => {a: 1, d: 4}
-    R.pickAll(['a', 'd'])({ a: 1, b: 2, c: 3, d: 4 }); // => {a: 1, d: 4}
-    R.pickAll(['a', 'e', 'f'], { a: 1, b: 2, c: 3, d: 4 }); // => {a: 1, e: undefined, f: undefined}
-    R.pickAll(['a', 'e', 'f'])({ a: 1, b: 2, c: 3, d: 4 }); // => {a: 1, e: undefined, f: undefined}
+    interface ABCD {
+        a: number;
+        b: number;
+        c: number;
+        d: number;
+    }
+
+    const obj: ABCD = { a: 1, b: 2, c: 3, d: 4 };
+
+    // $ExpectType Pick<ABCD, "a" | "d">
+    R.pickAll(['a', 'd'], obj); // => {a: 1, d: 4}
+    // $ExpectType unknown
+    R.pickAll(['a', 'd'])(obj); // => {a: 1, d: 4}
+    // $ExpectType unknown
+    R.pickAll(['a', 'e', 'f'], obj); // => {a: 1, e: undefined, f: undefined}
+    // $ExpectType unknown
+    R.pickAll(['a', 'e', 'f'])(obj); // => {a: 1, e: undefined, f: undefined}
 };


### PR DESCRIPTION
# assoc
```typescript
// Given this
type Foo = { foo: number };
const foo: Foo = { foo: 0 };
const next = assoc('foo', 1, foo); // return type === `Record<'foo', number> & Omit<foo, 'foo'>`

// While `Record<'foo', number> & Omit<foo, 'foo'>` does technically equal `Foo` here
// it would be better for `assoc` to simply return `Foo` in these cases
// The changes in MR do exactly that, only only does so for when the key `K` exists on obj `U` and if typeof value `T` equals typeof `U[K]'
```

# chain
```typescript
// add type support for Ramda's documentation on:
// > Dispatches to the chain method of the second argument, if present, according to the [FantasyLand Chain spec](https://github.com/fantasyland/fantasy-land#chain).

const findIndexMaybe = <A>(pred: (value: A) => boolean) => (arr: A[]): Maybe<number> => {
  const index = arr.findIndex(pred);
  return index === -1 ? Nothing.of<number>() : Just.of(index);
};

// before
R.chain(findIndexMaybe(x => x === 'red'), Just.of(['red', 'blue', 'green'])); // type error

// now
R.chain(findIndexMaybe(x => x === 'red'), Just.of(['red', 'blue', 'green'])); // return type === Maybe<number>

// caveat
// It is impossible to check that `Ma` and `Mb` are of the same type when those types are generics
// so it is simply assumed it is based on the spec
// This implementation returns the correct type regardless of that supposed implementation detail of the `.chain()` method that is delegated too
```

# path
```typescript
// added the same deep type checking that exists on `lensPath`
```

# pickAll
```
// when all values in `readonly K[]` are known keys in `T`, now returns type `Pick<T, K>`
// falls back to the previous implementation otherwise
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: **See above for description**
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
