### PR TITLE
[fontkit]: update `open` to reflect v2 api and add OS/2 table

### DIFF
--- a/types/fontkit/fontkit-tests.ts
+++ b/types/fontkit/fontkit-tests.ts
@@ -1,6 +1,29 @@
 import * as fontkit from 'fontkit';
 
+// -----------------
+// API: fontkit.open
+// -----------------
+// @ts-expect-error Should expect error for v1 api usage with v2 types
+const openV1 = fontkit.open('fonts/a-font.ttf', 'postscriptName', () => {});
+const openV2 = fontkit.open('fonts/a-font.ttf');
+const openV2withPostscriptName = fontkit.open('fonts/a-font.ttf', 'postscriptName');
+
+// -----------------
+// API: Font['OS/2']
+// -----------------
+openV2.then(font => {
+    const { xAvgCharWidth, fsSelection } = font['OS/2'];
+    const isNegative = fsSelection.negative;
+});
+
+// ---------------------
+// API: fontkit.openSync
+// ---------------------
 const f = fontkit.openSync('fonts/a-font.ttf');
+
+// ----------------
+// API: Font.layout
+// ----------------
 const { glyphs, positions } = f.layout('Hello World!');
 
 const res = [];
@@ -9,7 +32,7 @@ for (let i = 0; i < glyphs.length; i++) {
     const pos = positions[i];
     let x = `${glyph.id}`;
     if (pos.xOffset || pos.yOffset) {
-      x += `@${pos.xOffset},${pos.yOffset}`;
+        x += `@${pos.xOffset},${pos.yOffset}`;
     }
 
     x += `+${pos.xAdvance}`;

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -38,6 +38,8 @@ export interface Font {
     xHeight: number;
     /** the font’s bounding box, i.e. the box that encloses all glyphs in the font */
     bbox: BBOX;
+    /** the font metric table consisting of a set of metrics and other data required for OpenType fonts */
+    'OS/2': Os2Table;
 
     /** the number of glyphs in the font */
     numGlyphs: number;
@@ -260,12 +262,63 @@ export interface BBOX {
     maxY: number;
 }
 
+export interface Os2Table {
+    breakChar: number;
+    capHeight: number;
+    codePageRange: number[];
+    defaultChar: number;
+    fsSelection: {
+        italic: boolean;
+        underscore: boolean;
+        negative: boolean;
+        outlined: boolean;
+        strikeout: boolean;
+        underscore: boolean;
+        useTypoMetrics: boolean;
+        wws: boolean;       
+    };
+    fsType: {
+        bitmapOnly: boolean;
+        editable: boolean;
+        noEmbedding: boolean;
+        noSubsetting: boolean;
+        viewOnly: boolean;
+    };
+    maxContent: number;
+    panose: number[];
+    sFamilyClass: number;
+    typoAscender: number;
+    typoDescender: number;
+    typoLineGap: number;
+    ulCharRange: number[];
+    usFirstCharIndex: number;
+    usLastCharIndex: number;
+    usWeightClass: number;
+    usWidthClass: number;
+    vendorID: string;
+    version: number;
+    winAscent: number;
+    winDescent: number;
+    xAvgCharWidth: number;
+    xHeight: number;
+    yStrikeoutPosition: number;
+    yStrikeoutSize: number;
+    ySubscriptXOffset: number;
+    ySubscriptXSize: number;
+    ySubscriptYOffset: number;
+    ySubscriptYSize: number;
+    ySuperscriptXOffset: number;
+    ySuperscriptXSize: number;
+    ySuperscriptYOffset: number;
+    ySuperscriptYSize: number;
+}
+
 /**
- * Opens a font file asynchronously, and calls the callback with a font object.
+ * Opens a font file asynchronously, returning a promise that resolves with a font object.
  * For collection fonts (such as TrueType collection files),
  * you can pass a postscriptName to get that font out of the collection instead of a collection object.
  */
-export function open(filename: string, postscriptName: string, callback: (err: Error | null, font: Font) => void): void;
+export function open(filename: string, postscriptName?: string): Promise<Font>;
 
 /**
  * Opens a font file synchronously, and returns a font object.

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -85,7 +85,7 @@ export interface Font {
         features?: string[] | Record<string, boolean>,
         script?: string,
         language?: string,
-        direction?: string
+        direction?: string,
     ): GlyphRun;
 }
 
@@ -269,13 +269,12 @@ export interface Os2Table {
     defaultChar: number;
     fsSelection: {
         italic: boolean;
-        underscore: boolean;
         negative: boolean;
         outlined: boolean;
         strikeout: boolean;
         underscore: boolean;
         useTypoMetrics: boolean;
-        wws: boolean;       
+        wws: boolean;
     };
     fsType: {
         bitmapOnly: boolean;


### PR DESCRIPTION
The [previous PR] bumped the types to v2, but the `open` api change did not reflect the breaking change in `fontkit`, with the `open` method now being async and no longer using a callback.

Also adding `OS/2` metric table definition to support work in [Capsize](https://github.com/seek-oss/capsize).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[This test](https://github.com/foliojs/fontkit/blob/a5fe0a1834241dbc6eb02beea3b7414c118c5ac9/test/index.js#L6) demonstrates how the `open` api should be used in v2.
[This test](https://github.com/foliojs/fontkit/blob/13bf703d6c01acbb3d36437ba90c119501186512/test/metadata.js#L34) demonstrates how the metric tables can be accessed directly. Adding `OS/2` for my use cases, the other tables could be added in the future.

