### PR TITLE
Add new SendBasicOption

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -161,6 +161,7 @@ declare namespace TelegramBot {
         reply_to_message_id?: number | undefined;
         reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply | undefined;
         protect_content?: boolean | undefined;
+        allow_sending_without_reply?: boolean | undefined;
     }
 
     interface SendMessageOptions extends SendBasicOptions {

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -289,7 +289,6 @@ declare namespace TelegramBot {
         caption?: string | undefined;
         parse_mode?: ParseMode | undefined;
         caption_entities?: MessageEntity[] | undefined;
-        allow_sending_without_reply?: boolean | undefined;
     }
 
     interface RestrictChatMemberOptions {

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -23,7 +23,7 @@ MyTelegramBot.deleteWebHook();
 MyTelegramBot.getWebHookInfo();
 MyTelegramBot.getUpdates({ timeout: 10 });
 MyTelegramBot.processUpdate({ update_id: 1 });
-MyTelegramBot.sendMessage(1234, 'test-text', { disable_web_page_preview: true });
+MyTelegramBot.sendMessage(1234, 'test-text', { disable_web_page_preview: true, allow_sending_without_reply: true });
 const res: TelegramBot.InlineQueryResultArticle = {
     id: '1',
     type: 'article',


### PR DESCRIPTION
**allow_sending_without_reply** is used in multiple method on Telegram Api, ([sendMessage](https://core.telegram.org/bots/api#sendmessage), [copyMessage](https://core.telegram.org/bots/api#copymessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto))

In this PR https://core.telegram.org/bots/api#sendmessage this prop is deleted from CopyMessageOptions and added on SendBasicOptions, where it has to be.