### PR TITLE
Update expected types of conventional-* Commit

### DIFF
--- a/types/conventional-changelog-preset-loader/conventional-changelog-preset-loader-tests.ts
+++ b/types/conventional-changelog-preset-loader/conventional-changelog-preset-loader-tests.ts
@@ -7,9 +7,9 @@ namespace Module {
     declare const path: string;
     declare const config: conventionalChangelogPresetLoader.Config;
 
-    // $ExpectType Config<Commit<string | number | symbol>, Context>
+    // $ExpectType Config<Commit<string | number | symbol>, Context> || Config<Commit, Context>
     conventionalChangelogPresetLoader(path);
-    // $ExpectType Config<Commit<string | number | symbol>, Context>
+    // $ExpectType Config<Commit<string | number | symbol>, Context> || Config<Commit, Context>
     conventionalChangelogPresetLoader(config);
 
     // @ts-expect-error

--- a/types/conventional-commits-parser/conventional-commits-parser-tests.ts
+++ b/types/conventional-commits-parser/conventional-commits-parser-tests.ts
@@ -22,7 +22,7 @@ namespace Module.Commit {
     namespace Case01 {
         declare const commit: conventionalCommitsParser.Commit;
 
-        // $ExpectType Commit<string | number | symbol>
+        // $ExpectType Commit<string | number | symbol> || Commit
         commit;
         commit.body; // $ExpectType Field
         commit.footer; // $ExpectType Field


### PR DESCRIPTION
Typescript now omits default type parameters in quickinfo display when they were not provided by the caller.