### PR TITLE
fix for issue #59335 - dragoffset is an object with x y properties

### DIFF
--- a/types/scrollbooster/index.d.ts
+++ b/types/scrollbooster/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for scrollbooster 2.2
 // Project: https://github.com/ilyashubin/scrollbooster
 // Definitions by: Chris <https://github.com/chrisneven>
+//                 Chris Frewin <https://github.com/princefishthrower>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Position {
@@ -12,7 +13,10 @@ export interface ScrollingState {
     isMoving: boolean;
     isDragging: boolean;
     position: Required<Position>;
-    dragOffset: number;
+    dragOffset: {
+        x: number;
+        y: number;
+    };
     borderCollision: {
         left: boolean;
         right: boolean;

--- a/types/scrollbooster/scrollbooster-tests.ts
+++ b/types/scrollbooster/scrollbooster-tests.ts
@@ -24,6 +24,8 @@ const sb = new ScrollBooster({
                 ${-state.position.y}px
     )`;
         }
+        const dragOffsetX = state.dragOffset.x;
+        const dragOffsetY = state.dragOffset.y;
     },
     shouldScroll: (_, event) => {
         // disable scroll if clicked on button


### PR DESCRIPTION

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ilyashubin/scrollbooster/blob/31ee2d16b5df5dbe7abc6475abdffc58bd6a6e6e/src/index.js#L422 - `dragOffset` is not explicitly discussed or shown in the documentation, but looking at the source one can see that it indeed has parameters `x` and `y`, and is not simply a `number` as reflected in the previous typings
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
