### PR TITLE
Johnny-Five: Fix `Led` method return types and some signatures

### DIFF
--- a/types/johnny-five/index.d.ts
+++ b/types/johnny-five/index.d.ts
@@ -448,18 +448,19 @@ export declare class Led {
     id: string;
     pin: number;
 
-    on(): void;
-    off(): void;
-    toggle(): void;
-    strobe(ms: number): void;
-    blink(): void;
-    blink(ms: number): void;
-    brightness(val: number): void;
-    fade(brightness: number, ms: number): void;
-    fadeIn(ms: number): void;
-    fadeOut(ms: number): void;
-    pulse(ms: number): void;
-    stop(): void;
+    blink(ms: number = 100, callback?: () => void): this;
+    blink(callback?: () => void): this;
+    brightness(val: number): this;
+    fade(brightness: number, ms?: number = 1000, callback?: () => void): this;
+    fadeIn(ms: number = 1000, callback?: () => void): this;
+    fadeOut(ms: number = 1000, callback?: () => void): this;
+    off(): this;
+    on(): this;
+    pulse(ms: number = 1000, callback?: () => void): this;
+    stop(): this;
+    strobe(ms: number = 100, callback?: () => void): this;
+    strobe(callback?: () => void): this;
+    toggle(): this;
 }
 
 export declare module Led {

--- a/types/johnny-five/index.d.ts
+++ b/types/johnny-five/index.d.ts
@@ -448,17 +448,17 @@ export declare class Led {
     id: string;
     pin: number;
 
-    blink(ms: number = 100, callback?: () => void): this;
+    blink(ms?: number, callback?: () => void): this;
     blink(callback?: () => void): this;
     brightness(val: number): this;
-    fade(brightness: number, ms?: number = 1000, callback?: () => void): this;
-    fadeIn(ms: number = 1000, callback?: () => void): this;
-    fadeOut(ms: number = 1000, callback?: () => void): this;
+    fade(brightness: number, ms?: number, callback?: () => void): this;
+    fadeIn(ms?: number, callback?: () => void): this;
+    fadeOut(ms?: number, callback?: () => void): this;
     off(): this;
     on(): this;
-    pulse(ms: number = 1000, callback?: () => void): this;
+    pulse(ms?: number, callback?: () => void): this;
     stop(): this;
-    strobe(ms: number = 100, callback?: () => void): this;
+    strobe(ms?: number, callback?: () => void): this;
     strobe(callback?: () => void): this;
     toggle(): this;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](http://johnny-five.io/api/led/#api) The docs don't really explain the return value, but you can see in the description for `stop()` that they show chaining method calls. The [source code](https://github.com/rwaldron/johnny-five/blob/main/lib/led/led.js) is pretty clear though, with every method using `return this;`. The argument updates should all be covered by the docs.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
