### PR TITLE
[node-cron] `EventEmitter` - Replace `import = require()` with `import ... from`

### DIFF
--- a/types/node-cron/index.d.ts
+++ b/types/node-cron/index.d.ts
@@ -6,7 +6,7 @@
 //                 Ata Berk YILMAZ <https://github.com/ataberkylmz>
 //                 Alex Seidmann <https://github.com/aseidma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import EventEmitter = require('events');
+import { EventEmitter } from 'events';
 
 export function schedule(cronExpression: string, func: ((now: Date | "manual") => void) | string, options?: ScheduleOptions): ScheduledTask;
 


### PR DESCRIPTION
TypeScript Compiler produces following error for interface `ScheduledTask` which extends `EventEmitter`:
``` 
Cannot use namespace 'EventEmitter' as a type. ts(2709)
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/42164
  - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61094