### PR TITLE
update types/hapi/Catbox-memory types as per catbox-memory package

### DIFF
--- a/types/hapi__catbox-memory/hapi__catbox-memory-tests.ts
+++ b/types/hapi__catbox-memory/hapi__catbox-memory-tests.ts
@@ -2,7 +2,6 @@ import * as CatboxMemory from '@hapi/catbox-memory';
 import { Client } from '@hapi/catbox';
 
 const client = new CatboxMemory<string>({
-    allowMixedContent: true,
     cloneBuffersOnGet: false,
     maxByteSize: 1024,
     minCleanupIntervalMsec: 1000,
@@ -11,7 +10,6 @@ const client = new CatboxMemory<string>({
 const client2 = new CatboxMemory<string>();
 
 const catboxMemoryOptions: CatboxMemory.Options = {
-    allowMixedContent: true,
     cloneBuffersOnGet: false,
     maxByteSize: 1024,
     minCleanupIntervalMsec: 1000,

--- a/types/hapi__catbox-memory/index.d.ts
+++ b/types/hapi__catbox-memory/index.d.ts
@@ -7,14 +7,14 @@
 
 import { ClientApi, ClientOptions } from '@hapi/catbox';
 
-interface CatboxMemory<T> extends ClientApi<T> {}
+interface Engine<T> extends ClientApi<T> {}
 
 // tslint:disable-next-line:no-unnecessary-class
-declare class CatboxMemory<T> implements ClientApi<T> {
-    constructor(options?: CatboxMemory.Options);
+declare class Engine<T> implements ClientApi<T> {
+    constructor(options?: Engine.Options);
 }
 
-declare namespace CatboxMemory {
+declare namespace Engine {
     interface Options extends ClientOptions {
         /**
          * Sets an upper limit on the number of bytes that can be stored in the cache.
@@ -29,13 +29,6 @@ declare namespace CatboxMemory {
          */
         minCleanupIntervalMsec?: number | undefined;
         /**
-         * by default, all data is cached as JSON strings, and converted to an object using JSON.parse() on retrieval.
-         * By setting this option to true, Buffer data can be stored alongside the stringified data.
-         * Buffers are not stringified, and are copied before storage to prevent the value from changing while in the cache.
-         * @default false
-         */
-        allowMixedContent?: boolean | undefined;
-        /**
          * by default, buffers stored in the cache with allowMixedContent set to true are copied when they are set but not when they are retrieved.
          * This means a change to the buffer returned by a get() will change the value in the cache. To prevent this,
          * set cloneBuffersOnGet to true to always return a copy of the cached buffer.
@@ -45,4 +38,4 @@ declare namespace CatboxMemory {
     }
 }
 
-export = CatboxMemory;
+export = Engine;


### PR DESCRIPTION
Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The following the url for catbox-memory
It has a type allowMixedContent which is no longer used to I removed it from DefinatelyTyped->types->hapi__catbox-memory
Also CatboxMemory is renamed and exported as Engine in catbox-memory package, so in DefinatelyTyped->types->hapi__catbox-memory, I have renamed the CatboxMemory class to Engine
