### PR TITLE
fixing WebGLRenderingContext type

### DIFF
--- a/types/gl/gl-tests.ts
+++ b/types/gl/gl-tests.ts
@@ -3,10 +3,11 @@ import _default = require("gl");
 const createContext = _default;
 const WebGLRenderingContext = _default.WebGLRenderingContext;
 
-createContext(0, 0); // $ExpectType WebGLRenderingContext
-createContext(0, 0, { preserveDrawingBuffer: true }); // $ExpectType WebGLRenderingContext
+createContext(0, 0); // $ExpectType WebGLRenderingContext & StackGLExtension
+createContext(0, 0, { preserveDrawingBuffer: true }); // $ExpectType WebGLRenderingContext & StackGLExtension
 createContext(0, 0).getExtension("STACKGL_resize_drawingbuffer"); // $ExpectType STACKGL_resize_drawingbuffer | null
 createContext(0, 0).getExtension("STACKGL_destroy_context"); // $ExpectType STACKGL_destroy_context | null
 createContext(0, 0).getExtension("STACKGL_resize_drawingbuffer")!.resize(0, 0); // $ExpectType void
 createContext(0, 0).getExtension("STACKGL_destroy_context")!.destroy(); // $ExpectType void
-new WebGLRenderingContext(); // $ExpectType WebGLRenderingContext
+new WebGLRenderingContext(); // $ExpectType WebGLRenderingContext & StackGLExtension
+WebGLRenderingContext.prototype; // $ExpectType WebGLRenderingContext & StackGLExtension

--- a/types/gl/index.d.ts
+++ b/types/gl/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: DefinitelyTyped <https://github.com/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type WebGLRenderingContext = typeof window.WebGLRenderingContext & StackGLExtension;
-
 interface StackGLExtension {
     getExtension(extensionName: "STACKGL_resize_drawingbuffer"): STACKGL_resize_drawingbuffer | null;
     getExtension(extensionName: "STACKGL_destroy_context"): STACKGL_destroy_context | null;
@@ -18,10 +16,13 @@ interface STACKGL_destroy_context {
     destroy(): void;
 }
 
-declare function createContext(width: number, height: number, options?: WebGLContextAttributes): WebGLRenderingContext;
+declare function createContext(width: number, height: number, options?: WebGLContextAttributes): WebGLRenderingContext & StackGLExtension;
 
 declare namespace createContext {
-    const WebGLRenderingContext: WebGLRenderingContext;
+    export const WebGLRenderingContext: typeof window.WebGLRenderingContext & {
+        new(): WebGLRenderingContext;
+        prototype: WebGLRenderingContext;
+    } & StackGLExtension;
 }
 
 export = createContext;

--- a/types/gl/index.d.ts
+++ b/types/gl/index.d.ts
@@ -19,7 +19,7 @@ interface STACKGL_destroy_context {
 declare function createContext(width: number, height: number, options?: WebGLContextAttributes): WebGLRenderingContext & StackGLExtension;
 
 declare namespace createContext {
-    export const WebGLRenderingContext: WebGLRenderingContext & StackGLExtension & {
+    const WebGLRenderingContext: WebGLRenderingContext & StackGLExtension & {
         new(): WebGLRenderingContext & StackGLExtension;
         prototype: WebGLRenderingContext & StackGLExtension;
     };

--- a/types/gl/index.d.ts
+++ b/types/gl/index.d.ts
@@ -19,10 +19,10 @@ interface STACKGL_destroy_context {
 declare function createContext(width: number, height: number, options?: WebGLContextAttributes): WebGLRenderingContext & StackGLExtension;
 
 declare namespace createContext {
-    export const WebGLRenderingContext: typeof window.WebGLRenderingContext & {
-        new(): WebGLRenderingContext;
-        prototype: WebGLRenderingContext;
-    } & StackGLExtension;
+    export const WebGLRenderingContext: WebGLRenderingContext & StackGLExtension & {
+        new(): WebGLRenderingContext & StackGLExtension;
+        prototype: WebGLRenderingContext & StackGLExtension;
+    };
 }
 
 export = createContext;


### PR DESCRIPTION
Follow up to fix the types introduced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62647

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pixijs/pixijs/pull/8842 - trying to use the typing here. Realized that it didn't quite match how ts was understanding the DOM version of the type.

