### PR TITLE
Making OpenGraphImage height and width optional

### DIFF
--- a/types/open-graph-scraper/index.d.ts
+++ b/types/open-graph-scraper/index.d.ts
@@ -109,7 +109,7 @@ declare namespace run {
         ogDescription?: string | undefined;
         ogDeterminer?: string | undefined;
         ogImage?: string | undefined;
-        ogImageHeight?: string | undefined ;
+        ogImageHeight?: string | undefined;
         ogImageSecureURL?: string | undefined;
         ogImageType?: string | undefined;
         ogImageURL?: string | undefined;

--- a/types/open-graph-scraper/index.d.ts
+++ b/types/open-graph-scraper/index.d.ts
@@ -9,10 +9,10 @@ import { PassThrough } from 'stream';
 
 declare namespace run {
     interface OpenGraphImage {
-        height: string;
+        height: string | null;
         type: string;
         url: string;
-        width: string;
+        width: string | null;
     }
 
     interface OpenGraphProperties {
@@ -109,7 +109,7 @@ declare namespace run {
         ogDescription?: string | undefined;
         ogDeterminer?: string | undefined;
         ogImage?: string | undefined;
-        ogImageHeight?: string | undefined;
+        ogImageHeight?: string | undefined ;
         ogImageSecureURL?: string | undefined;
         ogImageType?: string | undefined;
         ogImageURL?: string | undefined;

--- a/types/open-graph-scraper/index.d.ts
+++ b/types/open-graph-scraper/index.d.ts
@@ -9,6 +9,8 @@ import { PassThrough } from 'stream';
 
 declare namespace run {
     interface OpenGraphImage {
+        // Height and Width can be optional, see doc on
+        // https://github.com/jshemas/openGraphScraper/blob/master/lib/media.js
         height?: string;
         type: string;
         url: string;

--- a/types/open-graph-scraper/index.d.ts
+++ b/types/open-graph-scraper/index.d.ts
@@ -9,10 +9,10 @@ import { PassThrough } from 'stream';
 
 declare namespace run {
     interface OpenGraphImage {
-        height: string | null;
+        height?: string;
         type: string;
         url: string;
-        width: string | null;
+        width?: string;
     }
 
     interface OpenGraphProperties {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Closes #62675

Height and Width can be optional, see doc on
https://github.com/jshemas/openGraphScraper/blob/master/lib/media.js
