### PR TITLE
[retry-as-promised] remove bluebird dependency

### DIFF
--- a/types/retry-as-promised/index.d.ts
+++ b/types/retry-as-promised/index.d.ts
@@ -1,10 +1,8 @@
-// Type definitions for retry-as-promised 2.3
+// Type definitions for retry-as-promised 5.0
 // Project: https://github.com/mickhansen/retry-as-promised
 // Definitions by: Florian Oellerich <https://github.com/Raigen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.2
-
-import Promise = require('bluebird');
 
 declare namespace retryAsPromised {
     type MatchOption =
@@ -24,7 +22,7 @@ declare namespace retryAsPromised {
         name?: string | undefined;
     }
 
-    type RetryCallback<T> = ({ current }: { current: Options['$current'] }) => Promise.Thenable<T>;
+    type RetryCallback<T> = ({ current }: { current: Options['$current'] }) => PromiseLike<T>;
     type RetryAsPromisedStatic = <T = any>(callback: RetryCallback<T>, options: Options | number) => Promise<T>;
 }
 

--- a/types/retry-as-promised/retry-as-promised-tests.ts
+++ b/types/retry-as-promised/retry-as-promised-tests.ts
@@ -16,6 +16,8 @@ declare class TestError extends BaseError {
 const log = (...args: any[]): void => {};
 
 retry(() => Promise.resolve(), {});
+// any PromiseLike can be passed as callback
+retry(() => Promise.resolve() as PromiseLike<void>, {});
 retry(() => Promise.reject('Error matching values'), {});
 retry(() => Promise.reject(new Error('No matching values')), {});
 retry(() => Promise.resolve(), {


### PR DESCRIPTION
Retry as promised uses native promises since v5.0 release

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mickhansen/retry-as-promised/commit/96b46c698e7fe4d23d2d3e91e2f1de1ffe53e1ef
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.