### PR TITLE
ws: `WebSocket.send` only support string or buffer like data

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -26,15 +26,15 @@ import { Duplex, DuplexOptions } from "stream";
 import { SecureContextOptions } from "tls";
 import { URL } from "url";
 import { ZlibOptions } from "zlib";
-
+import { Buffer } from 'buffer';
 
 type BufferLike =
     | string
     | Buffer
     | ArrayBuffer
     | ArrayBufferView
-    | { [Symbol.toPrimitive](): string } |
-    { valueOf(): string }
+    | { [Symbol.toPrimitive](): string }
+    | { valueOf(): string };
 
 // WebSocket socket.
 declare class WebSocket extends EventEmitter {

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -27,6 +27,15 @@ import { SecureContextOptions } from "tls";
 import { URL } from "url";
 import { ZlibOptions } from "zlib";
 
+
+type BufferLike =
+    | string
+    | Buffer
+    | ArrayBuffer
+    | ArrayBufferView
+    | { [Symbol.toPrimitive](): string } |
+    { valueOf(): string }
+
 // WebSocket socket.
 declare class WebSocket extends EventEmitter {
     /** The connection is not yet open. */
@@ -77,9 +86,9 @@ declare class WebSocket extends EventEmitter {
     close(code?: number, data?: string | Buffer): void;
     ping(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
     pong(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
-    send(data: any, cb?: (err?: Error) => void): void;
+    send(data: BufferLike, cb?: (err?: Error) => void): void;
     send(
-        data: any,
+        data: BufferLike,
         options: { mask?: boolean | undefined; binary?: boolean | undefined; compress?: boolean | undefined; fin?: boolean | undefined },
         cb?: (err?: Error) => void,
     ): void;
@@ -187,6 +196,7 @@ declare class WebSocket extends EventEmitter {
 }
 
 declare const WebSocketAlias: typeof WebSocket;
+
 interface WebSocketAlias extends WebSocket {} // tslint:disable-line no-empty-interface
 
 declare namespace WebSocket {
@@ -366,8 +376,10 @@ declare namespace WebSocket {
     }
 
     const WebSocketServer: typeof Server;
+
     interface WebSocketServer extends Server {} // tslint:disable-line no-empty-interface
     const WebSocket: typeof WebSocketAlias;
+
     interface WebSocket extends WebSocketAlias {} // tslint:disable-line no-empty-interface
 
     // WebSocket stream

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -27,16 +27,23 @@ import { SecureContextOptions } from "tls";
 import { URL } from "url";
 import { ZlibOptions } from "zlib";
 
-type FirstArgument<F extends typeof Buffer.from> = F extends (data: infer A) => any ? A : never;
-
+// don't know how to get all overload of BufferConstructor, just copy it's first arguments here
 type BufferLike =
     | string
     | Buffer
-    | ArrayBuffer
+    | number
     | ArrayBufferView
-    | Parameters<BufferConstructor['from']>[0]
+    | Uint8Array
+    | ArrayBuffer
+    | SharedArrayBuffer
+    | ReadonlyArray<any>
+    | ReadonlyArray<number>
+    | { valueOf(): ArrayBuffer }
+    | { valueOf(): SharedArrayBuffer }
+    | { valueOf(): Uint8Array }
+    | { valueOf(): ReadonlyArray<number> }
     | { valueOf(): string }
-    | Buffer[];
+    | { [Symbol.toPrimitive](hint: string): string };
 
 // WebSocket socket.
 declare class WebSocket extends EventEmitter {

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -32,6 +32,7 @@ import { ZlibOptions } from "zlib";
 type BufferLike =
     | string
     | Buffer
+    | DataView
     | number
     | ArrayBufferView
     | Uint8Array

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -28,11 +28,14 @@ import { URL } from "url";
 import { ZlibOptions } from "zlib";
 import { Buffer } from 'buffer';
 
+type FirstArgument<F extends Function> = F extends (...args: infer A) => any ? A : never;
+
 type BufferLike =
     | string
     | Buffer
     | ArrayBuffer
     | ArrayBufferView
+    | FirstArgument<typeof Buffer.from>
     | { [Symbol.toPrimitive](): string }
     | { valueOf(): string };
 

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -86,6 +86,7 @@ declare class WebSocket extends EventEmitter {
     close(code?: number, data?: string | Buffer): void;
     ping(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
     pong(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
+    // https://github.com/websockets/ws/issues/2076#issuecomment-1250354722
     send(data: BufferLike, cb?: (err?: Error) => void): void;
     send(
         data: BufferLike,

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -36,7 +36,8 @@ type BufferLike =
     | ArrayBuffer
     | ArrayBufferView
     | FirstArgument<typeof Buffer.from>
-    | { valueOf(): string };
+    | { valueOf(): string }
+    | Buffer[];
 
 // WebSocket socket.
 declare class WebSocket extends EventEmitter {

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -34,7 +34,7 @@ type BufferLike =
     | Buffer
     | ArrayBuffer
     | ArrayBufferView
-    | FirstArgument<typeof Buffer.from>
+    | Parameters<BufferConstructor['from']>[0]
     | { valueOf(): string }
     | Buffer[];
 

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -27,7 +27,8 @@ import { SecureContextOptions } from "tls";
 import { URL } from "url";
 import { ZlibOptions } from "zlib";
 
-// don't know how to get all overload of BufferConstructor, just copy it's first arguments here
+// can not get all overload of BufferConstructor['from'], need to copy all it's first arguments here
+// https://github.com/microsoft/TypeScript/issues/32164
 type BufferLike =
     | string
     | Buffer
@@ -97,8 +98,8 @@ declare class WebSocket extends EventEmitter {
     pong(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
     // https://github.com/websockets/ws/issues/2076#issuecomment-1250354722
     send(data: BufferLike, cb?: (err?: Error) => void): void;
-    send(
-        data: BufferLike,
+    send<T>(
+        data: BufferConstructor<T>,
         options: { mask?: boolean | undefined; binary?: boolean | undefined; compress?: boolean | undefined; fin?: boolean | undefined },
         cb?: (err?: Error) => void,
     ): void;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -28,7 +28,7 @@ import { URL } from "url";
 import { ZlibOptions } from "zlib";
 import { Buffer } from 'buffer';
 
-type FirstArgument<F extends Function> = F extends (...args: infer A) => any ? A : never;
+type FirstArgument<F extends typeof Buffer.from> = F extends (data: infer A) => any ? A : never;
 
 type BufferLike =
     | string
@@ -36,7 +36,6 @@ type BufferLike =
     | ArrayBuffer
     | ArrayBufferView
     | FirstArgument<typeof Buffer.from>
-    | { [Symbol.toPrimitive](): string }
     | { valueOf(): string };
 
 // WebSocket socket.

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -196,7 +196,6 @@ declare class WebSocket extends EventEmitter {
 }
 
 declare const WebSocketAlias: typeof WebSocket;
-
 interface WebSocketAlias extends WebSocket {} // tslint:disable-line no-empty-interface
 
 declare namespace WebSocket {
@@ -376,10 +375,8 @@ declare namespace WebSocket {
     }
 
     const WebSocketServer: typeof Server;
-
     interface WebSocketServer extends Server {} // tslint:disable-line no-empty-interface
     const WebSocket: typeof WebSocketAlias;
-
     interface WebSocket extends WebSocketAlias {} // tslint:disable-line no-empty-interface
 
     // WebSocket stream

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -26,7 +26,6 @@ import { Duplex, DuplexOptions } from "stream";
 import { SecureContextOptions } from "tls";
 import { URL } from "url";
 import { ZlibOptions } from "zlib";
-import { Buffer } from 'buffer';
 
 type FirstArgument<F extends typeof Buffer.from> = F extends (data: infer A) => any ? A : never;
 

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -98,8 +98,8 @@ declare class WebSocket extends EventEmitter {
     pong(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
     // https://github.com/websockets/ws/issues/2076#issuecomment-1250354722
     send(data: BufferLike, cb?: (err?: Error) => void): void;
-    send<T>(
-        data: BufferConstructor<T>,
+    send(
+        data: BufferLike,
         options: { mask?: boolean | undefined; binary?: boolean | undefined; compress?: boolean | undefined; fin?: boolean | undefined },
         cb?: (err?: Error) => void,
     ): void;

--- a/types/ws/tsconfig.json
+++ b/types/ws/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6"],
+        "lib": ["es2017"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -8,6 +8,8 @@ import * as wslib from "ws";
     const ws = new WebSocket("ws://www.host.com/path");
     ws.on("open", () => ws.send("something"));
     ws.on("message", data => {});
+    // @ts-expect-error
+    ws.send({hello: 'world'});
 }
 
 {

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -9,7 +9,8 @@ import * as wslib from "ws";
     ws.on("open", () => ws.send("something"));
     ws.on("message", data => {});
     // @ts-expect-error
-    ws.send({hello: 'world'});
+    ws.send({ hello: 'world' });
+    ws.send({ [Symbol.toPrimitive]: () => 'hello' });
 }
 
 {
@@ -351,8 +352,12 @@ declare module 'ws' {
             return 'foo';
         }
     }
+
     const server = new http.Server();
-    const webSocketServer = new WebSocket.WebSocketServer<CustomWebSocket>({WebSocket: CustomWebSocket, noServer: true});
+    const webSocketServer = new WebSocket.WebSocketServer<CustomWebSocket>({
+        WebSocket: CustomWebSocket,
+        noServer: true
+    });
     webSocketServer.on('connection', (ws) => {
         // $ExpectType CustomWebSocket
         ws;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -47,7 +47,7 @@ import * as wslib from "ws";
 {
     const wss = new WebSocket.Server({ port: 8082 });
 
-    const broadcast = (data: any) => {
+    const broadcast = (data: string) => {
         wss.clients.forEach(ws => ws.send(data));
     };
 }

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -352,12 +352,8 @@ declare module 'ws' {
             return 'foo';
         }
     }
-
     const server = new http.Server();
-    const webSocketServer = new WebSocket.WebSocketServer<CustomWebSocket>({
-        WebSocket: CustomWebSocket,
-        noServer: true
-    });
+    const webSocketServer = new WebSocket.WebSocketServer<CustomWebSocket>({WebSocket: CustomWebSocket, noServer: true});
     webSocketServer.on('connection', (ws) => {
         // $ExpectType CustomWebSocket
         ws;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -10,7 +10,17 @@ import * as wslib from "ws";
     ws.on("message", data => {});
     // @ts-expect-error
     ws.send({ hello: 'world' });
-    ws.send({ [Symbol.toPrimitive]: () => 'hello' });
+
+    ws.send(new Uint8Array([]));
+
+    const Any = null as any;
+
+    ws.send(Any as number);
+    ws.send(Any as ArrayBufferView);
+    ws.send(Any as { valueOf(): ArrayBuffer });
+    ws.send(Any as Uint8Array);
+    ws.send(Any as { valueOf(): Uint8Array });
+    ws.send(Any as { valueOf(): string });
 }
 
 {
@@ -353,7 +363,10 @@ declare module 'ws' {
         }
     }
     const server = new http.Server();
-    const webSocketServer = new WebSocket.WebSocketServer<CustomWebSocket>({WebSocket: CustomWebSocket, noServer: true});
+    const webSocketServer = new WebSocket.WebSocketServer<CustomWebSocket>({
+        WebSocket: CustomWebSocket,
+        noServer: true
+    });
     webSocketServer.on('connection', (ws) => {
         // $ExpectType CustomWebSocket
         ws;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

 > `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The
  data to send. `Object` values are only supported if they conform to the
  requirements of [`Buffer.from()`][]. If those constraints are not met, a
  `TypeError` is thrown.

https://github.com/websockets/ws/blob/master/doc/ws.md#websocketsenddata-options-callback


https://github.com/websockets/ws/issues/2076
https://github.com/websockets/ws/pull/2077

https://nodejs.org/api/buffer.html#static-method-bufferfromobject-offsetorencoding-length

https://github.com/websockets/ws/blob/0c0754b897f62a68d7da3600f96924fab54e4f8f/lib/buffer-util.js#L83


 