### PR TITLE
[@types/oojs] Use intersection instead of conditional types for EventEmitter overloads

### DIFF
--- a/types/oojs/EmitterList.d.ts
+++ b/types/oojs/EmitterList.d.ts
@@ -80,56 +80,6 @@ declare namespace OO {
          * Clear all items.
          */
         clearItems(): this;
-
-        // #region EventEmitter overloads
-        on<K extends keyof EmitterListEventMap, A extends ArgTuple = [], C = null>(
-            event: K,
-            method: EventHandler<C, (this: C, ...args: [...A, ...EmitterListEventMap[K]]) => void>,
-            args?: A,
-            context?: C,
-        ): this;
-        on<K extends string, C = null>(
-            event: K extends keyof EmitterListEventMap ? never : K,
-            method: EventHandler<C>,
-            args?: any[],
-            context?: C,
-        ): this;
-
-        once<K extends keyof EmitterListEventMap>(
-            event: K,
-            listener: (this: null, ...args: EmitterListEventMap[K]) => void,
-        ): this;
-        once<K extends string>(
-            event: K extends keyof EmitterListEventMap ? never : K,
-            listener: (this: null, ...args: any[]) => void,
-        ): this;
-
-        off<K extends keyof EmitterListEventMap, C = null>(
-            event: K,
-            method?: EventHandler<C, (this: C, ...args: EmitterListEventMap[K]) => void>,
-            context?: C,
-        ): this;
-        off<K extends string, C = null>(
-            event: K extends keyof EmitterListEventMap ? never : K,
-            method?: EventHandler<C>,
-            context?: C,
-        ): this;
-
-        emit<K extends keyof EmitterListEventMap>(event: K, ...args: EmitterListEventMap[K]): boolean;
-        emit<K extends string>(event: K extends keyof EmitterListEventMap ? never : K, ...args: any[]): boolean;
-
-        emitThrow<K extends keyof EmitterListEventMap>(event: K, ...args: EmitterListEventMap[K]): boolean;
-        emitThrow<K extends string>(event: K extends keyof EmitterListEventMap ? never : K, ...args: any[]): boolean;
-
-        connect<T extends Partial<Record<keyof EmitterListEventMap, any>>, C>(
-            context: C,
-            methods: EventConnectionMap<T, C, EmitterListEventMap>, // tslint:disable-line:no-unnecessary-generics
-        ): this;
-        disconnect<T extends Partial<Record<keyof EmitterListEventMap, any>>, C>(
-            context: C,
-            methods?: EventConnectionMap<T, C, EmitterListEventMap>, // tslint:disable-line:no-unnecessary-generics
-        ): this;
-        // #endregion
     }
 
     interface EmitterListConstructor {

--- a/types/oojs/EmitterList.d.ts
+++ b/types/oojs/EmitterList.d.ts
@@ -81,7 +81,7 @@ declare namespace OO {
          */
         clearItems(): this;
 
-        // #region Event utils
+        // #region EventEmitter overloads
         on<K extends keyof EmitterListEventMap, A extends ArgTuple = [], C = null>(
             event: K,
             method: EventHandler<C, (this: C, ...args: [...A, ...EmitterListEventMap[K]]) => void>,
@@ -123,24 +123,11 @@ declare namespace OO {
 
         connect<T extends Partial<Record<keyof EmitterListEventMap, any>>, C>(
             context: C,
-            methods: {
-                [K in keyof T]: EventConnectionMapEntry<
-                    C,
-                    K extends keyof EmitterListEventMap ? EmitterListEventMap[K] : any[],
-                    T[K]
-                >;
-            },
+            methods: EventConnectionMap<T, C, EmitterListEventMap>, // tslint:disable-line:no-unnecessary-generics
         ): this;
-
         disconnect<T extends Partial<Record<keyof EmitterListEventMap, any>>, C>(
             context: C,
-            methods?: {
-                [K in keyof T]: EventConnectionMapEntry<
-                    C,
-                    K extends keyof EmitterListEventMap ? EmitterListEventMap[K] : any[],
-                    T[K]
-                >;
-            },
+            methods?: EventConnectionMap<T, C, EmitterListEventMap>, // tslint:disable-line:no-unnecessary-generics
         ): this;
         // #endregion
     }

--- a/types/oojs/Factory.d.ts
+++ b/types/oojs/Factory.d.ts
@@ -64,7 +64,7 @@ declare namespace OO {
     }
 
     interface FactoryConstructor {
-        new(): Factory;
+        new (): Factory;
         prototype: Factory;
         super: RegistryConstructor;
         /** @deprecated Use `super` instead */

--- a/types/oojs/Registry.d.ts
+++ b/types/oojs/Registry.d.ts
@@ -40,7 +40,7 @@ declare namespace OO {
          */
         lookup(name: string): unknown | undefined;
 
-        // #region Event utils
+        // #region EventEmitter overloads
         on<K extends keyof RegistryEventMap, A extends ArgTuple = [], C = null>(
             event: K,
             method: EventHandler<C, (this: C, ...args: [...A, ...RegistryEventMap[K]]) => void>,
@@ -82,24 +82,13 @@ declare namespace OO {
 
         connect<T extends Partial<Record<keyof RegistryEventMap, any>>, C>(
             context: C,
-            methods: {
-                [K in keyof T]: EventConnectionMapEntry<
-                    C,
-                    K extends keyof RegistryEventMap ? RegistryEventMap[K] : any[],
-                    T[K]
-                >;
-            },
+            methods: EventConnectionMap<T, C, RegistryEventMap>, // tslint:disable-line:no-unnecessary-generics
         ): this;
 
+        // tslint:disable-next-line:no-unnecessary-generics
         disconnect<T extends Partial<Record<keyof RegistryEventMap, any>>, C>(
             context: C,
-            methods?: {
-                [K in keyof T]: EventConnectionMapEntry<
-                    C,
-                    K extends keyof RegistryEventMap ? RegistryEventMap[K] : any[],
-                    T[K]
-                >;
-            },
+            methods?: EventConnectionMap<T, C, RegistryEventMap>, // tslint:disable-line:no-unnecessary-generics
         ): this;
         // #endregion
     }

--- a/types/oojs/Registry.d.ts
+++ b/types/oojs/Registry.d.ts
@@ -85,7 +85,6 @@ declare namespace OO {
             methods: EventConnectionMap<T, C, RegistryEventMap>, // tslint:disable-line:no-unnecessary-generics
         ): this;
 
-        // tslint:disable-next-line:no-unnecessary-generics
         disconnect<T extends Partial<Record<keyof RegistryEventMap, any>>, C>(
             context: C,
             methods?: EventConnectionMap<T, C, RegistryEventMap>, // tslint:disable-line:no-unnecessary-generics

--- a/types/oojs/oojs-tests.ts
+++ b/types/oojs/oojs-tests.ts
@@ -330,30 +330,6 @@ emitterList.isEmpty();
     // $ExpectType EmitterList
     emitterList.removeItems([eventEmitter]);
 }
-
-{
-    emitterList.on('add', function (item, index) {
-        this; // $ExpectType null
-        item; // $ExpectType EventEmitter
-        index; // $ExpectType number
-    });
-
-    emitterList.on('clear', function () {
-        this; // $ExpectType null
-    });
-
-    emitterList.on('move', function (item, index, oldIndex) {
-        this; // $ExpectType null
-        index; // $ExpectType number
-        oldIndex; // $ExpectType number
-    });
-
-    emitterList.on('remove', function (item, index) {
-        this; // $ExpectType null
-        item; // $ExpectType EventEmitter
-        index; // $ExpectType number
-    });
-}
 // #endregion
 
 // #region Factory

--- a/types/oojs/oojs-tests.ts
+++ b/types/oojs/oojs-tests.ts
@@ -468,14 +468,26 @@ registry.lookup('foo');
 
     // @ts-expect-error
     registry.on('unregister', 'unregisterIllegal', [], funcObj);
+
+    registry.on('non-exist', function (arg) {
+        this; // $ExpectType null
+        arg; // $ExpectType any
+    });
 }
 
-// $ExpectType Registry
-registry.once('register', function (name, data) {
-    this; // $ExpectType null
-    name; // $ExpectType string
-    data; // $ExpectType unknown
-});
+{
+    // $ExpectType Registry
+    registry.once('register', function (name, data) {
+        this; // $ExpectType null
+        name; // $ExpectType string
+        data; // $ExpectType unknown
+    });
+
+    registry.once('non-exist', function (arg) {
+        this; // $ExpectType null
+        arg; // $ExpectType any
+    });
+}
 
 {
     let funcObj = {
@@ -511,6 +523,11 @@ registry.once('register', function (name, data) {
 
     // @ts-expect-error
     registry.off('unregister', 'unregisterIllegal', funcObj);
+
+    registry.off('non-exist', function (arg) {
+        this; // $ExpectType null
+        arg; // $ExpectType any
+    });
 }
 
 {
@@ -525,6 +542,9 @@ registry.once('register', function (name, data) {
 
     // @ts-expect-error
     registry.emit('unregister');
+
+    // $ExpectType boolean
+    registry.emit('non-exist', 1, 2, 3, 4);
 }
 
 {
@@ -539,6 +559,9 @@ registry.once('register', function (name, data) {
 
     // @ts-expect-error
     registry.emitThrow('unregister');
+
+    // $ExpectType boolean
+    registry.emitThrow('non-exist', 1, 2, 3, 4);
 }
 
 {
@@ -574,6 +597,10 @@ registry.once('register', function (name, data) {
             this; // $ExpectType null
             name; // $ExpectType string
             data; // $ExpectType unknown
+        },
+        nonExist(arg) {
+            this; // $ExpectType null
+            arg; // $ExpectType any
         },
     });
 
@@ -643,12 +670,17 @@ registry.once('register', function (name, data) {
             name; // $ExpectType string
             data; // $ExpectType unknown
         },
+        nonExist(arg) {
+            this; // $ExpectType null
+            arg; // $ExpectType any
+        },
     });
 
     registry.disconnect(null, {
         register: [
             function (arg1, arg2, arg3, arg4, arg5, name, data) {
                 this; // $ExpectType null
+                arg1; // $ExpectType number
                 arg2; // $ExpectType number
                 arg3; // $ExpectType number
                 arg4; // $ExpectType number

--- a/types/oojs/utils.d.ts
+++ b/types/oojs/utils.d.ts
@@ -68,6 +68,10 @@ declare namespace OO {
 
     type ArgTuple = [] | [any] | [any, any] | [any, any, any] | [any, any, any, any] | [any, any, any, any, any];
 
+    type EventConnectionMap<T extends object, C, M extends object> = {
+        [K in keyof T]: EventConnectionMapEntry<C, (M & Record<string | number | symbol, any[]>)[K], T[K]>;
+    };
+
     type EventConnectionMapEntry<C, P extends any[], T> = T extends ArgTuple
         ? [EventHandler<C, (this: C, ...args: [...T, ...P]) => void>, ...T]
         : EventHandler<C, (this: C, ...args: P) => void>;


### PR DESCRIPTION
This PR addresses an "`interface SubClass incorrectly extends interface SuperClass`" issue which occurs when EventEmitter overloads are included in both classes by using type intersections instead of conditional types.

It also remove non-exist methods of `EmitterList`, which were added accidentally.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.