### PR TITLE
[ramda] Add value first typings to prop function

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -479,7 +479,7 @@ export function applyTo<T>(el: T): <U>(fn: (t: T) => U) => U;
  *
  * @example
  * ```typescript
- * const byAge = R.ascend(R.prop<'age', number>('age'));
+ * const byAge = R.ascend(R.prop<number>('age'));
  * const people = [
  *   { name: 'Emma', age: 70 },
  *   { name: 'Peter', age: 78 },
@@ -4351,25 +4351,18 @@ export function promap<A, B>(
  * ```typescript
  * R.prop('x', {x: 100}); //=> 100
  * R.prop(0, [100]); //=> 100
- * R.compose(R.inc, R.prop<'x', number>('x'))({ x: 3 }) //=> 4
+ * R.compose(R.inc, R.prop<number>('x'))({ x: 3 }) //=> 4
  * ```
  */
-export function prop<T>(__: Placeholder, value: T): {
+export function prop<_, T>(__: Placeholder, value: T): {
     <P extends keyof Exclude<T, undefined>>(p: P): Prop<T, P>;
     <P extends keyof never>(p: P): Prop<T, P>;
 };
-export function prop<P extends keyof never, T>(__: Placeholder, value: T): (p: P) => Prop<T, P>;
-export function prop<P extends keyof never, T>(p: P, value: T): Prop<T, P>;
-export function prop<P extends keyof never>(p: P): {
-    <T>(value: Record<P, T>): T;
-    <T>(value: T): Prop<T, P>;
-};
-export function prop<P extends keyof T, T>(p: P): {
-    (value: T): Prop<T, P>;
-};
-export function prop<P extends keyof never, T>(p: P): {
-    (value: Record<P, T>): T;
-};
+export function prop<V>(__: Placeholder, value: unknown): (p: keyof never) => V;
+export function prop<_, P extends keyof never, T>(p: P, value: T): Prop<T, P>;
+export function prop<V>(p: keyof never, value: unknown): V;
+export function prop<_, P extends keyof never>(p: P): <T>(value: T) => Prop<T, P>;
+export function prop<V>(p: keyof never): (value: unknown) => V;
 
 // NOTE: `hair` property was added to `alois` to make example work.
 // A union of two types is a valid usecase but doesn't work with current types
@@ -5145,7 +5138,7 @@ export function symmetricDifference<T>(list: readonly T[]): <T>(list: readonly T
  *
  * @example
  * ```typescript
- * const eqA = R.eqBy(R.prop<'a', number>('a'));
+ * const eqA = R.eqBy(R.prop<number>('a'));
  * const l1 = [{a: 1}, {a: 2}, {a: 3}, {a: 4}];
  * const l2 = [{a: 3}, {a: 4}, {a: 5}, {a: 6}];
  * R.symmetricDifferenceWith(eqA, l1, l2); //=> [{a: 1}, {a: 2}, {a: 5}, {a: 6}]

--- a/types/ramda/test/indexBy-tests.ts
+++ b/types/ramda/test/indexBy-tests.ts
@@ -10,11 +10,12 @@ import * as R from 'ramda';
         { id: 'abc', title: 'B' },
     ];
     const a1 = R.indexBy(R.prop('id'), list);
-    const a2 = R.indexBy(R.prop('id'))(list);
+    // Typescript 3.3 incorrectly gives `a2: {}`, 3.4 gives an error instead.
+    // @ts-expect-error
+    const a2 = R.indexBy(R.prop("id"))(list);
     const a3 = R.indexBy<{ id: string }>(R.prop('id'))(list);
-    const a4 = R.indexBy(R.prop<'id', string>('id'))(list);
-    const a5 = R.indexBy<{ id: string }>(R.prop<'id', string>('id'))(list);
-    const a6 = R.indexBy(R.prop<'id', { id: string }>('id'))(list);
+    const a4 = R.indexBy(R.prop<string>('id'))(list);
+    const a5 = R.indexBy<{ id: string }>(R.prop<string>('id'))(list);
 };
 
 () => {
@@ -49,11 +50,11 @@ import * as R from 'ramda';
     // // @ts-expect-error
     // const b3: Book = a3.abc;
 
-    const a4 = R.indexBy<Book, Id>(R.prop<'id', Id | undefined>('id'))(list);
+    const a4 = R.indexBy<Book, Id>(R.prop('id'))(list);
 
     // prop should be not required (can be undefined)
     // // @ts-expect-error
     // const b4: Book = a4.abc;
 
-    const a5 = R.indexBy<Book, Id>(R.prop<'id', Id>('id'))(list);
+    const a5 = R.indexBy<Book, Id>(R.prop('id'))(list);
 };

