### PR TITLE
[mousetrap] Return type of callback should be `void`

### DIFF
--- a/types/mousetrap/index.d.ts
+++ b/types/mousetrap/index.d.ts
@@ -18,7 +18,7 @@ declare namespace Mousetrap {
         stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
         bind(
             keys: string | string[],
-            callback: (e: ExtendedKeyboardEvent, combo: string) => any,
+            callback: (e: ExtendedKeyboardEvent, combo: string) => void,
             action?: string,
         ): MousetrapInstance;
         unbind(keys: string | string[], action?: string): MousetrapInstance;
@@ -30,7 +30,7 @@ declare namespace Mousetrap {
         stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
         bind(
             keys: string | string[],
-            callback: (e: ExtendedKeyboardEvent, combo: string) => any,
+            callback: (e: ExtendedKeyboardEvent, combo: string) => void,
             action?: string,
         ): this;
         unbind(keys: string | string[], action?: string): this;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. (No need to edit tests because there are already several tests for callbacks)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test mousetrap`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ccampbell/mousetrap/blob/2f9a476ba6158ba69763e4fcf914966cc72ef433/mousetrap.js#L947 Callback return type is undocumented. I checked the implementation and confirmed the return value is unused.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.