### PR TITLE
[jest-image-snapshot] add `onlyDiff` option added in version 6.1.0

### DIFF
--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -66,6 +66,12 @@ export interface MatchImageSnapshotOptions {
      */
     diffDirection?: 'horizontal' | 'vertical' | undefined;
     /**
+     * Either only include the difference between the baseline and the received image in the diff image, or include
+     * the 3 images (following the direction set by `diffDirection`).
+     * @default false
+     */
+    onlyDiff?: boolean | undefined;
+    /**
      * Will output base64 string of a diff image to console in case of failed tests (in addition to creating a diff image).
      * This string can be copy-pasted to a browser address string to preview the diff for a failed test.
      * @default false

--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jest-image-snapshot 5.1
+// Type definitions for jest-image-snapshot 6.1
 // Project: https://github.com/americanexpress/jest-image-snapshot#readme
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 //                 erbridge <https://github.com/erbridge>

--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 //                 erbridge <https://github.com/erbridge>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+//                 Ayc0 <https://github.com/Ayc0>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 4.3
 

--- a/types/jest-image-snapshot/jest-image-snapshot-tests.ts
+++ b/types/jest-image-snapshot/jest-image-snapshot-tests.ts
@@ -19,6 +19,7 @@ it('should be able to use configureToMatchImageSnapshot in a test', () => {
             threshold: 5,
             includeAA: false,
         },
+        onlyDiff: false,
         failureThreshold: 10,
         failureThresholdType: 'percent',
     });
@@ -41,6 +42,7 @@ it('Should be able to use configuration directly in toMatchImageSnapshot', () =>
         storeReceivedOnFailure: true,
         customReceivedDir: '/usr/local/__received_output__',
         diffDirection: 'vertical',
+        onlyDiff: false,
         dumpInlineDiffToConsole: true,
         updatePassedSnapshot: true,
         failureThreshold: 10,


### PR DESCRIPTION
Add changes introduced in https://github.com/americanexpress/jest-image-snapshot/pull/317 to the types

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test jest-image-snapshot`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
  <img width="987" alt="image" src="https://user-images.githubusercontent.com/22725671/205862777-562cf5c0-1135-4c3c-ac6c-3297361eeb29.png">


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/americanexpress/jest-image-snapshot#%EF%B8%8F-api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


