### PR TITLE
updated the type of a property for the mssql config interface

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -182,7 +182,7 @@ export interface config {
     driver?: string | undefined;
     user?: string | undefined;
     password?: string | undefined;
-    server: string;
+    server: string | undefined;
     port?: number | undefined;
     domain?: string | undefined;
     database?: string | undefined;


### PR DESCRIPTION
The interface config for mssql has a property server that type is string only - I changed it to string or undefined.

test passed. 


