### PR TITLE
Export @ckeditor/ckeditor5-core EditorWithUI

### DIFF
--- a/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
+++ b/types/ckeditor__ckeditor5-core/ckeditor__ckeditor5-core-tests.ts
@@ -6,12 +6,12 @@ import {
     DataApiMixin,
     Editor,
     EditorUI,
+    EditorWithUI 
     MultiCommand,
     PendingActions,
     Plugin,
 } from '@ckeditor/ckeditor5-core';
 import CommandCollection from '@ckeditor/ckeditor5-core/src/commandcollection';
-import { EditorWithUI } from '@ckeditor/ckeditor5-core/src/editor/editorwithui';
 import Selection from '@ckeditor/ckeditor5-engine/src/model/selection';
 import ParagraphCommand from '@ckeditor/ckeditor5-paragraph/src/paragraphcommand';
 import View from '@ckeditor/ckeditor5-ui/src/view';

--- a/types/ckeditor__ckeditor5-core/index.d.ts
+++ b/types/ckeditor__ckeditor5-core/index.d.ts
@@ -12,6 +12,7 @@ export { default as Context } from './src/context';
 export { default as ContextPlugin } from './src/contextplugin';
 export { default as Editor } from './src/editor/editor';
 export { default as EditorUI } from './src/editor/editorui';
+export { default as EditorWithUI  } from './src/editor/editorwithui';
 export { default as attachToForm } from './src/editor/utils/attachtoform';
 export { default as DataApiMixin } from './src/editor/utils/dataapimixin';
 export { default as ElementApiMixin } from './src/editor/utils/elementapimixin';

--- a/types/ckeditor__ckeditor5-core/index.d.ts
+++ b/types/ckeditor__ckeditor5-core/index.d.ts
@@ -12,7 +12,7 @@ export { default as Context } from './src/context';
 export { default as ContextPlugin } from './src/contextplugin';
 export { default as Editor } from './src/editor/editor';
 export { default as EditorUI } from './src/editor/editorui';
-export { default as EditorWithUI  } from './src/editor/editorwithui';
+export { EditorWithUI  } from './src/editor/editorwithui';
 export { default as attachToForm } from './src/editor/utils/attachtoform';
 export { default as DataApiMixin } from './src/editor/utils/dataapimixin';
 export { default as ElementApiMixin } from './src/editor/utils/elementapimixin';

--- a/types/ckeditor__ckeditor5-core/src/editor/editorwithui.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editorwithui.d.ts
@@ -12,6 +12,6 @@ import EditorUI from './editorui';
  * which bases on {@link module:core/editor/editor~Editor} itself, and the UI part which bases on this interface.
  * This will make your features compatible with more types of editors.
  */
-export interface EditorWithUI extends Editor {
+export default interface EditorWithUI extends Editor {
     readonly ui: EditorUI;
 }

--- a/types/ckeditor__ckeditor5-core/src/editor/editorwithui.d.ts
+++ b/types/ckeditor__ckeditor5-core/src/editor/editorwithui.d.ts
@@ -12,6 +12,6 @@ import EditorUI from './editorui';
  * which bases on {@link module:core/editor/editor~Editor} itself, and the UI part which bases on this interface.
  * This will make your features compatible with more types of editors.
  */
-export default interface EditorWithUI extends Editor {
+export interface EditorWithUI extends Editor {
     readonly ui: EditorUI;
 }


### PR DESCRIPTION
Exports interface EditorWithUI from @ckeditor/ckeditor5-core

`EditorWithUI` was already typed but just not exported 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editorwithui-EditorWithUI.html](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editorwithui-EditorWithUI.html)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
