### PR TITLE
HEREMaps getRoutingService signature fix + add an interface for the service result

### DIFF
--- a/types/heremaps/heremaps-tests.ts
+++ b/types/heremaps/heremaps-tests.ts
@@ -114,8 +114,8 @@ let calculateRouteParams = {
 };
 router.calculateRoute(
     calculateRouteParams,
-    result => {
-        console.log(result.response.route[0]);
+    (result: H.service.RoutingService.RoutingServiceResult) => {
+        console.log(result.routes[0]);
     },
     error => {
         console.log(error);

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -880,6 +880,15 @@ declare namespace H {
             constructor(opt_latLngAlts?: number[], opt_ctx?: H.geo.AltitudeContext);
 
             /**
+             * Decodes the specified Flexible Polyline and converts it to the LineString.
+             *
+             * @param encodedPolyline {string}
+             * @throws {Error} - if the specified data has an invalid encoding.
+             * @throws {H.lang.InvalidArgumentError} - if the third dimension type is other then ABSENT or ALTITUDE
+             */
+            static fromFlexiblePolyline(encodedPolyline: string): LineString;
+
+            /**
              * This method pushes a lat, lng, alt to the end of this LineString.
              * @param lat {H.geo.Latitude}
              * @param lng {H.geo.Longitude}
@@ -2913,6 +2922,7 @@ declare namespace H {
             fillColor: string;
             lineWidth: number;
             lineCap: H.map.SpatialStyle.LineCap;
+            lineTailCap?: H.map.SpatialStyle.LineCap | undefined;
             lineJoin: H.map.SpatialStyle.LineJoin;
             miterLimit: number;
             lineDash: number[];
@@ -2949,6 +2959,7 @@ declare namespace H {
                 fillColor?: string | undefined;
                 lineWidth?: number | undefined;
                 lineCap?: H.map.SpatialStyle.LineCap | undefined;
+                lineTailCap?: H.map.SpatialStyle.LineCap | undefined;
                 lineJoin?: H.map.SpatialStyle.LineJoin | undefined;
                 miterLimit?: number | undefined;
                 lineDash?: number[] | undefined;
@@ -5450,6 +5461,7 @@ declare namespace H {
                     duration: number
                     length: number
                 };
+                polyline: string;
             }
 
             interface RoutingServicePlace {

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -2149,7 +2149,7 @@ declare namespace H {
                 anchor?: H.math.IPoint | undefined;
                 hitArea?: H.map.HitArea | undefined;
                 asCanvas?: H.map.HitArea | undefined;
-                crossOrigin: boolean;
+                crossOrigin?: boolean | undefined | null;
             }
         }
 
@@ -2922,6 +2922,7 @@ declare namespace H {
             fillColor: string;
             lineWidth: number;
             lineCap: H.map.SpatialStyle.LineCap;
+            lineHeadCap?: H.map.SpatialStyle.LineCap | undefined;
             lineTailCap?: H.map.SpatialStyle.LineCap | undefined;
             lineJoin: H.map.SpatialStyle.LineJoin;
             miterLimit: number;
@@ -2959,6 +2960,7 @@ declare namespace H {
                 fillColor?: string | undefined;
                 lineWidth?: number | undefined;
                 lineCap?: H.map.SpatialStyle.LineCap | undefined;
+                lineHeadCap?: H.map.SpatialStyle.LineCap | undefined;
                 lineTailCap?: H.map.SpatialStyle.LineCap | undefined;
                 lineJoin?: H.map.SpatialStyle.LineJoin | undefined;
                 miterLimit?: number | undefined;
@@ -5465,8 +5467,8 @@ declare namespace H {
             }
 
             interface RoutingServiceCoordinates {
-                lat: H.geo.Latitude,
-                lng: H.geo.Longitude,
+                lat: H.geo.Latitude;
+                lng: H.geo.Longitude;
             }
 
             interface RoutingServicePlace {

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -5407,10 +5407,10 @@ declare namespace H {
              * This method sends a "calculateroute" request to Routing REST API and calls the onResult callback function once the service response was received - providing a
              * H.service.ServiceResult object - or the onError callback if a communication error occured.
              * @param calculateRouteParams {H.service.ServiceParameters} - the service parameters to be sent with the routing request.
-             * @param onResult {function(H.service.ServiceResult)} - this function will be called once the Routing REST API provides a response to the request.
+             * @param onResult {function(H.service.RoutingServiceResult)} - this function will be called once the Routing REST API provides a response to the request.
              * @param onError {function(Error)} - this function will be called if a communication error occurs during the JSON-P request
              */
-            calculateRoute(calculateRouteParams: H.service.ServiceParameters, onResult: (result: H.service.ServiceResult) => void, onError: (error: Error) => void): void;
+            calculateRoute(calculateRouteParams: H.service.ServiceParameters, onResult: (result: H.service.RoutingService.RoutingServiceResult) => void, onError: (error: Error) => void): void;
         }
 
         namespace RoutingService {
@@ -5423,6 +5423,42 @@ declare namespace H {
                 subDomain?: string | undefined;
                 path?: string | undefined;
                 baseUrl?: H.service.Url | undefined;
+            }
+
+            interface RoutingServiceResult extends H.service.ServiceResult {
+                routes: {
+                    id: string
+                    sections: RoutingServiceSection[],
+                }[]
+            }
+
+            interface RoutingServiceSection {
+                id: string
+                type: string
+                transport: {
+                    mode: string
+                }
+                arrival: {
+                    time: string
+                    place: RoutingServicePlace
+                }
+                departure: {
+                    time: string
+                    place: RoutingServicePlace
+                }
+                summary: {
+                    duration: number
+                    length: number
+                }
+
+            }
+
+            interface RoutingServicePlace {
+                location: {
+                    lat: H.geo.Latitude
+                    lng: H.geo.Longitude
+                }
+                type: string
             }
         }
 

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -5320,9 +5320,10 @@ declare namespace H {
              * @param opt_options {H.service.RoutingService.Options=}
              * @returns {H.service.RoutingService}
              */
-            getRoutingService(opt_options?: H.service.RoutingService.Options): H.service.RoutingService;
+            getRoutingService(opt_options?: H.service.RoutingService.Options, opt_version?: number): H.service.RoutingService;
 
             /**
+             * @deprecated since 3.1.30.12 - This service is no longer being actively developed.
              * This method returns an instance of H.service.GeocodingService to query the Geocoder API
              * @param opt_options {H.service.GeocodingService.Options=} - an optional set of options for the new geocoding service to connect to
              * @returns {H.service.GeocodingService} - a new geocoding service instance
@@ -5760,6 +5761,25 @@ declare namespace H {
              * @returns {string} - the URL's string representation
              */
             toString(): string;
+        }
+
+        namespace Url {
+            /**
+             * This class represents the set of values to be associated to a key in cases where it is required to be repeated multiple times in a query string.
+             */
+            class MultiValueQueryParameter {
+                /**
+                 * @param values {Array<string|number>} - The list of values to be associated to a key in a query string. The order of the values in the list will be preserved to build the query string.
+                 * @throws {H.lang.InvalidArgumentError} - in case the argument of the constructor is not an array or its elements have types different from string and number.
+                 */
+                constructor(values: (string|number)[]);
+
+                /**
+                 * Returns the array of values.
+                 * @returns {Array<string|number>}
+                 */
+                getValues(): (string|number)[];
+            }
         }
 
         namespace metaInfo {

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -5426,39 +5426,38 @@ declare namespace H {
             }
 
             interface RoutingServiceResult extends H.service.ServiceResult {
-                routes: {
-                    id: string
+                routes: Array<{
+                    id: string,
                     sections: RoutingServiceSection[],
-                }[]
+                }>;
             }
 
             interface RoutingServiceSection {
-                id: string
-                type: string
+                id: string;
+                type: string;
                 transport: {
-                    mode: string
-                }
+                    mode: string,
+                };
                 arrival: {
-                    time: string
-                    place: RoutingServicePlace
-                }
+                    time: string,
+                    place: RoutingServicePlace,
+                };
                 departure: {
-                    time: string
+                    time: string,
                     place: RoutingServicePlace
-                }
+                };
                 summary: {
                     duration: number
                     length: number
-                }
-
+                };
             }
 
             interface RoutingServicePlace {
                 location: {
-                    lat: H.geo.Latitude
-                    lng: H.geo.Longitude
-                }
-                type: string
+                    lat: H.geo.Latitude,
+                    lng: H.geo.Longitude,
+                };
+                type: string;
             }
         }
 
