### PR TITLE
d3-shape: Correct series param in .order() method

### DIFF
--- a/types/d3-shape/d3-shape-tests.ts
+++ b/types/d3-shape/d3-shape-tests.ts
@@ -1477,6 +1477,8 @@ defaultStack = defaultStack.order([2, 3, 1]);
 defaultStack = defaultStack.order(null);
 
 overlyComplicatedStack = overlyComplicatedStack.order(d3Shape.stackOrderAscending);
+overlyComplicatedStack = overlyComplicatedStack.order((vals) =>
+  vals.map((val, i) => [val.key, i]).sort((a, b) => a.key < b.key ? -1 : 1).map(([, i]) => i);
 
 let orderStackDatumSeries: (series: d3Shape.Series<StackDatum, StackKey>) => Iterable<number>;
 orderStackDatumSeries = overlyComplicatedStack.order();

--- a/types/d3-shape/index.d.ts
+++ b/types/d3-shape/index.d.ts
@@ -2530,7 +2530,7 @@ export interface Stack<This, Datum, Key> {
      *
      * @param order A function returning a sort order array. It is passed the generated series array and must return an array of numeric indexes representing the stack order.
      */
-    order(order: (series: Series<Datum, Key>) => Iterable<number>): this;
+    order(order: (series: Array<Series<Datum, Key>>) => Iterable<number>): this;
 
     /**
      * Returns the current offset accessor, which defaults to stackOffsetNone; this uses a zero baseline.


### PR DESCRIPTION
Order gets a list of `Series` objects, rather than a single series object. See original source code here: https://github.com/d3/d3-shape/blob/c95704e618c91ffa51acf2fc8386aebdf1cdf627/src/stack.js#L33-L35

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203209647682449