### PR TITLE
Add new union orders to tests

### DIFF
--- a/types/amap-js-api/amap-js-api-tests.ts
+++ b/types/amap-js-api/amap-js-api-tests.ts
@@ -1421,7 +1421,7 @@ testLabelsLayer.on('click', (event: AMap.LabelsLayer.EventMap['click']) => {
             iconOptions.image;
 
             if (iconOptions.size !== undefined) {
-                // $ExpectType number[] | Size
+                // $ExpectType number[] | Size || Size | number[]
                 iconOptions.size;
             } else {
                 // $ExpectType undefined
@@ -1429,7 +1429,7 @@ testLabelsLayer.on('click', (event: AMap.LabelsLayer.EventMap['click']) => {
             }
 
             if (iconOptions.clipOrigin !== undefined) {
-                // $ExpectType number[] | Pixel
+                // $ExpectType number[] | Pixel || Pixel | number[]
                 iconOptions.clipOrigin;
             } else {
                 // $ExpectType undefined

--- a/types/amazon-cognito-auth-js/test/amazon-cognito-auth-js-tests.ts
+++ b/types/amazon-cognito-auth-js/test/amazon-cognito-auth-js-tests.ts
@@ -105,7 +105,7 @@ auth.makePOSTRequest({ 'Content-Type': 'application/json' }, { pool: '2' },
     'https://auth.com/signin',
     (data) => console.log(data),
     (error) => console.log(error));
-auth.createCORSRequest('POST', '/myapp/login'); // $ExpectType XMLHttpRequest | XDomainRequest
+auth.createCORSRequest('POST', '/myapp/login'); // $ExpectType XMLHttpRequest | XDomainRequest || XDomainRequest | XMLHttpRequest
 auth.onFailure('request failed'); // $ExpectType void
 auth.onSuccessRefreshToken('{"name":"John", "age":31}'); // $ExpectType void
 auth.onSuccessExchangeForToken('{"name":"Jane", "age":30}'); // $ExpectType void

--- a/types/amazon-cognito-auth-js/test/amazon-cognito-auth-js-umd-tests.ts
+++ b/types/amazon-cognito-auth-js/test/amazon-cognito-auth-js-umd-tests.ts
@@ -20,4 +20,4 @@ const authOptions: AmazonCognitoIdentity.CognitoAuthOptions = {
 const auth = new AmazonCognitoIdentity.CognitoAuth(authOptions);
 auth.userhandler; // $ExpectType CognitoAuthUserHandler
 auth.getCognitoConstants(); // $ExpectType CognitoConstants
-auth.createCORSRequest('', ''); // $ExpectType XMLHttpRequest | XDomainRequest
+auth.createCORSRequest('', '');  // $ExpectType XMLHttpRequest | XDomainRequest || XDomainRequest | XMLHttpRequest

--- a/types/check-sum/check-sum-tests.ts
+++ b/types/check-sum/check-sum-tests.ts
@@ -14,5 +14,5 @@ checksum('package.json', {
     md5: 'asdfasdfasdf',
     sha1: 'asdfasdfasdf'
 }, err => {
-    err; // $ExpectType Error | ChecksumError | undefined
+    err; // $ExpectType Error | ChecksumError | undefined || ChecksumError | Error | undefined
 });

--- a/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
+++ b/types/ckeditor__ckeditor5-engine/ckeditor__ckeditor5-engine-tests.ts
@@ -1514,7 +1514,7 @@ new BubblingEventInfo(viewDocument, '', new ViewRange(viewPosition));
 new BubblingEventInfo(viewDocument, '', new ViewRange(viewPosition)).startRange;
 // $ExpectType "none" | "capturing" | "atTarget" | "bubbling"
 new BubblingEventInfo(viewDocument, '', new ViewRange(viewPosition)).eventPhase;
-// $ExpectType Document | Node | null
+// $ExpectType Document | Node | null || Node | Document | null
 new BubblingEventInfo(viewDocument, '', new ViewRange(viewPosition)).currentTarget;
 
 viewDocument.isFocused = true;

--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -70,9 +70,9 @@ loc.column; // $ExpectType number
 sourceCode.getIndexFromLoc({ line: 0, column: 0 });
 
 sourceCode.getTokenByRangeStart(0); // $ExpectType Token | null
-sourceCode.getTokenByRangeStart(0, { includeComments: true }); // $ExpectType Comment | Token | null
+sourceCode.getTokenByRangeStart(0, { includeComments: true }); // $ExpectType Comment | Token | null || Token | Comment | null
 sourceCode.getTokenByRangeStart(0, { includeComments: false }); // $ExpectType Token | null
-sourceCode.getTokenByRangeStart(0, { includeComments: false as boolean }); // $ExpectType Comment | Token | null
+sourceCode.getTokenByRangeStart(0, { includeComments: false as boolean }); // $ExpectType Comment | Token | null || Token | Comment | null
 
 sourceCode.getFirstToken(AST); // $ExpectType Token | null
 sourceCode.getFirstToken(AST, 0);
@@ -80,7 +80,7 @@ sourceCode.getFirstToken(AST, { skip: 0 });
 sourceCode.getFirstToken(AST, (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier'); // $ExpectType (Token & { type: "Identifier"; }) | null
 sourceCode.getFirstToken(AST, { filter: (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier' }); // $ExpectType (Token & { type: "Identifier"; }) | null
 sourceCode.getFirstToken(AST, { skip: 0, filter: t => t.type === 'Identifier' });
-sourceCode.getFirstToken(AST, { includeComments: true }); // $ExpectType Comment | Token | null
+sourceCode.getFirstToken(AST, { includeComments: true }); // $ExpectType Comment | Token | null || Token | Comment | null
 sourceCode.getFirstToken(AST, { includeComments: true, skip: 0 });
 // prettier-ignore
 sourceCode.getFirstToken(AST, { // $ExpectType (Token & { type: "Identifier"; }) | null
@@ -188,7 +188,7 @@ sourceCode.getFirstTokenBetween(AST, AST, {
     skip: 0,
     filter: (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier',
 });
-sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true }); // $ExpectType Comment | Token | null
+sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true }); // $ExpectType Comment | Token | null || Token | Comment | null
 sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true, skip: 0 });
 // prettier-ignore
 sourceCode.getFirstTokenBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; }) | null
@@ -206,7 +206,7 @@ sourceCode.getFirstTokensBetween(AST, AST, { // $ExpectType (Token & { type: "Id
     filter: (t): t is AST.Token & { type: "Identifier" } => t.type === "Identifier",
 });
 sourceCode.getFirstTokensBetween(AST, AST, { count: 0, filter: t => t.type === 'Identifier' });
-sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true }); // $ExpectType (Comment | Token)[]
+sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true }); // $ExpectType (Comment | Token)[] || (Token | Comment)[]
 sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true, count: 0 });
 // prettier-ignore
 sourceCode.getFirstTokensBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; })[]
