### PR TITLE
Make Braintree Subscription type property paidThroughDate nullable.

### DIFF
--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -1293,7 +1293,7 @@ declare namespace braintree {
         nextBillingDate: string;
         nextBillingPeriodAmount: string;
         numberOfBillingCycles?: number | undefined;
-        paidThroughDate: Date;
+        paidThroughDate?: Date | undefined;
         paymentMethodToken: string;
         planId: string;
         price?: string | undefined;


### PR DESCRIPTION
The `Subscription` property `paidThroughDate` is described as nullable in the [Braintree API docs](https://developer.paypal.com/braintree/docs/reference/response/subscription#paid_through_date).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Braintree API](https://developer.paypal.com/braintree/docs/reference/response/subscription#paid_through_date)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
