### PR TITLE
[wordpress__components] Add missing `label` from `FormTokenField`

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -507,7 +507,7 @@ export type Transform<T extends Record<string, any> = Record<string, any>> =
 
 export type BlockAttributes = Record<string, any>;
 
-export type InnerBlockTemplate = [string, BlockAttributes | undefined, InnerBlockTemplate[] | undefined];
+export type InnerBlockTemplate = [string, BlockAttributes?, InnerBlockTemplate[]?];
 
 export type BlockVariationScope = 'block' | 'inserter' | 'transform';
 

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -514,6 +514,14 @@ blocks.getBlockVariations('core/columns');
 blocks.registerBlockVariation('core/columns', {
     name: 'core/columns/variation',
     title: 'Core Column Variation',
+    innerBlocks: [
+        [ 'core/paragraph' ],
+        [
+            'core/paragraph',
+            { placeholder: 'Enter side content...' },
+            [ [ 'core/paragraph' ] ]
+        ],
+    ],
 });
 
 // $ExpectType void

--- a/types/wordpress__components/form-token-field/index.d.ts
+++ b/types/wordpress__components/form-token-field/index.d.ts
@@ -3,6 +3,10 @@ import { ComponentType, FocusEventHandler, MouseEventHandler } from 'react';
 declare namespace FormTokenField {
     interface Props {
         /**
+         * The label for the control.
+         */
+        label?: string | undefined;
+        /**
          * An array of strings or objects to display as tokens in the field. If
          * objects are present in the array, they **must** have a property of
          * `value`. Here is an example object that could be passed in as a value:

--- a/types/wordpress__components/wordpress__components-tests.tsx
+++ b/types/wordpress__components/wordpress__components-tests.tsx
@@ -426,6 +426,7 @@ const buttonGroupRef = createRef<HTMLDivElement>();
 // form-token-field
 //
 <C.FormTokenField
+    label={'Select a FooBar'}
     value={[
         'foo',
         {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://wordpress.github.io/gutenberg/?path=/story/components-formtokenfield--default
