### PR TITLE
[aws-synthetics-puppeteer] Remove aws-sdk to fix CI

### DIFF
--- a/types/aws-synthetics-puppeteer/package.json
+++ b/types/aws-synthetics-puppeteer/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "aws-sdk": ">=2.814.0",
         "aws-xray-sdk-core": "=3.3.1"
     }
 }

--- a/types/aws-synthetics-puppeteer/src/SyntheticsTracing.d.ts
+++ b/types/aws-synthetics-puppeteer/src/SyntheticsTracing.d.ts
@@ -46,7 +46,7 @@ declare module 'SyntheticsTracing' {
          * @param service - An instance of an AWS.Service to wrap.
          * @returns instrumented service that was passed in
          */
-        captureAWSClient(service: AWS.Service): AWS.Service;
+        captureAWSClient<AWSClient>(service: AWSClient): AWSClient;
         /**
          * Configures the AWS SDK to automatically capture segment information
          * for each call made.
@@ -56,7 +56,7 @@ declare module 'SyntheticsTracing' {
          * @returns awssdk that was passed in
          * @see https://github.com/aws/aws-sdk-js
          */
-        captureAWS(awssdk: typeof AWS): typeof AWS;
+        captureAWS<AWS>(awssdk: AWS): AWS;
         /**
          * Wraps the http/https.request() and .get() calls to automatically capture information for the segment.
          * Returns an instance of the HTTP or HTTPS module that is patched.
@@ -185,6 +185,5 @@ declare module 'SyntheticsTracing' {
         resetSegments(): void;
     }
     import * as AWSXRaySDKClient from 'aws-xray-sdk-core';
-    import * as AWS from 'aws-sdk';
     import * as http from 'http';
 }


### PR DESCRIPTION
This is a workaround to remove aws-sdk from aws-synthetics-puppeteer. It provides little value, as it's only used on two function parameters, and it's breaking CI for three pull requests (#62907, #62948, #62887).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. (CI already breaks without this change)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62948#issuecomment-1297581517>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (not applicable)

