### PR TITLE
Adding className property to BlockSaveProps

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -27,7 +27,6 @@ export type CSSDirection = 'top' | 'right' | 'bottom' | 'left';
 export type BlockAlignment = 'left' | 'center' | 'right' | 'wide' | 'full';
 
 export interface BlockEditProps<T extends Record<string, any>> extends BlockSaveProps<T> {
-    readonly className: string;
     readonly clientId: string;
     readonly isSelected: boolean;
     readonly setAttributes: (attrs: Partial<T>) => void;
@@ -43,6 +42,7 @@ export interface BlockIconNormalized {
 export type BlockIcon = BlockIconNormalized['src'] | BlockIconNormalized;
 
 export interface BlockSaveProps<T extends Record<string, any>> {
+    readonly className: string;
     readonly attributes: Readonly<T>;
 }
 


### PR DESCRIPTION
Moving the className property from `BlockEditProps` to `BlockSaveProps`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Fixes:

https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63198#discussioncomment-4110752