### PR TITLE
Update expected types of final-form-* Mutator

### DIFF
--- a/types/final-form-set-field-data/final-form-set-field-data-tests.ts
+++ b/types/final-form-set-field-data/final-form-set-field-data-tests.ts
@@ -1,3 +1,3 @@
 import setFieldData from 'final-form-set-field-data';
 
-setFieldData; // $ExpectType Mutator<object, object>
+setFieldData; // $ExpectType Mutator<object, object> || Mutator

--- a/types/final-form-set-field-touched/final-form-set-field-touched-tests.ts
+++ b/types/final-form-set-field-touched/final-form-set-field-touched-tests.ts
@@ -1,3 +1,3 @@
 import setFieldTouched from 'final-form-set-field-touched';
 
-setFieldTouched; // $ExpectType Mutator<object, object>
+setFieldTouched; // $ExpectType Mutator<object, object> || Mutator


### PR DESCRIPTION
Typescript 5.0 now omits default type parameters in quickinfo display when they were not provided by the caller.
