### PR TITLE
fix: heremaps linecap options. Closes #62032

### DIFF
--- a/types/heremaps/heremaps-tests.ts
+++ b/types/heremaps/heremaps-tests.ts
@@ -240,3 +240,11 @@ const reader = new H.data.geojson.Reader('data/berlin.json', {
         }
     }
 });
+
+// Test https://developer.here.com/documentation/maps/3.1.3.0/dev_guide/topics_api/h-map-spatialstyle-linecap.html
+new H.map.Circle(position, 35)
+    .setStyle({ lineCap: 'butt' })
+    .setStyle({ lineCap: 'round' })
+    .setStyle({ lineCap: 'square' })
+    .setStyle({ lineCap: 'arrow-head' })
+    .setStyle({ lineCap: 'arrow-tail' });

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -2923,9 +2923,9 @@ declare namespace H {
 
         namespace SpatialStyle {
             /**
-             * The style of the end caps for a line, one of 'butt', 'round' or 'square'.
+             * The style of the end caps for a line, one of 'butt', 'round', 'square', 'arrow-head' or 'arrow-tail'.
              */
-            type LineCap = 'butt' | 'round' | 'square';
+            type LineCap = 'butt' | 'round' | 'square' | 'arrow-head' | 'arrow-tail';
 
             /**
              * The type of corner created, when two lines meet, one of 'round', 'bevel' or 'miter'.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.here.com/documentation/maps/3.1.3.0/dev_guide/topics_api/h-map-spatialstyle-linecap.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Closes #62032
