### PR TITLE
[react-datepicker] add new prop "monthAriaLabelPrefix"

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-datepicker 4.4
+// Type definitions for react-datepicker 4.8
 // Project: https://github.com/Hacker0x01/react-datepicker
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>
 //                 Greg Smith <https://github.com/smrq>

--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -194,6 +194,7 @@ export interface ReactDatePickerProps<
     useShortMonthInDropdown?: boolean | undefined;
     useWeekdaysShort?: boolean | undefined;
     weekAriaLabelPrefix?: string | undefined;
+    monthAriaLabelPrefix?: string | undefined;
     value?: string | undefined;
     weekLabel?: string | undefined;
     withPortal?: boolean | undefined;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -196,6 +196,7 @@ const topLogger: Modifier<'topLogger'> = {
     portalHost={document.body.shadowRoot!}
     wrapperClassName=""
     weekAriaLabelPrefix=""
+    monthAriaLabelPrefix=""
     excludeScrollbar={false}
     enableTabLoop={false}
     yearDropdownItemNumber={1}


### PR DESCRIPTION
new prop "monthAriaLabelPrefix" got added in https://github.com/Hacker0x01/react-datepicker/tree/v4.8.0

https://github.com/Hacker0x01/react-datepicker/blob/2400071e5ca3839d564cfca056eaeb5e76286329/src/index.jsx#L290

<img width="708" alt="Screen Shot 2022-10-26 at 17 49 55" src="https://user-images.githubusercontent.com/176037/198007634-f69183d4-7321-482d-bdae-7c97e8f7396a.png">

