### PR TITLE
[react-native] StyleSheet.create() now properly reports non-exist properties

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5462,7 +5462,7 @@ export namespace StyleSheet {
     /**
      * Creates a StyleSheet style reference from the given object.
      */
-    export function create<T extends NamedStyles<T> | NamedStyles<any>>(styles: T | NamedStyles<T>): T;
+    export function create<T extends NamedStyles<T> | NamedStyles<any>>(styles: NamedStyles<T>): T;
 
     /**
      * Flattens an array of style objects, into one aggregated style object.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

---

Hi, this is more like a discussion than a PR, but I think the problem should be seriously taken into account.
The original discussion is here: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/62481, but seems no one's had a look😥

I've dug a little deeper and discovered that non-exist properties will raise an error if **NO** valid property has been declared:
```tsx
const styles = StyleSheet.create({
  container: {
    // Error will be raised for this misspelled property because none of the valid props has been declared
    misspelled: 1
  }
})
```
But if any valid style property (even just one) has been declared, no error will be raised (which will be the case in most of the situations)
```tsx
const styles = StyleSheet.create({
  container: {
    flex: 1,
    // No TypeScript error is raised for the following wrong properties
    misspelled: 1,
    nonexistent: 'foo',
    // SURPRISINGLY the nested one works fine in runtime,
    // but I didn't find any documentation that encourages it, so it might be a hack
    nested: { 
      flex: 1
    }
  }
})
```
This problem is actually critical because you may have no idea that you misspelled one of the properties you need, and there's no Runtime error or TypeScript error, then you may think that `"Oh, that's not working, I need to find another solution"`.

### The reason behind it might be:
Because `T` is constrained by generic extending `<T extends NamedStyles<T> | NamedStyles<any>>`, but if you have at least one valid property that is in `NamedStyles`, TypeScript won't care about other props, no matter what the keys or values are.
If we keep `T` as a valid type for `styles` parameter, I don't think the problem can be fixed.
But if we remove it, It has some downside (see below)
Please read through, thanks.

---

### Changes:
changed the signature from
```tsx
export function create<T extends NamedStyles<T> | NamedStyles<any>>(styles: T | NamedStyles<T>): T;
```
to
```tsx
export function create<T extends NamedStyles<T> | NamedStyles<any>>(styles: NamedStyles<T>): T;
```

---

### Advantage:

1. Non-exist properties are now reported by TypeScript even with valid style props declared
```tsx
const styles = StyleSheet.create({
  container: {
    flex: 1,
    // TypeScript error is raised now for the following non-exist properties
    misspelled: 1,
    nonexistent: 'foo',
    nested: {
      flex: 1
    }
  }
})
```

---

### Disadvantage:

1. Lost detailed type of styles, e.g.
From
![Snipaste_2022-10-05_18-21-49](https://user-images.githubusercontent.com/45784210/194003371-a6692dd3-4b8a-42fb-828a-f4495bb08449.png)
![Snipaste_2022-10-05_18-21-59](https://user-images.githubusercontent.com/45784210/194003399-a8623cf2-d88f-4574-92b2-17a25293d57f.png)
To
![Snipaste_2022-10-05_18-22-13](https://user-images.githubusercontent.com/45784210/194003438-1494efe5-4fb5-47c3-9134-37634319ab0d.png)
![Snipaste_2022-10-05_18-22-21](https://user-images.githubusercontent.com/45784210/194003463-dfd18a43-4896-4914-8776-1c007159d221.png)
But I think it's worth a trade since we get Errors when using non-exist properties.

2. It may break code suggestion intelligence. It made me (WebStorm) lose detailed info about each option in the list (options are still there), but I have no idea what's happening in VSCode
From
![Snipaste_2022-10-05_18-25-30](https://user-images.githubusercontent.com/45784210/194004020-ff32ca6d-71c5-4bce-b0c8-b429c4d8a640.png)
To
![Snipaste_2022-10-05_18-25-18](https://user-images.githubusercontent.com/45784210/194003993-f127e316-7a90-422a-be68-cd51577dc3c8.png)
This may be a huge problem so,, help wanted😭

3. It may break some other related packages which I believe it 100% gonna happen.

---

### Extra

Is `NamedStyles<any>` in the generic still needed?
It's changed by: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30564, I'm not sure if something changed today, at least I didn't see any problem after I removed it for a while when coding.
*Removing `NamedStyle<any>` won't solve the problem. It's just another thought.*