### PR TITLE
[pdfkit] Allow `null` for `link` option on text

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -184,7 +184,7 @@ declare namespace PDFKit.Mixins {
         /** Whether to stroke the text */
         stroke?: boolean | undefined;
         /** A URL to link this text to (shortcut to create an annotation) */
-        link?: string | undefined;
+        link?: string | null | undefined;
         /** Whether to underline the text */
         underline?: boolean | undefined;
         /** Whether to strike out the text */

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -205,6 +205,8 @@ doc.text('Text with destination', {destination: "test-anchor"});
 
 doc.text('Text with goTo', {goTo: 'test-anchor'});
 
+doc.text('Text with null link', { link: null });
+
 doc.image('path/to/image.png', {
     fit: [250, 300],
     align: 'center',


### PR DESCRIPTION
Related discussion: #62936

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test pdfkit`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/foliojs/pdfkit/blob/master/docs/text.md#rich-text>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
