### PR TITLE
[react-native-global-props] Update types for RN 0.66+ compatibility

### DIFF
--- a/types/react-native-global-props/index.d.ts
+++ b/types/react-native-global-props/index.d.ts
@@ -9,7 +9,6 @@ import {
     KeyboardAvoidingViewProps,
     ListViewProps,
     ModalProps,
-    PickerProps,
     RefreshControlProps,
     ScrollViewProps,
     SliderProps,
@@ -50,8 +49,6 @@ export function setCustomKeyboardAvoidingView(customKeyboardAvoidingViewProps: K
 
 export function setCustomModal(customModalProps: ModalProps): void;
 
-export function setCustomPicker(customPickerProps: PickerProps): void;
-
 export function setCustomRefreshControl(customRefreshControlProps: RefreshControlProps): void;
 
 export function setCustomScrollView(customScrollViewProps: ScrollViewProps): void;
@@ -61,6 +58,12 @@ export function setCustomSlider(customSliderProps: SliderProps): void;
 export function setCustomStatusBar(customStatusBarProps: StatusBarProps): void;
 
 export function setCustomSwitch(customSwitchProps: SwitchProps): void;
+
+/**
+ * @deprecated Picker was a deprecated React Native component removed in RN 0.66 - https://reactnative.dev/docs/0.65/picker.
+ *             Use one of the community packages instead - https://reactnative.directory/?search=picker
+ */
+export function setCustomPicker(customPickerProps: any): void;
 
 /**
  * @deprecated ListView is a deprecated React Native component - https://reactnative.dev/docs/listview

--- a/types/react-native-global-props/react-native-global-props-tests.tsx
+++ b/types/react-native-global-props/react-native-global-props-tests.tsx
@@ -6,7 +6,6 @@ import {
     ListView,
     ListViewProps,
     ModalProps,
-    PickerProps,
     RefreshControlProps,
     ScrollViewProps,
     SliderProps,
@@ -91,10 +90,6 @@ const customModalProps: ModalProps = {};
 // $ExpectType void
 setCustomModal(customModalProps);
 
-const customPickerProps: PickerProps = {};
-// $ExpectType void
-setCustomPicker(customPickerProps);
-
 const customRefreshControlProps: RefreshControlProps = {
     refreshing: false,
 };
@@ -116,6 +111,10 @@ setCustomStatusBar(customStatusBarProps);
 const customSwitchProps: SwitchProps = {};
 // $ExpectType void
 setCustomSwitch(customSwitchProps);
+
+const customPickerProps = {};
+// $ExpectType void
+setCustomPicker(customPickerProps);
 
 const customListViewProps: ListViewProps = {
     dataSource: new ListView.DataSource({}),

--- a/types/react-native-global-props/tsconfig.json
+++ b/types/react-native-global-props/tsconfig.json
@@ -12,11 +12,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "react-native": [
-                "react-native/v0.65"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
setCustomPicker's params are now weakly typed to `any` so you still use the deprecated method with old versions of RN if necessary

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56525 ensured these types continued to work with RN 0.65 and earlier when Picker was dropped. The downside of this is that depending on these types in an RN 0.66+ project results in, potentially, multiple copies of @types/react-native being pulled in. To resolve this, weaken the types on the Picker-related function and deprecate with documentation about switching to a replacement. The module still works in RN 0.66+ as long as you don't call the deprecated Picker method.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
