### PR TITLE
CI: Use `secrets.GITHUB_TOKEN` instead of bare secret token

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,4 @@ jobs:
 
         # Danger failing (for example through rate-limiting) shouldn't fail the build
         run: |
-          TOKEN='ghp_i5wtj1l2AbpFv3OU96w6R'
-          TOKEN+='On3bHOkcV2AmVY6'
-          DANGER_GITHUB_API_TOKEN=$TOKEN yarn danger ci || $( exit 0 )
+          DANGER_GITHUB_API_TOKEN=${{ secrets.GITHUB_TOKEN }} yarn danger ci || $( exit 0 )


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.):
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

This PR does not change any `@types/*` packages.

This PR improves security of CI workflow. Currently CI workflow (`CI.yml`) contains bare secret token to run Danger. The token only has `public_repo` scope so leaking the secret is not so unsafe, but it has the following problems:

- Someone may use the token in other places
- Generated developer token is usually expired after some duration

GitHub Actions offers `secrets.GITHUB_TOKEN` which is automatically generated for CI workflow run. Using it is better than using a developer token.