### PR TITLE
Add node dependency to joi-phone-number

### DIFF
--- a/types/joi-phone-number/index.d.ts
+++ b/types/joi-phone-number/index.d.ts
@@ -4,6 +4,7 @@
 //                 James Lismore <https://github.com/jlismore/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
 import { StringSchema, Extension, Root, Reference } from 'joi';
 
 declare module 'joi' {


### PR DESCRIPTION
This is a new transitive dependency from joi, but it's external so DT doesn't otherwise detect it.