### PR TITLE
nodemailer-html-to-text - remove deprecated option

### DIFF
--- a/types/nodemailer-html-to-text/nodemailer-html-to-text-tests.ts
+++ b/types/nodemailer-html-to-text/nodemailer-html-to-text-tests.ts
@@ -14,8 +14,13 @@ function plugin_with_options_test() {
     const options: HtmlToTextOptions = {
         wordwrap: null,
         tables: true,
-        hideLinkHrefIfSameAsText: true,
         ignoreImage: true,
+        selectors: [
+            {
+                selector: 'a',
+                options: { hideLinkHrefIfSameAsText: true }
+            }
+        ]
     };
 
     transporter.use('compile', htmlToText(options));


### PR DESCRIPTION
Fix the test code by moving the specification of the option from general options to selector option.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/html-to-text/node-html-to-text/tree/master/packages/html-to-text)>>

Updating the test code to remove the use of deprecated options that are removed in the latest version of `html-to-text`.