### PR TITLE
node: Backport #59905 to ts4.8

### DIFF
--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -45,6 +45,7 @@
  */
 declare module 'buffer' {
     import { BinaryLike } from 'node:crypto';
+    import { ReadableStream as WebReadableStream } from 'node:stream/web';
     export const INSPECT_MAX_BYTES: number;
     export const kMaxLength: number;
     export const kStringMaxLength: number;
@@ -157,13 +158,15 @@ declare module 'buffer' {
          */
         text(): Promise<string>;
         /**
-         * Returns a new `ReadableStream` that allows the content of the `Blob` to be read.
+         * Returns a new (WHATWG) `ReadableStream` that allows the content of the `Blob` to be read.
          * @since v16.7.0
          */
-        stream(): unknown; // pending web streams types
+        stream(): WebReadableStream;
     }
     export import atob = globalThis.atob;
     export import btoa = globalThis.btoa;
+
+    import { Blob as _Blob } from 'buffer';
     global {
         // Buffer class
         type BufferEncoding = 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'base64url' | 'latin1' | 'binary' | 'hex';
@@ -2231,6 +2234,18 @@ declare module 'buffer' {
          * @param data An ASCII (Latin1) string.
          */
         function btoa(data: string): string;
+
+        /**
+         * `Blob` class is a global reference for `require('node:buffer').Blob`
+         * https://nodejs.org/api/buffer.html#class-blob
+         * @since v18.0.0
+         */
+        var Blob: typeof globalThis extends {
+            onmessage: any;
+            Blob: infer T;
+        }
+            ? T
+            : typeof _Blob;
     }
 }
 declare module 'node:buffer' {

--- a/types/node/ts4.8/dom-events.d.ts
+++ b/types/node/ts4.8/dom-events.d.ts
@@ -1,0 +1,126 @@
+export {}; // Don't export anything!
+
+//// DOM-like Events
+// NB: The Event / EventTarget / EventListener implementations below were copied
+// from lib.dom.d.ts, then edited to reflect Node's documentation at
+// https://nodejs.org/api/events.html#class-eventtarget.
+// Please read that link to understand important implementation differences.
+
+// This conditional type will be the existing global Event in a browser, or
+// the copy below in a Node environment.
+type __Event = typeof globalThis extends { onmessage: any, Event: infer T }
+? T
+: {
+    /** This is not used in Node.js and is provided purely for completeness. */
+    readonly bubbles: boolean;
+    /** Alias for event.stopPropagation(). This is not used in Node.js and is provided purely for completeness. */
+    cancelBubble: () => void;
+    /** True if the event was created with the cancelable option */
+    readonly cancelable: boolean;
+    /** This is not used in Node.js and is provided purely for completeness. */
+    readonly composed: boolean;
+    /** Returns an array containing the current EventTarget as the only entry or empty if the event is not being dispatched. This is not used in Node.js and is provided purely for completeness. */
+    composedPath(): [EventTarget?]
+    /** Alias for event.target. */
+    readonly currentTarget: EventTarget | null;
+    /** Is true if cancelable is true and event.preventDefault() has been called. */
+    readonly defaultPrevented: boolean;
+    /** This is not used in Node.js and is provided purely for completeness. */
+    readonly eventPhase: 0 | 2;
+    /** The `AbortSignal` "abort" event is emitted with `isTrusted` set to `true`. The value is `false` in all other cases. */
+    readonly isTrusted: boolean;
+    /** Sets the `defaultPrevented` property to `true` if `cancelable` is `true`. */
+    preventDefault(): void;
+    /** This is not used in Node.js and is provided purely for completeness. */
+    returnValue: boolean;
+    /** Alias for event.target. */
+    readonly srcElement: EventTarget | null;
+    /** Stops the invocation of event listeners after the current one completes. */
+    stopImmediatePropagation(): void;
+    /** This is not used in Node.js and is provided purely for completeness. */
+    stopPropagation(): void;
+    /** The `EventTarget` dispatching the event */
+    readonly target: EventTarget | null;
+    /** The millisecond timestamp when the Event object was created. */
+    readonly timeStamp: number;
+    /** Returns the type of event, e.g. "click", "hashchange", or "submit". */
+    readonly type: string;
+};
+
+// See comment above explaining conditional type
+type __EventTarget = typeof globalThis extends { onmessage: any, EventTarget: infer T }
+? T
+: {
+    /**
+     * Adds a new handler for the `type` event. Any given `listener` is added only once per `type` and per `capture` option value.
+     *
+     * If the `once` option is true, the `listener` is removed after the next time a `type` event is dispatched.
+     *
+     * The `capture` option is not used by Node.js in any functional way other than tracking registered event listeners per the `EventTarget` specification.
+     * Specifically, the `capture` option is used as part of the key when registering a `listener`.
+     * Any individual `listener` may be added once with `capture = false`, and once with `capture = true`.
+     */
+    addEventListener(
+        type: string,
+        listener: EventListener | EventListenerObject,
+        options?: AddEventListenerOptions | boolean,
+    ): void;
+    /** Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise. */
+    dispatchEvent(event: Event): boolean;
+    /** Removes the event listener in target's event listener list with the same type, callback, and options. */
+    removeEventListener(
+        type: string,
+        listener: EventListener | EventListenerObject,
+        options?: EventListenerOptions | boolean,
+    ): void;
+};
+
+interface EventInit {
+    bubbles?: boolean;
+    cancelable?: boolean;
+    composed?: boolean;
+}
+
+interface EventListenerOptions {
+    /** Not directly used by Node.js. Added for API completeness. Default: `false`. */
+    capture?: boolean;
+}
+
+interface AddEventListenerOptions extends EventListenerOptions {
+    /** When `true`, the listener is automatically removed when it is first invoked. Default: `false`. */
+    once?: boolean;
+    /** When `true`, serves as a hint that the listener will not call the `Event` object's `preventDefault()` method. Default: false. */
+    passive?: boolean;
+}
+
+interface EventListener {
+    (evt: Event): void;
+}
+
+interface EventListenerObject {
+    handleEvent(object: Event): void;
+}
+
+import {} from 'events';    // Make this an ambient declaration
+declare global {
+    /** An event which takes place in the DOM. */
+    interface Event extends __Event {}
+    var Event: typeof globalThis extends { onmessage: any, Event: infer T }
+        ? T
+        : {
+            prototype: __Event;
+            new (type: string, eventInitDict?: EventInit): __Event;
+        };
+
+    /**
+     * EventTarget is a DOM interface implemented by objects that can
+     * receive events and may have listeners for them.
+     */
+    interface EventTarget extends __EventTarget {}
+    var EventTarget: typeof globalThis extends { onmessage: any, EventTarget: infer T }
+        ? T
+        : {
+            prototype: __EventTarget;
+            new (): __EventTarget;
+        };
+}

--- a/types/node/ts4.8/events.d.ts
+++ b/types/node/ts4.8/events.d.ts
@@ -35,16 +35,53 @@
  * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/events.js)
  */
 declare module 'events' {
+    // NOTE: This class is in the docs but is **not actually exported** by Node.
+    // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
+    // actually starts exporting the class, uncomment below.
+
+    // import { EventListener, EventListenerObject } from '__dom-events';
+    // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
+    // interface NodeEventTarget extends EventTarget {
+    //     /**
+    //      * Node.js-specific extension to the `EventTarget` class that emulates the equivalent `EventEmitter` API.
+    //      * The only difference between `addListener()` and `addEventListener()` is that addListener() will return a reference to the EventTarget.
+    //      */
+    //     addListener(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
+    //     /** Node.js-specific extension to the `EventTarget` class that returns an array of event `type` names for which event listeners are registered. */
+    //     eventNames(): string[];
+    //     /** Node.js-specific extension to the `EventTarget` class that returns the number of event listeners registered for the `type`. */
+    //     listenerCount(type: string): number;
+    //     /** Node.js-specific alias for `eventTarget.removeListener()`. */
+    //     off(type: string, listener: EventListener | EventListenerObject): this;
+    //     /** Node.js-specific alias for `eventTarget.addListener()`. */
+    //     on(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
+    //     /** Node.js-specific extension to the `EventTarget` class that adds a `once` listener for the given event `type`. This is equivalent to calling `on` with the `once` option set to `true`. */
+    //     once(type: string, listener: EventListener | EventListenerObject): this;
+    //     /**
+    //      * Node.js-specific extension to the `EventTarget` class.
+    //      * If `type` is specified, removes all registered listeners for `type`,
+    //      * otherwise removes all registered listeners.
+    //      */
+    //     removeAllListeners(type: string): this;
+    //     /**
+    //      * Node.js-specific extension to the `EventTarget` class that removes the listener for the given `type`.
+    //      * The only difference between `removeListener()` and `removeEventListener()` is that `removeListener()` will return a reference to the `EventTarget`.
+    //      */
+    //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
+    // }
+
     interface EventEmitterOptions {
         /**
          * Enables automatic capturing of promise rejection.
          */
         captureRejections?: boolean | undefined;
     }
-    interface NodeEventTarget {
+    // Any EventTarget with a Node-style `once` function
+    interface _NodeEventTarget {
         once(eventName: string | symbol, listener: (...args: any[]) => void): this;
     }
-    interface DOMEventTarget {
+    // Any EventTarget with a DOM-style `addEventListener`
+    interface _DOMEventTarget {
         addEventListener(
             eventName: string,
             listener: (...args: any[]) => void,
@@ -154,8 +191,8 @@ declare module 'events' {
          * ```
          * @since v11.13.0, v10.16.0
          */
-        static once(emitter: NodeEventTarget, eventName: string | symbol, options?: StaticEventEmitterOptions): Promise<any[]>;
-        static once(emitter: DOMEventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
+        static once(emitter: _NodeEventTarget, eventName: string | symbol, options?: StaticEventEmitterOptions): Promise<any[]>;
+        static once(emitter: _DOMEventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
         /**
          * ```js
          * const { on, EventEmitter } = require('events');
@@ -259,7 +296,7 @@ declare module 'events' {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners(emitter: DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
          * ```js
          * const {
@@ -277,7 +314,7 @@ declare module 'events' {
          * @param eventsTargets Zero or more {EventTarget} or {EventEmitter} instances. If none are specified, `n` is set as the default max for all newly created {EventTarget} and {EventEmitter}
          * objects.
          */
-        static setMaxListeners(n?: number, ...eventTargets: Array<DOMEventTarget | NodeJS.EventEmitter>): void;
+        static setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
         /**
          * This symbol shall be used to install a listener for only monitoring `'error'`
          * events. Listeners installed using this symbol are called before the regular

--- a/types/node/ts4.8/globals.d.ts
+++ b/types/node/ts4.8/globals.d.ts
@@ -57,7 +57,7 @@ interface AbortController {
 }
 
 /** A signal object that allows you to communicate with a DOM request (such as a Fetch) and abort it if required via an AbortController object. */
-interface AbortSignal {
+interface AbortSignal extends EventTarget {
     /**
      * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
      */

--- a/types/node/ts4.8/index.d.ts
+++ b/types/node/ts4.8/index.d.ts
@@ -47,6 +47,7 @@
 /// <reference path="dns/promises.d.ts" />
 /// <reference path="dns/promises.d.ts" />
 /// <reference path="domain.d.ts" />
+/// <reference path="dom-events.d.ts" />
 /// <reference path="events.d.ts" />
 /// <reference path="fs.d.ts" />
 /// <reference path="fs/promises.d.ts" />

--- a/types/node/ts4.8/perf_hooks.d.ts
+++ b/types/node/ts4.8/perf_hooks.d.ts
@@ -604,6 +604,21 @@ declare module 'perf_hooks' {
      * @since v15.9.0, v14.18.0
      */
     function createHistogram(options?: CreateHistogramOptions): RecordableHistogram;
+
+    import { performance as _performance } from 'perf_hooks';
+    global {
+        /**
+         * `performance` is a global reference for `require('perf_hooks').performance`
+         * https://nodejs.org/api/globals.html#performance
+         * @since v16.0.0
+         */
+        var performance: typeof globalThis extends {
+            onmessage: any;
+            performance: infer T;
+        }
+            ? T
+            : typeof _performance;
+    }
 }
 declare module 'node:perf_hooks' {
     export * from 'perf_hooks';

--- a/types/node/ts4.8/stream.d.ts
+++ b/types/node/ts4.8/stream.d.ts
@@ -18,6 +18,7 @@
  */
 declare module 'stream' {
     import { EventEmitter, Abortable } from 'node:events';
+    import { Blob } from "node:buffer";
     import * as streamPromises from 'node:stream/promises';
     import * as streamConsumers from 'node:stream/consumers';
     import * as streamWeb from 'node:stream/web';

--- a/types/node/ts4.8/stream/consumers.d.ts
+++ b/types/node/ts4.8/stream/consumers.d.ts
@@ -1,22 +1,10 @@
-// Duplicates of interface in lib.dom.ts.
-// Duplicated here rather than referencing lib.dom.ts because doing so causes lib.dom.ts to be loaded for "test-all"
-// Which in turn causes tests to pass that shouldn't pass.
-//
-// This interface is not, and should not be, exported.
-interface Blob {
-    readonly size: number;
-    readonly type: string;
-    arrayBuffer(): Promise<ArrayBuffer>;
-    slice(start?: number, end?: number, contentType?: string): Blob;
-    stream(): NodeJS.ReadableStream;
-    text(): Promise<string>;
-}
 declare module 'stream/consumers' {
+    import { Blob as NodeBlob } from "node:buffer";
     import { Readable } from 'node:stream';
     function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
     function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
     function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Blob>;
+    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<NodeBlob>;
     function json(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<unknown>;
 }
 declare module 'node:stream/consumers' {

--- a/types/node/ts4.8/test/buffer.ts
+++ b/types/node/ts4.8/test/buffer.ts
@@ -1,14 +1,15 @@
 // Specifically test buffer module regression.
 import {
+    Blob as NodeBlob,
+    Blob,
     Buffer as ImportedBuffer,
-    SlowBuffer as ImportedSlowBuffer,
-    transcode,
-    TranscodeEncoding,
     constants,
     kMaxLength,
     kStringMaxLength,
-    Blob,
     resolveObjectURL,
+    SlowBuffer as ImportedSlowBuffer,
+    transcode,
+    TranscodeEncoding,
 } from 'node:buffer';
 import { Readable, Writable } from 'node:stream';
 
@@ -283,7 +284,7 @@ b.fill('a').fill('b');
 }
 
 async () => {
-    const blob = new Blob(['asd', Buffer.from('test'), new Blob(['dummy'])], {
+    const blob = new NodeBlob(['asd', Buffer.from('test'), new NodeBlob(['dummy'])], {
         type: 'application/javascript',
         encoding: 'base64',
     });
@@ -297,6 +298,15 @@ async () => {
     blob.slice(1); // $ExpectType Blob
     blob.slice(1, 2); // $ExpectType Blob
     blob.slice(1, 2, 'other'); // $ExpectType Blob
+    // ExpectType does not support disambiguating interfaces that have the same
+    // name but wildly different implementations, like Node native ReadableStream
+    // vs W3C ReadableStream, so we have to look at properties.
+    blob.stream().locked; // $ExpectType boolean
+
+    // As above but for global-scoped Blob, which should be an alias for NodeBlob
+    // as long as `lib-dom` is not included.
+    const blob2 = new Blob([]);
+    blob2.stream().locked; // $ExpectType boolean
 };
 
 {
@@ -409,9 +419,8 @@ buff.writeDoubleBE(123.123);
 buff.writeDoubleBE(123.123, 0);
 
 {
-    // The 'as any' is to make sure the Global DOM Blob does not clash with the
-    //  local "Blob" which comes with node.
-    resolveObjectURL(URL.createObjectURL(new Blob(['']) as any)); // $ExpectType Blob | undefined
+    // $ExpectType Blob | undefined
+    resolveObjectURL(URL.createObjectURL(new NodeBlob([''])));
 }
 
 {

--- a/types/node/ts4.8/test/crypto.ts
+++ b/types/node/ts4.8/test/crypto.ts
@@ -1425,6 +1425,8 @@ import { promisify } from 'node:util';
     // The lack of top level await makes it annoying to use generateKey so let's just fake it for typings.
     const key = null as unknown as crypto.webcrypto.CryptoKey;
     const buf = new Uint8Array(16);
+    // Oops, test relied on DOM `globalThis.length` before
+    const length = 123;
 
     subtle.encrypt({ name: 'AES-CBC', iv: new Uint8Array(16) }, key, new TextEncoder().encode('hello')); // $ExpectType Promise<ArrayBuffer>
     subtle.decrypt({ name: 'AES-CBC', iv: new Uint8Array(16) }, key, new ArrayBuffer(8)); // $ExpectType Promise<ArrayBuffer>

--- a/types/node/ts4.8/test/events.ts
+++ b/types/node/ts4.8/test/events.ts
@@ -1,4 +1,4 @@
-import events = require('node:events');
+import * as events from 'node:events';
 
 const emitter: events = new events.EventEmitter();
 declare const listener: (...args: any[]) => void;
@@ -124,4 +124,14 @@ async function test() {
 
     const eventEmitter = new events.EventEmitter();
     events.EventEmitter.setMaxListeners(42, eventTarget, eventEmitter);
+}
+
+{
+    // Some event properties differ from DOM types
+    const evt = new Event("fake");
+    evt.cancelBubble();
+    // @ts-expect-error
+    evt.composedPath[2];
+    // $ExpectType 0 | 2
+    evt.eventPhase;
 }

--- a/types/node/ts4.8/test/perf_hooks.ts
+++ b/types/node/ts4.8/test/perf_hooks.ts
@@ -1,5 +1,5 @@
 import {
-    performance,
+    performance as NodePerf,
     monitorEventLoopDelay,
     PerformanceObserverCallback,
     PerformanceObserver,
@@ -15,7 +15,8 @@ import {
     PerformanceMark,
 } from 'node:perf_hooks';
 
-const startMark: PerformanceMark = performance.mark('start');
+// Test module import once, the rest use global
+const startMark: PerformanceMark = NodePerf.mark('start');
 (() => {})();
 performance.mark('end');
 

--- a/types/node/ts4.8/test/stream.ts
+++ b/types/node/ts4.8/test/stream.ts
@@ -4,12 +4,13 @@ import { createReadStream, createWriteStream } from 'node:fs';
 import { createGzip, constants } from 'node:zlib';
 import assert = require('node:assert');
 import { Http2ServerResponse } from 'node:http2';
-import { text, json, buffer } from 'node:stream/consumers';
+import { text, json, buffer, arrayBuffer, blob } from 'node:stream/consumers';
 import { pipeline as pipelinePromise } from 'node:stream/promises';
 import { stdout } from 'node:process';
 import { ReadableStream, WritableStream, TransformStream } from 'node:stream/web';
 import { setInterval as every } from 'node:timers/promises';
-import { MessageChannel } from 'node:worker_threads';
+import { MessageChannel as NodeMC } from 'node:worker_threads';
+import { performance } from 'node:perf_hooks';
 
 // Simplified constructors
 function simplified_stream_ctor_test() {
@@ -458,25 +459,19 @@ async function streamPipelineAsyncPromiseAbortTransform() {
         });
 }
 
-async function readableToString() {
+async function testConsumers() {
     const r = createReadStream('file.txt');
 
     // $ExpectType string
     await text(r);
-}
-
-async function readableToJson() {
-    const r = createReadStream('file.txt');
-
     // $ExpectType unknown
     await json(r);
-}
-
-async function readableToBuffer() {
-    const r = createReadStream('file.txt');
-
     // $ExpectType Buffer
     await buffer(r);
+    // $ExpectType ArrayBuffer
+    await arrayBuffer(r);
+    // $ExpectType Blob
+    await blob(r);
 }
 
 // https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options
@@ -631,7 +626,14 @@ async function testTransformStream() {
 // https://nodejs.org/dist/latest-v16.x/docs/api/webstreams.html#transferring-with-postmessage_2
 async function testTransferringStreamWithPostMessage() {
     const stream = new TransformStream();
-    const {port1, port2} = new MessageChannel();
+    {
+        // Global constructor
+        const {port1, port2} = new MessageChannel();
+    }
+    {
+        // Constructor from module
+        const {port1, port2} = new NodeMC();
+    }
 
     // error: TypeError: port1.postMessage is not a function
     // port1.onmessage = ({data}) => {

--- a/types/node/ts4.8/test/url.ts
+++ b/types/node/ts4.8/test/url.ts
@@ -1,4 +1,4 @@
-import { Blob } from 'node:buffer';
+import { Blob as NodeBlob } from 'node:buffer';
 import assert = require('node:assert');
 import { RequestOptions } from 'node:http';
 import * as url from 'node:url';
@@ -165,7 +165,7 @@ import * as url from 'node:url';
     const opts: RequestOptions = url.urlToHttpOptions(new url.URL('test.com'));
 }
 {
-    const dataUrl: string = url.URL.createObjectURL(new Blob(['']));
+    const dataUrl: string = url.URL.createObjectURL(new NodeBlob(['']));
 }
 {
     const dataUrl1: URL = new url.URL('file://test');

--- a/types/node/ts4.8/test/util.ts
+++ b/types/node/ts4.8/test/util.ts
@@ -153,6 +153,10 @@ const td = new util.TextDecoder();
 new util.TextDecoder("utf-8");
 new util.TextDecoder("utf-8", { fatal: true });
 new util.TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+
+// Test global alias
+const td2 = new TextDecoder();
+
 const ignoreBom: boolean = td.ignoreBOM;
 const fatal: boolean = td.fatal;
 const encoding: string = td.encoding;
@@ -176,6 +180,9 @@ const decode: string = td.decode(new Int8Array(1));
 const te = new util.TextEncoder();
 const teEncoding: string = te.encoding;
 const teEncodeRes: Uint8Array = te.encode("TextEncoder");
+
+// Test global alias
+const te2 = new TextEncoder();
 
 const encIntoRes: util.EncodeIntoResult = te.encodeInto('asdf', new Uint8Array(16));
 

--- a/types/node/ts4.8/test/wasi.ts
+++ b/types/node/ts4.8/test/wasi.ts
@@ -1,5 +1,5 @@
 import { WASI } from 'node:wasi';
-import * as fs from 'node:fs';
+// import * as fs from 'node:fs';
 
 {
     const wasi = new WASI({
@@ -12,8 +12,11 @@ import * as fs from 'node:fs';
     const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
     (async () => {
-        const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
-        const instance = await WebAssembly.instantiate(wasm, importObject);
+        // TODO: Global WebAssembly types are not currently declared.; uncomment below when added.
+
+        // const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
+        // const instance = await WebAssembly.instantiate(wasm, importObject);
+        const instance = {};
 
         wasi.start(instance);
     })();

--- a/types/node/ts4.8/test/worker_threads.ts
+++ b/types/node/ts4.8/test/worker_threads.ts
@@ -123,6 +123,9 @@ import { EventLoopUtilization } from 'node:perf_hooks';
     bc.unref();
     bc.onmessage = (msg: unknown) => { };
     bc.onmessageerror = (msg: unknown) => { };
+
+    // Test global alias
+    const bc2 = new BroadcastChannel('test');
 }
 
 {
@@ -130,4 +133,10 @@ import { EventLoopUtilization } from 'node:perf_hooks';
     workerThreads.setEnvironmentData(123, { a: 1 });
     workerThreads.getEnvironmentData('test'); // $ExpectType Serializable
     workerThreads.getEnvironmentData(1); // $ExpectType Serializable
+}
+
+{
+    // Test module constructor, then global alias
+    const mp1 = new workerThreads.MessagePort();
+    const mp2 = new MessagePort();
 }

--- a/types/node/ts4.8/tsconfig.json
+++ b/types/node/ts4.8/tsconfig.json
@@ -7,7 +7,7 @@
         "module": "commonjs",
         "target": "esnext",
         "lib": [
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/node/ts4.8/url.d.ts
+++ b/types/node/ts4.8/url.d.ts
@@ -8,7 +8,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/url.js)
  */
 declare module 'url' {
-    import { Blob } from 'node:buffer';
+    import { Blob as NodeBlob } from 'node:buffer';
     import { ClientRequestArgs } from 'node:http';
     import { ParsedUrlQuery, ParsedUrlQueryInput } from 'node:querystring';
     // Input to `url.format`
@@ -395,7 +395,7 @@ declare module 'url' {
          * @since v16.7.0
          * @experimental
          */
-        static createObjectURL(blob: Blob): string;
+        static createObjectURL(blob: NodeBlob): string;
         /**
          * Removes the stored `Blob` identified by the given ID. Attempting to revoke a
          * ID that isn’t registered will silently fail.
@@ -875,9 +875,9 @@ declare module 'url' {
          */
         var URL: typeof globalThis extends {
             onmessage: any;
-            URL: infer URL;
+            URL: infer T;
         }
-            ? URL
+            ? T
             : typeof _URL;
         /**
          * `URLSearchParams` class is a global reference for `require('url').URLSearchParams`
@@ -886,9 +886,9 @@ declare module 'url' {
          */
         var URLSearchParams: typeof globalThis extends {
             onmessage: any;
-            URLSearchParams: infer URLSearchParams;
+            URLSearchParams: infer T;
         }
-            ? URLSearchParams
+            ? T
             : typeof _URLSearchParams;
     }
 }

--- a/types/node/ts4.8/util.d.ts
+++ b/types/node/ts4.8/util.d.ts
@@ -1067,6 +1067,8 @@ declare module 'util' {
         written: number;
     }
     export { types };
+
+    //// TextEncoder/Decoder
     /**
      * An implementation of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) `TextEncoder` API. All
      * instances of `TextEncoder` only support UTF-8 encoding.
@@ -1106,6 +1108,34 @@ declare module 'util' {
         encodeInto(src: string, dest: Uint8Array): EncodeIntoResult;
     }
 
+    import { TextDecoder as _TextDecoder, TextEncoder as _TextEncoder } from 'util';
+    global {
+        /**
+         * `TextDecoder` class is a global reference for `require('util').TextDecoder`
+         * https://nodejs.org/api/globals.html#textdecoder
+         * @since v11.0.0
+         */
+         var TextDecoder: typeof globalThis extends {
+            onmessage: any;
+            TextDecoder: infer TextDecoder;
+        }
+            ? TextDecoder
+            : typeof _TextDecoder;
+
+        /**
+         * `TextEncoder` class is a global reference for `require('util').TextEncoder`
+         * https://nodejs.org/api/globals.html#textencoder
+         * @since v11.0.0
+         */
+         var TextEncoder: typeof globalThis extends {
+            onmessage: any;
+            TextEncoder: infer TextEncoder;
+        }
+            ? TextEncoder
+            : typeof _TextEncoder;
+    }
+
+    //// parseArgs
     /**
      * Provides a high-level API for command-line argument parsing. Takes a
      * specification for the expected arguments and returns a structured object

--- a/types/node/ts4.8/worker_threads.d.ts
+++ b/types/node/ts4.8/worker_threads.d.ts
@@ -640,6 +640,49 @@ declare module 'worker_threads' {
      * for the `key` will be deleted.
      */
     function setEnvironmentData(key: Serializable, value: Serializable): void;
+
+    import {
+        BroadcastChannel as _BroadcastChannel,
+        MessageChannel as _MessageChannel,
+        MessagePort as _MessagePort,
+    } from 'worker_threads';
+    global {
+        /**
+         * `BroadcastChannel` class is a global reference for `require('worker_threads').BroadcastChannel`
+         * https://nodejs.org/api/globals.html#broadcastchannel
+         * @since v18.0.0
+         */
+        var BroadcastChannel: typeof globalThis extends {
+            onmessage: any;
+            BroadcastChannel: infer T;
+        }
+            ? T
+            : typeof _BroadcastChannel;
+
+        /**
+         * `MessageChannel` class is a global reference for `require('worker_threads').MessageChannel`
+         * https://nodejs.org/api/globals.html#messagechannel
+         * @since v15.0.0
+         */
+        var MessageChannel: typeof globalThis extends {
+            onmessage: any;
+            MessageChannel: infer T;
+        }
+            ? T
+            : typeof _MessageChannel;
+
+        /**
+         * `MessagePort` class is a global reference for `require('worker_threads').MessagePort`
+         * https://nodejs.org/api/globals.html#messageport
+         * @since v15.0.0
+         */
+         var MessagePort: typeof globalThis extends {
+            onmessage: any;
+            MessagePort: infer T;
+        }
+            ? T
+            : typeof _MessagePort;
+    }
 }
 declare module 'node:worker_threads' {
     export * from 'worker_threads';

--- a/types/node/v16/ts4.8/buffer.d.ts
+++ b/types/node/v16/ts4.8/buffer.d.ts
@@ -45,6 +45,7 @@
  */
 declare module 'buffer' {
     import { BinaryLike } from 'node:crypto';
+    import { ReadableStream as WebReadableStream } from 'node:stream/web';
     export const INSPECT_MAX_BYTES: number;
     export const kMaxLength: number;
     export const kStringMaxLength: number;
@@ -158,10 +159,10 @@ declare module 'buffer' {
          */
         text(): Promise<string>;
         /**
-         * Returns a new `ReadableStream` that allows the content of the `Blob` to be read.
+         * Returns a new (WHATWG) `ReadableStream` that allows the content of the `Blob` to be read.
          * @since v16.7.0
          */
-        stream(): unknown; // pending web streams types
+        stream(): WebReadableStream;
     }
     export import atob = globalThis.atob;
     export import btoa = globalThis.btoa;

--- a/types/node/v16/ts4.8/stream/consumers.d.ts
+++ b/types/node/v16/ts4.8/stream/consumers.d.ts
@@ -1,22 +1,10 @@
-// Duplicates of interface in lib.dom.ts.
-// Duplicated here rather than referencing lib.dom.ts because doing so causes lib.dom.ts to be loaded for "test-all"
-// Which in turn causes tests to pass that shouldn't pass.
-//
-// This interface is not, and should not be, exported.
-interface Blob {
-    readonly size: number;
-    readonly type: string;
-    arrayBuffer(): Promise<ArrayBuffer>;
-    slice(start?: number, end?: number, contentType?: string): Blob;
-    stream(): NodeJS.ReadableStream;
-    text(): Promise<string>;
-}
 declare module 'stream/consumers' {
     import { Readable } from 'node:stream';
+    import { Blob as NodeBlob } from "node:buffer";
     function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Buffer>;
     function text(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<string>;
     function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<Blob>;
+    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<NodeBlob>;
     function json(stream: NodeJS.ReadableStream | Readable | AsyncIterator<any>): Promise<unknown>;
 }
 declare module 'node:stream/consumers' {


### PR DESCRIPTION
Node.js types are currently out of sync between TS 4.9+ and TS <= 4.8 variants. Specifically, PR #59905 introduced many changes that were not copied over to ts4.8. This patch is an exact copy of that PR, but applied to ts4.8. The goal is that `@types/node` behaves the same on all versions of TypeScript.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  * See #59905 for the source of this patch (compare the diff to this PR via the "Files changed" tab - they should be identical).
  * The `ts4.8` directories were introduced in #62375.
