### PR TITLE
d3-org-chart: Remove namespace export, add function type definition

### DIFF
--- a/types/d3-org-chart/index.d.ts
+++ b/types/d3-org-chart/index.d.ts
@@ -6,8 +6,6 @@
 import { HierarchyNode } from 'd3-hierarchy';
 import { Selection } from 'd3-selection';
 
-export as namespace d3;
-
 export type NodeId = string | number;
 export type Connection = any;
 
@@ -106,6 +104,8 @@ export class OrgChart<Datum> {
     svgWidth(value: number): this;
     svgHeight(): number;
     svgHeight(value: number): this;
+    scaleExtent(): [number, number];
+    scaleExtent(value: [number, number]): this;
     container(): string; // CSS selector string, for example "#my-chart"
     container(value: string): this;
     defaultTextFill(): string; // CSS color, for example "#2C3E50"


### PR DESCRIPTION
### Closes #63266

This PR does 2 things:
- removes the d3 namespace export
- adds `scaleExtent` types to the class definition (it's a method that has since been exposed in the public API, resulting in a "Property 'scaleExtent' does not exist on type..." error)


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Package commit exposing `scaleExtent` method ](https://github.com/bumbeishvili/org-chart/commit/3b7cc9d332d657ed5e710631abaad36dfc5ebe0f)

