### PR TITLE
[draft-js] Fix `DraftEntityType` and `DraftBlockType`

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -377,22 +377,24 @@ declare namespace Draft {
             type DraftDragType = 'internal' | 'external';
 
             /**
-             * The list of default valid block types.
+             * The list of [default valid block types](https://draftjs.org/docs/advanced-topics-custom-block-render-map#draft-default-block-render-map),
+             * according to the [`DefaultDraftBlockRenderMap`](https://github.com/facebook/draft-js/blob/main/src/model/immutable/DefaultDraftBlockRenderMap.js)
              */
             type CoreDraftBlockType =
-                | 'unstyled'
-                | 'paragraph'
                 | 'header-one'
                 | 'header-two'
                 | 'header-three'
                 | 'header-four'
                 | 'header-five'
                 | 'header-six'
+                | 'section'
+                | 'article'
                 | 'unordered-list-item'
                 | 'ordered-list-item'
                 | 'blockquote'
+                | 'atomic'
                 | 'code-block'
-                | 'atomic';
+                | 'unstyled';
 
             type CustomBlockType = string;
 
@@ -422,14 +424,9 @@ declare namespace Draft {
             type DraftInlineStyleType = 'BOLD' | 'CODE' | 'ITALIC' | 'STRIKETHROUGH' | 'UNDERLINE';
 
             /**
-             * Default entity types.
+             * Possible entity types, like 'LINK', 'IMAGE', or custom ones.
              */
-            type ComposedEntityType = 'LINK' | 'TOKEN' | 'PHOTO' | 'IMAGE';
-
-            /**
-             * Possible entity types.
-             */
-            type DraftEntityType = string | ComposedEntityType;
+            type DraftEntityType = string;
 
             /**
              * Possible "mutability" options for an entity. This refers to the behavior


### PR DESCRIPTION
This PR does
* add `article` and `section` to `CoreDraftBlockType`, while still missing in the official docs they were added in https://github.com/facebook/draft-js/pull/2212
* remove `paragraph` from `CoreDraftBlockType`, while appearing in the [API reference](https://draftjs.org/docs/api-reference-content-block) and in [their flow types](https://github.com/facebook/draft-js/blob/9f2638c98c41cb49c99da01c6e38b7d2d57403f1/src/model/constants/DraftBlockType.js#L19), it's not actually supported by the library
* remove `'TOKEN'` and `'PHOTO'` from `ComposedEntityType`. They're only mentioned in examples or are part of custom-entity tests, but are not actually supported by the library
* remove the `ComposedEntityType` altogether. It seems kinda pointless? Is this a breaking change that needs to be avoided?
* write https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/54005#discussioncomment-4197937 for the proper way to tackle more issues, but I didn't want to put them in this first PR

I did
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>