### PR TITLE
[plotly.js] Missing definitions of "autocontour" and "ncontours"

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1347,6 +1347,8 @@ export interface PlotData {
         type: 'levels' | 'constraint';
         value: number | [lowerBound: number, upperBound: number];
     }>;
+    autocontour: boolean;
+    ncontours: number;
 }
 
 /**

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -1007,7 +1007,9 @@ function rand() {
                     family: 'monospace'
                 },
                 showlabels: true,
-            }
+            },
+            autocontour: true,
+            ncontours: 6,
         },
     ];
     const layout: Partial<Plotly.Layout> = {


### PR DESCRIPTION
It would appear that definitions for
- [autocontour](https://plotly.com/javascript/reference/contour/#contour-autocontour)
- [ncontours](https://plotly.com/javascript/reference/contour/#contour-ncontours)

are missing as well.

(There might be more definitions missing still. I can take a closer look but I cannot do that at company time. Is it okay to submit it separately?)
