### PR TITLE
[twitter-text] Fix typing for `modifyIndicesFrom...`

### DIFF
--- a/types/twitter-text/index.d.ts
+++ b/types/twitter-text/index.d.ts
@@ -57,8 +57,15 @@ export function extractCashtags(text: string): string[];
 export function extractCashtagsWithIndices(text: string): CashtagWithIndices[];
 export function extractEntitiesWithIndices(text: string): EntityWithIndices[];
 
-export function modifyIndicesFromUnicodeToUTF16<I>(i: I): I;
-export function modifyIndicesFromUTF16ToUnicode<I>(i: I): I;
+/**
+ * Modifies (in-place) entity indices meant for Unicode text for use with UTF-16 text.
+ */
+export function modifyIndicesFromUnicodeToUTF16(text: string, entities: EntityWithIndices[]): void;
+
+/**
+ * Modifies (in-place) entity indices meant for UTF-16 text for use with Unicode text.
+ */
+export function modifyIndicesFromUTF16ToUnicode(text: string, entities: EntityWithIndices[]): void;
 
 export interface UrlEntity {
     url: string;

--- a/types/twitter-text/index.d.ts
+++ b/types/twitter-text/index.d.ts
@@ -140,11 +140,13 @@ export interface ParseTweetOptions {
     scale?: number | undefined;
     defaultWeight?: number | undefined;
     transformedURLLength?: number | undefined;
-    ranges?: Array<{
-        start: number;
-        end: number;
-        weight: number;
-    }> | undefined;
+    ranges?:
+        | Array<{
+              start: number;
+              end: number;
+              weight: number;
+          }>
+        | undefined;
     emojiParsingEnabled?: boolean | undefined;
 }
 

--- a/types/twitter-text/twitter-text-tests.ts
+++ b/types/twitter-text/twitter-text-tests.ts
@@ -19,8 +19,8 @@ function isCashtagEntity(e: twitter.EntityWithIndices): e is twitter.CashtagWith
     return 'cashtag' in e;
 }
 
-for (let e of entities) {
-    e = twitter.modifyIndicesFromUnicodeToUTF16(e);
+twitter.modifyIndicesFromUnicodeToUTF16(text, entities);
+for (const e of entities) {
     if (isHashtagEntity(e)) {
         console.log('hashtag: ', e.hashtag);
     } else if (isUrlEntity(e)) {


### PR DESCRIPTION
This updates the types for the `modify*` functions. They haven't been correct for quite some time (ever?) - it's not related to a change in the `twitter-text` library.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [function definition](https://github.com/twitter/twitter-text/blob/33169dfd33d61debdbf58dc940f5a200c06def10/js/pkg/twitter-text-3.1.0.js#L3039) and [sleuthed types](https://github.com/twitter/twitter-text/blob/33169dfd33d61debdbf58dc940f5a200c06def10/js/pkg/twitter-text-3.1.0.js#L3004)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
