### PR TITLE
[eslint] add `allowLineSeparatedGroups` property to `sort-keys` rule typings

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -789,6 +789,7 @@ let eslintConfig: Linter.Config<ESLintRules>;
 eslintConfig = {
     rules: {
         'capitalized-comments': [2, 'always', { ignorePattern: 'const|let' }],
+        'sort-keys': [2, 'asc', { allowLineSeparatedGroups: true }],
     },
     overrides: [{
         files: '*.json',

--- a/types/eslint/rules/stylistic-issues.d.ts
+++ b/types/eslint/rules/stylistic-issues.d.ts
@@ -1723,6 +1723,10 @@ export interface StylisticIssues extends Linter.RulesRecord {
                  * @default false
                  */
                 natural: boolean;
+                /**
+                 * @default false
+                 */
+                allowLineSeparatedGroups: boolean;
             }>,
         ]
     >;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://eslint.org/docs/latest/rules/sort-keys#options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
