### PR TITLE
[axios-token-interceptor] Allow providing a type for the AxiosTokenProvider's InterceptorOptions param

### DIFF
--- a/types/axios-token-interceptor/axios-token-interceptor-tests.ts
+++ b/types/axios-token-interceptor/axios-token-interceptor-tests.ts
@@ -1,9 +1,27 @@
 import tokenProvider = require('axios-token-interceptor');
 
-const getToken = async (): Promise<{ access_token: string; expires_in: number }> => ({
+interface TokenData {
+    access_token: string;
+    expires_in: number;
+}
+
+const getToken = async (): Promise<TokenData> => ({
     access_token: 'token1',
     expires_in: 50,
 });
+
+// $ExpectType TokenCache
+const cacheToken = tokenProvider.tokenCache<TokenData>(
+    getToken,
+    { getMaxAge: token => token.expires_in },
+);
+
+const tokenProviderOptions: tokenProvider.InterceptorOptions<TokenData> = {
+    getToken: cacheToken,
+    headerFormatter: (token: TokenData) => `Bearer ${token.access_token}`,
+};
+
+tokenProvider(tokenProviderOptions); // $ExpectType TokenProvider
 
 tokenProvider.tokenCache(getToken, {
     getMaxAge: token => token.expires_in,

--- a/types/axios-token-interceptor/index.d.ts
+++ b/types/axios-token-interceptor/index.d.ts
@@ -8,7 +8,7 @@
 import { AxiosRequestConfig } from 'axios';
 
 // Module
-declare function AxiosTokenProvider(Options: AxiosTokenProvider.InterceptorOptions): AxiosTokenProvider.TokenProvider;
+declare function AxiosTokenProvider(Options: AxiosTokenProvider.InterceptorOptions<any>): AxiosTokenProvider.TokenProvider;
 declare namespace AxiosTokenProvider {
     function tokenCache<T>(getToken: () => Promise<T>, options: TokenCacheOptions<T>): TokenCache;
 


### PR DESCRIPTION
Without the `any` in the `AxiosTokenProvider` function declaration param for `AxiosTokenProvider.InterceptorOptions`, it will default to `unknown` as the generic type which causes type errors when attempting to type the options passed into the declared function.
```
error TS2345: Argument of type 'InterceptorOptions<TokenData>' is not assignable to parameter of type 'InterceptorOptions<unknown>'.
  Type 'unknown' is not assignable to type 'TokenData'.
```
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
