### PR TITLE
[win-ca] Add new win-ca typings

### DIFF
--- a/types/win-ca/OTHER_FILES.txt
+++ b/types/win-ca/OTHER_FILES.txt
@@ -1,0 +1,2 @@
+api.d.ts
+fallback.d.ts

--- a/types/win-ca/api.d.ts
+++ b/types/win-ca/api.d.ts
@@ -1,0 +1,7 @@
+import Api, { CaOptions, Certificate, der2, Store } from "./";
+
+declare module 'win-ca/api';
+
+export default Api;
+export { der2, Certificate, Store, CaOptions };
+

--- a/types/win-ca/api.d.ts
+++ b/types/win-ca/api.d.ts
@@ -1,4 +1,3 @@
-import Api, { CaOptions, Certificate, der2, Store } from "./";
+import Api from "./";
 
-export default Api;
-export { der2, Certificate, Store, CaOptions };
+export = Api;

--- a/types/win-ca/api.d.ts
+++ b/types/win-ca/api.d.ts
@@ -1,7 +1,4 @@
 import Api, { CaOptions, Certificate, der2, Store } from "./";
 
-declare module 'win-ca/api';
-
 export default Api;
 export { der2, Certificate, Store, CaOptions };
-

--- a/types/win-ca/fallback.d.ts
+++ b/types/win-ca/fallback.d.ts
@@ -1,0 +1,7 @@
+import Api, { CaOptions, Certificate, der2, Store } from "./";
+
+declare module 'win-ca/fallback';
+
+export default Api;
+export { der2, Certificate, Store, CaOptions };
+

--- a/types/win-ca/fallback.d.ts
+++ b/types/win-ca/fallback.d.ts
@@ -1,7 +1,4 @@
 import Api, { CaOptions, Certificate, der2, Store } from "./";
 
-declare module 'win-ca/fallback';
-
 export default Api;
 export { der2, Certificate, Store, CaOptions };
-

--- a/types/win-ca/fallback.d.ts
+++ b/types/win-ca/fallback.d.ts
@@ -1,4 +1,3 @@
-import Api, { CaOptions, Certificate, der2, Store } from "./";
+import Api from "./";
 
-export default Api;
-export { der2, Certificate, Store, CaOptions };
+export = Api;

--- a/types/win-ca/index.d.ts
+++ b/types/win-ca/index.d.ts
@@ -7,55 +7,58 @@
 
 import { pki } from "node-forge";
 
