### PR TITLE
Update mparticle__web-sdk test's enum values

### DIFF
--- a/types/mparticle__web-sdk/test/mparticle__web-sdk-instance-tests.ts
+++ b/types/mparticle__web-sdk/test/mparticle__web-sdk-instance-tests.ts
@@ -391,10 +391,10 @@ instance.eCommerce.logProductAction(
     eCommerceCustomFlags,
 );
 
-instance.eCommerce.logProductAction(300, [product1, product2], eCommerceCustomAttributes, eCommerceCustomFlags);
+instance.eCommerce.logProductAction(0, [product1, product2], eCommerceCustomAttributes, eCommerceCustomFlags);
 
 instance.eCommerce.logProductAction(
-    300,
+    0,
     [product1, product2],
     eCommerceCustomAttributes,
     eCommerceCustomFlags,

--- a/types/mparticle__web-sdk/test/mparticle__web-sdk-tests.ts
+++ b/types/mparticle__web-sdk/test/mparticle__web-sdk-tests.ts
@@ -392,10 +392,10 @@ mParticle.eCommerce.logProductAction(
     eCommerceCustomFlags,
 );
 
-mParticle.eCommerce.logProductAction(300, [product1, product2], eCommerceCustomAttributes, eCommerceCustomFlags);
+mParticle.eCommerce.logProductAction(0, [product1, product2], eCommerceCustomAttributes, eCommerceCustomFlags);
 
 mParticle.eCommerce.logProductAction(
-    300,
+    0,
     [product1, product2],
     eCommerceCustomAttributes,
     eCommerceCustomFlags,


### PR DESCRIPTION
Typescript 5.0 checks more number->enum assignments strictly than before. Update mparticle__web-sdk's tests to use real enum values instead of made-up ones.
