### PR TITLE
[roslib] Add v1.3.0 new type definitions and align docstrings

### DIFF
--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -240,6 +240,8 @@ declare namespace ROSLIB {
          * @param {function} [failedCallback] - The callback function when the service call failed with params:
          * @param {string} failedCallback.error - The error message reported by ROS.
          */
+        // Note: Use type overloading instead to provide better readability of the available function signature of getNodeDetails
+        // tslint:disable-next-line:unified-signatures
         getNodeDetails(
             node: string,
             callback: (subscriptions: string[], publications: string[], services: string[]) => void,
@@ -260,6 +262,8 @@ declare namespace ROSLIB {
          * @param {function} [failedCallback] - The callback function when the service call failed with params:
          * @param {string} failedCallback.error - The error message reported by ROS.
          */
+        // Note: Use type overloading instead to provide better readability of the available function signature of getNodeDetails
+        // tslint:disable-next-line:unified-signatures
         getNodeDetails(
             node: string,
             callback: (result: { subscribing: string[], publishing: string[], services: string[] }) => void,

--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -41,7 +41,6 @@ declare namespace ROSLIB {
          *  * &#60;serviceID&#62; - A service response came from rosbridge with the given ID.
          *
          * @constructor
-         * @param options - possible keys include:
          * @param {Object} options
          * @param {string} [options.url] - The WebSocket URL for rosbridge or the node server URL to connect using socket.io (if socket.io exists in the page). Can be specified later with `connect`.
          * @param {boolean} [options.groovyCompatibility=true] - Don't use interfaces that changed after the last groovy release or rosbridge_suite and related tools.
@@ -187,6 +186,38 @@ declare namespace ROSLIB {
         ): void;
 
         /**
+         * Retrieve the details of a ROS service request.
+         *
+         * @param {string} type - The type of the service.
+         * @param {function} callback - Function with the following params:
+         * @param {Object} callback.result - The result object with the following params:
+         * @param {string[]} callback.result.typedefs - An array containing the details of the service request.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
+         */
+         getServiceRequestDetails(
+            type: string,
+            callback: (result: { typedefs: string[] }) => void,
+            failedCallback?: (error: string) => void,
+        ): void;
+
+        /**
+         * Retrieve the details of a ROS service response.
+         *
+         * @param {string} type - The type of the service.
+         * @param {function} callback - Function with the following params:
+         * @param {Object} callback.result - The result object with the following params:
+         * @param {string[]} callback.result.typedefs - An array containing the details of the service response.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
+         */
+        getServiceResponseDetails(
+            type: string,
+            callback: (result: { typedefs: string[] }) => void,
+            failedCallback?: (error: string) => void,
+        ): void;
+
+        /**
          * Retrieve a list of active node names in ROS.
          *
          * @param {function} callback - Function with the following params:
@@ -208,9 +239,14 @@ declare namespace ROSLIB {
          * @param {string[]} callback.services - Array of service names hosted.
          * @param {function} [failedCallback] - The callback function when the service call failed with params:
          * @param {string} failedCallback.error - The error message reported by ROS.
-         *
-         * @also
-         *
+         */
+        getNodeDetails(
+            node: string,
+            callback: (subscriptions: string[], publications: string[], services: string[]) => void,
+            failedCallback?: (error: string) => void,
+        ): void;
+
+        /**
          * Retrieve a list of subscribed topics, publishing topics and services of a specific node.
          * <br>
          * These are the parameters if failedCallback is <strong>undefined</strong>.
@@ -224,9 +260,9 @@ declare namespace ROSLIB {
          * @param {function} [failedCallback] - The callback function when the service call failed with params:
          * @param {string} failedCallback.error - The error message reported by ROS.
          */
-        getNodeDetails(
+         getNodeDetails(
             node: string,
-            callback: ((subscriptions: string[], publications: string[], services: string[]) => void) | ((result: { subscribing: string[], publishing: string[], services: string[] }) => void),
+            callback: (result: { subscribing: string[], publishing: string[], services: string[] }) => void,
             failedCallback?: (error: string) => void,
         ): void;
 
@@ -282,7 +318,7 @@ declare namespace ROSLIB {
          *
          * @param {any[]} defs - Array of type_def dictionary.
          */
-        decodeTypeDefs(defs: any[]): void;
+        decodeTypeDefs(defs: any[]): any;
 
         /**
          * Retrieve a list of topics and their associated type definitions.
@@ -297,38 +333,6 @@ declare namespace ROSLIB {
          */
         getTopicsAndRawTypes(
             callback: (result: {topics: string[], types: string[], typedefs_full_text: string[]}) => void,
-            failedCallback?: (error: string) => void,
-        ): void;
-
-        /**
-         * Retrieve the details of a ROS service request.
-         *
-         * @param {string} type - The type of the service.
-         * @param {function} callback - Function with the following params:
-         * @param {Object} callback.result - The result object with the following params:
-         * @param {string[]} callback.result.typedefs - An array containing the details of the service request.
-         * @param {function} [failedCallback] - The callback function when the service call failed with params:
-         * @param {string} failedCallback.error - The error message reported by ROS.
-         */
-        getServiceRequestDetails(
-            type: string,
-            callback: (result: { typedefs: string[] }) => void,
-            failedCallback?: (error: string) => void,
-        ): void;
-
-        /**
-         * Retrieve the details of a ROS service response.
-         *
-         * @param {string} type - The type of the service.
-         * @param {function} callback - Function with the following params:
-         * @param {Object} callback.result - The result object with the following params:
-         * @param {string[]} callback.result.typedefs - An array containing the details of the service response.
-         * @param {function} [failedCallback] - The callback function when the service call failed with params:
-         * @param {string} failedCallback.error - The error message reported by ROS.
-         */
-        getServiceResponseDetails(
-            type: string,
-            callback: (result: { typedefs: string[] }) => void,
             failedCallback?: (error: string) => void,
         ): void;
     }
@@ -858,7 +862,7 @@ declare namespace ROSLIB {
          * @param {string} eventName - Name of event ('timeout', 'status', 'feedback', 'result').
          * @param {function} callback - Callback function executed on connected event.
          */
-        on(eventName: string, callback: (event: any) => void): void;
+        on(eventName: 'timeout' | 'status' | 'feedback' | 'result', callback: (event: any) => void): void;
 
         /**
          * Send the goal to the action server.

--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -260,7 +260,7 @@ declare namespace ROSLIB {
          * @param {function} [failedCallback] - The callback function when the service call failed with params:
          * @param {string} failedCallback.error - The error message reported by ROS.
          */
-         getNodeDetails(
+        getNodeDetails(
             node: string,
             callback: (result: { subscribing: string[], publishing: string[], services: string[] }) => void,
             failedCallback?: (error: string) => void,

--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for roslib.js 1.1.0
+// Type definitions for roslib.js 1.3.0
 // Project: http://wiki.ros.org/roslibjs
 // Definitions by: Stefan Profanter <https://github.com/Pro>
 //                 David Gonzalez <https://github.com/dgorobopec>
@@ -34,18 +34,19 @@ declare namespace ROSLIB {
          * Manages connection to the server and all interactions with ROS.
          *
          * Emits the following events:
-         *  * 'error' - there was an error with ROS
-         *  * 'connection' - connected to the WebSocket server
-         *  * 'close' - disconnected to the WebSocket server
-         *  * <topicName> - a message came from rosbridge with the given topic name
-         *  * <serviceID> - a service response came from rosbridge with the given ID
+         *  * 'error' - There was an error with ROS.
+         *  * 'connection' - Connected to the WebSocket server.
+         *  * 'close' - Disconnected to the WebSocket server.
+         *  * &#60;topicName&#62; - A message came from rosbridge with the given topic name.
+         *  * &#60;serviceID&#62; - A service response came from rosbridge with the given ID.
          *
          * @constructor
          * @param options - possible keys include:
-         *   * url (optional) - (can be specified later with `connect`) the WebSocket URL for rosbridge or the node server url to connect using socket.io (if socket.io exists in the page) <br>
-         *   * groovyCompatibility - don't use interfaces that changed after the last groovy release or rosbridge_suite and related tools (defaults to true)
-         *   * transportLibrary (optional) - one of 'websocket', 'workersocket' (default), 'socket.io' or RTCPeerConnection instance controlling how the connection is created in `connect`.
-         *   * transportOptions (optional) - the options to use use when creating a connection. Currently only used if `transportLibrary` is RTCPeerConnection.
+         * @param {Object} options
+         * @param {string} [options.url] - The WebSocket URL for rosbridge or the node server URL to connect using socket.io (if socket.io exists in the page). Can be specified later with `connect`.
+         * @param {boolean} [options.groovyCompatibility=true] - Don't use interfaces that changed after the last groovy release or rosbridge_suite and related tools.
+         * @param {string} [options.transportLibrary=websocket] - One of 'websocket', 'workersocket', 'socket.io' or RTCPeerConnection instance controlling how the connection is created in `connect`.
+         * @param {Object} [options.transportOptions={}] - The options to use when creating a connection. Currently only used if `transportLibrary` is RTCPeerConnection.
          */
         constructor(options: {
             url?: string | undefined;
@@ -67,7 +68,7 @@ declare namespace ROSLIB {
         /**
          * Connect to the specified WebSocket.
          *
-         * @param url - WebSocket URL for Rosbridge
+         * @param {string} url - WebSocket URL or RTCDataChannel label for rosbridge.
          */
         connect(url: string): void;
 
@@ -77,173 +78,263 @@ declare namespace ROSLIB {
         close(): void;
 
         /**
-         * Sends an authorization request to the server.
+         * Send an authorization request to the server.
          *
-         * @param mac - MAC (hash) string given by the trusted source.
-         * @param client - IP of the client.
-         * @param dest - IP of the destination.
-         * @param rand - Random string given by the trusted source.
-         * @param t - Time of the authorization request.
-         * @param level - User level as a string given by the client.
-         * @param end - End time of the client's session.
+         * @param {string} mac - MAC (hash) string given by the trusted source.
+         * @param {string} client - IP of the client.
+         * @param {string} dest - IP of the destination.
+         * @param {string} rand - Random string given by the trusted source.
+         * @param {Object} t - Time of the authorization request.
+         * @param {string} level - User level as a string given by the client.
+         * @param {Object} end - End time of the client's session.
          */
         authenticate(
             mac: string,
             client: string,
             dest: string,
             rand: string,
-            t: number,
+            t: Object,
             level: string,
-            end: number,
+            end: Object,
         ): void;
 
         /**
-         * Sends the message over the WebSocket, but queues the message up if not yet
+         * Send an encoded message over the WebSocket.
+         * 
+         * @param {Object} messageEncoded - The encoded message to be sent.
+         */
+         sendEncodedMessage(messageEncoded: Object): void;
+
+        /**
+         * Send the message over the WebSocket, but queue the message up if not yet
          * connected.
+         * 
+         * @param {Object} message - The message to be sent.
          */
-        callOnConnection(message: any): void;
+        callOnConnection(message: Object): void;
 
         /**
-         * Retrieves list of actionlib servers in ROS as an array.
-         *
-         * @param callback function with params:
-         *   * action_servers - Array of actionlib servers names
-         * @param failedCallback - the callback function when the ros call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * Send a set_level request to the server.
+         * 
+         * @param {string} level - Status level (none, error, warning, info).
+         * @param {number} [id] - Operation ID to change status level on.
          */
-        getActionServers(callback: (action_servers: string[]) => void, failedCallback?: (error: any) => void): void;
+        setStatusLevel(level: string, id?: number): void;
 
         /**
-         * Retrieves list of topics in ROS as an array.
+         * Retrieve a list of action servers in ROS as an array of string.
          *
-         * @param callback function with params:
-         *   * topics - Array of topic names
-         *   * types - Array of message type names
-         * @param failedCallback - the callback function when the service call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {function} callback - Function with the following params:
+         * @param {string[]} callback.actionservers - Array of action server names.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
+         */
+        getActionServers(callback: (actionservers: string[]) => void, failedCallback?: (error: string) => void): void;
+
+        /**
+         * Retrieve a list of topics in ROS as an array.
+         *
+         * @param {function} callback - Function with the following params:
+         * @param {Object} callback.result - The result object with the following params:
+         * @param {string[]} callback.result.topics - Array of topic names.
+         * @param {string[]} callback.result.types - Array of message type names.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
         getTopics(
-            callback: (topics: { topics: string[]; types: string[] }) => void,
-            failedCallback?: (error: any) => void,
+            callback: (result: { topics: string[]; types: string[] }) => void,
+            failedCallback?: (error: string) => void,
         ): void;
 
         /**
-         * Retrieves Topics in ROS as an array as specific type
+         * Retrieve a list of topics in ROS as an array of a specific type.
          *
-         * @param topicType topic type to find:
-         * @param callback function with params:
-         *   * topics - Array of topic names
-         * @param failedCallback - the callback function when the ros call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {string} topicType - The topic type to find.
+         * @param {function} callback - Function with the following params:
+         * @param {string[]} callback.topics - Array of topic names.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
         getTopicsForType(
             topicType: string,
             callback: (topics: string[]) => void,
-            failedCallback?: (error: any) => void,
+            failedCallback?: (error: string) => void,
         ): void;
 
         /**
-         * Retrieves list of active service names in ROS.
+         * Retrieve a list of active service names in ROS.
          *
-         * @param callback - function with the following params:
-         *   * services - array of service names
-         * @param failedCallback - the callback function when the ros call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {function} callback - Function with the following params:
+         * @param {string[]} callback.services - Array of service names.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
-        getServices(callback: (services: string[]) => void, failedCallback?: (error: any) => void): void;
+        getServices(callback: (services: string[]) => void, failedCallback?: (error: string) => void): void;
 
         /**
-         * Retrieves list of services in ROS as an array as specific type
+         * Retrieve a list of services in ROS as an array as specific type.
          *
-         * @param serviceType service type to find:
-         * @param callback function with params:
-         *   * topics - Array of service names
-         * @param failedCallback - the callback function when the ros call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {string} serviceType - The service type to find.
+         * @param {function} callback - Function with the following params:
+         * @param {string[]} callback.topics - Array of service names.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
         getServicesForType(
             serviceType: string,
-            callback: (services: string[]) => void,
-            failedCallback?: (error: any) => void,
+            callback: (topics: string[]) => void,
+            failedCallback?: (error: string) => void,
         ): void;
 
         /**
-         * Retrieves list of active node names in ROS.
+         * Retrieve a list of active node names in ROS.
          *
-         * @param callback - function with the following params:
-         *   * nodes - array of node names
-         * @param failedCallback - the callback function when the ros call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {function} callback - Function with the following params:
+         * @param {string[]} callback.nodes - Array of node names.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
-        getNodes(callback: (nodes: string[]) => void, failedCallback?: (error: any) => void): void;
+        getNodes(callback: (nodes: string[]) => void, failedCallback?: (error: string) => void): void;
 
         /**
-         * Retrieves list of param names from the ROS Parameter Server.
+         * Retrieve a list of subscribed topics, publishing topics and services of a specific node.
+         * <br>
+         * These are the parameters if failedCallback is <strong>defined</strong>.
          *
-         * @param callback function with params:
-         *  * params - array of param names.
-         * @param failedCallback - the callback function when the ros call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {string} node - Name of the node.
+         * @param {function} callback - Function with the following params:
+         * @param {string[]} callback.subscriptions - Array of subscribed topic names.
+         * @param {string[]} callback.publications - Array of published topic names.
+         * @param {string[]} callback.services - Array of service names hosted.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
-        getParams(callback: (params: string[]) => void, failedCallback?: (error: any) => void): void;
+        getNodeDetails(
+            node: string,
+            callback: (subscriptions: string[], publications: string[], services: string[]) => void,
+            failedCallback?: (error: string) => void,
+        ): void;
 
         /**
-         * Retrieves a type of ROS topic.
+         * Retrieve a list of subscribed topics, publishing topics and services of a specific node.
+         * <br>
+         * These are the parameters if failedCallback is <strong>undefined</strong>.
          *
-         * @param topic name of the topic:
-         * @param callback - function with params:
-         *   * type - String of the topic type
-         * @param failedCallback - the callback function when the ros call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {string} node - Name of the node.
+         * @param {function} callback - Function with the following params:
+         * @param {Object} callback.result - The result object with the following params:
+         * @param {string[]} callback.result.subscribing - Array of subscribed topic names.
+         * @param {string[]} callback.result.publishing - Array of published topic names.
+         * @param {string[]} callback.result.services - Array of service names hosted.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
-        getTopicType(topic: string, callback: (type: string) => void, failedCallback?: (error: any) => void): void;
+        getNodeDetails(
+            node: string,
+            callback: (result: { subscribing: string[], publishing: string[], services: string[] }) => void,
+            failedCallback?: (error: string) => void,
+        ): void;
 
         /**
-         * Retrieves a type of ROS service.
+         * Retrieve a list of parameter names from the ROS Parameter Server.
          *
-         * @param service name of service:
-         * @param callback - function with params:
-         *   * type - String of the service type
-         * @param failedCallback - the callback function when the ros call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {function} callback - Function with the following params:
+         * @param {string[]} callback.params - Array of param names.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
-        getServiceType(service: string, callback: (type: string) => void, failedCallback?: (error: any) => void): void;
+        getParams(callback: (params: string[]) => void, failedCallback?: (error: string) => void): void;
 
         /**
-         * Retrieves a detail of ROS message.
+         * Retrieve the type of a ROS topic.
          *
-         * @param callback - function with params:
-         *   * details - Array of the message detail
-         * @param message - String of a topic type
-         * @param failedCallback - the callback function when the ros call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {string} topic - Name of the topic.
+         * @param {function} callback - Function with the following params:
+         * @param {string} callback.type - The type of the topic.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
+         */
+        getTopicType(topic: string, callback: (type: string) => void, failedCallback?: (error: string) => void): void;
+
+        /**
+         * Retrieve the type of a ROS service.
+         *
+         * @param {string} service - Name of the service.
+         * @param {function} callback - Function with the following params:
+         * @param {string} callback.type - The type of the service.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
+         */
+        getServiceType(service: string, callback: (type: string) => void, failedCallback?: (error: string) => void): void;
+
+        /**
+         * Retrieve the details of a ROS message.
+         *
+         * @param {string} message - The name of the message type.
+         * @param {function} callback - Function with the following params:
+         * @param {string} callback.details - An array of the message details.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
         getMessageDetails(
-            message: Message,
-            callback: (detail: any) => void,
-            failedCallback?: (error: any) => void,
+            message: string,
+            callback: (details: string) => void,
+            failedCallback?: (error: string) => void,
         ): void;
 
         /**
-         * Decode a typedefs into a dictionary like `rosmsg show foo/bar`
+         * Decode a typedef array into a dictionary like `rosmsg show foo/bar`.
          *
-         * @param defs - array of type_def dictionary
+         * @param {Object[]} defs - Array of type_def dictionary.
          */
-        decodeTypeDefs(defs: any): void;
+        decodeTypeDefs(defs: Object[]): void;
 
         /**
-         * Retrieves a detail of ROS service request.
+         * Retrieve a list of topics and their associated type definitions.
          *
-         * @param service name of service:
-         * @param callback - function with params:
-         *   * type - String of the service type
-         * @param failedCallback - the callback function when the service call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {function} callback - Function with the following params:
+         * @param {Object} callback.result - The result object with the following params:
+         * @param {string[]} callback.result.topics - Array of topic names.
+         * @param {string[]} callback.result.types - Array of message type names.
+         * @param {string[]} callback.result.typedefs_full_text - Array of full definitions of message types, similar to `gendeps --cat`.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
+         */
+        getTopicsAndRawTypes(
+            callback: (result: {topics: string[], types: string[], typedefs_full_text: string[]}) => void,
+            failedCallback?: (error: string) => void,
+        ): void;
+
+        /**
+         * Retrieve the details of a ROS service request.
+         *
+         * @param {string} type - The type of the service.
+         * @param {function} callback - Function with the following params:
+         * @param {Object} callback.result - The result object with the following params:
+         * @param {string[]} callback.result.typedefs - An array containing the details of the service request.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
         getServiceRequestDetails(
-            service: string,
-            callback: (type: string) => void,
-            failedCallback?: (error: any) => void,
+            type: string,
+            callback: (result: { typedefs: string[] }) => void,
+            failedCallback?: (error: string) => void,
+        ): void;
+
+        /**
+         * Retrieve the details of a ROS service response.
+         * 
+         * @param {string} type - The type of the service.
+         * @param {function} callback - Function with the following params:
+         * @param {Object} callback.result - The result object with the following params:
+         * @param {string[]} callback.result.typedefs - An array containing the details of the service response.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
+         */
+        getServiceResponseDetails(
+            type: string,
+            callback: (result: { typedefs: string[] }) => void,
+            failedCallback?: (error: string) => void,
         ): void;
     }
 
@@ -252,9 +343,9 @@ declare namespace ROSLIB {
          * Message objects are used for publishing and subscribing to and from topics.
          *
          * @constructor
-         * @param values - object matching the fields defined in the .msg definition file
+         * @param {Object} values - An object matching the fields defined in the .msg definition file.
          */
-        constructor(values: any);
+        constructor(values: Object);
     }
 
     export class Param {
@@ -262,31 +353,32 @@ declare namespace ROSLIB {
          * A ROS parameter.
          *
          * @constructor
-         * @param options - possible keys include:
-         *   * ros - the ROSLIB.Ros connection handle
-         *   * name - the param name, like max_vel_x
+         * @param {Object} options
+         * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
+         * @param {string} options.name - The param name, like max_vel_x.
          */
         constructor(options: { ros: Ros; name: string });
 
         /**
-         * Fetches the value of the param.
+         * Fetch the value of the param.
          *
-         * @param callback - function with the following params:
-         *  * value - the value of the param from ROS.
+         * @param {function} callback - Function with the following params:
+         * @param {Object} callback.value - The value of the param from ROS.
          */
-        get(callback: (response: any) => void): void;
+        get(callback: (value: Object) => void): void;
 
         /**
-         * Sets the value of the param in ROS.
+         * Set the value of the param in ROS.
          *
-         * @param value - value to set param to.
-         * @param callback - function with params:
-         *   * response - the response from the service request
+         * @param {Object} value - The value to set param to.
+         * @param {function} callback - The callback function.
          */
-        set(value: any, callback?: (response: any) => void): void;
+        set(value: Object, callback: (response: any) => void): void;
 
         /**
          * Delete this parameter on the ROS server.
+         * 
+         * @param {function} callback - The callback function.
          */
         delete(callback: (response: any) => void): void;
     }
@@ -296,10 +388,10 @@ declare namespace ROSLIB {
          * A ROS service client.
          *
          * @constructor
-         * @params options - possible keys include:
-         *   * ros - the ROSLIB.Ros connection handle
-         *   * name - the service name, like /add_two_ints
-         *   * serviceType - the service type, like 'rospy_tutorials/AddTwoInts'
+         * @param {Object} options
+         * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
+         * @param {string} options.name - The service name, like '/add_two_ints'.
+         * @param {string} options.serviceType - The service type, like 'rospy_tutorials/AddTwoInts'.
          */
         constructor(data: { ros: Ros; name: string; serviceType: string });
 
@@ -309,31 +401,36 @@ declare namespace ROSLIB {
         public serviceType: string;
 
         /**
-         * Calls the service. Returns the service response in the callback.
+         * Call the service. Returns the service response in the
+         * callback. Does nothing if this service is currently advertised.
          *
-         * @param request - the ROSLIB.ServiceRequest to send
-         * @param callback - function with params:
-         *   * response - the response from the service request
-         * @param failedCallback - the callback function when the service call failed (optional). Params:
-         *   * error - the error message reported by ROS
+         * @param {TServiceRequest} request - The ROSLIB.ServiceRequest to send.
+         * @param {function} callback - Function with the following params:
+         * @param {TServiceResponse} callback.response - The response from the service request.
+         * @param {function} [failedCallback] - The callback function when the service call failed with params:
+         * @param {string} failedCallback.error - The error message reported by ROS.
          */
         callService(
             request: TServiceRequest,
             callback: (response: TServiceResponse) => void,
-            failedCallback?: (error: any) => void,
+            failedCallback?: (error: string) => void,
         ): void;
 
         /**
-         * Advertise this service and call the callback each time a client calls it.
+         * Advertise the service. This turns the Service object from a client
+         * into a server. The callback will be called with every request
+         * that's made on this service.
          *
-         * @param callback - function with the following params:
-         *   * request - the service request data
-         *   * response - the data which should be sent back to the caller
+         * @param {function} callback - This works similarly to the callback for a C++ service and should take the following params:
+         * @param {TServiceRequest} callback.request - The service request.
+         * @param {TServiceResponse} callback.response - An empty dictionary. Take care not to overwrite this. Instead, only modify the values within.
+         *     It should return true if the service has finished successfully,
+         *     i.e., without any fatal errors.
          */
         advertise(callback: (request: TServiceRequest, response: TServiceResponse) => void): void;
 
         /**
-         * Unadvertise a previously advertised service
+         * Unadvertise a previously advertised service.
          */
         unadvertise(): void;
     }
@@ -343,9 +440,9 @@ declare namespace ROSLIB {
          * A ServiceRequest is passed into the service call.
          *
          * @constructor
-         * @param values - object matching the fields defined in the .srv definition file
+         * @param {Object} values - Object matching the fields defined in the .srv definition file.
          */
-        constructor(values?: any);
+        constructor(values: Object);
     }
 
     export class ServiceResponse {
@@ -353,9 +450,9 @@ declare namespace ROSLIB {
          * A ServiceResponse is returned from the service call.
          *
          * @constructor
-         * @param values - object matching the fields defined in the .srv definition file
+         * @param {Object} values - Object matching the fields defined in the .srv definition file.
          */
-        constructor(values?: any);
+        constructor(values: Object);
     }
 
     export class Topic<TMessage = Message> extends EventEmitter2 {
@@ -363,19 +460,20 @@ declare namespace ROSLIB {
          * Publish and/or subscribe to a topic in ROS.
          *
          * Emits the following events:
-         *  * 'warning' - if there are any warning during the Topic creation
-         *  * 'message' - the message data from rosbridge
+         *  * 'warning' - If there are any warning during the Topic creation.
+         *  * 'message' - The message data from rosbridge.
          *
          * @constructor
-         * @param options - object with following keys:
-         *   * ros - the ROSLIB.Ros connection handle
-         *   * name - the topic name, like /cmd_vel
-         *   * messageType - the message type, like 'std_msgs/String'
-         *   * compression - the type of compression to use, like 'png'
-         *   * throttle_rate - the rate (in ms in between messages) at which to throttle the topics
-         *   * queue_size - the queue created at bridge side for re-publishing webtopics (defaults to 100)
-         *   * latch - latch the topic when publishing
-         *   * queue_length - the queue length at bridge side used when subscribing (defaults to 0, no queueing).
+         * @param {Object} options
+         * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
+         * @param {string} options.name - The topic name, like '/cmd_vel'.
+         * @param {string} options.messageType - The message type, like 'std_msgs/String'.
+         * @param {string} [options.compression=none] - The type of compression to use, like 'png', 'cbor', or 'cbor-raw'.
+         * @param {number} [options.throttle_rate=0] - The rate (in ms in between messages) at which to throttle the topics.
+         * @param {number} [options.queue_size=100] - The queue created at bridge side for re-publishing webtopics.
+         * @param {boolean} [options.latch=false] - Latch the topic when publishing.
+         * @param {number} [options.queue_length=0] - The queue length at bridge side used when subscribing.
+         * @param {boolean} [options.reconnect_on_close=true] - The flag to enable resubscription and readvertisement on close event.
          */
         constructor(options: {
             ros: Ros;
@@ -386,6 +484,7 @@ declare namespace ROSLIB {
             queue_size?: number | undefined;
             latch?: boolean | undefined;
             queue_length?: number | undefined;
+            reconnect_on_close?: boolean | undefined;
         });
 
         // getter
@@ -397,36 +496,36 @@ declare namespace ROSLIB {
          * Every time a message is published for the given topic, the callback
          * will be called with the message object.
          *
-         * @param callback - function with the following params:
-         *   * message - the published message
+         * @param {function} callback - Function with the following params:
+         * @param {TMessage} callback.message - The published message.
          */
         subscribe(callback: (message: TMessage) => void): void;
 
         /**
-         * Unregisters as a subscriber for the topic. Unsubscribing stop remove
-         * all subscribe callbacks. To remove a call back, you must explicitly
-         * pass the callback function in.
+         * Unregister as a subscriber for the topic. Unsubscribing will stop
+         * and remove all subscribe callbacks. To remove a callback, you must
+         * explicitly pass the callback function in.
          *
-         * @param callback - the optional callback to unregister, if
-         *     * provided and other listeners are registered the topic won't
-         *     * unsubscribe, just stop emitting to the passed listener
+         * @param {function} [callback] - The callback to unregister, if
+         *     provided and other listeners are registered the topic won't
+         *     unsubscribe, just stop emitting to the passed listener.
          */
         unsubscribe(callback?: (message: TMessage) => void): void;
 
         /**
-         * Registers as a publisher for the topic.
+         * Register as a publisher for the topic.
          */
         advertise(): void;
 
         /**
-         * Unregisters as a publisher for the topic.
+         * Unregister as a publisher for the topic.
          */
         unadvertise(): void;
 
         /**
          * Publish the message.
          *
-         * @param message - A ROSLIB.Message object.
+         * @param {TMessage} message - A ROSLIB.Message object.
          */
         publish(message: TMessage): void;
     }
@@ -436,16 +535,17 @@ declare namespace ROSLIB {
          * A TF Client that listens to TFs from tf2_web_republisher.
          *
          * @constructor
-         * @param options - object with following keys:
-         *   * ros - the ROSLIB.Ros connection handle
-         *   * fixedFrame - the fixed frame, like /base_link
-         *   * angularThres - the angular threshold for the TF republisher
-         *   * transThres - the translation threshold for the TF republisher
-         *   * rate - the rate for the TF republisher
-         *   * updateDelay - the time (in ms) to wait after a new subscription to update the TF republisher's list of TFs
-         *   * topicTimeout - the timeout parameter for the TF republisher
-         *   * serverName (optional) - the name of the tf2_web_republisher server
-         *   * repubServiceName (optional) - the name of the republish_tfs service (non groovy compatibility mode only) default: '/republish_tfs'
+         * @param {Object} options
+         * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
+         * @param {string} [options.fixedFrame=base_link] - The fixed frame.
+         * @param {number} [options.angularThres=2.0] - The angular threshold for the TF republisher.
+         * @param {number} [options.transThres=0.01] - The translation threshold for the TF republisher.
+         * @param {number} [options.rate=10.0] - The rate for the TF republisher.
+         * @param {number} [options.updateDelay=50] - The time (in ms) to wait after a new subscription
+         *     to update the TF republisher's list of TFs.
+         * @param {number} [options.topicTimeout=2.0] - The timeout parameter for the TF republisher.
+         * @param {string} [options.serverName=/tf2_web_republisher] - The name of the tf2_web_republisher server.
+         * @param {string} [options.repubServiceName=/republish_tfs] - The name of the republish_tfs service (non groovy compatibility mode only).
          */
         constructor(options: {
             ros: Ros;
@@ -465,36 +565,41 @@ declare namespace ROSLIB {
         dispose(): void;
 
         /**
-         * Process the service response and subscribe to the tf republisher topic.
+         * Process the service response and subscribe to the tf republisher
+         * topic.
          *
-         * @param response - the service response containing the topic name
+         * @param {any} response - The service response containing the topic name.
          */
         processResponse(response: any): void;
 
         /**
-         * Process the incoming TF message and send them out using the callback functions
-         * @param tf - the TF message from the server
+         * Process the incoming TF message and send them out using the callback
+         * functions.
+         *
+         * @param {any} tf - The TF message from the server.
          */
-        processTfArray(tf: any): void;
+        processTFArray(tf: any): void;
 
         /**
          * Subscribe to the given TF frame.
-         * @param frameId - the TF frame to subscribe to
-         * @param callback - function with params:
-         *  * transform - the transform data
+         *
+         * @param {string} frameID - The TF frame to subscribe to.
+         * @param {function} callback - Function with the following params:
+         * @param {Transform} callback.transform - The transform data.
          */
         subscribe(frameId: string, callback: (transform: Transform) => void): void;
 
         /**
          * Unsubscribe from the given TF frame.
          *
-         * @param frameId - the TF frame to unsubscribe from
-         * @param callback - the callback function to remove
+         * @param {string} frameID - The TF frame to unsubscribe from.
+         * @param {function} callback - The callback function to remove.
          */
-        unsubscribe(frameId: string, callback?: (transform: Transform) => void): void;
+        unsubscribe(frameId: string, callback: (transform: Transform) => void): void;
 
         /**
-         * Create and send a new goal (or service request) to the tf2_web_republisher based on the current list of TFs.
+         * Create and send a new goal (or service request) to the tf2_web_republisher
+         * based on the current list of TFs.
          */
         updateGoal(): void;
     }
@@ -504,9 +609,9 @@ declare namespace ROSLIB {
          * A Transform in 3-space. Values are copied into this object.
          *
          * @constructor
-         * @param options - object with following keys:
-         *   * translation - the Vector3 describing the translation
-         *   * rotation - the ROSLIB.Quaternion describing the rotation
+         * @param {Object} options
+         * @param {Vector3Like} options.translation - The ROSLIB.Vector3 describing the translation.
+         * @param {QuaternionLike} options.rotation - The ROSLIB.Quaternion describing the rotation.
          */
         constructor(options?: {
             translation?: Vector3Like | null | undefined;
@@ -519,6 +624,7 @@ declare namespace ROSLIB {
         /**
          * Clone a copy of this transform.
          *
+         * @returns {Transform} The cloned transform.
          */
         clone(): Transform;
     }
@@ -528,10 +634,10 @@ declare namespace ROSLIB {
          * A 3D vector.
          *
          * @constructor
-         * @param options - object with following keys:
-         *   * x - the x value
-         *   * y - the y value
-         *   * z - the z value
+         * @param {Object} options
+         * @param {number} [options.x=0] - The x value.
+         * @param {number} [options.y=0] - The y value.
+         * @param {number} [options.z=0] - The z value.
          */
         constructor(
             options?: {
@@ -549,25 +655,28 @@ declare namespace ROSLIB {
         /**
          * Set the values of this vector to the sum of itself and the given vector.
          *
-         * @param v - the vector to add with
+         * @param {Vector3} v - The vector to add with.
          */
         add(v: Vector3): void;
 
         /**
          * Clone a copy of this vector.
+         * 
+         * @returns {Vector3} The cloned vector.
          */
         clone(): Vector3;
 
         /**
          * Multiply the given Quaternion with this vector.
-         * @param q - the quaternion to multiply with
+         *
+         * @param {Quaternion} q - The quaternion to multiply with.
          */
         multiplyQuaternion(q: Quaternion): void;
 
         /**
          * Set the values of this vector to the difference of itself and the given vector.
          *
-         * @param v - the vector to subtract with
+         * @param {Vector3} v - The vector to subtract with.
          */
         subtract(v: Vector3): void;
     }
@@ -577,11 +686,11 @@ declare namespace ROSLIB {
          * A Quaternion.
          *
          * @constructor
-         * @param options - object with following keys:
-         *   * x - the x value
-         *   * y - the y value
-         *   * z - the z value
-         *   * w - the w value
+         * @param {Object} options
+         * @param {number} [options.x=0] - The x value.
+         * @param {number} [options.y=0] - The y value.
+         * @param {number} [options.z=0] - The z value.
+         * @param {number} [options.w=1] - The w value.
          */
         constructor(
             options?: {
@@ -600,6 +709,8 @@ declare namespace ROSLIB {
 
         /**
          * Clone a copy of this quaternion.
+         *
+         * @returns {Quaternion} The cloned quaternion.
          */
         clone(): Quaternion;
 
@@ -615,12 +726,15 @@ declare namespace ROSLIB {
 
         /**
          * Set the values of this quaternion to the product of itself and the given quaternion.
-         * @param q - the quaternion to multiply with
+         *
+         * @param {Quaternion} q - The quaternion to multiply with.
          */
         multiply(q: Quaternion): void;
 
         /**
          * Return the norm of this quaternion.
+         *
+         * @returns {number} The norm of this quaternion.
          */
         norm(): number;
 
@@ -637,10 +751,10 @@ declare namespace ROSLIB {
         /**
          * A Pose in 3D space. Values are copied into this object.
          *
-         *  @constructor
-         *  @param options - object with following keys:
-         *   * position - the Vector3 describing the position
-         *   * orientation - the ROSLIB.Quaternion describing the orientation
+         * @constructor
+         * @param {Object} options
+         * @param {Vector3Like} options.position - The ROSLIB.Vector3 describing the position.
+         * @param {QuaternionLike} options.orientation - The ROSLIB.Quaternion describing the orientation.
          */
         constructor(
             options?: {
@@ -652,37 +766,51 @@ declare namespace ROSLIB {
         /**
          * Apply a transform against this pose.
          *
-         * @param tf the transform
+         * @param {Transform} tf - The transform to be applied.
          */
         applyTransform(tf: Transform): void;
 
         /**
          * Clone a copy of this pose.
          *
-         * @returns the cloned pose
+         * @returns {Pose} The cloned pose.
          */
         clone(): Pose;
+
+        /**
+         * Multiply this pose with another pose without altering this pose.
+         *
+         * @returns {Pose} The result of the multiplication.
+         */
+        multiply(pose: Pose): void;
+
+        /**
+         * Compute the inverse of this pose.
+         *
+         * @returns {Pose} The inverse of the pose.
+         */
+        getInverse(): Pose;
     }
 
-    class ActionClient {
+    export class ActionClient {
         /**
          * An actionlib action client.
          *
          * Emits the following events:
-         *  * 'timeout' - if a timeout occurred while sending a goal
-         *  * 'status' - the status messages received from the action server
-         *  * 'feedback' -  the feedback messages received from the action server
-         *  * 'result' - the result returned from the action server
+         *  * 'timeout' - If a timeout occurred while sending a goal.
+         *  * 'status' - The status messages received from the action server.
+         *  * 'feedback' - The feedback messages received from the action server.
+         *  * 'result' - The result returned from the action server.
          *
-         *  @constructor
-         *  @param options - object with following keys:
-         *   * ros - the ROSLIB.Ros connection handle
-         *   * serverName - the action server name, like /fibonacci
-         *   * actionName - the action message name, like 'actionlib_tutorials/FibonacciAction'
-         *   * timeout - the timeout length when connecting to the action server
-         *   * omitFeedback - the boolean flag to indicate whether to omit the feedback channel or not
-         *   * omitStatus - the boolean flag to indicate whether to omit the status channel or not
-         *   * omitResult - the boolean flag to indicate whether to omit the result channel or not
+         * @constructor
+         * @param {Object} options
+         * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
+         * @param {string} options.serverName - The action server name, like '/fibonacci'.
+         * @param {string} options.actionName - The action message name, like 'actionlib_tutorials/FibonacciAction'.
+         * @param {number} [options.timeout] - The timeout length when connecting to the action server.
+         * @param {boolean} [options.omitFeedback] - The flag to indicate whether to omit the feedback channel or not.
+         * @param {boolean} [options.omitStatus] - The flag to indicate whether to omit the status channel or not.
+         * @param {boolean} [options.omitResult] - The flag to indicate whether to omit the result channel or not.
          */
         constructor(options: { ros: Ros; serverName: string; actionName: string; timeout?: number; omitFeedback?: boolean; omitStatus?: boolean; omitResult?: boolean });
 
@@ -697,32 +825,50 @@ declare namespace ROSLIB {
         dispose(): void;
     }
 
-    class Goal {
+    export class ActionListener {
         /**
-         * An actionlib goal goal is associated with an action server.
+         * An actionlib action listener.
          *
          * Emits the following events:
-         *  * 'timeout' - if a timeout occurred while sending a goal
+         *  * 'status' - The status messages received from the action server.
+         *  * 'feedback' - The feedback messages received from the action server.
+         *  * 'result' - The result returned from the action server.
          *
-         *  @constructor
-         *  @param options with following keys:
-         *   * actionClient - the ROSLIB.ActionClient to use with this goal
-         *   * goalMessage - The JSON object containing the goal for the action server
+         * @constructor
+         * @param {Object} options
+         * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
+         * @param {string} options.serverName - The action server name, like '/fibonacci'.
+         * @param {string} options.actionName - The action message name, like 'actionlib_tutorials/FibonacciAction'.
          */
-        constructor(options: { actionClient: ActionClient; goalMessage: any });
+        constructor(options: { ros: Ros; serverName: string; actionName: string });
+    }
+
+    export class Goal {
+        /**
+         * An actionlib goal that is associated with an action server.
+         *
+         * Emits the following events:
+         *  * 'timeout' - If a timeout occurred while sending a goal.
+         *
+         * @constructor
+         * @param {Object} options
+         * @param {ActionClient} options.actionClient - The ROSLIB.ActionClient to use with this goal.
+         * @param {Object} options.goalMessage - The JSON object containing the goal for the action server.
+         */
+        constructor(options: { actionClient: ActionClient; goalMessage: Object });
 
         /**
-         * Connect callback functions to goal based events
+         * Connect callback functions to goal based events.
          *
-         * @param eventName Name of event ('timeout', 'status', 'feedback', 'result')
-         * @param callback Callback function executed on connected event
+         * @param {string} eventName - Name of event ('timeout', 'status', 'feedback', 'result').
+         * @param {function} callback - Callback function executed on connected event.
          */
         on(eventName: string, callback: (event: any) => void): void;
 
         /**
          * Send the goal to the action server.
          *
-         * @param timeout (optional) - a timeout length for the goal's result
+         * @param {number} [timeout] - A timeout length for the goal's result.
          */
         send(timeout?: number): void;
 
@@ -730,6 +876,49 @@ declare namespace ROSLIB {
          * Cancel the current goal.
          */
         cancel(): void;
+    }
+
+    export class SimpleActionServer {
+        /**
+         * An actionlib action server client.
+         *
+         * Emits the following events:
+         *  * 'goal' - Goal sent by action client.
+         *  * 'cancel' - Action client has canceled the request.
+         *
+         * @constructor
+         * @param {Object} options
+         * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
+         * @param {string} options.serverName - The action server name, like '/fibonacci'.
+         * @param {string} options.actionName - The action message name, like 'actionlib_tutorials/FibonacciAction'.
+         */
+        constructor(options: { ros: Ros; serverName: string; actionName: string });
+
+        /**
+         * Set action state to succeeded and return to client.
+         *
+         * @param {Object} result - The result to return to the client.
+         */
+        setSucceeded(result: Object): void;
+
+        /**
+         * Set action state to aborted and return to client.
+         *
+         * @param {Object} result - The result to return to the client.
+         */
+        setAborted(result: Object): void;
+
+        /**
+         * Send a feedback message.
+         *
+         * @param {Object} feedback - The feedback to send to the client.
+         */
+        sendFeedback(feedback: Object): void;
+
+        /**
+         * Handle case where client requests preemption.
+         */
+        setPreempted(): void;
     }
 
     export class UrdfColor {
@@ -741,8 +930,8 @@ declare namespace ROSLIB {
          * A Color element in a URDF.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
          */
         constructor(options: { xml: Node });
     }
@@ -756,12 +945,14 @@ declare namespace ROSLIB {
          * A Material element in a URDF.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
          */
         constructor(options: { xml: Node });
 
         isLink(): boolean;
+
+        assign(obj: UrdfMaterial): UrdfMaterial;
     }
 
     export class UrdfJoint {
@@ -776,8 +967,8 @@ declare namespace ROSLIB {
          * A Joint element in a URDF.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
          */
         constructor(options: { xml: Node });
     }
@@ -797,8 +988,8 @@ declare namespace ROSLIB {
          * A Sphere element in a URDF.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
          */
         constructor(options: { xml: Node });
     }
@@ -811,8 +1002,8 @@ declare namespace ROSLIB {
          * A Box element in a URDF.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
          */
         constructor(options: { xml: Node });
     }
@@ -826,8 +1017,8 @@ declare namespace ROSLIB {
          * A Cylinder element in a URDF.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
          */
         constructor(options: { xml: Node });
     }
@@ -841,8 +1032,8 @@ declare namespace ROSLIB {
          * A Box element in a URDF.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
          */
         constructor(options: { xml: Node });
     }
@@ -856,8 +1047,8 @@ declare namespace ROSLIB {
          * A Visual element in a URDF.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
          */
         constructor(options: { xml: Node });
     }
@@ -870,8 +1061,8 @@ declare namespace ROSLIB {
          * A Link element in a URDF.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
          */
         constructor(options: { xml: Node });
     }
@@ -885,9 +1076,9 @@ declare namespace ROSLIB {
          * A URDF Model can be used to parse a given URDF into the appropriate elements.
          *
          * @constructor
-         * @param options - object with following keys:
-         *  * xml - the XML element to parse
-         *  * string - the XML element to parse as a string
+         * @param {Object} options
+         * @param {Node} options.xml - The XML element to parse.
+         * @param {string} options.string - The XML element to parse as a string.
          */
         constructor(options: { xml: Node; string?: string | null | undefined } | { string: string });
     }

--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -240,13 +240,9 @@ declare namespace ROSLIB {
          * @param {function} [failedCallback] - The callback function when the service call failed with params:
          * @param {string} failedCallback.error - The error message reported by ROS.
          */
-        // Note: Use type overloading instead to provide better readability of the available function signature of getNodeDetails
+        // Note: Use type overloading instead to provide better readability of the available function signatures of getNodeDetails
         // tslint:disable-next-line:unified-signatures
-        getNodeDetails(
-            node: string,
-            callback: (subscriptions: string[], publications: string[], services: string[]) => void,
-            failedCallback?: (error: string) => void,
-        ): void;
+        getNodeDetails(node: string, callback: (subscriptions: string[], publications: string[], services: string[]) => void, failedCallback?: (error: string) => void): void;
 
         /**
          * Retrieve a list of subscribed topics, publishing topics and services of a specific node.
@@ -262,13 +258,9 @@ declare namespace ROSLIB {
          * @param {function} [failedCallback] - The callback function when the service call failed with params:
          * @param {string} failedCallback.error - The error message reported by ROS.
          */
-        // Note: Use type overloading instead to provide better readability of the available function signature of getNodeDetails
+        // Note: Use type overloading instead to provide better readability of the available function signatures of getNodeDetails
         // tslint:disable-next-line:unified-signatures
-        getNodeDetails(
-            node: string,
-            callback: (result: { subscribing: string[], publishing: string[], services: string[] }) => void,
-            failedCallback?: (error: string) => void,
-        ): void;
+        getNodeDetails(node: string, callback: (result: { subscribing: string[], publishing: string[], services: string[] }) => void, failedCallback?: (error: string) => void): void;
 
         /**
          * Retrieve a list of parameter names from the ROS Parameter Server.

--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -84,7 +84,7 @@ declare namespace ROSLIB {
          * @param {string} client - IP of the client.
          * @param {string} dest - IP of the destination.
          * @param {string} rand - Random string given by the trusted source.
-         * @param {Object} t - Time of the authorization request.
+         * @param {any} t - Time of the authorization request.
          * @param {string} level - User level as a string given by the client.
          * @param {Object} end - End time of the client's session.
          */
@@ -93,29 +93,29 @@ declare namespace ROSLIB {
             client: string,
             dest: string,
             rand: string,
-            t: Object,
+            t: any,
             level: string,
-            end: Object,
+            end: any,
         ): void;
 
         /**
          * Send an encoded message over the WebSocket.
-         * 
-         * @param {Object} messageEncoded - The encoded message to be sent.
+         *
+         * @param {any} messageEncoded - The encoded message to be sent.
          */
-         sendEncodedMessage(messageEncoded: Object): void;
+         sendEncodedMessage(messageEncoded: any): void;
 
         /**
          * Send the message over the WebSocket, but queue the message up if not yet
          * connected.
-         * 
-         * @param {Object} message - The message to be sent.
+         *
+         * @param {any} message - The message to be sent.
          */
-        callOnConnection(message: Object): void;
+        callOnConnection(message: any): void;
 
         /**
          * Send a set_level request to the server.
-         * 
+         *
          * @param {string} level - Status level (none, error, warning, info).
          * @param {number} [id] - Operation ID to change status level on.
          */
@@ -208,14 +208,9 @@ declare namespace ROSLIB {
          * @param {string[]} callback.services - Array of service names hosted.
          * @param {function} [failedCallback] - The callback function when the service call failed with params:
          * @param {string} failedCallback.error - The error message reported by ROS.
-         */
-        getNodeDetails(
-            node: string,
-            callback: (subscriptions: string[], publications: string[], services: string[]) => void,
-            failedCallback?: (error: string) => void,
-        ): void;
-
-        /**
+         *
+         * @also
+         *
          * Retrieve a list of subscribed topics, publishing topics and services of a specific node.
          * <br>
          * These are the parameters if failedCallback is <strong>undefined</strong>.
@@ -231,7 +226,7 @@ declare namespace ROSLIB {
          */
         getNodeDetails(
             node: string,
-            callback: (result: { subscribing: string[], publishing: string[], services: string[] }) => void,
+            callback: ((subscriptions: string[], publications: string[], services: string[]) => void) | ((result: { subscribing: string[], publishing: string[], services: string[] }) => void),
             failedCallback?: (error: string) => void,
         ): void;
 
@@ -285,9 +280,9 @@ declare namespace ROSLIB {
         /**
          * Decode a typedef array into a dictionary like `rosmsg show foo/bar`.
          *
-         * @param {Object[]} defs - Array of type_def dictionary.
+         * @param {any[]} defs - Array of type_def dictionary.
          */
-        decodeTypeDefs(defs: Object[]): void;
+        decodeTypeDefs(defs: any[]): void;
 
         /**
          * Retrieve a list of topics and their associated type definitions.
@@ -323,7 +318,7 @@ declare namespace ROSLIB {
 
         /**
          * Retrieve the details of a ROS service response.
-         * 
+         *
          * @param {string} type - The type of the service.
          * @param {function} callback - Function with the following params:
          * @param {Object} callback.result - The result object with the following params:
@@ -343,9 +338,9 @@ declare namespace ROSLIB {
          * Message objects are used for publishing and subscribing to and from topics.
          *
          * @constructor
-         * @param {Object} values - An object matching the fields defined in the .msg definition file.
+         * @param {any} values - An object matching the fields defined in the .msg definition file.
          */
-        constructor(values: Object);
+        constructor(values: any);
     }
 
     export class Param {
@@ -363,21 +358,21 @@ declare namespace ROSLIB {
          * Fetch the value of the param.
          *
          * @param {function} callback - Function with the following params:
-         * @param {Object} callback.value - The value of the param from ROS.
+         * @param {any} callback.value - The value of the param from ROS.
          */
-        get(callback: (value: Object) => void): void;
+        get(callback: (value: any) => void): void;
 
         /**
          * Set the value of the param in ROS.
          *
-         * @param {Object} value - The value to set param to.
+         * @param {any} value - The value to set param to.
          * @param {function} callback - The callback function.
          */
-        set(value: Object, callback: (response: any) => void): void;
+        set(value: any, callback: (response: any) => void): void;
 
         /**
          * Delete this parameter on the ROS server.
-         * 
+         *
          * @param {function} callback - The callback function.
          */
         delete(callback: (response: any) => void): void;
@@ -440,9 +435,9 @@ declare namespace ROSLIB {
          * A ServiceRequest is passed into the service call.
          *
          * @constructor
-         * @param {Object} values - Object matching the fields defined in the .srv definition file.
+         * @param {any} values - Object matching the fields defined in the .srv definition file.
          */
-        constructor(values: Object);
+        constructor(values: any);
     }
 
     export class ServiceResponse {
@@ -450,9 +445,9 @@ declare namespace ROSLIB {
          * A ServiceResponse is returned from the service call.
          *
          * @constructor
-         * @param {Object} values - Object matching the fields defined in the .srv definition file.
+         * @param {any} values - Object matching the fields defined in the .srv definition file.
          */
-        constructor(values: Object);
+        constructor(values: any);
     }
 
     export class Topic<TMessage = Message> extends EventEmitter2 {
@@ -661,7 +656,7 @@ declare namespace ROSLIB {
 
         /**
          * Clone a copy of this vector.
-         * 
+         *
          * @returns {Vector3} The cloned vector.
          */
         clone(): Vector3;
@@ -853,9 +848,9 @@ declare namespace ROSLIB {
          * @constructor
          * @param {Object} options
          * @param {ActionClient} options.actionClient - The ROSLIB.ActionClient to use with this goal.
-         * @param {Object} options.goalMessage - The JSON object containing the goal for the action server.
+         * @param {any} options.goalMessage - The JSON object containing the goal for the action server.
          */
-        constructor(options: { actionClient: ActionClient; goalMessage: Object });
+        constructor(options: { actionClient: ActionClient; goalMessage: any });
 
         /**
          * Connect callback functions to goal based events.
@@ -897,23 +892,23 @@ declare namespace ROSLIB {
         /**
          * Set action state to succeeded and return to client.
          *
-         * @param {Object} result - The result to return to the client.
+         * @param {any} result - The result to return to the client.
          */
-        setSucceeded(result: Object): void;
+        setSucceeded(result: any): void;
 
         /**
          * Set action state to aborted and return to client.
          *
-         * @param {Object} result - The result to return to the client.
+         * @param {any} result - The result to return to the client.
          */
-        setAborted(result: Object): void;
+        setAborted(result: any): void;
 
         /**
          * Send a feedback message.
          *
-         * @param {Object} feedback - The feedback to send to the client.
+         * @param {any} feedback - The feedback to send to the client.
          */
-        sendFeedback(feedback: Object): void;
+        sendFeedback(feedback: any): void;
 
         /**
          * Handle case where client requests preemption.

--- a/types/roslib/roslib-tests.ts
+++ b/types/roslib/roslib-tests.ts
@@ -120,7 +120,7 @@ const tfClient = new ROSLIB.TFClient({
     ros: ros,
     fixedFrame: '/world',
 });
-const stub_tfclient_callback = function (transform: ROSLIB.Transform) {}
+const stub_tfclient_callback = function (transform: ROSLIB.Transform) {};
 const tfclient_callback = function (transform: ROSLIB.Transform) {
     console.log('Received transform: ' + transform);
     tfClient.unsubscribe('/transform', stub_tfclient_callback);

--- a/types/roslib/roslib-tests.ts
+++ b/types/roslib/roslib-tests.ts
@@ -109,7 +109,7 @@ var maxVelX = new ROSLIB.Param({
     name: 'max_vel_y',
 });
 
-maxVelX.set(0.8);
+maxVelX.set(0.8, function (response) {});
 maxVelX.get(function (value) {
     console.log('MAX VAL: ' + value);
 });
@@ -120,9 +120,10 @@ const tfClient = new ROSLIB.TFClient({
     ros: ros,
     fixedFrame: '/world',
 });
+const stub_tfclient_callback = function (transform: ROSLIB.Transform) {}
 const tfclient_callback = function (transform: ROSLIB.Transform) {
     console.log('Received transform: ' + transform);
-    tfClient.unsubscribe('/transform');
+    tfClient.unsubscribe('/transform', stub_tfclient_callback);
 };
 
 tfClient.subscribe('/transform', tfclient_callback);

--- a/types/roslib/tslint.json
+++ b/types/roslib/tslint.json
@@ -10,7 +10,6 @@
         "prefer-const": false,
         "prefer-template": false,
         "space-before-function-paren": false,
-        "strict-export-declare-modifiers": false,
-        "unified-signatures": false
+        "strict-export-declare-modifiers": false
     }
 }

--- a/types/roslib/tslint.json
+++ b/types/roslib/tslint.json
@@ -10,6 +10,7 @@
         "prefer-const": false,
         "prefer-template": false,
         "space-before-function-paren": false,
-        "strict-export-declare-modifiers": false
+        "strict-export-declare-modifiers": false,
+        "unified-signatures": false
     }
 }


### PR DESCRIPTION
This PR adds the following new method signature type definitions:

- `Ros`:
  - `sendEncodedMessage`
  - `setStatusLevel`
  - `getServiceResponseDetails`
  - `getNodeDetails`
  - `getTopicsAndRawTypes`
- `Pose`:
  - `multiply`
  - `getInverse`
- `UrdfMaterial`:
  - `assign`

This PR also fixes a few type definitions:

- `Topic`:
  - New `reconnect_on_close` constructor parameter
- `TFClient`:
  - Fix method name from `processTfArray` to `processTFArray`

Furthermore, this PR also adds the new classes `ActionListener` and `SimpleActionServer`, along with their corresponding available methods.

Finally, this PR also makes some optional parameters that are supposed to be not optional as not optional, fixes a few type signatures to possess more specific types (such as the `error` string parameter of `failedCallback`), and makes the corresponding docstring up-to-date.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  This PR adds a few missing type definitions for the `roslibjs` library version 1.3.0 and updates the docstrings to align with the changes submitted via [this PR](https://github.com/RobotWebTools/roslibjs/pull/562) to the `roslibjs` repository.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
