### PR TITLE
[relay-runtime] missingFieldsHandler is a `ReadOnlyRecordProxy`

### DIFF
--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -16,7 +16,7 @@ import {
     NormalizationSelectableNode,
     NormalizationSplitOperation,
 } from '../util/NormalizationNode';
-import { ReaderFragment } from '../util/ReaderNode';
+import { ReaderFragment, ReaderLinkedField } from '../util/ReaderNode';
 import { ConcreteRequest, RequestParameters } from '../util/RelayConcreteNode';
 import { CacheConfig, DataID, Disposable, FetchPolicy, RenderPolicy, Variables } from '../util/RelayRuntimeTypes';
 import { InvalidationState } from './RelayModernStore';
@@ -893,7 +893,7 @@ export type MissingFieldHandler =
           kind: 'scalar';
           handle: (
               field: NormalizationScalarField,
-              record: Record | null | undefined,
+              parentRecord: ReadOnlyRecordProxy | null | undefined,
               args: Variables,
               store: ReadOnlyRecordSourceProxy,
           ) => unknown;
@@ -901,8 +901,8 @@ export type MissingFieldHandler =
     | {
           kind: 'linked';
           handle: (
-              field: NormalizationLinkedField,
-              record: Record | null | undefined,
+              field: NormalizationLinkedField | ReaderLinkedField,
+              parentRecord: ReadOnlyRecordProxy | null | undefined,
               args: Variables,
               store: ReadOnlyRecordSourceProxy,
           ) => DataID | null | undefined;
@@ -910,8 +910,8 @@ export type MissingFieldHandler =
     | {
           kind: 'pluralLinked';
           handle: (
-              field: NormalizationLinkedField,
-              record: Record | null | undefined,
+              field: NormalizationLinkedField | ReaderLinkedField,
+              parentRecord: ReadOnlyRecordProxy | null | undefined,
               args: Variables,
               store: ReadOnlyRecordSourceProxy,
           ) => Array<DataID | null | undefined> | null | undefined;

--- a/types/relay-runtime/lib/util/ReaderNode.d.ts
+++ b/types/relay-runtime/lib/util/ReaderNode.d.ts
@@ -13,6 +13,17 @@ export interface ReaderInlineDataFragmentSpread {
     readonly selections: ReadonlyArray<ReaderSelection>;
 }
 
+export interface ReaderLinkedField {
+    readonly kind: string; // 'LinkedField';
+    readonly alias?: string | null | undefined;
+    readonly name: string;
+    readonly storageKey?: string | null | undefined;
+    readonly args?: ReadonlyArray<ReaderArgument> | null | undefined;
+    readonly concreteType?: string | null | undefined;
+    readonly plural: boolean;
+    readonly selections: ReadonlyArray<ReaderSelection>;
+}
+
 export interface ReaderFragment {
     readonly kind: string; // 'Fragment';
     readonly name: string;

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -94,7 +94,7 @@ const environment = new Environment({
             handle(field, record, argValues) {
                 if (
                     record != null &&
-                    record.__typename === ROOT_TYPE &&
+                    record.getType() === ROOT_TYPE &&
                     field.name === 'user' &&
                     argValues.hasOwnProperty('id')
                 ) {
@@ -103,7 +103,7 @@ const environment = new Environment({
                 }
                 if (
                     record != null &&
-                    record.__typename === ROOT_TYPE &&
+                    record.getType() === ROOT_TYPE &&
                     field.name === 'story' &&
                     argValues.hasOwnProperty('story_id')
                 ) {
@@ -162,11 +162,11 @@ function handlerProvider(handle: any) {
 interface UserFragment_updatable$data {
     name: string | null;
     readonly id: string;
-    readonly " $fragmentType": "UserFragment_updatable";
+    readonly ' $fragmentType': 'UserFragment_updatable';
 }
 interface UserFragment_updatable$key {
-    readonly " $data"?: UserFragment_updatable$data;
-    readonly $updatableFragmentSpreads: FragmentRefs<"UserFragment_updatable">;
+    readonly ' $data'?: UserFragment_updatable$data;
+    readonly $updatableFragmentSpreads: FragmentRefs<'UserFragment_updatable'>;
 }
 
 function storeUpdater(store: RecordSourceSelectorProxy, dataRef: UserFragment_updatable$key) {
@@ -185,9 +185,9 @@ function storeUpdater(store: RecordSourceSelectorProxy, dataRef: UserFragment_up
                 name
             }
         `,
-        dataRef
+        dataRef,
     );
-    updatableData.name = "NewName";
+    updatableData.name = 'NewName';
 }
 
 interface MessageEdge {


### PR DESCRIPTION
Updates the types to correct the `record` argument to be a `ReadOnlyRecordProxy`. 

See 👉 https://github.com/facebook/relay/blob/cd3f7033183ef27009f6ff2cd05080219fce9b35/packages/relay-runtime/store/RelayStoreTypes.js#L1084