### PR TITLE
[react-albus] Add explicit types for children in Wizard

### DIFF
--- a/types/react-albus/index.d.ts
+++ b/types/react-albus/index.d.ts
@@ -32,12 +32,11 @@ export function withWizard<P>(
     component: React.ComponentType<P & WizardComponentProps>
 ): React.ComponentType<P>;
 
-export interface WizardProps {
+export type WizardProps = {
     onNext?: ((wizard: WizardContext) => void) | undefined;
-    render?: ((wizard: WizardContext) => React.ReactNode) | undefined;
     history?: History | undefined;
     basename?: string | undefined;
-}
+} & WizardContextRenderProps;
 
 export const Wizard: React.ComponentType<WizardProps>;
 


### PR DESCRIPTION
Implicit children have been removed from @types/react in v18. The following changes are required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

https://github.com/americanexpress/react-albus/blob/v2.0.0/src/utils/renderCallback.js#L16-L21

This was previously added [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56354), but this also needs to be added for `<Wizard>`.