### PR TITLE
Update es-abstract isPropertyDescriptor tests

### DIFF
--- a/types/es-abstract/test/helpers/isPropertyDescriptor.test.ts
+++ b/types/es-abstract/test/helpers/isPropertyDescriptor.test.ts
@@ -5,7 +5,7 @@ declare const unknown: unknown;
 declare const optPropDesc: ES5.PropertyDescriptor<string> | null;
 
 if (isPropertyDescriptor(ES5, unknown)) {
-    unknown; // $ExpectType PropertyDescriptor<unknown>
+    unknown; // $ExpectType PropertyDescriptor<unknown> || PropertyDescriptor
 }
 
 if (isPropertyDescriptor(ES5, optPropDesc)) {


### PR DESCRIPTION
Typescript 5.0 quickinfo no longer includes default values for type parameters when they're not provided. Updat e the expected type accordingly.