### PR TITLE
[snowflake-sdk] Fix error data / response fields typing

### DIFF
--- a/types/snowflake-sdk/index.d.ts
+++ b/types/snowflake-sdk/index.d.ts
@@ -152,8 +152,8 @@ export enum ErrorCode {
 export interface SnowflakeErrorExternal extends Error {
     code?: ErrorCode;
     sqlState?: string;
-    data?: object;
-    response?: object;
+    data?: Record<string, any>;
+    response?: Record<string, any>;
     responseBody?: string;
     cause?: Error;
     isFatal?: boolean;

--- a/types/snowflake-sdk/snowflake-sdk-tests.ts
+++ b/types/snowflake-sdk/snowflake-sdk-tests.ts
@@ -16,8 +16,8 @@ const connectCallback = (err: snowflake.SnowflakeError | undefined, conn: snowfl
     if (err) {
         err.code; // $ExpectType ErrorCode | undefined
         err.sqlState; // $ExpectType string | undefined
-        err.data; // $ExpectType object | undefined
-        err.response; // $ExpectType object | undefined
+        err.data; // $ExpectType Record<string, any> | undefined
+        err.response; // $ExpectType Record<string, any> | undefined
         err.responseBody; // $ExpectType string | undefined
         err.cause; // $ExpectType Error | undefined
         err.isFatal; // $ExpectType boolean | undefined
@@ -28,8 +28,8 @@ const connectCallback = (err: snowflake.SnowflakeError | undefined, conn: snowfl
         binds: [1, ''],
         complete(err, stmt, rows) {
             err; // $ExpectType SnowflakeError | undefined
-            err?.data?.line;
-            err?.data?.pos;
+            err?.data?.line; // $ExpectType any | undefined
+            err?.data?.pos; // $ExpectType any | undefined
             stmt.cancel((err, stmt) => {
                 //
             });

--- a/types/snowflake-sdk/snowflake-sdk-tests.ts
+++ b/types/snowflake-sdk/snowflake-sdk-tests.ts
@@ -28,8 +28,8 @@ const connectCallback = (err: snowflake.SnowflakeError | undefined, conn: snowfl
         binds: [1, ''],
         complete(err, stmt, rows) {
             err; // $ExpectType SnowflakeError | undefined
-            err?.data?.line; // $ExpectType any | undefined
-            err?.data?.pos; // $ExpectType any | undefined
+            err?.data?.line; // $ExpectType any
+            err?.data?.pos; // $ExpectType any
             stmt.cancel((err, stmt) => {
                 //
             });

--- a/types/snowflake-sdk/snowflake-sdk-tests.ts
+++ b/types/snowflake-sdk/snowflake-sdk-tests.ts
@@ -28,6 +28,8 @@ const connectCallback = (err: snowflake.SnowflakeError | undefined, conn: snowfl
         binds: [1, ''],
         complete(err, stmt, rows) {
             err; // $ExpectType SnowflakeError | undefined
+            err?.data?.line;
+            err?.data?.pos;
             stmt.cancel((err, stmt) => {
                 //
             });


### PR DESCRIPTION
PR modifies the `data` and `response` fields on the `SnowflakeError` from `object` to `Record<string, any>` so that they better reflect the JSDoc of these fields which is `{Object}`. From my understanding, `object` doesn't make sense as these fields are not any primitive value, and make it hard to reference keys within the value, e.g. like reading `line` or `pos` for determining syntax error locations, without always having to do an additional cast downstream.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    * data:  https://github.com/snowflakedb/snowflake-connector-nodejs/blob/db6523250b8c26391d6a9b480bd1c1b40519f84e/lib/errors.js#L308
    * response: https://github.com/snowflakedb/snowflake-connector-nodejs/blob/db6523250b8c26391d6a9b480bd1c1b40519f84e/lib/errors.js#L274