### PR TITLE
Fix missing push permissions on codeowners workflow

### DIFF
--- a/.github/workflows/UpdateCodeowners.yml
+++ b/.github/workflows/UpdateCodeowners.yml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
   update:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     if: github.repository == 'DefinitelyTyped/DefinitelyTyped'
 


### PR DESCRIPTION
[This](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/UpdateCodeowners.yml) has been failing since #61065; the write permissions were removed for this job and we didn't notice in review.