### PR TITLE
fix: shpjs parseShp method, prj parameter is optional

### DIFF
--- a/types/shpjs/index.d.ts
+++ b/types/shpjs/index.d.ts
@@ -20,7 +20,7 @@ declare namespace shpjs {
         parseZip(buffer: ShpJSBuffer, whiteList?: ReadonlyArray<string>): Promise<FeatureCollectionWithFilename | FeatureCollectionWithFilename[]>;
         getShapeFile(base: string | ShpJSBuffer, whiteList?: ReadonlyArray<string>): Promise<FeatureCollectionWithFilename | FeatureCollectionWithFilename[]>;
         combine(arr: [ReadonlyArray<GeoJSON.Geometry>, ReadonlyArray<GeoJSON.GeoJsonProperties>]): GeoJSON.FeatureCollection;
-        parseShp(shp: ShpJSBuffer, prj: string | Buffer): GeoJSON.Geometry[];
+        parseShp(shp: ShpJSBuffer, prj?: string | Buffer): GeoJSON.Geometry[];
         parseDbf(dbf: ShpJSBuffer, cpg: ShpJSBuffer): GeoJSON.GeoJsonProperties[];
     }
 }

--- a/types/shpjs/shpjs-tests.ts
+++ b/types/shpjs/shpjs-tests.ts
@@ -34,6 +34,11 @@ parsedShp = shp.parseShp(new Buffer(''), new Buffer('proj'));
 parsedShp = shp.parseShp(new ArrayBuffer(50), 'proj');
 parsedShp = shp.parseShp(new Int32Array(50), 'proj');
 
+// Should parse shapes without projection (use default)
+parsedShp = shp.parseShp(new Int32Array(50));
+parsedShp = shp.parseShp(new ArrayBuffer(50));
+parsedShp = shp.parseShp(new Buffer(''));
+
 parsedDbf = shp.parseDbf(new Buffer(''), new Buffer(''));
 parsedDbf = shp.parseDbf(new ArrayBuffer(50), new Buffer(''));
 parsedDbf = shp.parseDbf(new Int32Array(50), new Buffer(''));


### PR DESCRIPTION
Please refer to shapefile-js documentation: https://github.com/calvinmetcalf/shapefile-js
Specifically combine method example:
`shp.combine([shp.parseShp(shpBuffer, /*optional prj str*/),shp.parseDbf(dbfBuffer)]);`
As you can see projection parameter is optional.

Code reference:
https://github.com/calvinmetcalf/shapefile-js/blob/7df2bb442d2daf0c2e1fb5761a7219da72bcdb96/lib/index.js#L166