### PR TITLE
chore(jest): loosen expect.any() type restrictions

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -695,7 +695,7 @@ declare namespace jest {
          *   expect(mock).toBeCalledWith(expect.any(Number));
          * });
          */
-        any<T extends Constructor>(classType: T): T extends Func ? ReturnType<T> : InstanceType<T>;
+        any<T>(classType: T): T extends Func ? ReturnType<T> : T extends Constructor ? InstanceType<T> : any;
         /**
          * Matches any array made up entirely of elements in the provided array.
          * You can use it inside `toEqual` or `toBeCalledWith` instead of a literal value.

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -695,7 +695,7 @@ declare namespace jest {
          *   expect(mock).toBeCalledWith(expect.any(Number));
          * });
          */
-        any<T>(classType: T): T extends Func ? ReturnType<T> : T extends Constructor ? InstanceType<T> : any;
+        any(classType: any): any;
         /**
          * Matches any array made up entirely of elements in the provided array.
          * You can use it inside `toEqual` or `toBeCalledWith` instead of a literal value.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1242,6 +1242,10 @@ describe('', () => {
             date: new Date(),
             dateTwo: Date,
             list: [1, 2, 3],
+            listOfStrings: ['one', 'two', 'three'],
+            symbolOne: Symbol('one'),
+            functionOne: () => {},
+            bigIntegerOne: BigInt('9007199254740991'),
         }).toMatchInlineSnapshot({
             one: expect.any(Number),
             // leave out two
@@ -1250,6 +1254,10 @@ describe('', () => {
             date: expect.any(Date),
             dateTwo: expect.any(Date),
             list: expect.any(Array),
+            listOfStrings: expect.any(Array),
+            symbolOne: expect.any(Symbol),
+            functionOne: expect.any(Function),
+            bigIntegerOne: expect.any(BigInt),
         });
 
         expect(jest.fn()).toReturn();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Loosen types a little to allow flexibility in jest's `expect.any` typings.
Based on discussions/issues reported on previous PR

 https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62831

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62831#issuecomment-1302241904