### PR TITLE
[ibm_db] Add Async Open/Close for Pooled Connection API

### DIFF
--- a/types/ibm_db/ibm_db-tests.ts
+++ b/types/ibm_db/ibm_db-tests.ts
@@ -35,6 +35,27 @@ ibmdb.open("DATABASE=<dbname>;HOSTNAME=<myhost>;UID=db2user;PWD=password;PORT=<d
     });
 });
 
+/** ibmdb.Pool */
+async function testPool() {
+  const pool = new ibmdb.Pool();
+  const conn = await pool.open("DATABASE=<dbname>;HOSTNAME=<myhost>;UID=db2user;PWD=password;PORT=<dbport>;PROTOCOL=TCPIP");
+  conn.query('select 1 from sysibm.sysdummy1', (err, data) => {
+      if (err) return false;
+      // $ExpectType false
+    conn.close((connErr) => {
+      if (connErr) {
+        // $ExpectType Error
+        connErr;
+      } else {
+        // $ExpectType undefined
+        connErr;
+      }
+    });
+  });
+  await pool.close();
+}
+testPool();
+
 /** imdb.ODBCStatement */
 const service = new ibmdb.ODBCStatement();
 service.executeSync();

--- a/types/ibm_db/index.d.ts
+++ b/types/ibm_db/index.d.ts
@@ -210,24 +210,26 @@ export function openSync(connStr: string | ConnStr, options?: Options): Database
 export function close(db: Database): void;
 
 export class Pool implements PoolOptions {
-  idleTimeout?: number | undefined;
-  autoCleanIdle?: boolean | undefined;
-  maxPoolSize?: number | undefined;
-  connectTimeout?: number | undefined;
-  systemNaming?: any;
+    idleTimeout?: number | undefined;
+    autoCleanIdle?: boolean | undefined;
+    maxPoolSize?: number | undefined;
+    connectTimeout?: number | undefined;
+    systemNaming?: any;
 
-  options: PoolOptions;
-  index: number;
-  availablePool: object;
-  usedPool: object;
-  poolsize: number;
-  odbc: ODBC;
-  openSync(connStr: string): Database;
-  constructor(options?: PoolOptions)
+    options: PoolOptions;
+    index: number;
+    availablePool: object;
+    usedPool: object;
+    poolsize: number;
+    odbc: ODBC;
+    constructor(options?: PoolOptions);
+    open(connStr: string): Promise<Database>;
     open(connStr: string, cb: (err: Error, db: Database) => void): void;
+    openSync(connStr: string): Database;
     init(count: number, connStr: string): boolean;
     setMaxPoolSize(count: number): boolean;
     setConnectTimeout(timeout: number): boolean;
     cleanup(connStr: string): boolean;
+    close(): Promise<boolean>
     close(cb: (foo: any, bar: any) => any): void;
 } // Class Pool

--- a/types/ibm_db/index.d.ts
+++ b/types/ibm_db/index.d.ts
@@ -230,6 +230,6 @@ export class Pool implements PoolOptions {
     setMaxPoolSize(count: number): boolean;
     setConnectTimeout(timeout: number): boolean;
     cleanup(connStr: string): boolean;
-    close(): Promise<boolean>
+    close(): Promise<boolean>;
     close(cb: (foo: any, bar: any) => any): void;
 } // Class Pool


### PR DESCRIPTION
The @types/ibm_db package included types for the asynchronous open/close methods for database connections but not for the pooled connection class even though the relevant functions in the main package are coded to return a promise if a callback function isn't provided as an argument. I've added the necessary signatures to allow code to compile correctly when the open and close methods return promises instead of using callback functions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://github.com/ibmdb/node-ibm_db/blob/master/lib/odbc.js)
