### PR TITLE
[wkhtmltopdf] Allow export options type for typing controller

### DIFF
--- a/types/wkhtmltopdf/index.d.ts
+++ b/types/wkhtmltopdf/index.d.ts
@@ -49,7 +49,7 @@ declare namespace wkhtmltopdf {
     let shell: string;
 }
 
-interface Options {
+export interface Options {
     /******************
      * Global options *
      ******************/


### PR DESCRIPTION
Its a recursive case, with need typing controller on options for wkhtmltopdf its nescessary!