### PR TITLE
[appium-adb] Fix parameter type in waitForEmulatorReady method.

### DIFF
--- a/types/appium-adb/appium-adb-tests.ts
+++ b/types/appium-adb/appium-adb-tests.ts
@@ -115,5 +115,6 @@ adb.powerAC(adb.POWER_AC_STATES.POWER_AC_ON);
 let devices = adb.getConnectedDevices();
 const verboseDevices: Promise<VerboseDevice[]> = adb.getConnectedDevices({ verbose: true });
 devices = verboseDevices;
+adb.waitForEmulatorReady(60000);
 
 const copy: ADB = adb.clone();

--- a/types/appium-adb/lib/tools/system-calls.d.ts
+++ b/types/appium-adb/lib/tools/system-calls.d.ts
@@ -390,7 +390,7 @@ interface SystemCalls {
      * @param timeoutMs [20000] - The maximum number of milliseconds to wait.
      * @throws If the emulator is not ready within the given timeout.
      */
-    waitForEmulatorReady(timeoutMs?: string): Promise<void>;
+    waitForEmulatorReady(timeoutMs?: number): Promise<void>;
 
     /**
      * Check if the current device is ready to accept further commands (booting completed).


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: J[SDoc for method](https://github.com/appium/appium-adb/blob/034e141a39524ce603f6c2311d96c943254e20c5/lib/tools/system-calls.js#L951)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
