### PR TITLE
Update dom-webcodecs for TS 4.9 RC

### DIFF
--- a/types/dom-mediacapture-transform/index.d.ts
+++ b/types/dom-mediacapture-transform/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://w3c.github.io/mediacapture-transform/
 // Definitions by: Ben Wagner <https://github.com/dogben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.7
+// Minimum TypeScript Version: 4.9
 
 // In general, these types are only available behind a command line flag or an origin trial in
 // Chrome 90+.

--- a/types/dom-webcodecs/index.d.ts
+++ b/types/dom-webcodecs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://w3c.github.io/webcodecs/
 // Definitions by: Ben Wagner <https://github.com/dogben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.7
+// Minimum TypeScript Version: 4.9
 
 // Versioning:
 // Until the WebCodecs spec is finalized, the major version number is 0. I have chosen to use minor

--- a/types/dom-webcodecs/webcodecs.generated.d.ts
+++ b/types/dom-webcodecs/webcodecs.generated.d.ts
@@ -105,10 +105,10 @@ interface PlaneLayout {
 }
 
 interface VideoColorSpaceInit {
-    fullRange?: boolean | undefined;
-    matrix?: VideoMatrixCoefficients | undefined;
-    primaries?: VideoColorPrimaries | undefined;
-    transfer?: VideoTransferCharacteristics | undefined;
+    fullRange?: boolean | null | undefined;
+    matrix?: VideoMatrixCoefficients | null | undefined;
+    primaries?: VideoColorPrimaries | null | undefined;
+    transfer?: VideoTransferCharacteristics | null | undefined;
 }
 
 interface VideoDecoderConfig {


### PR DESCRIPTION
VideoColorSpaceInit's four properties now allow `null` in addition to `undefined`.