### PR TITLE
added SerialPort.forget() method to w3c-web-serial

### DIFF
--- a/types/w3c-web-serial/index.d.ts
+++ b/types/w3c-web-serial/index.d.ts
@@ -53,6 +53,7 @@ declare class SerialPort extends EventTarget {
     getSignals(): Promise<SerialInputSignals>;
     getInfo(): SerialPortInfo;
     close(): Promise<void>;
+    forget?(): Promise<void>;
 
     addEventListener(
         type: 'connect' | 'disconnect',

--- a/types/w3c-web-serial/index.d.ts
+++ b/types/w3c-web-serial/index.d.ts
@@ -53,7 +53,7 @@ declare class SerialPort extends EventTarget {
     getSignals(): Promise<SerialInputSignals>;
     getInfo(): SerialPortInfo;
     close(): Promise<void>;
-    forget?(): Promise<void>;
+    forget(): Promise<void>;
 
     addEventListener(
         type: 'connect' | 'disconnect',

--- a/types/w3c-web-serial/w3c-web-serial-tests.ts
+++ b/types/w3c-web-serial/w3c-web-serial-tests.ts
@@ -190,3 +190,15 @@ async function example_7c() {
         }
     }, 1_000);
 }
+
+/*~ https://wicg.github.io/serial/#example-8 */
+
+async function example_8() {
+    // Request a serial port.
+    const port = await navigator.serial.requestPort();
+
+    // Then later... revoke permission to the serial port.
+    if (port.forget) {
+        await port.forget();
+    }
+}

--- a/types/w3c-web-serial/w3c-web-serial-tests.ts
+++ b/types/w3c-web-serial/w3c-web-serial-tests.ts
@@ -198,7 +198,5 @@ async function example_8() {
     const port = await navigator.serial.requestPort();
 
     // Then later... revoke permission to the serial port.
-    if (port.forget) {
-        await port.forget();
-    }
+    await port.forget();
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://wicg.github.io/serial/#forget-method>


The `SerialPort.forget()` method is implemented by newer WebSerial implementations. Adding it here as an optional method to be compatible with newer and older implementations.

[W3C forget method documentation](https://wicg.github.io/serial/#forget-method)

I also added the new [`example 8`](https://wicg.github.io/serial/#example-8) test as well.


Additional context on why the method is optional:

* <https://caniuse.com/web-serial>
* <https://caniuse.com/mdn-api_serialport_forget>

