### PR TITLE
* Add missing types to timed-cache: use string | object type on all operations involving the key

### DIFF
--- a/types/timed-cache/index.d.ts
+++ b/types/timed-cache/index.d.ts
@@ -11,16 +11,18 @@ export interface PutOptions {
     ttl: number;
 }
 
+export type Key = string | object;
+
 export default class Cache<T> {
     constructor(options?: CacheOptions);
 
     clear(): void;
 
-    get(key: string | object): T | undefined;
+    get(key: Key): T | undefined;
 
-    put(key: string, value: T, options?: PutOptions): void;
+    put(key: Key, value: T, options?: PutOptions): void;
 
-    remove(key: string): void;
+    remove(key: Key): void;
 
     size(): number;
 }

--- a/types/timed-cache/timed-cache-tests.ts
+++ b/types/timed-cache/timed-cache-tests.ts
@@ -12,3 +12,9 @@ interface Foo {
 const cache2 = new Cache<Foo>();
 cache2.put('key', {thing: 'foo'}); // $ExpectType void
 cache2.get('key'); // $Expect Type Foo
+
+const cache3 = new Cache<Foo>();
+const objKey = { what: "ever"};
+cache3.put(objKey, {thing: 'foo'}); // $ExpectType void
+cache3.get(objKey); // $Expect Type Foo
+cache3.remove(objKey); // $Expect Type void


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/HQarroum/timed-cache/blob/master/cache.js)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
