### PR TITLE
[yargs] Remove re-export of missing type

### DIFF
--- a/types/yargs/index.d.mts
+++ b/types/yargs/index.d.mts
@@ -29,7 +29,6 @@ export type {
     ToNumber,
     InferredOptionType,
     InferredOptionTypeInner,
-    RequiredOptionType,
     InferredOptionTypes,
     CommandModule,
     ParseCallback,

--- a/types/yargs/index.d.mts
+++ b/types/yargs/index.d.mts
@@ -28,6 +28,7 @@ export type {
     ToString,
     ToNumber,
     InferredOptionType,
+    InferredOptionTypePrimitive,
     InferredOptionTypeInner,
     InferredOptionTypes,
     CommandModule,


### PR DESCRIPTION
#63205 rearranged some of the types in `types/yargs/index.d.ts`, including removing `RequiredOptionType`, but the `index.d.mts` file for ESM consumers still tries to export that type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
