### PR TITLE
Update to the type definitions of the `Storage` interface to better reflect the specifications 

### DIFF
--- a/types/webextension-polyfill/namespaces/storage.d.ts
+++ b/types/webextension-polyfill/namespaces/storage.d.ts
@@ -186,15 +186,15 @@ export namespace Storage {
     /**
      * Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.
      */
-    interface StorageAreaOnChangedChangesType<Type = any> {
-        [s: string]: StorageChange<Type> | undefined;
+    interface StorageAreaOnChangedChangesType<OType = any, NType = OType> {
+        [s: string]: StorageChange<OType, NType> | undefined;
     }
 
     /**
      * Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.
      */
-    interface StorageAreaSyncOnChangedChangesType<Type = any> {
-        [s: string]: StorageChange<Type> | undefined;
+    interface StorageAreaSyncOnChangedChangesType<OType = any, NType = OType> {
+        [s: string]: StorageChange<OType, NType> | undefined;
     }
 
     interface Static {

--- a/types/webextension-polyfill/namespaces/storage.d.ts
+++ b/types/webextension-polyfill/namespaces/storage.d.ts
@@ -187,14 +187,14 @@ export namespace Storage {
      * Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.
      */
     interface StorageAreaOnChangedChangesType<OType = any, NType = OType> {
-        [s: string]: StorageChange<OType, NType> | undefined;
+        [s: string]: StorageChange<OType, NType>;
     }
 
     /**
      * Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.
      */
     interface StorageAreaSyncOnChangedChangesType<OType = any, NType = OType> {
-        [s: string]: StorageChange<OType, NType> | undefined;
+        [s: string]: StorageChange<OType, NType>;
     }
 
     interface Static {

--- a/types/webextension-polyfill/namespaces/storage.d.ts
+++ b/types/webextension-polyfill/namespaces/storage.d.ts
@@ -13,18 +13,18 @@
 import { Events } from "./events";
 
 export namespace Storage {
-    interface StorageChange {
+    interface StorageChange<OType=any,NType=OType> {
         /**
          * The old value of the item, if there was an old value.
          * Optional.
          */
-        oldValue?: any;
+        oldValue?: OType;
 
         /**
          * The new value of the item, if there is a new value.
          * Optional.
          */
-        newValue?: any;
+        newValue?: NType;
     }
 
     interface StorageArea {
@@ -186,15 +186,15 @@ export namespace Storage {
     /**
      * Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.
      */
-    interface StorageAreaOnChangedChangesType extends StorageChange {
-        [s: string]: unknown;
+    interface StorageAreaOnChangedChangesType {
+        [s: string]: StorageChange | undefined;
     }
 
     /**
      * Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.
      */
-    interface StorageAreaSyncOnChangedChangesType extends StorageChange {
-        [s: string]: unknown;
+    interface StorageAreaSyncOnChangedChangesType {
+        [s: string]: StorageChange | undefined;
     }
 
     interface Static {

--- a/types/webextension-polyfill/namespaces/storage.d.ts
+++ b/types/webextension-polyfill/namespaces/storage.d.ts
@@ -13,7 +13,7 @@
 import { Events } from "./events";
 
 export namespace Storage {
-    interface StorageChange<OType=any,NType=OType> {
+    interface StorageChange<OType = any, NType = OType> {
         /**
          * The old value of the item, if there was an old value.
          * Optional.

--- a/types/webextension-polyfill/namespaces/storage.d.ts
+++ b/types/webextension-polyfill/namespaces/storage.d.ts
@@ -186,15 +186,15 @@ export namespace Storage {
     /**
      * Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.
      */
-    interface StorageAreaOnChangedChangesType {
-        [s: string]: StorageChange | undefined;
+    interface StorageAreaOnChangedChangesType<Type = any> {
+        [s: string]: StorageChange<Type> | undefined;
     }
 
     /**
      * Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.
      */
-    interface StorageAreaSyncOnChangedChangesType {
-        [s: string]: StorageChange | undefined;
+    interface StorageAreaSyncOnChangedChangesType<Type = any> {
+        [s: string]: StorageChange<Type> | undefined;
     }
 
     interface Static {


### PR DESCRIPTION
## 1.

`StorageChange` made generic, so you can tell the compiler what type is expected

```ts
browser.storage.sync
    .onChanged
    .addListener(({someVal}:{[someVal:str]:browser.Storage.StorageChange<string,number>|undefined}) => {
        if (someval?.oldValue?.startsWith('pre')) // no error generated
            console.log(someval.newValue * 3);
    })
```

[The official documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageChange#type) states that the values can be any data type, but in the context of developing an isolated application, it makes sense that these types are known (and often the same, hence the default to having the same type)

## 2.

`StorageAreaOnChangedChangesType`
and
`StorageAreaSyncOnChangedChangesType`
changed to contain `StorageChange` interfaces, rather than inheriting from it, since that's how they're actually structured

```ts
browser.storage.sync
    .onChanged
    .addListener(({someVal}:{[someVal:str]:browser.Storage.StorageChange|undefined}) => {
        ...
    })
```
would formerly yield `type 'unknown' is not assignable to 'StorageChange | undefined'` when [this is the (technically)correct syntax](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged#addlistener_syntax).
