### PR TITLE
@ember/owner: introduce `Resolver` type

### DIFF
--- a/types/ember-resolver/ember-resolver-tests.ts
+++ b/types/ember-resolver/ember-resolver-tests.ts
@@ -3,10 +3,16 @@ import Ember from 'ember';
 
 const MyResolver = EmberResolver.extend({
     pluralizedTypes: {
-        sheep: 'sheep'
-    }
+        sheep: 'sheep',
+    },
 });
 
 const App = Ember.Application.extend({
-    Resolver: MyResolver
+    Resolver: MyResolver,
 });
+
+const resolver = MyResolver.create();
+resolver.resolve('some:name');
+resolver.normalize('some:name');
+// @ts-expect-error
+resolver.normalize('bad-name');

--- a/types/ember-resolver/index.d.ts
+++ b/types/ember-resolver/index.d.ts
@@ -8,13 +8,37 @@
 // Minimum TypeScript Version: 4.4
 
 import EmberObject from '@ember/object';
+import { Resolver } from '@ember/owner';
 
 /**
  * An Ember `Resolver` implementation used by ember-cli.
  */
-export default class EmberResolver extends EmberObject {
-    // TODO: add some types for this!
-    // NOTE: not doing this as part of the Ember v4 release, since it was an
-    // empty stub before. Will backfill it going forward (and/or just do it in)
-    // the repo proper if possible!
+export default class EmberResolver extends EmberObject implements Resolver {
+    resolve: (name: string) => object | undefined;
+    normalize: (fullName: `${string}:${string}`) => string;
+    /**
+     * To customize pluralization provide a `pluralizedTypes` object to your
+     * applications resolver:
+     *
+     * ```js
+     * // app/app.js
+     * import Resolver from 'ember-resolver';
+     *
+     * export default class AppResolver extends Resolver {
+     *   pluralizedTypes = {
+     *     'sheep': 'sheep',
+     *     'strategy': 'strategies'
+     *   }
+     * }
+     *
+     * // ...snip...
+     * export default class App extends Application {
+     *   // ...snip...
+     *   Resolver = AppResolver;
+     * }
+     *
+     * // ...snip...
+     * ```
+     */
+    pluralizedTypes: Record<string, string>;
 }

--- a/types/ember-resolver/tsconfig.json
+++ b/types/ember-resolver/tsconfig.json
@@ -1,15 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6",
-            "dom"
-        ],
+        "lib": ["es6", "dom"],
         "strict": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "paths": {
             "@ember/*": ["ember__*"]
         },
@@ -18,8 +13,5 @@
         "exactOptionalPropertyTypes": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "ember-resolver-tests.ts"
-    ]
+    "files": ["index.d.ts", "ember-resolver-tests.ts"]
 }

--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -13,9 +13,8 @@ import EventDispatcher from '@ember/application/-private/event-dispatcher';
 import { EventDispatcherEvents } from '@ember/application/types';
 import Router from '@ember/routing/router';
 import Registry from '@ember/application/-private/registry';
-import Resolver from 'ember-resolver';
 import { AnyFn } from 'ember/-private/type-utils';
-import Owner from '@ember/owner';
+import Owner, { Resolver } from '@ember/owner';
 import type GlimmerComponent from '@glimmer/component';
 import EmberObject from '@ember/object';
 

--- a/types/ember__debug/container-debug-adapter.d.ts
+++ b/types/ember__debug/container-debug-adapter.d.ts
@@ -1,4 +1,4 @@
-import Resolver from 'ember-resolver';
+import { Resolver } from '@ember/owner';
 
 /**
  * The ContainerDebugAdapter helps the container and resolver interface

--- a/types/ember__engine/index.d.ts
+++ b/types/ember__engine/index.d.ts
@@ -12,7 +12,7 @@ import EmberObject from '@ember/object';
 import RegistryProxyMixin from '@ember/engine/-private/registry-proxy-mixin';
 import Initializer from '@ember/engine/-private/types/initializer';
 import EngineInstance from '@ember/engine/instance';
-import Resolver from 'ember-resolver';
+import { Resolver } from '@ember/owner';
 
 /**
  * The `Engine` class contains core functionality for both applications and

--- a/types/ember__engine/test/engine.ts
+++ b/types/ember__engine/test/engine.ts
@@ -28,6 +28,8 @@ const Engine1 = BaseEngine.create({
     },
 });
 
+Engine1.resolver?.resolve('something');
+
 const Engine2 = BaseEngine.create({
     rootElement: '#engine-two',
     customEvents: {

--- a/types/ember__owner/ember__owner-tests.ts
+++ b/types/ember__owner/ember__owner-tests.ts
@@ -1,4 +1,4 @@
-import Owner, { Factory, FactoryManager, FullName, RegisterOptions } from '@ember/owner';
+import Owner, { Factory, FactoryManager, FullName, RegisterOptions, KnownForTypeResult, Resolver } from '@ember/owner';
 
 // Just a class we can construct in the Factory and FactoryManager tests
 declare class ConstructThis {
@@ -51,6 +51,14 @@ aFactoryManager.create({ hasProps: true, otherStuff: 'nope' });
 aFactoryManager.create(goodPojo); // $ExpectType ConstructThis
 // @ts-expect-error
 aFactoryManager.create(badPojo);
+
+// ----- Resolver ----- //
+declare let resolver: Resolver;
+resolver.resolve('some-name');
+const knownForFoo = resolver.knownForType?.('foo');
+knownForFoo?.['foo:bar']; // $ExpectType boolean | undefined
+// @ts-expect-error
+knownForFoo?.['blah'];
 
 // This one is last so it can reuse the bits from above!
 // ----- Owner ----- //

--- a/types/ember__owner/index.d.ts
+++ b/types/ember__owner/index.d.ts
@@ -101,5 +101,26 @@ export interface FactoryManager<T> extends Factory<T> {
     readonly class: Factory<T>;
 }
 
+/**
+ * A record mapping all known items of a given type: if the item is known it
+ * will be `true`; otherwise it will be `false` or `undefined`.
+ */
+export type KnownForTypeResult<Type extends string> = {
+    [FullName in `${Type}:${string}`]: boolean | undefined;
+};
+
+/**
+ * The contract a custom resolver must implement. Most apps never need to think
+ * about this: the application's resolver is supplied by `ember-resolver` in
+ * the default blueprint.
+ */
+export interface Resolver {
+    resolve: (name: string) => Factory<object> | object | undefined;
+    knownForType?: <Type extends string>(type: Type) => KnownForTypeResult<Type>;
+    lookupDescription?: (fullName: FullName) => string;
+    makeToString?: (factory: Factory<object>, fullName: FullName) => string;
+    normalize?: (fullName: FullName) => string;
+}
+
 // Don't export things unless we *intend* to.
 export {};


### PR DESCRIPTION
Implements the next part of Ember RFC 0821. Compare the PR in the preview types: emberjs/ember.js#20253.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://rfcs.emberjs.com/id/0821-public-types/#resolver>
