### PR TITLE
Made iconUrl optional in chrome NotificationOptions type

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5855,9 +5855,9 @@ declare namespace chrome.notifications {
     } & (T extends true ? {
         /**
          * A URL to the sender's avatar, app icon, or a thumbnail for image notifications.
-         * URLs can be a data URL, a blob URL, or a URL relative to a resource within this extension's .crx file. Required for notifications.create method.
+         * URLs can be a data URL, a blob URL, or a URL relative to a resource within this extension's .crx file. Optional for notifications.create method.
          */
-        iconUrl: string;
+        iconUrl?: string | undefined;
         /** Main notification content. Required for notifications.create method. */
         message: string;
         /** Which type of notification to display. Required for notifications.create method. */
@@ -5868,7 +5868,7 @@ declare namespace chrome.notifications {
         /**
          * Optional.
          * A URL to the sender's avatar, app icon, or a thumbnail for image notifications.
-         * URLs can be a data URL, a blob URL, or a URL relative to a resource within this extension's .crx file. Required for notifications.create method.
+         * URLs can be a data URL, a blob URL, or a URL relative to a resource within this extension's .crx file. Optional for notifications.create method.
          */
         iconUrl?: string | undefined;
         /** Optional. Main notification content. Required for notifications.create method. */


### PR DESCRIPTION
Please fill in this template.

Here is a [link](https://developer.chrome.com/docs/extensions/reference/notifications/#:~:text=PROPERTIES-,iconUrl,-string%C2%A0optional) to the chrome notification documentation which outlines that the iconUrl property is optional on the Notifcation type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developer.chrome.com/docs/extensions/reference/notifications/#:~:text=PROPERTIES-,iconUrl,-string%C2%A0optional>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
