### PR TITLE
fix: deep-extend: call the function with only one object

### DIFF
--- a/types/deep-extend/deep-extend-tests.ts
+++ b/types/deep-extend/deep-extend-tests.ts
@@ -35,3 +35,4 @@ deepExtend(obj1, obj1, obj1, obj1, obj1, obj1); // More than 5 arguments
 deepExtend({ a: 1 }, { b: true }); // $ExpectType { a: number; } & { b: boolean; }
 // @ts-expect-error
 deepExtend({ a: 1 }, 1);
+deepExtend({ a: 1 }); // $ExpectType { a: number; }

--- a/types/deep-extend/index.d.ts
+++ b/types/deep-extend/index.d.ts
@@ -1,9 +1,11 @@
-// Type definitions for deep-extend 0.4
+// Type definitions for deep-extend 0.6
 // Project: https://github.com/unclechu/node-deep-extend
 // Definitions by: rhysd <https://github.com/rhysd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.9
 
 /** Recursive object extending. */
+declare function deepExtend<T extends object>(target: T): T;
 declare function deepExtend<T extends object, U extends object>(target: T, source: U): T & U;
 declare function deepExtend<T extends object, U extends object, V extends object>(
     target: T,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/unclechu/node-deep-extend/blob/master/lib/deep-extend.js#L93)>>
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
