### PR TITLE
eslint: add rule `meta.replacedBy` property

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -357,7 +357,7 @@ rule = {
     create(context) {
         return {};
     },
-    meta: { deprecated: true },
+    meta: { deprecated: true, replacedBy: ['other-rule-name'] },
 };
 rule = {
     create(context) {

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -581,8 +581,12 @@ export namespace Rule {
          * so ESLint can prevent invalid [rule configurations](https://eslint.org/docs/latest/user-guide/configuring/rules#configuring-rules).
          */
         schema?: JSONSchema4 | JSONSchema4[] | undefined;
+
         /** Indicates whether the rule has been deprecated. Omit if not deprecated. */
         deprecated?: boolean | undefined;
+        /** The name of the rule(s) this rule was replaced by, if it was deprecated. */
+        replacedBy?: readonly string[];
+
         /**
          * Indicates the type of rule:
          * - `"problem"` means the rule is identifying code that either will cause an error or may cause a confusing behavior. Developers should consider this a high priority to resolve.


### PR DESCRIPTION

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Both ESLint core and @typescript-eslint have definitions for the `meta.replacedBy` string array rule metadata field which can be used to list replacement rule names for a deprecated rule.

* https://github.com/eslint/eslint/blob/4715787724a71494ba0bb0c5fe4639570bb6985b/lib/shared/types.js#L151
* https://github.com/typescript-eslint/typescript-eslint/blob/733b3598c17d3a712cf6f043115587f724dbe3ef/packages/utils/src/ts-eslint/Rule.ts#L74

It is also mentioned in the ESLint rule documentation: https://eslint.org/docs/latest/developer-guide/working-with-rules