### PR TITLE
Update node for 4.9 RC

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -76,7 +76,7 @@ declare var AbortSignal: typeof globalThis extends {onmessage: any; AbortSignal:
     : {
         prototype: AbortSignal;
         new(): AbortSignal;
-        // TODO: Add abort() static
+        abort(reason?: any): AbortSignal;
         timeout(milliseconds: number): AbortSignal;
     };
 //#endregion borrowed

--- a/types/node/v14/globals.d.ts
+++ b/types/node/v14/globals.d.ts
@@ -114,7 +114,7 @@ declare var AbortController: {
 declare var AbortSignal: {
     prototype: AbortSignal;
     new(): AbortSignal;
-    // TODO: Add abort() static
+    abort(reason?: any): AbortSignal;
     timeout(milliseconds: number): AbortSignal;
 };
 //#endregion borrowed

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -72,7 +72,7 @@ declare var AbortController: {
 declare var AbortSignal: {
     prototype: AbortSignal;
     new(): AbortSignal;
-    // TODO: Add abort() static
+    abort(reason?: any): AbortSignal;
     timeout(milliseconds: number): AbortSignal;
 };
 //#endregion borrowed


### PR DESCRIPTION
This includes node v18, even though there is a workaround in place. It could be that the workaround is no longer needed for 4.9.

Here is the workaround, which uses conditional types to get AbortSignal from globalThis if it exists:

```ts
declare var AbortSignal: typeof globalThis extends {onmessage: any; AbortSignal: infer T}
    ? T
     : {
         prototype: AbortSignal;
         new(): AbortSignal;
         // TODO: Add abort() static
         abort(reason?: any): AbortSignal;
         timeout(milliseconds: number): AbortSignal;
```

@thw0rted I think you put the workaround in place?