### PR TITLE
Fix problems with support window workflow & script

### DIFF
--- a/.github/workflows/support-window.yml
+++ b/.github/workflows/support-window.yml
@@ -6,7 +6,7 @@ on:
       - .github/workflows/support-window.yml
       - package.json
       - scripts/support-window.ts
-      - scripts/tsconfig.json
+      - scripts/jsconfig.json
   # Manually, when TypeScript is released
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
@@ -25,7 +25,6 @@ jobs:
         #with:
         #  cache: npm
       - run: npm install
-      - run: tsc --build scripts
       - name: Fetch TypeScript versions and release dates from npm
         run: |
           npm view --json typescript time |

--- a/scripts/support-window.js
+++ b/scripts/support-window.js
@@ -6,7 +6,7 @@ import { utcYear } from "d3-time";
 import { utcFormat } from "d3-time-format";
 import { JSDOM } from "jsdom";
 import serialize from "w3c-xmlserializer";
-import data from "../docs/support-window.json" assert { type: "json" };
+import data from "../docs/support-window.json";
 
 const width = 640;
 const height = 250;


### PR DESCRIPTION
The workflow to update the support window has been failing for about 3 months: <https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/support-window.yml>

The logs from the [latest run](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/3062156807/jobs/4942809465) say that `scripts/tsconfig.json` can't be found, since it doesn't exist anymore.

This PR removes the line that runs `tsc` from the workflow. It also removes the `assert { type: "json" }` from the JSON file import, since the script is run with `--experimental-json-modules` anyway.