### PR TITLE
[nodegit] Implement proper types for RebaseOptions

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -176,7 +176,14 @@ Git.Refspec.parse('+refs/heads/*:refs/remotes/origin/*', 0).then(refspec => {
     refspec.string(); // $ExpectType string
 });
 
-Git.Rebase.init(repo, annotatedCommit, null, annotatedCommit, null).then(rebase => {
+const rebaseOptions: Git.RebaseOptions = {
+    checkoutOptions: {
+        checkoutStrategy: Git.Checkout.STRATEGY.SAFE,
+    },
+    inmemory: 1,
+};
+
+Git.Rebase.init(repo, annotatedCommit, null, annotatedCommit, rebaseOptions).then(rebase => {
     return rebase.next().then(rebaseOperation => {
         rebaseOperation.id(); // $ExpectType Oid
         rebaseOperation.type(); // $ExpectType number | null

--- a/types/nodegit/rebase.d.ts
+++ b/types/nodegit/rebase.d.ts
@@ -4,13 +4,26 @@ import { Repository } from './repository';
 import { Signature } from './signature';
 import { Oid } from './oid';
 import { RebaseOperation } from './rebase-operation';
-import { Index } from './index';
+import { Index, MergeOptions, Tree } from './index';
 
-export interface RebaseOptions {
-    version: number;
-    quiet: number;
-    rewriteNotesRef: string;
-    checkoutOptions: CheckoutOptions;
+export interface RebaseOptions<PayloadType = any> {
+    version?: number | null;
+    quiet?: number | null;
+    inmemory?: number | null;
+    rewriteNotesRef?: string | null;
+    mergeOptions?: MergeOptions | null;
+    checkoutOptions?: CheckoutOptions | null;
+    commitCreateCb?: ((
+        author: Signature,
+        committer: Signature,
+        message_encoding: string,
+        message: string,
+        tree: Tree,
+        parent_count: number,
+        parents: Oid[],
+        payload?: PayloadType
+    ) => Oid) | null;
+    payload?: PayloadType | null;
 }
 
 export class Rebase {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

**Re URL:** The package hasn't updated the API docs on its website in years. Here's how I figured out the correct types for the definitions and how anyone else can verify that the changes are correct:

1. Clone the `nodegit` repo
2. `npm install`
3. Look at the file `generate/output/ifdefs.json`. It contains information about all types exposed by the package.