### PR TITLE
meteor: Support async publish functions

### DIFF
--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -415,7 +415,7 @@ declare namespace Meteor {
      */
     function publish(
         name: string | null,
-        func: (this: Subscription, ...args: any[]) => void,
+        func: (this: Subscription, ...args: any[]) => void | Mongo.Cursor<any> | Mongo.Cursor<any>[] | Promise<void | Mongo.Cursor<any> | Mongo.Cursor<any>[]>,
         options?: { is_auto: boolean },
     ): void;
 

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -420,7 +420,7 @@ declare module 'meteor/meteor' {
          */
         function publish(
             name: string | null,
-            func: (this: Subscription, ...args: any[]) => void,
+            func: (this: Subscription, ...args: any[]) => void | Mongo.Cursor<any> | Mongo.Cursor<any>[] | Promise<void | Mongo.Cursor<any> | Mongo.Cursor<any>[]>,
             options?: { is_auto: boolean },
         ): void;
 

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -563,7 +563,7 @@ namespace MeteorTests {
     Meteor.publish(
         null,
         function () {
-            return 3;
+            return;
         },
         { is_auto: true },
     );

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -145,6 +145,15 @@ namespace MeteorTests {
         Meteor.subscribe('counts-by-room', Session.get('roomId'));
     });
 
+    // Async publish function
+    Meteor.publish('userData', async function (userId: unknown) {
+        check(userId, String);
+        const user = await Meteor.users.findOneAsync(userId);
+        if (user) {
+            return Meteor.users.find(userId, { fields: { profile: 1 } });
+        }
+    });
+
     // Checking status
     let status: DDP.Status = 'connected';
 
@@ -580,7 +589,7 @@ namespace MeteorTests {
     Meteor.publish(
         null,
         function () {
-            return 3;
+            return;
         },
         { is_auto: true },
     );


### PR DESCRIPTION
As a note, this will effectively make publish functions more strict than they were in the past, since an interface which accepts a function of void return is effectively the same as accepting a function with any return. This is visible in the test case that returned `3`, which is no longer accepted (and would have been an error - Meteor throws if you return a truthy non-cursor value).

My motivation here is primarily appeasing `@typescript-eslint/no-misused-promises`, which assumes that passing an async function to something that expects a `void` function is an error.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/changelog.html#breakingchanges-16:~:text=Add%20support%20in,for%20async%20functions (support was introduced in meteor/meteor#11444 and meteor/meteor#11480)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
