### PR TITLE
React: Move `nonce` to global attributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1857,6 +1857,7 @@ declare namespace React {
         hidden?: boolean | undefined;
         id?: string | undefined;
         lang?: string | undefined;
+        nonce?: string | undefined;
         placeholder?: string | undefined;
         slot?: string | undefined;
         spellCheck?: Booleanish | undefined;
@@ -1977,7 +1978,6 @@ declare namespace React {
         multiple?: boolean | undefined;
         muted?: boolean | undefined;
         name?: string | undefined;
-        nonce?: string | undefined;
         noValidate?: boolean | undefined;
         open?: boolean | undefined;
         optimum?: number | undefined;
@@ -2390,7 +2390,6 @@ declare namespace React {
         defer?: boolean | undefined;
         integrity?: string | undefined;
         noModule?: boolean | undefined;
-        nonce?: string | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
         src?: string | undefined;
         type?: string | undefined;
@@ -2421,7 +2420,6 @@ declare namespace React {
 
     interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
         media?: string | undefined;
-        nonce?: string | undefined;
         scoped?: boolean | undefined;
         type?: string | undefined;
     }

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -68,6 +68,7 @@ const testCases = [
             event;
         }}
     ></dialog>,
+    <link nonce="8IBTHwOdqNKAWeKl7plt8g==" />,
 ];
 
 // Needed to check these HTML elements in event callbacks.

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1825,6 +1825,7 @@ declare namespace React {
         hidden?: boolean | undefined;
         id?: string | undefined;
         lang?: string | undefined;
+        nonce?: string | undefined;
         placeholder?: string | undefined;
         slot?: string | undefined;
         spellCheck?: Booleanish | undefined;
@@ -1945,7 +1946,6 @@ declare namespace React {
         multiple?: boolean | undefined;
         muted?: boolean | undefined;
         name?: string | undefined;
-        nonce?: string | undefined;
         noValidate?: boolean | undefined;
         open?: boolean | undefined;
         optimum?: number | undefined;
@@ -2357,7 +2357,6 @@ declare namespace React {
         defer?: boolean | undefined;
         integrity?: string | undefined;
         noModule?: boolean | undefined;
-        nonce?: string | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
         src?: string | undefined;
         type?: string | undefined;
@@ -2388,7 +2387,6 @@ declare namespace React {
 
     interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
         media?: string | undefined;
-        nonce?: string | undefined;
         scoped?: boolean | undefined;
         type?: string | undefined;
     }

--- a/types/react/v16/test/elementAttributes.tsx
+++ b/types/react/v16/test/elementAttributes.tsx
@@ -54,4 +54,5 @@ const testCases = [
             event;
         }}
     ></dialog>,
+    <link nonce="8IBTHwOdqNKAWeKl7plt8g==" />,
 ];

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1824,6 +1824,7 @@ declare namespace React {
         hidden?: boolean | undefined;
         id?: string | undefined;
         lang?: string | undefined;
+        nonce?: string | undefined;
         placeholder?: string | undefined;
         slot?: string | undefined;
         spellCheck?: Booleanish | undefined;
@@ -1944,7 +1945,6 @@ declare namespace React {
         multiple?: boolean | undefined;
         muted?: boolean | undefined;
         name?: string | undefined;
-        nonce?: string | undefined;
         noValidate?: boolean | undefined;
         open?: boolean | undefined;
         optimum?: number | undefined;
@@ -2355,7 +2355,6 @@ declare namespace React {
         defer?: boolean | undefined;
         integrity?: string | undefined;
         noModule?: boolean | undefined;
-        nonce?: string | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
         src?: string | undefined;
         type?: string | undefined;
@@ -2386,7 +2385,6 @@ declare namespace React {
 
     interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
         media?: string | undefined;
-        nonce?: string | undefined;
         scoped?: boolean | undefined;
         type?: string | undefined;
     }

--- a/types/react/v17/test/elementAttributes.tsx
+++ b/types/react/v17/test/elementAttributes.tsx
@@ -68,6 +68,7 @@ const testCases = [
             event;
         }}
     ></dialog>,
+    <link nonce="8IBTHwOdqNKAWeKl7plt8g==" />,
 ];
 
 // Needed to check these HTML elements in event callbacks.


### PR DESCRIPTION
Was previously allowed on `script` but not `link` despite being a global attribute. Allows to get rid of https://github.com/vercel/next.js/blob/63aab20a2ca4f0340e7ca5baff00a5f261dd12d2/packages/next/types/index.d.ts#L39-L41.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
   - [MDN: `nonce` global Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce)
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
