### PR TITLE
fix: stringify-object ESM support

### DIFF
--- a/types/stringify-object/index.d.ts
+++ b/types/stringify-object/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/yeoman/stringify-object
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.5
 
 /**
  * Stringify an object/array like JSON.stringify just without all the double-quotes

--- a/types/stringify-object/index.d.ts
+++ b/types/stringify-object/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/yeoman/stringify-object
 // Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.5
 
 /**
  * Stringify an object/array like JSON.stringify just without all the double-quotes

--- a/types/stringify-object/package.json
+++ b/types/stringify-object/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/types/stringify-object/package.json
+++ b/types/stringify-object/package.json
@@ -1,3 +1,4 @@
 {
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/types/stringify-object/stringify-object-tests.ts
+++ b/types/stringify-object/stringify-object-tests.ts
@@ -1,4 +1,5 @@
 import stringifyObject, { Options } from 'stringify-object';
+import { default as defaultStringifyObject } from 'stringify-object';
 
 const options: Options = {
     indent: '  ',
@@ -16,3 +17,12 @@ stringifyObject('abc', {
 stringifyObject('abc', options);
 
 stringifyObject([1, 2, 3], options, ' ');
+
+defaultStringifyObject({ a: 1, b: 2, c: 3 });
+
+defaultStringifyObject('abc', {
+    indent: '  ',
+});
+defaultStringifyObject('abc', options);
+
+defaultStringifyObject([1, 2, 3], options, ' ');

--- a/types/stringify-object/stringify-object-tests.ts
+++ b/types/stringify-object/stringify-object-tests.ts
@@ -1,5 +1,4 @@
-import stringifyObject, { Options } from 'stringify-object';
-import { default as defaultStringifyObject } from 'stringify-object';
+import { default as stringifyObject, type Options } from 'stringify-object';
 
 const options: Options = {
     indent: '  ',
@@ -17,12 +16,3 @@ stringifyObject('abc', {
 stringifyObject('abc', options);
 
 stringifyObject([1, 2, 3], options, ' ');
-
-defaultStringifyObject({ a: 1, b: 2, c: 3 });
-
-defaultStringifyObject('abc', {
-    indent: '  ',
-});
-defaultStringifyObject('abc', options);
-
-defaultStringifyObject([1, 2, 3], options, ' ');

--- a/types/stringify-object/stringify-object-tests.ts
+++ b/types/stringify-object/stringify-object-tests.ts
@@ -1,4 +1,6 @@
-import { default as stringifyObject, type Options } from 'stringify-object';
+import stringifyObject from 'stringify-object';
+// tslint:disable-next-line:no-duplicate-imports testing imports
+import type { Options } from 'stringify-object';
 
 const options: Options = {
     indent: '  ',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/issues/50690#issuecomment-1277917380
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

## Content
No idea how to test it. Do I have to add `package.json` within installed modules and see if it works on my machine?
The package only got a patch update since then so the changes sorta bring the definitions "up to date" but also don't incur package version change in the header.

The story so far:
- I was running typescript in a ESM mode in my code to be able to use ESM-only packages.
- `stringify-object` was giving me compile error on `import stringifyObject from "stringify-object";`.
- I rewrote it to `import { default as  stringifyObject } from "stringify-object";` and it worked.
- At some point I was running dependency maintenance and the construct above was giving me an error on the typescript 4.8.4+.
- Turns out there was [an issue for it already](https://github.com/microsoft/TypeScript/issues/50690).