### PR TITLE
fix: better-sqlite3: missing readonly property on Statement

### DIFF
--- a/types/better-sqlite3/better-sqlite3-tests.ts
+++ b/types/better-sqlite3/better-sqlite3-tests.ts
@@ -55,6 +55,7 @@ vtable.all();
 
 const stmt: Sqlite.Statement = db.prepare('SELECT * FROM test WHERE name == ?;');
 stmt.busy; // $ExpectType boolean
+stmt.readonly; // $ExpectType boolean
 
 stmt.get(['name']);
 stmt.all({ name: 'name' });

--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -20,6 +20,7 @@ declare namespace BetterSqlite3 {
         database: Database;
         source: string;
         reader: boolean;
+        readonly: boolean;
         busy: boolean;
 
         run(...params: BindParameters): Database.RunResult;


### PR DESCRIPTION
This property was added in v7.3.0, while the types are for 7.6

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  https://github.com/WiseLibs/better-sqlite3/releases/tag/v7.3.0
  https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md#properties-1