### PR TITLE
[@types/navermaps] add overalyType in ImageMapTypeOptions and linting test case

### DIFF
--- a/types/navermaps/index.d.ts
+++ b/types/navermaps/index.d.ts
@@ -220,6 +220,7 @@ declare namespace naver.maps {
         darktheme?: boolean;
         getTileUrl?: (x: number, y: number, z: number) => string[];
         tileSet?: string | string[];
+        overlayType?: string; // https://navermaps.github.io/maps.js.ncp/docs/tutorial-StyleMap-2-Custom-OverlayType.html
     }
 
     /**

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -8,8 +8,13 @@ let map = new naver.maps.Map('map', {
     minZoom: 7,
     zoomControl: true,
     zoomControlOptions: {
-        position: naver.maps.Position.TOP_RIGHT
-    }
+        position: naver.maps.Position.TOP_RIGHT,
+    },
+    mapTypes: new naver.maps.MapTypeRegistry({
+        normal: naver.maps.NaverStyleMapTypeOptions.getNormalMap({
+            overlayType: 'bg',
+        }),
+    }),
 });
 
 /**
@@ -20,11 +25,11 @@ const jeju = new naver.maps.LatLng(33.3590628, 126.534361);
 const busan = new naver.maps.LatLng(35.1797865, 129.0750194);
 const dokdo = new naver.maps.LatLngBounds(
     new naver.maps.LatLng(37.2380651, 131.8562652),
-    new naver.maps.LatLng(37.2444436, 131.8786475)
+    new naver.maps.LatLng(37.2444436, 131.8786475),
 );
 const seoul = new naver.maps.LatLngBounds(
     new naver.maps.LatLng(37.42829747263545, 126.76620435615891),
-    new naver.maps.LatLng(37.7010174173061, 127.18379493229875)
+    new naver.maps.LatLng(37.7010174173061, 127.18379493229875),
 );
 
 map.setCenter(jeju);
@@ -38,8 +43,8 @@ map.panBy(new naver.maps.Point(10, 10));
  * Event Basic Example
  * See https://navermaps.github.io/maps.js.ncp/docs/tutorial-1-event-simple.example.html
  */
-naver.maps.Event.addListener(map, 'click', function (e) { });
-naver.maps.Event.addListener(map, 'keydown', function (e) { });
+naver.maps.Event.addListener(map, 'click', function (e) {});
+naver.maps.Event.addListener(map, 'keydown', function (e) {});
 
 /**
  * Layer Example
@@ -63,8 +68,8 @@ const htmlMarker = new naver.maps.Marker({
     icon: {
         content: `<div>Marker</div>`,
         size: new naver.maps.Size(22, 35),
-        anchor: new naver.maps.Point(11, 35)
-    }
+        anchor: new naver.maps.Point(11, 35),
+    },
 });
 const imageMarker = new naver.maps.Marker({
     position: new naver.maps.LatLng(37.3849483, 127.1229117),
@@ -73,24 +78,28 @@ const imageMarker = new naver.maps.Marker({
         url: 'https://navermaps.github.io/maps.js.ncp/docs/img/example/sally.png',
         size: new naver.maps.Size(50, 52),
         origin: new naver.maps.Point(0, 0),
-        anchor: new naver.maps.Point(25, 26)
-    }
+        anchor: new naver.maps.Point(25, 26),
+    },
 });
 const symbolIconMarker = new naver.maps.Marker({
     position: new naver.maps.LatLng(37.3595704, 127.105399),
     map: map,
     icon: {
         path: [
-            new naver.maps.Point(0, 70), new naver.maps.Point(20, 100), new naver.maps.Point(40, 70),
-            new naver.maps.Point(30, 70), new naver.maps.Point(70, 0), new naver.maps.Point(10, 70)
+            new naver.maps.Point(0, 70),
+            new naver.maps.Point(20, 100),
+            new naver.maps.Point(40, 70),
+            new naver.maps.Point(30, 70),
+            new naver.maps.Point(70, 0),
+            new naver.maps.Point(10, 70),
         ],
         anchor: new naver.maps.Point(23, 103),
         fillColor: '#ff0000',
         fillOpacity: 1,
         strokeColor: '#000000',
         strokeStyle: 'solid',
-        strokeWeight: 3
-    }
+        strokeWeight: 3,
+    },
 });
 
 /**
@@ -98,7 +107,7 @@ const symbolIconMarker = new naver.maps.Marker({
  * See https://navermaps.github.io/maps.js.ncp/docs/tutorial-1-infowindow-simple.example.html
  */
 const infowindow = new naver.maps.InfoWindow({
-    content: `<div>InfoWindow Title</div>`
+    content: `<div>InfoWindow Title</div>`,
 });
 infowindow.open(map, htmlMarker);
 infowindow.close();
