### PR TITLE
[gettext-parser] Fix typing of Po parser export and add typing for `createParseStream`

### DIFF
--- a/types/gettext-parser/gettext-parser-tests.ts
+++ b/types/gettext-parser/gettext-parser-tests.ts
@@ -4,6 +4,10 @@ let parsed = po.parse("foo", "utf-8");
 let compiled = po.compile(parsed, {});
 parsed = po.parse(Buffer.from("bar"));
 compiled = po.compile(parsed, { anyOption: false });
+const stream = po.createParseStream(Buffer.from("bar"));
+stream.on('data', (data) => {
+    console.log(data);
+});
 
 parsed = mo.parse(compiled, "wrong-charset");
 compiled = mo.compile(parsed, { noOption: 3 });

--- a/types/gettext-parser/index.d.ts
+++ b/types/gettext-parser/index.d.ts
@@ -5,6 +5,8 @@
 
 /// <reference types="node" />
 
+import { Transform } from "readable-stream";
+
 export interface GetTextComment {
     translator: string;
     reference: string;
@@ -30,7 +32,7 @@ export interface GetTextTranslations {
 export interface PoParser {
     parse: (buffer: Buffer | string, defaultCharset?: string) => GetTextTranslations;
     compile: (table: GetTextTranslations, options?: any) => Buffer;
-    createParseStream: (buffer: any, defaultCharset?: string) => any;
+    createParseStream: (buffer: any, defaultCharset?: string) => Transform;
 }
 
 export interface MoParser {
@@ -38,5 +40,5 @@ export interface MoParser {
     compile: (table: GetTextTranslations, options?: any) => Buffer;
 }
 
-export const po: MoParser;
+export const po: PoParser;
 export const mo: MoParser;


### PR DESCRIPTION
The exports `po` and `mo` were both typed as `MoParser` but `po` should be of type `PoParser`.
Also added typing for return value of `createParseStream` instead of using `any`.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/smhg/gettext-parser/blob/v4.0.0/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
