### PR TITLE
`@types/chrome` | Add `identity.email` manifest permission

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7061,6 +7061,7 @@ declare namespace chrome.runtime {
         | 'geolocation'
         | 'history'
         | 'identity'
+        | 'identity.email'
         | 'idle'
         | 'loginState'
         | 'management'


### PR DESCRIPTION
Adds `'identity.email'` to the possible manifest permission values.

The permission is mentioned [here](https://developer.chrome.com/docs/extensions/reference/identity/#method-getProfileUserInfo) in the docs on the [getProfileUserInfo](https://developer.chrome.com/docs/extensions/reference/identity/#method-getProfileUserInfo) method.

> Requires the `identity.email` manifest permission. Otherwise, returns an empty result.