### PR TITLE
@types/google.accounts - add error_callback to CodeClientConfig & TokenClientConfig

### DIFF
--- a/types/google.accounts/google.accounts-tests.ts
+++ b/types/google.accounts/google.accounts-tests.ts
@@ -21,7 +21,7 @@ google.accounts.oauth2.initCodeClient({
         error.message;
         // $ExpectType string | undefined
         error.stack;
-        // $ExpectType string
+        // $ExpectType "unknown" | "popup_closed" | "popup_failed_to_open"
         error.type;
     }
 });
@@ -56,7 +56,7 @@ google.accounts.oauth2.initTokenClient({
         error.message;
         // $ExpectType string | undefined
         error.stack;
-        // $ExpectType string
+        // $ExpectType "unknown" | "popup_closed" | "popup_failed_to_open"
         error.type;
     }
 });

--- a/types/google.accounts/google.accounts-tests.ts
+++ b/types/google.accounts/google.accounts-tests.ts
@@ -15,6 +15,14 @@ google.accounts.oauth2.initCodeClient({
         response.error_description;
         // $ExpectType string
         response.error_uri;
+    },
+    error_callback: error => {
+        // $ExpectType string
+        error.message;
+        // $ExpectType string | undefined
+        error.stack;
+        // $ExpectType string
+        error.type;
     }
 });
 
@@ -43,6 +51,14 @@ google.accounts.oauth2.initTokenClient({
         // $ExpectType string
         response.error_uri;
     },
+    error_callback: error => {
+        // $ExpectType string
+        error.message;
+        // $ExpectType string | undefined
+        error.stack;
+        // $ExpectType string
+        error.type;
+    }
 });
 
 // $ExpectType boolean

--- a/types/google.accounts/index.d.ts
+++ b/types/google.accounts/index.d.ts
@@ -41,7 +41,7 @@ declare namespace google.accounts {
         interface ClientConfigError extends Error {
             message: string;
             stack?: string;
-            type: 'popup_failed_to_open' | 'popup_closed' | 'unknown';
+            type: 'unknown' | 'popup_closed' | 'popup_failed_to_open';
         }
 
         interface OverridableTokenClientConfig {

--- a/types/google.accounts/index.d.ts
+++ b/types/google.accounts/index.d.ts
@@ -38,7 +38,7 @@ declare namespace google.accounts {
          */
         function revoke(accessToken: string, done: () => void): void;
 
-        interface ko extends Error {
+        interface ClientConfigError extends Error {
             message: string;
             stack?: string;
             type: string;
@@ -267,7 +267,7 @@ declare namespace google.accounts {
              * errors, such as the popup window is failed to open; or closed
              * before an OAuth response is returned.
              */
-            error_callback?: (error: ko) => void;
+            error_callback?: (error: ClientConfigError) => void;
         }
 
         interface CodeClientConfig {
@@ -350,7 +350,7 @@ declare namespace google.accounts {
              * errors, such as the popup window is failed to open; or closed
              * before an OAuth response is returned.
              */
-            error_callback?: (error: ko) => void;
+            error_callback?: (error: ClientConfigError) => void;
         }
     }
 

--- a/types/google.accounts/index.d.ts
+++ b/types/google.accounts/index.d.ts
@@ -41,7 +41,7 @@ declare namespace google.accounts {
         interface ClientConfigError extends Error {
             message: string;
             stack?: string;
-            type: string;
+            type: 'popup_failed_to_open' | 'popup_closed' | 'unknown';
         }
 
         interface OverridableTokenClientConfig {

--- a/types/google.accounts/index.d.ts
+++ b/types/google.accounts/index.d.ts
@@ -38,6 +38,12 @@ declare namespace google.accounts {
          */
         function revoke(accessToken: string, done: () => void): void;
 
+        interface ko extends Error {
+            message: string;
+            stack?: string;
+            type: string;
+        }
+
         interface OverridableTokenClientConfig {
             /**
              * Optional. A space-delimited, case-sensitive list of prompts to
@@ -255,6 +261,13 @@ declare namespace google.accounts {
              * server's response.
              */
             state?: string;
+
+            /**
+             * Optional. The JavaScript function that handles some non-OAuth
+             * errors, such as the popup window is failed to open; or closed
+             * before an OAuth response is returned.
+             */
+            error_callback?: (error: ko) => void;
         }
 
         interface CodeClientConfig {
@@ -331,6 +344,13 @@ declare namespace google.accounts {
              * to select an account.
              */
             select_account?: boolean;
+
+            /**
+             * Optional. The JavaScript function that handles some non-OAuth
+             * errors, such as the popup window is failed to open; or closed
+             * before an OAuth response is returned.
+             */
+            error_callback?: (error: ko) => void;
         }
     }
 


### PR DESCRIPTION
The google.accounts package is missing the property `error_callback` from both `CodeClientConfig` & `TokenClientConfig`.  This PR defines the adds the property `error_callback` to both interfaces. I also define the type `ClientConfigError` which extends `Error` and adds the property `type: string` inline with the google reference. I've amended google.accounts-tests.ts accordingly and successfully ran the tests.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://developers.google.com/identity/oauth2/web/reference/js-reference#CodeResponse](https://developers.google.com/identity/oauth2/web/reference/js-reference#CodeResponse)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
