### PR TITLE
[args] fix command options argument typings

### DIFF
--- a/types/args/args-tests.ts
+++ b/types/args/args-tests.ts
@@ -1,6 +1,6 @@
 import * as args from "args";
 
-args
+const result = args
     .option("opt1", "desc")
     .option("opt2", "desc", false, (value: any): any => value)
     .options([
@@ -17,9 +17,16 @@ args
     ])
     .command("cm1", "desc")
     .command("cm2", "desc", (value: any): void => { }, ['a'])
-    .command("cm3", "desc", (name, subs, options: { opt3: number}): void => {
-        const x = options.opt3;
+    .command("cm3", "desc", (name, subs, options: { opt1: number}): void => {
+        const x = options.opt1;
      }, ['a'])
+     .command("cm4", "desc", (name, subs, options): void => {
+        const a = options.opt1;
+        const b = options.opt2;
+        const c = options.opt4;
+        // @ts-expect-error
+        const d = options.opt8;
+     }, )
     .example("ex1", "desc")
     .examples([
         {
@@ -27,6 +34,11 @@ args
             description: "desc",
         },
     ]);
+
+const {opt1, opt2, opt3, opt4} = result.parse([]);
+
+// @ts-expect-error
+const {opt5} = result.parse([]);
 
 args.parse(['~/bin/node', '~/dir', 'arg', '--param'], {
     help: true,
@@ -63,6 +75,12 @@ args.parse(['~/bin/node', '~/dir', 'arg', '--param'], {
     },
     mainColor: "yellow",
     subColor: "dim"
+});
+
+args.parse(['~/bin/node', '~/dir', 'arg', '--param'], {
+    mri: {
+        boolean: ['wat'],
+    }
 });
 
 args.showHelp();

--- a/types/args/args-tests.ts
+++ b/types/args/args-tests.ts
@@ -15,6 +15,14 @@ const result = args
             description: 'desc',
         },
     ])
