### PR TITLE
ramda: Support assertion function in tap function

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -5236,6 +5236,8 @@ export function takeWhile<T>(fn: (x: T) => boolean): (list: readonly T[]) => T[]
  * // logs 'x is 100'
  * ```
  */
+export function tap<T, R extends T = T>(fn: (a: T) => asserts a is R, value: T): R;
+export function tap<T, R extends T = T>(fn: (a: T) => asserts a is R): (value: T) => R;
 export function tap<T>(fn: (a: T) => void, value: T): T;
 export function tap<T>(fn: (a: T) => void): (value: T) => T;
 

--- a/types/ramda/test/tap-tests.ts
+++ b/types/ramda/test/tap-tests.ts
@@ -7,3 +7,18 @@ import * as R from 'ramda';
     // $ExpectType number
     const a: number = tapConsoleInput(100); // => 100
 };
+
+() => {
+    const assertsInput = (input: string | number): asserts input is number => {
+        if (typeof input !== 'number') {
+            throw new Error('input is not number');
+        }
+        console.log('input is: ' + input);
+    };
+    // $ExpectType (value: string | number) => number
+    const tapUnionTypeInput = R.tap(assertsInput);
+
+    const stringOrNumber: string | number = 100;
+    // $ExpectType number
+    const a: number = tapUnionTypeInput(stringOrNumber); // => 100
+};


### PR DESCRIPTION
Add support assertion function to tap function of ramda as shown below.
```typescript
pipe(
  (): string | number => {
    return 'str' || 213;
  },
  tap((value: string | number): asserts value is string => {
    if (typeof value !== 'string') {
      throw new Error('value is not string');
    }
  }),
  (value: string) => {
    console.log('value is string', value);
  },
);
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ramda/ramda/tree/master/source
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

ramda issue: https://github.com/ramda/ramda/issues/3310