### PR TITLE
Update types definition for react-tags removeComponent prop

### DIFF
--- a/types/react-tag-input/index.d.ts
+++ b/types/react-tag-input/index.d.ts
@@ -34,7 +34,7 @@ export interface ReactTagsProps {
     handleInputFocus?: ((value: string) => void) | undefined;
     handleInputBlur?: ((textInputValue: string) => void) | undefined;
     minQueryLength?: number | undefined;
-    removeComponent?: React.Component<any, any> | undefined;
+    removeComponent?: React.Component<any, any> | JSX.Element<any, any> |  undefined;
     autocomplete?: boolean | 1 | undefined;
     readOnly?: boolean | undefined;
 


### PR DESCRIPTION
The type for removeComponent was not accepting a functional component, as specified in the issue on the main library https://github.com/react-tags/react-tags/issues/853

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
