### PR TITLE
Add missing History module typ quill.js typings

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -99,6 +99,13 @@ export class RangeStatic implements RangeStatic {
     length: number;
 }
 
+export interface History {
+    clear(): void;
+    cutoff(): void;
+    undo(): void;
+    redo(): void;
+}
+
 export interface EventEmitter {
     on(eventName: "text-change", handler: TextChangeHandler): EventEmitter;
     on(eventName: "selection-change", handler: SelectionChangeHandler): EventEmitter;
@@ -119,6 +126,7 @@ export class Quill implements EventEmitter {
     clipboard: ClipboardStatic;
     scroll: Blot;
     keyboard: KeyboardStatic;
+    history: History;
     constructor(container: string | Element, options?: QuillOptionsStatic);
     deleteText(index: number, length: number, source?: Sources): Delta;
     disable(): void;

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -404,3 +404,11 @@ function test_KeyboardBool() {
     );
     // If typescript thorws an error then the key type is invalid
 }
+
+function test_history() {
+  const quillEditor = new Quill("#editor");
+  quillEditor.history.undo();
+  quillEditor.history.redo();
+  quillEditor.history.cutoff();
+  quillEditor.history.clear();
+}


### PR DESCRIPTION
Added missing History module with its four methods (https://quilljs.com/docs/modules/history/) to the quill.js typings.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://quilljs.com/docs/modules/history/)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

