### PR TITLE
better-sqlite3: SQLiteError actually extends Error

### DIFF
--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -92,7 +92,7 @@ declare namespace BetterSqlite3 {
     }
 }
 
-declare class SqliteError implements Error {
+declare class SqliteError extends Error {
     name: string;
     message: string;
     code: string;


### PR DESCRIPTION
The SQLiteError actually extends Error versus implementing it.  I have some code that adds some common functionality to Error and expands the global type.  The implements clause is causing breakages as part of the contract is unfullfliled as SQLiteError does not know about it.

Moving to an extends solves this problem and properply represents the relationsihp in the actual code.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
(https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WiseLibs/better-sqlite3/blob/master/lib/sqlite-error.js