### PR TITLE
Updating ckeditor5-editor-decoupled to include sourceElement

### DIFF
--- a/types/ckeditor__ckeditor5-editor-decoupled/ckeditor__ckeditor5-editor-decoupled-tests.ts
+++ b/types/ckeditor__ckeditor5-editor-decoupled/ckeditor__ckeditor5-editor-decoupled-tests.ts
@@ -47,7 +47,7 @@ class MyPlugin extends Plugin {}
     editor.ui;
     // $ExpectType DecoupledEditorUIView
     editor.ui.view;
-    // $expectType HTMLElement
+    // $ExpectType HTMLElement
     editor.sourceElement;
 
     editor = await DecoupledEditor.create(htmlElement, {

--- a/types/ckeditor__ckeditor5-editor-decoupled/ckeditor__ckeditor5-editor-decoupled-tests.ts
+++ b/types/ckeditor__ckeditor5-editor-decoupled/ckeditor__ckeditor5-editor-decoupled-tests.ts
@@ -47,6 +47,8 @@ class MyPlugin extends Plugin {}
     editor.ui;
     // $ExpectType DecoupledEditorUIView
     editor.ui.view;
+    // $expectType HTMLElement
+    editor.sourceElement;
 
     editor = await DecoupledEditor.create(htmlElement, {
         toolbar: {

--- a/types/ckeditor__ckeditor5-editor-decoupled/index.d.ts
+++ b/types/ckeditor__ckeditor5-editor-decoupled/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @ckeditor/ckeditor5-editor-decoupled 29.0
+// Type definitions for @ckeditor/ckeditor5-editor-decoupled 28.1
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/editor-decoupled.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ckeditor__ckeditor5-editor-decoupled/index.d.ts
+++ b/types/ckeditor__ckeditor5-editor-decoupled/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @ckeditor/ckeditor5-editor-decoupled 28.1
+// Type definitions for @ckeditor/ckeditor5-editor-decoupled 28.0
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/editor-decoupled.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ckeditor__ckeditor5-editor-decoupled/index.d.ts
+++ b/types/ckeditor__ckeditor5-editor-decoupled/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @ckeditor/ckeditor5-editor-decoupled 28.0
+// Type definitions for @ckeditor/ckeditor5-editor-decoupled 29.0
 // Project: https://ckeditor.com/docs/ckeditor5/latest/api/editor-decoupled.html
 // Definitions by: Federico Panico <https://github.com/fedemp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ckeditor__ckeditor5-editor-decoupled/src/decouplededitor.d.ts
+++ b/types/ckeditor__ckeditor5-editor-decoupled/src/decouplededitor.d.ts
@@ -7,6 +7,7 @@ import DecoupledEditorUI from './decouplededitorui';
 export default class DecoupledEditor extends Editor implements DataApi, EditorWithUI {
     protected constructor(sourceElementOrData: HTMLElement | string, config: EditorConfig);
     ui: DecoupledEditorUI;
+    sourceElement: HTMLElement;
     setData(data: string): void;
     getData(options?: { rootName?: string | undefined; trim?: 'empty' | 'none' | undefined }): string;
     destroy(): Promise<void>;


### PR DESCRIPTION
Updating decoupled Editor type definition to include sourceElement as it is a property on the DecoupledEditor on the CKEditor documentation (find link below)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-decoupled_decouplededitor-DecoupledEditor.html>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
