### PR TITLE
@ember/controller: remove non-public-API exports

### DIFF
--- a/types/ember__controller/index.d.ts
+++ b/types/ember__controller/index.d.ts
@@ -26,7 +26,7 @@ interface QueryParamConfig {
 /**
  * Additional methods for the Controller.
  */
-export interface ControllerMixin extends ActionHandler {
+interface ControllerMixin extends ActionHandler {
     /**
      * @deprecated until 5.0. Use `RouterService.reaplceWith` instead.
      */
@@ -43,17 +43,20 @@ export interface ControllerMixin extends ActionHandler {
     queryParams: Array<string | Record<string, QueryParamConfig | string | undefined>>;
     target: object;
 }
-export const ControllerMixin: Mixin<ControllerMixin>;
+
 export default class Controller extends EmberObject {}
 // tslint:disable-next-line:no-empty-interface -- used for declaration merge
 export default interface Controller extends ControllerMixin {}
+
 export function inject(): ComputedProperty<Controller>;
-export function inject<K extends keyof Registry>(
-    name: K
-): ComputedProperty<Registry[K]>;
+export function inject<K extends keyof Registry>(name: K): ComputedProperty<Registry[K]>;
 export function inject(target: object, propertyKey: string | symbol): void;
 
 // A type registry for Ember `Controller`s. Meant to be declaration-merged
 // so string lookups resolve to the correct type.
 // tslint:disable-next-line no-empty-interface
 export interface Registry {}
+
+// We need to define the `ControllerMixin` type above, but it is not public API
+// and should not be importable, so shut off auto-importing.
+export {};


### PR DESCRIPTION
The `ControllerMixin` type was required for internal details of how the class hierarchy is constructed, but is not public API and does not exist at runtime, so should not be importable. (See also https://github.com/emberjs/ember.js/pull/20228.)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~ Can't, because we're literally removing something which doesn't exist.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://api.emberjs.com/ember/4.7/modules/@ember%2Fcontroller> – note the lack of exports matching this
