### PR TITLE
[jsts] buffer overloads + hashCode on jsts.geom.Geometry

### DIFF
--- a/types/jsts/index.d.ts
+++ b/types/jsts/index.d.ts
@@ -2419,6 +2419,15 @@ declare namespace jsts {
             equal(a: Coordinate, b: Coordinate, tolerance: number): boolean;
 
             /**
+             * Gets a hash code for the Geometry.
+             *
+             * @override hashCode in class Object
+             *
+             * @return {int} an integer value suitable for use as a hashcode
+             */
+            hashCode(): number;
+
+            /**
              * Returns a WKT representation of this geometry.
              */
             toString(): string;

--- a/types/jsts/index.d.ts
+++ b/types/jsts/index.d.ts
@@ -1990,6 +1990,51 @@ declare namespace jsts {
             equals(o: Object): boolean;
 
             /**
+             * Computes a buffer area around this geometry having the given width.
+             * The buffer of a Geometry is the Minkowski sum or difference of the geometry with a disc of radius abs(distance).
+             * Mathematically-exact buffer area boundaries can contain circular arcs.
+             * To represent these arcs using linear geometry they must be approximated with line segments.
+             * The buffer geometry is constructed using 8 segments per quadrant to approximate the circular arcs.
+             * The end cap style is CAP_ROUND.
+             * The buffer operation always returns a polygonal result.
+             * The negative or zero-distance buffer of lines and points is always an empty Polygon.
+             * This is also the result for the buffers of degenerate (zero-area) polygons.
+             *
+             * @param {double} distance the width of the buffer (may be positive, negative or 0)
+             *
+             * @returns a polygonal geometry representing the buffer region (which may be empty)
+             *
+             * @throws {TopologyException} if a robustness error occurs
+             *
+             * @see buffer(double, int)
+             * @see buffer(double, int, int)
+             */
+            buffer(distance: number): Polygon | MultiPolygon;
+
+            /**
+             * Computes a buffer area around this geometry having the given width and
+             * with a specified accuracy of approximation for circular arcs. 
+             * Mathematically-exact buffer area boundaries can contain circular arcs.
+             * To represent these arcs using linear geometry they must be approximated with line segments.
+             * The quadrantSegments argument allows controlling the accuracy of the approximation
+             * by specifying the number of line segments used to represent a quadrant of a circle. 
+             * The buffer operation always returns a polygonal result.
+             * The negative or zero-distance buffer of lines and points is always an empty Polygon.
+             * This is also the result for the buffers of degenerate (zero-area) polygons.
+        
+             * @param {double} distance the width of the buffer (may be positive, negative or 0)
+             * @param {int} quadrantSegments the number of line segments used to represent a quadrant of a circle
+             * 
+             * @returns a polygonal geometry representing the buffer region (which may be empty)
+             * 
+             * @throws {TopologyException} if a robustness error occurs
+             * 
+             * @see #buffer(double)
+             * @see #buffer(double, int, int)
+             */
+            buffer(distance: number, quadrantSegments: number): Polygon | MultiPolygon;
+
+            /**
              * Computes a buffer area around this geometry having the given width and with a
              * specified accuracy of approximation for circular arcs, and using a specified
              * end cap style.

--- a/types/jsts/jsts-tests.ts
+++ b/types/jsts/jsts-tests.ts
@@ -89,6 +89,8 @@ str = e.toString();
 e.translate(n, n);
 
 g.apply({filter: Geometry => {}});
+g = g.buffer(n);
+g = g.buffer(n, n);
 g = g.buffer(n, n, n);
 if (g instanceof jsts.geom.Polygon) {
   poly = g;

--- a/types/jsts/jsts-tests.ts
+++ b/types/jsts/jsts-tests.ts
@@ -154,6 +154,7 @@ str = g.toString();
 bool = g.touches(g);
 g = g.union(g);
 bool = g.within(g);
+n = g.hashCode();
 
 c = ls.getCoordinateN(n);
 p = ls.getEndPoint();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://locationtech.github.io/jts/javadoc-1.17.0/org/locationtech/jts/geom/Geometry.html#buffer-double-
https://locationtech.github.io/jts/javadoc-1.17.0/org/locationtech/jts/geom/Geometry.html#hashCode--
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