-export enum der2 {
-    /** DER-format (binary, Node's Buffer) */
-    der = 0,
-    /** PEM-format (text, Base64-encoded) */
-    pem = 1,
-    /** PEM-format plus some laconic header */
-    txt = 2,
-    /** ASN.1-parsed certificate */
-    asn1 = 3,
-    /** Certificate in node-forge format (RSA only!) */
-    x509 = 4,
+declare namespace Api {
+    enum der2 {
+        /** DER-format (binary, Node's Buffer) */
+        der = 0,
+        /** PEM-format (text, Base64-encoded) */
+        pem = 1,
+        /** PEM-format plus some laconic header */
+        txt = 2,
+        /** ASN.1-parsed certificate */
+        asn1 = 3,
+        /** Certificate in node-forge format (RSA only!) */
+        x509 = 4,
+    }
+
+    type Store = "root" | "ca" | "my" | "trustedpublisher";
+    type Certificate = Buffer | string | pki.Certificate;
+
+    interface CaOptions {
+        /** which Windows' store to use. Default is Root (ie Trusted Root Certification Authorities). */
+        store: Store[];
+        /** how to save certificates to disk (default: false, ie use no I/O at all) */
+        save?: boolean;
+        /** whether certificates list should be deduplicated. Default is true (no duplicates returned). */
+        unique?: boolean;
+        /** defines representation of certificates to fetch. */
+        format: der2;
+        /** callback fired for each certificate found. */
+        ondata?: Certificate[] | ((...items: Certificate[]) => void);
+        /** callback fired (with no parameters) at the end of retrieval */
+        onend?: () => void;
+        /** callback called at the end of saving (if save is truthy) */
+        onsave?: () => void;
+        /**
+         * boolean flag, indicating N-API shouldn't be used even if it is available.
+         * Default value depends on Node.js version (4, 5 and 7 {fallback: true}; modern versions {fallback: false}).
+         * It is also true if Electron is detected.
+         */
+        fallback?: boolean;
+        /** boolean flag to make retrieval process asynchronous (false by default) */
+        async?: boolean;
+        /** boolean flag to emulate ES6 generator (default: false) */
+        generator?: boolean;
+        /**
+         * how to install certificates (default: false, ie just fetch from store, do not install).
+         * If set to true, certificated fetched will be also added to https.globalAgent.options.ca
+         * (in PEM format, regardless of format parameter), so all subsequent calls to https client
+         * methods (https.request, https.get etc.) will silently use them instead of built-in ones.
+         */
+        inject?: boolean;
+    }
 }
 
-export type Store = "root" | "ca" | "my" | "trustedpublisher";
-export type Certificate = Buffer | string | pki.Certificate;
+declare function Api(params: Api.CaOptions): void;
 
-export interface CaOptions {
-    /** which Windows' store to use. Default is Root (ie Trusted Root Certification Authorities). */
-    store: Store[];
-    /** how to save certificates to disk (default: false, ie use no I/O at all) */
-    save?: boolean;
-    /** whether certificates list should be deduplicated. Default is true (no duplicates returned). */
-    unique?: boolean;
-    /** defines representation of certificates to fetch. */
-    format: der2;
-    /** callback fired for each certificate found. */
-    ondata?: Certificate[] | ((...items: Certificate[]) => void);
-    /** callback fired (with no parameters) at the end of retrieval */
-    onend?: () => void;
-    /** callback called at the end of saving (if save is truthy) */
-    onsave?: () => void;
-    /**
-     * boolean flag, indicating N-API shouldn't be used even if it is available.
-     * Default value depends on Node.js version (4, 5 and 7 {fallback: true}; modern versions {fallback: false}).
-     * It is also true if Electron is detected.
-     */
-    fallback?: boolean;
-    /** boolean flag to make retrieval process asynchronous (false by default) */
-    async?: boolean;
-    /** boolean flag to emulate ES6 generator (default: false) */
-    generator?: boolean;
-    /**
-     * how to install certificates (default: false, ie just fetch from store, do not install).
-     * If set to true, certificated fetched will be also added to https.globalAgent.options.ca
-     * (in PEM format, regardless of format parameter), so all subsequent calls to https client
-     * methods (https.request, https.get etc.) will silently use them instead of built-in ones.
-     */
-    inject?: boolean;
-}
-declare function Api(params: CaOptions): void;
-
-export default Api;
+export = Api;

--- a/types/win-ca/index.d.ts
+++ b/types/win-ca/index.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for win-ca 3.5
+// Project: https://github.com/ukoloff/win-ca
+// Definitions by: Marcos Junior <https://github.com/junalmeida>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+/// <reference types="node-forge" />
+
+import { pki } from "node-forge";
+
+export enum der2 {
+    /** DER-format (binary, Node's Buffer) */
+    der = 0,
+    /** PEM-format (text, Base64-encoded) */
+    pem = 1,
+    /** PEM-format plus some laconic header */
+    txt = 2,
+    /** ASN.1-parsed certificate */
+    asn1 = 3,
+    /** Certificate in node-forge format (RSA only!) */
+    x509 = 4,
+}
+
+export type Store = "root" | "ca" | "my" | "trustedpublisher";
+export type Certificate = Buffer | string | pki.Certificate;
+
+export interface CaOptions {
+    /** which Windows' store to use. Default is Root (ie Trusted Root Certification Authorities). */
+    store: Store[],
+    /** how to save certificates to disk (default: false, ie use no I/O at all) */
+    save?: boolean;
+    /** whether certificates list should be deduplicated. Default is true (no duplicates returned). */
+    unique?: boolean;
+    /** defines representation of certificates to fetch. */
+    format: der2,
+    /** callback fired for each certificate found. */
+    ondata?: Certificate[] | ((...items: Certificate[]) => void);
+    /** callback fired (with no parameters) at the end of retrieval */
+    onend?: () => void;
+    /** callback called at the end of saving (if save is truthy).*/
+    onsave?: () => void;
+    /** boolean flag, indicating N-API shouldn't be used even if it is available.
+     * Default value depends on Node.js version (4, 5 and 7 {fallback: true}; modern versions {fallback: false}). It is also true if Electron is detected.*/
+    fallback?: boolean;
+    /** boolean flag to make retrieval process asynchronous (false by default) */
+    async?: boolean;
+    /** boolean flag to emulate ES6 generator (default: false) */
+    generator?: boolean;
+    /** how to install certificates (default: false, ie just fetch from store, do not install). If set to true, certificated fetched will be also added to https.globalAgent.options.ca (in PEM format, regardless of format parameter), so all subsequent calls to https client methods (https.request, https.get etc.) will silently use them instead of built-in ones. */
+    inject?: boolean;
+}
+declare function Api(params: CaOptions): void;
+
+
+declare module "win-ca";
+export default Api;

--- a/types/win-ca/index.d.ts
+++ b/types/win-ca/index.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-/// <reference types="node-forge" />
 
 import { pki } from "node-forge";
 
@@ -26,31 +25,37 @@ export type Certificate = Buffer | string | pki.Certificate;
 
 export interface CaOptions {
     /** which Windows' store to use. Default is Root (ie Trusted Root Certification Authorities). */
-    store: Store[],
+    store: Store[];
     /** how to save certificates to disk (default: false, ie use no I/O at all) */
     save?: boolean;
     /** whether certificates list should be deduplicated. Default is true (no duplicates returned). */
     unique?: boolean;
     /** defines representation of certificates to fetch. */
-    format: der2,
+    format: der2;
     /** callback fired for each certificate found. */
     ondata?: Certificate[] | ((...items: Certificate[]) => void);
     /** callback fired (with no parameters) at the end of retrieval */
     onend?: () => void;
-    /** callback called at the end of saving (if save is truthy).*/
+    /** callback called at the end of saving (if save is truthy) */
     onsave?: () => void;
-    /** boolean flag, indicating N-API shouldn't be used even if it is available.
-     * Default value depends on Node.js version (4, 5 and 7 {fallback: true}; modern versions {fallback: false}). It is also true if Electron is detected.*/
+    /**
+     * boolean flag, indicating N-API shouldn't be used even if it is available.
+     * Default value depends on Node.js version (4, 5 and 7 {fallback: true}; modern versions {fallback: false}).
+     * It is also true if Electron is detected.
+     */
     fallback?: boolean;
     /** boolean flag to make retrieval process asynchronous (false by default) */
     async?: boolean;
     /** boolean flag to emulate ES6 generator (default: false) */
     generator?: boolean;
-    /** how to install certificates (default: false, ie just fetch from store, do not install). If set to true, certificated fetched will be also added to https.globalAgent.options.ca (in PEM format, regardless of format parameter), so all subsequent calls to https client methods (https.request, https.get etc.) will silently use them instead of built-in ones. */
+    /**
+     * how to install certificates (default: false, ie just fetch from store, do not install).
+     * If set to true, certificated fetched will be also added to https.globalAgent.options.ca
+     * (in PEM format, regardless of format parameter), so all subsequent calls to https client
+     * methods (https.request, https.get etc.) will silently use them instead of built-in ones.
+     */
     inject?: boolean;
 }
 declare function Api(params: CaOptions): void;
 
-
-declare module "win-ca";
 export default Api;

--- a/types/win-ca/tsconfig.json
+++ b/types/win-ca/tsconfig.json
@@ -8,6 +8,7 @@
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
+        "esModuleInterop": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/win-ca/tsconfig.json
+++ b/types/win-ca/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "strict": true,
         "module": "commonjs",
         "lib": [
             "es6"

--- a/types/win-ca/tsconfig.json
+++ b/types/win-ca/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts"
+    ]
+}

