### PR TITLE
fix (cacheable-request): reintroduce temporarily to fix dependency semver

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -464,10 +464,6 @@
             "libraryName": "burns",
             "asOfVersion": "2.1.0"
         },
-        "cacheable-request": {
-            "libraryName": "cacheable-request",
-            "asOfVersion": "8.3.1"
-        },
         "cachefactory": {
             "libraryName": "cachefactory",
             "asOfVersion": "3.0.0"

--- a/types/cacheable-request/cacheable-request-tests.ts
+++ b/types/cacheable-request/cacheable-request-tests.ts
@@ -1,0 +1,26 @@
+import * as http from 'http';
+import * as https from 'https';
+import CacheableRequest = require('cacheable-request');
+
+// You can do
+let cacheableRequest = new CacheableRequest(http.request);
+const cacheReq = cacheableRequest('http://example.com', res => {
+    res; // $ExpectType ServerResponse<IncomingMessage> | ResponseLike
+});
+cacheReq.on('request', req => req.end());
+
+cacheableRequest = new CacheableRequest(https.request);
+
+cacheableRequest = new CacheableRequest(http.request, 'redis://user:pass@localhost:6379');
+cacheableRequest = new CacheableRequest(http.request, new Map());
+
+cacheableRequest('example.com', res => {
+    res; // $ExpectType ServerResponse<IncomingMessage> | ResponseLike
+})
+    .on('error', err => {
+        err; // $ExpectType RequestErrorCls | CacheErrorCls
+    })
+    .on('request', req => {
+        req.on('error', () => {});
+        req.end();
+    });

--- a/types/cacheable-request/index.d.ts
+++ b/types/cacheable-request/index.d.ts
@@ -1,0 +1,137 @@
+// Type definitions for cacheable-request 6.0
+// Project: https://github.com/lukechilds/cacheable-request#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+//                 Paul Melnikow <https://github.com/paulmelnikow>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+import { request, RequestOptions, ClientRequest, ServerResponse } from 'http';
+import { URL } from 'url';
+import { EventEmitter } from 'events';
+import { Store } from 'keyv';
+import { Options as CacheSemanticsOptions } from 'http-cache-semantics';
+import ResponseLike = require('responselike');
+
+export = CacheableRequest;
+
+declare const CacheableRequest: CacheableRequest;
+
+type RequestFn = typeof request;
+
+interface CacheableRequest {
+    new (requestFn: RequestFn, storageAdapter?: string | CacheableRequest.StorageAdapter): (
+        opts: string | URL | (RequestOptions & CacheSemanticsOptions),
+        cb?: (response: ServerResponse | ResponseLike) => void
+    ) => CacheableRequest.Emitter;
+
+    RequestError: typeof RequestErrorCls;
+    CacheError: typeof CacheErrorCls;
+}
+
+declare namespace CacheableRequest {
+    type StorageAdapter = Store<any>;
+
+    interface Options {
+        /**
+         * If the cache should be used. Setting this to `false` will completely bypass the cache for the current request.
+         * @default true
+         */
+        cache?: boolean | undefined;
+
+        /**
+         * If set to `true` once a cached resource has expired it is deleted and will have to be re-requested.
+         *
+         * If set to `false`, after a cached resource's TTL expires it is kept in the cache and will be revalidated
+         * on the next request with `If-None-Match`/`If-Modified-Since` headers.
+         * @default false
+         */
+        strictTtl?: boolean | undefined;
+
+        /**
+         * Limits TTL. The `number` represents milliseconds.
+         * @default undefined
+         */
+        maxTtl?: number | undefined;
+
+        /**
+         * When set to `true`, if the DB connection fails we will automatically fallback to a network request.
+         * DB errors will still be emitted to notify you of the problem even though the request callback may succeed.
+         * @default false
+         */
+        automaticFailover?: boolean | undefined;
+
+        /**
+         * Forces refreshing the cache. If the response could be retrieved from the cache, it will perform a
+         * new request and override the cache instead.
+         * @default false
+         */
+        forceRefresh?: boolean | undefined;
+    }
+
+    interface Emitter extends EventEmitter {
+        addListener(event: 'request', listener: (request: ClientRequest) => void): this;
+        addListener(
+            event: 'response',
+            listener: (response: ServerResponse | ResponseLike) => void
+        ): this;
+        addListener(event: 'error', listener: (error: RequestError | CacheError) => void): this;
+        on(event: 'request', listener: (request: ClientRequest) => void): this;
+        on(event: 'response', listener: (response: ServerResponse | ResponseLike) => void): this;
+        on(event: 'error', listener: (error: RequestError | CacheError) => void): this;
+        once(event: 'request', listener: (request: ClientRequest) => void): this;
+        once(event: 'response', listener: (response: ServerResponse | ResponseLike) => void): this;
+        once(event: 'error', listener: (error: RequestError | CacheError) => void): this;
+        prependListener(event: 'request', listener: (request: ClientRequest) => void): this;
+        prependListener(
+            event: 'response',
+            listener: (response: ServerResponse | ResponseLike) => void
+        ): this;
+        prependListener(event: 'error', listener: (error: RequestError | CacheError) => void): this;
+        prependOnceListener(event: 'request', listener: (request: ClientRequest) => void): this;
+        prependOnceListener(
+            event: 'response',
+            listener: (response: ServerResponse | ResponseLike) => void
+        ): this;
+        prependOnceListener(
+            event: 'error',
+            listener: (error: RequestError | CacheError) => void
+        ): this;
+        removeListener(event: 'request', listener: (request: ClientRequest) => void): this;
+        removeListener(
+            event: 'response',
+            listener: (response: ServerResponse | ResponseLike) => void
+        ): this;
+        removeListener(event: 'error', listener: (error: RequestError | CacheError) => void): this;
+        off(event: 'request', listener: (request: ClientRequest) => void): this;
+        off(event: 'response', listener: (response: ServerResponse | ResponseLike) => void): this;
+        off(event: 'error', listener: (error: RequestError | CacheError) => void): this;
+        removeAllListeners(event?: 'request' | 'response' | 'error'): this;
+        listeners(event: 'request'): Array<(request: ClientRequest) => void>;
+        listeners(event: 'response'): Array<(response: ServerResponse | ResponseLike) => void>;
+        listeners(event: 'error'): Array<(error: RequestError | CacheError) => void>;
+        rawListeners(event: 'request'): Array<(request: ClientRequest) => void>;
+        rawListeners(event: 'response'): Array<(response: ServerResponse | ResponseLike) => void>;
+        rawListeners(event: 'error'): Array<(error: RequestError | CacheError) => void>;
+        emit(event: 'request', request: ClientRequest): boolean;
+        emit(event: 'response', response: ServerResponse | ResponseLike): boolean;
+        emit(event: 'error', error: RequestError | CacheError): boolean;
+        eventNames(): Array<'request' | 'response' | 'error'>;
+        listenerCount(type: 'request' | 'response' | 'error'): number;
+    }
+
+    type RequestError = RequestErrorCls;
+    type CacheError = CacheErrorCls;
+}
+
+declare class RequestErrorCls extends Error {
+    readonly name: 'RequestError';
+
+    constructor(error: Error);
+}
+declare class CacheErrorCls extends Error {
+    readonly name: 'CacheError';
+
+    constructor(error: Error);
+}

--- a/types/cacheable-request/package.json
+++ b/types/cacheable-request/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "@types/keyv": "^3.1.4",
+        "@types/responselike": "^1.0.0"
+    }
+}

--- a/types/cacheable-request/tsconfig.json
+++ b/types/cacheable-request/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cacheable-request-tests.ts"
+    ]
+}

--- a/types/cacheable-request/tslint.json
+++ b/types/cacheable-request/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [~] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

this re-introduces cacheable-request's types **temporarily** for the sole purpose of publishing a version with a specific dependency list.

im guessing if a DT package has no explicit dependencies, it falls back to auto-generating a package.json with a semver range of `*`.

basically `@types/cacheable-request` never had a package manifest, but the published package does, and that specifies `*` for each implicit dependency.

because we want to remove `responselike` and `keyv` from DT (we have for the latter), that `*` range will match the newly published stub package, leading to breaking builds ofc.

so im reintroducing this only so i can specify a range, i'll then follow it up with a PR to remove it again.

@sandersn or another DT maintainer: will this result in the published package dropping back to its original version? (the one specified in the DTS, thats what we want it to do ideally)

depends on microsoft/DefinitelyTyped-tools#561
