### PR TITLE
[styled-components-react-native] Remove deprecated components

### DIFF
--- a/types/styled-components-react-native/index.d.ts
+++ b/types/styled-components-react-native/index.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for styled-components-react-native 5.1
+// Type definitions for styled-components-react-native 5.2
 // Project: https://github.com/styled-components/styled-components
 // Definitions by: Nathan Bierema <https://github.com/Methuselah96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // tslint:disable-next-line:no-single-declare-module
-declare module "styled-components/native" {
-    import * as ReactNative from "react-native";
-    import * as React from "react";
+declare module 'styled-components/native' {
+    import * as ReactNative from 'react-native';
+    import * as React from 'react';
 
     export {
         css,
@@ -18,7 +18,7 @@ declare module "styled-components/native" {
         ThemeProvider,
         withTheme,
         useTheme,
-    } from "styled-components";
+    } from 'styled-components';
 
     import {
         AnyStyledComponent,
@@ -32,13 +32,13 @@ declare module "styled-components/native" {
         ThemedStyledInterface,
         ThemeProviderComponent,
         WithThemeFnInterface,
-    } from "styled-components";
+    } from 'styled-components';
 
     type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
     export type ReactNativeThemedStyledFunction<
         C extends React.ComponentType<any>,
-        T extends object
+        T extends object,
     > = ThemedStyledFunction<C, T>;
 
     // Copied over from "ThemedBaseStyledInterface" in index.d.ts in order to remove DOM element typings
@@ -52,7 +52,7 @@ declare module "styled-components/native" {
         <C extends React.ComponentType<any>>(
             // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
             // causes tests to fail in TS 3.1
-            component: C
+            component: C,
         ): ThemedStyledFunction<C, T>;
     }
 
@@ -70,13 +70,10 @@ declare module "styled-components/native" {
         ListView: ReactNativeThemedStyledFunction<typeof ReactNative.ListView, T>;
         Modal: ReactNativeThemedStyledFunction<typeof ReactNative.Modal, T>;
         NavigatorIOS: ReactNativeThemedStyledFunction<typeof ReactNative.NavigatorIOS, T>;
-        Picker: ReactNativeThemedStyledFunction<typeof ReactNative.Picker, T>;
-        PickerIOS: ReactNativeThemedStyledFunction<typeof ReactNative.PickerIOS, T>;
         Pressable: ReactNativeThemedStyledFunction<typeof ReactNative.Pressable, T>;
         ProgressBarAndroid: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressBarAndroid, T>;
         ProgressViewIOS: ReactNativeThemedStyledFunction<typeof ReactNative.ProgressViewIOS, T>;
         ScrollView: ReactNativeThemedStyledFunction<typeof ReactNative.ScrollView, T>;
-        SegmentedControlIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SegmentedControlIOS, T>;
         Slider: ReactNativeThemedStyledFunction<typeof ReactNative.Slider, T>;
         SliderIOS: ReactNativeThemedStyledFunction<typeof ReactNative.Slider, T>;
         SnapshotViewIOS: ReactNativeThemedStyledFunction<typeof ReactNative.SnapshotViewIOS, T>;

--- a/types/styled-components-react-native/tsconfig.json
+++ b/types/styled-components-react-native/tsconfig.json
@@ -13,11 +13,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "react-native": [
-                "react-native/v0.65"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Basically being using the types of react native@0.65, it made it depend on the types of react in a smaller version which caused conflicts mainly in ContextType.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://reactnative.dev/docs/0.65/picker
https://reactnative.dev/docs/0.65/segmentedcontrolios
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
