### PR TITLE
graphql-upload: Update types to v15

### DIFF
--- a/types/graphql-upload/GraphQLUpload.d.ts
+++ b/types/graphql-upload/GraphQLUpload.d.ts
@@ -1,0 +1,4 @@
+import { GraphQLScalarType } from 'graphql';
+
+const GraphQLUpload: GraphQLScalarType;
+export default GraphQLUpload;

--- a/types/graphql-upload/GraphQLUpload.d.ts
+++ b/types/graphql-upload/GraphQLUpload.d.ts
@@ -1,4 +1,4 @@
 import { GraphQLScalarType } from 'graphql';
 
-const GraphQLUpload: GraphQLScalarType;
+declare const GraphQLUpload: GraphQLScalarType;
 export default GraphQLUpload;

--- a/types/graphql-upload/GraphQLUpload.d.ts
+++ b/types/graphql-upload/GraphQLUpload.d.ts
@@ -1,4 +1,4 @@
 import { GraphQLScalarType } from 'graphql';
 
-declare const GraphQLUpload: GraphQLScalarType;
+const GraphQLUpload: GraphQLScalarType;
 export default GraphQLUpload;

--- a/types/graphql-upload/OTHER_FILES.txt
+++ b/types/graphql-upload/OTHER_FILES.txt
@@ -1,0 +1,5 @@
+GraphQLUpload.d.ts
+Upload.d.ts
+graphqlUploadExpress.d.ts
+graphqlUploadKoa.d.ts
+processRequest.d.ts

--- a/types/graphql-upload/OTHER_FILES.txt
+++ b/types/graphql-upload/OTHER_FILES.txt
@@ -1,5 +1,0 @@
-GraphQLUpload.d.ts
-Upload.d.ts
-graphqlUploadExpress.d.ts
-graphqlUploadKoa.d.ts
-processRequest.d.ts

--- a/types/graphql-upload/OTHER_FILES.txt
+++ b/types/graphql-upload/OTHER_FILES.txt
@@ -1,0 +1,1 @@
+GraphQLUpload.d.ts

--- a/types/graphql-upload/OTHER_FILES.txt
+++ b/types/graphql-upload/OTHER_FILES.txt
@@ -1,1 +1,5 @@
 GraphQLUpload.d.ts
+Upload.d.ts
+graphqlUploadExpress.d.ts
+graphqlUploadKoa.d.ts
+processRequest.d.ts

--- a/types/graphql-upload/Upload.d.ts
+++ b/types/graphql-upload/Upload.d.ts
@@ -1,0 +1,8 @@
+import { FileUpload } from './';
+
+export { FileUpload };
+
+export default class Upload {
+    promise: Promise<FileUpload>;
+    file?: FileUpload;
+}

--- a/types/graphql-upload/Upload.d.ts
+++ b/types/graphql-upload/Upload.d.ts
@@ -1,6 +1,11 @@
-import { FileUpload } from './';
+import { ReadStream } from 'fs-capacitor';
 
