### PR TITLE
@reach/router: align NavigateFn variants

### DIFF
--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -111,7 +111,7 @@ export class Match<TParams> extends React.Component<MatchProps<TParams>> {}
 
 export interface NavigateFn {
     (to: string, options?: NavigateOptions<{}>): Promise<void>;
-    (to: number): Promise<void>;
+    (to: number, options?: undefined): Promise<void>;
 }
 
 export interface NavigateOptions<TState> {

--- a/types/reach__router/reach__router-tests.tsx
+++ b/types/reach__router/reach__router-tests.tsx
@@ -72,6 +72,7 @@ render(
                 <>
                     <div>hostname is {context.location.hostname}</div>
                     <button onClick={(): Promise<void> => context.navigate('/')}>Go Home</button>
+                    <button onClick={(): Promise<void> => context.navigate(-1)}>Go Back</button>
                 </>
             )}
         </Location>
@@ -80,6 +81,7 @@ render(
                 <>
                     <div>hostname is {context.location.hostname}</div>
                     <button onClick={(): Promise<void> => context.navigate('/')}>Go Home</button>
+                    <button onClick={(): Promise<void> => context.navigate(-1)}>Go Back</button>
                 </>
             )}
         </LocationProvider>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

My major pain point without this change is the type inference of a wrapped `NavigateFn`. For example,

```typescript
import { NavigateFn } from '@reach/router'

const myNavigate: NavigateFn = (to, options) => { # here the compiler infers the type as `to: string | number, options: unknown`. Even if I use `typeof to === 'string' && ...`, the type of `options` is always `unknown`
  // ...
}
```