### PR TITLE
RFC: React: Allow anything to be rendered by function components

### DIFF
--- a/types/af-utils__react-virtual-headless/af-utils__react-virtual-headless-tests.tsx
+++ b/types/af-utils__react-virtual-headless/af-utils__react-virtual-headless-tests.tsx
@@ -72,12 +72,12 @@ useComponentSubscription(useVirtual(), EVT_FROM);
 // @ts-expect-error
 useComponentSubscription(undefined, [EVT_FROM]);
 
-// $ExpectType Element
-useOnce(() => <>Abc</>);
+const returnABCFragment = () => <>Abc</>;
+const abcFragment: ReturnType<typeof returnABCFragment> = useOnce(returnABCFragment);
 
-// $ExpectType Element
+// $ExpectType ReactElement<any, any>
 useOnce(() => {
-    const testComponent = () => {
+    const testComponent = (): React.ReactElement<any, any> => {
         return <>Abc</>;
     };
     return testComponent();
@@ -89,17 +89,28 @@ useOnce(() => null);
 // @ts-expect-error
 useOnce(() => {});
 
-// $ExpectType ReactElement<any, any> | null
-Subscription({ model: useVirtual(), children: <>Abc</> });
+<Subscription model={useVirtual()}>
+    <>Abc</>
+</Subscription>;
 
-// $ExpectType ReactElement<any, any> | null
-Subscription({ model: useVirtual(), events: [EVT_FROM], children: <>Abc</> });
+<Subscription model={useVirtual()} events={[EVT_FROM]}>
+    <>Abc</>
+</Subscription>;
 
-// @ts-expect-error
-Subscription({ model: useVirtual(), events: EVT_FROM, children: <>Abc</> });
+<Subscription
+    model={useVirtual()}
+    // @ts-expect-error
+    events={EVT_FROM}
+>
+    <>Abc</>
+</Subscription>;
 
-// @ts-expect-error
-Subscription({ model: useVirtual(), children: { abc: 1 } });
+<Subscription model={useVirtual()}>
+    {
+        // @ts-expect-error
+        { abc: 1 }
+    }
+</Subscription>;
 
 // $ExpectType void
 mapVisibleRange(useVirtual(), (index: number) => {});
@@ -113,5 +124,5 @@ mapVisibleRange(useVirtual(), (index: number, offset?: number) => {}, 'abc');
 // @ts-expect-error
 mapVisibleRange(useVirtual(), (index: number, offset: number) => {});
 
-// @ts-expect-error
+// Undesired behavior. Should error but doesn't because JSX.Element is `any`.
 mapVisibleRange(<></>, (index: number, offset?: number) => {});

--- a/types/carbon__icons-react/carbon__icons-react-tests.tsx
+++ b/types/carbon__icons-react/carbon__icons-react-tests.tsx
@@ -23,29 +23,29 @@ import {
     Plan,
 } from "@carbon/icons-react";
 
-<UserAccess />; // $ExpectType Element
-<TextClearFormat />; // $ExpectType Element
-<IceVision />; // $ExpectType Element
+<UserAccess />;
+<TextClearFormat />;
+<IceVision />;
 
-<AccumulationIce />; // $ExpectType Element
-<Layers />; // $ExpectType Element
-<BorderLeft />; // $ExpectType Element
-<AccessibilityAlt />; // $ExpectType Element
+<AccumulationIce />;
+<Layers />;
+<BorderLeft />;
+<AccessibilityAlt />;
 <Add>
     <title>Icon title</title>
 </Add>;
-<Add aria-label="Add" />; // $ExpectType Element
-<Add size={32} title="Add" aria-label="Add" tabIndex="0" className="add-32" />; // $ExpectType Element
-<DataBaseAlt />; // $ExpectType Element
-<GasStation />; // $ExpectType Element
-<AnalyticsReference />; // $ExpectType Element
-<Lasso />; // $ExpectType Element
-<BookmarkFilled />; // $ExpectType Element
-<CalendarHeatMap />; // $ExpectType Element
-<ChartColumn />; // $ExpectType Element
-<LogoKeybase />; // $ExpectType Element
-<Barcode />; // $ExpectType Element
-<CalculationAlt />; // $ExpectType Element
-<IbmCloudKubernetesService />; // $ExpectType Element
-<LogoSvelte />; // $ExpectType Element
-<Plan />; // $ExpectType Element
+<Add aria-label="Add" />;
+<Add size={32} title="Add" aria-label="Add" tabIndex="0" className="add-32" />;
+<DataBaseAlt />;
+<GasStation />;
+<AnalyticsReference />;
+<Lasso />;
+<BookmarkFilled />;
+<CalendarHeatMap />;
+<ChartColumn />;
+<LogoKeybase />;
+<Barcode />;
+<CalculationAlt />;
+<IbmCloudKubernetesService />;
+<LogoSvelte />;
+<Plan />;

--- a/types/carbon__pictograms-react/carbon__pictograms-react-tests.tsx
+++ b/types/carbon__pictograms-react/carbon__pictograms-react-tests.tsx
@@ -30,32 +30,32 @@ import {
     Ai,
 } from "@carbon/pictograms-react";
 
-<Airplane />; // $ExpectType Element
-<Airplane title="airplane" aria-label="label" tabIndex="0" fill="#fff" className="className" />; // $ExpectType Element
-<ClientFinancing_01 />; // $ExpectType Element
-<GlobalMarkets />; // $ExpectType Element
-<SolarField />; // $ExpectType Element
-<SystemsDevopsAnalyze />; // $ExpectType Element
-<AddDocument />; // $ExpectType Element
-<Backpack />; // $ExpectType Element
-<IbmCloud />; // $ExpectType Element
-<Download_01 />; // $ExpectType Element
-<Export_01 />; // $ExpectType Element
-<Upload_01 />; // $ExpectType Element
-<Video_01 />; // $ExpectType Element
-<WatsonLogo />; // $ExpectType Element
-<AdvancedFraudProtection />; // $ExpectType Element
-<DoctorPatient />; // $ExpectType Element
-<Hpi />; // $ExpectType Element
-<CloudPakForApplications />; // $ExpectType Element
-<AcceleratedComputing />; // $ExpectType Element
-<Dashboard />; // $ExpectType Element
-<Bluepages />; // $ExpectType Element
-<ContentDesign />; // $ExpectType Element
-<AiExplainability />; // $ExpectType Element
-<RedHatApplications />; // $ExpectType Element
-<AudioData />; // $ExpectType Element
-<Visibility />; // $ExpectType Element
-<IbmZ />; // $ExpectType Element
-<IbmZAndLinuxoneMultiFrame />; // $ExpectType Element
-<Ai />; // $ExpectType Element
+<Airplane />;
+<Airplane title="airplane" aria-label="label" tabIndex="0" fill="#fff" className="className" />;
+<ClientFinancing_01 />;
+<GlobalMarkets />;
+<SolarField />;
+<SystemsDevopsAnalyze />;
+<AddDocument />;
+<Backpack />;
+<IbmCloud />;
+<Download_01 />;
+<Export_01 />;
+<Upload_01 />;
+<Video_01 />;
+<WatsonLogo />;
+<AdvancedFraudProtection />;
+<DoctorPatient />;
+<Hpi />;
+<CloudPakForApplications />;
+<AcceleratedComputing />;
+<Dashboard />;
+<Bluepages />;
+<ContentDesign />;
+<AiExplainability />;
+<RedHatApplications />;
+<AudioData />;
+<Visibility />;
+<IbmZ />;
+<IbmZAndLinuxoneMultiFrame />;
+<Ai />;

--- a/types/mjml-react/mjml-react-tests.tsx
+++ b/types/mjml-react/mjml-react-tests.tsx
@@ -162,7 +162,7 @@ function renderOutTestEmail() {
 
     // children cannot be anything other than string
     // prettier-ignore
-    // @ts-expect-error
+    // Undesired behavior. Should error but doesn't because JSX.Element is `any`.
     const childError: React.ReactNode = <MjmlPreview><p>""</p></MjmlPreview>;
 }
 // TestMjmlStyleTag
@@ -172,7 +172,7 @@ function renderOutTestEmail() {
 
     // children cannot be anything other than string
     // prettier-ignore
-    // @ts-expect-error
+    // Undesired behavior. Should error but doesn't because JSX.Element is `any`.
     const childError: React.ReactNode = <MjmlStyle><p>""</p></MjmlStyle>;
 }
 // TestMjmlTitleTag
@@ -182,7 +182,7 @@ function renderOutTestEmail() {
 
     // children cannot be anything other than string
     // prettier-ignore
-    // @ts-expect-error
+    // Undesired behavior. Should error but doesn't because JSX.Element is `any`.
     const childError: React.ReactNode = <MjmlStyle><p>""</p></MjmlStyle>;
 }
 // TestMjmlButtonTag

--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -85,7 +85,7 @@ export interface MenuProps<T extends HTMLElement>
      * The HTML tag for this element. Default: 'div'.
      */
     tag?: T["tagName"] | undefined;
-    children: JSX.Element | (({ isOpen }: { isOpen: boolean }) => JSX.Element);
+    children: React.ReactElement<any, any> | (({ isOpen }: { isOpen: boolean }) => React.ReactElement<any, any>);
 }
 
 /**

--- a/types/react-form/v1/index.d.ts
+++ b/types/react-form/v1/index.d.ts
@@ -15,7 +15,7 @@ export type FormValues = Nested<FormValue>;
 export type Touched = Nested<boolean>;
 export type FormErrors = {[key: string]: FormError} | [{[key: string]: FormError}];
 export type NestedErrors = Nested<FormErrors>;
-export type RenderReturn = JSX.Element | false | null;
+export type RenderReturn = React.ReactElement<any, any> | false | null;
 
 export interface FormProps {
     loadState?(props: FormProps, self: Form): FormState | undefined;

--- a/types/react-form/v2/index.d.ts
+++ b/types/react-form/v2/index.d.ts
@@ -19,7 +19,7 @@ export interface FormErrors {
     [key: string]: FormError;
 }
 export type NestedErrors = Nested<FormErrors>;
-export type RenderReturn = JSX.Element | false | null | never[];
+export type RenderReturn = React.ReactElement<any, any> | false | null | never[];
 
 export interface FormState {
     values: FormValues;

--- a/types/react-key-handler/react-key-handler-tests.tsx
+++ b/types/react-key-handler/react-key-handler-tests.tsx
@@ -18,13 +18,16 @@ const missingRequired = <KeyHandler />;
 // @ts-expect-error
 const invalidExample = <KeyHandler onKeyHandle={true} />;
 
-// $ExpectType Element
+// Undesired behavior. Should be `Element`.
+// $ExpectType any
 const validExample = <KeyHandler onKeyHandle={onKeyHandleCallback} />;
 
-// $ExpectType (props: ReactKeyHandlerProps) => (Component: Element) => (...args: any[]) => Element
+// Undesired behavior. Should be `(props: ReactKeyHandlerProps) => (Component: Element) => (...args: any[]) => Element`.
+// $ExpectType (props: ReactKeyHandlerProps) => (Component: any) => (...args: any[]) => any
 keyHandleDecorator();
 
-// $ExpectType (props: ReactKeyHandlerProps) => (Component: Element) => (...args: any[]) => Element
+// Undesired behavior. Should be `(props: ReactKeyHandlerProps) => (Component: Element) => (...args: any[]) => Element`.
+// $ExpectType (props: ReactKeyHandlerProps) => (Component: any) => (...args: any[]) => any
 keyHandleDecorator(matcher);
 
 // $ExpectType "keydown"
@@ -42,7 +45,8 @@ keyHandler()();
 // @ts-expect-error
 keyHandler({ keyEventName: KEYPRESS, keyValue: 's' })();
 
-// $ExpectType (...args: any[]) => Element
+// Undesired behavior. Should be `(...args: any[]) => Element`
+// $ExpectType (...args: any[]) => any
 keyHandler({ keyEventName: KEYPRESS, keyValue: 's' })(<div />);
 
 // @ts-expect-error
@@ -51,5 +55,6 @@ keyToggleHandler()();
 // @ts-expect-error
 keyToggleHandler({ keyEventName: KEYPRESS, keyValue: 's' })();
 
-// $ExpectType (...args: any[]) => Element
+// Undesired behavior. Should be `(...args: any[]) => Element`
+// $ExpectType (...args: any[]) => any
 keyToggleHandler({ keyEventName: KEYPRESS, keyValue: 's' })(<div />);

--- a/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
+++ b/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
@@ -127,7 +127,8 @@ const TestComponent: React.FC = () => <div>Hello world</div>;
 // Test `children`
 <PrismLightHighlighter>{codeString}</PrismLightHighlighter>;
 <PrismLightHighlighter>{[codeString, "hello world"]}</PrismLightHighlighter>;
-// @ts-expect-error
+// Undesired behavior.
+// JSX elements should not be accepted as `children`.
 <PrismLightHighlighter><div>Hello world</div></PrismLightHighlighter>;
 // @ts-expect-error
 <PrismLightHighlighter />;
@@ -177,7 +178,7 @@ const TestComponent: React.FC = () => <div>Hello world</div>;
         temp = props.rows; // $ExpectType rendererNode[]
         temp = props.stylesheet; // $ExpectType { [key: string]: CSSProperties; }
         temp = props.useInlineStyles; // $ExpectType boolean
-        temp = props.rows[0].type; // $ExpectType "text" | "element"
+        const type: "text" | "element" = props.rows[0].type;
         return <code>hello world</code>;
     }}
 >

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -75,7 +75,7 @@ declare namespace React {
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type JSXElementConstructor<P> =
-        | ((props: P) => ReactElement<any, any> | null)
+        | ((props: P) => ReactNode)
         | (new (props: P) => Component<any, any>);
 
     interface RefObject<T> {
@@ -347,7 +347,7 @@ declare namespace React {
         /**
          * **NOTE**: Exotic components are not callable.
          */
-        (props: P): (ReactElement|null);
+        (props: P): ReactNode;
         readonly $$typeof: symbol;
     }
 
@@ -517,7 +517,7 @@ declare namespace React {
     type FC<P = {}> = FunctionComponent<P>;
 
     interface FunctionComponent<P = {}> {
-        (props: P, context?: any): ReactElement<any, any> | null;
+        (props: P, context?: any): ReactNode;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
         defaultProps?: Partial<P> | undefined;
@@ -533,7 +533,7 @@ declare namespace React {
      * @deprecated - Equivalent with `React.FunctionComponent`.
      */
     interface VoidFunctionComponent<P = {}> {
-        (props: P, context?: any): ReactElement<any, any> | null;
+        (props: P, context?: any): ReactNode;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
         defaultProps?: Partial<P> | undefined;
@@ -543,7 +543,7 @@ declare namespace React {
     type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
 
     interface ForwardRefRenderFunction<T, P = {}> {
-        (props: P, ref: ForwardedRef<T>): ReactElement | null;
+        (props: P, ref: ForwardedRef<T>): ReactNode;
         displayName?: string | undefined;
         // explicit rejected with `never` required due to
         // https://github.com/microsoft/TypeScript/issues/36826
@@ -3119,7 +3119,7 @@ type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps
 
 declare global {
     namespace JSX {
-        interface Element extends React.ReactElement<any, any> { }
+        type Element = any;
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;
         }

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -220,9 +220,7 @@ FunctionComponent2.defaultProps = {
 // allows null as props
 const FunctionComponent4: React.FunctionComponent = props => null;
 
-// undesired: Rejects `false` because of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
-// leaving here to document limitation and inspect error message
-// @ts-expect-error
+// Desired
 const FunctionComponent5: React.FunctionComponent = () => false;
 
 // React.createFactory
@@ -554,14 +552,17 @@ const mappedChildrenArray0 = React.Children.map(null, num => num);
 const mappedChildrenArray1 = React.Children.map(undefined, num => num);
 // $ExpectType number[]
 const mappedChildrenArray2 = React.Children.map(numberChildren, num => num);
-// $ExpectType Element[]
+// Desired: Element[]
+// $ExpectType any
 const mappedChildrenArray3 = React.Children.map(elementChildren, element => element);
-// $ExpectType (string | Element)[]
+// Desired: (string | Element)[]
+// $ExpectType any
 const mappedChildrenArray4 = React.Children.map(mixedChildren, elementOrString => elementOrString);
 // This test uses a conditional type because otherwise it gets flaky and can resolve to either Key or ReactText, both
 // of which are aliases for `string | number`.
 const mappedChildrenArray5 = React.Children.map(singlePluralChildren, element => element.key);
-// $ExpectType true
+// Desired: true
+// $ExpectType boolean
 type mappedChildrenArray5Type = typeof mappedChildrenArray5 extends React.Key[] ? true : false;
 // $ExpectType string[]
 const mappedChildrenArray6 = React.Children.map(renderPropsChildren, element => element.name);

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -650,7 +650,6 @@ function elementTypeTests() {
     }
 
     // Desired behavior.
-    // @ts-expect-error
     <ReturnVoid />;
     // @ts-expect-error
     React.createElement(ReturnVoid);
@@ -659,10 +658,8 @@ function elementTypeTests() {
     // @ts-expect-error
     React.createElement(RenderVoid);
 
-    // Undesired behavior. Returning `undefined` should be accepted in all forms.
-    // @ts-expect-error
+    // Desired behavior.
     <ReturnUndefined />;
-    // @ts-expect-error
     React.createElement(ReturnUndefined);
     <RenderUndefined />;
     React.createElement(RenderUndefined);
@@ -673,24 +670,19 @@ function elementTypeTests() {
     <RenderNull />;
     React.createElement(RenderNull);
 
-    // Undesired behavior. Returning `number` should be accepted in all forms.
-    // @ts-expect-error
+    // Desired behavior.
     <ReturnNumber />;
-    // @ts-expect-error
     React.createElement(ReturnNumber);
     <RenderNumber />;
     React.createElement(RenderNumber);
 
-    // Undesired behavior. Returning `string` should be accepted in all forms.
-    // @ts-expect-error
+    // Desired behavior.
     <ReturnString />;
-    // @ts-expect-error
     React.createElement(ReturnString);
     <RenderString />;
     React.createElement(RenderString);
 
     // Desired behavior.
-    // @ts-expect-error
     <ReturnSymbol />;
     // @ts-expect-error
     React.createElement(ReturnSymbol);
@@ -699,10 +691,8 @@ function elementTypeTests() {
     // @ts-expect-error
     React.createElement(RenderSymbol);
 
-    // Undesired behavior. Returning `Array` should be accepted in all forms.
-    // @ts-expect-error
+    // Desired behavior.
     <ReturnArray />;
-    // @ts-expect-error
     React.createElement(ReturnArray);
     <RenderArray />;
     React.createElement(RenderArray);
@@ -713,11 +703,14 @@ function elementTypeTests() {
     <RenderElement />;
     React.createElement(RenderElement);
 
-    // Undesired behavior. Returning `ReactNode` should be accepted in all forms.
-    // @ts-expect-error
+    // Desired behavior.
     <ReturnReactNode />;
-    // @ts-expect-error
     React.createElement(ReturnReactNode);
     <RenderReactNode />;
     React.createElement(RenderReactNode);
+
+    function compute(): number {
+        // Undesired behavior. JSX elements are not assignable to number.
+        return <div />;
+    }
 }

--- a/types/react_ujs/react_ujs-tests.tsx
+++ b/types/react_ujs/react_ujs-tests.tsx
@@ -7,9 +7,9 @@ function TestComponent() {
 }
 
 ReactRailsUJS.getConstructor = (className: string) => TestComponent;
-// @ts-expect-error
+// Undesired behavior. Should error but doesn't because JSX.Element is `any`.
 ReactRailsUJS.getConstructor = (className: string) => <TestComponent />;
-// @ts-expect-error
+// Undesired behavior. Should error but doesn't because JSX.Element is `any`.
 ReactRailsUJS.getConstructor = (className: string) => <div />;
 
 // @ts-expect-error

--- a/types/rr-notifications/rr-notifications-tests.ts
+++ b/types/rr-notifications/rr-notifications-tests.ts
@@ -10,4 +10,4 @@ const node = NotificationsProvider({
     },
 });
 
-node; // $ExpectType ReactElement<any, any> | null
+node; // $ExpectType ReactNode

--- a/types/simple-react-lightbox/simple-react-lightbox-tests.tsx
+++ b/types/simple-react-lightbox/simple-react-lightbox-tests.tsx
@@ -132,7 +132,6 @@ openLightbox();
 closeLightbox();
 
 // Don't allow children when user gives element
-// @ts-expect-error
 <SRLWrapper elements={elements} options={options}>
     <div></div>
 </SRLWrapper>;

--- a/types/wordpress__components/icon/index.d.ts
+++ b/types/wordpress__components/icon/index.d.ts
@@ -1,9 +1,10 @@
 import { ComponentType, SVGProps, ReactComponentElement, ReactDOM } from 'react';
+import React = require('react');
 
 import Dashicon from '../dashicon';
 
 declare namespace Icon {
-    type IconType<P> = Dashicon.Icon | ComponentType<P> | JSX.Element;
+    type IconType<P> = Dashicon.Icon | ComponentType<P> | React.ReactElement<any, any>;
     interface BaseProps<P> {
         /**
          * The icon to render. Supported values are: Dashicons (specified as

--- a/types/yaireo__tagify/test/yaireo__tagify-react-tests.tsx
+++ b/types/yaireo__tagify/test/yaireo__tagify-react-tests.tsx
@@ -25,7 +25,8 @@ export function TestTagsChildren(): React.ReactElement {
         <Tags>a,b,c</Tags>
         <Tags>{["a", "b", "c"]}</Tags>
         {
-            // @ts-expect-error
+            // Undesired behavior.
+            // JSX elements should not be accepted as `children`.
             <Tags><span>a</span></Tags>
         }
         {
@@ -360,7 +361,8 @@ export function TestMixedTagsChildren(): React.ReactElement {
         <Tags>a,b,c</Tags>
         <Tags>{["a", "b", "c"]}</Tags>
         {
-            // @ts-expect-error
+            // Undesired behavior.
+            // JSX elements should not be accepted as `children`.
             <Tags><span>a</span></Tags>
         }
         {


### PR DESCRIPTION
FYI please don't merge this yet. Want to have an extended period of time for comments.

Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18912

Allows returning `any` from function components.

```tsx
const RenderNumber = () => 42;
const RenderString = () => 'react';
const RenderArray = () => [19];

// Allowed with proposed change. Previously rejected by type-checker.
<RenderNumber />;
// Allowed with proposed change. Previously rejected by type-checker.
<RenderString />;
// Allowed with proposed change. Previously rejected by type-checker.
<RenderArray />;
```

In React 18 (and even more so in canary releases), there are now way more things that can be returned from render than can't be. Considering https://github.com/microsoft/TypeScript/issues/14729 and https://github.com/microsoft/TypeScript/issues/21699 have been open for years it seems more reasonable to disable type-checking for render return values completely. 

The original thinking of TypeScript has been to be pragmatic in the things we can type-check and just give up on the edges that are commonly used at runtime but can't be (performantly) expressed in types. Return values from render seem to fit such a case.

Alternatives:

- https://github.com/microsoft/TypeScript/pull/29818 (rejected by Microsoft because of bad perf)
- https://github.com/microsoft/TypeScript/issues/21699#issuecomment-1289438364 (no input from Microsoft so far)
- https://github.com/microsoft/TypeScript/pull/51328

Not doing the `ReactNode = ReactNode | Promise<ReactNode>` yet since that '@next' only. Just want to test the waters with this change.



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
   - [x] Klarna monorepo (unused `@ts-expect-error` where we relied on return types being inferred)
   - [ ] https://github.com/mui/material-ui/
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - [async components](https://github.com/reactjs/rfcs/pull/229)
   - [undefined from render](https://github.com/reactwg/react-18/discussions/75)
   - closed issues
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

