### PR TITLE
[i18n] Add parser type

### DIFF
--- a/types/i18n/i18n-tests.ts
+++ b/types/i18n/i18n-tests.ts
@@ -1,6 +1,7 @@
 /**
  * Test suite created by Maxime LUCE <https://github.com/SomaticIT>
  * Updated by FindQ for version 0.8 of i18n-node
+ * Updated by Nirsi on version 0.15 for missing parser option.
  *
  * Created by using code samples from https://github.com/mashpie/i18n-node.
  */
@@ -19,7 +20,7 @@ declare const req: Express.Request & Request;
  */
 i18n.configure({
     locales: ['en', 'de'],
-    directory: __dirname + '/locales'
+    directory: __dirname + '/locales',
 });
 
 i18n.configure({
@@ -125,6 +126,8 @@ i18n.configure({
         tags: ['{{', '}}'],
         disable: false,
     },
+    // Set JSON as buildin object which is acceptable as an parser object.
+    parser: JSON,
 });
 
 /**

--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -177,6 +177,15 @@ declare namespace i18n {
              */
             disable?: boolean | undefined;
         } | undefined;
+
+        /**
+         * Parser can be any object that responds to .parse & .stringify
+         */
+        parser?: ParserOptions | undefined;
+    }
+    interface ParserOptions {
+        parse: (src: string, options?: any) => any;
+        stringify: (value: any, options?: any) => string;
     }
     interface TranslateOptions {
         phrase: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [npmjs.com](https://www.npmjs.com/package/i18n#api)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Docs: On the npmjs.com site for i18n parser is defined in "list of all configuration options"