### PR TITLE
[redux-first-router-link] Add children for React 18 compatibility

### DIFF
--- a/types/redux-first-router-link/index.d.ts
+++ b/types/redux-first-router-link/index.d.ts
@@ -25,6 +25,7 @@ export interface LinkProps extends React.HTMLAttributes<HTMLElement> {
     down?: boolean | undefined;
     shouldDispatch?: boolean | undefined;
     target?: string | undefined;
+    children?: React.ReactNode;
 }
 
 export default class Link extends React.Component<LinkProps> {}
@@ -35,6 +36,7 @@ export interface NavLinkProps extends LinkProps {
     ariaCurrent?: string | undefined;
     exact?: boolean | undefined;
     strict?: boolean | undefined;
+    children?: React.ReactNode;
     isActive?(match: Match<object>, location: Location): boolean;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This fixes the compability issue with the new children typings for React 18. The definition change has been tested in a medium scale project without issues.

No tests has been modified since no real changes is affecting the code, even though I wonder why the test was successful before my changes (since React 18 broke these typings)?
