### PR TITLE
@types/query-selector-shadow-dom Add overloads for simple selectors

### DIFF
--- a/types/query-selector-shadow-dom/index.d.ts
+++ b/types/query-selector-shadow-dom/index.d.ts
@@ -17,7 +17,17 @@
  * ```
  * @license Apache-2.0
  */
-export function querySelectorDeep(selector: string, root?: Document | HTMLElement, cachedElements?: HTMLElement[] | null): HTMLElement | null;
+export function querySelectorDeep<K extends keyof HTMLElementTagNameMap>(
+  selector: K,
+  root?: Document | HTMLElement,
+  cachedElements?: ReadonlyArray<HTMLElementTagNameMap[K]> | null
+): HTMLElementTagNameMap[K] | null;
+export function querySelectorDeep<K extends keyof SVGElementTagNameMap>(
+  selector: K,
+  root?: Document | HTMLElement,
+  cachedElements?: ReadonlyArray<SVGElementTagNameMap[K]> | null
+): SVGElementTagNameMap[K] | null;
+export function querySelectorDeep(selector: string, root?: Document | HTMLElement, cachedElements?: readonly HTMLElement[] | null): HTMLElement | null;
 
 /**
  * Finds first matching elements on the page that may be in a shadow root using a complex selector of n-depth
@@ -28,7 +38,17 @@ export function querySelectorDeep(selector: string, root?: Document | HTMLElemen
  * @returns the HTMLElement's found or an empty array if none found
  * @license Apache-2.0
  */
-export function querySelectorAllDeep(selector: string, root?: Document | HTMLElement, cachedElements?: HTMLElement[] | null): HTMLElement[];
+export function querySelectorAllDeep<K extends keyof HTMLElementTagNameMap>(
+  selector: K,
+  root?: Document | HTMLElement,
+  cachedElements?: ReadonlyArray<HTMLElementTagNameMap[K]> | null
+): Array<HTMLElementTagNameMap[K]>;
+export function querySelectorAllDeep<K extends keyof SVGElementTagNameMap>(
+  selector: K,
+  root?: Document | HTMLElement,
+  cachedElements?: ReadonlyArray<SVGElementTagNameMap[K]> | null
+): Array<SVGElementTagNameMap[K]>;
+export function querySelectorAllDeep(selector: string, root?: Document | HTMLElement, cachedElements?: readonly HTMLElement[] | null): HTMLElement[];
 
 /**
  * Finds all elements on the page, inclusive of those within shadow roots
@@ -38,4 +58,14 @@ export function querySelectorAllDeep(selector: string, root?: Document | HTMLEle
  * @returns all elements on the page, inclusive of those within shadow roots.
  * @license Apache-2.0
  */
-export function collectAllElementsDeep(selector: string | null, root: Document | HTMLElement, cachedElements?: HTMLElement[] | null): HTMLHtmlElement[];
+export function collectAllElementsDeep<K extends keyof HTMLElementTagNameMap>(
+  selector: K,
+  root?: Document | HTMLElement,
+  cachedElements?: ReadonlyArray<HTMLElementTagNameMap[K]> | null
+): Array<HTMLElementTagNameMap[K]>;
+export function collectAllElementsDeep<K extends keyof SVGElementTagNameMap>(
+  selector: K,
+  root?: Document | HTMLElement,
+  cachedElements?: ReadonlyArray<SVGElementTagNameMap[K]> | null
+): Array<SVGElementTagNameMap[K]>;
+export function collectAllElementsDeep(selector: string | null, root: Document | HTMLElement, cachedElements?: readonly HTMLElement[] | null): HTMLElement[];

--- a/types/query-selector-shadow-dom/query-selector-shadow-dom-tests.ts
+++ b/types/query-selector-shadow-dom/query-selector-shadow-dom-tests.ts
@@ -3,8 +3,14 @@ import { querySelectorDeep, querySelectorAllDeep, collectAllElementsDeep } from 
 // $ExpectType HTMLElement | null
 const doc = querySelectorDeep('document');
 
+// $ExpectType HTMLDivElement | null
+const div = querySelectorDeep('div');
+
+// $ExpectType SVGGElement | null
+const g = querySelectorDeep('g');
+
 // $ExpectType HTMLElement | null
-const doc2 = querySelectorDeep('div.test');
+const divTest = querySelectorDeep('div.test');
 
 // @ts-expect-error
 querySelectorDeep(42);
@@ -16,6 +22,15 @@ querySelectorDeep({});
 // $ExpectType HTMLElement[]
 const docs = querySelectorAllDeep('document');
 
+// $ExpectType HTMLDivElement[]
+const divs = querySelectorAllDeep('div');
+
+// $ExpectType SVGGElement[]
+const gs = querySelectorAllDeep('g');
+
+// $ExpectType HTMLElement[]
+const divTests = querySelectorAllDeep('div.test');
+
 // @ts-expect-error
 querySelectorAllDeep(42);
 // @ts-expect-error
@@ -23,8 +38,14 @@ querySelectorAllDeep(true);
 // @ts-expect-error
 querySelectorAllDeep({});
 
-// $Expect HTMLHtmlElement
+// $Expect HTMLElement[]
 const whole1 = collectAllElementsDeep(null, document);
+
+// $Expect HTMLDivElement[]
+const allDivs = collectAllElementsDeep('div', document);
+
+// $Expect SVGGElement[]
+const allGs = collectAllElementsDeep('svg', document);
 
 // @ts-expect-error
 const whole2 = collectAllElementsDeep();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/webdriverio/query-selector-shadow-dom/blob/main/src/querySelectorDeep.js)

This copies the overloads from `querySelector` and `querySelectorAll`:

```ts
/** Returns the first element that is a descendant of node that matches selectors. */
querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
querySelector<K extends keyof SVGElementTagNameMap>(selectors: K): SVGElementTagNameMap[K] | null;
querySelector<E extends Element = Element>(selectors: string): E | null;
/** Returns all element descendants of node that match selectors. */
querySelectorAll<K extends keyof HTMLElementTagNameMap>(selectors: K): NodeListOf<HTMLElementTagNameMap[K]>;
querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf<SVGElementTagNameMap[K]>;
querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
```