### PR TITLE
fix(mousetrap): correct callback return type for `bind`

### DIFF
--- a/types/mousetrap/index.d.ts
+++ b/types/mousetrap/index.d.ts
@@ -18,7 +18,7 @@ declare namespace Mousetrap {
         stopCallback: (e: ExtendedKeyboardEvent, element: Element, combo: string) => boolean;
         bind(
             keys: string | string[],
-            callback: (e: ExtendedKeyboardEvent, combo: string) => void,
+            callback: (e: ExtendedKeyboardEvent, combo: string) => boolean | void,
             action?: string,
         ): MousetrapInstance;
         unbind(keys: string | string[], action?: string): MousetrapInstance;

--- a/types/mousetrap/test/index-module.ts
+++ b/types/mousetrap/test/index-module.ts
@@ -47,3 +47,11 @@ Mousetrap.bind('* a', () => {
 Mousetrap.bind('up up down down left right left right b a enter', () => {
     console.log('konami code');
 });
+
+const handler = (e: ExtendedKeyboardEvent, combo: string) => {
+    return false;
+};
+Mousetrap.bind(['command+k', 'ctrl+k'], handler);
+Mousetrap.bind(['command+k', 'ctrl+k'], e => {
+    return false;
+});


### PR DESCRIPTION
Shouls support JS convention:
https://craig.is/killing/mice#:~:text=As%20a%20convenience%20you%20can%20also%20return%20false%20in%20your%20callback

Thanks!

/cc @brunnre8

Fixes #63233

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).