### PR TITLE
ioredis-mock: mock Redis take different options than `ioredis.Redis`

### DIFF
--- a/types/ioredis-mock/index.d.ts
+++ b/types/ioredis-mock/index.d.ts
@@ -6,8 +6,7 @@
 
 import ioredis = require('ioredis');
 
-
-export type RedisOptions = { data?: Record<string, unknown> } & ioredis.RedisOptions
+export type RedisOptions = { data?: Record<string, unknown> } & ioredis.RedisOptions;
 
 export interface Constructor {
     new(port: number, host: string, options: RedisOptions): ioredis.Redis;

--- a/types/ioredis-mock/index.d.ts
+++ b/types/ioredis-mock/index.d.ts
@@ -5,4 +5,10 @@
 // Minimum TypeScript Version: 4.2
 
 import ioredis = require('ioredis');
-export = ioredis;
+
+export interface Constructor {
+    new(option?: { data: Record<string, unknown> }): RealIORedis.Redis;
+}
+
+export const redisMock: Constructor;
+export { redisMock as default };

--- a/types/ioredis-mock/index.d.ts
+++ b/types/ioredis-mock/index.d.ts
@@ -7,18 +7,18 @@
 import ioredis = require('ioredis');
 
 
-type Option = { data?: Record<string, unknown> } & ioredis.RedisOptions
+export type RedisOptions = { data?: Record<string, unknown> } & ioredis.RedisOptions
 
 export interface Constructor {
-    new(port: number, host: string, options: Option): ioredis.Redis;
-    new(path: string, options: Option): ioredis.Redis;
-    new(port: number, options: Option): ioredis.Redis;
+    new(port: number, host: string, options: RedisOptions): ioredis.Redis;
+    new(path: string, options: RedisOptions): ioredis.Redis;
+    new(port: number, options: RedisOptions): ioredis.Redis;
     new(port: number, host: string): ioredis.Redis;
-    new(options: Option): ioredis.Redis;
+    new(options: RedisOptions): ioredis.Redis;
     new(port: number): ioredis.Redis;
     new(path: string): ioredis.Redis;
     new(): ioredis.Redis;
 }
 
 export const redisMock: Constructor;
-export {redisMock as default};
+export { redisMock as default };

--- a/types/ioredis-mock/index.d.ts
+++ b/types/ioredis-mock/index.d.ts
@@ -7,7 +7,7 @@
 import ioredis = require('ioredis');
 
 export interface Constructor {
-    new(option?: { data: Record<string, unknown> }): RealIORedis.Redis;
+    new(option?: { data: Record<string, unknown> }): ioredis.Redis;
 }
 
 export const redisMock: Constructor;

--- a/types/ioredis-mock/index.d.ts
+++ b/types/ioredis-mock/index.d.ts
@@ -6,9 +6,19 @@
 
 import ioredis = require('ioredis');
 
+
+type Option = { data?: Record<string, unknown> } & ioredis.RedisOptions
+
 export interface Constructor {
-    new(option?: { data: Record<string, unknown> }): ioredis.Redis;
+    new(port: number, host: string, options: Option): ioredis.Redis;
+    new(path: string, options: Option): ioredis.Redis;
+    new(port: number, options: Option): ioredis.Redis;
+    new(port: number, host: string): ioredis.Redis;
+    new(options: Option): ioredis.Redis;
+    new(port: number): ioredis.Redis;
+    new(path: string): ioredis.Redis;
+    new(): ioredis.Redis;
 }
 
 export const redisMock: Constructor;
-export { redisMock as default };
+export {redisMock as default};

--- a/types/ioredis-mock/ioredis-mock-tests.ts
+++ b/types/ioredis-mock/ioredis-mock-tests.ts
@@ -3,7 +3,7 @@ import IORedis, { RedisOptions } from 'ioredis-mock';
 // see https://www.npmjs.com/package/ioredis-mock for MockRedisInput input
 // see https://github.com/luin/ioredis/tree/master/examples
 
-const emptyOption = new IORedis()
+const emptyOption = new IORedis();
 
 const redis = new IORedis({
     data: {

--- a/types/ioredis-mock/ioredis-mock-tests.ts
+++ b/types/ioredis-mock/ioredis-mock-tests.ts
@@ -2,11 +2,19 @@ import IORedis, { RedisOptions } from 'ioredis-mock';
 
 // see https://github.com/luin/ioredis/tree/master/examples
 
+const emptyOption = new IORedis()
+
+
 const redis = new IORedis({
-    port: 1234,
-    host: process.env.redisEndpoint,
-    username: process.env.redisUsername,
-    password: process.env.redisPW,
+    data: {
+        user_next: '3',
+        emails: {
+            'clark@daily.planet': '1',
+            'bruce@wayne.enterprises': '2',
+        },
+        'user:1': { id: '1', username: 'superman', email: 'clark@daily.planet' },
+        'user:2': { id: '2', username: 'batman', email: 'bruce@wayne.enterprises' },
+    },
 });
 
 // ioredis supports all Redis commands:

--- a/types/ioredis-mock/ioredis-mock-tests.ts
+++ b/types/ioredis-mock/ioredis-mock-tests.ts
@@ -1,4 +1,4 @@
-import IORedis from 'ioredis-mock';
+import IORedis, { RedisOptions } from 'ioredis-mock';
 
 // see https://www.npmjs.com/package/ioredis-mock for MockRedisInput input
 // see https://github.com/luin/ioredis/tree/master/examples
@@ -15,6 +15,10 @@ const redis = new IORedis({
         'user:1': { id: '1', username: 'superman', email: 'clark@daily.planet' },
         'user:2': { id: '2', username: 'batman', email: 'bruce@wayne.enterprises' },
     },
+    port: 1234,
+    host: process.env.redisEndpoint,
+    username: process.env.redisUsername,
+    password: process.env.redisPW,
 });
 
 // ioredis supports all Redis commands:
@@ -56,6 +60,9 @@ redis.hgetall('myhash').then(res => console.log(res));
 
 // All arguments are passed directly to the redis server:
 redis.set('key', 100, 'EX', 10); // set's key to value 100 and expires it after 10 seconds
+
+const options: RedisOptions = {};
+console.log(options.port);
 
 const f = async () => {
     const channel = 'ioredis_channel';

--- a/types/ioredis-mock/ioredis-mock-tests.ts
+++ b/types/ioredis-mock/ioredis-mock-tests.ts
@@ -1,9 +1,9 @@
 import IORedis from 'ioredis-mock';
 
+// see https://www.npmjs.com/package/ioredis-mock for MockRedisInput input
 // see https://github.com/luin/ioredis/tree/master/examples
 
 const emptyOption = new IORedis()
-
 
 const redis = new IORedis({
     data: {

--- a/types/ioredis-mock/ioredis-mock-tests.ts
+++ b/types/ioredis-mock/ioredis-mock-tests.ts
@@ -1,4 +1,4 @@
-import IORedis, { RedisOptions } from 'ioredis-mock';
+import IORedis from 'ioredis-mock';
 
 // see https://github.com/luin/ioredis/tree/master/examples
 
@@ -56,9 +56,6 @@ redis.hgetall('myhash').then(res => console.log(res));
 
 // All arguments are passed directly to the redis server:
 redis.set('key', 100, 'EX', 10); // set's key to value 100 and expires it after 10 seconds
-
-const options: RedisOptions = {};
-console.log(options.port);
 
 const f = async () => {
     const channel = 'ioredis_channel';

--- a/types/ioredis-mock/tslint.json
+++ b/types/ioredis-mock/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "@definitelytyped/dtslint/dt.json",
     "rules": {
+        "unified-signatures": false,
         "npm-naming": [
             true,
             {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
it doesn't pass because of missing eslint rule  `no-bad-reference` and `trim-file`, also missingn def of `console` ...


Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.


https://www.npmjs.com/package/ioredis-mock

I'm getting a litte confused by `@types/ioredis-mock`

the document https://www.npmjs.com/package/ioredis-mock says it take a `ioredis.Redis` option with extra `data` property, but `@types/ioredis-mock` just re-export `ioredis` make it doesn't match the actually behavior.
