### PR TITLE
[color-thief-node] Fixed return type of getColor method

### DIFF
--- a/types/color-thief-node/color-thief-node-tests.ts
+++ b/types/color-thief-node/color-thief-node-tests.ts
@@ -1,7 +1,12 @@
-import { getColorFromURL, getPaletteFromURL } from "color-thief-node";
+import { getColor, getColorFromURL, getPaletteFromURL } from 'color-thief-node';
 
 const imageUrl =
     "https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Firefox_Logo%2C_2017.svg/1024px-Firefox_Logo%2C_2017.svg.png";
+
+const image = new Image();
+image.src = imageUrl;
+// $ExpectType Palette
+getColor(image);
 
 getColorFromURL(imageUrl).then(color => {
     // $ExpectType Palette

--- a/types/color-thief-node/index.d.ts
+++ b/types/color-thief-node/index.d.ts
@@ -10,7 +10,7 @@ export type Palette = [red: number, green: number, blue: number];
  * Use the median cut algorithm provided by quantize.js to cluster similar
  * colors and return the base color from the largest cluster.
  */
-export function getColor(sourceImage: HTMLImageElement, quality?: number): Promise<Palette>;
+export function getColor(sourceImage: HTMLImageElement, quality?: number): Palette;
 
 /**
  * Use the median cut algorithm provided by quantize.js


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - `getColor()`: According to [color-thief.js](https://github.com/zicodeng/color-thief-node/blob/e4b37fb1593590ea3c369052721c63bf422d5eb0/src/color-thief.js#L88-L107) in [zicodeng/color-thief-node](https://github.com/zicodeng/color-thief-node), this method is not async and does not return Promise.
   -  `getColor()` test: I wrote a simple test that takes an HTMLImageElement as input argument and verifies that the Palette type is returned successfully.  
     According to [README.md](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#create-a-new-package), this file is not executed, but if you actually want to use it, you must wait for the image to be loaded by onload.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

This is my first contribution to DefinitelyTyped.
I have thoroughly checked it to make sure there are no problems, but please let me know if there is anything inappropriate. Thank you.