### PR TITLE
feat(metro-resolver): add error types and `formatFileCandidates`

### DIFF
--- a/types/metro-resolver/FailedToResolveNameError.d.ts
+++ b/types/metro-resolver/FailedToResolveNameError.d.ts
@@ -1,0 +1,5 @@
+export class FailedToResolveNameError extends Error {
+    dirPaths: ReadonlyArray<string>;
+    extraPaths: ReadonlyArray<string>;
+    constructor(dirPaths: ReadonlyArray<string>, extraPaths: ReadonlyArray<string>);
+}

--- a/types/metro-resolver/FailedToResolvePathError.d.ts
+++ b/types/metro-resolver/FailedToResolvePathError.d.ts
@@ -1,0 +1,6 @@
+import { FileAndDirCandidates } from './types';
+
+export class FailedToResolvePathError extends Error {
+    candidates: FileAndDirCandidates;
+    constructor(candidates: FileAndDirCandidates);
+}

--- a/types/metro-resolver/InvalidPackageError.d.ts
+++ b/types/metro-resolver/InvalidPackageError.d.ts
@@ -1,15 +1,4 @@
-import type { FileAndDirCandidates, FileCandidates } from './types';
-
-export class FailedToResolvePathError extends Error {
-    candidates: FileAndDirCandidates;
-    constructor(candidates: FileAndDirCandidates);
-}
-
-export class FailedToResolveNameError extends Error {
-    dirPaths: ReadonlyArray<string>;
-    extraPaths: ReadonlyArray<string>;
-    constructor(dirPaths: ReadonlyArray<string>, extraPaths: ReadonlyArray<string>);
-}
+import { FileCandidates } from './types';
 
 export class InvalidPackageError extends Error {
     /**
@@ -37,10 +26,12 @@ export class InvalidPackageError extends Error {
      */
     packageJsonPath: string;
 
-    constructor(opts: Readonly<{
-        fileCandidates: FileCandidates;
-        indexCandidates: FileCandidates;
-        mainPrefixPath: string;
-        packageJsonPath: string;
-    }>);
+    constructor(
+        opts: Readonly<{
+            fileCandidates: FileCandidates;
+            indexCandidates: FileCandidates;
+            mainPrefixPath: string;
+            packageJsonPath: string;
+        }>,
+    );
 }

--- a/types/metro-resolver/errors.d.ts
+++ b/types/metro-resolver/errors.d.ts
@@ -1,0 +1,46 @@
+import type { FileAndDirCandidates, FileCandidates } from './types';
+
+export class FailedToResolvePathError extends Error {
+    candidates: FileAndDirCandidates;
+    constructor(candidates: FileAndDirCandidates);
+}
+
+export class FailedToResolveNameError extends Error {
+    dirPaths: ReadonlyArray<string>;
+    extraPaths: ReadonlyArray<string>;
+    constructor(dirPaths: ReadonlyArray<string>, extraPaths: ReadonlyArray<string>);
+}
+
+export class InvalidPackageError extends Error {
+    /**
+     * The file candidates we tried to find to resolve the `main` field of the
+     * package. Ex. `/js/foo/beep(.js|.json)?` if `main` is specifying `./beep`
+     * as the entry point.
+     */
+    fileCandidates: FileCandidates;
+
+    /**
+     * The 'index' file candidates we tried to find to resolve the `main` field of
+     * the package. Ex. `/js/foo/beep/index(.js|.json)?` if `main` is specifying
+     * `./beep` as the entry point.
+     */
+    indexCandidates: FileCandidates;
+
+    /**
+     * The module path prefix we where trying to resolve. For example './beep'.
+     */
+    mainPrefixPath: string;
+
+    /**
+     * Full path the package we were trying to resolve.
+     * Ex. `/js/foo/package.json`.
+     */
+    packageJsonPath: string;
+
+    constructor(opts: Readonly<{
+        fileCandidates: FileCandidates;
+        indexCandidates: FileCandidates;
+        mainPrefixPath: string;
+        packageJsonPath: string;
+    }>);
+}

