### PR TITLE
[properties-parser] Add types for properties-parser

### DIFF
--- a/types/properties-parser/index.d.ts
+++ b/types/properties-parser/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for properties-parser 0.3
+// Project: https://github.com/xavi-/node-properties-parser
+// Definitions by: Segev Finer <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import type * as fs from 'fs';
+import type { promisify } from 'util';
+
+export type Properties = Record<string, string>;
+
+export interface EditorOptions {
+    separator?: string;
+    path?: string;
+    callback?: (err: Error | null, editor: Editor) => void;
+}
+
+export function parse(text: string): Properties;
+export function read(path: fs.PathLike): Properties;
+export function read(path: fs.PathLike, callback: (err: Error | null, data: Properties) => void): void;
+
+export const createEditor: {
+    (options?: EditorOptions): Editor;
+    (path: fs.PathLike, options?: EditorOptions): Editor;
+    (path: fs.PathLike, options?: EditorOptions, callback?: (err: Error | null, editor: Editor) => void): void;
+    [promisify.custom]: (path: fs.PathLike, options?: EditorOptions) => Promise<Editor>;
+};
+
+export interface Editor {
+    get(key: string): string | undefined;
+    set(key: string, value?: string | null, comment?: string): void;
+    unset(key: string): void;
+
+    save(callback: (err: Error | null) => void, path?: fs.PathLike): void;
+    save(path?: fs.PathLike, callback?: (err: Error | null) => void): void;
+
+    addHeadComment(comment: string): void;
+
+    toString(): string;
+}

--- a/types/properties-parser/index.d.ts
+++ b/types/properties-parser/index.d.ts
@@ -38,4 +38,5 @@ export interface Editor {
     addHeadComment(comment: string): void;
 
     toString(): string;
+    valueOf(): string;
 }

--- a/types/properties-parser/properties-parser-tests.ts
+++ b/types/properties-parser/properties-parser-tests.ts
@@ -1,0 +1,38 @@
+import * as propertiesParser from 'properties-parser';
+import { promisify } from 'util';
+
+// $ExpectType Properties
+propertiesParser.parse('test=hello');
+
+// $ExpectType Properties
+propertiesParser.read('test.properties');
+
+propertiesParser.read('test.properties', (err, data) => {
+    // $ExpectType Error | null
+    err;
+    // $ExpectType Properties
+    data;
+});
+
+// $ExpectType Promise<Properties>
+promisify(propertiesParser.read)('test.properties');
+
+// $ExpectType (path: PathLike, options?: EditorOptions | undefined) => Promise<Editor>
+promisify(propertiesParser.createEditor);
+
+// $ExpectType Editor
+const editor = propertiesParser.createEditor('test.properties');
+
+// $ExpectType string | undefined
+editor.get('test');
+editor.set('test');
+editor.set('test', 'hello');
+
+editor.save();
+editor.save(err => {
+    // $ExpectType Error | null
+    err;
+});
+
+// $ExpectType Editor
+propertiesParser.createEditor({ path: 'test.properties', separator: '=' });

--- a/types/properties-parser/tsconfig.json
+++ b/types/properties-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "properties-parser-tests.ts"
+    ]
+}

--- a/types/properties-parser/tslint.json
+++ b/types/properties-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
