### PR TITLE
Update types for VS Code 1.72

### DIFF
--- a/types/vscode/index.d.ts
+++ b/types/vscode/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Visual Studio Code 1.71
+// Type definitions for Visual Studio Code 1.72
 // Project: https://github.com/microsoft/vscode
 // Definitions by: Visual Studio Code Team, Microsoft <https://github.com/microsoft>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -2281,6 +2281,18 @@ declare module 'vscode' {
         static readonly RefactorInline: CodeActionKind;
 
         /**
+         * Base kind for refactoring move actions: `refactor.move`
+         *
+         * Example move actions:
+         *
+         * - Move a function to a new file
+         * - Move a property between classes
+         * - Move method to base class
+         * - ...
+         */
+        static readonly RefactorMove: CodeActionKind;
+
+        /**
          * Base kind for refactoring rewrite actions: `refactor.rewrite`
          *
          * Example rewrite actions:
@@ -2289,7 +2301,6 @@ declare module 'vscode' {
          * - Add or remove parameter
          * - Encapsulate field
          * - Make method static
-         * - Move method to base class
          * - ...
          */
         static readonly RefactorRewrite: CodeActionKind;
@@ -3432,6 +3443,120 @@ declare module 'vscode' {
     }
 
     /**
+     * A snippet edit represents an interactive edit that is performed by
+     * the editor.
+     *
+     * *Note* that a snippet edit can always be performed as a normal {@link TextEdit text edit}.
+     * This will happen when no matching editor is open or when a {@link WorkspaceEdit workspace edit}
+     * contains snippet edits for multiple files. In that case only those that match the active editor
+     * will be performed as snippet edits and the others as normal text edits.
+     */
+    export class SnippetTextEdit {
+
+        /**
+         * Utility to create a replace snippet edit.
+         *
+         * @param range A range.
+         * @param snippet A snippet string.
+         * @return A new snippet edit object.
+         */
+        static replace(range: Range, snippet: SnippetString): SnippetTextEdit;
+
+        /**
+         * Utility to create an insert snippet edit.
+         *
+         * @param position A position, will become an empty range.
+         * @param snippet A snippet string.
+         * @return A new snippet edit object.
+         */
+        static insert(position: Position, snippet: SnippetString): SnippetTextEdit;
+
+        /**
+         * The range this edit applies to.
+         */
+        range: Range;
+
+        /**
+         * The {@link SnippetString snippet} this edit will perform.
+         */
+        snippet: SnippetString;
+
+        /**
+         * Create a new snippet edit.
+         *
+         * @param range A range.
+         * @param snippet A snippet string.
+         */
+        constructor(range: Range, snippet: SnippetString);
+    }
+
+    /**
+     * A notebook edit represents edits that should be applied to the contents of a notebook.
+     */
+    export class NotebookEdit {
+
+        /**
+         * Utility to create a edit that replaces cells in a notebook.
+         *
+         * @param range The range of cells to replace
+         * @param newCells The new notebook cells.
+         */
+        static replaceCells(range: NotebookRange, newCells: NotebookCellData[]): NotebookEdit;
+
+        /**
+         * Utility to create an edit that replaces cells in a notebook.
+         *
+         * @param index The index to insert cells at.
+         * @param newCells The new notebook cells.
+         */
+        static insertCells(index: number, newCells: NotebookCellData[]): NotebookEdit;
+
+        /**
+         * Utility to create an edit that deletes cells in a notebook.
+         *
+         * @param range The range of cells to delete.
+         */
+        static deleteCells(range: NotebookRange): NotebookEdit;
+
+        /**
+         * Utility to create an edit that update a cell's metadata.
+         *
+         * @param index The index of the cell to update.
+         * @param newCellMetadata The new metadata for the cell.
+         */
+        static updateCellMetadata(index: number, newCellMetadata: { [key: string]: any }): NotebookEdit;
+
+        /**
+         * Utility to create an edit that updates the notebook's metadata.
+         *
+         * @param newNotebookMetadata The new metadata for the notebook.
+         */
+        static updateNotebookMetadata(newNotebookMetadata: { [key: string]: any }): NotebookEdit;
+
+        /**
+         * Range of the cells being edited. May be empty.
+         */
+        range: NotebookRange;
+
+        /**
+         * New cells being inserted. May be empty.
+         */
+        newCells: NotebookCellData[];
+
+        /**
+         * Optional new metadata for the cells.
+         */
+        newCellMetadata?: { [key: string]: any };
+
+        /**
+         * Optional new metadata for the notebook.
+         */
+        newNotebookMetadata?: { [key: string]: any };
+
+        constructor(range: NotebookRange, newCells: NotebookCellData[]);
+    }
+
+    /**
      * Additional data for entries of a workspace edit. Supports to label entries and marks entries
      * as needing confirmation by the user. The editor groups edits with equal labels into tree nodes,
      * for instance all edits labelled with "Changes in Strings" would be a tree node.
@@ -3510,12 +3635,36 @@ declare module 'vscode' {
         has(uri: Uri): boolean;
 
         /**
-         * Set (and replace) text edits for a resource.
+         * Set (and replace) notebook edits for a resource.
          *
          * @param uri A resource identifier.
-         * @param edits An array of text edits.
+         * @param edits An array of edits.
          */
