### PR TITLE
Fix the `@types/eslint` package type for the ESLint config field `globals`

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -515,6 +515,7 @@ linter.verify(
 );
 linter.verify(SOURCE, { env: { node: true } }, 'test.js');
 linter.verify(SOURCE, { globals: { foo: true } }, 'test.js');
+linter.verify(SOURCE, { globals: { foo: 'off' } }, 'test.js');
 linter.verify(SOURCE, { globals: { foo: 'readonly' } }, 'test.js');
 linter.verify(SOURCE, { globals: { foo: 'readable' } }, 'test.js');
 linter.verify(SOURCE, { globals: { foo: 'writable' } }, 'test.js');

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -727,7 +727,7 @@ export namespace Linter {
         $schema?: string | undefined;
         env?: { [name: string]: boolean } | undefined;
         extends?: string | string[] | undefined;
-        globals?: { [name: string]: boolean | "readonly" | "readable" | "writable" | "writeable" } | undefined;
+        globals?: { [name: string]: boolean | "off" | "readonly" | "readable" | "writable" | "writeable" } | undefined;
         noInlineConfig?: boolean | undefined;
         overrides?: Array<ConfigOverride<OverrideRules>> | undefined;
         parser?: string | undefined;


### PR DESCRIPTION
This fixes the `@types/eslint` package type for the ESLint config field `globals` object, which should be able to accept `"off"` values to disable certain globals. See:

https://eslint.org/docs/latest/user-guide/configuring/language-options#using-configuration-files-1

> Globals can be disabled with the string `"off"`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://eslint.org/docs/latest/user-guide/configuring/language-options#using-configuration-files-1
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
