### PR TITLE
Fix the extraTunnelHeaders type in guacamole-common-js

### DIFF
--- a/types/guacamole-common-js/index.d.ts
+++ b/types/guacamole-common-js/index.d.ts
@@ -4,6 +4,7 @@
 //                 Alex Vakrilov <https://github.com/vakrilov>
 //                 Petar Metodiev <https://github.com/PetarMetodiev>
 //                 Jon Sun <https://github.com/Talent30>
+//                 Linh Nguyen <https://github.com/linn-gith>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // This is a fork of https://github.com/DefinitelyTyped/DefinitelyTyped/tree/4f7f0feac5f5a43f56a1d579a3b2aff67c65e461/types/guacamole-client
 // Thanks to all the contributors!

--- a/types/guacamole-common-js/lib/HTTPTunnel.d.ts
+++ b/types/guacamole-common-js/lib/HTTPTunnel.d.ts
@@ -12,5 +12,5 @@ export class HTTPTunnel extends Tunnel {
      * @param [extraTunnelHeaders={}] Key value pairs containing the header names and values of any additional
      * headers to be sent in tunnel requests. By default, no extra headers will be added.
      */
-    constructor(tunnelURL: string, crossDomain?: boolean, extraTunnelHeaders?: boolean);
+    constructor(tunnelURL: string, crossDomain?: boolean, extraTunnelHeaders?: Record<string, string>);
 }

--- a/types/guacamole-common-js/test/guacamole-common-js-test.ts
+++ b/types/guacamole-common-js/test/guacamole-common-js-test.ts
@@ -113,7 +113,8 @@ i$.onblob = x => {
 const vp = new Guacamole.VideoPlayer();
 vp.sync();
 
-new Guacamole.Client(new Guacamole.HTTPTunnel('https://hey.hey')).sendKeyEvent(1 as 1 | 0, 10);
+const httpTunnel = new Guacamole.HTTPTunnel('https://hey.hey', false, { 'X-Any': 'foobar' });
+new Guacamole.Client(httpTunnel).sendKeyEvent(1 as 1 | 0, 10);
 new Guacamole.Client(tunnel)
   // @ts-expect-error
   .sendKeyEvent(true, 5);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/glyptodon/guacamole-client/blob/master/guacamole-common-js/src/main/webapp/modules/Tunnel.js#L246-L251 and https://github.com/padarom/guacamole-common-js/issues/19
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header (it does not at this point, it just fixes one type issue)