### PR TITLE
[@types/oojs]: Fix doc licensing issue & OO.Factory.register() incorrect typing

### DIFF
--- a/types/oojs/Factory.d.ts
+++ b/types/oojs/Factory.d.ts
@@ -2,29 +2,21 @@ declare namespace OO {
     // HACK: Omit register and unregister because Factory changed their call signatures (!)
     interface Factory extends Omit<Registry, 'register' | 'unregister'> {
         /**
-         * Register a class with the factory.
+         * Register a constructor with the factory.
          *
          *     function MyClass() {};
          *     OO.initClass( MyClass );
-         *     MyClass.key = 'hello';
-         *
-         *     // Register class with the factory
+         *     MyClass.static.name = 'hello';
+         *     // Register class with the factory, available via the symbolic name "hello"
          *     factory.register( MyClass );
          *
-         *     // Instantiate a class based on its registered key (also known as a "symbolic name")
-         *     factory.create( 'hello' );
-         *
-         * @param constructor Class to use when creating an object
-         * @param key The key for {@link create}.
-         *  This parameter is usually omitted in favour of letting the class declare
-         *  its own key, through `MyClass.key`.
-         *  For backwards-compatibility with OOjs 6.0 (2021) and older, it can also be declared
-         *  via `MyClass.static.name`.
+         * @param constructor Constructor to use when creating object
+         * @param name Symbolic name to use for {@link create()}.
+         *  This parameter may be omitted in favour of letting the constructor decide
+         *  its own name, through `constructor.static.name`.
          * @throws {Error} If a parameter is invalid
          */
-        register(
-            constructor: (ConstructorLike & { key: string }) | (ConstructorLike & { static: { name: string } }),
-        ): void;
+        register(constructor: ConstructorLike & { static: { name: string } }): void;
 
         /**
          * Register a class with the factory.
@@ -72,7 +64,7 @@ declare namespace OO {
     }
 
     interface FactoryConstructor {
-        new (): Factory;
+        new(): Factory;
         prototype: Factory;
         super: RegistryConstructor;
         /** @deprecated Use `super` instead */

--- a/types/oojs/README.MD
+++ b/types/oojs/README.MD
@@ -1,0 +1,28 @@
+## Usage
+When writing MediaWiki [gadgets](https://www.mediawiki.org/wiki/Extension:Gadgets) or [user scripts](https://en.wikipedia.org/wiki/Wikipedia:User_scripts), please ensure `oojs` is a dependency of your script, then use `OO` globally.
+
+## Credits
+This package uses JSDoc documentation from OOjs, which is licensed under the MIT License.
+
+```
+Copyright 2011-2017 OOjs Team and other contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/types/oojs/oojs-tests.ts
+++ b/types/oojs/oojs-tests.ts
@@ -338,10 +338,6 @@ let factory = new OO.Factory();
 // $ExpectType RegistryConstructor
 OO.Factory.super;
 
-class FactoryClass {
-    static key = 'FactoryClass';
-}
-
 class FactoryClass2 {
     static static = {
         name: 'FactoryClass2',
@@ -351,9 +347,6 @@ class FactoryClass2 {
 {
     // @ts-expect-error
     factory.register(SubClass);
-
-    // $ExpectType void
-    factory.register(FactoryClass);
 
     // $ExpectType void
     factory.register(FactoryClass2);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wikimedia/oojs/blob/master/LICENSE-MIT, https://github.com/wikimedia/oojs/commit/97a5992c8447b1b71633a24ff120c05c8552ffaa
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
