### PR TITLE
Add back JSON assertion to support-window script

### DIFF
--- a/.github/workflows/support-window.yml
+++ b/.github/workflows/support-window.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - .github/workflows/support-window.yml
       - package.json
-      - scripts/support-window.ts
+      - scripts/support-window.js
       - scripts/jsconfig.json
   # Manually, when TypeScript is released
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

--- a/scripts/support-window.js
+++ b/scripts/support-window.js
@@ -6,7 +6,7 @@ import { utcYear } from "d3-time";
 import { utcFormat } from "d3-time-format";
 import { JSDOM } from "jsdom";
 import serialize from "w3c-xmlserializer";
-import data from "../docs/support-window.json";
+import data from "../docs/support-window.json" assert { type: "json" };
 
 const width = 640;
 const height = 250;


### PR DESCRIPTION
Undoes a problematic change from #62526.

Also updates another path in the `support-window.yml` file that I didn't see in the last PR.
