### PR TITLE
fix: allow `without` to take in `unknown[]` in the first argument

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -6064,8 +6064,8 @@ export function whereEq<T>(spec: T): <U>(obj: U) => boolean;
  * R.without([1, 2], [1, 2, 1, 3, 4]); //=> [3, 4]
  * ```
  */
-export function without<T>(list1: readonly T[], list2: readonly T[]): T[];
-export function without<T>(list1: readonly T[]): (list2: readonly T[]) => T[];
+export function without<T>(list1: readonly unknown[], list2: readonly T[]): T[];
+export function without<T>(list1: readonly T[] | readonly unknown[]): (list2: readonly T[]) => T[];
 
 /**
  * Exclusive disjunction logical operation.

--- a/types/ramda/test/without-tests.ts
+++ b/types/ramda/test/without-tests.ts
@@ -3,3 +3,15 @@ import * as R from 'ramda';
 () => {
     const a: number[] = R.without([1, 2], [1, 2, 1, 3, 4]); // => [3, 4]
 };
+
+() => {
+    const a: number[] = R.without([1, 2, 3])([3, 4, 4, 5]); // => [4, 4, 5]
+};
+
+() => {
+    const a: number[] = R.without([1, undefined, 2], [1, 2, 1, 3, 4]); // => [3, 4]
+};
+
+() => {
+    const a: number[] = R.without<number>([1, undefined, 3])([3, 4, 4, 5]); // => [4, 4, 5]
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ramdajs.com/repl/?v=0.28.0#?without%28%5B1%2C%20undefined%5D%2C%20%5B1%2C%202%2C%203%5D%29
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~


---

Although the official type in ramda documentation for `without` is `[a] → [a] → [a]`. There is no meaning to infer the type from the first argument in `without`. 

E.g.

```ts
without([1, undefined], [1, 2, 3]) 
```

You should expect `number[]` instead of `(number | undefined)[]`, but is currently inferred as the latter. This PR fixes it and infer to `number[]` instead.