--- a/types/win-ca/tsconfig.json
+++ b/types/win-ca/tsconfig.json
@@ -17,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "win-ca-tests.ts"
     ]
 }

--- a/types/win-ca/tslint.json
+++ b/types/win-ca/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/win-ca/tslint.json
+++ b/types/win-ca/tslint.json
@@ -1,1 +1,3 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json"
+}

--- a/types/win-ca/tslint.json
+++ b/types/win-ca/tslint.json
@@ -1,17 +1,3 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json",
-    "rules": {
-        "npm-naming": [
-            true,
-            {
-                "mode": "code",
-                "errors": [
-                    [
-                        "NeedsExportEquals",
-                        false
-                    ]
-                ]
-            }
-        ]
-    }
+    "extends": "@definitelytyped/dtslint/dt.json"
 }

--- a/types/win-ca/tslint.json
+++ b/types/win-ca/tslint.json
@@ -1,3 +1,17 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": [
+            true,
+            {
+                "mode": "code",
+                "errors": [
+                    [
+                        "NeedsExportEquals",
+                        false
+                    ]
+                ]
+            }
+        ]
+    }
 }

--- a/types/win-ca/win-ca-tests.ts
+++ b/types/win-ca/win-ca-tests.ts
@@ -1,4 +1,4 @@
-import ca, { der2 } from "./";
+import ca, { der2 } from "win-ca";
 
 // $ExpectType void
 ca({

--- a/types/win-ca/win-ca-tests.ts
+++ b/types/win-ca/win-ca-tests.ts
@@ -1,0 +1,11 @@
+import ca, { der2 } from "./";
+
+// $ExpectType void
+ca({
+    store: ["ca"],
+    format: der2.x509,
+    ondata: (item) => {
+        // $ExpectType Certificate
+        const value = item;
+    }
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` should be present and it shouldn't have any additional or disabling of rules. Just content as `{ "extends": "dtslint/dt.json" }`. If for reason the some rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]`  and not for whole package so that the need for disabling can be reviewed.
- [x] `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

