### PR TITLE
Add typings for newrelic.getBrowserTimingHeader options

### DIFF
--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -88,14 +88,14 @@ export function addCustomAttributes(atts: { [key: string]: string | number | boo
  *
  * Most recently set value wins.
  */
- export function addCustomSpanAttribute(key: string, value: string | number | boolean): void;
+export function addCustomSpanAttribute(key: string, value: string | number | boolean): void;
 
- /**
-  * Adds all custom attributes in an object to the the currently executing span.
-  *
-  * See documentation for `addCustomSpanAttribute` for more information on setting custom attributes.
-  */
- export function addCustomSpanAttributes(atts: { [key: string]: string | number | boolean }): void;
+/**
+ * Adds all custom attributes in an object to the the currently executing span.
+ *
+ * See documentation for `addCustomSpanAttribute` for more information on setting custom attributes.
+ */
+export function addCustomSpanAttributes(atts: { [key: string]: string | number | boolean }): void;
 
 /**
  * Send errors to New Relic that you've already handled yourself.
@@ -157,7 +157,7 @@ export function addIgnoringRule(pattern: RegExp | string): void;
  *
  * Do *not* reuse the headers between users, or even between requests.
  */
-export function getBrowserTimingHeader(): string;
+export function getBrowserTimingHeader(options?: { nonce?: string; hasToRemoveScriptWrapper?: boolean }): string;
 
 /**
  * Instrument a particular method to improve visibility into a transaction,
@@ -344,7 +344,11 @@ export const instrumentMessages: Instrument;
  */
 export function shutdown(cb?: (error?: Error) => void): void;
 export function shutdown(
-    options?: { collectPendingData?: boolean | undefined; timeout?: number | undefined; waitForIdle?: boolean | undefined },
+    options?: {
+        collectPendingData?: boolean | undefined;
+        timeout?: number | undefined;
+        waitForIdle?: boolean | undefined;
+    },
     cb?: (error?: Error) => void,
 ): void;
 

--- a/types/newrelic/newrelic-tests.ts
+++ b/types/newrelic/newrelic-tests.ts
@@ -7,8 +7,8 @@ const trans = newrelic.getTransaction();
 trans.ignore(); // $ExpectType void
 trans.end(); // $ExpectType void
 trans.end(() => {}); // $ExpectType void
-trans.insertDistributedTraceHeaders({ test: 'test' }); // $ExpectType void
-trans.acceptDistributedTraceHeaders('Test', { test: 'test' }); // $ExpectType void
+trans.insertDistributedTraceHeaders({ test: "test" }); // $ExpectType void
+trans.acceptDistributedTraceHeaders("Test", { test: "test" }); // $ExpectType void
 trans.isSampled(); // $ExpectType boolean
 
 newrelic.setDispatcher('foo'); // $ExpectType void
@@ -43,12 +43,7 @@ newrelic.getBrowserTimingHeader({ hasToRemoveScriptWrapper: true }); // $ExpectT
 newrelic.getBrowserTimingHeader({ hasToRemoveScriptWrapper: true, nonce: 'foo' }); // $ExpectType string
 
 newrelic.startSegment('foo', false, () => 'bar'); // $ExpectType string
-newrelic.startSegment(
-    'foo',
-    false,
-    () => 'bar',
-    () => 'baz',
-); // $ExpectType string
+newrelic.startSegment('foo', false, () => 'bar', () => 'baz'); // $ExpectType string
 newrelic.startSegment('foo', true, async () => 'bar'); // $ExpectType Promise<string>
 
 const wrappedFn = newrelic.createTracer('foo', (x: number) => {
@@ -98,11 +93,7 @@ newrelic.recordCustomEvent('my_event', {
 });
 
 newrelic.instrument('foo', () => {}); // $ExpectType void
-newrelic.instrumentDatastore(
-    'foo',
-    () => {},
-    (err: Error) => {},
-);
+newrelic.instrumentDatastore('foo', () => {}, (err: Error) => {});
 newrelic.instrumentLoadedModule('foo', () => {}); // $ExpectType boolean
 newrelic.instrumentWebframework({
     moduleName: 'foo',
@@ -136,6 +127,6 @@ newrelic.getLinkingMetadata(true);
 newrelic.getTraceMetadata();
 
 newrelic.setLambdaHandler(() => void 0); // $ExpectType () => undefined
-newrelic.setLambdaHandler((event: unknown, context: unknown) => ({ statusCode: 200, body: 'Hello!' })); // $ExpectType (event: unknown, context: unknown) => { statusCode: number; body: string; }
+newrelic.setLambdaHandler((event: unknown, context: unknown) => ({ statusCode: 200, body: "Hello!" })); // $ExpectType (event: unknown, context: unknown) => { statusCode: number; body: string; }
 // @ts-expect-error
-newrelic.setLambdaHandler({ some: 'object' });
+newrelic.setLambdaHandler({some: "object"});

--- a/types/newrelic/newrelic-tests.ts
+++ b/types/newrelic/newrelic-tests.ts
@@ -7,8 +7,8 @@ const trans = newrelic.getTransaction();
 trans.ignore(); // $ExpectType void
 trans.end(); // $ExpectType void
 trans.end(() => {}); // $ExpectType void
-trans.insertDistributedTraceHeaders({ test: "test" }); // $ExpectType void
-trans.acceptDistributedTraceHeaders("Test", { test: "test" }); // $ExpectType void
+trans.insertDistributedTraceHeaders({ test: 'test' }); // $ExpectType void
+trans.acceptDistributedTraceHeaders('Test', { test: 'test' }); // $ExpectType void
 trans.isSampled(); // $ExpectType boolean
 
 newrelic.setDispatcher('foo'); // $ExpectType void
@@ -38,9 +38,17 @@ newrelic.addIgnoringRule('^/items/[0-9]+$'); // $ExpectType void
 newrelic.addIgnoringRule(/^[0-9]+$/); // $ExpectType void
 
 newrelic.getBrowserTimingHeader(); // $ExpectType string
+newrelic.getBrowserTimingHeader({ nonce: 'foo' }); // $ExpectType string
+newrelic.getBrowserTimingHeader({ hasToRemoveScriptWrapper: true }); // $ExpectType string
+newrelic.getBrowserTimingHeader({ hasToRemoveScriptWrapper: true, nonce: 'foo' }); // $ExpectType string
 
 newrelic.startSegment('foo', false, () => 'bar'); // $ExpectType string
-newrelic.startSegment('foo', false, () => 'bar', () => 'baz'); // $ExpectType string
+newrelic.startSegment(
+    'foo',
+    false,
+    () => 'bar',
+    () => 'baz',
+); // $ExpectType string
 newrelic.startSegment('foo', true, async () => 'bar'); // $ExpectType Promise<string>
 
 const wrappedFn = newrelic.createTracer('foo', (x: number) => {
@@ -90,7 +98,11 @@ newrelic.recordCustomEvent('my_event', {
 });
 
 newrelic.instrument('foo', () => {}); // $ExpectType void
-newrelic.instrumentDatastore('foo', () => {}, (err: Error) => {});
+newrelic.instrumentDatastore(
+    'foo',
+    () => {},
+    (err: Error) => {},
+);
 newrelic.instrumentLoadedModule('foo', () => {}); // $ExpectType boolean
 newrelic.instrumentWebframework({
     moduleName: 'foo',
@@ -124,6 +136,6 @@ newrelic.getLinkingMetadata(true);
 newrelic.getTraceMetadata();
 
 newrelic.setLambdaHandler(() => void 0); // $ExpectType () => undefined
-newrelic.setLambdaHandler((event: unknown, context: unknown) => ({ statusCode: 200, body: "Hello!" })); // $ExpectType (event: unknown, context: unknown) => { statusCode: number; body: string; }
+newrelic.setLambdaHandler((event: unknown, context: unknown) => ({ statusCode: 200, body: 'Hello!' })); // $ExpectType (event: unknown, context: unknown) => { statusCode: number; body: string; }
 // @ts-expect-error
-newrelic.setLambdaHandler({some: "object"});
+newrelic.setLambdaHandler({ some: 'object' });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://newrelic.github.io/node-newrelic/docs/API.html#getBrowserTimingHeader
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.