### PR TITLE
snowflake-sdk: add 'Buffer' as valid fetchAsString value

### DIFF
--- a/types/snowflake-sdk/index.d.ts
+++ b/types/snowflake-sdk/index.d.ts
@@ -553,7 +553,7 @@ export type Connection = NodeJS.EventEmitter & {
          * ### Related Docs
          * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#fetching-data-types-as-strings Fetching Data Types As Strings}
          */
-        fetchAsString?: Array<'String' | 'Boolean' | 'Number' | 'Date' | 'JSON'> | undefined;
+        fetchAsString?: Array<'String' | 'Boolean' | 'Number' | 'Date' | 'JSON' | 'Buffer'> | undefined;
         complete?: (err: SnowflakeError | undefined, stmt: Statement, rows: any[] | undefined) => void;
     }): Statement;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See explanation below.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

By default, the snowflake-sdk returns `BINARY` data as type `Buffer` (see [here](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/0c7eea1c3056c54f1a1a7b18b57a683393b8cb5b/lib/connection/result/data_types.js#L246)). When `'Buffer'` is provided as a value to the `fetchAsString` config option, it correctly prevents binary data types from being returned as a `Buffer` (returning them as a `String` instead). This is not well documented, but the snowflake-sdk [validates](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/5848cb627cf9ad5b90e0e2a69b4a1abd4b7cefc3/lib/connection/connection_config.js#L331-L334) that the arguments to `fetchAsString` are in this [list of native types](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/5848cb627cf9ad5b90e0e2a69b4a1abd4b7cefc3/lib/connection/result/data_types.js#L192-L197), which includes `Buffer`. And the [logic](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/0c7eea1c3056c54f1a1a7b18b57a683393b8cb5b/lib/connection/result/row_stream.js#L365-L381) that actually handles the `fetchAsString` config option works correctly when `'Buffer'` is provided as an argument. I therefore believe that `'Buffer'` should be a valid `fetchAsString` value. This PR updates the type definition to allow that.

Also see: https://github.com/snowflakedb/snowflake-connector-nodejs/issues/351