### PR TITLE
mapbox-gl - Add `worldview` to MapboxOptions

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -870,10 +870,9 @@ declare namespace mapboxgl {
          * @default null
          */
         testMode?: boolean | undefined;
-        
         /**
-         * Sets the map's worldview. A worldview determines the way that certain disputed boundaries are rendered. 
-         * By default, GL JS will not set a worldview so that the worldview of Mapbox tiles will be determined by 
+         * Sets the map's worldview. A worldview determines the way that certain disputed boundaries are rendered.
+         * By default, GL JS will not set a worldview so that the worldview of Mapbox tiles will be determined by
          * the vector tile source's TileJSON. Valid worldview strings must be an ISO alpha-2 country code.
          *
          * @default null

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -870,6 +870,15 @@ declare namespace mapboxgl {
          * @default null
          */
         testMode?: boolean | undefined;
+        
+        /**
+         * Sets the map's worldview. A worldview determines the way that certain disputed boundaries are rendered. 
+         * By default, GL JS will not set a worldview so that the worldview of Mapbox tiles will be determined by 
+         * the vector tile source's TileJSON. Valid worldview strings must be an ISO alpha-2 country code.
+         *
+         * @default null
+        */
+        worldview?: string | undefined;
     }
 
     type quat = number[];


### PR DESCRIPTION
This PR adds the option `worldview` to the interface `MapboxOptions`.

This option can be found in the [official documentation](https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters) for the map options.

- [ X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters
