### PR TITLE
Fix typo in ckeditor4 labeledElement::setLabel

### DIFF
--- a/types/ckeditor4/ckeditor4-tests.ts
+++ b/types/ckeditor4/ckeditor4-tests.ts
@@ -459,6 +459,8 @@ function test_dialog() {
     dialog = dialog.foreach(() => console.log('hey'));
 
     const button: CKEDITOR.ui.dialog.button = dialog.getButton('button1');
+    const textInput = new CKEDITOR.ui.dialog.textInput(dialog, {}, []);
+    textInput.setLabel('label');
     const uiEl: CKEDITOR.ui.dialog.uiElement = dialog.getContentElement('page1', 'element1');
     element = dialog.getElement();
     const str: string = dialog.getName();

--- a/types/ckeditor4/index.d.ts
+++ b/types/ckeditor4/index.d.ts
@@ -2485,7 +2485,7 @@ declare namespace CKEDITOR {
                 constructor(dialog: dialog, elementDefinition: definitions.labeledElement, htmlList: any[], contentHtml: () => string);
 
                 getLabel(): string;
-                setlabel(label: string): labeledElement;
+                setLabel(label: string): labeledElement;
             }
 
             class radio extends labeledElement {


### PR DESCRIPTION
`setlabel` is supposed to be `setLabel` as per https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_dialog_labeledElement.html#method-setLabel

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui_dialog_labeledElement.html#method-setLabel
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
