### PR TITLE
[react-pdf]: Fix reason arg type in onPassword handler of Document

### DIFF
--- a/types/react-pdf/dist/Document.d.ts
+++ b/types/react-pdf/dist/Document.d.ts
@@ -96,7 +96,7 @@ export interface Props {
      * Function called when a password-protected PDF is loaded.
      * Defaults to a function that prompts the user for password.
      */
-    onPassword?: ((callback: (password: string) => void, reason: string) => void) | undefined;
+    onPassword?: ((callback: (password: string) => void, reason: number) => void) | undefined;
 
     /**
      * Function called in case of an error while retrieving document source from `file` prop.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/wojtekmaj/react-pdf/blob/main/src/Document.jsx#L352-L360
https://github.com/wojtekmaj/react-pdf/blob/main/src/PasswordResponses.js
