### PR TITLE
fix(applest-atem): correct invalid test

### DIFF
--- a/types/applest-atem/applest-atem-tests.ts
+++ b/types/applest-atem/applest-atem-tests.ts
@@ -44,7 +44,7 @@ const state: ATEM.State = {
         numberOfDVEs: 0,
         numberOfSuperSources: 0,
     },
-    tallys: [1, 3, 0, 2, 0, 1],
+    tallys: [1, 0, 2, 0, 1],
     channels: {
         0: { name: 'Black', label: 'BLK' },
         1: { name: 'SDI 1', label: 'SDI1' },


### PR DESCRIPTION
Under TS5.0 CI now catches invalid enum value. The source (.d.ts) lists removed value as todo:
```ts
// TODO: 3 is also a valid option
```
but without implementation.

Fixing for a greater cause (@types/node):
https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/3554168943/jobs/5970098761#step:6:3397

Thanks!

/cc @Semigradsky

x-ref: #63201

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the changes