### PR TITLE
[Jasmine] Fix resolveTo and rejectWith to work for spies that return a promise in a union type

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -1060,15 +1060,13 @@ declare namespace jasmine {
     /**
      * Obtains the promised type that a promise-returning function resolves to.
      */
-    type PromisedReturnType<Fn extends Func> = Fn extends (...args: any[]) => PromiseLike<infer TResult>
-        ? TResult
-        : never;
+    type PromisedResolveType<T> = T extends PromiseLike<infer TResult> ? TResult : never;
 
     /**
      * Obtains the type that a promise-returning function can be rejected with.
      * This is so we can use .and.rejectWith() only for functions that return a promise.
      */
-    type PromisedRejectType<Fn extends Function> = Fn extends (...args: any[]) => PromiseLike<unknown> ? any : never;
+    type PromisedRejectType<T> = T extends PromiseLike<unknown> ? any : never;
 
     interface SpyAnd<Fn extends Func> {
         identity: string;
@@ -1082,9 +1080,9 @@ declare namespace jasmine {
         /** By chaining the spy with and.callFake, all calls to the spy will delegate to the supplied function. */
         callFake(fn: Fn): Spy<Fn>;
         /** Tell the spy to return a promise resolving to the specified value when invoked. */
-        resolveTo(val?: PromisedReturnType<Fn>): Spy<Fn>;
+        resolveTo(val?: PromisedResolveType<ReturnType<Fn>>): Spy<Fn>;
         /** Tell the spy to return a promise rejecting with the specified value when invoked. */
-        rejectWith(val?: PromisedRejectType<Fn>): Spy<Fn>;
+        rejectWith(val?: PromisedRejectType<ReturnType<Fn>>): Spy<Fn>;
         /** By chaining the spy with and.throwError, all calls to the spy will throw the specified value. */
         throwError(msg: string | Error): Spy;
         /** When a calling strategy is used for a spy, the original stubbing behavior can be returned at any time with and.stub. */

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -620,7 +620,7 @@ describe("A spy, when configured to fake a promised return value", () => {
         getAsyncBar: () => {
             return Promise.resolve(bar);
         },
-        getMaybeAsyncBar: (): number|Promise<number> => {
+        getMaybeAsyncBar: (): number | Promise<number> => {
             return bar;
         },
     };

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -620,12 +620,19 @@ describe("A spy, when configured to fake a promised return value", () => {
         getAsyncBar: () => {
             return Promise.resolve(bar);
         },
+        getMaybeAsyncBar: (): number|Promise<number> => {
+            return bar;
+        },
     };
 
     it("verifies return value type", () => {
         spyOn(foo, "getAsyncBar").and.resolveTo(745);
         // @ts-expect-error
         spyOn(foo, "getAsyncBar").and.resolveTo("42");
+
+        spyOn(foo, "getMaybeAsyncBar").and.resolveTo(745);
+        // @ts-expect-error
+        spyOn(foo, "getMaybeAsyncBar").and.resolveTo("42");
     });
 
     it("tracks that the spy was called", async () => {
@@ -645,6 +652,9 @@ describe("A spy, when configured to fake a promised rejection", () => {
         getAsyncBar: () => {
             return Promise.resolve(bar);
         },
+        getMaybeAsyncBar: (): number|Promise<number> => {
+            return bar;
+        },
         getBar: () => {
             return bar;
         },
@@ -652,6 +662,7 @@ describe("A spy, when configured to fake a promised rejection", () => {
 
     it("verifies rejection value type", () => {
         spyOn(foo, "getAsyncBar").and.rejectWith("Error message");
+        spyOn(foo, "getMaybeAsyncBar").and.rejectWith("Error message");
         // @ts-expect-error
         spyOn(foo, "getBar").and.rejectWith("42");
     });

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -652,7 +652,7 @@ describe("A spy, when configured to fake a promised rejection", () => {
         getAsyncBar: () => {
             return Promise.resolve(bar);
         },
-        getMaybeAsyncBar: (): number|Promise<number> => {
+        getMaybeAsyncBar: (): number | Promise<number> => {
             return bar;
         },
         getBar: () => {

--- a/types/jasmine/v3/index.d.ts
+++ b/types/jasmine/v3/index.d.ts
@@ -1101,15 +1101,13 @@ declare namespace jasmine {
     /**
      * Obtains the promised type that a promise-returning function resolves to.
      */
-    type PromisedReturnType<Fn extends Func> = Fn extends (...args: any[]) => PromiseLike<infer TResult>
-        ? TResult
-        : never;
+    type PromisedResolveType<T> = T extends PromiseLike<infer TResult> ? TResult : never;
 
     /**
      * Obtains the type that a promise-returning function can be rejected with.
      * This is so we can use .and.rejectWith() only for functions that return a promise.
      */
-    type PromisedRejectType<Fn extends Function> = Fn extends (...args: any[]) => PromiseLike<unknown> ? any : never;
+    type PromisedRejectType<T> = T extends PromiseLike<unknown> ? any : never;
 
     interface SpyAnd<Fn extends Func> {
         identity: string;
@@ -1123,9 +1121,9 @@ declare namespace jasmine {
         /** By chaining the spy with and.callFake, all calls to the spy will delegate to the supplied function. */
         callFake(fn: Fn): Spy<Fn>;
         /** Tell the spy to return a promise resolving to the specified value when invoked. */
-        resolveTo(val?: PromisedReturnType<Fn>): Spy<Fn>;
+        resolveTo(val?: PromisedResolveType<ReturnType<Fn>>): Spy<Fn>;
         /** Tell the spy to return a promise rejecting with the specified value when invoked. */
-        rejectWith(val?: PromisedRejectType<Fn>): Spy<Fn>;
+        rejectWith(val?: PromisedRejectType<ReturnType<Fn>>): Spy<Fn>;
         /** By chaining the spy with and.throwError, all calls to the spy will throw the specified value. */
         throwError(msg: string | Error): Spy;
         /** When a calling strategy is used for a spy, the original stubbing behavior can be returned at any time with and.stub. */

--- a/types/jasmine/v3/jasmine-tests.ts
+++ b/types/jasmine/v3/jasmine-tests.ts
@@ -622,12 +622,19 @@ describe("A spy, when configured to fake a promised return value", () => {
         getAsyncBar: () => {
             return Promise.resolve(bar);
         },
+        getMaybeAsyncBar: (): number|Promise<number> => {
+            return bar;
+        },
     };
 
     it("verifies return value type", () => {
         spyOn(foo, "getAsyncBar").and.resolveTo(745);
         // @ts-expect-error
         spyOn(foo, "getAsyncBar").and.resolveTo("42");
+
+        spyOn(foo, "getMaybeAsyncBar").and.resolveTo(745);
+        // @ts-expect-error
+        spyOn(foo, "getMaybeAsyncBar").and.resolveTo("42");
     });
 
     it("tracks that the spy was called", async () => {
@@ -647,6 +654,9 @@ describe("A spy, when configured to fake a promised rejection", () => {
         getAsyncBar: () => {
             return Promise.resolve(bar);
         },
+        getMaybeAsyncBar: (): number|Promise<number> => {
+            return bar;
+        },
         getBar: () => {
             return bar;
         },
@@ -654,6 +664,7 @@ describe("A spy, when configured to fake a promised rejection", () => {
 
     it("verifies rejection value type", () => {
         spyOn(foo, "getAsyncBar").and.rejectWith("Error message");
+        spyOn(foo, "getMaybeAsyncBar").and.rejectWith("Error message");
         // @ts-expect-error
         spyOn(foo, "getBar").and.rejectWith("42");
     });

--- a/types/jasmine/v3/jasmine-tests.ts
+++ b/types/jasmine/v3/jasmine-tests.ts
@@ -622,7 +622,7 @@ describe("A spy, when configured to fake a promised return value", () => {
         getAsyncBar: () => {
             return Promise.resolve(bar);
         },
-        getMaybeAsyncBar: (): number|Promise<number> => {
+        getMaybeAsyncBar: (): number | Promise<number> => {
             return bar;
         },
     };

--- a/types/jasmine/v3/jasmine-tests.ts
+++ b/types/jasmine/v3/jasmine-tests.ts
@@ -654,7 +654,7 @@ describe("A spy, when configured to fake a promised rejection", () => {
         getAsyncBar: () => {
             return Promise.resolve(bar);
         },
-        getMaybeAsyncBar: (): number|Promise<number> => {
+        getMaybeAsyncBar: (): number | Promise<number> => {
             return bar;
         },
         getBar: () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/api/edge/SpyStrategy.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