@@ -107,12 +116,12 @@ infowindow.close();
  * Overlay(Rectangle, Circle, Ellipse, Polyline) Example
  * See https://navermaps.github.io/maps.js.ncp/docs/tutorial-1-shape-simple.example.html
  */
- const rectangle = new naver.maps.Rectangle({
+const rectangle = new naver.maps.Rectangle({
     map: map,
     bounds: new naver.maps.LatLngBounds(
         new naver.maps.LatLng(37.1793196, 125.8795594),
-        new naver.maps.LatLng(37.5398662, 126.3312422)
-    )
+        new naver.maps.LatLng(37.5398662, 126.3312422),
+    ),
 });
 
 const circle = new naver.maps.Circle({
@@ -120,20 +129,20 @@ const circle = new naver.maps.Circle({
     center: new naver.maps.LatLng(37.3595953, 127.1053971),
     radius: 20000,
     fillColor: 'crimson',
-    fillOpacity: 0.8
+    fillOpacity: 0.8,
 });
 
 const ellipse = new naver.maps.Ellipse({
     map: map,
     bounds: new naver.maps.LatLngBounds(
         new naver.maps.LatLng(37.1793196, 127.6795594),
-        new naver.maps.LatLng(37.5398662, 128.4312422)
+        new naver.maps.LatLng(37.5398662, 128.4312422),
     ),
     strokeColor: 'yellowgreen',
     strokeOpacity: 1,
     strokeWeight: 3,
     fillColor: 'yellowgreen',
-    fillOpacity: 0.3
+    fillOpacity: 0.3,
 });
 
 const coords = [
@@ -172,9 +181,9 @@ const pano = new naver.maps.Panorama('pano', {
     pov: {
         pan: -135,
         tilt: 29,
-        fov: 100
+        fov: 100,
     },
-    flightSpot: true
+    flightSpot: true,
 });
 
 /**
@@ -214,8 +223,8 @@ naver.maps.Service.reverseGeocode(
         v2Status.code;
         v2Status.name;
         v2Status.message;
-     }
- );
+    },
+);
 
 /*
  * LatLng
@@ -232,16 +241,18 @@ expectType<naver.maps.Point>(new naver.maps.Point(1, 1));
  */
 new naver.maps.LatLngBounds([-100, -90, 100, 90]);
 new naver.maps.LatLngBounds(new naver.maps.LatLng(37.5, 126.9), new naver.maps.LatLng(37.5, 126.9));
-expectType<naver.maps.LatLngBounds>(naver.maps.LatLngBounds.bounds(new naver.maps.LatLng(-180, -90), new naver.maps.LatLng(0, 0)));
+expectType<naver.maps.LatLngBounds>(
+    naver.maps.LatLngBounds.bounds(new naver.maps.LatLng(-180, -90), new naver.maps.LatLng(0, 0)),
+);
 
 /**
  * PointBounds
  */
 new naver.maps.PointBounds([0, 0, 10, 10]);
-new naver.maps.PointBounds(
-    new naver.maps.Point(-10, -10), new naver.maps.Point(10, 10)
+new naver.maps.PointBounds(new naver.maps.Point(-10, -10), new naver.maps.Point(10, 10));
+expectType<naver.maps.PointBounds>(
+    naver.maps.PointBounds.bounds(new naver.maps.Point(-1, -1), new naver.maps.Point(0, 0)),
 );
-expectType<naver.maps.PointBounds>(naver.maps.PointBounds.bounds(new naver.maps.Point(-1, -1), new naver.maps.Point(0, 0)));
 
 function expectType<T>(value: T) {
     return value;


### PR DESCRIPTION
사용자 정의 OverlayType 설정 시 overlayType 필드가 누락 되어 있어 추가 하였습니다. 
Testcase Lint 처리도 하였습니다.

----
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [사용자 정의 OverlayType 설정](https://navermaps.github.io/maps.js.ncp/docs/tutorial-StyleMap-2-Custom-OverlayType.html)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
