### PR TITLE
[node] Bring in v16.18.0 additions (setMaxIdleHTTPParsers, localFamily)

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1560,6 +1560,13 @@ declare module 'http' {
      */
     function validateHeaderValue(name: string, value: string): void;
 
+    /**
+     * Set the maximum number of idle HTTP parsers. Default: 1000.
+     * @param count
+     * @since v18.8.0, v16.18.0
+     */
+    function setMaxIdleHTTPParsers(count: number): void;
+
     let globalAgent: Agent;
     /**
      * Read-only property specifying the maximum allowed size of HTTP headers in bytes.

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -606,4 +606,6 @@ import * as dns from 'node:dns';
 {
     http.validateHeaderName('Location');
     http.validateHeaderValue('Location', '/');
+
+    http.setMaxIdleHTTPParsers(1337);
 }

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -125,6 +125,9 @@ import { Socket } from 'node:dgram';
     // test the types of the address object fields
     const address: net.AddressInfo | {} = _socket.address();
 
+    const _socketLocalPort: number | undefined = _socket.localPort;
+    const _socketLocalFamily: string | undefined = _socket.localFamily;
+
     /// addListener
 
     _socket = _socket.addListener("close", had_error => {

--- a/types/node/ts4.8/http.d.ts
+++ b/types/node/ts4.8/http.d.ts
@@ -1560,6 +1560,13 @@ declare module 'http' {
      */
     function validateHeaderValue(name: string, value: string): void;
 
+    /**
+     * Set the maximum number of idle HTTP parsers. Default: 1000.
+     * @param count
+     * @since v18.8.0, v16.18.0
+     */
+    function setMaxIdleHTTPParsers(count: number): void;
+
     let globalAgent: Agent;
     /**
      * Read-only property specifying the maximum allowed size of HTTP headers in bytes.

--- a/types/node/ts4.8/test/http.ts
+++ b/types/node/ts4.8/test/http.ts
@@ -606,4 +606,6 @@ import * as dns from 'node:dns';
 {
     http.validateHeaderName('Location');
     http.validateHeaderValue('Location', '/');
+
+    http.setMaxIdleHTTPParsers(1337);
 }

--- a/types/node/ts4.8/test/net.ts
+++ b/types/node/ts4.8/test/net.ts
@@ -125,6 +125,9 @@ import { Socket } from 'node:dgram';
     // test the types of the address object fields
     const address: net.AddressInfo | {} = _socket.address();
 
+    const _socketLocalPort: number | undefined = _socket.localPort;
+    const _socketLocalFamily: string | undefined = _socket.localFamily;
+
     /// addListener
 
     _socket = _socket.addListener("close", had_error => {

--- a/types/node/v16/http.d.ts
+++ b/types/node/v16/http.d.ts
@@ -1484,6 +1484,13 @@ declare module 'http' {
      */
     function validateHeaderValue(name: string, value: string): void;
 
+    /**
+     * Set the maximum number of idle HTTP parsers. Default: 1000.
+     * @param count
+     * @since v18.8.0, v16.18.0
+     */
+    function setMaxIdleHTTPParsers(count: number): void;
+
     let globalAgent: Agent;
     /**
      * Read-only property specifying the maximum allowed size of HTTP headers in bytes.

--- a/types/node/v16/index.d.ts
+++ b/types/node/v16/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 16.11
+// Type definitions for non-npm package Node.js 16.18
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/v16/net.d.ts
+++ b/types/node/v16/net.d.ts
@@ -267,6 +267,11 @@ declare module 'net' {
          */
         readonly localPort?: number;
         /**
+         * The string representation of the local IP family. `'IPv4'` or `'IPv6'`.
+         * @since v18.8.0, v16.18.0
+         */
+        readonly localFamily?: string;
+        /**
          * This property represents the state of the connection as a string.
          * @see {https://nodejs.org/api/net.html#socketreadystate}
          * @since v0.5.0

--- a/types/node/v16/test/http.ts
+++ b/types/node/v16/test/http.ts
@@ -604,4 +604,6 @@ import * as dns from 'node:dns';
 {
     http.validateHeaderName('Location');
     http.validateHeaderValue('Location', '/');
+
+    http.setMaxIdleHTTPParsers(1337);
 }

--- a/types/node/v16/test/net.ts
+++ b/types/node/v16/test/net.ts
@@ -124,6 +124,9 @@ import { Socket } from 'node:dgram';
     // test the types of the address object fields
     const address: net.AddressInfo | {} = _socket.address();
 
+    const _socketLocalPort: number | undefined = _socket.localPort;
+    const _socketLocalFamily: string | undefined = _socket.localFamily;
+
     /// addListener
 
     _socket = _socket.addListener("close", had_error => {

--- a/types/node/v16/ts4.8/http.d.ts
+++ b/types/node/v16/ts4.8/http.d.ts
@@ -1484,6 +1484,13 @@ declare module 'http' {
      */
     function validateHeaderValue(name: string, value: string): void;
 
+    /**
+     * Set the maximum number of idle HTTP parsers. Default: 1000.
+     * @param count
+     * @since v18.8.0, v16.18.0
+     */
+    function setMaxIdleHTTPParsers(count: number): void;
+
     let globalAgent: Agent;
     /**
      * Read-only property specifying the maximum allowed size of HTTP headers in bytes.

--- a/types/node/v16/ts4.8/net.d.ts
+++ b/types/node/v16/ts4.8/net.d.ts
@@ -267,6 +267,11 @@ declare module 'net' {
          */
         readonly localPort?: number;
         /**
+         * The string representation of the local IP family. `'IPv4'` or `'IPv6'`.
+         * @since v18.8.0, v16.18.0
+         */
+        readonly localFamily?: string;
+        /**
          * This property represents the state of the connection as a string.
          * @see {https://nodejs.org/api/net.html#socketreadystate}
          * @since v0.5.0

--- a/types/node/v16/ts4.8/test/http.ts
+++ b/types/node/v16/ts4.8/test/http.ts
@@ -604,4 +604,6 @@ import * as dns from 'node:dns';
 {
     http.validateHeaderName('Location');
     http.validateHeaderValue('Location', '/');
+
+    http.setMaxIdleHTTPParsers(1337);
 }

--- a/types/node/v16/ts4.8/test/net.ts
+++ b/types/node/v16/ts4.8/test/net.ts
@@ -124,6 +124,9 @@ import { Socket } from 'node:dgram';
     // test the types of the address object fields
     const address: net.AddressInfo | {} = _socket.address();
 
+    const _socketLocalPort: number | undefined = _socket.localPort;
+    const _socketLocalFamily: string | undefined = _socket.localFamily;
+
     /// addListener
 
     _socket = _socket.addListener("close", had_error => {


### PR DESCRIPTION
This patch adds the `http.setMaxIdleHTTPParsers` function and the `localFamily` property on `net.Socket`. These also exist in Node 18.8.0 and were backported to 16.x just now. I updated `v16/index.d.ts` to reflect the Node.js version for these methods.

Node.js 16.18.0 also added methods to `assert.CallTracker`, but these
are part of a different PR to simplify the reviewing process: #62678.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - v16 (just released: https://github.com/nodejs/node/releases/tag/v16.18.0):
    - https://nodejs.org/docs/latest-v16.x/api/http.html#httpsetmaxidlehttpparsers
    - https://nodejs.org/docs/latest-v16.x/api/net.html#socketlocalfamily
  - v18:
    - https://nodejs.org/docs/latest-v18.x/api/http.html#httpsetmaxidlehttpparsers
    - https://nodejs.org/docs/latest-v18.x/api/net.html#socketlocalfamily
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
