### PR TITLE
fix(jsdom): reference `dom.iterable` lib in source

### DIFF
--- a/types/jsdom/base.d.ts
+++ b/types/jsdom/base.d.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 /// <reference types="node" />
 
 import { EventEmitter } from "events";

--- a/types/jsdom/jsdom-tests.ts
+++ b/types/jsdom/jsdom-tests.ts
@@ -28,3 +28,5 @@ domWindow.FinalizationRegistry; // $ExpectType FinalizationRegistryConstructor
 domWindow.WeakRef; // $ExpectType WeakRefConstructor
 
 dom.nodeLocation(domWindow.document.createElement('br')); // $ExpectType Location | null | undefined
+
+const childNodesArray = [...(domWindow.document.getElementById('parent')?.childNodes || [])]; // $ExpectType ChildNode[]

--- a/types/jsdom/tsconfig.json
+++ b/types/jsdom/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": ["ESNext"],
+        "target": "ES2015",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,


### PR DESCRIPTION
This is similar to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57432

`jsdom` has supported iterable APIs as early as v6.5.0 https://github.com/jsdom/jsdom/blob/6.5.0/Changelog.md#650

So `dom.iterable` *should* be added alongside the `dom` lib.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The bug was originally found by a Vue.js & Vitest user, @segevfiner, that the following line couldn't pass type-checking with `jsdom` types:
https://github.com/segevfiner/create-vue-159/blob/main/src/App.vue#L9
(Originally posted at https://github.com/vuejs/create-vue/issues/159#issuecomment-1264668341)