### PR TITLE
yargs: fix inferred option types for options with default

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -836,24 +836,35 @@ declare namespace yargs {
     // prettier-ignore
     type InferredOptionType<O extends Options | PositionalOptions> =
         O extends (
+            | { coerce: (arg: any) => infer T }
+        ) ? IsRequiredOrHasDefault<O> extends true ? T : T | undefined :
+        O extends (
+            | { choices: ReadonlyArray<infer C> }
+        ) ? IsRequiredOrHasDefault<O> extends true ? C : C | undefined :
+        O extends (
+            | { type: "count"; default: infer D }
+            | { count: true; default: infer D }
+        ) ? number | Exclude<D, undefined> :
+        O extends (
+            | { type: "count" }
+            | { count: true }
+        ) ? number :
+        IsRequiredOrHasDefault<O> extends true
+            ? Exclude<InferredOptionTypeInner<O>, undefined>
+            : InferredOptionTypeInner<O> | undefined;
+
+    // prettier-ignore
+    type IsRequiredOrHasDefault<O extends Options | PositionalOptions> =
+        O extends (
             | { required: string | true }
             | { require: string | true }
             | { demand: string | true }
             | { demandOption: string | true }
-        ) ?
-        Exclude<InferredOptionTypeInner<O>, undefined> :
-        InferredOptionTypeInner<O>;
+            | { default: {} }
+        ) ? true : false;
 
     // prettier-ignore
     type InferredOptionTypeInner<O extends Options | PositionalOptions> =
-        O extends { default: any, coerce: (arg: any) => infer T } ? T :
-        O extends { default: infer D } ? D :
-        O extends { type: "count" } ? number :
-        O extends { count: true } ? number :
-        RequiredOptionType<O> | undefined;
-
-    // prettier-ignore
-    type RequiredOptionType<O extends Options | PositionalOptions> =
         O extends { type: "array", string: true } ? string[] :
         O extends { type: "array", number: true } ? number[] :
         O extends { type: "array", normalize: true } ? string[] :
@@ -871,8 +882,7 @@ declare namespace yargs {
         O extends { number: true } ? number :
         O extends { string: true } ? string :
         O extends { normalize: true } ? string :
-        O extends { choices: ReadonlyArray<infer C> } ? C :
-        O extends { coerce: (arg: any) => infer T } ? T :
+        O extends { default: infer D } ? D :
         unknown;
 
     type InferredOptionTypes<O extends { [key: string]: Options }> = { [key in keyof O]: InferredOptionType<O[key]> };

--- a/types/yargs/ts4.1/yargs-tests.ts
+++ b/types/yargs/ts4.1/yargs-tests.ts
@@ -958,6 +958,14 @@ async function Argv$inferOptionTypes() {
         .option("normalize", { normalize: true })
         .parseSync();
 
+    // $ExpectType { [x: string]: unknown; choices: Color; numberChoices: Stage; coerce: Date; count: string | number; _: (string | number)[]; $0: string; }
+    yargs
+        .option("choices", { choices: colors, default: "red" })
+        .option("numberChoices", { choices: stages, default: 1 })
+        .option("coerce", { coerce: () => new Date(), default: "abc" })
+        .option("count", { type: "count", default: "no" })
+        .parseSync();
+
     // $ExpectType (string | number)[] | undefined
     (await yargs.array("x").argv).x;
 

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -990,6 +990,14 @@ async function Argv$inferOptionTypes() {
         .option("normalize", { normalize: true })
         .parseSync();
 
+    // $ExpectType { [x: string]: unknown; choices: Color; numberChoices: Stage; coerce: Date; count: string | number; _: (string | number)[]; $0: string; }
+    yargs
+        .option("choices", { choices: colors, default: "red" })
+        .option("numberChoices", { choices: stages, default: 1 })
+        .option("coerce", { coerce: () => new Date(), default: "abc" })
+        .option("count", { type: "count", default: "no" })
+        .parseSync();
+
     // $ExpectType (string | number)[] | undefined
     (await yargs.array("x").argv).x;
 


### PR DESCRIPTION
This commit fixes inferred option types for options with default value.

```js
// should be "red" | "blue" instead of "red"
yargs
  .option("color", {
    choices: ["red", "blue"],
    default: "red"
  } as const)
  .parseSync()
  .color
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://yargs.js.org/docs/#api-reference-defaultkey-value-description
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.