### PR TITLE
fix: react-email-editor types for ToolsConfig

### DIFF
--- a/types/react-email-editor/index.d.ts
+++ b/types/react-email-editor/index.d.ts
@@ -10,164 +10,168 @@ import { Component as ReactComponent, CSSProperties } from 'react';
 export type ThemeColor = 'light' | 'dark';
 export type DockPosition = 'right' | 'left';
 export interface AppearanceConfig {
-  readonly theme?: ThemeColor | undefined;
-  readonly panels?: {
-    readonly tools?: {
-      readonly dock: DockPosition;
-    } | undefined;
-  } | undefined;
+    readonly theme?: ThemeColor | undefined;
+    readonly panels?:
+        | {
+              readonly tools?:
+                  | {
+                        readonly dock: DockPosition;
+                    }
+                  | undefined;
+          }
+        | undefined;
 }
 
 export interface User {
-  readonly id?: number | undefined;
-  readonly name?: string | undefined;
-  readonly email?: string | undefined;
+    readonly id?: number | undefined;
+    readonly name?: string | undefined;
+    readonly email?: string | undefined;
 }
 
 export interface GroupedSpecialLink {
-  readonly name: string;
-  readonly specialLinks: Array<SimpleSpecialLink | GroupedSpecialLink>;
+    readonly name: string;
+    readonly specialLinks: Array<SimpleSpecialLink | GroupedSpecialLink>;
 }
 
 export interface SimpleSpecialLink {
-  readonly name: string;
-  readonly href: string;
-  readonly target: string;
+    readonly name: string;
+    readonly href: string;
+    readonly target: string;
 }
 
 export type SpecialLink = SimpleSpecialLink | GroupedSpecialLink;
 
 export interface GroupedMergeTag {
-  readonly name: string;
-  readonly mergeTags: Array<SimpleMergeTag | GroupedMergeTag>;
+    readonly name: string;
+    readonly mergeTags: Array<SimpleMergeTag | GroupedMergeTag>;
 }
 
 export interface SimpleMergeTag {
-  readonly name: string;
-  readonly value: string;
-  readonly sample?: string;
+    readonly name: string;
+    readonly value: string;
+    readonly sample?: string;
 }
 
 export interface ConditionalMergeTagRule {
-  readonly name: string;
-  readonly before: string;
-  readonly after: string;
+    readonly name: string;
+    readonly before: string;
+    readonly after: string;
 }
 
 export interface ConditionalMergeTag {
-  readonly name: string;
-  readonly rules: ConditionalMergeTagRule[];
-  readonly mergeTags?: SimpleMergeTag[] | undefined;
+    readonly name: string;
+    readonly rules: ConditionalMergeTagRule[];
+    readonly mergeTags?: SimpleMergeTag[] | undefined;
 }
 
 export type MergeTag = SimpleMergeTag | ConditionalMergeTag | GroupedMergeTag;
 
 export interface DesignTagConfig {
-  readonly delimiter: [string, string];
+    readonly delimiter: [string, string];
 }
 
 export interface DisplayCondition {
-  readonly type: string;
-  readonly label: string;
-  readonly description: string;
-  readonly before: string;
-  readonly after: string;
+    readonly type: string;
+    readonly label: string;
+    readonly description: string;
+    readonly before: string;
+    readonly after: string;
 }
 
 export type EmptyDisplayCondition = object;
 
 export interface ToolPropertiesConfig {
-  readonly [key: string]: { value: string }
+    readonly [key: string]: { value: string };
 }
 
 export interface ToolConfig {
-  readonly enabled?: boolean | undefined;
-  readonly position?: number | undefined;
-  readonly properties?: ToolPropertiesConfig | StringList | undefined;
+    readonly enabled?: boolean | undefined;
+    readonly position?: number | undefined;
+    readonly properties?: ToolPropertiesConfig | StringList | undefined;
 }
 
 export interface ToolsConfig {
-  readonly [key: string]: ToolConfig;
+    readonly [key: string]: ToolConfig;
 }
 
 export interface EditorConfig {
-  readonly minRows?: number | undefined;
-  readonly maxRows?: number | undefined;
+    readonly minRows?: number | undefined;
+    readonly maxRows?: number | undefined;
 }
 
 export interface Features {
-  readonly preview?: boolean | undefined;
-  readonly imageEditor?: boolean | undefined;
-  readonly undoRedo?: boolean | undefined;
-  readonly stockImages?: boolean | undefined;
-  readonly textEditor?: TextEditor | undefined;
+    readonly preview?: boolean | undefined;
+    readonly imageEditor?: boolean | undefined;
+    readonly undoRedo?: boolean | undefined;
+    readonly stockImages?: boolean | undefined;
+    readonly textEditor?: TextEditor | undefined;
 }
 
 export interface TextEditor {
-  readonly spellChecker?: boolean | undefined;
-  readonly tables?: boolean | undefined;
-  readonly cleanPaste?: boolean | undefined;
-  readonly emojis?: boolean | undefined;
+    readonly spellChecker?: boolean | undefined;
+    readonly tables?: boolean | undefined;
+    readonly cleanPaste?: boolean | undefined;
+    readonly emojis?: boolean | undefined;
 }
 
 export type Translations = Record<string, Record<string, string>>;
 
 export type DisplayMode = 'email' | 'web';
 export interface UnlayerOptions {
-  readonly id?: string | undefined;
-  readonly displayMode?: DisplayMode | undefined;
-  readonly projectId?: number | undefined;
-  readonly locale?: string | undefined;
-  readonly appearance?: AppearanceConfig | undefined;
-  readonly user?: User | undefined;
-  readonly mergeTags?: MergeTag[] | undefined;
-  readonly specialLinks?: SpecialLink[] | undefined;
-  readonly designTags?: StringList | undefined;
-  readonly designTagsConfig?: DesignTagConfig | undefined;
-  readonly tools?: ToolsConfig | undefined;
-  readonly blocks?: object[] | undefined;
-  readonly editor?: EditorConfig | undefined;
-  readonly safeHtml?: boolean | undefined;
-  readonly customJS?: string[] | undefined;
-  readonly customCSS?: string[] | undefined;
-  readonly features?: Features | undefined;
-  readonly translations?: Translations | undefined;
-  readonly displayConditions?: DisplayCondition[] | undefined;
+    readonly id?: string | undefined;
+    readonly displayMode?: DisplayMode | undefined;
+    readonly projectId?: number | undefined;
+    readonly locale?: string | undefined;
+    readonly appearance?: AppearanceConfig | undefined;
+    readonly user?: User | undefined;
+    readonly mergeTags?: MergeTag[] | undefined;
+    readonly specialLinks?: SpecialLink[] | undefined;
+    readonly designTags?: StringList | undefined;
+    readonly designTagsConfig?: DesignTagConfig | undefined;
+    readonly tools?: ToolsConfig | undefined;
+    readonly blocks?: object[] | undefined;
+    readonly editor?: EditorConfig | undefined;
+    readonly safeHtml?: boolean | undefined;
+    readonly customJS?: string[] | undefined;
+    readonly customCSS?: string[] | undefined;
+    readonly features?: Features | undefined;
+    readonly translations?: Translations | undefined;
+    readonly displayConditions?: DisplayCondition[] | undefined;
 }
 
 export interface EmailEditorProps {
-  readonly style?: CSSProperties | undefined;
-  readonly minHeight?: number | string | undefined;
-  readonly options?: UnlayerOptions | undefined;
-  readonly tools?: ToolsConfig | undefined;
-  readonly appearance?: AppearanceConfig | undefined;
-  readonly projectId?: number | undefined;
-  /** @deprecated Use **onReady** instead */
-  onLoad?(): void;
-  onReady?(): void;
+    readonly style?: CSSProperties | undefined;
+    readonly minHeight?: number | string | undefined;
+    readonly options?: UnlayerOptions | undefined;
+    readonly tools?: ToolsConfig | undefined;
+    readonly appearance?: AppearanceConfig | undefined;
+    readonly projectId?: number | undefined;
+    /** @deprecated Use **onReady** instead */
+    onLoad?(): void;
+    onReady?(): void;
 }
 
 export interface HtmlExport {
-  readonly design: Design;
-  readonly html: string;
+    readonly design: Design;
+    readonly html: string;
 }
 
 export interface FileInfo {
-  readonly accepted: File[];
-  readonly attachments: File[];
+    readonly accepted: File[];
+    readonly attachments: File[];
 }
 
 export interface FileUploadDoneData {
-  readonly progress: number;
-  readonly url?: string | undefined;
+    readonly progress: number;
+    readonly url?: string | undefined;
 }
 
 export interface Design {
-  readonly counters?: object | undefined;
-  readonly body: {
-    readonly rows: object[];
-    readonly values?: object | undefined;
-  };
+    readonly counters?: object | undefined;
+    readonly body: {
+        readonly rows: object[];
+        readonly values?: object | undefined;
+    };
 }
 
 export type SaveDesignCallback = (data: Design) => void;
