### PR TITLE
chore(jest): expect.any interface strong typings

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -694,7 +694,7 @@ declare namespace jest {
          *   expect(mock).toBeCalledWith(expect.any(Number));
          * });
          */
-        any(classType: any): any;
+        any<T extends Constructor>(classType: T): T extends Func ? ReturnType<T> : InstanceType<T>;
         /**
          * Matches any array made up entirely of elements in the provided array.
          * You can use it inside `toEqual` or `toBeCalledWith` instead of a literal value.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1225,12 +1225,16 @@ describe('', () => {
             three: 3,
             four: { four: 3 },
             date: new Date(),
+            dateTwo: Date,
+            list: [1, 2, 3],
         }).toMatchInlineSnapshot({
             one: expect.any(Number),
             // leave out two
             three: 3,
             four: { four: expect.any(Number) },
             date: expect.any(Date),
+            dateTwo: expect.any(Date),
+            list: expect.any(Array),
         });
 
         expect(jest.fn()).toReturn();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Context of this change

This change adds strong typing to jest's `expect.any` interface. This change will make life easier for assertions and matchers with strong types. 



### Before typing 

```JavaScript
type ResultType = {
    version: string
}
```

```JavaScript
expect(result).toMatchObject({
   version: expect.any(String) as string // Notice string casting
})

```

### After typing 

```JavaScript
expect(result).toMatchObject({
   version: expect.any(String) // no string casting needed
})

```




