### PR TITLE
Use correct email/name for typescript-bot in codeowners workflow

### DIFF
--- a/.github/workflows/UpdateCodeowners.yml
+++ b/.github/workflows/UpdateCodeowners.yml
@@ -27,8 +27,8 @@ jobs:
 
       - uses: actions/setup-node@v3
 
-      - run: git config --global user.email "bot@typescriptlang.org"
-      - run: git config --global user.name "TS Bot"
+      - run: git config --global user.email "typescriptbot@microsoft.com"
+      - run: git config --global user.name "TypeScript Bot"
 
       - run: npm install
       - run: npm run update-codeowners


### PR DESCRIPTION
Noticed this after #51045; we should be using the same bot account info as all of our other automated tasks. The ghostbuster has this set correctly.