### PR TITLE
[jsreport-core] Add httpPort field to Configuration

### DIFF
--- a/types/jsreport-core/index.d.ts
+++ b/types/jsreport-core/index.d.ts
@@ -172,6 +172,7 @@ declare namespace JsReport {
 
     interface Configuration {
         mode?: any;
+        httpPort: number;
         /** specifies where is the application root and where jsreport searches for extensions */
         rootDirectory?: string | undefined;
         /** specifies directory of the script that was used to start node.js, this value is mostly metadata that is useful for your own code inside jsreport scripts */

--- a/types/jsreport-core/index.d.ts
+++ b/types/jsreport-core/index.d.ts
@@ -172,7 +172,7 @@ declare namespace JsReport {
 
     interface Configuration {
         mode?: any;
-        httpPort: number;
+        httpPort?: number;
         /** specifies where is the application root and where jsreport searches for extensions */
         rootDirectory?: string | undefined;
         /** specifies directory of the script that was used to start node.js, this value is mostly metadata that is useful for your own code inside jsreport scripts */


### PR DESCRIPTION
It's supported like stated here: https://jsreport.net/learn/configuration#application-code

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>