### PR TITLE
encoding-japanese: Remove the redundant type and add more tests

### DIFF
--- a/types/encoding-japanese/index.d.ts
+++ b/types/encoding-japanese/index.d.ts
@@ -27,7 +27,6 @@ type IntArrayType =
     | Int8Array
     | Int16Array
     | Int32Array;
-type RawType = IntArrayType | ReadonlyArray<number>;
 type EncodingDetection = Encoding | false;
 
 export type ConvertOptions =
@@ -67,14 +66,14 @@ export interface ConvertUnknownOptions {
     bom?: boolean | string | undefined;
 }
 
-export function detect(data: RawType | string, encodings?: Encoding | Encoding[]): EncodingDetection;
-export function convert(data: RawType, to: Encoding, from?: Encoding): number[];
+export function detect(data: IntArrayType | string, encodings?: Encoding | Encoding[]): EncodingDetection;
+export function convert(data: IntArrayType, to: Encoding, from?: Encoding): number[];
 export function convert(data: string, to: Encoding, from?: Encoding): string;
-export function convert(data: RawType | string, options: ConvertStringOptions): string;
-export function convert(data: RawType | string, options: ConvertArrayBufferOptions): ArrayBuffer;
-export function convert(data: RawType | string, options: ConvertArrayOptions): number[];
+export function convert(data: IntArrayType | string, options: ConvertStringOptions): string;
+export function convert(data: IntArrayType | string, options: ConvertArrayBufferOptions): ArrayBuffer;
+export function convert(data: IntArrayType | string, options: ConvertArrayOptions): number[];
 export function convert(data: string, options: ConvertUnknownOptions): string;
-export function convert(data: RawType, options: ConvertUnknownOptions): number[];
+export function convert(data: IntArrayType, options: ConvertUnknownOptions): number[];
 export function urlEncode(data: IntArrayType): string;
 export function urlDecode(data: string): number[];
 export function base64Encode(data: IntArrayType): string;

--- a/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
+++ b/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
@@ -142,3 +142,16 @@ const decoded2 = Encoding.base64Decode(encoded2); // $ExpectType number[]
 
 Encoding.version; // $ExpectType string
 Encoding.orders; // $ExpectType string[]
+
+Encoding.toZenkakuCase([1, 2, 3]); // $ExpectType number[]
+Encoding.toZenkakuCase('abcdef'); // $ExpectType string
+Encoding.toHankakuCase([1, 2, 3]); // $ExpectType number[]
+Encoding.toHankakuCase('ＡＢＣＤＥＦ'); // $ExpectType string
+Encoding.toZenkanaCase([1, 2, 3]); // $ExpectType number[]
+Encoding.toZenkanaCase('ｱｲｳｴｵ'); // $ExpectType string
+Encoding.toHankanaCase([1, 2, 3]); // $ExpectType number[]
+Encoding.toHankanaCase('アイウエオ'); // $ExpectType string
+Encoding.toZenkakuSpace([1, 2, 3]); // $ExpectType number[]
+Encoding.toZenkakuSpace('     '); // $ExpectType string
+Encoding.toHankakuSpace([1, 2, 3]); // $ExpectType number[]
+Encoding.toHankakuSpace('\u{3000}'); // $ExpectType string

--- a/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
+++ b/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
@@ -9,6 +9,8 @@ const utf8Array_4 = new Uint16Array([1, 2, 3]);
 const utf8Array_5 = new Uint32Array([1, 2, 3]);
 const utf8Array_6 = new Int16Array([1, 2, 3]);
 const utf8Array_7 = new Int32Array([1, 2, 3]);
+const utf8Array_8 = new Int8Array([1, 2, 3]);
+const utf8Array_9: ReadonlyArray<number> = [1, 2, 3];
 Encoding.convert(utf8Array_1, 'SJIS', 'UTF8'); // $ExpectType number[]
 Encoding.convert(utf8Array_2, 'UTF16', 'UTF8'); // $ExpectType number[]
 Encoding.convert(utf8Array_3, 'UTF16LE', 'UTF8'); // $ExpectType number[]
@@ -16,6 +18,8 @@ Encoding.convert(utf8Array_4, 'UTF16BE', 'UTF8'); // $ExpectType number[]
 Encoding.convert(utf8Array_5, 'BINARY', 'UTF8'); // $ExpectType number[]
 Encoding.convert(utf8Array_6, 'UTF32', 'UTF8'); // $ExpectType number[]
 Encoding.convert(utf8Array_7, 'AUTO', 'UTF8'); // $ExpectType number[]
+Encoding.convert(utf8Array_8, 'ASCII', 'UTF8'); // $ExpectType number[]
+Encoding.convert(utf8Array_9, 'JIS', 'UTF8'); // $ExpectType number[]
 Encoding.convert('string value', 'UTF16', 'UTF8'); // $ExpectType string
 
 // Convert character encoding by automatic detection (AUTO detect).


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/polygonplanet/encoding.js#readme
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Since `ReadonlyArray<number>` is duplicated in union of `RawType`, the type is redundant. I removed the redundant type and used `IntArrayType` directly. Since `RawType` is not exported, this change does not affect users.

And I noticed that some APIs were not covered by tests. So I added more tests in this PR too.