### PR TITLE
Use WPDefinedAsset type for relevant properties in @wordpress/blocks

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -21,7 +21,7 @@ declare module '@wordpress/data' {
 }
 
 /**
- * This asset can be a local file path relative to the block.json file (must be prefixed with `file:`) or 
+ * This asset can be a local file path relative to the block.json file (must be prefixed with `file:`) or
  * it can be a style or script handle from a registered asset.
  *
  * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedasset}

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -20,6 +20,14 @@ declare module '@wordpress/data' {
     function select(key: 'core/blocks'): typeof import('./store/selectors');
 }
 
+/**
+ * This asset can be a local file path relative to the block.json file (must be prefixed with `file:`) or 
+ * it can be a style or script handle from a registered asset.
+ *
+ * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedasset}
+ */
+export type WPDefinedAsset = string;
+
 export type AxialDirection = 'horizontal' | 'vertical';
 
 export type CSSDirection = 'top' | 'right' | 'bottom' | 'left';
@@ -181,14 +189,14 @@ export interface Block<T extends Record<string, any> = {}> {
      *
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-script}
      */
-    readonly editorScript?: string;
+    readonly editorScript?: WPDefinedAsset | WPDefinedAsset[];
     /**
      * Block type editor style definition.
      * It will only be enqueued in the context of the editor.
      *
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style}
      */
-    readonly editorStyle?: string | string[];
+    readonly editorStyle?: WPDefinedAsset | WPDefinedAsset[];
     /**
      * It provides structured example data for the block.
      *
@@ -231,14 +239,14 @@ export interface Block<T extends Record<string, any> = {}> {
      *
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#script}
      */
-    readonly script?: string;
+    readonly script?: WPDefinedAsset | WPDefinedAsset[];
     /**
      * Block type editor style definition.
      * It will only be enqueued in the context of the editor.
      *
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style}
      */
-    readonly style?: string | string[];
+    readonly style?: WPDefinedAsset | WPDefinedAsset[];
     /**
      * Block styles.
      *

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -188,7 +188,7 @@ export interface Block<T extends Record<string, any> = {}> {
      *
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style}
      */
-    readonly editorStyle?: string;
+    readonly editorStyle?: string | string[];
     /**
      * It provides structured example data for the block.
      *
@@ -238,7 +238,7 @@ export interface Block<T extends Record<string, any> = {}> {
      *
      * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style}
      */
-    readonly style?: string;
+    readonly style?: string | string[];
     /**
      * Block styles.
      *

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -21,12 +21,21 @@ declare module '@wordpress/data' {
 }
 
 /**
+ * The WPDefinedPath type is a subtype of string, where the value represents a path to a JavaScript,
+ * CSS or PHP file relative to where block.json file is located. The path provided must be prefixed
+ * with file:. This approach is based on how npm handles local paths for packages.
+ *
+ * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedpath}
+ */
+export type WPDefinedPath = `file:${string}`;
+
+/**
  * This asset can be a local file path relative to the block.json file (must be prefixed with `file:`) or
  * it can be a style or script handle from a registered asset.
  *
  * @see {@link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedasset}
  */
-export type WPDefinedAsset = string;
+export type WPDefinedAsset = WPDefinedPath | string;
 
 export type AxialDirection = 'horizontal' | 'vertical';
 


### PR DESCRIPTION
This PR allows arrays of strings for `style`, `editorStyle`, `script` and `editorScript` using the WP documented WPDefinedAsset type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedasset
https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#style
https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-style
https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#script
https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#editor-script

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
N/A