### PR TITLE
[chrome-remote-interface] support the Promise version of events

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -27,9 +27,11 @@ function assertType<T>(value: T): T {
         await Network.setAcceptedEncodings({encodings: []});
         await Page.enable();
         await Page.navigate({ url: 'https://github.com' });
-        const loadEvent = await client['Page.loadEventFired'](); // instead of: await Page.loadEventFired();
+        let loadEvent = await Page.loadEventFired();
+        loadEvent = await client['Page.loadEventFired']();
         loadEvent.timestamp;
-        await client['Page.interstitialHidden'](); // instead of: await Page.interstitialHidden();
+        await Page.interstitialHidden();
+        await client['Page.interstitialHidden']();
         const unsubscribe = Network.requestWillBeSent((params, sessionId) => {
             params.request.url;
             unsubscribe();

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -158,10 +158,16 @@ declare namespace CDP {
     type GetReturnType<D extends string, E extends string> =
         `${D}.${E}` extends keyof ProtocolMappingApi.Events ?
             ProtocolMappingApi.Events[`${D}.${E}`][0] : never;
-    type DoEventProps<D extends string> = {
+    type DoEventPromises<D extends string> = {
         [event in GetEvent<D>]:
-            (listener: (params: GetReturnType<D, event>, sessionId?: string) => void) => () => Client};
-    type DoEventObj<D> = D extends string ? DoEventProps<D> : Record<keyof any, never>;
+            // tslint:disable-next-line: void-return
+            () => Promise<GetReturnType<D, event> extends undefined ? void : GetReturnType<D, event>>
+    };
+    type DoEventListeners<D extends string> = {
+        [event in GetEvent<D>]:
+            (listener: (params: GetReturnType<D, event>, sessionId?: string) => void) => () => Client
+    };
+    type DoEventObj<D> = D extends string ? DoEventPromises<D> & DoEventListeners<D> : Record<keyof any, never>;
 
     type IsNullableObj<T> = Record<keyof T, undefined> extends T ? true : false;
     /**


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cyrus-and/chrome-remote-interface/issues/500#issuecomment-1248272589 (statement in 1st para)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The pr adds support for event statements of the form:

```ts
await Page.loadEventFired();
```

JSDoc is not carried over, but I have realized that I almost exclusively get my API info from web documentation.