### PR TITLE
Update remark and unified package versions for remark-prism

### DIFF
--- a/types/remark-prism/index.d.ts
+++ b/types/remark-prism/index.d.ts
@@ -29,7 +29,7 @@ declare namespace remarkPrism {
      * Plugin to use prism with remark.
      * https://github.com/unifiedjs/unified/blob/main/index.d.ts#L488-L489
      */
-    type Prism = Plugin<[Options?] | void[], Root, Root>;
+    type Prism = Plugin<[Options?] | undefined[], Root, Root>;
 }
 
 declare const remarkPrism: remarkPrism.Prism;

--- a/types/remark-prism/index.d.ts
+++ b/types/remark-prism/index.d.ts
@@ -5,6 +5,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.0
 
+import { Root } from 'mdast';
+import { Plugin } from 'unified';
+
 type SupportedPlugins =
     | 'autolinker'
     | 'command-line'
@@ -17,15 +20,16 @@ type SupportedPlugins =
     | 'treeview';
 
 declare namespace remarkPrism {
-    /**
-     * Plugin to use prism with remark.
-     * https://github.com/unifiedjs/unified/blob/main/index.d.ts#L488-L489
-     */
-    type Prism = (settings?: Options) => void;
     interface Options {
         transformInlineCode?: boolean;
         plugins?: SupportedPlugins[];
     }
+
+    /**
+     * Plugin to use prism with remark.
+     * https://github.com/unifiedjs/unified/blob/main/index.d.ts#L488-L489
+     */
+    type Prism = Plugin<[Options?] | void[], Root, Root>;
 }
 
 declare const remarkPrism: remarkPrism.Prism;

--- a/types/remark-prism/package.json
+++ b/types/remark-prism/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "remark": "^12.0.0",
-        "unified": "^9.2.1"
+        "remark": "^14.0.2",
+        "unified": "^10.0.0"
     }
 }

--- a/types/remark-prism/remark-prism-tests.ts
+++ b/types/remark-prism/remark-prism-tests.ts
@@ -1,7 +1,7 @@
 import remark = require('remark');
 import remarkPrism = require('remark-prism');
 
-remark().use(remarkPrism);
+remark.remark().use(remarkPrism);
 
 const options: remarkPrism.Options = {
     transformInlineCode: true,
@@ -17,9 +17,9 @@ const options: remarkPrism.Options = {
         'treeview',
     ],
 };
-remark().use(remarkPrism, options);
+remark.remark().use(remarkPrism, options);
 
 const partialOptions: remarkPrism.Options = {
     plugins: ['show-invisibles', 'autolinker'],
 };
-remark().use(remarkPrism, partialOptions);
+remark.remark().use(remarkPrism, partialOptions);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

Made these changes for two reasons -
1. The packages this definition depends on have high severity vulnerabilities - [Here is the advisory](https://github.com/advisories/GHSA-w5p7-h5w8-2hfq). Below is the `npm audit` log
```
trim  <0.0.3
Severity: high
Regular Expression Denial of Service in trim - https://github.com/advisories/GHSA-w5p7-h5w8-2hfq
No fix available
node_modules/trim
  remark-parse  <=8.0.3
  Depends on vulnerable versions of trim
  node_modules/@types/remark-prism/node_modules/remark-parse
    remark  5.0.0 - 12.0.1
    Depends on vulnerable versions of remark-parse
    node_modules/@types/remark-prism/node_modules/remark
      @types/remark-prism  *
      Depends on vulnerable versions of remark
      node_modules/@types/remark-prism

4 high severity vulnerabilities
``` 

2. The definition does not follow the preferred way of typing remark-prism plugin mentioned here - https://github.com/remarkjs/remark/blob/main/readme.md?plain=1#L378-L381

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
