### PR TITLE
[prettier] Add 'string' options for plugins

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -545,7 +545,7 @@ export interface SupportOptionRange {
     step: number;
 }
 
-export type SupportOptionType = 'int' | 'boolean' | 'choice' | 'path';
+export type SupportOptionType = 'int' | 'string' | 'boolean' | 'choice' | 'path';
 
 export type CoreCategoryType = 'Config' | 'Editor' | 'Format' | 'Other' | 'Output' | 'Global' | 'Special';
 
@@ -589,6 +589,16 @@ export interface IntArraySupportOption extends BaseSupportOption<'int'> {
     array: true;
 }
 
+export interface StringSupportOption extends BaseSupportOption<'string'> {
+    default?: string | undefined;
+    array?: false | undefined;
+}
+
+export interface StringArraySupportOption extends BaseSupportOption<'string'> {
+    default?: Array<{ value: string[] }> | undefined;
+    array: true;
+}
+
 export interface BooleanSupportOption extends BaseSupportOption<'boolean'> {
     default?: boolean | undefined;
     array?: false | undefined;
@@ -624,6 +634,8 @@ export interface PathArraySupportOption extends BaseSupportOption<'path'> {
 export type SupportOption =
     | IntSupportOption
     | IntArraySupportOption
+    | StringSupportOption
+    | StringArraySupportOption
     | BooleanSupportOption
     | BooleanArraySupportOption
     | ChoiceSupportOption

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -197,6 +197,21 @@ const plugin: prettier.Plugin<PluginAST> = {
             array: true,
             description: 'This is a number.',
         },
+        testStringOption: {
+            since: '1.0.0',
+            type: 'string',
+            category: 'Test',
+            default: 'default',
+            description: 'This is a string.',
+        },
+        testStringArrOption: {
+            since: '1.0.0',
+            type: 'string',
+            category: 'Test',
+            default: [{ value: ['one', 'two', 'three'] }],
+            array: true,
+            description: 'This is a string.',
+        },
         testChoiceOption: {
             since: '1.0.3',
             type: 'choice',


### PR DESCRIPTION
String options have been supported by Prettier since v1.19.0, but they were missing from the type definition here. The plugin options type has been extended to include string options.

----------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/prettier/prettier/pull/6219