### PR TITLE
[selenium-webdriver] Allow .wait to pass polling duration (part 2)

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -1805,7 +1805,8 @@ export class WebDriver {
    * @param {number=} opt_timeout How long to wait for the condition to be true.
    * @param {string=} opt_message An optional message to use if the wait times
    *     out.
-   * @param {number=} opt_pollTimeout How long to wait between polling the condition.
+   * @param {number=} opt_pollTimeout Duration in milliseconds to wait between
+   *     polling the condition.
    * @return {!WebElementPromise} A promise that will be fulfilled
    *     with the first truthy value returned by the condition function, or
    *     rejected if the condition times out.
@@ -1859,6 +1860,8 @@ export class WebDriver {
    * @param {number=} opt_timeout How long to wait for the condition to be true.
    * @param {string=} opt_message An optional message to use if the wait times
    *     out.
+   * @param {number=} opt_pollTimeout Duration in milliseconds to wait between
+   *     polling the condition.
    * @return {!Promise<T>} A promise that will be fulfilled
    *     with the first truthy value returned by the condition function, or
    *     rejected if the condition times out.
@@ -1866,7 +1869,7 @@ export class WebDriver {
    */
   wait<T>(
       condition: PromiseLike<T>|Condition<T>|((driver: WebDriver) => T | PromiseLike<T>)|Function,
-      opt_timeout?: number, opt_message?: string): Promise<T>;
+      opt_timeout?: number, opt_message?: string, opt_pollTimeout?: number): Promise<T>;
 
   /**
    * Schedules a command to make the driver sleep for the given amount of time.

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -460,6 +460,7 @@ async function TestWebDriver() {
     booleanPromise = driver.wait((driver: webdriver.WebDriver) => Promise.resolve(true));
     booleanPromise = driver.wait(booleanPromise, 123);
     booleanPromise = driver.wait(booleanPromise, 123, 'Message');
+    booleanPromise = driver.wait(booleanPromise, 123, 'Message', 10);
     webElementPromise = driver.wait(webElementCondition);
     webElementPromise = driver.wait(webElementCondition, 50, 'Message');
     webElementPromise = driver.wait(webElementCondition, 50, 'Message', 10);


### PR DESCRIPTION
#58469 missed updating this overload of .wait

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #58469 missed this overload. Upstream code is https://github.com/SeleniumHQ/selenium/blob/a019e92c29a1024c8e3426c3a0960bffb319d2e6/javascript/node/selenium-webdriver/lib/webdriver.js#L453