### PR TITLE
[chai-dom] Add missing overload signature to `.class()` method

### DIFF
--- a/types/chai-dom/chai-dom-tests.ts
+++ b/types/chai-dom/chai-dom-tests.ts
@@ -9,6 +9,7 @@ function test() {
     expect(testElement).to.have.attribute('foo', 'bar');
     expect(testElement).to.have.attr('foo').match(/bar/);
     expect(testElement).to.have.class('foo');
+    expect(testElement).to.have.class(/foo/);
     expect(testElement).to.have.id('id');
     expect(testElement).to.have.html('foo');
     expect(testElement).to.have.text('foo');

--- a/types/chai-dom/index.d.ts
+++ b/types/chai-dom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for chai-dom
+// Type definitions for chai-dom 1.11
 // Project: https://github.com/nathanboktae/chai-dom
 // Definitions by: Matt Lewis <https://github.com/mattlewis92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -12,7 +12,7 @@ declare namespace Chai {
 
         attribute(name: string, value?: string): Assertion;
 
-        class(className: string): Assertion;
+        class(className: string | RegExp): Assertion;
 
         id(id: string): Assertion;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nathanboktae/chai-dom#classclassname
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

