### PR TITLE
Added destroy method to from2 types

### DIFF
--- a/types/from2/from2-tests.ts
+++ b/types/from2/from2-tests.ts
@@ -16,7 +16,7 @@ function fromString(str: string) {
 
 fromString('hello world').pipe(process.stdout);
 
-let stream: NodeJS.ReadableStream;
+let stream: from.Stream;
 stream = from((size, next) => next(null, 'foo'));
 stream = from((size, next) => next(null, new Buffer(1)));
 stream = from((size, next) => next(null, new Uint8Array(1)));
@@ -24,6 +24,12 @@ stream = from((size, next) => next(null, null));
 stream = from(['foo', new Buffer(1), new Uint8Array(1), null]);
 // following should fail:
 // stream = from((size, next) => next(null, {}));
+
+stream = from((size, next) => next(null, 'foo'));
+stream.destroy();
+stream = from((size, next) => next(null, 'foo'));
+stream.on('error', err => {});
+stream.destroy(new Error('destroyed'));
 
 stream = from({objectMode: false}, (size, next) => next(null, 'foo'));
 stream = from({objectMode: false}, (size, next) => next(null, new Buffer(1)));

--- a/types/from2/index.d.ts
+++ b/types/from2/index.d.ts
@@ -8,13 +8,17 @@ import * as stream from 'stream';
 
 export = from2;
 
-declare function from2(read: from2.ReadInput): NodeJS.ReadableStream;
-declare function from2(opts: from2.ObjectModeOptions, read: from2.ReadObjectInput): NodeJS.ReadableStream;
-declare function from2(opts: from2.Options, read: from2.ReadInput): NodeJS.ReadableStream;
+declare function from2(read: from2.ReadInput): from2.Stream;
+declare function from2(opts: from2.ObjectModeOptions, read: from2.ReadObjectInput): from2.Stream;
+declare function from2(opts: from2.Options, read: from2.ReadInput): from2.Stream;
 
 declare namespace from2 {
-    function obj(read: ReadObjectInput): NodeJS.ReadableStream;
-    function obj(opts: { objectMode?: true | undefined } & stream.ReadableOptions, read: ReadObjectInput): NodeJS.ReadableStream;
+    interface Stream extends NodeJS.ReadableStream {
+        destroyed: boolean;
+        destroy: (err?: Error) => void;
+    }
+    function obj(read: ReadObjectInput): Stream;
+    function obj(opts: { objectMode?: true | undefined } & stream.ReadableOptions, read: ReadObjectInput): Stream;
 
     function ctor(opts?: Options): From2Ctor<ReadInput>;
     function ctor(opts: ObjectModeOptions): From2Ctor<ReadObjectInput>;
@@ -22,7 +26,7 @@ declare namespace from2 {
     type ObjectModeOptions = { objectMode: true } & stream.ReadableOptions;
     type Options = { objectMode?: false | undefined } & stream.ReadableOptions;
 
-    type From2Ctor<R extends ReadInput | ReadObjectInput> = new(read: R) => NodeJS.ReadableStream;
+    type From2Ctor<R extends ReadInput | ReadObjectInput> = new (read: R) => Stream;
 
     type ReadObjectInput = ReadCallback<NextObjectCallback> | any[];
     type ReadInput = ReadCallback<NextCallback> | Chunk[];

--- a/types/from2/index.d.ts
+++ b/types/from2/index.d.ts
@@ -14,7 +14,7 @@ declare function from2(opts: from2.Options, read: from2.ReadInput): from2.Stream
 
 declare namespace from2 {
     interface Stream extends NodeJS.ReadableStream {
-        destroyed: boolean;
+        readonly destroyed: boolean;
         destroy: (err?: Error) => void;
     }
     function obj(read: ReadObjectInput): Stream;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hughsk/from2/blob/master/index.js#L71
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- Same version, just added missing method
