### PR TITLE
`Object3D.copy`: object.copy is not made to copy its self.

### DIFF
--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -413,5 +413,5 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
      * @param object
      * @param recursive
      */
-    copy(source: this, recursive?: boolean): this;
+    copy(source: Object3D, recursive?: boolean): this;
 }

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -406,7 +406,7 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
 
     toJSON(meta?: { geometries: any; materials: any; textures: any; images: any }): any;
 
-    clone(recursive?: boolean): this;
+    clone(recursive?: boolean): Object3D;
 
     /**
      *


### PR DESCRIPTION
its meant to copy other Object3D or objects that extends Object3D
