### PR TITLE
RFC(react): Allow returning string, boolean etc from FunctionComponent

### DIFF
--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -59,7 +59,8 @@ declare module '.' {
          * It does, however, allow those children to be wrapped inside a single
          * level of `<React.Fragment>`.
          */
-        children: ReactElement | Iterable<ReactElement>;
+        // Another bad workaround. These really need to be React elements.
+        children: JSX.Element | Iterable<JSX.Element>;
     }
 
     interface DirectionalSuspenseListProps extends SuspenseListCommonProps {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -75,7 +75,7 @@ declare namespace React {
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type JSXElementConstructor<P> =
-        | ((props: P) => ReactElement<any, any> | null)
+        | ((props: P) => JSX.Element)
         | (new (props: P) => Component<any, any>);
 
     interface RefObject<T> {
@@ -517,7 +517,7 @@ declare namespace React {
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {
-        (props: P, context?: any): ReactElement<any, any> | null;
+        (props: P, context?: any): JSX.Element;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
         defaultProps?: Partial<P> | undefined;
@@ -533,7 +533,7 @@ declare namespace React {
      * @deprecated - Equivalent with `React.FunctionComponent`.
      */
     interface VoidFunctionComponent<P = {}> {
-        (props: P, context?: any): ReactElement<any, any> | null;
+        (props: P, context?: any): JSX.Element;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
         defaultProps?: Partial<P> | undefined;
@@ -543,7 +543,7 @@ declare namespace React {
     type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
 
     interface ForwardRefRenderFunction<T, P = {}> {
-        (props: P, ref: ForwardedRef<T>): ReactElement | null;
+        (props: P, ref: ForwardedRef<T>): JSX.Element;
         displayName?: string | undefined;
         // explicit rejected with `never` required due to
         // https://github.com/microsoft/TypeScript/issues/36826
@@ -3119,9 +3119,9 @@ type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps
 
 declare global {
     namespace JSX {
-        interface Element extends React.ReactElement<any, any> { }
+        type Element = React.ReactNode;
         interface ElementClass extends React.Component<any> {
-            render(): React.ReactNode;
+            render(): Element;
         }
         interface ElementAttributesProperty { props: {}; }
         interface ElementChildrenAttribute { children: {}; }

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -220,9 +220,6 @@ FunctionComponent2.defaultProps = {
 // allows null as props
 const FunctionComponent4: React.FunctionComponent = props => null;
 
-// undesired: Rejects `false` because of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
-// leaving here to document limitation and inspect error message
-// @ts-expect-error
 const FunctionComponent5: React.FunctionComponent = () => false;
 
 // React.createFactory
@@ -554,14 +551,20 @@ const mappedChildrenArray0 = React.Children.map(null, num => num);
 const mappedChildrenArray1 = React.Children.map(undefined, num => num);
 // $ExpectType number[]
 const mappedChildrenArray2 = React.Children.map(numberChildren, num => num);
-// $ExpectType Element[]
+// ExpectType Element[] no longer works since TypeScript expands the type non-deterministically
 const mappedChildrenArray3 = React.Children.map(elementChildren, element => element);
-// $ExpectType (string | Element)[]
+// ExpectType Element[] no longer works since TypeScript expands the type non-deterministically
 const mappedChildrenArray4 = React.Children.map(mixedChildren, elementOrString => elementOrString);
 // This test uses a conditional type because otherwise it gets flaky and can resolve to either Key or ReactText, both
 // of which are aliases for `string | number`.
-const mappedChildrenArray5 = React.Children.map(singlePluralChildren, element => element.key);
-// $ExpectType true
+const mappedChildrenArray5 = React.Children.map(
+    singlePluralChildren,
+    element =>
+        // @ts-expect-error Undesired behavior JSX.Element is no longer the object returned from createElement
+        element.key,
+);
+// Undesired
+// $ExpectType false
 type mappedChildrenArray5Type = typeof mappedChildrenArray5 extends React.Key[] ? true : false;
 // $ExpectType string[]
 const mappedChildrenArray6 = React.Children.map(renderPropsChildren, element => element.name);

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -45,6 +45,7 @@ const annotatedPropTypesAndDefaultPropsTests = [
         fnc={() => {}}
         node={<span />}
         num={0}
+        // @ts-expect-error Undesired behavior. JSX elements are now nullable.
         reqNode={<span />}
         str='abc'
     />
@@ -69,6 +70,7 @@ const unannotatedPropTypesAndDefaultPropsTests = [
         fnc={() => {}}
         node={<span />}
         num={0}
+        // @ts-expect-error Undesired behavior. JSX elements are now nullable.
         reqNode={<span />}
         str='abc'
     />
@@ -81,7 +83,13 @@ class AnnotatedPropTypes extends React.Component<Props> {
 const annotatedPropTypesTests = [
     // @ts-expect-error
     <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
-    <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} />,
+    <AnnotatedPropTypes
+        fnc={() => {}}
+        extraStr="abc"
+        str="abc"
+        // @ts-expect-error Undesired behavior. JSX elements are now nullable.
+        reqNode={<span />}
+    />,
     // @ts-expect-error
     <AnnotatedPropTypes fnc={() => {}} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
     // @ts-expect-error
@@ -93,6 +101,7 @@ const annotatedPropTypesTests = [
         fnc={() => {}}
         node={<React.Fragment />}
         num={0}
+        // @ts-expect-error Undesired behavior. JSX elements are now nullable.
         reqNode={<React.Fragment />}
         str='abc'
     />
@@ -128,10 +137,14 @@ class AnnotatedDefaultProps extends React.Component<Props> {
 const annotatedDefaultPropsTests = [
     // @ts-expect-error
     <AnnotatedDefaultProps />, // str is required
-    <AnnotatedDefaultProps str='abc' />,
-    <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
+    <AnnotatedDefaultProps str="abc" />,
+    <AnnotatedDefaultProps
+        str="abc"
+        // @ts-expect-error Undesired behavior. JSX elements are now nullable.
+        reqNode={<span />}
+    />,
     // @ts-expect-error
-    <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
+    <AnnotatedDefaultProps str={() => {}} />, // str type mismatch
     <AnnotatedDefaultProps
         bool={true}
         extraBool={false}
@@ -139,8 +152,8 @@ const annotatedDefaultPropsTests = [
         node={null}
         num={0}
         reqNode={undefined}
-        str='abc'
-    />
+        str="abc"
+    />,
 ];
 
 class UnannotatedDefaultProps extends React.Component {
@@ -152,6 +165,7 @@ const unannotatedDefaultPropsTests = [
     <UnannotatedDefaultProps
         extraBool={true}
         fnc={() => {}}
+        // @ts-expect-error Undesired behavior. JSX elements are now nullable.
         reqNode={<span />}
     />
 ];
@@ -196,6 +210,7 @@ const forwardRefTests = [
     <ForwardRef />,
     <ForwardRef
         fnc={() => {}}
+        // @ts-expect-error Undesired behavior. JSX elements are now nullable.
         reqNode={<span />}
         str=''
     />,

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -558,10 +558,14 @@ function CustomSelectOption(props: {
 }
 function Example() {
     return (
-        <CustomSelect>
-        <CustomSelectOption value="one">One</CustomSelectOption>
-        <CustomSelectOption value="two">Two</CustomSelectOption>
-        </CustomSelect>
+        <CustomSelect
+            children={[
+                // @ts-expect-error Undesired behavior. JSX elements have no typed props.
+                <CustomSelectOption value="one">One</CustomSelectOption>,
+                // @ts-expect-error Undesired behavior. JSX elements have no typed props.
+                <CustomSelectOption value="two">Two</CustomSelectOption>,
+            ]}
+        />
     );
 }
 
@@ -659,32 +663,22 @@ function elementTypeTests() {
     // @ts-expect-error
     React.createElement(RenderVoid);
 
-    // Undesired behavior. Returning `undefined` should be accepted in all forms.
-    // @ts-expect-error
     <ReturnUndefined />;
-    // @ts-expect-error
     React.createElement(ReturnUndefined);
     <RenderUndefined />;
     React.createElement(RenderUndefined);
 
-    // Desired behavior.
     <ReturnNull />;
     React.createElement(ReturnNull);
     <RenderNull />;
     React.createElement(RenderNull);
 
-    // Undesired behavior. Returning `number` should be accepted in all forms.
-    // @ts-expect-error
     <ReturnNumber />;
-    // @ts-expect-error
     React.createElement(ReturnNumber);
     <RenderNumber />;
     React.createElement(RenderNumber);
 
-    // Undesired behavior. Returning `string` should be accepted in all forms.
-    // @ts-expect-error
     <ReturnString />;
-    // @ts-expect-error
     React.createElement(ReturnString);
     <RenderString />;
     React.createElement(RenderString);
@@ -699,24 +693,17 @@ function elementTypeTests() {
     // @ts-expect-error
     React.createElement(RenderSymbol);
 
-    // Undesired behavior. Returning `Array` should be accepted in all forms.
-    // @ts-expect-error
     <ReturnArray />;
-    // @ts-expect-error
     React.createElement(ReturnArray);
     <RenderArray />;
     React.createElement(RenderArray);
 
-    // Desired behavior.
     <ReturnElement />;
     React.createElement(ReturnElement);
     <RenderElement />;
     React.createElement(RenderElement);
 
-    // Undesired behavior. Returning `ReactNode` should be accepted in all forms.
-    // @ts-expect-error
     <ReturnReactNode />;
-    // @ts-expect-error
     React.createElement(ReturnReactNode);
     <RenderReactNode />;
     React.createElement(RenderReactNode);


### PR DESCRIPTION
Hack to fix all the "why can't I return X from a function component" issues. We would no longer need a fix for https://github.com/microsoft/TypeScript/issues/14729 or https://github.com/microsoft/TypeScript/issues/21699.

Only worked on the React type tests for now since it highlights the issues we would have with this change.

The problem with this is that you can no longer enforce receiving actual JSX elements (the ones with `{ props: P, type: T, key: string }`). `SuspenseList` is an example of a built-in component that relies on that.

In other words, we basically disable type-safe introspection of JSX elements.


Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18912