@@ -5805,16 +5804,16 @@ declare namespace H {
              */
             class MultiValueQueryParameter {
                 /**
-                 * @param values {Array<string|number>} - The list of values to be associated to a key in a query string. The order of the values in the list will be preserved to build the query string.
+                 * @param values {Array<string|number>} - The list of values to be associated to a key in a query string. The the values order in the list will be preserved in the query string.
                  * @throws {H.lang.InvalidArgumentError} - in case the argument of the constructor is not an array or its elements have types different from string and number.
                  */
-                constructor(values: (string|number)[]);
+                constructor(values: Array<string|number>);
 
                 /**
                  * Returns the array of values.
                  * @returns {Array<string|number>}
                  */
-                getValues(): (string|number)[];
+                getValues(): Array<string|number>;
             }
         }
 

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -5464,11 +5464,14 @@ declare namespace H {
                 polyline: string;
             }
 
+            interface RoutingServiceCoordinates {
+                lat: H.geo.Latitude,
+                lng: H.geo.Longitude,
+            }
+
             interface RoutingServicePlace {
-                location: {
-                    lat: H.geo.Latitude,
-                    lng: H.geo.Longitude,
-                };
+                location: RoutingServiceCoordinates;
+                originalLocation?: RoutingServiceCoordinates | undefined;
                 type: string;
             }
         }


### PR DESCRIPTION
Changing an existing definitions:

Fix `H.service.Platform.getRoutingService` signature following https://developer.here.com/documentation/maps/3.1.35.3/api_reference/H.service.Platform.html#getRoutingService
Add a `H.service.Url.MultiValueQueryParameter` class following https://developer.here.com/documentation/maps/3.1.35.3/api_reference/H.service.Url.MultiValueQueryParameter.html
Mark `H.service.Platform.getGeocodingService` as deprecated following https://developer.here.com/documentation/maps/3.1.35.3/api_reference/H.service.Platform.html#getGeocodingService
Add `H.map.SpatialStyle.lineTailCap` and `H.map.SpatialStyle.Options.lineTailCap` following https://developer.here.com/documentation/maps/3.1.35.3/api_reference/H.map.SpatialStyle.html#lineTailCap
Add `H.geo.LineString.fromFlexiblePolyline` following https://developer.here.com/documentation/maps/3.1.35.3/api_reference/H.geo.LineString.html#.fromFlexiblePolyline
Make a specialized `H.service.RoutingService.RoutingServiceResult` interface extending the `H.service.ServiceResult` following the API spec at https://developer.here.com/documentation/routing-api/api-reference-swagger.html#operation%2FcalculateRoutesPost

About this last point : I'm not sure this is the best way or appropriate place to introduce this interface, as it does not exist at all in the original lib source code. If I'm not doing it right, please feel free to revert the second commit here and indicate the best practice !

Mention : @Josh-ES @denyo @fx88 @life777 @DaSchTour