### PR TITLE
feat(chai-subset-in-order): add missing types

### DIFF
--- a/types/chai-subset-in-order/chai-subset-in-order-tests.ts
+++ b/types/chai-subset-in-order/chai-subset-in-order-tests.ts
@@ -1,0 +1,14 @@
+import { expect, use, assert } from 'chai';
+import * as chaiSubsetInOrder from 'chai-subset-in-order';
+
+use(chaiSubsetInOrder);
+
+expect({ foo: 2, bar: 3 }).to.containSubsetInOrder({ foo: 2 });
+expect({ foo: 2, bar: 3 }).to.containSubsetInOrder({ bar: 3 });
+expect({ foo: 2, bar: 3 }).to.containSubsetInOrder({ foo: 2, bar: 3 });
+expect({ foo: 2, bar: 3 }).to.not.containSubsetInOrder({ foo: 5 });
+expect([{ foo: 123, bar: 456 }, { baz: 111 }]).to.containSubsetInOrder([{ foo: 123 }]);
+expect([{ foo: 123, bar: 456 }, { baz: 111 }]).to.containSubsetInOrder([{ bar: 456 }]);
+expect([{ foo: 123, bar: 456 }, { baz: 111 }]).to.containSubsetInOrder([{ foo: 123 }, { baz: 111 }]);
+expect([{ foo: 123, bar: 456 }, { baz: 111 }]).to.not.containSubsetInOrder([{ baz: 111 }, { foo: 123 }]);
+assert.containSubsetInOrder({ foo: 2, bar: 3 }, { foo: 2 });

--- a/types/chai-subset-in-order/index.d.ts
+++ b/types/chai-subset-in-order/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for chai-subset-in-order 3.1
+// Project: https://github.com/oprogramador/chai-subset-in-order
+// Definitions by: Mario Ramundo <https://github.com/ramundomario>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare global {
+    namespace Chai {
+        interface Assertion {
+            containSubsetInOrder(expected: unknown): Assertion;
+        }
+        interface Assert {
+            containSubsetInOrder(val: unknown, exp: unknown, msg?: string): void;
+        }
+    }
+}
+
+declare const chaiSubsetInOrder: Chai.ChaiPlugin;
+export = chaiSubsetInOrder;

--- a/types/chai-subset-in-order/index.d.ts
+++ b/types/chai-subset-in-order/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Mario Ramundo <https://github.com/ramundomario>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="chai" />
+
 declare global {
     namespace Chai {
         interface Assertion {

--- a/types/chai-subset-in-order/tsconfig.json
+++ b/types/chai-subset-in-order/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "chai-subset-in-order-tests.ts"
+    ]
+}

--- a/types/chai-subset-in-order/tslint.json
+++ b/types/chai-subset-in-order/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Add missing types for chai-subset-in-order library ([NPM](https://www.npmjs.com/package/chai-subset-in-order), [GitHub](https://github.com/oprogramador/chai-subset-in-order))

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
