### PR TITLE
Add emoji type and emoji field to MessageEntity

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -102,7 +102,8 @@ declare namespace TelegramBot {
         | 'pre'
         | 'text_link'
         | 'text_mention'
-        | 'spoiler';
+        | 'spoiler'
+        | 'custom_emoji';
 
     type ParseMode = 'Markdown' | 'MarkdownV2' | 'HTML';
 
@@ -536,6 +537,7 @@ declare namespace TelegramBot {
         url?: string | undefined;
         user?: User | undefined;
         language?: string | undefined;
+        custom_emoji_id?: string | undefined;
     }
 
     interface FileBase {

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -131,7 +131,7 @@ MyTelegramBot.unpinAllChatMessages(1234);
 MyTelegramBot.answerCallbackQuery('432832');
 MyTelegramBot.answerCallbackQuery({ callback_query_id: '432832' });
 MyTelegramBot.editMessageText('test-text', { disable_web_page_preview: true });
-MyTelegramBot.editMessageCaption('My Witty Caption', { message_id: 1245 });
+MyTelegramBot.editMessageCaption('My Witty Caption', { message_id: 1245, caption_entities: [{ type: 'custom_emoji', offset: 0, length: 2, custom_emoji_id: 'test_emoji' }] });
 MyTelegramBot.editMessageMedia(
     {
         media: 'photo/path',


### PR DESCRIPTION
Added a type an a new field to MessageEntity class as described in the docu of the last release of Telegram

https://core.telegram.org/bots/api#messageentity

