### PR TITLE
[react] add fetchpriority to ImgHTMLAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2181,6 +2181,7 @@ declare namespace React {
         alt?: string | undefined;
         crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
         decoding?: "async" | "auto" | "sync" | undefined;
+        fetchpriority?: "high" | "low" | "auto" | undefined;
         height?: number | string | undefined;
         loading?: "eager" | "lazy" | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -468,12 +468,17 @@ const imgProps: ImgProps = {};
 imgProps.decoding = 'async';
 imgProps.decoding = 'auto';
 imgProps.decoding = 'sync';
+imgProps.fetchpriority = 'high';
+imgProps.fetchpriority = 'low';
+imgProps.fetchpriority = 'auto';
 imgProps.loading = 'eager';
 imgProps.loading = 'lazy';
 // @ts-expect-error
-imgProps.loading = 'nonsense';
-// @ts-expect-error
 imgProps.decoding = 'nonsense';
+// @ts-expect-error
+imgProps.fetchpriority = 'nonsense';
+// @ts-expect-error
+imgProps.loading = 'nonsense';
 type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
 // $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
 type ImgPropsWithRefRef = ImgPropsWithRef['ref'];


### PR DESCRIPTION
Add the `fetchpriority` priority hint to the `ImgHTMLAttributes`. You can see it on [MDN](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes)(experimental) or [web.dev](https://web.dev/priority-hints/).

## example
```tsx
<img src="https://examples.com/path/to/main/image.avif" fetchpriority="high" />
{/* ... /*}
<img src="https://examples.com/path/to/not/main/image.avif" fetchpriority="low" />
```

## before
```bash
error TS2322: Type '{ alt: string; src: string; width: number; height: number; loading: "lazy" | undefined; css: SerializedStyles; fetchpriority: "high" | undefined; }' is not assignable to type 'ClassAttributes<HTMLImageElement> & ImgHTMLAttributes<HTMLImageElement> & { css?: Interpolation<Theme>; }'.
  Property 'fetchpriority' does not exist on type 'ClassAttributes<HTMLImageElement> & ImgHTMLAttributes<HTMLImageElement> & { css?: Interpolation<Theme>; }'.
```

## after
no error

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://web.dev/priority-hints/

- ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ N/A

