### PR TITLE
Sticker changes and new functionality

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -814,16 +814,6 @@ declare namespace TelegramBot {
         thumb?: PhotoSize | undefined;
     }
 
-    interface GetStickerSetOptions { }
-
-    interface GetCustomEmojiStickersOptions { }
-
-    interface UploadStickerFileOptions { }
-
-    interface DeleteStickerFromSetOptions { }
-
-    interface setStickerSetThumbOptions { }
-
     interface CreateStickerSetOptions {
         tgs_sticker?: string | Stream | Buffer;
         webm_sticker?: string | Stream | Buffer;
@@ -1415,18 +1405,18 @@ declare class TelegramBot extends EventEmitter {
 
     getStickerSet(
         name: string,
-        options?: TelegramBot.GetStickerSetOptions,
+        options?: {},
     ): Promise<TelegramBot.StickerSet>;
 
     getCustomEmojiStickers(
         customEmojiIds: string[],
-        options?: TelegramBot.GetCustomEmojiStickersOptions,
+        options?: {},
     ): Promise<TelegramBot.Sticker[]>;
 
     uploadStickerFile(
         userId: string,
         pngSticker: string | Stream | Buffer,
-        options?: TelegramBot.UploadStickerFileOptions,
+        options?: {},
         fileOptions?: TelegramBot.FileOptions,
     ): Promise<TelegramBot.File>;
 
@@ -1457,14 +1447,14 @@ declare class TelegramBot extends EventEmitter {
 
     deleteStickerFromSet(
         sticker: string,
-        options?: TelegramBot.DeleteStickerFromSetOptions,
+        options?: {},
     ): Promise<boolean>;
 
     setStickerSetThumb(
         userId: string,
         name: string,
         pngThumb: string | Stream | Buffer,
-        options?: TelegramBot.setStickerSetThumbOptions,
+        options?: {},
         fileOptions?: TelegramBot.FileOptions,
     ): Promise<boolean>;
 

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -1424,8 +1424,8 @@ declare class TelegramBot extends EventEmitter {
         userId: string,
         name: string,
         title: string,
+        pngSticker: string | Stream | Buffer,
         emojis: string,
-        pngSticker?: string | Stream | Buffer,
         options?: TelegramBot.CreateStickerSetOptions,
         fileOptions?: TelegramBot.FileOptions,
     ): Promise<boolean>;

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -788,17 +788,20 @@ declare namespace TelegramBot {
         can_pin_messages?: boolean | undefined;
     }
 
-    interface Sticker {
-        file_id: string;
-        file_unique_id: string;
+    type StickerType = 'regular' | 'mask' | 'custom_emoji';
+
+    interface Sticker extends FileBase {
+        type: StickerType;
         is_animated: boolean;
+        is_video: boolean;
         width: number;
         height: number;
         thumb?: PhotoSize | undefined;
         emoji?: string | undefined;
         set_name?: string | undefined;
+        premium_animation?: File | undefined;
         mask_position?: MaskPosition | undefined;
-        file_size?: number | undefined;
+        custom_emoji_id?: string | undefined;
     }
 
     interface StickerSet {

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -814,6 +814,27 @@ declare namespace TelegramBot {
         thumb?: PhotoSize | undefined;
     }
 
+    interface GetStickerSetOptions { }
+
+    interface GetCustomEmojiStickersOptions { }
+
+    interface UploadStickerFileOptions { }
+
+    interface DeleteStickerFromSetOptions { }
+
+    interface setStickerSetThumbOptions { }
+
+    interface CreateStickerSetOptions {
+        tgs_sticker?: string | Stream | Buffer;
+        webm_sticker?: string | Stream | Buffer;
+        sticker_type?: 'regular' | 'mask';
+        mask_position?: MaskPosition;
+    }
+
+    interface AddStickerToSetOptions {
+        mask_position?: MaskPosition;
+    }
+
     interface MaskPosition {
         point: string;
         x_shift: number;
@@ -1391,6 +1412,61 @@ declare class TelegramBot extends EventEmitter {
         options?: TelegramBot.SendStickerOptions,
         fileOptions?: TelegramBot.FileOptions,
     ): Promise<TelegramBot.Message>;
+
+    getStickerSet(
+        name: string,
+        options?: TelegramBot.GetStickerSetOptions
+    ): Promise<TelegramBot.StickerSet>
+
+    getCustomEmojiStickers(
+        customEmojiIds: string[],
+        options?: TelegramBot.GetCustomEmojiStickersOptions
+    ): Promise<TelegramBot.Sticker[]>
+
+    uploadStickerFile(
+        userId: string,
+        pngSticker: string | Stream | Buffer,
+        options?: TelegramBot.UploadStickerFileOptions,
+        fileOptions?: TelegramBot.FileOptions
+    ): Promise<TelegramBot.File>
+
+    createNewStickerSet(
+        userId: string,
+        name: string,
+        title: string,
+        emojis: string,
+        pngSticker?: string | Stream | Buffer,
+        options?: TelegramBot.CreateStickerSetOptions,
+        fileOptions?: TelegramBot.FileOptions
+    ): Promise<boolean>
+
+    addStickerToSet(
+        userId: string,
+        name: string,
+        sticker: string | Stream | Buffer,
+        emojis: string,
+        stickerType: 'png_sticker' | 'tgs_sticker' | 'webm_sticker',
+        options?: TelegramBot.AddStickerToSetOptions,
+        fileOptions?: TelegramBot.FileOptions
+    ): Promise<boolean>
+
+    setStickerPositionInSet(
+        sticker: string,
+        position: number
+    ): Promise<boolean>
+
+    deleteStickerFromSet(
+        sticker: string,
+        options?: TelegramBot.DeleteStickerFromSetOptions
+    ): Promise<boolean>
+
+    setStickerSetThumb(
+        userId: string,
+        name: string,
+        pngThumb: string | Stream | Buffer,
+        options?: TelegramBot.setStickerSetThumbOptions,
+        fileOptions?: TelegramBot.FileOptions
+    ): Promise<boolean>
 
     sendVideo(
         chatId: TelegramBot.ChatId,

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -807,8 +807,11 @@ declare namespace TelegramBot {
     interface StickerSet {
         name: string;
         title: string;
-        contains_masks: boolean;
+        sticker_type: StickerType;
+        is_animated: boolean;
+        is_video: boolean;
         stickers: Sticker[];
+        thumb?: PhotoSize | undefined;
     }
 
     interface MaskPosition {

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -1415,20 +1415,20 @@ declare class TelegramBot extends EventEmitter {
 
     getStickerSet(
         name: string,
-        options?: TelegramBot.GetStickerSetOptions
-    ): Promise<TelegramBot.StickerSet>
+        options?: TelegramBot.GetStickerSetOptions,
+    ): Promise<TelegramBot.StickerSet>;
 
     getCustomEmojiStickers(
         customEmojiIds: string[],
-        options?: TelegramBot.GetCustomEmojiStickersOptions
-    ): Promise<TelegramBot.Sticker[]>
+        options?: TelegramBot.GetCustomEmojiStickersOptions,
+    ): Promise<TelegramBot.Sticker[]>;
 
     uploadStickerFile(
         userId: string,
         pngSticker: string | Stream | Buffer,
         options?: TelegramBot.UploadStickerFileOptions,
-        fileOptions?: TelegramBot.FileOptions
-    ): Promise<TelegramBot.File>
+        fileOptions?: TelegramBot.FileOptions,
+    ): Promise<TelegramBot.File>;
 
     createNewStickerSet(
         userId: string,
@@ -1437,8 +1437,8 @@ declare class TelegramBot extends EventEmitter {
         emojis: string,
         pngSticker?: string | Stream | Buffer,
         options?: TelegramBot.CreateStickerSetOptions,
-        fileOptions?: TelegramBot.FileOptions
-    ): Promise<boolean>
+        fileOptions?: TelegramBot.FileOptions,
+    ): Promise<boolean>;
 
     addStickerToSet(
         userId: string,
@@ -1447,26 +1447,26 @@ declare class TelegramBot extends EventEmitter {
         emojis: string,
         stickerType: 'png_sticker' | 'tgs_sticker' | 'webm_sticker',
         options?: TelegramBot.AddStickerToSetOptions,
-        fileOptions?: TelegramBot.FileOptions
-    ): Promise<boolean>
+        fileOptions?: TelegramBot.FileOptions,
+    ): Promise<boolean>;
 
     setStickerPositionInSet(
         sticker: string,
-        position: number
-    ): Promise<boolean>
+        position: number,
+    ): Promise<boolean>;
 
     deleteStickerFromSet(
         sticker: string,
-        options?: TelegramBot.DeleteStickerFromSetOptions
-    ): Promise<boolean>
+        options?: TelegramBot.DeleteStickerFromSetOptions,
+    ): Promise<boolean>;
 
     setStickerSetThumb(
         userId: string,
         name: string,
         pngThumb: string | Stream | Buffer,
         options?: TelegramBot.setStickerSetThumbOptions,
-        fileOptions?: TelegramBot.FileOptions
-    ): Promise<boolean>
+        fileOptions?: TelegramBot.FileOptions,
+    ): Promise<boolean>;
 
     sendVideo(
         chatId: TelegramBot.ChatId,

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -350,3 +350,11 @@ MyTelegramBot.setMyDefaultAdministratorRights({
 });
 MyTelegramBot.getMyDefaultAdministratorRights({});
 MyTelegramBot.answerWebAppQuery('query_id', res);
+MyTelegramBot.getStickerSet('custom-set-name');
+MyTelegramBot.getCustomEmojiStickers(['123', '986']);
+MyTelegramBot.uploadStickerFile('user_id', 'my_png_sticker_file');
+MyTelegramBot.createNewStickerSet('user_id', 'short_name', 'my sticker set name', 'hello');
+MyTelegramBot.addStickerToSet('user_id', 'custom_sticker', 'sticker_path', 'emoji', 'png_sticker');
+MyTelegramBot.setStickerPositionInSet('sticker_on_position_one', 2);
+MyTelegramBot.deleteStickerFromSet('sticker_on_position_one');
+MyTelegramBot.setStickerSetThumb('user_id', 'my_set_thumb', 'thumb_file');

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -353,7 +353,7 @@ MyTelegramBot.answerWebAppQuery('query_id', res);
 MyTelegramBot.getStickerSet('custom-set-name');
 MyTelegramBot.getCustomEmojiStickers(['123', '986']);
 MyTelegramBot.uploadStickerFile('user_id', 'my_png_sticker_file');
-MyTelegramBot.createNewStickerSet('user_id', 'short_name', 'my sticker set name', 'hello');
+MyTelegramBot.createNewStickerSet('user_id', 'short_name', 'my sticker set name', 'my_png_sticker_file', 'hello');
 MyTelegramBot.addStickerToSet('user_id', 'custom_sticker', 'sticker_path', 'emoji', 'png_sticker');
 MyTelegramBot.setStickerPositionInSet('sticker_on_position_one', 2);
 MyTelegramBot.deleteStickerFromSet('sticker_on_position_one');


### PR DESCRIPTION
Added new functions and change some interfaces. All this is related with last update of Telegram Bot APi.

Here are the links for the doc related to the interfaces and methods added:

- [Sticker](https://core.telegram.org/bots/api#sticker)
- [StickerSet](https://core.telegram.org/bots/api#stickerset)
- [getStickerSet](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#TelegramBot+getStickerSet)
- [getCustomEmojiStickers](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#TelegramBot+getCustomEmojiStickers)
- [uploadStickerFile](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#TelegramBot+uploadStickerFile)
- [createNewStickerSet](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#TelegramBot+createNewStickerSet)
- [addStickerToSet](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#TelegramBot+addStickerToSet)
- [setStickerPositionInSet](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#TelegramBot+setStickerPositionInSet)
- [deleteStickerFromSet](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#TelegramBot+deleteStickerFromSet)
- [setStickerSetThumb](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#TelegramBot+setStickerSetThumb)
