### PR TITLE
Fix ckeditor4 style overrides type

### DIFF
--- a/types/ckeditor4/index.d.ts
+++ b/types/ckeditor4/index.d.ts
@@ -2728,7 +2728,7 @@ declare namespace CKEDITOR {
             element: string;
             attributes?: { [key: string]: any } | undefined;
             styles?: { [key: string]: any } | undefined;
-            overrides?: { [key: string]: any } | undefined;
+            overrides?: string | { [key: string]: any } | undefined;
         }
     }
 


### PR DESCRIPTION
This change adds a `string` type as a possible overrides value.
The official basicStyles plugin, for example, uses this on bold with
```
CKEDITOR.config.coreStyles_bold = { element: 'strong', overrides: 'b' };
```
(https://github.com/ckeditor/ckeditor4/blob/4a7a6d1cd81b598b3ec6cfcca7367c6a457c0a40/plugins/basicstyles/plugin.js#L159).
