### PR TITLE
Include 'chrome' to puppeteer headless modes types

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -2182,7 +2182,7 @@ export interface ChromeArgOptions {
      * Whether to run browser in headless mode.
      * @default true unless the devtools option is true.
      */
-    headless?: boolean | undefined;
+    headless?: boolean | 'chrome' | undefined;
     /**
      * Additional arguments to pass to the browser instance.
      * The list of Chromium flags can be found here: https://peter.sh/experiments/chromium-command-line-switches

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -220,6 +220,25 @@ puppeteer.launch().then(async browser => {
   browser.close();
 })();
 
+// Example with launch headless options
+(async () => {
+  const browser = await puppeteer.launch({
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+    ],
+    headless: 'chrome',
+    defaultViewport: { width: 800, height: 600 },
+    handleSIGINT: true,
+    handleSIGHUP: true,
+    handleSIGTERM: true,
+  });
+  const page = await browser.newPage();
+  await page.goto("https://example.com");
+  await page.screenshot({ path: "example.png" });
+  browser.close();
+})();
+
 // `product` support
 (async () => {
     await puppeteer.launch({


### PR DESCRIPTION
Puppeteer Browser launch [documentation](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions.headless/) 

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pptr.dev/api/puppeteer.browserlaunchargumentoptions.headless/