### PR TITLE
[async] Add AsyncIterable to IterableCollection type

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -15,7 +15,7 @@
 export as namespace async;
 
 export interface Dictionary<T> { [key: string]: T; }
-export type IterableCollection<T> = T[] | IterableIterator<T> | Dictionary<T>;
+export type IterableCollection<T> = T[] | IterableIterator<T> | AsyncIterable<T> | Dictionary<T>;
 
 export interface ErrorCallback<E = Error> { (err?: E | null): void; }
 export interface AsyncBooleanResultCallback<E = Error> { (err?: E | null, truthValue?: boolean): void; }
@@ -247,12 +247,12 @@ export const eachOf: typeof forEachOf;
 export const eachOfSeries: typeof forEachOf;
 export const eachOfLimit: typeof forEachOfLimit;
 export function map<T, R, E = Error>(
-    arr: T[] | IterableIterator<T> | Dictionary<T>,
+    arr: IterableCollection<T>,
     iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>),
     callback: AsyncResultArrayCallback<R, E>
     ): void;
 export function map<T, R, E = Error>(
-    arr: T[] | IterableIterator<T> | Dictionary<T>,
+    arr: IterableCollection<T>,
     iterator: (AsyncResultIterator<T, R, E> | AsyncResultIteratorPromise<T, R>)
     ): Promise<R[]>;
 

--- a/types/async/test/async-generators.ts
+++ b/types/async/test/async-generators.ts
@@ -1,0 +1,56 @@
+import * as async from 'async';
+
+async function* collectionGenerator<T>(): AsyncIterable<T> { }
+
+function funcMapIterator<T, E>(value: T, callback: async.AsyncResultCallback<T, E>) { }
+function funcMapComplete<T, E>(error: E, results: T[]) { }
+
+function booleanIterator<T>(v: T, cb: (err: Error, res: boolean) => void) { }
+
+function eachIterator<T, E>(item: T, callback: (err: Error) => void) { }
+function eachOfIterator<T, K, E>(item: T, key: K, callback: (err: Error) => void) { }
+
+function concatIterator<T, R, E>(item: T, callback: (err: E, res: R[]) => void) { }
+
+async.map(collectionGenerator(), funcMapIterator, funcMapComplete);
+async.mapSeries(collectionGenerator(), funcMapIterator, funcMapComplete);
+async.mapLimit(collectionGenerator(), 2, funcMapIterator, funcMapComplete);
+
+async.filter(collectionGenerator(), booleanIterator, (err: Error, results: any[]) => { });
+async.filterSeries(collectionGenerator(), booleanIterator, (err: Error, results: any[]) => { });
+async.filterLimit(collectionGenerator(), 2, booleanIterator, (err: Error, results: any[]) => { });
+async.select(collectionGenerator(), booleanIterator, (err: Error, results: any[]) => { });
+async.selectSeries(collectionGenerator(), booleanIterator, (err: Error, results: any[]) => { });
+async.selectLimit(collectionGenerator(), 2, booleanIterator, (err: Error, results: any[]) => { });
+
+async.reject(collectionGenerator(), booleanIterator, (err: Error, results: any[]) => { });
+async.rejectSeries(collectionGenerator(), booleanIterator, (err: Error, results: any[]) => { });
+async.rejectLimit(collectionGenerator(), 2, booleanIterator, (err: Error, results: any[]) => { });
+
+async.each(collectionGenerator(), eachIterator, (err: Error) => { });
+async.eachLimit(collectionGenerator(), 2, eachIterator, (err: Error) => { });
+async.eachSeries(collectionGenerator(), eachIterator, (err: Error) => { });
+async.eachOf(collectionGenerator(), eachOfIterator, (err: Error) => { });
+async.eachOfLimit(collectionGenerator(), 2, eachOfIterator, (err: Error) => { });
+async.eachOfSeries(collectionGenerator(), eachOfIterator, (err: Error) => { });
+async.forEach(collectionGenerator(), eachIterator, (err: Error) => { });
+async.forEachLimit(collectionGenerator(), 2, eachIterator, (err: Error) => { });
+async.forEachSeries(collectionGenerator(), eachIterator, (err: Error) => { });
+async.forEachOf(collectionGenerator(), eachOfIterator, (err: Error) => { });
+async.forEachOfLimit(collectionGenerator(), 2, eachOfIterator, (err: Error) => { });
+async.forEachOfSeries(collectionGenerator(), eachOfIterator, (err: Error) => { });
+
+async.every(collectionGenerator(), booleanIterator, (err: Error, res: boolean) => { });
+async.everyLimit(collectionGenerator(), 2, booleanIterator, (err: Error, res: boolean) => { });
+async.everySeries(collectionGenerator(), booleanIterator, (err: Error, res: boolean) => { });
+
+async.some(collectionGenerator(), booleanIterator, (err: Error, res: boolean) => { });
+async.someLimit(collectionGenerator(), 2, booleanIterator, (err: Error, res: boolean) => { });
+async.someSeries(collectionGenerator(), booleanIterator, (err: Error, res: boolean) => { });
+
+async.detect(collectionGenerator(), booleanIterator, (err: Error, res: boolean) => { });
+async.detectLimit(collectionGenerator(), 2, booleanIterator, (err: Error, res: boolean) => { });
+async.detectSeries(collectionGenerator(), booleanIterator, (err: Error, res: boolean) => { });
+
+async.concat(collectionGenerator(), concatIterator, (err: Error, res: any[]) => { });
+async.concatSeries(collectionGenerator(), concatIterator, (err: Error, res: any[]) => { });

--- a/types/async/tsconfig.json
+++ b/types/async/tsconfig.json
@@ -21,6 +21,7 @@
         "index.d.ts",
         "test/index.ts",
         "test/explicit.ts",
-        "test/es6-generators.ts"
+        "test/es6-generators.ts",
+        "test/async-generators.ts"
     ]
 }


### PR DESCRIPTION
The async library supports reading from an async iterable in addition to synchronous forms, update the types to reflect that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [async docs list "AsyncIterable" as valid type on collection parameters](http://caolan.github.io/async/v3/docs.html#collections)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.