### PR TITLE
[jest] revert spyOn overload breaking change

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -390,17 +390,17 @@ declare namespace jest {
         : Value extends Func
         ? SpyInstance<ReturnType<Value>, ArgsType<Value>>
         : never;
-    function spyOn<T extends {}, M extends ConstructorPropertyNames<Required<T>>>(
-        object: T,
-        method: M,
-    ): Required<T>[M] extends new (...args: any[]) => any
-        ? SpyInstance<InstanceType<Required<T>[M]>, ConstructorArgsType<Required<T>[M]>>
-        : never;
     function spyOn<T extends {}, M extends FunctionPropertyNames<Required<T>>>(
         object: T,
         method: M,
     ): FunctionProperties<Required<T>>[M] extends Func
         ? SpyInstance<ReturnType<FunctionProperties<Required<T>>[M]>, ArgsType<FunctionProperties<Required<T>>[M]>>
+        : never;
+    function spyOn<T extends {}, M extends ConstructorPropertyNames<Required<T>>>(
+        object: T,
+        method: M,
+    ): Required<T>[M] extends new (...args: any[]) => any
+        ? SpyInstance<InstanceType<Required<T>[M]>, ConstructorArgsType<Required<T>[M]>>
         : never;
     /**
      * Indicates that the module system should never return a mocked version of

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -567,6 +567,8 @@ jest.spyOn(spiedTarget, 'setValue', undefined);
 // @ts-expect-error
 jest.spyOn(spiedTarget2, 'value');
 
+jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => null);
+
 const spy1 = jest.spyOn(spiedTarget, 'returnsVoid');
 const spy3 = jest.spyOn(spiedTarget, 'returnsString');
 const spy1Name: string = spy1.getMockName();
@@ -677,8 +679,8 @@ jest.spyOn(spyWithIndexSignatureImpl, 'prop', 'get');
 let typedSpy: jest.Spied<typeof spiedTarget.returnsVoid>;
 typedSpy = jest.spyOn(spiedTarget, 'returnsVoid');
 
-let typedSpy1: jest.SpiedClass<typeof globalThis.Date>;
-typedSpy1 = jest.spyOn(globalThis, 'Date');
+let typedSpy1: jest.SpiedClass<typeof globalThis.Error>;
+typedSpy1 = jest.spyOn(globalThis, 'Error');
 
 let typedSpy2: jest.SpiedFunction<typeof spiedTarget.setValue>;
 typedSpy2 = jest.spyOn(spiedTarget, 'setValue');


### PR DESCRIPTION
PR #6278 introduced a breaking change to the jest types for spyOn by changing the overload ordering. This undoes that change.

An example that was affected by the breaking change is added to the tests.

Reverting the ordering broke one of the tests that was added in #6278. However, that test was ambiguous because `Date` is function in addition to a class. Replacing it with a class that requires the `new` keyword like `Error` passes the test.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
