### PR TITLE
[karma-browserstack-launcher] Fix: credentials are mistakenly required

### DIFF
--- a/types/karma-browserstack-launcher/index.d.ts
+++ b/types/karma-browserstack-launcher/index.d.ts
@@ -44,9 +44,9 @@ declare module 'karma' {
 
     interface BrowserStackOptions {
         /** BS username, you can also use BROWSERSTACK_USERNAME env variable */
-        username: string;
+        username?: string | undefined;
         /**  BS access key, you can also use BROWSERSTACK_ACCESS_KEY env variable */
-        accessKey: string;
+        accessKey?: string | undefined;
         /** do you wanna establish the BrowserStack tunnel */
         startTunnel?: boolean | undefined;
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/karma-runner/karma-browserstack-launcher/blob/2d3189ad00fe71b11694816dc44d8d3399284f17/index.js#L45

    The library loads the credentials from environment as a backup, i.e. the library can run fine without these parameters in the code. Also, since the whole `browserStack` property is optional, the credentials are meant to be optional anyway.
- [x] (not applicable) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
