### PR TITLE
[chromecast-caf-receiver]: Include new TS_HE_AAC format in HlsSegmentFormat

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -132,7 +132,7 @@ export enum HdrType {
 
 /**
  * Format of an HLS audio segment.
- * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.HlsSegmentFormat}
+ * [Documentation]{@link https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages#.HlsSegmentFormat}
  */
 export enum HlsSegmentFormat {
     AAC = 'aac',
@@ -142,6 +142,7 @@ export enum HlsSegmentFormat {
     MP3 = 'mp3',
     TS = 'ts',
     TS_AAC = 'ts_aac',
+    TS_HE_AAC = 'ts_he_aac',
 }
 
 /**


### PR DESCRIPTION
Updates the `HlsSegmentFormat` enum to include `TS_HE_AAC`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages#.HlsSegmentFormat>>
