### PR TITLE
updated scan gun return data structure for CT60 models

### DIFF
--- a/types/react-native-honeywell-scanner/index.d.ts
+++ b/types/react-native-honeywell-scanner/index.d.ts
@@ -6,7 +6,7 @@
 
 declare namespace HoneywellScanner {
     const isCompatible: boolean;
-    function on(eventName: string, handler: (event: string | null) => void): void;
+    function on(eventName: string, handler: (event: { data: string } | string | null) => void): void;
     function off(eventName: string, handler: () => void): void;
     function startReader(): Promise<boolean>;
     function stopReader(): Promise<void>;

--- a/types/react-native-honeywell-scanner/react-native-honeywell-scanner-tests.ts
+++ b/types/react-native-honeywell-scanner/react-native-honeywell-scanner-tests.ts
@@ -14,11 +14,8 @@ class Example {
 
         HoneywellScanner.on('barcodeReadSuccess', event => {
             if (event && typeof event === 'object') {
-                return event.data;
+                const data = event.data;
             }
-            
-            return event;
-            // TODO
         });
 
         HoneywellScanner.on('barcodeReadFail', () => {

--- a/types/react-native-honeywell-scanner/react-native-honeywell-scanner-tests.ts
+++ b/types/react-native-honeywell-scanner/react-native-honeywell-scanner-tests.ts
@@ -13,6 +13,11 @@ class Example {
         }
 
         HoneywellScanner.on('barcodeReadSuccess', event => {
+            if (event && typeof event === 'object') {
+                return event.data;
+            }
+            
+            return event;
             // TODO
         });
 


### PR DESCRIPTION
Added an object type for the returned data structure of events to support the CT60 models.  Will still be backwards compatible with old models that simply return event as a string.