### PR TITLE
node: Add validateHeaderName/validateHeaderValue to v14 and v16

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1541,23 +1541,25 @@ declare module 'http' {
      */
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+
     /**
-     * Performs the low-level validations on the provided name that are done when res.setHeader(name, value) is called.
-     * Passing illegal value as name will result in a TypeError being thrown, identified by code: 'ERR_INVALID_HTTP_TOKEN'.
+     * Performs the low-level validations on the provided name that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as name will result in a TypeError being thrown, identified by `code: 'ERR_INVALID_HTTP_TOKEN'`.
      * @param name Header name
      * @since v14.3.0
      */
     function validateHeaderName(name: string): void;
     /**
-     * Performs the low-level validations on the provided value that are done when res.setHeader(name, value) is called.
+     * Performs the low-level validations on the provided value that are done when `res.setHeader(name, value)` is called.
      * Passing illegal value as value will result in a TypeError being thrown.
-     * - Undefined value error is identified by code: 'ERR_HTTP_INVALID_HEADER_VALUE'.
-     * - Invalid value character error is identified by code: 'ERR_INVALID_CHAR'.
+     * - Undefined value error is identified by `code: 'ERR_HTTP_INVALID_HEADER_VALUE'`.
+     * - Invalid value character error is identified by `code: 'ERR_INVALID_CHAR'`.
      * @param name Header name
      * @param value Header value
      * @since v14.3.0
      */
     function validateHeaderValue(name: string, value: string): void;
+
     let globalAgent: Agent;
     /**
      * Read-only property specifying the maximum allowed size of HTTP headers in bytes.

--- a/types/node/ts4.8/http.d.ts
+++ b/types/node/ts4.8/http.d.ts
@@ -1541,23 +1541,25 @@ declare module 'http' {
      */
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+
     /**
-     * Performs the low-level validations on the provided name that are done when res.setHeader(name, value) is called.
-     * Passing illegal value as name will result in a TypeError being thrown, identified by code: 'ERR_INVALID_HTTP_TOKEN'.
+     * Performs the low-level validations on the provided name that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as name will result in a TypeError being thrown, identified by `code: 'ERR_INVALID_HTTP_TOKEN'`.
      * @param name Header name
      * @since v14.3.0
      */
     function validateHeaderName(name: string): void;
     /**
-     * Performs the low-level validations on the provided value that are done when res.setHeader(name, value) is called.
+     * Performs the low-level validations on the provided value that are done when `res.setHeader(name, value)` is called.
      * Passing illegal value as value will result in a TypeError being thrown.
-     * - Undefined value error is identified by code: 'ERR_HTTP_INVALID_HEADER_VALUE'.
-     * - Invalid value character error is identified by code: 'ERR_INVALID_CHAR'.
+     * - Undefined value error is identified by `code: 'ERR_HTTP_INVALID_HEADER_VALUE'`.
+     * - Invalid value character error is identified by `code: 'ERR_INVALID_CHAR'`.
      * @param name Header name
      * @param value Header value
      * @since v14.3.0
      */
     function validateHeaderValue(name: string, value: string): void;
+
     let globalAgent: Agent;
     /**
      * Read-only property specifying the maximum allowed size of HTTP headers in bytes.

--- a/types/node/v14/http.d.ts
+++ b/types/node/v14/http.d.ts
@@ -548,6 +548,25 @@ declare module 'http' {
     ): ClientRequest;
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+
+    /**
+     * Performs the low-level validations on the provided name that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as name will result in a TypeError being thrown, identified by `code: 'ERR_INVALID_HTTP_TOKEN'`.
+     * @param name Header name
+     * @since v14.3.0
+     */
+    function validateHeaderName(name: string): void;
+    /**
+     * Performs the low-level validations on the provided value that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as value will result in a TypeError being thrown.
+     * - Undefined value error is identified by `code: 'ERR_HTTP_INVALID_HEADER_VALUE'`.
+     * - Invalid value character error is identified by `code: 'ERR_INVALID_CHAR'`.
+     * @param name Header name
+     * @param value Header value
+     * @since v14.3.0
+     */
+    function validateHeaderValue(name: string, value: string): void;
+
     let globalAgent: Agent;
 
     /**

--- a/types/node/v14/test/http.ts
+++ b/types/node/v14/test/http.ts
@@ -570,3 +570,8 @@ import * as dns from 'node:dns';
   http.request({ lookup: dns.lookup });
   http.request({ lookup: (hostname, options, cb) => { cb(null, '', 1); } });
 }
+
+{
+    http.validateHeaderName('Location');
+    http.validateHeaderValue('Location', '/');
+}

--- a/types/node/v14/ts4.8/http.d.ts
+++ b/types/node/v14/ts4.8/http.d.ts
@@ -548,6 +548,25 @@ declare module 'http' {
     ): ClientRequest;
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+
+    /**
+     * Performs the low-level validations on the provided name that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as name will result in a TypeError being thrown, identified by `code: 'ERR_INVALID_HTTP_TOKEN'`.
+     * @param name Header name
+     * @since v14.3.0
+     */
+    function validateHeaderName(name: string): void;
+    /**
+     * Performs the low-level validations on the provided value that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as value will result in a TypeError being thrown.
+     * - Undefined value error is identified by `code: 'ERR_HTTP_INVALID_HEADER_VALUE'`.
+     * - Invalid value character error is identified by `code: 'ERR_INVALID_CHAR'`.
+     * @param name Header name
+     * @param value Header value
+     * @since v14.3.0
+     */
+    function validateHeaderValue(name: string, value: string): void;
+
     let globalAgent: Agent;
 
     /**

--- a/types/node/v14/ts4.8/test/http.ts
+++ b/types/node/v14/ts4.8/test/http.ts
@@ -570,3 +570,8 @@ import * as dns from 'node:dns';
   http.request({ lookup: dns.lookup });
   http.request({ lookup: (hostname, options, cb) => { cb(null, '', 1); } });
 }
+
+{
+    http.validateHeaderName('Location');
+    http.validateHeaderValue('Location', '/');
+}

--- a/types/node/v16/http.d.ts
+++ b/types/node/v16/http.d.ts
@@ -1465,6 +1465,25 @@ declare module 'http' {
      */
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+
+    /**
+     * Performs the low-level validations on the provided name that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as name will result in a TypeError being thrown, identified by `code: 'ERR_INVALID_HTTP_TOKEN'`.
+     * @param name Header name
+     * @since v14.3.0
+     */
+    function validateHeaderName(name: string): void;
+    /**
+     * Performs the low-level validations on the provided value that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as value will result in a TypeError being thrown.
+     * - Undefined value error is identified by `code: 'ERR_HTTP_INVALID_HEADER_VALUE'`.
+     * - Invalid value character error is identified by `code: 'ERR_INVALID_CHAR'`.
+     * @param name Header name
+     * @param value Header value
+     * @since v14.3.0
+     */
+    function validateHeaderValue(name: string, value: string): void;
+
     let globalAgent: Agent;
     /**
      * Read-only property specifying the maximum allowed size of HTTP headers in bytes.

--- a/types/node/v16/test/http.ts
+++ b/types/node/v16/test/http.ts
@@ -600,3 +600,8 @@ import * as dns from 'node:dns';
   http.request({ lookup: dns.lookup });
   http.request({ lookup: (hostname, options, cb) => { cb(null, '', 1); } });
 }
+
+{
+    http.validateHeaderName('Location');
+    http.validateHeaderValue('Location', '/');
+}

--- a/types/node/v16/ts4.8/http.d.ts
+++ b/types/node/v16/ts4.8/http.d.ts
@@ -1465,6 +1465,25 @@ declare module 'http' {
      */
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+
+    /**
+     * Performs the low-level validations on the provided name that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as name will result in a TypeError being thrown, identified by `code: 'ERR_INVALID_HTTP_TOKEN'`.
+     * @param name Header name
+     * @since v14.3.0
+     */
+    function validateHeaderName(name: string): void;
+    /**
+     * Performs the low-level validations on the provided value that are done when `res.setHeader(name, value)` is called.
+     * Passing illegal value as value will result in a TypeError being thrown.
+     * - Undefined value error is identified by `code: 'ERR_HTTP_INVALID_HEADER_VALUE'`.
+     * - Invalid value character error is identified by `code: 'ERR_INVALID_CHAR'`.
+     * @param name Header name
+     * @param value Header value
+     * @since v14.3.0
+     */
+    function validateHeaderValue(name: string, value: string): void;
+
     let globalAgent: Agent;
     /**
      * Read-only property specifying the maximum allowed size of HTTP headers in bytes.

--- a/types/node/v16/ts4.8/test/http.ts
+++ b/types/node/v16/ts4.8/test/http.ts
@@ -600,3 +600,8 @@ import * as dns from 'node:dns';
   http.request({ lookup: dns.lookup });
   http.request({ lookup: (hostname, options, cb) => { cb(null, '', 1); } });
 }
+
+{
+    http.validateHeaderName('Location');
+    http.validateHeaderValue('Location', '/');
+}


### PR DESCRIPTION
This patch iterates on PR #62456, which added `validateHeaderName()` and `validateHeaderValue()` to `@types/node`. These methods exist since Node.js version 14.3.0, hence they are now included in the v14 and v16 variants of `http.d.ts` as well.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  * https://nodejs.org/api/http.html#httpvalidateheadernamename
  * https://nodejs.org/api/http.html#httpvalidateheadervaluename-value
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
