### PR TITLE
aws-lambda: Add DeadLetterQueueSourceArn to SQS attributes for lambda event

### DIFF
--- a/types/aws-lambda/test/sqs-tests.ts
+++ b/types/aws-lambda/test/sqs-tests.ts
@@ -38,6 +38,7 @@ const event: SQSEvent = {
                 SentTimestamp: '1529104986221',
                 SenderId: '594035263019',
                 ApproximateFirstReceiveTimestamp: '1529104986230',
+                DeadLetterQueueSourceArn: 'arn:aws:sqs:123456789012:source-queue',
             },
             messageAttributes: {
                 testAttr: {
@@ -74,7 +75,8 @@ const fifoEvent: SQSEvent = {
                 MessageGroupId: "1",
                 SenderId: "AIDAIO23YVJENQZJOL4VO",
                 MessageDeduplicationId: "1",
-                ApproximateFirstReceiveTimestamp: "1573251510774"
+                ApproximateFirstReceiveTimestamp: "1573251510774",
+                DeadLetterQueueSourceArn: "arn:aws:sqs:123456789012:source-queue",
             },
             messageAttributes: {},
             md5OfBody: "e4e68fb7bd0e697a0ae8f1bb342846b3",

--- a/types/aws-lambda/trigger/sqs.d.ts
+++ b/types/aws-lambda/trigger/sqs.d.ts
@@ -30,6 +30,7 @@ export interface SQSRecordAttributes {
     SequenceNumber?: string | undefined;
     MessageGroupId?: string | undefined;
     MessageDeduplicationId?: string | undefined;
+    DeadLetterQueueSourceArn?: string | undefined; // Undocumented, but used by AWS to support their re-drive functionality in the console
 }
 
 export type SQSMessageAttributeDataType = 'String' | 'Number' | 'Binary' | string;


### PR DESCRIPTION
This is not officially documented (but a requirement for the internal redrive system), but here are some mention of it: https://raaviblog.com/automate-replay-of-messages-from-aws-sqs-dead-letter-fifo-queue-using-python-script-in-lambda/