### PR TITLE
Making two Trees API's have optional args

### DIFF
--- a/types/antlr4/test/tree.ts
+++ b/types/antlr4/test/tree.ts
@@ -82,7 +82,13 @@ const testTreeInstance = new TestTree();
 
 // Trees
 Trees.toStringTree(testTreeInstance, [''], parserInstance); // $ExpectType string
-Trees.getNodeText(testTreeInstance, [''], parserInstance); // $ExpectType string
+Trees.toStringTree(testTreeInstance, ['']); // $ExpectType string
+Trees.toStringTree(testTreeInstance); // $ExpectType string
+Trees.toStringTree(testTreeInstance, undefined, parserInstance); // $ExpectType string
+Trees.getNodeText(testTreeInstance, [''], parserInstance);  // $ExpectType string
+Trees.getNodeText(testTreeInstance, ['']);  // $ExpectType string
+Trees.getNodeText(testTreeInstance); // $ExpectType string
+Trees.getNodeText(testTreeInstance, undefined, parserInstance);  // $ExpectType string
 Trees.getChildren(testTreeInstance); // $ExpectType Tree[]
 Trees.getAncestors(testTreeInstance); // $ExpectType Tree[]
 Trees.findAllTokenNodes(parseTreeInstance, 0); // $ExpectType ParseTree[]

--- a/types/antlr4/tree/Trees.d.ts
+++ b/types/antlr4/tree/Trees.d.ts
@@ -11,9 +11,9 @@ declare namespace Trees {
      *
      * Detect parse trees and extract data appropriately.
      */
-    function toStringTree(t: Tree, ruleNames: string[], recog: Parser): string;
+    function toStringTree(t: Tree, ruleNames?: string[], recog?: Parser): string;
 
-    function getNodeText(t: Tree, ruleNames: string[], recog: Parser): string;
+    function getNodeText(t: Tree, ruleNames?: string[], recog?: Parser): string;
 
     /**
      * @return ordered list of all children of this node


### PR DESCRIPTION
The javascript runtime code for ANTLR4 handles not supplying the second and third args to Trees.toStringTree and Trees.getNodeText.   I made the approropriate change to the Trees.d.ts to make these args optional in TypeScript.

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
