### PR TITLE
fix(parse): change flaky tests failing under TSv5

### DIFF
--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -618,9 +618,6 @@ async function test_cloud_functions() {
         // result
     });
 
-    const CUSTOM_ERROR_INVALID_CONDITION = 1001;
-    const CUSTOM_ERROR_IMMUTABLE_FIELD = 1002;
-
     interface BeforeSaveObject {
         immutable: boolean;
     }
@@ -632,14 +629,11 @@ async function test_cloud_functions() {
             const original = request.original;
             if (original == null) {
                 // When the object is not new, request.original must be defined
-                throw new Parse.Error(
-                    CUSTOM_ERROR_INVALID_CONDITION,
-                    'Original must me defined for an existing object',
-                );
+                throw new Error('Original must me defined for an existing object');
             }
 
             if (original.get('immutable') !== request.object.get('immutable')) {
-                throw new Parse.Error(CUSTOM_ERROR_IMMUTABLE_FIELD, 'This field cannot be changed');
+                throw new Error('This field cannot be changed');
             }
         }
         if (!request.context) {


### PR DESCRIPTION
Under TS CI tests now catch invalid param enum value when using Parse.Error.
Corrected to use default Error as per docs:
https://docs.parseplatform.org/cloudcode/guide/#beforelogin

Fixed for greater cause failing @types/node tests: https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/3554168943/jobs/5970098761#step:6:3418

/cc @Semiradzki
x-ref: #63201

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)