### PR TITLE
[powerapps-component-framework] update EntityRecord interface according to learn.microsoft

### DIFF
--- a/types/powerapps-component-framework/componentframework.d.ts
+++ b/types/powerapps-component-framework/componentframework.d.ts
@@ -1878,7 +1878,7 @@ declare namespace ComponentFramework {
                  * Get the raw value of the record's column
                  * @param columnName Column name of the record
                  */
-                getValue(columnName: string): string | Date | number | number[] | boolean | EntityReference | EntityReference[] | LookupValue | LookupValue[];
+                getValue(columnName: string): string | Date | number | number[] | boolean | EntityReference | EntityReference[] | LookupValue | LookupValue[] | FileObject;
 
                 /**
                  * Get the object that encapsulates an Entity Reference as a plain object

--- a/types/powerapps-component-framework/componentframework.d.ts
+++ b/types/powerapps-component-framework/componentframework.d.ts
@@ -1884,6 +1884,23 @@ declare namespace ComponentFramework {
                  * Get the object that encapsulates an Entity Reference as a plain object
                  */
                 getNamedReference(): EntityReference;
+
+                /**
+                 * Whether this record is dirty. Only applicable if the dataset is editable and this record has dirty values.
+                 */
+                isDirty(): boolean;
+
+                /**
+                 * Saves the record.
+                 */
+                save(): Promise<void>;
+
+                /**
+                 * Set value for the column.
+                 * @param columnName Name of the column
+                 * @param value New value for the record
+                 */
+                setValue(columnName: string, value: string | Date | number | number[] | boolean | EntityReference | EntityReference[] | LookupValue | LookupValue[] | FileObject): Promise<void>;
             }
 
             /**

--- a/types/powerapps-component-framework/powerapps-component-framework-tests.ts
+++ b/types/powerapps-component-framework/powerapps-component-framework-tests.ts
@@ -207,3 +207,26 @@ const pagingTest: ComponentFramework.PropertyHelper.DataSetApi.Paging = {
     setPageSize: (pageSize: number) => {},
     loadExactPage: (pageNumber: number) => {},
 };
+
+type EntityRecordValue =
+    | string
+    | Date
+    | number
+    | number[]
+    | boolean
+    | ComponentFramework.EntityReference
+    | ComponentFramework.EntityReference[]
+    | ComponentFramework.LookupValue
+    | ComponentFramework.LookupValue[]
+    | ComponentFramework.FileObject;
+
+const tmpEntityRecordValue: EntityRecordValue = '';
+const entityRecordTest: ComponentFramework.PropertyHelper.DataSetApi.EntityRecord = {
+    getFormattedValue: (columnName: string) => '',
+    getRecordId: () => '',
+    getValue: () => tmpEntityRecordValue,
+    getNamedReference: () => EntityReferenceTest,
+    isDirty: () => true,
+    save: () => Promise.resolve(),
+    setValue: (columnName: string, value: EntityRecordValue) => Promise.resolve()
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [EntityRecord Reference](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/reference/entityrecord)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

## Additional Information
This PR adds missing isDirty, save and setValue signatures to the EntityRecord, see [EntityRecord Reference](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/reference/entityrecord).  

In addition, I noticed some differences in the types vs. the [EntityRecord Reference](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/reference/entityrecord). The [EntityRecord.getValue](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/reference/entityrecord/getvalue) has two more possible return types [FileObject](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/reference/fileobject) | [ImageObject](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/reference/imageobject). Where `ImageObject` does not exist in the types. **With this PR only the `FileObject` was added to the value type.**

@JimDaly @lesyk @Nkrb @KumarVivek You are probably interested in updating the  [EntityRecord.getValue](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/reference/entityrecord/getvalue) and  [EntityRecord.setValue](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/reference/entityrecord/setvalue) to include `LookupValue | LookupValue[]` in the return type or parameter type.

