### PR TITLE
[@mapbox/mapbox-gl-draw] Add the exact interfaces of different `DrawFeature` sub-types.

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -1,14 +1,11 @@
 // Type definitions for @mapbox/mapbox-gl-draw 1.3
 // Project: https://github.com/mapbox/mapbox-gl-draw
 // Definitions by: Tudor Gergely <https://github.com/tudorgergely>
+//                 Shayan Toqraee <https://github.com/Shayan-To>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Feature, GeoJSON, FeatureCollection, Geometry, Point, Position, BBox, GeoJsonProperties } from 'geojson';
-import {
-    IControl, Map,
-    MapMouseEvent as MapboxMapMouseEvent,
-    MapTouchEvent as MapboxMapTouchEvent,
-} from 'mapbox-gl';
+import { BBox, Feature, FeatureCollection, GeoJSON, GeoJsonTypes, Geometry, Point, Position } from 'geojson';
+import { IControl, Map, MapMouseEvent as MapboxMapMouseEvent, MapTouchEvent as MapboxMapTouchEvent } from 'mapbox-gl';
 
 export = MapboxDraw;
 export as namespace MapboxDraw;
@@ -51,26 +48,72 @@ declare namespace MapboxDraw {
         uncombineFeatures: boolean;
     }
 
-    interface DrawFeature {
-        properties: GeoJsonProperties;
-        coordinates: Position;
+    interface DrawFeatureBase<Coordinates> {
+        readonly properties: Readonly<Feature['properties']>;
+        readonly coordinates: Coordinates;
+        readonly id: NonNullable<Feature['id']>;
+        readonly type: GeoJsonTypes;
 
         changed(): void;
-
-        incomingCoords(coords: Position): void;
-
-        setCoordinates(coords: Position): void;
-
-        getCoordinates(): Position;
-
+        isValid(): boolean;
+        incomingCoords: this['setCoordinates'];
+        setCoordinates(coords: Coordinates): void;
+        getCoordinates(): Coordinates;
+        getCoordinate(path: string): Position;
+        updateCoordinate(path: string, lng: number, lat: number): void;
         setProperty(property: string, value: any): void;
-
         toGeoJSON(): GeoJSON;
     }
+
+    interface DrawMultiFeature<Type extends 'MultiPoint' | 'MultiLineString' | 'MultiPolygon'>
+        extends Omit<
+            DrawFeatureBase<
+                | (Type extends 'MultiPoint' ? Array<DrawPoint['coordinates']> : never)
+                | (Type extends 'MultiLineString' ? Array<DrawLineString['coordinates']> : never)
+                | (Type extends 'MultiPolygon' ? Array<DrawPolygon['coordinates']> : never)
+            >,
+            'coordinates'
+        > {
+        readonly type: Type;
+        readonly features: Array<
+            | (Type extends 'MultiPoint' ? DrawPoint : never)
+            | (Type extends 'MultiLineString' ? DrawLineString : never)
+            | (Type extends 'MultiPolygon' ? DrawPolygon : never)
+        >;
+        getFeatures(): this['features'];
+    }
+
+    interface DrawPoint extends DrawFeatureBase<Position> {
+        readonly type: 'Point';
+        getCoordinate(): Position;
+        updateCoordinate(lng: number, lat: number): void;
+        updateCoordinate(path: string, lng: number, lat: number): void;
+    }
+
+    interface DrawLineString extends DrawFeatureBase<Position[]> {
+        readonly type: 'LineString';
+        addCoordinate(path: string | number, lng: number, lat: number): void;
+        removeCoordinate(path: string | number): void;
+    }
+
+    interface DrawPolygon extends DrawFeatureBase<Position[][]> {
+        readonly type: 'Polygon';
+        addCoordinate(path: string, lng: number, lat: number): void;
+        removeCoordinate(path: string): void;
+    }
+
+    type DrawFeature =
+        | DrawPoint
+        | DrawLineString
+        | DrawPolygon
+        | DrawMultiFeature<'MultiPoint'>
+        | DrawMultiFeature<'MultiLineString'>
+        | DrawMultiFeature<'MultiPolygon'>;
 
     interface MapMouseEvent extends MapboxMapMouseEvent {
         featureTarget: DrawFeature;
     }
+
     interface MapTouchEvent extends MapboxMapTouchEvent {
         featureTarget: DrawFeature;
     }
@@ -131,6 +174,8 @@ declare namespace MapboxDraw {
     }
 
     interface DrawCustomModeThis {
+        map: mapboxgl.Map;
+
         setSelected(features?: string | string[]): void;
 
         setSelectedCoordinates(coords: Array<{ coord_path: string; feature_id: string }>): void;
@@ -216,16 +261,14 @@ declare namespace MapboxDraw {
     }
 
     interface Modes {
-        [modeKey: string]: DrawCustomMode;
         draw_line_string: DrawCustomMode;
         draw_polygon: DrawCustomMode;
         draw_point: DrawCustomMode;
         simple_select: DrawCustomMode;
         direct_select: DrawCustomMode;
-        static: DrawCustomMode;
     }
 
-    type IMapboxDrawOptions = ConstructorParameters<typeof MapboxDraw>[0];
+    type MapboxDrawOptions = ConstructorParameters<typeof MapboxDraw>[0];
 }
 
 declare class MapboxDraw implements IControl {
@@ -275,7 +318,7 @@ declare class MapboxDraw implements IControl {
 
     uncombineFeatures(): this;
 
-    getMode(): MapboxDraw.DrawMode;
+    getMode(): (MapboxDraw.DrawMode & {}) | string;
 
     changeMode(mode: 'simple_select', options?: { featureIds: string[] }): this;
     changeMode(mode: 'direct_select', options: { featureId: string }): this;
@@ -284,7 +327,7 @@ declare class MapboxDraw implements IControl {
         options?: { featureId: string; from: Feature<Point> | Point | number[] },
     ): this;
     changeMode(mode: Exclude<MapboxDraw.DrawMode, 'direct_select' | 'simple_select' | 'draw_line_string'>): this;
-    changeMode<T extends string>(mode: T & (T extends MapboxDraw.DrawMode ? never : T), options?: any): this;
+    changeMode<T extends string>(mode: T & (T extends MapboxDraw.DrawMode ? never : T), options?: object): this;
 
     setFeatureProperty(featureId: string, property: string, value: any): this;
 

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -1,4 +1,10 @@
-import MapboxDraw, { DrawCustomMode, DrawMode, DrawUpdateEvent, IMapboxDrawOptions } from '@mapbox/mapbox-gl-draw';
+import MapboxDraw, {
+    DrawCustomMode,
+    DrawFeature,
+    DrawMode,
+    DrawUpdateEvent,
+    MapboxDrawOptions,
+} from '@mapbox/mapbox-gl-draw';
 
 const draw = new MapboxDraw({});
 
@@ -44,6 +50,18 @@ draw.changeMode('custom_mode');
 // $ExpectType MapboxDraw
 draw.changeMode('custom_mode', {});
 
+if (draw.getMode() === 'draw_line_string') {
+}
+
+if (draw.getMode() === 'some_custom_mode') {
+}
+
+// $ExpectType "direct_select"
+draw.modes.DIRECT_SELECT;
+
+// $ExpectType DrawCustomMode<any, any>
+MapboxDraw.modes.direct_select;
+
 function callback(event: DrawUpdateEvent) {
     // $ExpectType "draw.update"
     event.type;
@@ -60,18 +78,22 @@ const customMode: CustomMode = {
         // $ExpectType DrawFeature
         e.featureTarget;
 
-        this.setSelectedCoordinates([{
-            coord_path: '0',
-            feature_id: '1',
-        }]);
+        // $ExpectType Map
+        this.map;
+
+        this.setSelectedCoordinates([
+            {
+                coord_path: '0',
+                feature_id: '1',
+            },
+        ]);
 
         this.setSelected();
         this.setSelected('1');
         this.setSelected(['1', '2']);
 
         // $ExpectType DrawFeature
-        const feat = this.getFeature('1');
-        feat.setCoordinates(feat.coordinates);
+        this.getFeature('1');
 
         // $ExpectType number
         this.customMethod();
@@ -87,7 +109,7 @@ const customMode: CustomMode = {
 // @ts-expect-error
 const CustomModeMissingDisplayFeatures: DrawCustomMode<{}, {}> = {};
 
-const options: IMapboxDrawOptions = {
+const options: MapboxDrawOptions = {
     modes: {
         custom_mode: customMode,
         ...MapboxDraw.modes,
@@ -95,3 +117,72 @@ const options: IMapboxDrawOptions = {
 };
 
 const drawWithCustomMode = new MapboxDraw(options);
+
+// @ts-expect-error
+const feature: DrawFeature = {};
+
+// $ExpectType void
+feature.changed();
+
+// $ExpectType boolean
+feature.isValid();
+
+// $ExpectType Position
+feature.getCoordinate('');
+
+// $ExpectType void
+feature.updateCoordinate('', 0, 0);
+
+// $ExpectType void
+feature.setProperty('', 0);
+
+// $ExpectType GeoJSON
+feature.toGeoJSON();
+
+if (feature.type === 'Point') {
+    // $ExpectType Position
+    feature.coordinates;
+
+    // $ExpectType Position
+    feature.getCoordinate();
+
+    // $ExpectType void
+    feature.updateCoordinate(0, 0);
+}
+
+if (feature.type === 'LineString') {
+    // $ExpectType Position[]
+    feature.coordinates;
+
+    // $ExpectType void
+    feature.addCoordinate('', 0, 0);
+
+    // $ExpectType void
+    feature.removeCoordinate('');
+}
+
+if (feature.type === 'Polygon') {
+    // $ExpectType Position[][]
+    feature.coordinates;
+
+    // $ExpectType void
+    feature.addCoordinate('', 0, 0);
+
+    // $ExpectType void
+    feature.removeCoordinate('');
+}
+
+if (feature.type === 'MultiPoint') {
+    // $ExpectType DrawPoint[]
+    feature.features;
+}
+
+if (feature.type === 'MultiLineString') {
+    // $ExpectType DrawLineString[]
+    feature.features;
+}
+
+if (feature.type === 'MultiPolygon') {
+    // $ExpectType DrawPolygon[]
+    feature.features;
+}


### PR DESCRIPTION
- Add the exact interfaces of different `DrawFeature` sub-types.
- `DrawCustomModeThis` was missing the `map` property.
- `getMode` did not return the correct type when using custom modes.
- Other small fixes.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/mapbox/mapbox-gl-draw (I read through most of the relevant parts of the source code.)
