### PR TITLE
[react-scroll] add new prop "horizontal" to Link

### DIFF
--- a/types/react-scroll/modules/components/Link.d.ts
+++ b/types/react-scroll/modules/components/Link.d.ts
@@ -6,6 +6,7 @@ export interface ReactScrollLinkProps {
     activeClass?: string | undefined;
     spy?: boolean | undefined;
     hashSpy?: boolean | undefined;
+    horizontal?: boolean | undefined;
     smooth?: boolean | string | undefined;
     offset?: number | undefined;
     delay?: number | undefined;

--- a/types/react-scroll/test/react-scroll-tests.tsx
+++ b/types/react-scroll/test/react-scroll-tests.tsx
@@ -109,6 +109,7 @@ const linkTest5 = (
             console.log(element);
         }}
         ignoreCancelEvents={false}
+        horizontal={true}
     >
         Your name
     </Link>


### PR DESCRIPTION
new prop "horizontal" got added in v1.8 https://github.com/fisshy/react-scroll/blob/master/CHANGELOG.md

https://github.com/fisshy/react-scroll/blob/989d4407da26c39ecb72284f719a2de12cf4138e/modules/mixins/scroll-link.js#L14

![Screen Shot 2022-10-26 at 17 09 48](https://user-images.githubusercontent.com/176037/197999551-b2b2cabd-cf77-4340-8843-b4dd765b5adc.png)
