### PR TITLE
[d3-scale] scaleTime().nice() should accept TimeInterval

### DIFF
--- a/types/d3-scale/d3-scale-tests.ts
+++ b/types/d3-scale/d3-scale-tests.ts
@@ -569,17 +569,18 @@ localTimeScaleNumString = localTimeScaleNumString.interpolate((a, b) => {
 
 // nice(...) -----------------------------------------------------------------------
 
+const timeInterval = timeHour.every(5);
+
 // chainable
 localTimeScaleNumber = localTimeScaleNumber.nice();
 localTimeScaleNumber = localTimeScaleNumber.nice(5);
 localTimeScaleNumber = localTimeScaleNumber.nice(timeHour);
 
-// @ts-expect-error
-localTimeScaleNumber = localTimeScaleNumber.nice(timeHour.every(5)); // fails, requires CountableTimeInterval
+if (timeInterval !== null) {
+  localTimeScaleNumber = localTimeScaleNumber.nice(timeInterval);
+}
 
 // ticks(...) -----------------------------------------------------------------
-
-const timeInterval = timeHour.every(5);
 
 ticksDates = localTimeScaleNumber.ticks();
 ticksDates = localTimeScaleNumber.ticks(50);

--- a/types/d3-scale/index.d.ts
+++ b/types/d3-scale/index.d.ts
@@ -10,7 +10,7 @@
 
 // Last module patch version validated against: 4.0.2
 
-import { CountableTimeInterval, TimeInterval } from 'd3-time';
+import { TimeInterval } from 'd3-time';
 
 // -------------------------------------------------------------------------------
 // Shared Types and Interfaces
@@ -1195,7 +1195,7 @@ export interface ScaleTime<Range, Output, Unknown = never> {
      *
      * @param interval A time interval to specify the expected ticks.
      */
-    nice(interval: CountableTimeInterval): this;
+    nice(interval: TimeInterval): this;
 
     /**
      * Returns an exact copy of this scale. Changes to this scale will not affect the returned scale, and vice versa.


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-scale#time_nice
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

According to the documentation, 
> An optional tick count argument allows greater control over the step size used to extend the bounds, guaranteeing that the returned [ticks](https://github.com/d3/d3-scale#time_ticks) will exactly cover the domain. Alternatively, a [time interval](https://github.com/d3/d3-time/blob/master/README.md#intervals) may be specified to explicitly set the ticks. If an interval is specified, an optional step may also be specified to skip some ticks. For example, time.nice(d3.timeSecond.every(10)) will extend the domain to an even ten seconds (0, 10, 20, etc.). See [time.ticks](https://github.com/d3/d3-scale#time_ticks) and [interval.every](https://github.com/d3/d3-time/blob/master/README.md#interval_every) for further detail.

`d3.timeSecond.every(10)` returns a `TimeInterval` not a `CountableTimeInterval`. `nice()` expects an interval to respond to [`range`](https://github.com/d3/d3-scale/blob/main/src/time.js#L58) or [`floor` and `ceil`](https://github.com/d3/d3-scale/blob/main/src/nice.js#L15-L16)

I wasn't able to see a current use of the `CountableTimeInterval`, but I have so far left that test in place for explicit backwards compatibility. Although it doesn't really test anything, since it extends `TimeInterval`. Please advise if it (or something like it) is indeed needed