### PR TITLE
@types/google.accounts - add CodeResponse type and update tests

### DIFF
--- a/types/google.accounts/google.accounts-tests.ts
+++ b/types/google.accounts/google.accounts-tests.ts
@@ -2,13 +2,27 @@
 google.accounts.oauth2.initCodeClient({
     client_id: '',
     scope: '',
+    callback: response => {
+        // $ExpectType string
+        response.code;
+        // $ExpectType string
+        response.scope;
+        // $ExpectType string
+        response.state;
+        // $ExpectType string
+        response.error;
+        // $ExpectType string
+        response.error_description;
+        // $ExpectType string
+        response.error_uri;
+    }
 });
 
 // $ExpectType TokenClient
 google.accounts.oauth2.initTokenClient({
     client_id: '',
     callback: response => {
-        // response.access_token
+        // $ExpectType string
         response.access_token;
         // $ExpectType string
         response.expires_in;

--- a/types/google.accounts/index.d.ts
+++ b/types/google.accounts/index.d.ts
@@ -87,7 +87,7 @@ declare namespace google.accounts {
          * A TokenResponse JavaScript object will be passed to your callback
          * method (as defined in TokenClientConfig) in the popup UX.
          */
-         interface TokenResponse {
+        interface TokenResponse {
             /**
              * The access token of a successful token response.
              */

--- a/types/google.accounts/index.d.ts
+++ b/types/google.accounts/index.d.ts
@@ -85,9 +85,9 @@ declare namespace google.accounts {
 
         /**
          * A TokenResponse JavaScript object will be passed to your callback
-         * method in the popup UX.
+         * method (as defined in TokenClientConfig) in the popup UX.
          */
-        interface TokenResponse {
+         interface TokenResponse {
             /**
              * The access token of a successful token response.
              */
@@ -134,6 +134,47 @@ declare namespace google.accounts {
              * Human-readable ASCII text providing additional information, used
              * to assist the client developer in understanding the error that
              * occurred.
+             */
+            error_description: string;
+
+            /**
+             * A URI identifying a human-readable web page with information
+             * about the error, used to provide the client developer with
+             * additional information about the error.
+             */
+            error_uri: string;
+        }
+
+        /**
+         * A CodeResponse JavaScript object will be passed to your callback
+         * method (as defined in CodeClientConfig) in the popup UX.
+         */
+        interface CodeResponse {
+            /**
+             * The authorization code of a successful token response.
+             */
+            code: string;
+
+            /**
+             * A space-delimited list of scopes that are approved by the user.
+             */
+            scope: string;
+
+            /**
+             * The string value that your application uses to maintain state
+             * between your authorization request and the response.
+             */
+            state: string;
+
+            /**
+             * A single ASCII error code.
+             */
+            error: string;
+
+            /**
+             * Human-readable ASCII text providing additional information,
+             * used to assist the client developer in understanding
+             * the error that occurred.
              */
             error_description: string;
 
@@ -246,7 +287,7 @@ declare namespace google.accounts {
              * returned code response. The property will be ignored by the
              * redirect UX.
              */
-            callback?: (response: unknown) => void;
+            callback?: (response: CodeResponse) => void;
 
             /**
              * Optional. Recommended for redirect UX. Specifies any string value


### PR DESCRIPTION
The `google.accounts` package was using `unknown` in place of a `CodeResponse` type defined in the library's [official documentation](https://developers.google.com/identity/oauth2/web/reference/js-reference#CodeResponse). This PR defines the `CodeResponse` type, updates the `callback` property of the `CodeClientConfig` type to use `CodeResponse` instead of `unknown`, and updates `google.accounts-tests.ts` accordingly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/identity/oauth2/web/reference/js-reference#CodeResponse
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
