### PR TITLE
[three] allow GLBufferAttribute as an attribute type

### DIFF
--- a/types/three/src/core/BufferAttribute.d.ts
+++ b/types/three/src/core/BufferAttribute.d.ts
@@ -43,6 +43,8 @@ export class BufferAttribute {
     set needsUpdate(value: boolean);
 
     readonly isBufferAttribute: true;
+    readonly isInterleavedBufferAttribute: false;
+    readonly isGLBufferAttribute: false;
 
     onUploadCallback: () => void;
     onUpload(callback: () => void): this;

--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -1,4 +1,6 @@
 import { BufferAttribute } from './BufferAttribute';
+import { InterleavedBufferAttribute } from './InterleavedBufferAttribute';
+import { GLBufferAttribute } from './GLBufferAttribute';
 import { Box3 } from './../math/Box3';
 import { Sphere } from './../math/Sphere';
 import { Matrix4 } from './../math/Matrix4';
@@ -6,7 +8,6 @@ import { Quaternion } from './../math/Quaternion';
 import { Vector2 } from './../math/Vector2';
 import { Vector3 } from './../math/Vector3';
 import { EventDispatcher } from './EventDispatcher';
-import { InterleavedBufferAttribute } from './InterleavedBufferAttribute';
 import { BuiltinShaderAttributeName } from '../constants';
 
 /**
@@ -47,7 +48,7 @@ export class BufferGeometry extends EventDispatcher {
      * @default {}
      */
     attributes: {
-        [name: string]: BufferAttribute | InterleavedBufferAttribute;
+        [name: string]: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute;
     };
 
     /**
@@ -93,9 +94,11 @@ export class BufferGeometry extends EventDispatcher {
 
     setAttribute(
         name: BuiltinShaderAttributeName | (string & {}),
-        attribute: BufferAttribute | InterleavedBufferAttribute,
+        attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute,
     ): BufferGeometry;
-    getAttribute(name: BuiltinShaderAttributeName | (string & {})): BufferAttribute | InterleavedBufferAttribute;
+    getAttribute(
+        name: BuiltinShaderAttributeName | (string & {}),
+    ): BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute;
     deleteAttribute(name: BuiltinShaderAttributeName | (string & {})): BufferGeometry;
     hasAttribute(name: BuiltinShaderAttributeName | (string & {})): boolean;
 

--- a/types/three/src/core/GLBufferAttribute.d.ts
+++ b/types/three/src/core/GLBufferAttribute.d.ts
@@ -5,6 +5,10 @@
 export class GLBufferAttribute {
     constructor(buffer: WebGLBuffer, type: number, itemSize: number, elementSize: 1 | 2 | 4, count: number);
 
+    /**
+     * @default ''
+     */
+    name: string;
     buffer: WebGLBuffer;
     type: number;
     itemSize: number;
@@ -12,6 +16,8 @@ export class GLBufferAttribute {
     count: number;
     version: number;
 
+    readonly isBufferAttribute: false;
+    readonly isInterleavedBufferAttribute: false;
     readonly isGLBufferAttribute: true;
 
     set needsUpdate(value: boolean);

--- a/types/three/src/core/InterleavedBufferAttribute.d.ts
+++ b/types/three/src/core/InterleavedBufferAttribute.d.ts
@@ -25,7 +25,9 @@ export class InterleavedBufferAttribute {
     get array(): ArrayLike<number>;
     set needsUpdate(value: boolean);
 
+    readonly isBufferAttribute: false;
     readonly isInterleavedBufferAttribute: true;
+    readonly isGLBufferAttribute: false;
 
     applyMatrix4(m: Matrix4): this;
     clone(data?: object): BufferAttribute;

--- a/types/three/src/renderers/webgl/WebGLAttributes.d.ts
+++ b/types/three/src/renderers/webgl/WebGLAttributes.d.ts
@@ -1,18 +1,19 @@
 import { WebGLCapabilities } from './WebGLCapabilities';
 import { BufferAttribute } from '../../core/BufferAttribute';
 import { InterleavedBufferAttribute } from '../../core/InterleavedBufferAttribute';
+import { GLBufferAttribute } from '../../core/GLBufferAttribute';
 
 export class WebGLAttributes {
     constructor(gl: WebGLRenderingContext | WebGL2RenderingContext, capabilities: WebGLCapabilities);
 
-    get(attribute: BufferAttribute | InterleavedBufferAttribute): {
+    get(attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute): {
         buffer: WebGLBuffer;
         type: number;
         bytesPerElement: number;
         version: number;
     };
 
-    remove(attribute: BufferAttribute | InterleavedBufferAttribute): void;
+    remove(attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute): void;
 
-    update(attribute: BufferAttribute | InterleavedBufferAttribute, bufferType: number): void;
+    update(attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute, bufferType: number): void;
 }

--- a/types/three/test/controls/controls-pointercontrols.ts
+++ b/types/three/test/controls/controls-pointercontrols.ts
@@ -126,14 +126,16 @@ function init() {
 
     let position = floorGeometry.attributes.position;
 
-    for (let i = 0, l = position.count; i < l; i++) {
-        vertex.fromBufferAttribute(position, i);
+    if (!position.isGLBufferAttribute) {
+        for (let i = 0, l = position.count; i < l; i++) {
+            vertex.fromBufferAttribute(position, i);
 
-        vertex.x += Math.random() * 20 - 10;
-        vertex.y += Math.random() * 2;
-        vertex.z += Math.random() * 20 - 10;
+            vertex.x += Math.random() * 20 - 10;
+            vertex.y += Math.random() * 2;
+            vertex.z += Math.random() * 20 - 10;
 
-        position.setXYZ(i, vertex.x, vertex.y, vertex.z);
+            position.setXYZ(i, vertex.x, vertex.y, vertex.z);
+        }
     }
 
     const indexedGeometry = floorGeometry.toNonIndexed(); // ensure each face has unique vertices


### PR DESCRIPTION
This change allows the use of `GLBufferAttribute` as an attribute using the `setAttribute` method in `BufferGeometry`. The type for `GLBufferAttribute` had already been defined and exported but it was not used anywhere else in the typings. The feature was introduced in https://github.com/mrdoob/three.js/pull/13196.

Note that the change can break consumers of the typings as `GLBufferAttribute` does not implement the same interface as `BufferAttribute`. The way to fix these issues is to use the boolean flags (`isBufferAttribute`, `isInterleavedBufferAttribute`, or `isGLBufferAttribute`) to discriminate between the different options (or alternatively by resorting to type assertions). Despite the potential breakage, I believe these typings are more correct.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/pull/13196
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.