### PR TITLE
prompts: Add missing onRender method to PromptObject

### DIFF
--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -6,6 +6,7 @@
 //                 theweirdone <https://github.com/theweirdone>
 //                 whoaa512 <https://github.com/whoaa512>
 //                 John Reilly <https://github.com/johnnyreilly>
+//                 Christopher Hiller <https://github.com/boneskull>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -14,6 +15,7 @@
 export = prompts;
 
 import { Readable, Writable } from 'stream';
+import { Kleur } from 'kleur';
 
 declare function prompts<T extends string = string>(
     questions: prompts.PromptObject<T> | Array<prompts.PromptObject<T>>,
@@ -83,6 +85,7 @@ declare namespace prompts {
         format?: PrevCaller<T, void> | undefined;
         validate?: PrevCaller<T, boolean | string | Promise<boolean | string>> | undefined;
         onState?: PrevCaller<T, void> | undefined;
+        onRender?: ((kleur: Kleur) => void) | undefined;
         min?: number | PrevCaller<T, number | Falsy> | undefined;
         max?: number | PrevCaller<T, number | Falsy> | undefined;
         float?: boolean | PrevCaller<T, boolean | Falsy> | undefined;

--- a/types/prompts/package.json
+++ b/types/prompts/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "kleur": "^3.0.3"
+  }
+}


### PR DESCRIPTION
The new dependency on `kleur` has been merged; see https://github.com/microsoft/DefinitelyTyped-tools/pull/573.

This method is mentioned in the `README`: https://github.com/terkelg/prompts/blob/a0c1777ae86d04e46cb42eb3af69ca74ae5d79e2/readme.md#-prompt-objects

I cannot run any tests locally (via `npm test prompts`), as `dtslint` fails, reporting invalid rules:

```
/Users/boneskull/projects/DefinitelyTyped/DefinitelyTyped/types/prompts/index.d.ts
  1:1  error  Definition for rule 'export-just-namespace' was not found  export-just-namespace
  1:1  error  Definition for rule 'no-bad-reference' was not found       no-bad-reference
  1:1  error  Definition for rule 'trim-file' was not found              trim-file

/Users/boneskull/projects/DefinitelyTyped/DefinitelyTyped/types/prompts/prompts-tests.ts
  1:1  error  Definition for rule 'export-just-namespace' was not found  export-just-namespace
  1:1  error  Definition for rule 'no-bad-reference' was not found       no-bad-reference
  1:1  error  Definition for rule 'trim-file' was not found              trim-file
```

I don't know what's wrong with my working copy or environment to cause this.  If I can get it working, I will add a test for the new method.

* * *

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
