### PR TITLE
fix: add optional sessionToken to amazon-dax-client

### DIFF
--- a/types/amazon-dax-client/index.d.ts
+++ b/types/amazon-dax-client/index.d.ts
@@ -17,6 +17,7 @@ interface AmazonDaxClientOptions {
     endpoints?: ReadonlyArray<string> | undefined;
     accessKeyId?: string | undefined;
     secretAccessKey?: string | undefined;
+    sessionToken?: string | undefined;
     region?: string | undefined;
     maxRetries?: number | undefined;
     maxRedirects?: number | undefined;


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

When instantiating a AmazonDaxClient with assumed credentials, the `sessionToken` is required.

Without:
```js
const daxClient = new AmazonDaxClient({
      region: process.env.AWS_REGION,
      endpoints: [process.env.DAX_ENDPOINT],
      accessKeyId: credentials.AccessKeyId,
      secretAccessKey: credentials.SecretAccessKey,
});
```
The following error occurs:
```shell
Failed to pull from <REMOVED_DAX_CLUSTER_ENDPOINT>.amazonaws.com (*.*.*.*): DaxServiceError: Connection requires authentication
    at Custom_endpoints_455855874_1_Assembler._assembleError (/Users/dylanfiedler/Documents/ario/scripts/node_modules/amazon-dax-client/src/Assembler.js:120:12)
    at Custom_endpoints_455855874_1_Assembler.feed (/Users/dylanfiedler/Documents/ario/scripts/node_modules/amazon-dax-client/src/Assembler.js:65:20)
    at Socket.<anonymous> (/Users/dylanfiedler/Documents/ario/scripts/node_modules/amazon-dax-client/src/BaseOperations.js:67:30)
    at Socket.emit (node:events:527:28)
    at Socket.emit (node:domain:475:12)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  time: 1665613490420,
  code: undefined,
  retryable: true,
  requestId: null,
  statusCode: -1,
  _tubeInvalid: true,
  waitForRecoveryBeforeRetrying: false,
  _message: 'Connection requires authentication',
  codeSeq: [ 4, 23, 31, 33 ],
  cancellationReasons: undefined
}
```
With session token provided:
```js
const daxClient = new AmazonDaxClient({
      region: process.env.AWS_REGION,
      endpoints: [process.env.DAX_ENDPOINT],
      accessKeyId: credentials.AccessKeyId,
      secretAccessKey: credentials.SecretAccessKey,
});
```

Authentication works, and `DaxClient` can be provided to `DynamoDb.DocumentClient`

