### PR TITLE
[@types/i18n] add plurals definition to catalog

### DIFF
--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -191,9 +191,15 @@ declare namespace i18n {
     interface Replacements {
         [key: string]: string;
     }
-
-    interface LocaleCatalog {
+    /**
+     * This interface represents a plural translation.
+     * e.g. { one: "you have 1 friend", other: "you have many friends" }
+     */
+    interface Plurals {
         [key: string]: string;
+    }
+    interface LocaleCatalog {
+        [key: string]: string | Plurals;
     }
     interface GlobalCatalog {
         [key: string]: LocaleCatalog;


### PR DESCRIPTION
The following throws a type error `Type '{ one: string; other: string; }' is not assignable to type 'string'.ts(2322)`:
```
import * as i18n from 'i18n';
i18n.configure({
  defaultLocale: 'en',
  staticCatalog: {
    'en': {
      'TEST_STRING': {
        'one': '1 test string',
        'other': 'many test strings',
      },
    },
    'nl': {
      'TEST_STRING': {
        'one': 'een test string',
        'other': 'meerdere test strings',
      },
    },
  },
});
```
But this is supported by the library. I suggest adding types to support plurals.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://www.npmjs.com/package/i18n
