### PR TITLE
[cookie-signature] Accept the same secret types as createHmac

### DIFF
--- a/types/cookie-signature/cookie-signature-tests.ts
+++ b/types/cookie-signature/cookie-signature-tests.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import * as cookie from "cookie-signature";
 
 let val = cookie.sign('hello', 'tobiiscool');
@@ -5,3 +7,11 @@ let val = cookie.sign('hello', 'tobiiscool');
 val = cookie.sign('hello', 'tobiiscool');
 cookie.unsign(val, 'tobiiscool');
 cookie.unsign(val, 'luna');
+
+import * as crypto from "node:crypto";
+
+val = cookie.sign('hello', crypto.createSecretKey('tobiiscool', 'ascii'));
+
+val = cookie.sign('hello', crypto.createSecretKey('tobiiscool', 'ascii'));
+cookie.unsign(val, crypto.createSecretKey('tobiiscool', 'ascii'));
+cookie.unsign(val, crypto.createSecretKey('luna', 'ascii'));

--- a/types/cookie-signature/cookie-signature-tests.ts
+++ b/types/cookie-signature/cookie-signature-tests.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 import * as cookie from "cookie-signature";
 
 let val = cookie.sign('hello', 'tobiiscool');

--- a/types/cookie-signature/index.d.ts
+++ b/types/cookie-signature/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cookie-signature 1.0
+// Type definitions for cookie-signature 1.1
 // Project: https://github.com/tj/node-cookie-signature, https://github.com/visionmedia/node-cookie-signature
 // Definitions by: Junyoung Choi <https://github.com/Rokt33r>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/cookie-signature/index.d.ts
+++ b/types/cookie-signature/index.d.ts
@@ -3,11 +3,15 @@
 // Definitions by: Junyoung Choi <https://github.com/Rokt33r>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
+import type { CipherKey } from "node:crypto";
+
 /** Sign the given `val` with `secret`. */
-export function sign(value: string, secret: string): string;
+export function sign(value: string, secret: CipherKey): string;
 
 /**
  * Unsign and decode the given `val` with `secret`,
  * returning `false` if the signature is invalid.
  */
-export function unsign(value: string, secret: string): string | false;
+export function unsign(value: string, secret: CipherKey): string | false;


### PR DESCRIPTION
cookie-signature passes the secret straight to the second argument of createHmac, so the typing should reflect that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tj/node-cookie-signature/blob/7deca8b38110a3bd65841c34359794706cc7c60f/index.js#L16-L20
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. [The version did increase, but none of the types changed.]