### PR TITLE
[aws-synthetics-puppeteer] Specify return type of `executeStep` using generics

### DIFF
--- a/types/aws-synthetics-puppeteer/aws-synthetics-puppeteer-tests.ts
+++ b/types/aws-synthetics-puppeteer/aws-synthetics-puppeteer-tests.ts
@@ -5,3 +5,15 @@ export const handler = async () => {
     await page.goto('https://example.com');
     await page.screenshot({ path: '/tmp/example.png' });
 };
+
+export const runTestStep = <
+  NextPage,
+>(
+  stepName: string,
+  runTestsAndReturnNextPage: () => Promise<NextPage>,
+): Promise<NextPage> => {
+    return synthetics.executeStep(stepName, async () => {
+        const nextPage = await runTestsAndReturnNextPage();
+        return nextPage;
+    });
+};

--- a/types/aws-synthetics-puppeteer/src/Synthetics.d.ts
+++ b/types/aws-synthetics-puppeteer/src/Synthetics.d.ts
@@ -104,7 +104,11 @@ declare module 'Synthetics' {
          * * Finally, returns what the functionToExecute returned or re-throws what functionToExecute threw.
          * @param stepConfig Optional Step config key-value pairs
          */
-        executeStep<Return = void>(stepName: string, functionToExecute: () => Promise<Return>, stepConfig?: any): Promise<Return>;
+        executeStep<Return = void>(
+            stepName: string,
+            functionToExecute: () => Promise<Return>,
+            stepConfig?: any,
+        ): Promise<Return>;
         publishStepResult(
             result: any,
             startTime: Date,

--- a/types/aws-synthetics-puppeteer/src/Synthetics.d.ts
+++ b/types/aws-synthetics-puppeteer/src/Synthetics.d.ts
@@ -89,19 +89,22 @@ declare module 'Synthetics' {
         getScreenshotResult(stepName: string): ScreenshotResult[];
         addReport(report: any): void;
         /**
-         * Execute the provided step, wrapping it with start/succeed/fail logging, screen shots, metrics
-         * and eventually events
-         *
-         * Log start, screen shot,
-         * start timer,
-         * execute function,
-         * then end timer (pass or fail),
-         * log pass/fail, screen shot pass/fail,
-         * emit pass/fail metrics, events, and step duration metrics,
-         * then return returnValue on success and throw exception on fail
+         * Executes the provided step, wrapping it with start/pass/fail logging, start/pass/fail screenshots, and pass/fail and duration metrics.
+         * The executeStep function also does the following:
+         * * Logs that the step started.
+         * * Takes a screenshot named <stepName>-starting.
+         * * Starts a timer.
+         * * Executes the provided function.
+         * * If the function returns normally, it counts as passing. If the function throws, it counts as failing.
+         * * Ends the timer.
+         * * Logs whether the step passed or failed
+         * * Takes a screenshot named <stepName>-succeeded or <stepName>-failed.
+         * * Emits the stepName SuccessPercent metric, 100 for pass or 0 for failure.
+         * * Emits the stepName Duration metric, with a value based on the step start and end times.
+         * * Finally, returns what the functionToExecute returned or re-throws what functionToExecute threw.
          * @param stepConfig Optional Step config key-value pairs
          */
-        executeStep(stepName: string, functionToExecute: () => Promise<void>, stepConfig?: any): Promise<any>;
+        executeStep<Return = void>(stepName: string, functionToExecute: () => Promise<Return>, stepConfig?: any): Promise<Return>;
         publishStepResult(
             result: any,
             startTime: Date,


### PR DESCRIPTION
It is not `any` - it returns the result of the passed function

Also copy the [official docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Library_Nodejs.html#CloudWatch_Synthetics_Library_executeStep) into the docstring.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:(https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Library_Nodejs.html#CloudWatch_Synthetics_Library_executeStep)
