### PR TITLE
[react-dom] [react-native] fix incorrect typedefs for unstable_batchedUpdates

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -34,9 +34,8 @@ export const hydrate: Renderer;
 export function flushSync<R>(fn: () => R): R;
 export function flushSync<A, R>(fn: (a: A) => R, a: A): R;
 
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 export function unstable_renderSubtreeIntoContainer<T extends Element>(
     parentComponent: Component<any>,

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -218,7 +218,7 @@ describe('React dom test utils', () => {
                 await ReactTestUtils.act(async () => null);
             });
             it('a callback that returns a value', async () => {
-                await ReactTestUtils.act(async () => "value");
+                await ReactTestUtils.act(async () => 'value');
             });
             it('returns a Promise-like', () => {
                 const result = ReactTestUtils.act(async () => {});
@@ -227,6 +227,15 @@ describe('React dom test utils', () => {
         });
     });
 });
+
+async function batchTests() {
+    // $ExpectType string
+    const output1 = ReactDOM.unstable_batchedUpdates(input => {
+        // $ExpectType number
+        input;
+        return 'hi';
+    }, 1);
+}
 
 function createRoot() {
     const root = ReactDOMClient.createRoot(document.documentElement);

--- a/types/react-dom/v15/index.d.ts
+++ b/types/react-dom/v15/index.d.ts
@@ -49,9 +49,8 @@ export function unmountComponentAtNode(container: Element): boolean;
 
 export const version: string;
 
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 export function unstable_renderSubtreeIntoContainer<P extends DOMAttributes<T>, T extends Element>(
     parentComponent: Component<any>,

--- a/types/react-dom/v16/index.d.ts
+++ b/types/react-dom/v16/index.d.ts
@@ -34,9 +34,8 @@ export const hydrate: Renderer;
 export function flushSync<R>(fn: () => R): R;
 export function flushSync<A, R>(fn: (a: A) => R, a: A): R;
 
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 export function unstable_renderSubtreeIntoContainer<T extends Element>(
     parentComponent: Component<any>,

--- a/types/react-dom/v17/index.d.ts
+++ b/types/react-dom/v17/index.d.ts
@@ -30,9 +30,8 @@ export const hydrate: Renderer;
 export function flushSync<R>(fn: () => R): R;
 export function flushSync<A, R>(fn: (a: A) => R, a: A): R;
 
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 export function unstable_renderSubtreeIntoContainer<T extends Element>(
     parentComponent: Component<any>,

--- a/types/react-native/public/ReactNativeRenderer.d.ts
+++ b/types/react-native/public/ReactNativeRenderer.d.ts
@@ -131,10 +131,5 @@ export interface GestureResponderHandlers {
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(
-  callback: (a: A, b: B) => any,
-  a: A,
-  b: B,
-): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;

--- a/types/react-native/v0.63/index.d.ts
+++ b/types/react-native/v0.63/index.d.ts
@@ -9679,9 +9679,8 @@ export function unstable_enableLogBox(): void;
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 //////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/v0.64/index.d.ts
+++ b/types/react-native/v0.64/index.d.ts
@@ -9616,9 +9616,8 @@ export function unstable_enableLogBox(): void;
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 //////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/v0.65/index.d.ts
+++ b/types/react-native/v0.65/index.d.ts
@@ -9723,9 +9723,8 @@ export function unstable_enableLogBox(): void;
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 //////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/v0.66/index.d.ts
+++ b/types/react-native/v0.66/index.d.ts
@@ -9665,9 +9665,8 @@ export function unstable_enableLogBox(): void;
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 //////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/v0.67/index.d.ts
+++ b/types/react-native/v0.67/index.d.ts
@@ -9663,9 +9663,8 @@ export function unstable_enableLogBox(): void;
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 //////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/v0.68/index.d.ts
+++ b/types/react-native/v0.68/index.d.ts
@@ -9699,9 +9699,8 @@ export function unstable_enableLogBox(): void;
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 //////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/v0.69/index.d.ts
+++ b/types/react-native/v0.69/index.d.ts
@@ -9627,9 +9627,8 @@ export function unstable_enableLogBox(): void;
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 //////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-native/v0.70/index.d.ts
+++ b/types/react-native/v0.70/index.d.ts
@@ -9854,9 +9854,8 @@ export function unstable_enableLogBox(): void;
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 //////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
The type definitions of `unstable_batchedUpdates` have been wrong for a long time. It only accepts 2 arguments, not 3, and the return value from the callback is passed through. 

_**(Examples edited to remove unlikely async pattern)**_ 

This matters because the following code is flagged as wrong in VSCode:
```js
const result = unstable_batchedUpdates(() => {
    return 123;
});
```
VSCode/TS thinks that the return value from `unstable_batchedUpdates` is always `void`

---

The second issue is that only one argument is passed through to the callback function:

```js
unstable_batchedUpdates((x, y) => {
  console.log({ x, y });
}, 1, 2);
// the typedefs claim that this will print `{ x: 1, y: 2 }`. This is wrong. 
// It will actually print `{ x: 1, y: undefined }`. Only the first argument 
// is passed through.
```

---

Reference:
 - [react 18 source code](https://github.com/facebook/react/blob/v18.2.0/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L1319-L1337)
 - [react 17 source code](https://github.com/facebook/react/blob/v17.0.2/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L1128-L1141)
 - [react 16 source code](https://github.com/facebook/react/blob/v16.14.0/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L1128-L1141)
 - [react-native 0.71 source code](https://github.com/facebook/react-native/blob/0.71-stable/Libraries/ReactNative/RendererImplementation.js#L99-L108)

 ---


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _See links above_
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~
