### PR TITLE
[mapbox-gl-draw] Add missing properties to DrawFeature and DrawCustomModeThis

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -131,7 +131,25 @@ declare namespace MapboxDraw {
         type: 'draw.actionable';
     }
 
+    interface MapboxDrawOptions {
+        displayControlsDefault?: boolean | undefined;
+        keybindings?: boolean | undefined;
+        touchEnabled?: boolean | undefined;
+        boxSelect?: boolean | undefined;
+        clickBuffer?: number | undefined;
+        touchBuffer?: number | undefined;
+        controls?: MapboxDrawControls | undefined;
+        styles?: object[] | undefined;
+        modes?: { [modeKey: string]: DrawCustomMode } | undefined;
+        defaultMode?: string | undefined;
+        userProperties?: boolean | undefined;
+    }
+
     interface DrawCustomModeThis {
+        map: Map;
+
+        drawConfig: MapboxDrawOptions | {};
+
         setSelected(features?: string | string[]): void;
 
         setSelectedCoordinates(coords: Array<{ coord_path: string; feature_id: string }>): void;
@@ -236,19 +254,7 @@ declare class MapboxDraw implements IControl {
 
     getDefaultPosition: () => string;
 
-    constructor(options?: {
-        displayControlsDefault?: boolean | undefined;
-        keybindings?: boolean | undefined;
-        touchEnabled?: boolean | undefined;
-        boxSelect?: boolean | undefined;
-        clickBuffer?: number | undefined;
-        touchBuffer?: number | undefined;
-        controls?: MapboxDraw.MapboxDrawControls | undefined;
-        styles?: object[] | undefined;
-        modes?: { [modeKey: string]: MapboxDraw.DrawCustomMode } | undefined;
-        defaultMode?: string | undefined;
-        userProperties?: boolean | undefined;
-    });
+    constructor(options?: MapboxDraw.MapboxDrawOptions);
 
     add(geojson: Feature | FeatureCollection | Geometry): string[];
 

--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tudor Gergely <https://github.com/tudorgergely>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Feature, GeoJSON, FeatureCollection, Geometry, Point, Position, BBox, GeoJsonProperties } from 'geojson';
+import { Feature, GeoJSON, FeatureCollection, Geometry, Point, BBox, GeoJsonProperties, GeometryCollection } from 'geojson';
 import {
     IControl, Map,
     MapMouseEvent as MapboxMapMouseEvent,
@@ -50,18 +50,19 @@ declare namespace MapboxDraw {
         combineFeatures: boolean;
         uncombineFeatures: boolean;
     }
-
-    interface DrawFeature {
-        properties: GeoJsonProperties;
-        coordinates: Position;
+    interface DrawFeature<G extends Exclude<Geometry, GeometryCollection> = Exclude<Geometry, GeometryCollection>, P = GeoJsonProperties> {
+        properties: P;
+        coordinates: G['coordinates'];
+        id?: string | number | undefined;
+        type: G['type'];
 
         changed(): void;
 
-        incomingCoords(coords: Position): void;
+        incomingCoords(coords: G['coordinates']): void;
 
-        setCoordinates(coords: Position): void;
+        setCoordinates(coords: G['coordinates']): void;
 
-        getCoordinates(): Position;
+        getCoordinates(): G['coordinates'];
 
         setProperty(property: string, value: any): void;
 

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -1,4 +1,11 @@
-import MapboxDraw, { DrawCustomMode, DrawMode, DrawUpdateEvent, IMapboxDrawOptions } from '@mapbox/mapbox-gl-draw';
+import MapboxDraw, {
+    DrawCustomMode,
+    DrawFeature,
+    DrawMode,
+    DrawUpdateEvent,
+    IMapboxDrawOptions,
+} from '@mapbox/mapbox-gl-draw';
+import { LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon } from 'geojson';
 
 const draw = new MapboxDraw({});
 
@@ -54,22 +61,64 @@ interface CustomMode extends DrawCustomMode<{}, {}> {
 }
 
 const customMode: CustomMode = {
+    onSetup(this, options) {
+        const pointFeature = this.getFeature('1') as DrawFeature<Point>;
+        // $ExpectType "Point"
+        pointFeature.type;
+        // $ExpectType Position
+        pointFeature.coordinates;
+
+        const multiPointFeature = this.getFeature('2') as DrawFeature<MultiPoint>;
+        // $ExpectType "MultiPoint"
+        multiPointFeature.type;
+        // $ExpectType Position[]
+        multiPointFeature.coordinates;
+
+        const lineStringFeature = this.getFeature('3') as DrawFeature<LineString>;
+        // $ExpectType "LineString"
+        lineStringFeature.type;
+        // $ExpectType Position[]
+        lineStringFeature.coordinates;
+
+        const multiLineStringFeature = this.getFeature('4') as DrawFeature<MultiLineString>;
+        // $ExpectType "MultiLineString"
+        multiLineStringFeature.type;
+        // $ExpectType Position[][]
+        multiLineStringFeature.coordinates;
+
+        const polygonFeature = this.getFeature('5') as DrawFeature<Polygon>;
+        // $ExpectType "Polygon"
+        polygonFeature.type;
+        // $ExpectType Position[][]
+        polygonFeature.coordinates;
+
+        const multiPolygonFeature = this.getFeature('6') as DrawFeature<MultiPolygon>;
+        // $ExpectType "MultiPolygon"
+        multiPolygonFeature.type;
+        // $ExpectType Position[][][]
+        multiPolygonFeature.coordinates;
+
+        return {};
+    },
+
     onClick(state, e) {
         // $ExpectType LngLat
         e.lngLat;
-        // $ExpectType DrawFeature
+        // $ExpectType DrawFeature<Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon, GeoJsonProperties>
         e.featureTarget;
 
-        this.setSelectedCoordinates([{
-            coord_path: '0',
-            feature_id: '1',
-        }]);
+        this.setSelectedCoordinates([
+            {
+                coord_path: '0',
+                feature_id: '1',
+            },
+        ]);
 
         this.setSelected();
         this.setSelected('1');
         this.setSelected(['1', '2']);
 
-        // $ExpectType DrawFeature
+        // $ExpectType DrawFeature<Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon, GeoJsonProperties>
         const feat = this.getFeature('1');
         feat.setCoordinates(feat.coordinates);
 


### PR DESCRIPTION
## DrawFeature
- Add missing properties: `id` and `type` to DrawFeature. 
  cf. https://github.com/mapbox/mapbox-gl-draw/blob/8f935fd652747b3f3ff946a8c8c7d88c64fb3c1d/src/feature_types/feature.js#L4
- DrawFeature’s `type` is limited to six types: `Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, and `MultiPolygon`.
  cf. 
  - https://github.com/mapbox/mapbox-gl-draw/blob/main/src/modes/mode_interface_accessors.js#L190
  - https://github.com/mapbox/mapbox-gl-draw/blob/main/src/feature_types/multi_feature.js#L26
  - [mapbox-gl-draw | API Methods](https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/API.md#api-methods)
- Fix `coordinates` type definition. It is possiblly an array of `Position` depending on the feature type.  
  cf. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/geojson/index.d.ts#L124

## DrawCustomModeThis
- Add missing properties: `map` and `drawConfig` to DrawCustomModeThis.  
  cf. https://github.com/mapbox/mapbox-gl-draw/blob/main/src/modes/mode_interface_accessors.js#L8

=======================================

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
