### PR TITLE
nodemailer-html-to-text - remove deprecated options in test code

### DIFF
--- a/types/nodemailer-html-to-text/nodemailer-html-to-text-tests.ts
+++ b/types/nodemailer-html-to-text/nodemailer-html-to-text-tests.ts
@@ -13,12 +13,18 @@ function plugin_with_options_test() {
 
     const options: HtmlToTextOptions = {
         wordwrap: null,
-        tables: true,
-        ignoreImage: true,
         selectors: [
             {
                 selector: 'a',
                 options: { hideLinkHrefIfSameAsText: true }
+            },
+            {
+                selector: 'img',
+                format: 'skip'
+            },
+            {
+                selector: 'table',
+                format: 'dataTable'
             }
         ]
     };


### PR DESCRIPTION
Tested with html-to-text v9 and needed to convert more tests to use selectors.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Updating test code for latest version of [html-to-text](https://github.com/html-to-text/node-html-to-text).