### PR TITLE
fix(proc-log): Make types better reflect actual structure

### DIFF
--- a/types/proc-log/index.d.ts
+++ b/types/proc-log/index.d.ts
@@ -3,44 +3,49 @@
 // Definitions by: JDB <https://github.com/legodude17>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/**
- * Calls process.emit('log', 'error', ...args). The highest log level. For printing extremely serious errors that indicate something went wrong.
- */
-export function error(...args: any[]): void;
-/**
- * Calls process.emit('log', 'warn', ...args). A fairly high log level. Things that the user needs to be aware of, but which won't necessarily cause improper functioning of the system.
- */
-export function warn(...args: any[]): void;
-/**
- * Calls process.emit('log', 'notice', ...args). Notices which are important, but not necessarily dangerous or a cause for excess concern.
- */
-export function notice(...args: any[]): void;
-/**
- * Calls process.emit('log', 'info', ...args). Informative messages that may benefit the user, but aren't particularly important.
- */
-export function info(...args: any[]): void;
-/**
- * Calls process.emit('log', 'verbose', ...args). Noisy output that is more detail that most users will care about.
- */
-export function verbose(...args: any[]): void;
-/**
- * Calls process.emit('log', 'silly', ...args). Extremely noisy excessive logging messages that are typically only useful for debugging.
- */
-export function silly(...args: any[]): void;
-/**
- * Calls process.emit('log', 'http', ...args). Information about HTTP requests made and/or completed.
- */
-export function http(...args: any[]): void;
-/**
- * Calls process.emit('log', 'pause'). Used to tell the consumer to stop printing messages.
- */
-export function pause(): void;
-/**
- * Calls process.emit('log', 'resume'). Used to tell the consumer that it is ok to print messages again.
- */
-export function resume(): void;
-/**
- * An array of strings of all log method names.
- */
-export const LEVELS: ['error', 'warn', 'notice', 'info', 'verbose', 'silly', 'http'];
-export type LogLevel = 'error' | 'warn' | 'notice' | 'info' | 'verbose' | 'silly' | 'http';
+interface Logger {
+    /**
+     * Calls process.emit('log', 'error', ...args). The highest log level. For printing extremely serious errors that indicate something went wrong.
+     */
+    error(...args: any[]): void;
+    /**
+     * Calls process.emit('log', 'warn', ...args). A fairly high log level. Things that the user needs to be aware of, but which won't necessarily cause improper functioning of the system.
+     */
+    warn(...args: any[]): void;
+    /**
+     * Calls process.emit('log', 'notice', ...args). Notices which are important, but not necessarily dangerous or a cause for excess concern.
+     */
+    notice(...args: any[]): void;
+    /**
+     * Calls process.emit('log', 'info', ...args). Informative messages that may benefit the user, but aren't particularly important.
+     */
+    info(...args: any[]): void;
+    /**
+     * Calls process.emit('log', 'verbose', ...args). Noisy output that is more detail that most users will care about.
+     */
+    verbose(...args: any[]): void;
+    /**
+     * Calls process.emit('log', 'silly', ...args). Extremely noisy excessive logging messages that are typically only useful for debugging.
+     */
+    silly(...args: any[]): void;
+    /**
+     * Calls process.emit('log', 'http', ...args). Information about HTTP requests made and/or completed.
+     */
+    http(...args: any[]): void;
+    /**
+     * Calls process.emit('log', 'pause'). Used to tell the consumer to stop printing messages.
+     */
+    pause(): void;
+    /**
+     * Calls process.emit('log', 'resume'). Used to tell the consumer that it is ok to print messages again.
+     */
+    resume(): void;
+    /**
+     * An array of strings of all log method names.
+     */
+    LEVELS: ['error', 'warn', 'notice', 'info', 'verbose', 'silly', 'http'];
+}
+
+declare const logger: Logger;
+
+export = logger;

--- a/types/proc-log/proc-log-tests.ts
+++ b/types/proc-log/proc-log-tests.ts
@@ -21,7 +21,7 @@ log.verbose();
  */
 log.http(Symbol('hi!'));
 /**
- * This should be a failure case but they accept any combination of arguments
+ * They accept any combination of arguments, so I can't really test the failure case
  */
 log.silly('fail');
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/proc-log/blob/main/lib/index.js#L16

Reasoning: While the current method of `export function`... works fine when using CommonJS, when using ESM typescript will allow something like `import {error} from "proc-log";`, which will then error on runtime when Node.JS can't find the named export. Unfortunately this means we can no longer export the convenience type of `LogLevels`, but that can easily be gotten otherwise from either `logger` itself or `logger.LEVELS`.
