### PR TITLE
twitter-text: Add several missing APIs and tests for them

### DIFF
--- a/types/twitter-text/index.d.ts
+++ b/types/twitter-text/index.d.ts
@@ -56,6 +56,10 @@ export function extractReplies(text: string): string[];
 export function extractCashtags(text: string): string[];
 export function extractCashtagsWithIndices(text: string): CashtagWithIndices[];
 export function extractEntitiesWithIndices(text: string): EntityWithIndices[];
+export interface HtmlAttributes {
+    [name: string]: any;
+}
+export function extractHtmlAttrsFromOptions(options: HtmlAttributes): HtmlAttributes;
 
 /**
  * Modifies (in-place) entity indices meant for Unicode text for use with UTF-16 text.
@@ -105,6 +109,30 @@ export function autoLinkEntities(
     entities: ReadonlyArray<EntityWithIndices>,
     options?: AutoLinkOptions,
 ): string;
+export function autoLinkWithJSON(text: string, json: { [key: string]: any }, options?: AutoLinkOptions): string;
+
+export function linkTextWithEntity(entity: UrlEntity, options?: AutoLinkOptions): string;
+
+export function linkToText(
+    entity: EntityWithIndices,
+    text: string,
+    attributes: HtmlAttributes,
+    options?: AutoLinkOptions,
+): string;
+export function linkToTextWithSymbol(
+    entity: EntityWithIndices,
+    symbol: string,
+    text: string,
+    attributes: HtmlAttributes,
+    options?: AutoLinkOptions,
+): string;
+export function linkToCashtag(entity: EntityWithIndices, text: string, options?: AutoLinkOptions): string;
+export function linkToHashtag(entity: EntityWithIndices, text: string, options?: AutoLinkOptions): string;
+export function linkToMentionAndList(entity: EntityWithIndices, text: string, options?: AutoLinkOptions): string;
+export function linkToUrl(entity: EntityWithIndices, text: string, options?: AutoLinkOptions): string;
+
+export function removeOverlappingEntities(entities: EntityWithIndices[]): void;
+export function tagAttrs(attributes: HtmlAttributes): string;
 
 export interface TweetLengthOptions {
     short_url_length: number;
@@ -118,7 +146,8 @@ export function isValidHashtag(hashtag: string): boolean;
 // Note: unicodeDomainsa and requireProtocol can be null
 export function isValidUrl(url: string, unicodeDomains: boolean, requireProtocol: boolean): boolean;
 export function hasInvalidCharacters(text: string): boolean;
-export function isInvalidTweet(text: string): string;
+export function isInvalidTweet(text: string, options?: ParseTweetOptions): boolean;
+export function isValidTweet(text: string, options?: ParseTweetOptions): boolean;
 
 export function getUnicodeTextLength(text: string): number;
 // Note: This function directly modify entities" indices

--- a/types/twitter-text/twitter-text-tests.ts
+++ b/types/twitter-text/twitter-text-tests.ts
@@ -1,7 +1,7 @@
 import * as twitter from 'twitter-text';
 
 const text: string = twitter.htmlEscape('@you #hello < @world > https://github.com');
-const entities = twitter.extractEntitiesWithIndices(text);
+const entities: twitter.EntityWithIndices[] = twitter.extractEntitiesWithIndices(text);
 
 function isHashtagEntity(e: twitter.EntityWithIndices): e is twitter.HashtagWithIndices {
     return 'hashtag' in e;
@@ -42,21 +42,22 @@ result = twitter.autoLinkHashtags(text);
 result = twitter.autoLinkCashtags(text);
 result = twitter.autoLinkUrlsCustom(text, { targetBlank: true, suppressNoFollow: true });
 result = twitter.autoLinkUrlsCustom(text, { usernameIncludeSymbol: true, linkTextBlock: (entity, text) => {} });
+result = twitter.autoLinkWithJSON(text, { user_mentions: [] });
 
 const len: number = twitter.getTweetLength(text);
 
-const linked: string = twitter.autoLink('link @user, and expand url... http://t.co/0JG5Mcq', {
-    urlEntities: [
-        {
-            url: 'http://t.co/0JG5Mcq',
-            display_url: 'blog.twitter.com/2011/05/twitte…',
-            expanded_url: 'http://blog.twitter.com/2011/05/twitter-for-mac-update.html',
-            indices: [30, 48],
-        },
-    ],
+const urlEntity = {
+    url: 'http://t.co/0JG5Mcq',
+    display_url: 'blog.twitter.com/2011/05/twitte…',
+    expanded_url: 'http://blog.twitter.com/2011/05/twitter-for-mac-update.html',
+    indices: [30, 48] as [number, number],
+};
+let linked: string = twitter.autoLink('link @user, and expand url... http://t.co/0JG5Mcq', {
+    urlEntities: [urlEntity],
 });
 
 const usernames: string[] = twitter.extractMentions('Mentioning @twitter and @jack');
+const attrs: { [k: string]: any } = twitter.extractHtmlAttrsFromOptions({ displayed: true, id: 'foo' });
 
 const tweet: twitter.ParsedTweet = twitter.parseTweet('foo');
 const tweetWithOptions: twitter.ParsedTweet = twitter.parseTweet('foo', {
@@ -66,3 +67,24 @@ const tweetWithOptions: twitter.ParsedTweet = twitter.parseTweet('foo', {
 const [start, end]: [number, number] = twitter.standardizeIndices('hello', 0, 3);
 
 const isValidReply = twitter.regexen.validReply.test('@twitter');
+
+const isValid: boolean = twitter.isValidTweet(text);
+const isInvalid: boolean = twitter.isInvalidTweet(text);
+
+const attributes: twitter.HtmlAttributes = {
+    displayed: true,
+    id: 'foo',
+};
+
+const extracted: twitter.HtmlAttributes = twitter.extractHtmlAttrsFromOptions(attributes);
+
+linked = twitter.linkTextWithEntity(urlEntity);
+linked = twitter.linkToText(entities[0], text, attributes);
+linked = twitter.linkToTextWithSymbol(entities[0], '$', text, attributes);
+linked = twitter.linkToCashtag(entities[0], text);
+linked = twitter.linkToHashtag(entities[0], text);
+linked = twitter.linkToMentionAndList(entities[0], text);
+linked = twitter.linkToUrl(entities[0], text);
+
+twitter.removeOverlappingEntities(entities);
+const attrsString: string = twitter.tagAttrs(attributes);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/twitter/twitter-text/tree/master/js/src
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

While I was reading the implementation of twitter-text package, I noticed several APIs are missing in its type definitions. So I added the types reading its implementation because there is no good documentation of twitter-text package.

This PR adds the missing several APIs and tests for them.