### PR TITLE
[react-dom] Don't trigger dangling Promise lint rules on void `act` callbacks

### DIFF
--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -298,7 +298,7 @@ export function createRenderer(): ShallowRenderer;
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 // tslint:disable-next-line: void-return
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
-// While act does always return Thenable, if a void function is passed, the behavior is synchronous
+// While act does always return Thenable, if a void function is passed, we pretend the return value is also void to not trigger dangling Promise lint rules.
 export function act(callback: () => VoidOrUndefinedOnly): void;
 export function act<T>(callback: () => T | Promise<T>): Promise<T>;
 

--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -298,8 +298,9 @@ export function createRenderer(): ShallowRenderer;
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 // tslint:disable-next-line: void-return
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+// While act does always return Thenable, if a void function is passed, the behavior is synchronous
+export function act(callback: () => VoidOrUndefinedOnly): void;
 export function act<T>(callback: () => T | Promise<T>): Promise<T>;
-export function act(callback: () => VoidOrUndefinedOnly): Promise<void>;
 
 // Intentionally doesn't extend PromiseLike<never>.
 // Ideally this should be as hard to accidentally use as possible.

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -199,16 +199,15 @@ describe('React dom test utils', () => {
             it('accepts a callback that is void', () => {
                 ReactTestUtils.act(() => {});
             });
-            it('accepts a callback that returns null', () => {
-                ReactTestUtils.act(() => null);
-            });
             it('accepts a callback that returns a value', () => {
-                ReactTestUtils.act(() => "value");
+                const result = ReactTestUtils.act(() => "value");
+                result.then(x => {});
             });
-            it('returns a type that is Promise-like', () => {
+            it('returns void', () => {
                 // tslint:disable-next-line no-void-expression
                 const result = ReactTestUtils.act(() => {});
-                result.then(x => {});
+                // @ts-expect-error
+                result.then;
             });
         });
         describe('with async callback', () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/b14d7fa4b88dad5f0017d084e462952c700aa2ad/packages/react/src/ReactAct.js#L169-L184

This fixes the issue introduced by #63186 and is further explained in #63394.