### PR TITLE
[node] Fix @since for stream closed,destroyed properties

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -124,12 +124,12 @@ declare module 'stream' {
             readonly readableObjectMode: boolean;
             /**
              * Is `true` after `readable.destroy()` has been called.
-             * @since v18.0.0
+             * @since v8.0.0
              */
             destroyed: boolean;
             /**
              * Is true after 'close' has been emitted.
-             * @since v8.0.0
+             * @since v18.0.0
              */
             readonly closed: boolean;
             /**
@@ -579,7 +579,7 @@ declare module 'stream' {
             destroyed: boolean;
             /**
              * Is true after 'close' has been emitted.
-             * @since v8.0.0
+             * @since v18.0.0
              */
             readonly closed: boolean;
             /**


### PR DESCRIPTION
PR fixes the `@since` annotation on the `Readable.closed`, `Readable.destroyed`, and `Writable.closed` properties so that it lines up with the NodeJS documentation on when these properties were added.

`Writable.destroyed` did not need to be changed as it correctly has `@since v8.0.0` already.
---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~ - Doc change, so cannot add / edit meaningful tests for this.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

