### PR TITLE
[nova-editor-node] Add missing thisValue to Configuration.observe function signature

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -294,7 +294,7 @@ type ConfigurationValue = string | number | string[] | boolean;
 
 interface Configuration {
     onDidChange<T>(key: string, callback: (newValue: T, oldValue: T) => void): Disposable;
-    observe<T>(key: string, callback: (newValue: T, oldValue: T) => void): Disposable;
+    observe<T, K>(key: string, callback: (this: K, newValue: T, oldValue: T) => void, thisValue?: K): Disposable;
     get(key: string): ConfigurationValue | null;
     get(key: string, coerce: 'string'): string | null;
     get(key: string, coerce: 'number'): number | null;

--- a/types/nova-editor-node/nova-editor-node-tests.ts
+++ b/types/nova-editor-node/nova-editor-node-tests.ts
@@ -415,3 +415,57 @@ nova.workspace.openNewTextDocument({ syntax: "html", line: 1 });
 // @ts-expect-error
 nova.workspace.openNewTextDocument({ syntax: "html", column: 2 });
 nova.workspace.openNewTextDocument({ content: "<!doctype html>", syntax: "html", line: 1, column: 2 });
+
+/// https://docs.nova.app/api-reference/configuration/
+
+type ConfigCustomThis = number & { __t: 'ConfigCustomThis' };
+const configCustomThis: ConfigCustomThis = 2 as ConfigCustomThis;
+nova.config.observe(
+    'apexskier.testConfig',
+    function(newValue: string, oldValue: string) {
+        // $ExpectType string
+        newValue;
+        // $ExpectType string
+        oldValue;
+        // $ExpectType ConfigCustomThis
+        this;
+    },
+    configCustomThis,
+);
+
+nova.config.observe<string, ConfigCustomThis>(
+    'apexskier.testConfig',
+    function(newValue: string, oldValue: string) {
+        // $ExpectType string
+        newValue;
+        // $ExpectType string
+        oldValue;
+        // $ExpectType ConfigCustomThis
+        this;
+    },
+    // @ts-expect-error
+    'should fail because string is not the right type',
+);
+
+nova.config.observe(
+    'apexskier.testConfig',
+    (newValue: string, oldValue: string) => {
+        // $ExpectType string
+        newValue;
+        // $ExpectType string
+        oldValue;
+        // Closures (arrow functions) do not preserve this value.
+        // $ExpectType undefined
+        this;
+    },
+    configCustomThis,
+);
+
+nova.config.observe('apexskier.testConfig', (newValue: string, oldValue: string) => {
+    // $ExpectType string
+    newValue;
+    // $ExpectType string
+    oldValue;
+    // $ExpectType undefined
+    this;
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

_(Not adding a new definition)_

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.nova.app/api-reference/configuration/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:

_(Not removing declarations)_

***

The type declaration for the `observe` function in the Nova `Configuration` API is missing the type information for the optional `thisValue` argument that can be provided to set the value of `this` in the callback function.
This PR adds the declaration necessary to cover that argument as well as the appropriate tests.
