### PR TITLE
[dockerode] Improve types for Container#logs()

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -117,6 +117,9 @@ container.remove({v: true, force: false, link: true}, (err, data) => {
     // NOOP
 });
 
+// $ExpectType Promise<ReadableStream>
+container.logs({ since: 0, until: 10, stdout: true, stderr: true });
+
 const abortController = new AbortController();
 container.wait({
     condition: 'next-exit',

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -117,8 +117,33 @@ container.remove({v: true, force: false, link: true}, (err, data) => {
     // NOOP
 });
 
-// $ExpectType Promise<ReadableStream>
+container.logs((err, logs) => {
+    // $ExpectType Buffer
+    logs;
+});
+
+container.logs({}, (err, logs) => {
+    // $ExpectType Buffer
+    logs;
+});
+
+container.logs({ follow: true }, (err, logs) => {
+    // $ExpectType ReadableStream
+    logs;
+});
+
+container.logs({ follow: false }, (err, logs) => {
+    // $ExpectType Buffer
+    logs;
+});
+// $ExpectType Promise<Buffer>
 container.logs({ since: 0, until: 10, stdout: true, stderr: true });
+
+// $ExpectType Promise<ReadableStream>
+container.logs({ follow: true });
+
+// $ExpectType Promise<Buffer>
+container.logs({ follow: false });
 
 const abortController = new AbortController();
 container.wait({

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -136,8 +136,12 @@ container.logs({ follow: false }, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });
+
 // $ExpectType Promise<Buffer>
 container.logs({ since: 0, until: 10, stdout: true, stderr: true });
+
+// $ExpectType Promise<Buffer>
+container.logs({ since: '12345.987654321', until: '54321.123456789', stdout: true, stderr: true });
 
 // $ExpectType Promise<ReadableStream>
 container.logs({ follow: true });

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1748,8 +1748,8 @@ declare namespace Dockerode {
         stdout?: boolean | undefined;
         stderr?: boolean | undefined;
         follow?: boolean | undefined;
-        since?: number | undefined;
-        until?: number | undefined;
+        since?: number | string | undefined;
+        until?: number | string | undefined;
         details?: boolean | undefined;
         tail?: number | undefined;
         timestamps?: boolean | undefined;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1747,6 +1747,7 @@ declare namespace Dockerode {
         stderr?: boolean | undefined;
         follow?: boolean | undefined;
         since?: number | undefined;
+        until?: number | undefined;
         details?: boolean | undefined;
         tail?: number | undefined;
         timestamps?: boolean | undefined;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -112,9 +112,11 @@ declare namespace Dockerode {
         ): void;
         putArchive(file: string | Buffer | NodeJS.ReadableStream, options: {}): Promise<NodeJS.ReadWriteStream>;
 
-        logs(options: ContainerLogsOptions, callback: Callback<NodeJS.ReadableStream>): void;
-        logs(callback: Callback<NodeJS.ReadableStream>): void;
-        logs(options?: ContainerLogsOptions): Promise<NodeJS.ReadableStream>;
+        logs(options: ContainerLogsOptions & { follow?: false }, callback: Callback<Buffer>): void;
+        logs(options: ContainerLogsOptions & { follow: true }, callback: Callback<NodeJS.ReadableStream>): void;
+        logs(callback: Callback<Buffer>): void;
+        logs(options?: ContainerLogsOptions & { follow?: false }): Promise<Buffer>;
+        logs(options?: ContainerLogsOptions & { follow: true }): Promise<NodeJS.ReadableStream>;
 
         stats(options: {}, callback: Callback<ContainerStats>): void;
         stats(callback: Callback<ContainerStats>): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Docker API documentation: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerLogs

The return type of `logs()` (or the value passed to the callback) depends on the `follow` option:

https://github.com/apocas/dockerode/blob/d66880397605c526d882104022b56d08ccde4fa7/lib/container.js#L1020

If `follow` is undefined or false, the result will be a `Buffer`; otherwise, it will be a `ReadableStream`.