### PR TITLE
[aws-lambda]: Add domainName property to AppSync resolver request object

### DIFF
--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -55,6 +55,7 @@ const handler: AppSyncResolverHandler<TestArguments, TestEntity> = async (event,
     anyObj = (event.identity as AppSyncIdentityLambda).resolverContext;
 
     strOrUndefined = event.request.headers.host;
+    strOrNull = event.request.domainName;
 
     str = event.info.fieldName;
     str = event.info.parentTypeName;
@@ -103,6 +104,7 @@ const batchHandler: AppSyncBatchResolverHandler<TestArguments, TestEntity> = asy
         anyObj = (event.identity as AppSyncIdentityLambda).resolverContext;
 
         strOrUndefined = event.request.headers.host;
+        strOrNull = event.request.domainName;
 
         str = event.info.fieldName;
         str = event.info.parentTypeName;

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -50,6 +50,8 @@ export interface AppSyncResolverEvent<TArguments, TSource = Record<string, any> 
     source: TSource;
     request: {
         headers: AppSyncResolverEventHeaders;
+        /** The API's custom domain if used for the request. */
+        domainName: string | null;
     };
     info: {
         selectionSetList: string[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html#aws-access-requested-custom-domain-names
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

This adds the missing (newish?) `domainName` property as hinted in #62643 to the existing AppSync handler.