### PR TITLE
bugfix(feather-icons): partial attrs for replace() and toSvg()

### DIFF
--- a/types/feather-icons/index.d.ts
+++ b/types/feather-icons/index.d.ts
@@ -12,7 +12,7 @@ export type FeatherIconNames = keyof typeof genIcons;
 export type FeatherStrokeLineCap = 'butt' | 'round' | 'square';
 export type FeatherStrokeLineJoin = 'arcs' | 'bevel' | 'miter' | 'miter-clip' | 'round';
 
-type FeatherToSvg = (options?: FeatherAttributes) => string;
+type FeatherToSvg = (options?: Partial<FeatherAttributes>) => string;
 
 export interface FeatherAttributes {
     [index: string]: string | number;
@@ -37,8 +37,8 @@ export interface FeatherIcon {
     toSvg: FeatherToSvg;
 }
 
-export function replace(options?: FeatherAttributes): void;
+export function replace(options?: Partial<FeatherAttributes>): void;
 
 export const icons: {
-    [key in FeatherIconNames]: FeatherIcon
+    [key in FeatherIconNames]: FeatherIcon;
 };

--- a/types/feather-icons/test/feather-icons-tests.ts
+++ b/types/feather-icons/test/feather-icons-tests.ts
@@ -18,6 +18,11 @@ feather.icons['activity'].contents; // $ExpectType string
 feather.icons['activity'].tags; // $ExpectType string[]
 feather.icons['activity'].attrs; // $ExpectType FeatherAttributes
 feather.icons['activity'].toSvg(); // $ ExpectType FeatherToSvg
+/** @link https://github.com/feathericons/feather/tree/v4.29.0#feathericonsnametosvgattrs */
+feather.icons.circle.toSvg({ 'stroke-width': 1 }); // $ ExpectType FeatherToSvg
+feather.icons.circle.toSvg({ class: 'foo bar' }); // $ ExpectType FeatherToSvg
 
 // Test Function
 feather.replace(); // $ExpectType void
+/** @link https://github.com/feathericons/feather/tree/v4.29.0#featherreplaceattrs */
+feather.replace({ class: 'foo bar', 'stroke-width': 1 }); // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/feathericons/feather/tree/v4.29.0#featherreplaceattrs
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
