### PR TITLE
[@types/nova-editor] [@types/nova-editor-node] Update min ECMAScript version for Nova

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -9,7 +9,7 @@
 // This runs in an extension of Apple's JavaScriptCore, manually set libs
 
 /// <reference no-default-lib="true"/>
-/// <reference lib="es7" />
+/// <reference lib="es2020" />
 /// <reference lib="WebWorker" />
 
 /// https://docs.nova.app/api-reference/assistants-registry/

--- a/types/nova-editor-node/tsconfig.json
+++ b/types/nova-editor-node/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es2020"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/nova-editor/tsconfig.json
+++ b/types/nova-editor/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es2020"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
    - => Not needed
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://devforum.nova.app/t/which-javascript-ecmascript-version-are-supported/1901
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-----------------

As discussed in https://devforum.nova.app/t/which-javascript-ecmascript-version-are-supported/1901, recent enough versions of Nova (8+) all support at least the ECMAScript 2020 spec.

This PR updates the supported JS lib version in these types declarations, allowing consumers to make use of recent additions to the JS language (e.g. `Array.prototype.flatMap` in my case).