### PR TITLE
fix(video.js): return type of defaultPlaybackRate

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -6561,7 +6561,7 @@ export interface VideoJsPlayer extends videojs.Component {
      */
     defaultPlaybackRate(rate: number): videojs.Player;
 
-    defaultPlaybackRate(): boolean;
+    defaultPlaybackRate(): number;
 
     /**
      * A getter/setter for the `Player`'s width & height.

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -208,6 +208,9 @@ videojs('example_video_1', playerOptions).ready(function playerReady() {
     // $ExpectType number[]
     const playbackRates: number[] = this.playbackRates();
 
+    // $ExpectType number
+    const defaultPlaybackRate: number = this.defaultPlaybackRate();
+
     // $ExpectType string
     const currentBreakPoint = this.currentBreakpoint();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://docs.videojs.com/player#defaultPlaybackRate](https://docs.videojs.com/player#defaultPlaybackRate)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.