### PR TITLE
[mapbox-gl]: Added the getter and setter for the projection

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -867,7 +867,7 @@ declare namespace mapboxgl {
          * the vector tile source's TileJSON. Valid worldview strings must be an ISO alpha-2 country code.
          *
          * @default null
-        */
+         */
         worldview?: string | undefined;
     }
 
@@ -1422,7 +1422,12 @@ declare namespace mapboxgl {
     }
 
     export interface GeoJSONSourceOptions {
-        data?: GeoJSON.Feature<GeoJSON.Geometry> | GeoJSON.FeatureCollection<GeoJSON.Geometry> | GeoJSON.Geometry | string | undefined;
+        data?:
+            | GeoJSON.Feature<GeoJSON.Geometry>
+            | GeoJSON.FeatureCollection<GeoJSON.Geometry>
+            | GeoJSON.Geometry
+            | string
+            | undefined;
 
         maxzoom?: number | undefined;
 

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -600,6 +600,9 @@ declare namespace mapboxgl {
 
         getFog(): Fog | null;
         setFog(fog: Fog): this;
+
+        getProjection(): Projection;
+        setProjection(projection: Projection | string): this;
     }
 
     export interface MapboxOptions {
@@ -778,19 +781,7 @@ declare namespace mapboxgl {
          *
          * @default 'mercator'
          */
-        projection?: {
-            name:
-                | 'albers'
-                | 'equalEarth'
-                | 'equirectangular'
-                | 'lambertConformalConic'
-                | 'mercator'
-                | 'naturalEarth'
-                | 'winkelTripel'
-                | 'globe';
-            center?: [number, number];
-            parallels?: [number, number];
-        };
+        projection?: Projection;
 
         /**
          * If `false`, the map's pitch (tilt) control with "drag to rotate" interaction will be disabled.
@@ -2660,4 +2651,18 @@ declare namespace mapboxgl {
     export type ElevationQueryOptions = {
         exaggerated: boolean;
     };
+
+    export interface Projection {
+        name:
+            | 'albers'
+            | 'equalEarth'
+            | 'equirectangular'
+            | 'lambertConformalConic'
+            | 'mercator'
+            | 'naturalEarth'
+            | 'winkelTripel'
+            | 'globe';
+        center?: [number, number];
+        parallels?: [number, number];
+    }
 }

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -1979,10 +1979,10 @@ expectType<mapboxgl.Projection>({ name: 'mercator' });
 expectType<mapboxgl.Projection>({ name: 'lambertConformalConic', center: [0, 0], parallels: [30, 60] });
 
 // set projection with string
-map.setProjection('mercator')
+map.setProjection('mercator');
 
 // set projection with config
-map.setProjection({ name: 'globe'})
+map.setProjection({ name: 'globe' });
 
 // get projections
 expectType<mapboxgl.Projection>(map.getProjection());

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -1967,3 +1967,22 @@ var keyboardHandler = new mapboxgl.KeyboardHandler(map);
 keyboardHandler.enableRotation();
 // $ExpectType void
 keyboardHandler.disableRotation();
+
+/**
+ * Test projections
+ */
+
+// projection config: name only
+expectType<mapboxgl.Projection>({ name: 'mercator' });
+
+// projection config: with center and parallels
+expectType<mapboxgl.Projection>({ name: 'lambertConformalConic', center: [0, 0], parallels: [30, 60] });
+
+// set projection with string
+map.setProjection('mercator')
+
+// set projection with config
+map.setProjection({ name: 'globe'})
+
+// get projections
+expectType<mapboxgl.Projection>(map.getProjection());


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - `setProjection()`:
        - source: https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/map.js#L1209
        - documentation: https://docs.mapbox.com/mapbox-gl-js/guides/projections/#set-a-projection-at-runtime
    - `getProjection()`:
        - source: https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/map.js#L1175
        - documentation: https://docs.mapbox.com/mapbox-gl-js/guides/projections/#get-current-map-projection
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