-export { FileUpload };
+export interface FileUpload {
+    filename: string;
+    mimetype: string;
+    encoding: string;
+    createReadStream(): ReadStream;
+}
 
 export default class Upload {
     promise: Promise<FileUpload>;

--- a/types/graphql-upload/graphql-upload-tests.ts
+++ b/types/graphql-upload/graphql-upload-tests.ts
@@ -1,18 +1,18 @@
-import express from "express";
-import Koa from "koa";
-import { graphqlUploadExpress, graphqlUploadKoa, Upload } from "graphql-upload";
+import express from 'express';
+import Koa from 'koa';
+import graphqlUploadExpress from 'graphql-upload/graphqlUploadExpress.js';
+import graphqlUploadKoa from 'graphql-upload/graphqlUploadKoa.js';
+import Upload from 'graphql-upload/Upload.js';
 
 express()
-  .use(graphqlUploadExpress({ maxFileSize: 10000000, maxFiles: 10 }))
-  .listen(3000);
+    .use(graphqlUploadExpress({ maxFileSize: 10000000, maxFiles: 10 }))
+    .listen(3000);
 
-new Koa()
-  .use(graphqlUploadKoa({ maxFileSize: 10000000, maxFiles: 10 }))
-  .listen(3000);
+new Koa().use(graphqlUploadKoa({ maxFileSize: 10000000, maxFiles: 10 })).listen(3000);
 
 const manuallyHandleUpload = async (upload: Upload) => {
-  if (upload instanceof Upload) {
-    return upload.promise;
-  }
-  throw new Error("Upload is not an instance of Upload");
+    if (upload instanceof Upload) {
+        return upload.promise;
+    }
+    throw new Error('Upload is not an instance of Upload');
 };

--- a/types/graphql-upload/graphql-upload-tests.ts
+++ b/types/graphql-upload/graphql-upload-tests.ts
@@ -1,8 +1,11 @@
+import http from 'http';
 import express from 'express';
 import Koa from 'koa';
 import graphqlUploadExpress from 'graphql-upload/graphqlUploadExpress.js';
 import graphqlUploadKoa from 'graphql-upload/graphqlUploadKoa.js';
 import Upload from 'graphql-upload/Upload.js';
+import GraphQLUpload from 'graphql-upload/GraphQLUpload.js';
+import processRequest from 'graphql-upload/processRequest.js';
 
 express()
     .use(graphqlUploadExpress({ maxFileSize: 10000000, maxFiles: 10 }))
@@ -16,3 +19,9 @@ const manuallyHandleUpload = async (upload: Upload) => {
     }
     throw new Error('Upload is not an instance of Upload');
 };
+
+const stringified: string = GraphQLUpload.toString();
+
+http.createServer((req, res) => {
+    const operations = processRequest(req, res);
+});

--- a/types/graphql-upload/graphql-upload-tests.ts
+++ b/types/graphql-upload/graphql-upload-tests.ts
@@ -1,11 +1,8 @@
-import http from 'http';
 import express from 'express';
 import Koa from 'koa';
 import graphqlUploadExpress from 'graphql-upload/graphqlUploadExpress.js';
 import graphqlUploadKoa from 'graphql-upload/graphqlUploadKoa.js';
 import Upload from 'graphql-upload/Upload.js';
-import GraphQLUpload from 'graphql-upload/GraphQLUpload.js';
-import processRequest from 'graphql-upload/processRequest.js';
 
 express()
     .use(graphqlUploadExpress({ maxFileSize: 10000000, maxFiles: 10 }))
@@ -19,9 +16,3 @@ const manuallyHandleUpload = async (upload: Upload) => {
     }
     throw new Error('Upload is not an instance of Upload');
 };
-
-const stringified: string = GraphQLUpload.toString();
-
-http.createServer((req, res) => {
-    const operations = processRequest(req, res);
-});

--- a/types/graphql-upload/graphqlUploadExpress.d.ts
+++ b/types/graphql-upload/graphqlUploadExpress.d.ts
@@ -1,0 +1,6 @@
+import { RequestHandler } from 'express';
+import { UploadOptions } from './';
+
+export { UploadOptions };
+
+export default function graphqlUploadExpress(uploadOptions?: UploadOptions): RequestHandler;

--- a/types/graphql-upload/graphqlUploadExpress.d.ts
+++ b/types/graphql-upload/graphqlUploadExpress.d.ts
@@ -1,6 +1,9 @@
 import { RequestHandler } from 'express';
-import { UploadOptions } from './';
 
-export { UploadOptions };
+export interface UploadOptions {
+    maxFieldSize?: number | undefined;
+    maxFileSize?: number | undefined;
+    maxFiles?: number | undefined;
+}
 
 export default function graphqlUploadExpress(uploadOptions?: UploadOptions): RequestHandler;

--- a/types/graphql-upload/graphqlUploadKoa.d.ts
+++ b/types/graphql-upload/graphqlUploadKoa.d.ts
@@ -1,7 +1,10 @@
 import { DefaultContext, DefaultState, Middleware } from 'koa';
-import { UploadOptions } from './';
 