+    .options([
+        {
+            name: ['o', 'opt5'],
+            description: 'desc',
+            defaultValue: 1,
+            init: (value: any) => { },
+        },
+    ])
     .command("cm1", "desc")
     .command("cm2", "desc", (value: any): void => { }, ['a'])
     .command("cm3", "desc", (name, subs, options: { opt1: number}): void => {
@@ -26,7 +34,7 @@ const result = args
         const c = options.opt4;
         // @ts-expect-error
         const d = options.opt8;
-     }, )
+     })
     .example("ex1", "desc")
     .examples([
         {
@@ -38,7 +46,7 @@ const result = args
 const {opt1, opt2, opt3, opt4} = result.parse([]);
 
 // @ts-expect-error
-const {opt5} = result.parse([]);
+const {opt6} = result.parse([]);
 
 args.parse(['~/bin/node', '~/dir', 'arg', '--param'], {
     help: true,

--- a/types/args/args-tests.ts
+++ b/types/args/args-tests.ts
@@ -17,6 +17,9 @@ args
     ])
     .command("cm1", "desc")
     .command("cm2", "desc", (value: any): void => { }, ['a'])
+    .command("cm3", "desc", (name, subs, options: { opt3: number}): void => {
+        const x = options.opt3;
+     }, ['a'])
     .example("ex1", "desc")
     .examples([
         {

--- a/types/args/args-tests.ts
+++ b/types/args/args-tests.ts
@@ -1,8 +1,9 @@
 import * as args from "args";
 
 const result = args
-    .option("opt1", "desc")
+    .option(["opt1", "op2"], "desc")
     .option("opt2", "desc", false, (value: any): any => value)
+    .example("opt2", "desc")
     .options([
         {
             name: 'opt3',
@@ -17,10 +18,20 @@ const result = args
     ])
     .options([
         {
-            name: ['o', 'opt5'],
+            name: ['o5', 'opt5'],
             description: 'desc',
             defaultValue: 1,
             init: (value: any) => { },
+        },
+        {
+            name: ['opt6', "o6"],
+            description: 'desc',
+            defaultValue: 1,
+        },
+        {
+            name: 'opt7',
+            description: 'desc',
+            defaultValue: 1,
         },
     ])
     .command("cm1", "desc")
@@ -46,7 +57,7 @@ const result = args
 const {opt1, opt2, opt3, opt4} = result.parse([]);
 
 // @ts-expect-error
-const {opt6} = result.parse([]);
+const {opt99} = result.parse([]);
 
 args.parse(['~/bin/node', '~/dir', 'arg', '--param'], {
     help: true,
@@ -95,3 +106,8 @@ args.showHelp();
 args.showVersion();
 
 const x: string = args.sub[0];
+
+args.parse([]).foo;
+args.command("direct", "direct call demo", (name, sub, options) => {
+    const z = options.bar;
+});

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -11,7 +11,7 @@ interface args {
 
     option(name: string | [string, string], description: string, defaultValue?: any, init?: OptionInitFunction): args;
     options(list: Option[]): args;
-    command(name: string, description: string, init?: (name: string, sub: string[], options: ConfigurationOptions) => void, aliases?: string[]): args;
+    command<TOptions extends Record<string, unknown>>(name: string, description: string, init?: (name: string, sub: string[], options: TOptions) => void, aliases?: string[]): args;
     example(usage: string, description: string): args;
     examples(list: Example[]): args;
     parse(argv: string[], options?: ConfigurationOptions): { [key: string]: any };

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -7,15 +7,64 @@ declare const c: args< { }>;
 export = c;
 
 interface args <TOptions extends Record<string, any>> {
+    /**
+     * This property exposes all sub arguments that have been parsed by mri.
+     * This is useful when trying to get the value after the command.
+     *
+     * https://github.com/leo/args#sub
+     */
     sub: string[];
-
-    option<TName extends string | [string, string]>(name: TName, description: string, defaultValue?: any, init?: OptionInitFunction): args<TOptions & {[key in OptionName<TName>]: any}>;
+    /**
+     * Register a new option for the binary in which it's being called.
+     *
+     * https://github.com/leo/args#optionname-description-default-init
+     */
+    option<TName extends string | [string, string]>(name: TName, description: string, defaultValue?: any, init?: OptionInitFunction): args<TOptions & {[key in UnwrapOptionName<TName>]: any}>;
+    /**
+     * Takes in an array of objects that are each defining an option that shall be registered.
+     * This is basically a minimalistic way to register a huge list of options at once.
+     *
+     * https://github.com/leo/args#optionslist
+     */
     options<TNames extends string>(list: Array<Option<TNames>>): args<TOptions & {[key in TNames]: any}>;
+    /**
+     * Register a new sub command. Args requires all binaries to be defined in the style of git's.
+     *
+     * https://github.com/leo/args#commandname-description-init-aliases
+     */
     command(name: string, description: string, init?: (name: string, sub: string[], options: TOptions) => void, aliases?: string[]): args<TOptions>;
+    /**
+     * Register an example which will be shown when calling `help`.
+     *
+     * https://github.com/leo/args#exampleusage-description
+     */
     example(usage: string, description: string): args<TOptions>;
+    /**
+     * Takes in an array of objects that are each defining an example that shall be registered.
+     * This is basically a minimalistic way to register a huge list of examples at once.
+     *
+     * https://github.com/leo/args#exampleslist
+     */
     examples(list: Example[]): args<TOptions>;
+    /**
+     * This method takes the process' command line arguments (command and options) and uses the internal methods
+     * to get their values and assign them to the current instance of args.
+     * It needs to be run after all of the `.option` and `.command` calls.
+     *
+     * https://github.com/leo/args#parseargv-options
+     */
     parse(argv: string[], options?: ConfigurationOptions): TOptions;
+    /**
+     * Outputs the usage information based on the options and comments you've registered
+     * so far and exits, if configured to do so.
+     *
+     * https://github.com/leo/args#showhelp
+     */
     showHelp(): void;
+    /**
+     * Outputs the version and exits, if configured to do so.
+     * https://github.com/leo/args#showversion
+     */
     showVersion(): void;
 }
 
@@ -50,7 +99,8 @@ interface MinimistOptions {
 
 /**
  * Parsing options
- * @see https://github.com/leo/args#configuration
+ *
+ * https://github.com/leo/args#configuration
  */
 interface ConfigurationOptions {
     help?: boolean | undefined;
@@ -76,4 +126,8 @@ interface Example {
     description: string;
 }
 
-type OptionName<TOptionName extends string | [string, string]> = TOptionName extends string ? TOptionName : TOptionName extends [string, string] ? TOptionName[0] | TOptionName[1] : never;
+type UnwrapOptionName<TOptionName extends string | [string, string]> = TOptionName extends string
+    ? TOptionName
+    : TOptionName extends [string, string]
+        ? TOptionName[0] | TOptionName[1]
+        : never;

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -10,7 +10,7 @@ interface args <TOptions extends Record<string, any>> {
     sub: string[];
 
     option<TName extends string | [string, string]>(name: TName, description: string, defaultValue?: any, init?: OptionInitFunction): args<TOptions & {[key in OptionName<TName>]: any}>;
-    options<TNames extends string, TOptionList extends Option<TNames>[]>(list: TOptionList): args<TOptions & {[key in OptionNames<TOptionList>]: any}>;
+    options<TNames extends string>(list: Array<Option<TNames>>): args<TOptions & {[key in TNames]: any}>;
     command(name: string, description: string, init?: (name: string, sub: string[], options: TOptions) => void, aliases?: string[]): args<TOptions>;
     example(usage: string, description: string): args<TOptions>;
     examples(list: Example[]): args<TOptions>;
@@ -64,8 +64,8 @@ interface ConfigurationOptions {
     subColor?: string | string[];
 }
 
-interface Option<TName extends string | [string | string]> {
-    name: TName;
+interface Option<TName extends string> {
+    name: TName | [TName, TName];
     description: string;
     init?: OptionInitFunction | undefined;
     defaultValue?: any;
@@ -76,5 +76,4 @@ interface Example {
     description: string;
 }
 
-type OptionNames<TOptions extends Option<any>[]> = TOptions extends Option<infer U>[] ? U : never;
 type OptionName<TOptionName extends string | [string, string]> = TOptionName extends string ? TOptionName : TOptionName extends [string, string] ? TOptionName[0] | TOptionName[1] : never;

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -3,18 +3,18 @@
 // Definitions by: Slessi <https://github.com/Slessi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare const c: args;
+declare const c: args< { }>;
 export = c;
 
-interface args {
+interface args <TOptions extends Record<string, any>> {
     sub: string[];
 
-    option(name: string | [string, string], description: string, defaultValue?: any, init?: OptionInitFunction): args;
-    options(list: Option[]): args;
-    command<TOptions extends Record<string, unknown>>(name: string, description: string, init?: (name: string, sub: string[], options: TOptions) => void, aliases?: string[]): args;
-    example(usage: string, description: string): args;
-    examples(list: Example[]): args;
-    parse(argv: string[], options?: ConfigurationOptions): { [key: string]: any };
+    option<TName extends string | [string, string]>(name: TName, description: string, defaultValue?: any, init?: OptionInitFunction): args<TOptions & {[key in OptionName<TName>]: any}>;
+    options<TNames extends string, TOptionList extends Option<TNames>[]>(list: TOptionList): args<TOptions & {[key in OptionNames<TOptionList>]: any}>;
+    command(name: string, description: string, init?: (name: string, sub: string[], options: TOptions) => void, aliases?: string[]): args<TOptions>;
+    example(usage: string, description: string): args<TOptions>;
+    examples(list: Example[]): args<TOptions>;
+    parse(argv: string[], options?: ConfigurationOptions): TOptions;
     showHelp(): void;
     showVersion(): void;
 }
@@ -48,20 +48,24 @@ interface MinimistOptions {
     unknown?: ((param: string) => boolean) | undefined;
 }
 
+/**
+ * Parsing options
+ * @see https://github.com/leo/args#configuration
+ */
 interface ConfigurationOptions {
     help?: boolean | undefined;
     name?: string | undefined;
     version?: boolean | undefined;
     usageFilter?: ((output: any) => any) | undefined;
     value?: string | undefined;
-    mri: MriOptions;
+    mri?: MriOptions;
     minimist?: MinimistOptions | undefined;
-    mainColor: string | string[];
-    subColor: string | string[];
+    mainColor?: string | string[];
+    subColor?: string | string[];
 }
 
-interface Option {
-    name: string | [string, string];
+interface Option<TName extends string | [string | string]> {
+    name: TName;
     description: string;
     init?: OptionInitFunction | undefined;
     defaultValue?: any;
@@ -71,3 +75,6 @@ interface Example {
     usage: string;
     description: string;
 }
+
+type OptionNames<TOptions extends Option<any>[]> = TOptions extends Option<infer U>[] ? U : never;
+type OptionName<TOptionName extends string | [string, string]> = TOptionName extends string ? TOptionName : TOptionName extends [string, string] ? TOptionName[0] | TOptionName[1] : never;

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -3,10 +3,10 @@
 // Definitions by: Slessi <https://github.com/Slessi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare const c: args< { }>;
+declare const c: args<unknown>;
 export = c;
 
-interface args <TOptions extends Record<string, any>> {
+interface args <TOptions extends unknown | Record<string, any>> {
     /**
      * This property exposes all sub arguments that have been parsed by mri.
      * This is useful when trying to get the value after the command.
@@ -19,7 +19,7 @@ interface args <TOptions extends Record<string, any>> {
      *
      * https://github.com/leo/args#optionname-description-default-init
      */
-    option<TName extends string | [string, string]>(name: TName, description: string, defaultValue?: any, init?: OptionInitFunction): args<TOptions & {[key in UnwrapOptionName<TName>]: any}>;
+    option<TName extends string>(name: TName | [TName, TName], description: string, defaultValue?: any, init?: OptionInitFunction): args<TOptions & {[key in UnwrapOptionName<TName>]: any}>;
     /**
      * Takes in an array of objects that are each defining an option that shall be registered.
      * This is basically a minimalistic way to register a huge list of options at once.
@@ -32,7 +32,7 @@ interface args <TOptions extends Record<string, any>> {
      *
      * https://github.com/leo/args#commandname-description-init-aliases
      */
-    command(name: string, description: string, init?: (name: string, sub: string[], options: TOptions) => void, aliases?: string[]): args<TOptions>;
+    command(name: string, description: string, init?: (name: string, sub: string[], options: CastUnknownResultToAny<TOptions>) => void, aliases?: string[]): args<TOptions>;
     /**
      * Register an example which will be shown when calling `help`.
      *
@@ -53,7 +53,7 @@ interface args <TOptions extends Record<string, any>> {
      *
      * https://github.com/leo/args#parseargv-options
      */
-    parse(argv: string[], options?: ConfigurationOptions): TOptions;
+    parse(argv: string[], options?: ConfigurationOptions): CastUnknownResultToAny<TOptions>;
     /**
      * Outputs the usage information based on the options and comments you've registered
      * so far and exits, if configured to do so.
@@ -131,3 +131,7 @@ type UnwrapOptionName<TOptionName extends string | [string, string]> = TOptionNa
     : TOptionName extends [string, string]
         ? TOptionName[0] | TOptionName[1]
         : never;
+
+// To avoid breaking changes when calling `args.parse()` without chaining
+// the return type of `args.parse()` is `any` if `TOptions` is `unknown`
+type CastUnknownResultToAny<T> = T extends Record<any, any> ? T : any;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/leo/args#commandname-description-init-aliases 
> the "options" argument [...] will contain the options registered within the current binary

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/leo/args#configuration
all configuration options are optional

The current typings are reusing a different type which is only usefull for the `parse` function `options` argument.  
However the `command` function `options` argument is similar to the return value of the `parse` function.
