### PR TITLE
[aws-lambda]: Add AWS Amplify GraphQL resolver

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -89,5 +89,6 @@ export * from "./trigger/sqs";
 export * from './trigger/msk';
 export * from "./trigger/secretsmanager";
 export * from "./trigger/s3-event-notification";
+export * from "./trigger/amplify-resolver";
 
 export as namespace AWSLambda;

--- a/types/aws-lambda/test/amplify-resolver-tests.ts
+++ b/types/aws-lambda/test/amplify-resolver-tests.ts
@@ -1,0 +1,56 @@
+import {
+    AppSyncIdentityIAM,
+    AppSyncIdentityCognito,
+    AppSyncIdentityOIDC,
+    AppSyncIdentityLambda,
+    AmplifyGraphQlResolverHandler,
+} from 'aws-lambda';
+
+const handler: AmplifyGraphQlResolverHandler = async (event, context) => {
+    str = event.fieldName;
+    str = event.typeName;
+
+    obj = event.arguments;
+
+    str = (event.identity as AppSyncIdentityIAM).accountId;
+    str = (event.identity as AppSyncIdentityIAM).cognitoIdentityAuthProvider;
+    str = (event.identity as AppSyncIdentityIAM).cognitoIdentityAuthType;
+    str = (event.identity as AppSyncIdentityIAM).cognitoIdentityId;
+    str = (event.identity as AppSyncIdentityIAM).cognitoIdentityPoolId;
+    str = (event.identity as AppSyncIdentityIAM).sourceIp[0];
+    str = (event.identity as AppSyncIdentityIAM).userArn;
+    str = (event.identity as AppSyncIdentityIAM).username;
+
+    str = (event.identity as AppSyncIdentityCognito).defaultAuthStrategy;
+    str = (event.identity as AppSyncIdentityCognito).issuer;
+    str = (event.identity as AppSyncIdentityCognito).sourceIp[0];
+    str = (event.identity as AppSyncIdentityCognito).sub;
+    str = (event.identity as AppSyncIdentityCognito).username;
+    anyObj = (event.identity as AppSyncIdentityCognito).claims;
+
+    str = (event.identity as AppSyncIdentityOIDC).sub;
+    str = (event.identity as AppSyncIdentityOIDC).issuer;
+    anyObj = (event.identity as AppSyncIdentityOIDC).claims;
+
+    anyObj = (event.identity as AppSyncIdentityLambda).resolverContext;
+
+    obj = event.source;
+
+    strOrUndefined = event.request.headers.host;
+    strOrNull = event.request.domainName;
+
+    anyObj = (event.prev as { result: { [key: string]: any } }).result;
+
+    return anyObj;
+};
+
+interface CustomArgs {
+    arg1: string;
+}
+interface SourceType {
+    source1: number;
+}
+const handlerWithArguments: AmplifyGraphQlResolverHandler<CustomArgs, SourceType> = async (event, context) => {
+    str = event.arguments.arg1;
+    num = event.source.source1;
+};

--- a/types/aws-lambda/trigger/amplify-resolver.d.ts
+++ b/types/aws-lambda/trigger/amplify-resolver.d.ts
@@ -1,0 +1,36 @@
+import { Handler } from '../handler';
+import { AppSyncIdentity, AppSyncResolverEventHeaders } from './appsync-resolver';
+
+/**
+ * An AWS Amplify GraphQL resolver event. It differs slightly from a native ('direct') AppSync resolver event.
+ *
+ * @see https://docs.amplify.aws/cli/graphql/custom-business-logic/#structure-of-the-function-event
+ */
+export interface AmplifyGraphQlResolverEvent<TArguments = Record<string, any>, TSource = Record<string, any>> {
+    /** The name of the parent object type (data model) of the field being resolved. */
+    typeName: string;
+    /** The field within the given type to resolve. */
+    fieldName: string;
+    /** A map of GraphQL arguments passed to the field being resolved. */
+    arguments: TArguments;
+    /** The identity used to authenticate the request to AppSync. */
+    identity?: AppSyncIdentity;
+    /** The parent object's value if resolving a nested field. */
+    source: TSource;
+    /** The request headers  */
+    request: {
+        headers: AppSyncResolverEventHeaders;
+        domainName: string | null;
+    };
+    /** The object returned by a possible previous pipeline resolver function. */
+    prev: { result: { [key: string]: any } } | null;
+}
+
+/**
+ * A handler for Amplify GraphQL Lambda resolvers. The returned result will be resolved as the value (no need to convert to a JSON string).
+ *
+ * @see https://docs.amplify.aws/cli/graphql/custom-business-logic/#structure-of-the-function-event
+ */
+export type AmplifyGraphQlResolverHandler<TArguments = Record<string, any>, TSource = Record<string, any>> = Handler<
+    AmplifyGraphQlResolverEvent<TArguments, TSource>
+>;

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -44,6 +44,8 @@ export type AppSyncIdentity =
  * @param TArguments type of the arguments
  * @param TSource type of the source
  */
+// Maintainer's note: Some of these properties are shared with the Amplify resolver.
+// It may be worth checking if changes here may be applicable there too.
 export interface AppSyncResolverEvent<TArguments, TSource = Record<string, any> | null> {
     arguments: TArguments;
     identity?: AppSyncIdentity;

--- a/types/aws-lambda/tsconfig.json
+++ b/types/aws-lambda/tsconfig.json
@@ -43,6 +43,7 @@
         "test/sqs-tests.ts",
         "test/msk-tests.ts",
         "test/secretsmanager-tests.ts",
-        "test/s3-event-notification-tests.ts"
+        "test/s3-event-notification-tests.ts",
+        "test/amplify-resolver-tests.ts"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.amplify.aws/cli/graphql/custom-business-logic/#lambda-function-resolver and https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

This PR adds the Amplify-specific GraphQL resolver type as discussed in #62590. This event is effectively a slimmed down AppSync resolve event with two extra fields as per the generated AppSync function mapping template:
```
{
  "version": "2018-05-29",
  "operation": "Invoke",
  "payload": {
      "typeName": $util.toJson($ctx.stash.get("typeName")),
      "fieldName": $util.toJson($ctx.stash.get("fieldName")),
      "arguments": $util.toJson($ctx.arguments),
      "identity": $util.toJson($ctx.identity),
      "source": $util.toJson($ctx.source),
      "request": $util.toJson($ctx.request),
      "prev": $util.toJson($ctx.prev)
  }
}
```