### PR TITLE
[xml2js] Add generics to replace explicit any values

### DIFF
--- a/types/xml2js/index.d.ts
+++ b/types/xml2js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-xml2js 0.4
+// Type definitions for xml2js 0.4
 // Project: https://github.com/Leonidas-from-XIV/node-xml2js
 // Definitions by: Michel Salib <https://github.com/michelsalib>
 //                 Jason McNeil <https://github.com/jasonrm>
@@ -14,13 +14,12 @@
 import { EventEmitter } from 'events';
 import * as processors from './lib/processors';
 
-export function parseString(str: convertableToString, callback: (err: Error | null, result: any) => void): void;
-export function parseString(
-    str: convertableToString,
-    options: ParserOptions,
-    callback: (err: Error | null, result: any) => void,
-): void;
-export function parseStringPromise(str: convertableToString, options?: ParserOptions): Promise<any>;
+// tslint:disable-next-line no-unnecessary-generics
+export function parseString<T = any>(str: convertableToString, callback: (err: Error | null, result: T) => void): void;
+// tslint:disable-next-line no-unnecessary-generics
+export function parseString<T = any>(str: convertableToString, options: ParserOptions, callback: (err: Error | null, result: T) => void): void;
+// tslint:disable-next-line no-unnecessary-generics
+export function parseStringPromise<T = any>(str: convertableToString, options?: ParserOptions): Promise<T>;
 
 export const defaults: {
     '0.1': Options;
@@ -46,8 +45,10 @@ export class Builder {
 
 export class Parser extends EventEmitter {
     constructor(options?: ParserOptions);
-    parseString(str: convertableToString, cb?: (error: Error | null, result: any) => void): void;
-    parseStringPromise(str: convertableToString): Promise<any>;
+    // tslint:disable-next-line no-unnecessary-generics
+    parseString<T = any>(str: convertableToString, cb?: (error: Error | null, result: T) => void): void;
+    // tslint:disable-next-line no-unnecessary-generics
+    parseStringPromise<T = any>(str: convertableToString): Promise<T>;
     reset(): void;
 }
 

--- a/types/xml2js/xml2js-tests.ts
+++ b/types/xml2js/xml2js-tests.ts
@@ -2,9 +2,29 @@ import xml2js = require('xml2js');
 import * as processors from 'xml2js/lib/processors';
 import fs = require('fs');
 
+interface TestObject {
+    foo: string;
+}
+
 xml2js.parseString('<root>Hello xml2js!</root>', (err: Error | null, result: any) => { });
 
+// $ExpectType void
+xml2js.parseString<TestObject>('<root>Hello xml2js!</root>', (err: Error | null, result: TestObject) => {
+    // $ExpectType TestObject
+    const test1 = result;
+
+    // $ExpectType string
+    const test2 = result.foo;
+
+    // @ts-expect-error
+    const test3 = result.bar;
+});
+
+// $ExpectType Promise<any>
 xml2js.parseStringPromise('<root>Hello xml2js!</root>');
+
+// $ExpectType Promise<TestObject>
+xml2js.parseStringPromise<TestObject>('<root>Hello xml2js!</root>');
 
 xml2js.parseString('<root>Hello xml2js!</root>', {trim: true}, (err: Error | null, result: any) => { });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

# Motivation

- I'm using this package https://www.npmjs.com/package/xml2js to transform my XML string into JS. Currently the return value is an explicit `any` for all the parse methods. I've added generics (with fallback to `any` for backwards compatibility), so I could type my JS object.
