### PR TITLE
fix(node): support for `symbol` type in `diagnostic_channel`

### DIFF
--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -41,7 +41,7 @@ declare module 'diagnostics_channel' {
      * @param name The channel name
      * @return If there are active subscribers
      */
-    function hasSubscribers(name: string): boolean;
+    function hasSubscribers(name: string | symbol): boolean;
     /**
      * This is the primary entry-point for anyone wanting to interact with a named
      * channel. It produces a channel object which is optimized to reduce overhead at
@@ -56,8 +56,8 @@ declare module 'diagnostics_channel' {
      * @param name The channel name
      * @return The named channel object
      */
-    function channel(name: string): Channel;
-    type ChannelListener = (message: unknown, name: string) => void;
+    function channel(name: string | symbol): Channel;
+    type ChannelListener = (message: unknown, name: string | symbol) => void;
     /**
      * The class `Channel` represents an individual named channel within the data
      * pipeline. It is use to track subscribers and to publish messages when there
@@ -68,7 +68,7 @@ declare module 'diagnostics_channel' {
      * @since v15.1.0, v14.17.0
      */
     class Channel {
-        readonly name: string;
+        readonly name: string | symbol;
         /**
          * Check if there are active subscribers to this channel. This is helpful if
          * the message you want to send might be expensive to prepare.
@@ -88,7 +88,7 @@ declare module 'diagnostics_channel' {
          * @since v15.1.0, v14.17.0
          */
         readonly hasSubscribers: boolean;
-        private constructor(name: string);
+        private constructor(name: string | symbol);
         /**
          * Publish a message to any subscribers to the channel. This will
          * trigger message handlers synchronously so they will execute within

--- a/types/node/test/diagnostics_channel.ts
+++ b/types/node/test/diagnostics_channel.ts
@@ -1,11 +1,11 @@
 import { Channel, channel, hasSubscribers } from 'node:diagnostics_channel';
 
-const ch1: Channel = channel('test');
+const ch1: Channel = channel(Symbol.for('test'));
 function listener(data: unknown) {}
-function anotherListener(data: unknown, name: string) {}
+function anotherListener(data: unknown, name: string | symbol) {}
 
 const active: boolean = ch1.hasSubscribers;
-const name: string = ch1.name;
+const name: string | symbol = ch1.name;
 
 ch1.publish({ some: 'message' });
 

--- a/types/node/ts4.8/diagnostics_channel.d.ts
+++ b/types/node/ts4.8/diagnostics_channel.d.ts
@@ -41,7 +41,7 @@ declare module 'diagnostics_channel' {
      * @param name The channel name
      * @return If there are active subscribers
      */
-    function hasSubscribers(name: string): boolean;
+    function hasSubscribers(name: string | symbol): boolean;
     /**
      * This is the primary entry-point for anyone wanting to interact with a named
      * channel. It produces a channel object which is optimized to reduce overhead at
@@ -56,8 +56,8 @@ declare module 'diagnostics_channel' {
      * @param name The channel name
      * @return The named channel object
      */
-    function channel(name: string): Channel;
-    type ChannelListener = (message: unknown, name: string) => void;
+    function channel(name: string | symbol): Channel;
+    type ChannelListener = (message: unknown, name: string | symbol) => void;
     /**
      * The class `Channel` represents an individual named channel within the data
      * pipeline. It is use to track subscribers and to publish messages when there
@@ -68,7 +68,7 @@ declare module 'diagnostics_channel' {
      * @since v15.1.0, v14.17.0
      */
     class Channel {
-        readonly name: string;
+        readonly name: string | symbol;
         /**
          * Check if there are active subscribers to this channel. This is helpful if
          * the message you want to send might be expensive to prepare.
@@ -88,7 +88,7 @@ declare module 'diagnostics_channel' {
          * @since v15.1.0, v14.17.0
          */
         readonly hasSubscribers: boolean;
-        private constructor(name: string);
+        private constructor(name: string | symbol);
         /**
          * Publish a message to any subscribers to the channel. This will
          * trigger message handlers synchronously so they will execute within

--- a/types/node/ts4.8/test/diagnostics_channel.ts
+++ b/types/node/ts4.8/test/diagnostics_channel.ts
@@ -1,11 +1,11 @@
 import { Channel, channel, hasSubscribers } from 'node:diagnostics_channel';
 
-const ch1: Channel = channel('test');
+const ch1: Channel = channel(Symbol.for('test'));
 function listener(data: unknown) {}
-function anotherListener(data: unknown, name: string) {}
+function anotherListener(data: unknown, name: string | symbol) {}
 
 const active: boolean = ch1.hasSubscribers;
-const name: string = ch1.name;
+const name: string | symbol = ch1.name;
 
 ch1.publish({ some: 'message' });
 

--- a/types/node/v16/diagnostics_channel.d.ts
+++ b/types/node/v16/diagnostics_channel.d.ts
@@ -41,7 +41,7 @@ declare module 'diagnostics_channel' {
      * @param name The channel name
      * @return If there are active subscribers
      */
-    function hasSubscribers(name: string): boolean;
+    function hasSubscribers(name: string | symbol): boolean;
     /**
      * This is the primary entry-point for anyone wanting to interact with a named
      * channel. It produces a channel object which is optimized to reduce overhead at
@@ -56,8 +56,8 @@ declare module 'diagnostics_channel' {
      * @param name The channel name
      * @return The named channel object
      */
-    function channel(name: string): Channel;
-    type ChannelListener = (message: unknown, name: string) => void;
+    function channel(name: string | symbol): Channel;
+    type ChannelListener = (message: unknown, name: string | symbol) => void;
     /**
      * The class `Channel` represents an individual named channel within the data
      * pipeline. It is use to track subscribers and to publish messages when there
@@ -68,7 +68,7 @@ declare module 'diagnostics_channel' {
      * @since v15.1.0, v14.17.0
      */
     class Channel {
-        readonly name: string;
+        readonly name: string | symbol;
         /**
          * Check if there are active subscribers to this channel. This is helpful if
          * the message you want to send might be expensive to prepare.
@@ -88,7 +88,7 @@ declare module 'diagnostics_channel' {
          * @since v15.1.0, v14.17.0
          */
         readonly hasSubscribers: boolean;
-        private constructor(name: string);
+        private constructor(name: string | symbol);
         /**
          * Publish a message to any subscribers to the channel. This will
          * trigger message handlers synchronously so they will execute within

--- a/types/node/v16/test/diagnostics_channel.ts
+++ b/types/node/v16/test/diagnostics_channel.ts
@@ -1,11 +1,11 @@
 import { Channel, channel, hasSubscribers } from 'node:diagnostics_channel';
 
-const ch1: Channel = channel('test');
+const ch1: Channel = channel(Symbol.for('test'));
 function listener(data: unknown) {}
-function anotherListener(data: unknown, name: string) {}
+function anotherListener(data: unknown, name: string | symbol) {}
 
 const active: boolean = ch1.hasSubscribers;
-const name: string = ch1.name;
+const name: string | symbol = ch1.name;
 
 ch1.publish({ some: 'message' });
 

--- a/types/node/v16/ts4.8/diagnostics_channel.d.ts
+++ b/types/node/v16/ts4.8/diagnostics_channel.d.ts
@@ -41,7 +41,7 @@ declare module 'diagnostics_channel' {
      * @param name The channel name
      * @return If there are active subscribers
      */
-    function hasSubscribers(name: string): boolean;
+    function hasSubscribers(name: string | symbol): boolean;
     /**
      * This is the primary entry-point for anyone wanting to interact with a named
      * channel. It produces a channel object which is optimized to reduce overhead at
@@ -56,8 +56,8 @@ declare module 'diagnostics_channel' {
      * @param name The channel name
      * @return The named channel object
      */
-    function channel(name: string): Channel;
-    type ChannelListener = (message: unknown, name: string) => void;
+    function channel(name: string | symbol): Channel;
+    type ChannelListener = (message: unknown, name: string | symbol) => void;
     /**
      * The class `Channel` represents an individual named channel within the data
      * pipeline. It is use to track subscribers and to publish messages when there
@@ -68,7 +68,7 @@ declare module 'diagnostics_channel' {
      * @since v15.1.0, v14.17.0
      */
     class Channel {
-        readonly name: string;
+        readonly name: string | symbol;
         /**
          * Check if there are active subscribers to this channel. This is helpful if
          * the message you want to send might be expensive to prepare.
@@ -88,7 +88,7 @@ declare module 'diagnostics_channel' {
          * @since v15.1.0, v14.17.0
          */
         readonly hasSubscribers: boolean;
-        private constructor(name: string);
+        private constructor(name: string | symbol);
         /**
          * Publish a message to any subscribers to the channel. This will
          * trigger message handlers synchronously so they will execute within

--- a/types/node/v16/ts4.8/test/diagnostics_channel.ts
+++ b/types/node/v16/ts4.8/test/diagnostics_channel.ts
@@ -1,11 +1,11 @@
 import { Channel, channel, hasSubscribers } from 'node:diagnostics_channel';
 
-const ch1: Channel = channel('test');
+const ch1: Channel = channel(Symbol.for('test'));
 function listener(data: unknown) {}
-function anotherListener(data: unknown, name: string) {}
+function anotherListener(data: unknown, name: string | symbol) {}
 
 const active: boolean = ch1.hasSubscribers;
-const name: string = ch1.name;
+const name: string | symbol = ch1.name;
 
 ch1.publish({ some: 'message' });
 


### PR DESCRIPTION
Adds support for Symbol type, as per current Node JS implementation:

https://nodejs.org/docs/latest-v18.x/api/diagnostics_channel.html#diagnostics_channelchannelname (and e.t.c.)

Thanks!

/cc @destumme

Fixes #63098

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.