--- a/types/metro-resolver/formatFileCandidates.d.ts
+++ b/types/metro-resolver/formatFileCandidates.d.ts
@@ -1,0 +1,3 @@
+import { FileCandidates } from './types';
+
+export function formatFileCandidates(candidates: FileCandidates): string;

--- a/types/metro-resolver/index.d.ts
+++ b/types/metro-resolver/index.d.ts
@@ -3,9 +3,12 @@
 // Definitions by: Adam Foxman <https://github.com/afoxman>
 //                 Tommy Nguyen <https://github.com/tido64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 export * from './types';
+export * from './errors';
 
-import { ResolutionContext, Resolution } from './types';
+import type { FileCandidates, ResolutionContext, Resolution } from './types';
 
+export function formatFileCandidates(candidates: FileCandidates): string;
 export function resolve(context: ResolutionContext, moduleName: string, platform: string | null): Resolution;

--- a/types/metro-resolver/index.d.ts
+++ b/types/metro-resolver/index.d.ts
@@ -5,10 +5,30 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-export * from './types';
-export * from './errors';
+export {
+    AssetFileResolution,
+    CustomResolutionContext,
+    CustomResolver,
+    CustomResolverOptions,
+    DoesFileExist,
+    FileAndDirCandidates,
+    FileCandidates,
+    FileResolution,
+    IsAssetFile,
+    ResolutionContext,
+    Resolution,
+    ResolveAsset,
+    Result,
 
-import type { FileCandidates, ResolutionContext, Resolution } from './types';
+    // didn't exported in the origin code
+    FileContext,
+    FileOrDirContext,
+    HasteContext,
+    ModulePathContext,
+} from './types';
 
-export function formatFileCandidates(candidates: FileCandidates): string;
-export function resolve(context: ResolutionContext, moduleName: string, platform: string | null): Resolution;
+export { FailedToResolveNameError } from './FailedToResolveNameError';
+export { FailedToResolvePathError } from './FailedToResolvePathError';
+export { InvalidPackageError } from './InvalidPackageError';
+export { formatFileCandidates } from './formatFileCandidates';
+export { resolve } from './resolve';

--- a/types/metro-resolver/metro-resolver-tests.ts
+++ b/types/metro-resolver/metro-resolver-tests.ts
@@ -1,4 +1,8 @@
-import { resolve, ResolutionContext } from 'metro-resolver';
+import { resolve, formatFileCandidates } from 'metro-resolver';
+
+formatFileCandidates(
+    { type: 'asset', name: 'testAsset' },
+);
 
 resolve(
     {

--- a/types/metro-resolver/metro-resolver-tests.ts
+++ b/types/metro-resolver/metro-resolver-tests.ts
@@ -1,8 +1,6 @@
 import { resolve, formatFileCandidates } from 'metro-resolver';
 
-formatFileCandidates(
-    { type: 'asset', name: 'testAsset' },
-);
+formatFileCandidates({ type: 'asset', name: 'testAsset' });
 
 resolve(
     {

--- a/types/metro-resolver/resolve.d.ts
+++ b/types/metro-resolver/resolve.d.ts
@@ -1,0 +1,3 @@
+import { ResolutionContext, Resolution } from './types';
+
+export function resolve(context: ResolutionContext, moduleName: string, platform: string | null): Resolution;

--- a/types/metro-resolver/types.d.ts
+++ b/types/metro-resolver/types.d.ts
@@ -101,9 +101,18 @@ export interface ResolutionContext extends ModulePathContext, HasteContext {
     resolveRequest?: CustomResolver;
 }
 
+export interface CustomResolutionContext extends ResolutionContext {
+    resolveRequest: CustomResolver;
+}
+
 export type CustomResolver = (
     context: ResolutionContext,
     realModuleName: string,
     platform: string | null,
     moduleName: string | null,
 ) => Resolution;
+
+export interface CustomResolverOptions {
+    __proto__: null;
+    readonly [key: string]: any;
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/facebook/metro/blob/90a7dedc697ee4524fb615f8d83d5ffed8f079dd/packages/metro-resolver/src/index.js#L30-L36)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