--- a/types/ramda/test/prop-tests.ts
+++ b/types/ramda/test/prop-tests.ts
@@ -109,8 +109,9 @@ function maybe<T>(value: T): T | undefined { return value; }
     R.prop<number>(R.__, obj)('x'); // $ExpectType number
 };
 
-() => { // map using prop function
+() => { // community failed tests
     const objArray = [{ foo: 'bar' }];
     objArray.map(R.prop('foo')); // $ExpectType string[]
     R.map(R.prop('foo'), objArray); // $ExpectType string[]
+    Promise.resolve({ foo: "bar" }).then(R.prop('foo')); // $ExpectType Promise<string>
 };

--- a/types/ramda/test/prop-tests.ts
+++ b/types/ramda/test/prop-tests.ts
@@ -5,19 +5,19 @@ import * as R from 'ramda';
 };
 
 () => {
-    const x: number = R.prop('x', { x: 100 }); // => 100
+    R.prop('x', { x: 100 }); // $ExpectType number
     const obj = {
         str: 'string',
         num: 5,
     };
 
-    const strVal: string = R.prop('str', obj); // => 'string'
-    const numVal: number = R.prop('num', obj); // => 5
+    R.prop('str', obj); // $ExpectType string
+    R.prop('num', obj); // $ExpectType number
 
-    const strValPl: string = R.prop(R.__, obj)('str'); // => 'string'
+    R.prop(R.__, obj)('str'); // $ExpectType string
 
-    const strValCur: string = R.prop('str')(obj); // => 'string'
-    const numValCur: number = R.prop('num')(obj); // => 5
+    R.prop('str')(obj); // $ExpectType string
+    R.prop('num')(obj); // $ExpectType number
 };
 
 () => {
@@ -102,13 +102,15 @@ function maybe<T>(value: T): T | undefined { return value; }
     R.prop(R.__, array)(0); // $ExpectType number | undefined
 };
 
-() => { // pass types
+() => { // without inference
     const obj = { x: 100 };
-    R.prop<'x', { x: number }>('x')(obj); // $ExpectType number
-    R.prop<'x', number>('x')(obj); // $ExpectType number
-    R.prop<'x'>('x')<{ x: number }>(obj); // $ExpectType number
-    R.prop<'x'>('x')<number>(obj); // $ExpectType number
-    R.prop<'x', { x: number }>('x', obj); // $ExpectType number
-    R.prop<'x', { x: number }>(R.__, obj)('x'); // $ExpectType number
-    R.prop<{ x: number }>(R.__, obj)<'x'>('x'); // $ExpectType number
+    R.prop<number>('x', obj); // $ExpectType number
+    R.prop<number>('x')({ x: 'as' }); // $ExpectType number
+    R.prop<number>(R.__, obj)('x'); // $ExpectType number
+};
+
+() => { // map using prop function
+    const objArray = [{ foo: 'bar' }];
+    objArray.map(R.prop('foo')); // $ExpectType string[]
+    R.map(R.prop('foo'), objArray); // $ExpectType string[]
 };

--- a/types/ramda/test/tryCatch-tests.ts
+++ b/types/ramda/test/tryCatch-tests.ts
@@ -87,7 +87,7 @@ import * as R from 'ramda';
     )(123); // $ExpectType 123
 
     R.tryCatch(R.prop('x'), R.F)({ x: true }); // $ExpectType boolean
-    R.tryCatch(R.prop<'x', true>('x'), R.F)({ x: true }); // $ExpectType boolean
+    R.tryCatch(R.prop<true>('x'), R.F)({ x: true }); // $ExpectType boolean
     R.tryCatch(R.prop('x'), R.F)({ x: 13 }); // $ExpectType number | false
     R.tryCatch(R.prop('x'))(R.F)({ x: 13 }); // $ExpectType number | false
     R.tryCatch(R.prop('x'), R.F)(null); // $ExpectType false | undefined


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/62985#discussioncomment-4089206 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62789#issuecomment-1307601621

Changes: 
- delete `complability` with old typings (no more `<T>(value: Record<P, T>): T;`)
- add ability to specify output type on the start `R.prop<number>('whatever')({ whatever: 4 }) // number`

Problems:
- had to separate `inferred types` and `passed type parameter` usages
