### PR TITLE
[mapbox-gl-draw] Add drawConfig to DrawCustomModeThis

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -176,6 +176,8 @@ declare namespace MapboxDraw {
     interface DrawCustomModeThis {
         map: mapboxgl.Map;
 
+        drawConfig: Exclude<MapboxDrawOptions, undefined>;
+
         setSelected(features?: string | string[]): void;
 
         setSelectedCoordinates(coords: Array<{ coord_path: string; feature_id: string }>): void;

--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -277,9 +277,9 @@ declare namespace MapboxDraw {
         boxSelect?: boolean | undefined;
         clickBuffer?: number | undefined;
         touchBuffer?: number | undefined;
-        controls?: MapboxDraw.MapboxDrawControls | undefined;
+        controls?: MapboxDrawControls | undefined;
         styles?: object[] | undefined;
-        modes?: { [modeKey: string]: MapboxDraw.DrawCustomMode } | undefined;
+        modes?: { [modeKey: string]: DrawCustomMode } | undefined;
         defaultMode?: string | undefined;
         userProperties?: boolean | undefined;
     }

--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -176,7 +176,7 @@ declare namespace MapboxDraw {
     interface DrawCustomModeThis {
         map: mapboxgl.Map;
 
-        drawConfig: Exclude<MapboxDrawOptions, undefined>;
+        drawConfig: MapboxDrawOptions;
 
         setSelected(features?: string | string[]): void;
 
@@ -270,17 +270,7 @@ declare namespace MapboxDraw {
         direct_select: DrawCustomMode;
     }
 
-    type MapboxDrawOptions = ConstructorParameters<typeof MapboxDraw>[0];
-}
-
-declare class MapboxDraw implements IControl {
-    static modes: MapboxDraw.Modes;
-
-    modes: MapboxDraw.DrawModes;
-
-    getDefaultPosition: () => string;
-
-    constructor(options?: {
+    interface MapboxDrawOptions {
         displayControlsDefault?: boolean | undefined;
         keybindings?: boolean | undefined;
         touchEnabled?: boolean | undefined;
@@ -292,7 +282,17 @@ declare class MapboxDraw implements IControl {
         modes?: { [modeKey: string]: MapboxDraw.DrawCustomMode } | undefined;
         defaultMode?: string | undefined;
         userProperties?: boolean | undefined;
-    });
+    }
+}
+
+declare class MapboxDraw implements IControl {
+    static modes: MapboxDraw.Modes;
+
+    modes: MapboxDraw.DrawModes;
+
+    getDefaultPosition: () => string;
+
+    constructor(options?: MapboxDraw.MapboxDrawOptions);
 
     add(geojson: Feature | FeatureCollection | Geometry): string[];
 

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -81,6 +81,9 @@ const customMode: CustomMode = {
         // $ExpectType Map
         this.map;
 
+        // $ExpectType boolean | undefined
+        this.drawConfig.displayControlsDefault;
+
         this.setSelectedCoordinates([
             {
                 coord_path: '0',


### PR DESCRIPTION
## DrawCustomModeThis
- Add missing property `drawConfig` to DrawCustomModeThis.  
  cf. https://github.com/mapbox/mapbox-gl-draw/blob/main/src/modes/mode_interface_accessors.js#L10
  At first, according to above implementation, I considered the type of `drawConfig` should be `Exclude<MapboxDrawOptions, undefined> | Record<string, never>` (union with empty object), but I found all properties in the type `MapboxDrawOptions` are optional. So I define it simply `Exclude<MapboxDrawOptions, undefined>` since drawConfig cannot be narrowed from union type with empty object.

====================

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.