### PR TITLE
Safer types for `http-errors`

### DIFF
--- a/types/http-errors/http-errors-tests.ts
+++ b/types/http-errors/http-errors-tests.ts
@@ -89,8 +89,10 @@ new create.InternalServerError(); // $ExpectType HttpError<500>
 new create[404](); // $ExpectType HttpError<404>
 new create['404'](); // $ExpectType HttpError<404>
 
-// @ts-expect-error
-create['404']();
+create['404'](); // $ExpectType HttpError<404>
+create(404, 'Not Found'); // $ExpectType HttpError<404>
+create(); // $ExpectType HttpError<number>
+
 // @ts-expect-error
 new create();
 

--- a/types/http-errors/http-errors-tests.ts
+++ b/types/http-errors/http-errors-tests.ts
@@ -6,7 +6,7 @@ const app = express();
 
 app.use((req, res, next) => {
     if (!req) {
-        next(create('Please login to view this page.', 401));
+        next(create(401, 'Please login to view this page.'));
         return;
     }
     next();
@@ -53,7 +53,7 @@ create({id: 1});
 err.id;
 
 // create(msg, status)
-// $ExpectType HttpError<number>
+// @ts-expect-error Since 2.0, number arguments can only be the first argument
 create('LOL', 404);
 
 // create(msg)

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -22,7 +22,7 @@ declare namespace createHttpError {
         [key: string]: any;
     }
 
-    type UnknownError = Error | string | number | { [key: string]: any };
+    type UnknownError = Error | string | { [key: string]: any };
 
     interface HttpErrorConstructor<N extends number = number> {
         (msg?: string): HttpError<N>;
@@ -62,7 +62,7 @@ declare namespace createHttpError {
     & Record<'UnprocessableEntity' | '422', HttpErrorConstructor<422>>
     & Record<'Locked' | '423', HttpErrorConstructor<423>>
     & Record<'FailedDependency' | '424', HttpErrorConstructor<424>>
-    & Record<'UnorderedCollection' | '425', HttpErrorConstructor<425>>
+    & Record<'TooEarly' | '425', HttpErrorConstructor<425>>
     & Record<'UpgradeRequired' | '426', HttpErrorConstructor<426>>
     & Record<'PreconditionRequired' | '428', HttpErrorConstructor<428>>
     & Record<'TooManyRequests' | '429', HttpErrorConstructor<429>>

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 export = createHttpError;
 
@@ -30,7 +29,7 @@ declare namespace createHttpError {
     }
 
     interface CreateHttpError {
-        <N extends number = number>(arg?: N, ...rest: UnknownError[]): HttpError<N>;
+        <N extends number = number>(arg: N, ...rest: UnknownError[]): HttpError<N>;
         (...rest: UnknownError[]): HttpError;
     }
 

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for http-errors 1.8
+// Type definitions for http-errors 2.0
 // Project: https://github.com/jshttp/http-errors
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 BendingBender <https://github.com/BendingBender>

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -24,14 +24,19 @@ declare namespace createHttpError {
 
     type UnknownError = Error | string | number | { [key: string]: any };
 
-    type HttpErrorConstructor<N extends number = number> = new (msg?: string) => HttpError<N>;
+    interface HttpErrorConstructor<N extends number = number> {
+        (msg?: string): HttpError<N>;
+        new (msg?: string): HttpError<N>;
+    }
 
-    type CreateHttpError = <N extends UnknownError>(arg: N, ...rest: UnknownError[]) => HttpError<N extends number ? N : number>;
+    interface CreateHttpError {
+        <N extends number = number>(arg?: N, ...rest: UnknownError[]): HttpError<N>;
+        (...rest: UnknownError[]): HttpError;
+    }
 
     type IsHttpError = (error: unknown) => error is HttpError;
 
     type NamedConstructors = {
-        [code: string]: HttpErrorConstructor;
         HttpError: HttpErrorConstructor;
     }
     & Record<'BadRequest' | '400', HttpErrorConstructor<400>>


### PR DESCRIPTION
### Changes

- Remove the index signature that allowed arbitrary error names (which results in TypeError at runtime). This is potentially a breaking change to the **types** if users were for some reason accessing arbitrary keys that are non-existent at runtime. But in my opition this change avoids typo errors and accurately reflects the runtime behaviour of the module.
- Make "new" operator optional on the constructor function (optional at runtime)
- Make CreateHttpError accept zero arguments (accepts zero arguments at runtime)



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