@@ -177,21 +181,24 @@ export type FileUploadCallback = (file: FileInfo, done: FileUploadDoneCallback) 
 export type FileUploadDoneCallback = (data: FileUploadDoneData) => void;
 
 export type DisplayConditionDoneCallback = (data: DisplayCondition | null) => void;
-export type DisplayConditionCallback = (data: DisplayCondition | EmptyDisplayCondition, done: DisplayConditionDoneCallback) => void;
+export type DisplayConditionCallback = (
+    data: DisplayCondition | EmptyDisplayCondition,
+    done: DisplayConditionDoneCallback,
+) => void;
 
 export default class Component extends ReactComponent<EmailEditorProps> {
-  private unlayerReady(): void;
-  registerCallback(type: 'image', callback: FileUploadCallback): void;
-  registerCallback(type: 'displayCondition', callback: DisplayConditionCallback): void;
-  addEventListener(type: string, callback: EventCallback): void;
-  loadDesign(design: Design): void;
-  saveDesign(callback: SaveDesignCallback): void;
-  exportHtml(callback: ExportHtmlCallback): void;
-  setMergeTags(mergeTags: ReadonlyArray<MergeTag>): void;
+    private unlayerReady(): void;
+    registerCallback(type: 'image', callback: FileUploadCallback): void;
+    registerCallback(type: 'displayCondition', callback: DisplayConditionCallback): void;
+    addEventListener(type: string, callback: EventCallback): void;
+    loadDesign(design: Design): void;
+    saveDesign(callback: SaveDesignCallback): void;
+    exportHtml(callback: ExportHtmlCallback): void;
+    setMergeTags(mergeTags: ReadonlyArray<MergeTag>): void;
 }
 
