### PR TITLE
[react-calendar] add new prop "formatWeekday"

### DIFF
--- a/types/react-calendar/index.d.ts
+++ b/types/react-calendar/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for react-calendar 3.5
+// Type definitions for react-calendar 3.9
 // Project: https://github.com/wojtekmaj/react-calendar
 // Definitions by: Stéphane Saquet <https://github.com/Guymestef>
 //                 Katie Soldau <https://github.com/ksoldau>
+//                 Pirasis Leelatanon <https://github.com/1pete>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.5
 
@@ -34,6 +35,7 @@ export interface CalendarProps {
     formatMonth?: FormatterCallback | undefined;
     formatMonthYear?: FormatterCallback | undefined;
     formatShortWeekday?: FormatterCallback | undefined;
+    formatWeekday?: FormatterCallback | undefined;
     formatYear?: FormatterCallback | undefined;
     goToRangeStartOnSelect?: boolean | undefined;
     inputRef?:

--- a/types/react-calendar/react-calendar-tests.tsx
+++ b/types/react-calendar/react-calendar-tests.tsx
@@ -53,6 +53,7 @@ export default class Sample extends React.Component<{}, State> {
                             value={value}
                             locale="ko-KR"
                             formatDay={(locale, date) => date.getDate().toString()}
+                            formatWeekday={(locale, date) => "customFormatWeekday"}
                             inputRef={this.ref}
                             selectRange
                         />


### PR DESCRIPTION
new prop "formatWeekday" got added in https://github.com/wojtekmaj/react-calendar/releases/tag/v3.9.0

https://github.com/wojtekmaj/react-calendar#props

<img width="790" alt="Screen Shot 2022-10-26 at 18 43 27" src="https://user-images.githubusercontent.com/176037/198017573-88cea126-1e1d-47d5-801a-add240363df8.png">
