### PR TITLE
Added type definitions for fluent-reveal-effect

### DIFF
--- a/types/fluent-reveal-effect/fluent-reveal-effect-tests.ts
+++ b/types/fluent-reveal-effect/fluent-reveal-effect-tests.ts
@@ -1,0 +1,18 @@
+import { FluentRevealEffect } from 'fluent-reveal-effect';
+
+// tests all values for the options object
+FluentRevealEffect.applyEffect('#element', {
+    clickEffect: true,
+    lightColor: "rgba(255,255,255,0.6)",
+    gradientSize: 80,
+    isContainer: true,
+    children: {
+        borderSelector: ".btn-border",
+        elementSelector: ".btn",
+        lightColor: "rgba(255,255,255,0.3)",
+        gradientSize: 150
+    }
+});
+
+// tests no values for the options object
+FluentRevealEffect.applyEffect('.element2', {});

--- a/types/fluent-reveal-effect/index.d.ts
+++ b/types/fluent-reveal-effect/index.d.ts
@@ -1,20 +1,25 @@
-declare module 'fluent-reveal-effect' {
-    interface FluentRevealEffectType {
-        applyEffect: (element: string, options: RevealOptions) => void;
-    }
+// Type definitions for fluent-reveal-effect 2.0
+// Project: https://www.npmjs.com/package/fluent-reveal-effect
+// Definitions by: Alen Mukaca <https://github.com/ShinzenATT>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-    interface RevealOptions{
-        lightColor?: string | "rgba(255,255,255,0.25)",
-        gradientSize?: number | 150,
-        clickEffect?: boolean | false,
-        isContainer?: boolean | false,
-        children?: {
-            borderSelector?: string | ".eff-reveal-border",
-            elementSelector?: string | ".eff-reveal",
-            lightColor?: string | "rgba(255,255,255,0.25)",
-            gradientSize?: number | 150
-        }
-    }
-
-    export const FluentRevealEffect: FluentRevealEffectType;
+export interface FluentRevealEffectType {
+    applyEffect: (element: string, options: RevealOptions) => void;
 }
+
+export interface RevealOptions {
+    lightColor?: string | "rgba(255,255,255,0.25)";
+    gradientSize?: number | 150;
+    clickEffect?: boolean | false;
+    isContainer?: boolean | false;
+    children?: {
+        borderSelector?: string | ".eff-reveal-border";
+        elementSelector?: string | ".eff-reveal";
+        lightColor?: string | "rgba(255,255,255,0.25)";
+        gradientSize?: number | 150;
+    };
+}
+
+export const FluentRevealEffect: FluentRevealEffectType;
+
+export {};

--- a/types/fluent-reveal-effect/index.d.ts
+++ b/types/fluent-reveal-effect/index.d.ts
@@ -1,0 +1,20 @@
+declare module 'fluent-reveal-effect' {
+    interface FluentRevealEffectType {
+        applyEffect: (element: string, options: RevealOptions) => void;
+    }
+
+    interface RevealOptions{
+        lightColor?: string | "rgba(255,255,255,0.25)",
+        gradientSize?: number | 150,
+        clickEffect?: boolean | false,
+        isContainer?: boolean | false,
+        children?: {
+            borderSelector?: string | ".eff-reveal-border",
+            elementSelector?: string | ".eff-reveal",
+            lightColor?: string | "rgba(255,255,255,0.25)",
+            gradientSize?: number | 150
+        }
+    }
+
+    export const FluentRevealEffect: FluentRevealEffectType;
+}

--- a/types/fluent-reveal-effect/tsconfig.json
+++ b/types/fluent-reveal-effect/tsconfig.json
@@ -4,5 +4,12 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "lib": ["es6"],
+        "module": "commonjs",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": []
     }
 }

--- a/types/fluent-reveal-effect/tsconfig.json
+++ b/types/fluent-reveal-effect/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+    }
+}

--- a/types/fluent-reveal-effect/tsconfig.json
+++ b/types/fluent-reveal-effect/tsconfig.json
@@ -11,5 +11,9 @@
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": []
-    }
+    },
+    "files": [
+        "index.d.ts",
+        "fluent-reveal-effect-tests.ts"
+    ]
 }

--- a/types/fluent-reveal-effect/tslint.json
+++ b/types/fluent-reveal-effect/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }

--- a/types/fluent-reveal-effect/tslint.json
+++ b/types/fluent-reveal-effect/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "@definitelytyped/dtslint/dtslint.json"
+    "extends": "@definitelytyped/dtslint/dt.json"
 }

--- a/types/fluent-reveal-effect/tslint.json
+++ b/types/fluent-reveal-effect/tslint.json
@@ -1,1 +1,3 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dtslint.json"
+}


### PR DESCRIPTION
If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. 
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