-export { UploadOptions };
+export interface UploadOptions {
+    maxFieldSize?: number | undefined;
+    maxFileSize?: number | undefined;
+    maxFiles?: number | undefined;
+}
 
 export default function graphqlUploadKoa<StateT = DefaultState, ContextT = DefaultContext>(
     uploadOptions?: UploadOptions,

--- a/types/graphql-upload/graphqlUploadKoa.d.ts
+++ b/types/graphql-upload/graphqlUploadKoa.d.ts
@@ -1,0 +1,10 @@
+import { DefaultContext, DefaultState, Middleware } from 'koa';
+import { UploadOptions } from './';
+
+/* tslint:disable:no-unnecessary-generics */
+
+export { UploadOptions };
+
+export default function graphqlUploadKoa<StateT = DefaultState, ContextT = DefaultContext>(
+    uploadOptions?: UploadOptions,
+): Middleware<StateT, ContextT>;

--- a/types/graphql-upload/graphqlUploadKoa.d.ts
+++ b/types/graphql-upload/graphqlUploadKoa.d.ts
@@ -1,10 +1,8 @@
 import { DefaultContext, DefaultState, Middleware } from 'koa';
 import { UploadOptions } from './';
 
-/* tslint:disable:no-unnecessary-generics */
-
 export { UploadOptions };
 
 export default function graphqlUploadKoa<StateT = DefaultState, ContextT = DefaultContext>(
     uploadOptions?: UploadOptions,
-): Middleware<StateT, ContextT>;
+): Middleware<StateT, ContextT>; // tslint:disable-line:no-unnecessary-generics

--- a/types/graphql-upload/index.d.ts
+++ b/types/graphql-upload/index.d.ts
@@ -5,23 +5,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.8
 
-import { ReadStream } from 'fs-capacitor';
-
-export interface FileUpload {
-    filename: string;
-    mimetype: string;
-    encoding: string;
-    createReadStream(): ReadStream;
-}
-
-export interface GraphQLOperation {
-    query: string;
-    operationName?: null | string | undefined;
-    variables?: null | unknown | undefined;
-}
-
-export interface UploadOptions {
-    maxFieldSize?: number | undefined;
-    maxFileSize?: number | undefined;
-    maxFiles?: number | undefined;
-}
+// Linter does not accept files without definitions. Disabling the rule at
+// the top of the file doesn't work either: It breaks the meta data parser.
+type Dummy = never;

--- a/types/graphql-upload/index.d.ts
+++ b/types/graphql-upload/index.d.ts
@@ -7,4 +7,5 @@
 
 // Linter does not accept files without definitions. Disabling the rule at
 // the top of the file doesn't work either: It breaks the meta data parser.
-type Dummy = never;
+
+export {};

--- a/types/graphql-upload/index.d.ts
+++ b/types/graphql-upload/index.d.ts
@@ -1,53 +1,27 @@
-// Type definitions for graphql-upload 8.0
+// Type definitions for graphql-upload 15.0
 // Project: https://github.com/jaydenseric/graphql-upload#readme
 // Definitions by: Mike Marcacci <https://github.com/mike-marcacci>
+//                 Simon Feiden <https://github.com/rdsfj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 4.1
+// TypeScript Version: 4.8
 
-/* tslint:disable:no-unnecessary-generics */
+import { ReadStream } from 'fs-capacitor';
 
