### PR TITLE
fix(get-image-colors): support for missing options object

### DIFF
--- a/types/get-image-colors/get-image-colors-tests.ts
+++ b/types/get-image-colors/get-image-colors-tests.ts
@@ -17,6 +17,9 @@ const options: Options = {
     });
 
     // $ExpectType Color[]
+    await getColors(buffer, options);
+
+    // $ExpectType Color[]
     await getColors(buffer, 'image/gif');
 
     // $ExpectType Color[]

--- a/types/get-image-colors/index.d.ts
+++ b/types/get-image-colors/index.d.ts
@@ -10,11 +10,11 @@ import { Color } from 'chroma-js';
 /**
  * Extract colors from images. Supports GIF, JPG, PNG, and even SVG!
  */
-declare function colorPalette(input: Buffer, options: colorPalette.Options, callback: Color[]): void;
 declare function colorPalette(input: Buffer, type: string, callback: colorPalette.Callback): void;
-declare function colorPalette(input: Buffer, type: string): Promise<Color[]>;
-declare function colorPalette(input: string, options?: colorPalette.Options): Promise<Color[]>;
+declare function colorPalette(input: Buffer, options: colorPalette.Options, callback: Color[]): void;
+declare function colorPalette(input: Buffer, typeOrOptions: string | colorPalette.Options): Promise<Color[]>;
 declare function colorPalette(input: string, callback: colorPalette.Callback): void;
+declare function colorPalette(input: string, options?: colorPalette.Options): Promise<Color[]>;
 
 declare namespace colorPalette {
     interface Options {

--- a/types/get-image-colors/index.d.ts
+++ b/types/get-image-colors/index.d.ts
@@ -10,11 +10,9 @@ import { Color } from 'chroma-js';
 /**
  * Extract colors from images. Supports GIF, JPG, PNG, and even SVG!
  */
-declare function colorPalette(input: Buffer, type: string, callback: colorPalette.Callback): void;
-declare function colorPalette(input: Buffer, options: colorPalette.Options, callback: Color[]): void;
-declare function colorPalette(input: Buffer, typeOrOptions: string | colorPalette.Options): Promise<Color[]>;
-declare function colorPalette(input: string, callback: colorPalette.Callback): void;
-declare function colorPalette(input: string, options?: colorPalette.Options): Promise<Color[]>;
+declare function colorPalette(input: Buffer | string, typeOrOptions: string | colorPalette.Options, callback: colorPalette.Callback): void;
+declare function colorPalette(input: Buffer | string, typeOrOptions?: string | colorPalette.Options): Promise<Color[]>;
+declare function colorPalette(input: Buffer | string, callback: colorPalette.Callback): void;
 
 declare namespace colorPalette {
     interface Options {


### PR DESCRIPTION
This adds support for missing options object as parameter in:
```ts
colorPalette(input: Buffer, typeOrOptions: string | colorPalette.Options)
```

/cc @Nysosis

Thanks!

Fixes #63314