### PR TITLE
[chrome-remote-interface] put `@types\chrome-remote-interface` overloads before `devtools-protocol` overloads

### DIFF
--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -176,7 +176,7 @@ declare namespace CDP {
             T[key]
     };
 
-    type ImproveAPI<T> = {[key in keyof T]: OptIfParamNullable<T[key]> & DoEventObj<key>};
+    type ImproveAPI<T> = {[key in keyof T]: DoEventObj<key> & OptIfParamNullable<T[key]>};
     interface StableDomains {
         Browser: ProtocolProxyApi.BrowserApi;
         Debugger: ProtocolProxyApi.DebuggerApi;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

This pr puts `@types\chrome-remote-interface` overloads before any (possibly patched) `devtools-protocol` overloads, so that TypeScript prioritizes the overloads in `@types\chrome-remote-interface`.  This is necessary specifically because an overload return type in `@types\chrome-remote-interface` can refer to `CDP.Client`, while this can't be done with a `devtools-protocol` `patch-package` patch.