### PR TITLE
[chrome-remote-interface] add support for `Network.enable()` and its ilk

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -20,7 +20,11 @@ function assertType<T>(value: T): T {
             if (message.method === 'Network.requestWillBeSent') {}
         });
         const { Network, Page, Runtime } = client;
+        await Network.enable();
         await Network.enable({});
+        // @ts-expect-error
+        await Network.setAcceptedEncodings();
+        await Network.setAcceptedEncodings({encodings: []});
         await Page.enable();
         await Page.navigate({ url: 'https://github.com' });
         const loadEvent = await client['Page.loadEventFired'](); // instead of: await Page.loadEventFired();

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -153,22 +153,20 @@ declare namespace CDP {
     // Generated content end.
     /////////////////////////////////////////////////
 
-    type Client = {
-        close: () => Promise<void>;
-        on(event: 'event', callback: (message: EventMessage) => void): void;
-        on(event: 'ready' | 'disconnect', callback: () => void): void;
-        // '<domain>.<method>' i.e. Network.requestWillBeSent
-        on<T extends keyof ProtocolMappingApi.Events>(event: T, callback: (params: ProtocolMappingApi.Events[T][0], sessionId?: string) => void): void;
-        // '<domain>.<method>.<sessionId>' i.e. Network.requestWillBeSent.abc123
-        on(event: string, callback: (params: object, sessionId?: string) => void): void;
-        // client.send(method, [params], [sessionId], [callback])
-        send<T extends keyof ProtocolMappingApi.Commands>(event: T, callback: SendCallback<T>): void;
-        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], callback: SendCallback<T>): void;
-        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId: string, callback: SendCallback<T>): void;
-        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params?: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId?: string):
-            Promise<ProtocolMappingApi.Commands[T]['returnType']>;
-
-        // stable domains
+    type IsNullableObj<T> = Record<keyof T, undefined> extends T ? true : false;
+    /**
+     * Checks whether the only parameter of `T[key]` is nullable i.e. all of
+     * its properties are optional, and makes it optional if so.
+     */
+    type OptIfParamNullable<T> = {
+        [key in keyof T]: T[key] extends (params: any) => any ?
+            IsNullableObj<Parameters<T[key]>[0]> extends true ?
+                (params?: Parameters<T[key]>[0]) => ReturnType<T[key]> :
+                T[key] :
+            T[key]
+    };
+    type ImproveAPI<T> = {[key in keyof T]: OptIfParamNullable<T[key]>};
+    interface StableDomains {
         Browser: ProtocolProxyApi.BrowserApi;
         Debugger: ProtocolProxyApi.DebuggerApi;
         DOM: ProtocolProxyApi.DOMApi;
@@ -184,14 +182,14 @@ declare namespace CDP {
         Runtime: ProtocolProxyApi.RuntimeApi;
         Security: ProtocolProxyApi.SecurityApi;
         Target: ProtocolProxyApi.TargetApi;
-
-        // deprecated domains
+    }
+    interface DeprecatedDomains {
         /** @deprecated This domain is deprecated - use Runtime or Log instead. */
         Console: ProtocolProxyApi.ConsoleApi;
         /** @deprecated This domain is deprecated. */
         Schema: ProtocolProxyApi.SchemaApi;
-
-        // experimental domains
+    }
+    interface ExperimentalDomains {
         /** @deprecated this API is experimental. */
         Accessibility: ProtocolProxyApi.AccessibilityApi;
         /** @deprecated this API is experimental. */
@@ -248,7 +246,23 @@ declare namespace CDP {
         WebAudio: ProtocolProxyApi.WebAudioApi;
         /** @deprecated this API is experimental. */
         WebAuthn: ProtocolProxyApi.WebAuthnApi;
-    } & EventPromises<ProtocolMappingApi.Events> & EventCallbacks<ProtocolMappingApi.Events>;
+    }
+    type AllDomains = StableDomains & DeprecatedDomains & ExperimentalDomains;
+    type Client = {
+        close: () => Promise<void>;
+        on(event: 'event', callback: (message: EventMessage) => void): void;
+        on(event: 'ready' | 'disconnect', callback: () => void): void;
+        // '<domain>.<method>' i.e. Network.requestWillBeSent
+        on<T extends keyof ProtocolMappingApi.Events>(event: T, callback: (params: ProtocolMappingApi.Events[T][0], sessionId?: string) => void): void;
+        // '<domain>.<method>.<sessionId>' i.e. Network.requestWillBeSent.abc123
+        on(event: string, callback: (params: object, sessionId?: string) => void): void;
+        // client.send(method, [params], [sessionId], [callback])
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, callback: SendCallback<T>): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], callback: SendCallback<T>): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId: string, callback: SendCallback<T>): void;
+        send<T extends keyof ProtocolMappingApi.Commands>(event: T, params?: ProtocolMappingApi.Commands[T]['paramsType'][0], sessionId?: string):
+            Promise<ProtocolMappingApi.Commands[T]['returnType']>;
+    } & EventPromises<ProtocolMappingApi.Events> & EventCallbacks<ProtocolMappingApi.Events> & ImproveAPI<AllDomains>;
 
     // '<domain>.<event>' i.e. Page.loadEventFired
     type EventPromises<T extends ProtocolMappingApi.Events> = {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cyrus-and/chrome-remote-interface/issues/500#issuecomment-1248272589 (2nd item in the list)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I thought it was not possible to support
```ts
Network.enable()
```
in addition to
```ts
Network.enable({})
```
. It turns out that I was wrong (with current versions of TypeScript that is).

Btw, the beginning of the `Client` type has not been changed (deliberately). It's just the diff algorithm getting confused.