### PR TITLE
Fix rerender function export in @ember/test-helpers package

### DIFF
--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -53,7 +53,8 @@ export { visit, currentRouteName, currentURL } from '@ember/test-helpers/setup-a
 
 // Rendering Helpers
 
-export { render, rerender, clearRender } from '@ember/test-helpers/setup-rendering-context';
+export { render, clearRender } from '@ember/test-helpers/setup-rendering-context';
+export { default as rerender } from '@ember/test-helpers/rerender';
 
 // Wait Helpers
 

--- a/types/ember__test-helpers/rerender.d.ts
+++ b/types/ember__test-helpers/rerender.d.ts
@@ -1,0 +1,1 @@
+export default function rerender(): Promise<void>;

--- a/types/ember__test-helpers/setup-rendering-context.d.ts
+++ b/types/ember__test-helpers/setup-rendering-context.d.ts
@@ -2,5 +2,4 @@ import { TemplateFactory } from "htmlbars-inline-precompile";
 
 export default function<Context extends object>(context: Context): Promise<Context>;
 export function render(template: TemplateFactory): Promise<void>;
-export function rerender(): Promise<void>;
 export function clearRender(): Promise<void>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
with `@ember/test-helpers` having v2.9.0 and publishing types https://github.com/emberjs/ember-test-helpers/releases/tag/v2.9.0, CI fails in packages that utilize `@types/emebr__test-helpers` due to incorrect implementation of `rerender` function.

as an example see https://github.com/ember-modifier/ember-modifier/actions/runs/3700955750/jobs/6269831630

The thing is that `@types/emebr__test-helpers` had implemented `rerender` in `setup-rendering-context` but actual implementation lives in it's own file, see https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/rerender.ts