### PR TITLE
[antlr4] Method `ParserRuleContext.getTypedRuleContext(s)` should accept class type instead of instance

### DIFF
--- a/types/antlr4/context/ParserRuleContext.d.ts
+++ b/types/antlr4/context/ParserRuleContext.d.ts
@@ -36,7 +36,7 @@ export default class ParserRuleContext extends RuleContext {
 
     getTokens(ttype: number): Token[];
 
-    getTypedRuleContext<T extends ParserRuleContext>(cxtType: T, i: number): T;
+    getTypedRuleContext<T extends ParserRuleContext>(cxtType: { new (...args: any[]): T }, i: number): T;
 
-    getTypedRuleContexts<T extends ParserRuleContext>(cxtType: T): T[];
+    getTypedRuleContexts<T extends ParserRuleContext>(cxtType: { new (...args: any[]): T }): T[];
 }

--- a/types/antlr4/context/ParserRuleContext.d.ts
+++ b/types/antlr4/context/ParserRuleContext.d.ts
@@ -30,7 +30,7 @@ export default class ParserRuleContext extends RuleContext {
 
     addErrorNode(badToken: Token): ErrorNode;
 
-    getChild<T extends ParseTree>(i: number, type?: T): T | null;
+    getChild<T extends ParseTree>(i: number, type?: { new (...args: any[]): T }): T | null;
 
     getToken(ttype: number, i: number): Token;
 

--- a/types/antlr4/test/context.ts
+++ b/types/antlr4/test/context.ts
@@ -32,7 +32,7 @@ parserRuleContextInstance.removeLastChild(); // $ExpectType void
 parserRuleContextInstance.addTokenNode(tokenInstance); // $ExpectType Token
 parserRuleContextInstance.addErrorNode(tokenInstance); // $ExpectType ErrorNode
 parserRuleContextInstance.getChild(0); // $ExpectType ParseTree | null
-parserRuleContextInstance.getChild(0, parserRuleContextInstance); // $ExpectType ParserRuleContext | null
+parserRuleContextInstance.getChild(0, ParserRuleContext); // $ExpectType ParserRuleContext | null
 parserRuleContextInstance.getToken(0, 0); // $ExpectType Token
 parserRuleContextInstance.getTokens(0); // $ExpectType Token[]
 parserRuleContextInstance.getTypedRuleContext(ParserRuleContext, 0); // $ExpectType ParserRuleContext

--- a/types/antlr4/test/context.ts
+++ b/types/antlr4/test/context.ts
@@ -35,8 +35,8 @@ parserRuleContextInstance.getChild(0); // $ExpectType ParseTree | null
 parserRuleContextInstance.getChild(0, parserRuleContextInstance); // $ExpectType ParserRuleContext | null
 parserRuleContextInstance.getToken(0, 0); // $ExpectType Token
 parserRuleContextInstance.getTokens(0); // $ExpectType Token[]
-parserRuleContextInstance.getTypedRuleContext(parserRuleContextInstance, 0); // $ExpectType ParserRuleContext
-parserRuleContextInstance.getTypedRuleContexts(parserRuleContextInstance); // $ExpectType ParserRuleContext[]
+parserRuleContextInstance.getTypedRuleContext(ParserRuleContext, 0); // $ExpectType ParserRuleContext
+parserRuleContextInstance.getTypedRuleContexts(ParserRuleContext); // $ExpectType ParserRuleContext[]
 
 // PredictionContext
 PredictionContext.EMPTY; // $ExpectType null


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/antlr/antlr4/blob/e1455c06f0b330a49a67361c8df9f242aa877059/runtime/JavaScript/src/antlr4/context/ParserRuleContext.js#L178
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

