### PR TITLE
Bootstrap: Toast: Add isShown() method

### DIFF
--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -4,6 +4,7 @@
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 //                 Martin Badin <https://github.com/martin-badin>
 //                 Kyle Tsang <https://github.com/kyletsang>
+//                 Luke Nelson <https://github.com/luc122c>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.8
 

--- a/types/bootstrap/js/dist/toast.d.ts
+++ b/types/bootstrap/js/dist/toast.d.ts
@@ -36,6 +36,11 @@ declare class Toast extends BaseComponent {
      * You have to manually call this method if you made autohide to false.
      */
     hide(): void;
+
+    /**
+     * Returns a boolean according to toast’s visibility state.
+     */
+    isShown(): boolean;
 }
 
 declare namespace Toast {

--- a/types/bootstrap/test/toast-tests.ts
+++ b/types/bootstrap/test/toast-tests.ts
@@ -4,8 +4,10 @@ import * as $ from 'jquery';
 const element = new Element();
 
 // $ExpectType Toast
-const myToast = new Toast(element, { animation: false });
-const myBool = myToast.isShown();
+// $ExpectType Toast
+const toast = new Toast(element, { animation: false });
+// $ExpectType boolean
+toast.isShown();
 
 // $ExpectType Toast | null
 Toast.getInstance(element);

--- a/types/bootstrap/test/toast-tests.ts
+++ b/types/bootstrap/test/toast-tests.ts
@@ -10,6 +10,8 @@ new Toast(element, { animation: false });
 Toast.getInstance(element);
 // $ExpectType Toast
 Toast.getOrCreateInstance(element);
+// $ExpectType boolean
+Toast.isShown();
 
 // $ExpectType string
 Toast.VERSION;

--- a/types/bootstrap/test/toast-tests.ts
+++ b/types/bootstrap/test/toast-tests.ts
@@ -4,7 +4,6 @@ import * as $ from 'jquery';
 const element = new Element();
 
 // $ExpectType Toast
-// $ExpectType Toast
 const toast = new Toast(element, { animation: false });
 // $ExpectType boolean
 toast.isShown();

--- a/types/bootstrap/test/toast-tests.ts
+++ b/types/bootstrap/test/toast-tests.ts
@@ -4,14 +4,13 @@ import * as $ from 'jquery';
 const element = new Element();
 
 // $ExpectType Toast
-new Toast(element, { animation: false });
+const myToast = new Toast(element, { animation: false });
+const myBool = myToast.isShown();
 
 // $ExpectType Toast | null
 Toast.getInstance(element);
 // $ExpectType Toast
 Toast.getOrCreateInstance(element);
-// $ExpectType boolean
-Toast.isShown();
 
 // $ExpectType string
 Toast.VERSION;


### PR DESCRIPTION
This PR adds the `isShown()` method [documented here](https://getbootstrap.com/docs/5.2/components/toasts/#methods). 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://getbootstrap.com/docs/5.2/components/toasts/#methods](https://getbootstrap.com/docs/5.2/components/toasts/#methods)
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

