### PR TITLE
[chrome-remote-interface] add support for shorthand callback version of events

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -30,17 +30,27 @@ function assertType<T>(value: T): T {
         const loadEvent = await client['Page.loadEventFired'](); // instead of: await Page.loadEventFired();
         loadEvent.timestamp;
         await client['Page.interstitialHidden'](); // instead of: await Page.interstitialHidden();
-        // instead of: Network.requestWillBeSent((params, sessionId) => {});
-        const unsubscribe = client['Network.requestWillBeSent']((params, sessionId) => {
+        const unsubscribe = Network.requestWillBeSent((params, sessionId) => {
             params.request.url;
             unsubscribe();
         });
-        const unsubscribe2 = client['Network.requestWillBeSent']((params) => {
+        const unsubscribeAlt = client['Network.requestWillBeSent']((params, sessionId) => {
+            params.request.url;
+            unsubscribeAlt();
+        });
+        const unsubscribe2 = Network.requestWillBeSent((params) => {
             params.request.url;
             unsubscribe2();
         });
-        const unsubscribe3 = client['Page.frameResized'](() => {
+        const unsubscribeAlt2 = client['Network.requestWillBeSent']((params) => {
+            params.request.url;
+            unsubscribeAlt2();
+        });
+        const unsubscribe3 = Page.frameResized(() => {
             unsubscribe3();
+        });
+        const unsubscribeAlt3 = client['Page.frameResized'](() => {
+            unsubscribeAlt3();
         });
         await Runtime.enable();
         const loc = await Runtime.evaluate({ expression: 'window.location.toString()' });

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -153,6 +153,18 @@ declare namespace CDP {
     // Generated content end.
     /////////////////////////////////////////////////
 
+    type GetEventFromString<D extends string, S extends string> = S extends `${D}.${infer E}` ? E : never;
+    type GetEvent<D extends string> = GetEventFromString<D, keyof ProtocolMappingApi.Events>;
+    type GetReturnType<D extends string, E extends string> =
+        `${D}.${E}` extends keyof ProtocolMappingApi.Events ?
+            ProtocolMappingApi.Events[`${D}.${E}`][0] : never;
+    type DoEventProps<D extends string> = {
+        [event in GetEvent<D>]: (listener: GetReturnType<D, event> extends undefined ?
+                (sessionId?: string) => void :
+                (params: GetReturnType<D, event>, sessionId?: string) => void)
+            => () => Client};
+    type DoEventObj<D> = D extends string ? DoEventProps<D> : Record<keyof any, never>;
+
     type IsNullableObj<T> = Record<keyof T, undefined> extends T ? true : false;
     /**
      * Checks whether the only parameter of `T[key]` is nullable i.e. all of
@@ -165,7 +177,8 @@ declare namespace CDP {
                 T[key] :
             T[key]
     };
-    type ImproveAPI<T> = {[key in keyof T]: OptIfParamNullable<T[key]>};
+
+    type ImproveAPI<T> = {[key in keyof T]: OptIfParamNullable<T[key]> & DoEventObj<key>};
     interface StableDomains {
         Browser: ProtocolProxyApi.BrowserApi;
         Debugger: ProtocolProxyApi.DebuggerApi;

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -159,10 +159,8 @@ declare namespace CDP {
         `${D}.${E}` extends keyof ProtocolMappingApi.Events ?
             ProtocolMappingApi.Events[`${D}.${E}`][0] : never;
     type DoEventProps<D extends string> = {
-        [event in GetEvent<D>]: (listener: GetReturnType<D, event> extends undefined ?
-                (sessionId?: string) => void :
-                (params: GetReturnType<D, event>, sessionId?: string) => void)
-            => () => Client};
+        [event in GetEvent<D>]:
+            (listener: (params: GetReturnType<D, event>, sessionId?: string) => void) => () => Client};
     type DoEventObj<D> = D extends string ? DoEventProps<D> : Record<keyof any, never>;
 
     type IsNullableObj<T> = Record<keyof T, undefined> extends T ? true : false;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cyrus-and/chrome-remote-interface/issues/500#issuecomment-1248272589 (1st item in the list)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This pr adds support for statements of the form:

```ts
Network.requestWillBeSent((params) => {
    // ...
});
```

as shorthand for

```ts
client['Network.requestWillBeSent']((params) => {
    // ...
});
```

Unfortunately there doesn't seem to be a way to copy over associated JSDoc, but they can be retrieved easily (with slight inconvenience) using the second form above, e.g. by typing in

```ts
client['Network.requestWillBeSent']
```

and then hovering the mouse over the partial statement.
