### PR TITLE
[buffer-crc32] type fixes (partials, strings)

### DIFF
--- a/types/buffer-crc32/buffer-crc32-tests.ts
+++ b/types/buffer-crc32/buffer-crc32-tests.ts
@@ -5,7 +5,15 @@ crc32(buf); // $ExpectType Buffer
 crc32('自動販売機'); // $ExpectType Buffer
 
 crc32.signed(buf); // $ExpectType number
+crc32.signed('自動販売機'); // $ExpectType number
 crc32.unsigned(buf); // $ExpectType number
+crc32.unsigned('自動販売機'); // $ExpectType number
 
 const partialCrc = crc32('hey');
 crc32(' ', partialCrc); // $ExpectType Buffer
+
+const partialUnsignedCrc = crc32.unsigned('hey');
+crc32.unsigned(' ', partialUnsignedCrc); // $ExpectType number
+
+const partialSignedCrc = crc32.signed('hey');
+crc32.signed(' ', partialSignedCrc); // $ExpectType number

--- a/types/buffer-crc32/index.d.ts
+++ b/types/buffer-crc32/index.d.ts
@@ -10,6 +10,6 @@ export = crc32;
 declare function crc32(input: string | Buffer, partialCrc?: Buffer | number): Buffer;
 
 declare namespace crc32 {
-    function signed(buffer: Buffer, partialCrc?: Buffer | number): number;
-    function unsigned(buffer: Buffer, partialCrc?: Buffer | number): number;
+    function signed(buffer: string | Buffer, partialCrc?: Buffer | number): number;
+    function unsigned(buffer: string | Buffer, partialCrc?: Buffer | number): number;
 }

--- a/types/buffer-crc32/index.d.ts
+++ b/types/buffer-crc32/index.d.ts
@@ -7,9 +7,9 @@
 
 export = crc32;
 
-declare function crc32(input: string | Buffer, partialCrc?: Buffer): Buffer;
+declare function crc32(input: string | Buffer, partialCrc?: Buffer | number): Buffer;
 
 declare namespace crc32 {
-    function signed(buffer: Buffer): number;
-    function unsigned(buffer: Buffer): number;
+    function signed(buffer: Buffer, partialCrc?: Buffer | number): number;
+    function unsigned(buffer: Buffer, partialCrc?: Buffer | number): number;
 }


### PR DESCRIPTION
- Correctly allows 'partial' value (either number or buffer) passed in as second arg to `signed` and `unsigned`
- Source: https://github.com/brianloveswords/buffer-crc32/blob/62cfcdb738845626d8d66eadf2bf303d58afe05e/index.js#L110

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