-export { };
+export {};
 
 interface StringList {
-  [key: string]: string;
+    [key: string]: string;
 }

--- a/types/react-email-editor/index.d.ts
+++ b/types/react-email-editor/index.d.ts
@@ -10,160 +10,164 @@ import { Component as ReactComponent, CSSProperties } from 'react';
 export type ThemeColor = 'light' | 'dark';
 export type DockPosition = 'right' | 'left';
 export interface AppearanceConfig {
-    readonly theme?: ThemeColor | undefined;
-    readonly panels?: {
-        readonly tools?: {
-            readonly dock: DockPosition;
-        } | undefined;
+  readonly theme?: ThemeColor | undefined;
+  readonly panels?: {
+    readonly tools?: {
+      readonly dock: DockPosition;
     } | undefined;
+  } | undefined;
 }
 
 export interface User {
-    readonly id?: number | undefined;
-    readonly name?: string | undefined;
-    readonly email?: string | undefined;
+  readonly id?: number | undefined;
+  readonly name?: string | undefined;
+  readonly email?: string | undefined;
 }
 
 export interface GroupedSpecialLink {
-    readonly name: string;
-    readonly specialLinks: Array<SimpleSpecialLink | GroupedSpecialLink>;
+  readonly name: string;
+  readonly specialLinks: Array<SimpleSpecialLink | GroupedSpecialLink>;
 }
 
 export interface SimpleSpecialLink {
-    readonly name: string;
-    readonly href: string;
-    readonly target: string;
+  readonly name: string;
+  readonly href: string;
+  readonly target: string;
 }
 
 export type SpecialLink = SimpleSpecialLink | GroupedSpecialLink;
 
 export interface GroupedMergeTag {
-    readonly name: string;
-    readonly mergeTags: Array<SimpleMergeTag | GroupedMergeTag>;
+  readonly name: string;
+  readonly mergeTags: Array<SimpleMergeTag | GroupedMergeTag>;
 }
 
 export interface SimpleMergeTag {
-    readonly name: string;
-    readonly value: string;
-    readonly sample?: string;
+  readonly name: string;
+  readonly value: string;
+  readonly sample?: string;
 }
 
 export interface ConditionalMergeTagRule {
-    readonly name: string;
-    readonly before: string;
-    readonly after: string;
+  readonly name: string;
+  readonly before: string;
+  readonly after: string;
 }
 
 export interface ConditionalMergeTag {
-    readonly name: string;
-    readonly rules: ConditionalMergeTagRule[];
-    readonly mergeTags?: SimpleMergeTag[] | undefined;
+  readonly name: string;
+  readonly rules: ConditionalMergeTagRule[];
+  readonly mergeTags?: SimpleMergeTag[] | undefined;
 }
 
 export type MergeTag = SimpleMergeTag | ConditionalMergeTag | GroupedMergeTag;
 
 export interface DesignTagConfig {
-    readonly delimiter: [string, string];
+  readonly delimiter: [string, string];
 }
 
 export interface DisplayCondition {
-    readonly type: string;
-    readonly label: string;
-    readonly description: string;
-    readonly before: string;
-    readonly after: string;
+  readonly type: string;
+  readonly label: string;
+  readonly description: string;
+  readonly before: string;
+  readonly after: string;
 }
 
 export type EmptyDisplayCondition = object;
 
+export interface ToolPropertiesConfig {
+  readonly [key: string]: { value: string }
+}
+
 export interface ToolConfig {
-    readonly enabled?: boolean | undefined;
-    readonly position?: number | undefined;
-    readonly data?: StringList | undefined;
+  readonly enabled?: boolean | undefined;
+  readonly position?: number | undefined;
+  readonly properties?: ToolPropertiesConfig | StringList | undefined;
 }
 
 export interface ToolsConfig {
-    readonly [key: string]: ToolConfig;
+  readonly [key: string]: ToolConfig;
 }
 
 export interface EditorConfig {
-    readonly minRows?: number | undefined;
-    readonly maxRows?: number | undefined;
+  readonly minRows?: number | undefined;
+  readonly maxRows?: number | undefined;
 }
 
 export interface Features {
-    readonly preview?: boolean | undefined;
-    readonly imageEditor?: boolean | undefined;
-    readonly undoRedo?: boolean | undefined;
-    readonly stockImages?: boolean | undefined;
-    readonly textEditor?: TextEditor | undefined;
+  readonly preview?: boolean | undefined;
+  readonly imageEditor?: boolean | undefined;
+  readonly undoRedo?: boolean | undefined;
+  readonly stockImages?: boolean | undefined;
+  readonly textEditor?: TextEditor | undefined;
 }
 
 export interface TextEditor {
-    readonly spellChecker?: boolean | undefined;
-    readonly tables?: boolean | undefined;
-    readonly cleanPaste?: boolean | undefined;
-    readonly emojis?: boolean | undefined;
+  readonly spellChecker?: boolean | undefined;
+  readonly tables?: boolean | undefined;
+  readonly cleanPaste?: boolean | undefined;
+  readonly emojis?: boolean | undefined;
 }
 
 export type Translations = Record<string, Record<string, string>>;
 
 export type DisplayMode = 'email' | 'web';
 export interface UnlayerOptions {
-    readonly id?: string | undefined;
-    readonly displayMode?: DisplayMode | undefined;
-    readonly projectId?: number | undefined;
-    readonly locale?: string | undefined;
-    readonly appearance?: AppearanceConfig | undefined;
-    readonly user?: User | undefined;
-    readonly mergeTags?: MergeTag[] | undefined;
-    readonly specialLinks?: SpecialLink[] | undefined;
-    readonly designTags?: StringList | undefined;
-    readonly designTagsConfig?: DesignTagConfig | undefined;
-    readonly tools?: ToolsConfig | undefined;
-    readonly blocks?: object[] | undefined;
-    readonly editor?: EditorConfig | undefined;
-    readonly safeHtml?: boolean | undefined;
-    readonly customJS?: string[] | undefined;
-    readonly customCSS?: string[] | undefined;
-    readonly features?: Features | undefined;
-    readonly translations?: Translations | undefined;
-    readonly displayConditions?: DisplayCondition[] | undefined;
+  readonly id?: string | undefined;
+  readonly displayMode?: DisplayMode | undefined;
+  readonly projectId?: number | undefined;
+  readonly locale?: string | undefined;
+  readonly appearance?: AppearanceConfig | undefined;
+  readonly user?: User | undefined;
+  readonly mergeTags?: MergeTag[] | undefined;
+  readonly specialLinks?: SpecialLink[] | undefined;
+  readonly designTags?: StringList | undefined;
+  readonly designTagsConfig?: DesignTagConfig | undefined;
+  readonly tools?: ToolsConfig | undefined;
+  readonly blocks?: object[] | undefined;
+  readonly editor?: EditorConfig | undefined;
+  readonly safeHtml?: boolean | undefined;
+  readonly customJS?: string[] | undefined;
+  readonly customCSS?: string[] | undefined;
+  readonly features?: Features | undefined;
+  readonly translations?: Translations | undefined;
+  readonly displayConditions?: DisplayCondition[] | undefined;
 }
 
 export interface EmailEditorProps {
-    readonly style?: CSSProperties | undefined;
-    readonly minHeight?: number | string | undefined;
-    readonly options?: UnlayerOptions | undefined;
-    readonly tools?: ToolsConfig | undefined;
-    readonly appearance?: AppearanceConfig | undefined;
-    readonly projectId?: number | undefined;
-    /** @deprecated Use **onReady** instead */
-    onLoad?(): void;
-    onReady?(): void;
+  readonly style?: CSSProperties | undefined;
+  readonly minHeight?: number | string | undefined;
+  readonly options?: UnlayerOptions | undefined;
+  readonly tools?: ToolsConfig | undefined;
+  readonly appearance?: AppearanceConfig | undefined;
+  readonly projectId?: number | undefined;
+  /** @deprecated Use **onReady** instead */
+  onLoad?(): void;
+  onReady?(): void;
 }
 
 export interface HtmlExport {
-    readonly design: Design;
-    readonly html: string;
+  readonly design: Design;
+  readonly html: string;
 }
 
 export interface FileInfo {
-    readonly accepted: File[];
-    readonly attachments: File[];
+  readonly accepted: File[];
+  readonly attachments: File[];
 }
 
 export interface FileUploadDoneData {
-    readonly progress: number;
-    readonly url?: string | undefined;
+  readonly progress: number;
+  readonly url?: string | undefined;
 }
 
 export interface Design {
-    readonly counters?: object | undefined;
-    readonly body: {
-        readonly rows: object[];
-        readonly values?: object | undefined;
-    };
+  readonly counters?: object | undefined;
+  readonly body: {
+    readonly rows: object[];
+    readonly values?: object | undefined;
+  };
 }
 
 export type SaveDesignCallback = (data: Design) => void;
@@ -176,18 +180,18 @@ export type DisplayConditionDoneCallback = (data: DisplayCondition | null) => vo
 export type DisplayConditionCallback = (data: DisplayCondition | EmptyDisplayCondition, done: DisplayConditionDoneCallback) => void;
 
 export default class Component extends ReactComponent<EmailEditorProps> {
-    private unlayerReady(): void;
-    registerCallback(type: 'image', callback: FileUploadCallback): void;
-    registerCallback(type: 'displayCondition', callback: DisplayConditionCallback): void;
-    addEventListener(type: string, callback: EventCallback): void;
-    loadDesign(design: Design): void;
-    saveDesign(callback: SaveDesignCallback): void;
-    exportHtml(callback: ExportHtmlCallback): void;
-    setMergeTags(mergeTags: ReadonlyArray<MergeTag>): void;
+  private unlayerReady(): void;
+  registerCallback(type: 'image', callback: FileUploadCallback): void;
+  registerCallback(type: 'displayCondition', callback: DisplayConditionCallback): void;
+  addEventListener(type: string, callback: EventCallback): void;
+  loadDesign(design: Design): void;
+  saveDesign(callback: SaveDesignCallback): void;
+  exportHtml(callback: ExportHtmlCallback): void;
+  setMergeTags(mergeTags: ReadonlyArray<MergeTag>): void;
 }
 
-export {};
+export { };
 
 interface StringList {
-    [key: string]: string;
+  [key: string]: string;
 }

--- a/types/react-email-editor/react-email-editor-tests.tsx
+++ b/types/react-email-editor/react-email-editor-tests.tsx
@@ -1,24 +1,36 @@
 import * as React from 'react';
 import EmailEditor, {
-    Design,
-    FileInfo,
-    FileUploadDoneCallback,
-    HtmlExport,
-    SimpleMergeTag,
-    GroupedMergeTag,
-    ConditionalMergeTag, DisplayCondition, EmptyDisplayCondition, DisplayConditionDoneCallback,
-    SimpleSpecialLink,
-    GroupedSpecialLink
+  ConditionalMergeTag,
+  Design,
+  DisplayCondition,
+  DisplayConditionDoneCallback,
+  EmptyDisplayCondition,
+  FileInfo,
+  FileUploadDoneCallback,
+  GroupedMergeTag,
+  GroupedSpecialLink,
+  HtmlExport,
+  SimpleMergeTag,
+  SimpleSpecialLink
 } from 'react-email-editor';
 
 const TOOLS_CONFIG = {
   image: {
     enabled: true,
     position: 1,
-    data: {
-      alt: 'this is a test alt text',
-    },
+    properties: {
+      altText: {
+        value: "Image"
+      }
+    }
   },
+  heading: {
+    properties: {
+      text: {
+        value: 'This is a different heading'
+      }
+    }
+  }
 };
 
 const simpleMergeTag: SimpleMergeTag = { value: '{{simple_merge_tag}}', name: 'Simple Merge Tag' };
@@ -30,7 +42,7 @@ const groupedMergeTag: GroupedMergeTag = {
       name: 'Tag 2',
       mergeTags: [{ name: 'Tag 4', value: '{tag_4}' }]
     },
-    { name: 'Tag 3', value: '{tag_3}', sample: 'sample value'},
+    { name: 'Tag 3', value: '{tag_3}', sample: 'sample value' },
   ],
 };
 const conditionalMergeTag: ConditionalMergeTag = {
@@ -83,7 +95,7 @@ class App extends React.Component {
       );
       this.editorRef.current.registerCallback(
         'displayCondition',
-         (data: DisplayCondition | EmptyDisplayCondition, done: DisplayConditionDoneCallback) => done(null),
+        (data: DisplayCondition | EmptyDisplayCondition, done: DisplayConditionDoneCallback) => done(null),
       );
       this.editorRef.current.registerCallback(
         'displayCondition',
@@ -96,9 +108,9 @@ class App extends React.Component {
         }),
       );
       this.editorRef.current.setMergeTags([
-          simpleMergeTag,
-          groupedMergeTag,
-          conditionalMergeTag
+        simpleMergeTag,
+        groupedMergeTag,
+        conditionalMergeTag
       ]);
     }
   }


### PR DESCRIPTION
Updated `ToolConfig` in `react-email-editor/index.d.ts` 


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Unlayer Documentations for Tools does not contain `data`](https://docs.unlayer.com/docs/heading) also inside nested `properties` contains `{value: string}` object
