### PR TITLE
[node] fix: stream depends on global Blob not available in v16

### DIFF
--- a/types/node/v16/stream.d.ts
+++ b/types/node/v16/stream.d.ts
@@ -18,6 +18,7 @@
  */
 declare module 'stream' {
     import { EventEmitter, Abortable } from 'node:events';
+    import { Blob } from 'node:buffer';
     import * as streamPromises from 'node:stream/promises';
     import * as streamConsumers from 'node:stream/consumers';
     class internal extends EventEmitter {

--- a/types/node/v16/ts4.8/stream.d.ts
+++ b/types/node/v16/ts4.8/stream.d.ts
@@ -18,6 +18,7 @@
  */
 declare module 'stream' {
     import { EventEmitter, Abortable } from 'node:events';
+    import { Blob } from 'node:buffer';
     import * as streamPromises from 'node:stream/promises';
     import * as streamConsumers from 'node:stream/consumers';
     class internal extends EventEmitter {


### PR DESCRIPTION
Blob is only available on the global object starting in Node 18. Still, the `stream` definitions used the global Blob. This means that `@types/node` 16.x is currently broken. This patch adds the correct import to resolve this problem. For more info please refer to #62654.

Long-term, IMHO we should remove `"lib": ["dom"]` from the v16 TSConfig like it was already done for v18, but I'd much rather get this fix out quickly and worry about that later.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
  - I made a local repro of the problem (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62654#issuecomment-1274432749), and after editing `node_modules/@types/node/ts4.8/stream.d.ts` the problem went away.
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
  - Don't know how to test this. I think it should be fine once we remove  `"lib": ["dom"]` from the v16 TSConfig, since TypeScript would then complain if using global `Blob` anywhere.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62654#issuecomment-1274432749
  - global `Blob` in Node.js 18: https://nodejs.org/docs/latest-v18.x/api/globals.html#class-blob
  - no global `Blob` in Node.js 16: https://nodejs.org/docs/latest-v16.x/api/globals.html#class-blob
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
