### PR TITLE
fix(types/arangodb): KeyGeneratorType accepts valid literals "uuid" and "padded"

### DIFF
--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -55,6 +55,19 @@ const bananas = db._createDocumentCollection("bananas", {
         offset: 23
     }
 }) as ArangoDB.Collection<Banana>;
+
+const bananas2 =  db._createDocumentCollection("bananas2", {
+    keyOptions: {
+        type: "padded",
+    }
+}) as ArangoDB.Collection<Banana>;
+
+const bananas3 =  db._createDocumentCollection("bananas3", {
+    keyOptions: {
+        type: "uuid",
+    }
+}) as ArangoDB.Collection<Banana>;
+
 bananas.ensureIndex({
     type: "hash",
     unique: true,

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -91,7 +91,7 @@ declare namespace ArangoDB {
     type EngineType = "mmfiles" | "rocksdb";
     type IndexType = "persistent" | "hash" | "skiplist" | "fulltext" | "geo" | "ttl";
     type ViewType = "arangosearch";
-    type KeyGeneratorType = "traditional" | "autoincrement";
+    type KeyGeneratorType = "traditional" | "autoincrement" | "padded" | "uuid";
     type ErrorName =
         | "ERROR_NO_ERROR"
         | "ERROR_FAILED"


### PR DESCRIPTION


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  -` arangodb >= 3.4`
  - https://www.arangodb.com/docs/3.3/data-modeling-collections-database-methods.html#create 
  - https://www.arangodb.com/docs/3.4/data-modeling-collections-database-methods.html#create 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
   - The header already states it should support >= 3.5
