### PR TITLE
[knex-cleaner] Update Knex dependency to v2.3.0

### DIFF
--- a/types/knex-cleaner/package.json
+++ b/types/knex-cleaner/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "knex": ">=0.95.0 <1.0.0"
+        "knex": ">=2.3.0"
     }
 }


### PR DESCRIPTION
The older version of Knex did not compile with TypeScript 4.8+ because of [this breaking change][1].

[1]: https://github.com/microsoft/TypeScript/wiki/Breaking-Changes#unconstrained-type-parameters-no-longer-assignable-to--in-strictnullchecks

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>  *The library remains unchanged. This only updates the dependency of the types.*
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. *The library remains unchanged. This only updates the dependency of the types.*
