### PR TITLE
web-bluetooth: remove non-existant method unwatchAdvertisements 

### DIFF
--- a/types/web-bluetooth/index.d.ts
+++ b/types/web-bluetooth/index.d.ts
@@ -151,7 +151,6 @@ interface BluetoothDevice extends EventTarget, BluetoothDeviceEventHandlers, Cha
     readonly gatt?: BluetoothRemoteGATTServer | undefined;
     forget(): Promise<void>;
     watchAdvertisements(options?: WatchAdvertisementsOptions): Promise<void>;
-    unwatchAdvertisements(): void;
     readonly watchingAdvertisements: boolean;
     addEventListener(type: "gattserverdisconnected", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "advertisementreceived", listener: (this: this, ev: BluetoothAdvertisingEvent) => any, useCapture?: boolean): void;


### PR DESCRIPTION
The BluetoothDevice.unwatchAdvertisements property is not part of the specification: https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdevice-interface. It was removed from the spec here: [Use AbortController for watchAdvertisements() #480](https://github.com/WebBluetoothCG/web-bluetooth/pull/480)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdevice-interface)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