-import { IncomingMessage, ServerResponse } from "http";
-import { GraphQLScalarType } from "graphql";
-import { RequestHandler } from "express";
-import { DefaultContext, DefaultState, Middleware } from "koa";
-import { ReadStream } from "fs-capacitor";
-
-export interface UploadOptions {
-  maxFieldSize?: number | undefined;
-  maxFileSize?: number | undefined;
-  maxFiles?: number | undefined;
+export interface FileUpload {
+    filename: string;
+    mimetype: string;
+    encoding: string;
+    createReadStream(): ReadStream;
 }
 
 export interface GraphQLOperation {
-  query: string;
-  operationName?: null | string | undefined;
-  variables?: null | unknown | undefined;
+    query: string;
+    operationName?: null | string | undefined;
+    variables?: null | unknown | undefined;
 }
 
-export function processRequest(
-  request: IncomingMessage,
-  response: ServerResponse,
-  uploadOptions?: UploadOptions
-): Promise<GraphQLOperation | GraphQLOperation[]>;
-
-export function graphqlUploadExpress(
-  uploadOptions?: UploadOptions
-): RequestHandler;
-
-export function graphqlUploadKoa <StateT = DefaultState, ContextT = DefaultContext>(
-  uploadOptions?: UploadOptions
-): Middleware<StateT, ContextT>;
-
-export const GraphQLUpload: GraphQLScalarType;
-
-export interface FileUpload {
-  filename: string;
-  mimetype: string;
-  encoding: string;
-  createReadStream(): ReadStream;
-}
-
-export class Upload {
-  promise: Promise<FileUpload>;
-  file?: FileUpload;
+export interface UploadOptions {
+    maxFieldSize?: number | undefined;
+    maxFileSize?: number | undefined;
+    maxFiles?: number | undefined;
 }

--- a/types/graphql-upload/package.json
+++ b/types/graphql-upload/package.json
@@ -3,5 +3,23 @@
   "dependencies": {
     "graphql": "0.13.1 - 16",
     "fs-capacitor": "^8.0.0"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    "./GraphQLUpload.js": {
+      "types": "./GraphQLUpload.d.ts"
+    },
+    "./Upload.js": {
+      "types": "./Upload.d.ts"
+    },
+    "./graphqlUploadExpress.js": {
+      "types": "./graphqlUploadExpress.d.ts"
+    },
+    "./graphqlUploadKoa.js": {
+      "types": "./graphqlUploadKoa.d.ts"
+    },
+    "./processRequest.js": {
+      "types": "./processRequest.d.ts"
+    }
   }
 }

--- a/types/graphql-upload/processRequest.d.ts
+++ b/types/graphql-upload/processRequest.d.ts
@@ -1,7 +1,16 @@
 import { IncomingMessage, ServerResponse } from 'http';
-import { GraphQLOperation, UploadOptions } from './';
 
-export { GraphQLOperation, UploadOptions };
+export interface UploadOptions {
+    maxFieldSize?: number | undefined;
+    maxFileSize?: number | undefined;
+    maxFiles?: number | undefined;
+}
+
+export interface GraphQLOperation {
+    query: string;
+    operationName?: null | string | undefined;
+    variables?: null | unknown | undefined;
+}
 
 export default function processRequest(
     request: IncomingMessage,

--- a/types/graphql-upload/processRequest.d.ts
+++ b/types/graphql-upload/processRequest.d.ts
@@ -1,3 +1,4 @@
+import { IncomingMessage, ServerResponse } from 'http';
 import { GraphQLOperation, UploadOptions } from './';
 
 export { GraphQLOperation, UploadOptions };

--- a/types/graphql-upload/processRequest.d.ts
+++ b/types/graphql-upload/processRequest.d.ts
@@ -1,0 +1,9 @@
+import { GraphQLOperation, UploadOptions } from './';
+
+export { GraphQLOperation, UploadOptions };
+
+export default function processRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+    uploadOptions?: UploadOptions,
+): Promise<GraphQLOperation | GraphQLOperation[]>;


### PR DESCRIPTION
Hello everyone 🙋‍♀️ 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaydenseric/graphql-upload/blob/master/changelog.md#1500
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


<br>
I've updated the types of `graphql-upload` to its version 15 as linked above. v15 is not the latest version, but still in use so it's necessary to haves the types available.
The latest version is v16, so I'd also like to create a follow-up PR to update again.

All definitions stayed the same for v15, only the structure of the package changed: All its exports have been moved to separate files, so I created corresponding `.d.ts `files and updated the tests.
I defined common interfaces in `index.d.ts` and for convenience they are exported again in the files that use them.

This is my first PR, so I hope I followed the process correctly.
Let me know if something needs to be changed 🙂 