### PR TITLE
[ramda] Update prop: allow to handle more variants of usage

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -74,6 +74,7 @@ import {
     IfFunctionsArgumentsDoNotOverlap,
     LargestArgumentsList,
     mergeArrWithLeft,
+    Prop,
 } from './tools';
 
 export * from './tools';
@@ -4353,10 +4354,22 @@ export function promap<A, B>(
  * R.compose(R.inc, R.prop<'x', number>('x'))({ x: 3 }) //=> 4
  * ```
  */
-export function prop<T>(__: Placeholder, obj: T): <P extends keyof T>(p: P) => T[P];
-export function prop<P extends keyof T, T>(p: P, obj: T): T[P];
-export function prop<P extends string>(p: P): <T>(obj: Record<P, T>) => T;
-export function prop<P extends string, T>(p: P): (obj: Record<P, T>) => T;
+export function prop<T>(__: Placeholder, value: T): {
+    <P extends keyof Exclude<T, undefined>>(p: P): Prop<T, P>;
+    <P extends keyof never>(p: P): Prop<T, P>;
+};
+export function prop<P extends keyof never, T>(__: Placeholder, value: T): (p: P) => Prop<T, P>;
+export function prop<P extends keyof never, T>(p: P, value: T): Prop<T, P>;
+export function prop<P extends keyof never>(p: P): {
+    <T>(value: Record<P, T>): T;
+    <T>(value: T): Prop<T, P>;
+};
+export function prop<P extends keyof T, T>(p: P): {
+    (value: T): Prop<T, P>;
+};
+export function prop<P extends keyof never, T>(p: P): {
+    (value: Record<P, T>): T;
+};
 
 // NOTE: `hair` property was added to `alois` to make example work.
 // A union of two types is a valid usecase but doesn't work with current types

--- a/types/ramda/test/indexBy-tests.ts
+++ b/types/ramda/test/indexBy-tests.ts
@@ -10,11 +10,11 @@ import * as R from 'ramda';
         { id: 'abc', title: 'B' },
     ];
     const a1 = R.indexBy(R.prop('id'), list);
-    // Typescript 3.3 incorrectly gives `a2: {}`, 3.4 gives an error instead.
-    // const a2 = R.indexBy(R.prop("id"))(list);
+    const a2 = R.indexBy(R.prop('id'))(list);
     const a3 = R.indexBy<{ id: string }>(R.prop('id'))(list);
     const a4 = R.indexBy(R.prop<'id', string>('id'))(list);
-    const a5 = R.indexBy<{ id: string }>(R.prop<'id', string>('id'))(list);
+    const a5 = R.indexBy(R.prop<'id', { id: string }>('id'))(list);
+    const a6 = R.indexBy<{ id: string }>(R.prop<'id', string>('id'))(list);
 };
 
 () => {

--- a/types/ramda/test/indexBy-tests.ts
+++ b/types/ramda/test/indexBy-tests.ts
@@ -13,8 +13,8 @@ import * as R from 'ramda';
     const a2 = R.indexBy(R.prop('id'))(list);
     const a3 = R.indexBy<{ id: string }>(R.prop('id'))(list);
     const a4 = R.indexBy(R.prop<'id', string>('id'))(list);
-    const a5 = R.indexBy(R.prop<'id', { id: string }>('id'))(list);
-    const a6 = R.indexBy<{ id: string }>(R.prop<'id', string>('id'))(list);
+    const a5 = R.indexBy<{ id: string }>(R.prop<'id', string>('id'))(list);
+    const a6 = R.indexBy(R.prop<'id', { id: string }>('id'))(list);
 };
 
 () => {

--- a/types/ramda/test/prop-tests.ts
+++ b/types/ramda/test/prop-tests.ts
@@ -1,25 +1,89 @@
 import * as R from 'ramda';
 
-() => {
-    const x = R.prop('x');
+function maybe<T>(value: T): T | undefined { return value; }
+
+() => { // get defined prop from obj
+    const obj = { x: 100 };
+    R.prop('x')(obj); // $ExpectType number
+    R.prop('x', obj); // $ExpectType number
+    R.prop(R.__, obj)('x'); // $ExpectType number
 };
 
-() => {
-    const x: number = R.prop('x', { x: 100 }); // => 100
-    const obj = {
-        str: 'string',
-        num: 5,
-    };
-
-    const strVal: string = R.prop('str', obj); // => 'string'
-    const numVal: number = R.prop('num', obj); // => 5
-
-    const strValPl: string = R.prop(R.__, obj)('str'); // => 'string'
-
-    const strValCur: string = R.prop('str')(obj); // => 'string'
-    const numValCur: number = R.prop('num')(obj); // => 5
+() => { // get defined typed prop from obj
+    const obj: { x: 100 } = { x: 100 };
+    R.prop('x')(obj); // $ExpectType 100
+    R.prop('x', obj); // $ExpectType 100
+    R.prop(R.__, obj)('x'); // $ExpectType 100
 };
 
-() => {
-    const favorite = R.prop('favoriteLibrary');
+() => { // get undefined prop from obj
+    const obj = { y: 100 };
+    R.prop('x')(obj); // $ExpectType undefined
+    R.prop('x', obj); // $ExpectType undefined
+    R.prop(R.__, obj)('x'); // $ExpectType undefined
+};
+
+() => { // get prop from undefined
+    R.prop('x')(undefined); // $ExpectType undefined
+    R.prop('x', undefined); // $ExpectType undefined
+    R.prop(R.__, undefined)('x'); // $ExpectType undefined
+};
+
+() => { // get prop from maybe obj
+    const obj = maybe({ x: 100 });
+    R.prop('x')(obj); // $ExpectType number | undefined
+    R.prop('x', obj); // $ExpectType number | undefined
+    R.prop(R.__, obj)('x'); // $ExpectType number | undefined
+};
+
+() => { // get first element from array
+    const array = [100, 200];
+    R.prop(0)(array); // $ExpectType number
+    R.prop(0, array); // $ExpectType number
+    R.prop(R.__, array)(0); // $ExpectType number
+};
+
+() => { // get first element from tuple
+    const tuple = [100, 200] as const;
+    R.prop(0)(tuple); // $ExpectType 100
+    R.prop(0, tuple); // $ExpectType 100
+    R.prop(R.__, tuple)(0); // $ExpectType 100
+};
+
+() => { // get overflow element from tuple
+    const tuple = [100, 200] as const;
+    R.prop(2)(tuple); // $ExpectType undefined
+    R.prop(2, tuple); // $ExpectType undefined
+    R.prop(R.__, tuple)(2); // $ExpectType undefined
+};
+
+() => { // get variadic element from tuple
+    const tuple = [100, '200'] as [number, ...string[]];
+    R.prop(2)(tuple); // $ExpectType string
+    R.prop(2, tuple); // $ExpectType string
+    R.prop(R.__, tuple)(2); // $ExpectType string
+};
+
+() => { // get first element from undefined
+    R.prop(0)(undefined); // $ExpectType undefined
+    R.prop(0, undefined); // $ExpectType undefined
+    R.prop(R.__, undefined)(0); // $ExpectType undefined
+};
+
+() => { // get prop from maybe array
+    const array = maybe([100, 200]);
+    R.prop(0)(array); // $ExpectType number | undefined
+    R.prop(0, array); // $ExpectType number | undefined
+    R.prop(R.__, array)(0); // $ExpectType number | undefined
+};
+
+() => { // pass types
+    const obj = { x: 100 };
+    R.prop<'x', { x: number }>('x')(obj); // $ExpectType number
+    R.prop<'x', number>('x')(obj); // $ExpectType number
+    R.prop<'x'>('x')<{ x: number }>(obj); // $ExpectType number
+    R.prop<'x'>('x')<number>(obj); // $ExpectType number
+    R.prop<'x', { x: number }>('x', obj); // $ExpectType number
+    R.prop<'x', { x: number }>(R.__, obj)('x'); // $ExpectType number
+    R.prop<{ x: number }>(R.__, obj)<'x'>('x'); // $ExpectType number
 };

--- a/types/ramda/test/prop-tests.ts
+++ b/types/ramda/test/prop-tests.ts
@@ -1,5 +1,29 @@
 import * as R from 'ramda';
 
+() => {
+    const x = R.prop('x');
+};
+
+() => {
+    const x: number = R.prop('x', { x: 100 }); // => 100
+    const obj = {
+        str: 'string',
+        num: 5,
+    };
+
+    const strVal: string = R.prop('str', obj); // => 'string'
+    const numVal: number = R.prop('num', obj); // => 5
+
+    const strValPl: string = R.prop(R.__, obj)('str'); // => 'string'
+
+    const strValCur: string = R.prop('str')(obj); // => 'string'
+    const numValCur: number = R.prop('num')(obj); // => 5
+};
+
+() => {
+    const favorite = R.prop('favoriteLibrary');
+};
+
 // FIXME: TS 4.9 handles `const a = value as Value | undefined;` as `Value`
 function maybe<T>(value: T): T | undefined { return value; }
 

--- a/types/ramda/test/prop-tests.ts
+++ b/types/ramda/test/prop-tests.ts
@@ -1,5 +1,6 @@
 import * as R from 'ramda';
 
+// FIXME: TS 4.9 handles `const a = value as Value | undefined;` as `Value`
 function maybe<T>(value: T): T | undefined { return value; }
 
 () => { // get defined prop from obj

--- a/types/ramda/test/tryCatch-tests.ts
+++ b/types/ramda/test/tryCatch-tests.ts
@@ -90,10 +90,8 @@ import * as R from 'ramda';
     R.tryCatch(R.prop<'x', true>('x'), R.F)({ x: true }); // $ExpectType boolean
     R.tryCatch(R.prop('x'), R.F)({ x: 13 }); // $ExpectType number | false
     R.tryCatch(R.prop('x'))(R.F)({ x: 13 }); // $ExpectType number | false
-    // @ts-expect-error
-    R.tryCatch(R.prop('x'), R.F)(null);
-    // @ts-expect-error
-    R.tryCatch(R.prop('x'), R.F)(null);
+    R.tryCatch(R.prop('x'), R.F)(null); // $ExpectType false | undefined
+    R.tryCatch(R.prop('x'), R.F)(null); // $ExpectType false | undefined
 
     // Curried generic tryer
 

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -576,4 +576,23 @@ export type ToTupleOfFunction<R, Tuple extends any[]> = Tuple extends []
     ? [(arg: R) => X, ...ToTupleOfFunction<R, Xs>]
     : never;
 
+/**
+ * Getter of property from any value. Supports objects, arrays, tuples and maybe values
+ *
+ * @param T Value type
+ * @param P Maybe key type
+ *
+ * @example
+ * ```typescript
+ * type K = Prop<{ x: number } | undefined, 'x'>
+ * type L = Prop<[1, ...string[]] | undefined, 0>
+ * type M = Prop<[1, ...string[]] | undefined, 1>
+ * ```
+ *
+ * <created by @anion155>
+ */
+export type Prop<T, P extends keyof never> = P extends keyof Exclude<T, undefined>
+    ? T extends undefined ? undefined : T[Extract<P, keyof T>]
+    : undefined;
+
 export {};


### PR DESCRIPTION
Update `prop` function:

+ allow usages with proper typings with maybe undefined values
+ allow usages with props not included in type of the value
+ allow usage of arrays as values with number keys, with proper typings for tuple types
+ add more usable cases for manual passed generic types
+ updated currying

All usage cases are in the updated [test file](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62789/files#diff-b0160efc3802fbf27927d8436d8c405c1e4820e5bd2945cf0b6dc8100ab6d878)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  + [prop function](https://ramdajs.com/docs/#prop)
  + [currying placeholder](https://ramdajs.com/docs/#__)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
