### PR TITLE
Capsule.getCenter argument type mistake

### DIFF
--- a/types/three/examples/jsm/math/Capsule.d.ts
+++ b/types/three/examples/jsm/math/Capsule.d.ts
@@ -9,7 +9,7 @@ export class Capsule {
     set(start: Vector3, end: Vector3, radius: number): this;
     clone(): Capsule;
     copy(capsule: Capsule): this;
-    getCenter(target: number): Vector3;
+    getCenter(target: Vector3): Vector3;
     translate(v: Vector3): this;
     checkAABBAxis(
         p1x: number,


### PR DESCRIPTION
The target argument in getCenter is a Vector3 not a number