-        set(uri: Uri, edits: TextEdit[]): void;
+        set(uri: Uri, edits: NotebookEdit[]): void;
+
+        /**
+         * Set (and replace) notebook edits with metadata for a resource.
+         *
+         * @param uri A resource identifier.
+         * @param edits An array of edits.
+         */
+        set(uri: Uri, edits: [NotebookEdit, WorkspaceEditEntryMetadata][]): void;
+
+        /**
+         * Set (and replace) text edits or snippet edits for a resource.
+         *
+         * @param uri A resource identifier.
+         * @param edits An array of edits.
+         */
+        set(uri: Uri, edits: (TextEdit | SnippetTextEdit)[]): void;
+
+        /**
+         * Set (and replace) text edits or snippet edits with metadata for a resource.
+         *
+         * @param uri A resource identifier.
+         * @param edits An array of edits.
+         */
+        set(uri: Uri, edits: [TextEdit | SnippetTextEdit, WorkspaceEditEntryMetadata][]): void;
 
         /**
          * Get the text edits for a resource.
@@ -3528,14 +3677,15 @@ declare module 'vscode' {
         /**
          * Create a regular file.
          *
-         * @param uri Uri of the new file..
+         * @param uri Uri of the new file.
          * @param options Defines if an existing file should be overwritten or be
-         * ignored. When overwrite and ignoreIfExists are both set overwrite wins.
+         * ignored. When `overwrite` and `ignoreIfExists` are both set `overwrite` wins.
          * When both are unset and when the file already exists then the edit cannot
-         * be applied successfully.
+         * be applied successfully. The `content`-property allows to set the initial contents
+         * the file is being created with.
          * @param metadata Optional metadata for the entry.
          */
-        createFile(uri: Uri, options?: { overwrite?: boolean; ignoreIfExists?: boolean }, metadata?: WorkspaceEditEntryMetadata): void;
+        createFile(uri: Uri, options?: { overwrite?: boolean; ignoreIfExists?: boolean; contents?: Uint8Array }, metadata?: WorkspaceEditEntryMetadata): void;
 
         /**
          * Delete a file or folder.
@@ -8576,6 +8726,12 @@ declare module 'vscode' {
         description?: string;
 
         /**
+         * The badge to display for this webview view.
+         * To remove the badge, set to undefined.
+         */
+        badge?: ViewBadge | undefined;
+
+        /**
          * Event fired when the view is disposed.
          *
          * Views are disposed when they are explicitly hidden by a user (this happens when a user
@@ -10262,6 +10418,22 @@ declare module 'vscode' {
     }
 
     /**
+     * A badge presenting a value for a view
+     */
+    export interface ViewBadge {
+
+        /**
+         * A label to present in tooltip for the badge.
+         */
+        readonly tooltip: string;
+
+        /**
+         * The value to present in the badge.
+         */
+        readonly value: number;
+    }
+
+    /**
      * Represents a Tree view
      */
     export interface TreeView<T> extends Disposable {
@@ -10313,6 +10485,12 @@ declare module 'vscode' {
          * Setting the title description to null, undefined, or empty string will remove the description from the view.
          */
         description?: string;
+
+        /**
+         * The badge to display for this TreeView.
+         * To remove the badge, set to undefined.
+         */
+        badge?: ViewBadge | undefined;
 
         /**
          * Reveals the given element in the tree view.
@@ -13130,7 +13308,7 @@ declare module 'vscode' {
     export interface NotebookDocumentCellChange {
 
         /**
-         * The affected notebook.
+         * The affected cell.
          */
         readonly cell: NotebookCell;
 


### PR DESCRIPTION
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/vscode/blob/42a198b98b279460e1c11310759c4fb34d6be2ab/src/vscode-dts/vscode.d.ts#L1
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

