### PR TITLE
meteor: add callAsync

### DIFF
--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -137,11 +137,18 @@ declare namespace Meteor {
     function methods(methods: { [key: string]: (this: MethodThisType, ...args: any[]) => any }): void;
 
     /**
-     * Invokes a method passing any number of arguments.
+     * Invokes a method with a sync stub, passing any number of arguments.
      * @param name Name of method to invoke
      * @param args Optional method arguments
      */
     function call(name: string, ...args: any[]): any;
+
+    /**
+     * Invokes a method with an async stub, passing any number of arguments.
+     * @param name Name of method to invoke
+     * @param args Optional method arguments
+     */
+    function callAsync(name: string, ...args: any[]): Promise<any>;
 
     function apply<Result extends EJSONable | EJSONable[] | EJSONableProperty | EJSONableProperty[]>(
         name: string,

--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Meteor 2.7
+// Type definitions for Meteor 2.8
 // Project: http://www.meteor.com/
 // Definitions by: Alex Borodach <https://github.com/barbatus>
 //                 Dave Allen <https://github.com/fullflavedave>

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -142,11 +142,18 @@ declare module 'meteor/meteor' {
         function methods(methods: { [key: string]: (this: MethodThisType, ...args: any[]) => any }): void;
 
         /**
-         * Invokes a method passing any number of arguments.
+         * Invokes a method with a sync stub, passing any number of arguments.
          * @param name Name of method to invoke
          * @param args Optional method arguments
          */
         function call(name: string, ...args: any[]): any;
+
+        /**
+         * Invokes a method with an async stub, passing any number of arguments.
+         * @param name Name of method to invoke
+         * @param args Optional method arguments
+         */
+        function callAsync(name: string, ...args: any[]): Promise<any>;
 
         function apply<Result extends EJSONable | EJSONable[] | EJSONableProperty | EJSONableProperty[]>(
             name: string,

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -197,7 +197,7 @@ namespace MeteorTests {
     Meteor.call('foo', 1, 2, function (error: any, result: any) {});
     var result = Meteor.call('foo', 1, 2);
 
-    (async function(){
+    (async function() {
         var result = await Meteor.callAsync('foo', 1, 2);
     })();
 

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -197,6 +197,10 @@ namespace MeteorTests {
     Meteor.call('foo', 1, 2, function (error: any, result: any) {});
     var result = Meteor.call('foo', 1, 2);
 
+    (async function(){
+        var result = await Meteor.callAsync('foo', 1, 2);
+    })();
+
     /**
      * From Methods, Meteor.apply section
      */

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -214,6 +214,10 @@ namespace MeteorTests {
     Meteor.call('foo', 1, 2, function (error: any, result: any) {});
     var result = Meteor.call('foo', 1, 2);
 
+    (async function(){
+        var result = await Meteor.callAsync('foo', 1, 2);
+    })();
+
     /**
      * From Methods, Meteor.apply section
      */

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -214,7 +214,7 @@ namespace MeteorTests {
     Meteor.call('foo', 1, 2, function (error: any, result: any) {});
     var result = Meteor.call('foo', 1, 2);
 
-    (async function(){
+    (async function() {
         var result = await Meteor.callAsync('foo', 1, 2);
     })();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://guide.meteor.com/2.8-migration.html#callasync
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