@@ -243,7 +243,7 @@ sourceCode.getTokens(AST, 0);
 sourceCode.getTokens(AST, 0, 0);
 sourceCode.getTokens(AST, (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier'); // $ExpectType (Token & { type: "Identifier"; })[]
 sourceCode.getTokens(AST, { filter: (t): t is AST.Token & { type: 'Identifier' } => t.type === 'Identifier' }); // $ExpectType (Token & { type: "Identifier"; })[]
-sourceCode.getTokens(AST, { includeComments: true }); // $ExpectType (Comment | Token)[]
+sourceCode.getTokens(AST, { includeComments: true }); // $ExpectType (Comment | Token)[] || (Token | Comment)[]
 // prettier-ignore
 sourceCode.getTokens(AST, { // $ExpectType (Token & { type: "Identifier"; })[]
     includeComments: true,

--- a/types/human-object-diff/human-object-diff-tests.ts
+++ b/types/human-object-diff/human-object-diff-tests.ts
@@ -37,5 +37,5 @@ diffEngine.sentences; // $ExpectType string[]
 diffEngine.templates; // $ExpectType Record<TemplateType, string>
 if (diffEngine.config.prefilter) {
     const { prefilter } = diffEngine.config;
-    prefilter; // $ExpectType string[] | PathPredicate
+    prefilter; // $ExpectType string[] | PathPredicate || PathPredicate | string[]
 }

--- a/types/node-dijkstra/node-dijkstra-tests.ts
+++ b/types/node-dijkstra/node-dijkstra-tests.ts
@@ -10,9 +10,9 @@ graph
     .addNode('A', {B: 1})
     .removeNode('C');
 
-// $ExpectType string[] | PathResult
+// $ExpectType string[] | PathResult || PathResult | string[]
 graph2.path('A', 'B');
-// $ExpectType string[] | PathResult
+// $ExpectType string[] | PathResult || PathResult | string[]
 graph.path('A', 'B', {cost: false, reverse: true});
-// $ExpectType string[] | PathResult
+// $ExpectType string[] | PathResult || PathResult | string[]
 graph.path('A', 'B', {cost: true});

--- a/types/node/v14/test/util.ts
+++ b/types/node/v14/test/util.ts
@@ -257,7 +257,7 @@ function testUtilTypes(
         object; // $ExpectType Map<any, any>
 
         if (util.types.isMap(readonlyMapOrRecord)) {
-            readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any> || Map<any, any> | ReadonlyMap<any, any>
+            readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any> || Map<any, any> | ReadonlyMap<any, any> || ReadonlyMap<any, any> | Map<any, any>
         }
     }
     if (util.types.isNativeError(object)) {
@@ -289,7 +289,7 @@ function testUtilTypes(
         object; // $ExpectType Set<any>
 
         if (util.types.isSet(readonlySetOrArray)) {
-            readonlySetOrArray; // $ExpectType ReadonlySet<any> || Set<any> | ReadonlySet<any>
+            readonlySetOrArray; // $ExpectType ReadonlySet<any> || Set<any> | ReadonlySet<any> || ReadonlySet<any> | Set<any>
         }
     }
     if (util.types.isSharedArrayBuffer(object)) {

--- a/types/node/v14/test/util.ts
+++ b/types/node/v14/test/util.ts
@@ -257,7 +257,7 @@ function testUtilTypes(
         object; // $ExpectType Map<any, any>
 
         if (util.types.isMap(readonlyMapOrRecord)) {
-            readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any> || Map<any, any> | ReadonlyMap<any, any> || ReadonlyMap<any, any> | Map<any, any>
+            readonlyMapOrRecord; // $ExpectType ReadonlyMap<any, any> || Map<any, any> | ReadonlyMap<any, any>
         }
     }
     if (util.types.isNativeError(object)) {
@@ -289,7 +289,7 @@ function testUtilTypes(
         object; // $ExpectType Set<any>
 
         if (util.types.isSet(readonlySetOrArray)) {
-            readonlySetOrArray; // $ExpectType ReadonlySet<any> || Set<any> | ReadonlySet<any> || ReadonlySet<any> | Set<any>
+            readonlySetOrArray; // $ExpectType ReadonlySet<any> || Set<any> | ReadonlySet<any>
         }
     }
     if (util.types.isSharedArrayBuffer(object)) {

--- a/types/postman-collection/postman-collection-tests.ts
+++ b/types/postman-collection/postman-collection-tests.ts
@@ -65,7 +65,7 @@ Property.replaceSubstitutionsIn({}, [new pmCollection.VariableList(p, [])], fals
 
 // CertificateDefinition Tests
 const certDef: pmCollection.CertificateDefinition = {};
-certDef.matches; // $ExpectType string[] | UrlMatchPatternList | undefined
+certDef.matches; // $ExpectType string[] | UrlMatchPatternList | undefined || UrlMatchPatternList | string[] | undefined
 certDef.key; // $ExpectType string | { src?: string | undefined; } | undefined
 certDef.cert; // $ExpectType string | { src?: string | undefined; } | undefined
 certDef.passphrase; // $ExpectType string | undefined

--- a/types/ramda/test/fromPairs-tests.ts
+++ b/types/ramda/test/fromPairs-tests.ts
@@ -18,7 +18,7 @@ import * as R from 'ramda';
      * Typescript implementation of union order is not guaranteed and can
      * change. Therefor using `||` here, which is a feature of $ExpectType
      */
-    // $ExpectType { [index: string]: 2 | 3 | 1; } || { [index: string]: 2 | 1 | 3; }
+    // $ExpectType { [index: string]: 2 | 3 | 1; } || { [index: string]: 2 | 1 | 3; } || { [index: string]: 1 | 2 | 3; }
     R.fromPairs([
         ['a', 1],
         ['b', 2],

--- a/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
+++ b/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
@@ -177,7 +177,7 @@ const TestComponent: React.FC = () => <div>Hello world</div>;
         temp = props.rows; // $ExpectType rendererNode[]
         temp = props.stylesheet; // $ExpectType { [key: string]: CSSProperties; }
         temp = props.useInlineStyles; // $ExpectType boolean
-        temp = props.rows[0].type; // $ExpectType "text" | "element"
+        temp = props.rows[0].type; // $ExpectType "text" | "element" || "element" | "text"
         return <code>hello world</code>;
     }}
 >

--- a/types/yargs/v15/yargs-tests.ts
+++ b/types/yargs/v15/yargs-tests.ts
@@ -1053,7 +1053,7 @@ function Argv$inferRequiredOptionTypes() {
 
 function Argv$inferMultipleOptionTypes() {
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; } ||  { [x: string]: unknown; b: boolean; a: string; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .option({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
@@ -1061,7 +1061,7 @@ function Argv$inferMultipleOptionTypes() {
         .argv;
 
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .options({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])

--- a/types/yargs/v16/yargs-tests.ts
+++ b/types/yargs/v16/yargs-tests.ts
@@ -1054,7 +1054,7 @@ function Argv$inferRequiredOptionTypes() {
 
 function Argv$inferMultipleOptionTypes() {
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; } ||  { [x: string]: unknown; b: boolean; a: string; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .option({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
@@ -1062,7 +1062,7 @@ function Argv$inferMultipleOptionTypes() {
         .argv;
 
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .options({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -1091,7 +1091,7 @@ function Argv$inferRequiredOptionTypes() {
 
 function Argv$inferMultipleOptionTypes() {
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; } ||  { [x: string]: unknown; b: boolean; a: string; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .option({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])
@@ -1099,7 +1099,7 @@ function Argv$inferMultipleOptionTypes() {
         .parseSync();
 
     // tslint:disable-next-line
-    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; a: string; b: boolean; c: number; d: number; e: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; d: number; e: number; c: number; _: (string | number)[]; $0: string; } || { [x: string]: unknown; b: boolean; a: string; c: number; d: number; e: number; _: (string | number)[]; $0: string; }
     yargs
         .options({ a: { default: "a" }, b: { default: false } })
         .number(["c", "d", "e"])


### PR DESCRIPTION
Typescript re-ordered union output (*again*) on November 3rd. This PR adds the new orders to `$ExpectType` where they changed.