### PR TITLE
[jest] add `jest.Spied*` utility types

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -26,6 +26,7 @@
 //                 Pawel Fajfer <https://github.com/pawfa>
 //                 Alexandre Germain <https://github.com/gerkindev>
 //                 Adam Jones <https://github.com/domdomegg>
+//                 Tom Mrazauskas <https://github.com/mrazauskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.3
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -389,17 +389,17 @@ declare namespace jest {
         : Value extends Func
         ? SpyInstance<ReturnType<Value>, ArgsType<Value>>
         : never;
-    function spyOn<T extends {}, M extends FunctionPropertyNames<Required<T>>>(
-        object: T,
-        method: M,
-    ): FunctionProperties<Required<T>>[M] extends Func
-        ? SpyInstance<ReturnType<FunctionProperties<Required<T>>[M]>, ArgsType<FunctionProperties<Required<T>>[M]>>
-        : never;
     function spyOn<T extends {}, M extends ConstructorPropertyNames<Required<T>>>(
         object: T,
         method: M,
     ): Required<T>[M] extends new (...args: any[]) => any
         ? SpyInstance<InstanceType<Required<T>[M]>, ConstructorArgsType<Required<T>[M]>>
+        : never;
+    function spyOn<T extends {}, M extends FunctionPropertyNames<Required<T>>>(
+        object: T,
+        method: M,
+    ): FunctionProperties<Required<T>>[M] extends Func
+        ? SpyInstance<ReturnType<FunctionProperties<Required<T>>[M]>, ArgsType<FunctionProperties<Required<T>>[M]>>
         : never;
     /**
      * Indicates that the module system should never return a mocked version of
@@ -1166,9 +1166,38 @@ declare namespace jest {
     interface SpyInstance<T = any, Y extends any[] = any> extends MockInstance<T, Y> {}
 
     /**
-     * Represents a function that has been spied on.
+     * Constructs the type of a spied class.
      */
-    type SpiedFunction<T extends (...args: any[]) => any> = SpyInstance<ReturnType<T>, ArgsType<T>>;
+    type SpiedClass<T extends abstract new (...args: any) => any> = SpyInstance<
+        InstanceType<T>,
+        ConstructorParameters<T>
+    >;
+
+    /**
+     * Constructs the type of a spied function.
+     */
+    type SpiedFunction<T extends (...args: any) => any> = SpyInstance<ReturnType<T>, ArgsType<T>>;
+
+    /**
+     * Constructs the type of a spied getter.
+     */
+    type SpiedGetter<T> = SpyInstance<T, []>;
+
+    /**
+     * Constructs the type of a spied setter.
+     */
+    type SpiedSetter<T> = SpyInstance<void, [T]>;
+
+    /**
+     * Constructs the type of a spied class or function.
+     */
+    type Spied<T extends (abstract new (...args: any) => any) | ((...args: any) => any)> = T extends abstract new (
+        ...args: any
+    ) => any
+        ? SpiedClass<T>
+        : T extends (...args: any) => any
+        ? SpiedFunction<T>
+        : never;
 
     /**
      * Wrap a function with mock definitions

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -674,6 +674,21 @@ jest.spyOn(spyWithIndexSignatureImpl, 'prop');
 // $ExpectType SpyInstance<{ some: string; }, []>
 jest.spyOn(spyWithIndexSignatureImpl, 'prop', 'get');
 
+let typedSpy: jest.Spied<typeof spiedTarget.returnsVoid>;
+typedSpy = jest.spyOn(spiedTarget, 'returnsVoid');
+
+let typedSpy1: jest.SpiedClass<typeof globalThis.Date>;
+typedSpy1 = jest.spyOn(globalThis, 'Date');
+
+let typedSpy2: jest.SpiedFunction<typeof spiedTarget.setValue>;
+typedSpy2 = jest.spyOn(spiedTarget, 'setValue');
+
+let typedSpy3: jest.SpiedGetter<typeof spiedTarget2.value>;
+typedSpy3 = jest.spyOn(spiedTarget2, 'value', 'get');
+
+let typedSpy4: jest.SpiedSetter<typeof spiedTarget2.value>;
+typedSpy4 = jest.spyOn(spiedTarget2, 'value', 'set');
+
 // $ExpectType MockedObjectDeep<{}>
 jest.mocked({});
 // $ExpectType MockedObjectDeep<{}>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/pull/13440

### Summary

Jest [v29.2.1](https://github.com/facebook/jest/releases/tag/v29.2.1) just got released with `jest.Spied*` utility types, which were added in https://github.com/facebook/jest/pull/13440. I adapted typings from this PR and added tests.