### PR TITLE
Update onAuthenticate function - resolve to boolean or promise<boolean>

### DIFF
--- a/types/swagger-stats/index.d.ts
+++ b/types/swagger-stats/index.d.ts
@@ -104,7 +104,7 @@ export type SWStats = Partial<{
    * - password - password
    * Must return true if user authenticated, false if not.
    */
-  onAuthenticate: (req: IncomingMessage, username: string, password: string) => boolean;
+  onAuthenticate: (req: IncomingMessage, username: string, password: string) => boolean | Promise<boolean>;
   /**
    * If authentication is enabled, max age of the session, in seconds.
    *


### PR DESCRIPTION
onAuthenticate function must resolve to boolean or a Promise<boolean> with the objective of use async/await inside the callback. This way, i will be able to get user from my database

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
My example: 

onAuthenticate:  async (req, username, password)=> {
      return await authService.validateSwaggerStatusUser(username, password) ;
 } 


Without "Promise<boolean>" will give an error saying must be boolean;
With Promise<boolean> will pass;
