### PR TITLE
Adding optional missed construction parameters to @types/lambda-log v3

### DIFF
--- a/types/lambda-log/index.d.ts
+++ b/types/lambda-log/index.d.ts
@@ -61,7 +61,7 @@ export interface LambdaLogOptions {
     levelKey?: string | null;
     // Override the key in the JSON log message for the message. Default is "msg".
     messageKey?: string;
-    // Override the key in the JSON log message for the tags. Set to null to remove this key from the JSON output. Default is "_tags".
+    // Override the key in the JSON log message for the tags. Set to null to remove this key from the JSON output. Default is '_tags'.
     tagsKey?: string | null;
 }
 

--- a/types/lambda-log/index.d.ts
+++ b/types/lambda-log/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for lambda-log 2.2
+// Type definitions for lambda-log 3.0
 // Project: https://github.com/KyleRoss/node-lambda-log
 // Definitions by: Andrés Reyes Monge <https://github.com/armonge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/lambda-log/index.d.ts
+++ b/types/lambda-log/index.d.ts
@@ -55,10 +55,14 @@ export interface LambdaLogOptions {
     silent?: boolean | undefined;
     // Optional replacer function for `JSON.stringify`
     replacer?: ((key: string, value: any) => any) | undefined;
-    // Optional stream to write stdout messages to
-    stdoutStream?: WriteStream | undefined;
-    // Optional stream to write stderr messages to
-    stderrStream?: WriteStream | undefined;
+    // Console-like object containing all standard console functions. Allows logs to be written to any custom location. Default is console.
+    logHandler?: Console;
+    // Override the key in the JSON log message for the message. Default is "msg".
+    levelKey?: string | null;
+    // Override the key in the JSON log message for the message. Default is "msg".
+    messageKey?: string;
+    // Override the key in the JSON log message for the tags. Set to null to remove this key from the JSON output. Default is "_tags".
+    tagsKey?: string | null;
 }
 
 export interface LogLevels {

--- a/types/lambda-log/lambda-log-tests.ts
+++ b/types/lambda-log/lambda-log-tests.ts
@@ -1,7 +1,7 @@
-import * as log from "lambda-log";
+import * as log from 'lambda-log';
 
-const logMessage: log.LogMessage = log.log("customLevel", "custom", {
-    key: "value"
+const logMessage: log.LogMessage = log.log('customLevel', 'custom', {
+    key: 'value',
 });
 logMessage.level;
 logMessage.meta;
@@ -11,22 +11,26 @@ logMessage.value;
 logMessage.log;
 logMessage.toJSON(true);
 
-log.info("info", { key: "value" });
-log.warn("warn", { key: "value" });
-log.error(new Error("This is an error"), { key: "value" });
-log.debug("debug", { key: "value" });
-log.assert(true, "this will print");
+log.info('info', { key: 'value' });
+log.warn('warn', { key: 'value' });
+log.error(new Error('This is an error'), { key: 'value' });
+log.debug('debug', { key: 'value' });
+log.assert(true, 'this will print');
 
 const logInstance = new log.LambdaLog({
     dynamicMeta: (logMessage: log.LogMessage) => {
         return {
-            value: logMessage.value
+            value: logMessage.value,
         };
-    }
+    },
+    logHandler: console,
+    levelKey: 'msg',
+    messageKey: 'msg',
+    tagsKey: '_tags',
 });
-logInstance.log("customLevel", "custom", { key: "value" });
-logInstance.info("info", { key: "value" });
-logInstance.warn("warn", { key: "value" });
-logInstance.error(new Error("This is an error"), { key: "value" });
-logInstance.debug("debug", { key: "value" });
-logInstance.assert(true, "this will print");
+logInstance.log('customLevel', 'custom', { key: 'value' });
+logInstance.info('info', { key: 'value' });
+logInstance.warn('warn', { key: 'value' });
+logInstance.error(new Error('This is an error'), { key: 'value' });
+logInstance.debug('debug', { key: 'value' });
+logInstance.assert(true, 'this will print');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lambdalog.dev/docs/v3/api#logoptions
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
