### PR TITLE
Add hide_zero_doc_count for aggregations in itemsjs

### DIFF
--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -123,6 +123,8 @@ declare namespace itemsjs {
         order?: Order | undefined;
         /** @default false */
         show_facet_stats?: boolean | undefined;
+        /** @default false */
+        hide_zero_doc_count?: boolean | undefined;
     }
 
     /** Configuration for itemsjs */

--- a/types/itemsjs/itemsjs-tests.ts
+++ b/types/itemsjs/itemsjs-tests.ts
@@ -29,6 +29,7 @@ const items = itemsjs(myitems, {
     aggregations: {
         anAggregation: {
             title: 'A Number',
+            hide_zero_doc_count: true,
             conjunction: false,
         },
     },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Aggregations doc](https://github.com/itemsapi/itemsjs#configuration)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -- only fixed what I need, so not sure about version.
