### PR TITLE
Add unsigned array types to ArrayType options

### DIFF
--- a/types/kdbush/index.d.ts
+++ b/types/kdbush/index.d.ts
@@ -12,6 +12,9 @@ type ArrayType =
   | typeof Int32Array
   | typeof Float32Array
   | typeof Float64Array
+  | typeof Uint8Array
+  | typeof Uint16Array
+  | typeof Uint32Array
   | typeof Array;
 
 declare class KDBush<T> {

--- a/types/kdbush/kdbush-tests.ts
+++ b/types/kdbush/kdbush-tests.ts
@@ -12,6 +12,9 @@ new KDBush(points, pick(0), pick(1), 64, Int32Array);
 new KDBush(points, pick(0), pick(1), 64, Float32Array);
 new KDBush(points, pick(0), pick(1), 64, Float64Array);
 new KDBush(points, pick(0), pick(1), 64, Array);
+new KDBush(points, pick(0), pick(1), 64, Uint8Array);
+new KDBush(points, pick(0), pick(1), 64, Uint16Array);
+new KDBush(points, pick(0), pick(1), 64, Uint32Array);
 
 // properties
 index.nodeSize;


### PR DESCRIPTION
KDBush doesn't actually restrict the types of arrays that can be used. If you only have positive integers the Uint*Array types can also be used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [kdbush github](https://github.com/mourner/kdbush#api)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
