### PR TITLE
[debounce-promise] Allow `wait` to accept a function

### DIFF
--- a/types/debounce-promise/debounce-promise-tests.ts
+++ b/types/debounce-promise/debounce-promise-tests.ts
@@ -6,9 +6,13 @@ const optionsA: DebounceOptions = { leading: true };
 const f = async () => 2;
 const f2 = (a: string) => 2;
 debounce(f, 100);
+debounce(f, () => 100);
 debounce(f, 0, options);
+debounce(f, () => 0, options);
 debounce(f, 100, optionsA);
+debounce(f, () => 100, optionsA);
 debounce(f, 10, { accumulate: true });
+debounce(f, () => 10, { accumulate: true });
 const foo = debounce(async () => f2, 10, {
     leading: true,
     accumulate: true

--- a/types/debounce-promise/index.d.ts
+++ b/types/debounce-promise/index.d.ts
@@ -12,7 +12,7 @@ declare namespace debounce {
 
 declare function debounce<T extends (...args: any[]) => any>(
     func: T,
-    wait?: number,
+    wait?: number | (() => number),
     options?: debounce.DebounceOptions
 ): (
     ...args: Parameters<T>


### PR DESCRIPTION
This is documented as a feature supported by the debounce-promise API:

> Supports passing a function as the `wait` parameter, which provides a
> way to lazily or dynamically define a wait timeout.

https://github.com/bjoerge/debounce-promise#api

To confirm, we can see in the code that `wait` can be a function here:

https://github.com/bjoerge/debounce-promise/blob/d85e8d12/index.js#L55-L57

Finally, we can see that this functionality is verified by a test:

https://github.com/bjoerge/debounce-promise/blob/d85e8d12/test/index.js#L67-L82

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bjoerge/debounce-promise#api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

