### PR TITLE
[node] Add callTracker.getCalls and callTracker.reset in 'node:assert'

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -66,6 +66,27 @@ declare module 'assert' {
             calls(exact?: number): () => void;
             calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func;
             /**
+             * Example:
+             *
+             * ```js
+             * import assert from 'node:assert';
+             *
+             * const tracker = new assert.CallTracker();
+             *
+             * function func() {}
+             * const callsfunc = tracker.calls(func);
+             * callsfunc(1, 2, 3);
+             *
+             * assert.deepStrictEqual(tracker.getCalls(callsfunc),
+             *                        [{ thisArg: this, arguments: [1, 2, 3 ] }]);
+             * ```
+             *
+             * @since v18.8.0, v16.18.0
+             * @params fn
+             * @returns An Array with the calls to a tracked function.
+             */
+            getCalls(fn: Function): CallTrackerCall[];
+            /**
              * The arrays contains information about the expected and actual number of calls of
              * the functions that have not been called the expected number of times.
              *
@@ -101,6 +122,31 @@ declare module 'assert' {
              */
             report(): CallTrackerReportInformation[];
             /**
+             * Reset calls of the call tracker.
+             * If a tracked function is passed as an argument, the calls will be reset for it.
+             * If no arguments are passed, all tracked functions will be reset.
+             *
+             * ```js
+             * import assert from 'node:assert';
+             *
+             * const tracker = new assert.CallTracker();
+             *
+             * function func() {}
+             * const callsfunc = tracker.calls(func);
+             *
+             * callsfunc();
+             * // Tracker was called once
+             * tracker.getCalls(callsfunc).length === 1;
+             *
+             * tracker.reset(callsfunc);
+             * tracker.getCalls(callsfunc).length === 0;
+             * ```
+             *
+             * @since v18.8.0, v16.18.0
+             * @param fn a tracked function to reset.
+             */
+            reset(fn?: Function): void;
+            /**
              * Iterates through the list of functions passed to `tracker.calls()` and will throw an error for functions that
              * have not been called the expected number of times.
              *
@@ -124,6 +170,10 @@ declare module 'assert' {
              * @since v14.2.0, v12.19.0
              */
             verify(): void;
+        }
+        interface CallTrackerCall {
+            thisArg: object;
+            arguments: unknown[];
         }
         interface CallTrackerReportInformation {
             message: string;

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -31,6 +31,13 @@ import assert = require('node:assert');
     const res = callsFunc(42);
     const report = tracker.report();
 
+    const calls = tracker.getCalls(callsFunc);
+    calls[0].thisArg;
+    calls[0].arguments;
+
+    tracker.reset();
+    tracker.reset(callsFunc);
+
     try {
         tracker.verify();
     } catch (err) {

--- a/types/node/ts4.8/assert.d.ts
+++ b/types/node/ts4.8/assert.d.ts
@@ -66,6 +66,27 @@ declare module 'assert' {
             calls(exact?: number): () => void;
             calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func;
             /**
+             * Example:
+             *
+             * ```js
+             * import assert from 'node:assert';
+             *
+             * const tracker = new assert.CallTracker();
+             *
+             * function func() {}
+             * const callsfunc = tracker.calls(func);
+             * callsfunc(1, 2, 3);
+             *
+             * assert.deepStrictEqual(tracker.getCalls(callsfunc),
+             *                        [{ thisArg: this, arguments: [1, 2, 3 ] }]);
+             * ```
+             *
+             * @since v18.8.0, v16.18.0
+             * @params fn
+             * @returns An Array with the calls to a tracked function.
+             */
+            getCalls(fn: Function): CallTrackerCall[];
+            /**
              * The arrays contains information about the expected and actual number of calls of
              * the functions that have not been called the expected number of times.
              *
@@ -101,6 +122,31 @@ declare module 'assert' {
              */
             report(): CallTrackerReportInformation[];
             /**
+             * Reset calls of the call tracker.
+             * If a tracked function is passed as an argument, the calls will be reset for it.
+             * If no arguments are passed, all tracked functions will be reset.
+             *
+             * ```js
+             * import assert from 'node:assert';
+             *
+             * const tracker = new assert.CallTracker();
+             *
+             * function func() {}
+             * const callsfunc = tracker.calls(func);
+             *
+             * callsfunc();
+             * // Tracker was called once
+             * tracker.getCalls(callsfunc).length === 1;
+             *
+             * tracker.reset(callsfunc);
+             * tracker.getCalls(callsfunc).length === 0;
+             * ```
+             *
+             * @since v18.8.0, v16.18.0
+             * @param fn a tracked function to reset.
+             */
+            reset(fn?: Function): void;
+            /**
              * Iterates through the list of functions passed to `tracker.calls()` and will throw an error for functions that
              * have not been called the expected number of times.
              *
@@ -124,6 +170,10 @@ declare module 'assert' {
              * @since v14.2.0, v12.19.0
              */
             verify(): void;
+        }
+        interface CallTrackerCall {
+            thisArg: object;
+            arguments: unknown[];
         }
         interface CallTrackerReportInformation {
             message: string;

--- a/types/node/ts4.8/test/assert.ts
+++ b/types/node/ts4.8/test/assert.ts
@@ -31,6 +31,13 @@ import assert = require('node:assert');
     const res = callsFunc(42);
     const report = tracker.report();
 
+    const calls = tracker.getCalls(callsFunc);
+    calls[0].thisArg;
+    calls[0].arguments;
+
+    tracker.reset();
+    tracker.reset(callsFunc);
+
     try {
         tracker.verify();
     } catch (err) {

--- a/types/node/v16/assert.d.ts
+++ b/types/node/v16/assert.d.ts
@@ -66,6 +66,27 @@ declare module 'assert' {
             calls(exact?: number): () => void;
             calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func;
             /**
+             * Example:
+             *
+             * ```js
+             * import assert from 'node:assert';
+             *
+             * const tracker = new assert.CallTracker();
+             *
+             * function func() {}
+             * const callsfunc = tracker.calls(func);
+             * callsfunc(1, 2, 3);
+             *
+             * assert.deepStrictEqual(tracker.getCalls(callsfunc),
+             *                        [{ thisArg: this, arguments: [1, 2, 3 ] }]);
+             * ```
+             *
+             * @since v18.8.0, v16.18.0
+             * @params fn
+             * @returns An Array with the calls to a tracked function.
+             */
+            getCalls(fn: Function): CallTrackerCall[];
+            /**
              * The arrays contains information about the expected and actual number of calls of
              * the functions that have not been called the expected number of times.
              *
@@ -101,6 +122,31 @@ declare module 'assert' {
              */
             report(): CallTrackerReportInformation[];
             /**
+             * Reset calls of the call tracker.
+             * If a tracked function is passed as an argument, the calls will be reset for it.
+             * If no arguments are passed, all tracked functions will be reset.
+             *
+             * ```js
+             * import assert from 'node:assert';
+             *
+             * const tracker = new assert.CallTracker();
+             *
+             * function func() {}
+             * const callsfunc = tracker.calls(func);
+             *
+             * callsfunc();
+             * // Tracker was called once
+             * tracker.getCalls(callsfunc).length === 1;
+             *
+             * tracker.reset(callsfunc);
+             * tracker.getCalls(callsfunc).length === 0;
+             * ```
+             *
+             * @since v18.8.0, v16.18.0
+             * @param fn a tracked function to reset.
+             */
+            reset(fn?: Function): void;
+            /**
              * Iterates through the list of functions passed to `tracker.calls()` and will throw an error for functions that
              * have not been called the expected number of times.
              *
@@ -124,6 +170,10 @@ declare module 'assert' {
              * @since v14.2.0, v12.19.0
              */
             verify(): void;
+        }
+        interface CallTrackerCall {
+            thisArg: object;
+            arguments: unknown[];
         }
         interface CallTrackerReportInformation {
             message: string;

--- a/types/node/v16/index.d.ts
+++ b/types/node/v16/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 16.11
+// Type definitions for non-npm package Node.js 16.18
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/v16/test/assert.ts
+++ b/types/node/v16/test/assert.ts
@@ -31,6 +31,13 @@ import assert = require('node:assert');
     const res = callsFunc(42);
     const report = tracker.report();
 
+    const calls = tracker.getCalls(callsFunc);
+    calls[0].thisArg;
+    calls[0].arguments;
+
+    tracker.reset();
+    tracker.reset(callsFunc);
+
     try {
         tracker.verify();
     } catch (err) {

--- a/types/node/v16/ts4.8/assert.d.ts
+++ b/types/node/v16/ts4.8/assert.d.ts
@@ -66,6 +66,27 @@ declare module 'assert' {
             calls(exact?: number): () => void;
             calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func;
             /**
+             * Example:
+             *
+             * ```js
+             * import assert from 'node:assert';
+             *
+             * const tracker = new assert.CallTracker();
+             *
+             * function func() {}
+             * const callsfunc = tracker.calls(func);
+             * callsfunc(1, 2, 3);
+             *
+             * assert.deepStrictEqual(tracker.getCalls(callsfunc),
+             *                        [{ thisArg: this, arguments: [1, 2, 3 ] }]);
+             * ```
+             *
+             * @since v18.8.0, v16.18.0
+             * @params fn
+             * @returns An Array with the calls to a tracked function.
+             */
+            getCalls(fn: Function): CallTrackerCall[];
+            /**
              * The arrays contains information about the expected and actual number of calls of
              * the functions that have not been called the expected number of times.
              *
@@ -101,6 +122,31 @@ declare module 'assert' {
              */
             report(): CallTrackerReportInformation[];
             /**
+             * Reset calls of the call tracker.
+             * If a tracked function is passed as an argument, the calls will be reset for it.
+             * If no arguments are passed, all tracked functions will be reset.
+             *
+             * ```js
+             * import assert from 'node:assert';
+             *
+             * const tracker = new assert.CallTracker();
+             *
+             * function func() {}
+             * const callsfunc = tracker.calls(func);
+             *
+             * callsfunc();
+             * // Tracker was called once
+             * tracker.getCalls(callsfunc).length === 1;
+             *
+             * tracker.reset(callsfunc);
+             * tracker.getCalls(callsfunc).length === 0;
+             * ```
+             *
+             * @since v18.8.0, v16.18.0
+             * @param fn a tracked function to reset.
+             */
+            reset(fn?: Function): void;
+            /**
              * Iterates through the list of functions passed to `tracker.calls()` and will throw an error for functions that
              * have not been called the expected number of times.
              *
@@ -124,6 +170,10 @@ declare module 'assert' {
              * @since v14.2.0, v12.19.0
              */
             verify(): void;
+        }
+        interface CallTrackerCall {
+            thisArg: object;
+            arguments: unknown[];
         }
         interface CallTrackerReportInformation {
             message: string;

--- a/types/node/v16/ts4.8/test/assert.ts
+++ b/types/node/v16/ts4.8/test/assert.ts
@@ -31,6 +31,13 @@ import assert = require('node:assert');
     const res = callsFunc(42);
     const report = tracker.report();
 
+    const calls = tracker.getCalls(callsFunc);
+    calls[0].thisArg;
+    calls[0].arguments;
+
+    tracker.reset();
+    tracker.reset(callsFunc);
+
     try {
         tracker.verify();
     } catch (err) {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - for v16 (just released: https://github.com/nodejs/node/releases/tag/v16.18.0):
    - https://nodejs.org/docs/latest-v16.x/api/assert.html#trackergetcallsfn
    - https://nodejs.org/docs/latest-v16.x/api/assert.html#trackerresetfn
  - for v18:
    - https://nodejs.org/docs/latest-v18.x/api/assert.html#trackergetcallsfn
    - https://nodejs.org/docs/latest-v18.x/api/assert.html#trackerresetfn
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
