### PR TITLE
[node:util] Update types

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -18,6 +18,8 @@ util.inspect(["This is nice"], {
         return b.localeCompare(a);
     },
     getters: false,
+    showHidden: true,
+    numericSeparator: true,
 });
 util.inspect(["This is nice"], {
     colors: true,
@@ -29,6 +31,8 @@ util.inspect(["This is nice"], {
     compact: false,
     sorted: true,
     getters: 'set',
+    showHidden: false,
+    numericSeparator: false,
 });
 util.inspect(["This is nice"], {
     compact: 42,
@@ -41,6 +45,10 @@ util.inspect.replDefaults = {
 
 util.inspect({
     [util.inspect.custom]: <util.CustomInspectFunction> ((depth, opts) => opts.stylize('woop', 'module')),
+});
+
+util.inspect({
+    [util.inspect.custom]: <util.CustomInspectFunction> (() => ({ bar: 'baz' })),
 });
 
 (options?: util.InspectOptions) => util.inspect({ }, options);
@@ -218,6 +226,8 @@ access('file/that/does/not/exist', (err) => {
             bar: { type: 'boolean', multiple: true },
         },
     } as const;
+
+    util.parseArgs();
 
     // $ExpectType { values: { foo: string | undefined; bar: boolean[] | undefined; }; positionals: string[]; }
     util.parseArgs(config);

--- a/types/node/ts4.8/test/util.ts
+++ b/types/node/ts4.8/test/util.ts
@@ -18,6 +18,8 @@ util.inspect(["This is nice"], {
         return b.localeCompare(a);
     },
     getters: false,
+    showHidden: true,
+    numericSeparator: true,
 });
 util.inspect(["This is nice"], {
     colors: true,
@@ -29,6 +31,8 @@ util.inspect(["This is nice"], {
     compact: false,
     sorted: true,
     getters: 'set',
+    showHidden: false,
+    numericSeparator: false,
 });
 util.inspect(["This is nice"], {
     compact: 42,
@@ -41,6 +45,10 @@ util.inspect.replDefaults = {
 
 util.inspect({
     [util.inspect.custom]: <util.CustomInspectFunction> ((depth, opts) => opts.stylize('woop', 'module')),
+});
+
+util.inspect({
+    [util.inspect.custom]: <util.CustomInspectFunction> (() => ({ bar: 'baz' })),
 });
 
 (options?: util.InspectOptions) => util.inspect({ }, options);
@@ -218,6 +226,8 @@ access('file/that/does/not/exist', (err) => {
             bar: { type: 'boolean', multiple: true },
         },
     } as const;
+
+    util.parseArgs();
 
     // $ExpectType { values: { foo: string | undefined; bar: boolean[] | undefined; }; positionals: string[]; }
     util.parseArgs(config);

--- a/types/node/ts4.8/util.d.ts
+++ b/types/node/ts4.8/util.d.ts
@@ -6,28 +6,44 @@
  * ```js
  * const util = require('util');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/util.js)
+ * @see [source](https://github.com/nodejs/node/blob/v18.x/lib/util.js)
  */
 declare module 'util' {
     import * as types from 'node:util/types';
     export interface InspectOptions {
         /**
-         * If set to `true`, getters are going to be
-         * inspected as well. If set to `'get'` only getters without setter are going
-         * to be inspected. If set to `'set'` only getters having a corresponding
-         * setter are going to be inspected. This might cause side effects depending on
-         * the getter function.
-         * @default `false`
+         * If `true`, object's non-enumerable symbols and properties are included in the formatted result.
+         * `WeakMap` and `WeakSet` entries are also included as well as user defined prototype properties (excluding method properties).
+         * @default false
          */
-        getters?: 'get' | 'set' | boolean | undefined;
         showHidden?: boolean | undefined;
         /**
+         * Specifies the number of times to recurse while formatting object.
+         * This is useful for inspecting large objects.
+         * To recurse up to the maximum call stack size pass `Infinity` or `null`.
          * @default 2
          */
         depth?: number | null | undefined;
+        /**
+         * If `true`, the output is styled with ANSI color codes. Colors are customizable.
+         */
         colors?: boolean | undefined;
+        /**
+         * If `false`, `[util.inspect.custom](depth, opts, inspect)` functions are not invoked.
+         * @default true
+         */
         customInspect?: boolean | undefined;
+        /**
+         * If `true`, `Proxy` inspection includes the target and handler objects.
+         * @default false
+         */
         showProxy?: boolean | undefined;
+        /**
+         * Specifies the maximum number of `Array`, `TypedArray`, `WeakMap`, and `WeakSet` elements
+         * to include when formatting. Set to `null` or `Infinity` to show all elements.
+         * Set to `0` or negative to show no elements.
+         * @default 100
+         */
         maxArrayLength?: number | null | undefined;
         /**
          * Specifies the maximum number of characters to
@@ -36,6 +52,12 @@ declare module 'util' {
          * @default 10000
          */
         maxStringLength?: number | null | undefined;
+        /**
+         * The length at which input values are split across multiple lines.
+         * Set to `Infinity` to format the input as a single line
+         * (in combination with `compact` set to `true` or any number >= `1`).
+         * @default 80
+         */
         breakLength?: number | undefined;
         /**
          * Setting this to `false` causes each object key
@@ -45,13 +67,33 @@ declare module 'util' {
          * `breakLength`. Short array elements are also grouped together. Note that no
          * text will be reduced below 16 characters, no matter the `breakLength` size.
          * For more information, see the example below.
-         * @default `true`
+         * @default true
          */
         compact?: boolean | number | undefined;
+        /**
+         * If set to `true` or a function, all properties of an object, and `Set` and `Map`
+         * entries are sorted in the resulting string.
+         * If set to `true` the default sort is used.
+         * If set to a function, it is used as a compare function.
+         */
         sorted?: boolean | ((a: string, b: string) => number) | undefined;
+        /**
+         * If set to `true`, getters are going to be
+         * inspected as well. If set to `'get'` only getters without setter are going
+         * to be inspected. If set to `'set'` only getters having a corresponding
+         * setter are going to be inspected. This might cause side effects depending on
+         * the getter function.
+         * @default false
+         */
+        getters?: 'get' | 'set' | boolean | undefined;
+        /**
+         * If set to `true`, an underscore is used to separate every three digits in all bigints and numbers.
+         * @default false
+         */
+        numericSeparator?: boolean | undefined;
     }
     export type Style = 'special' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null' | 'string' | 'symbol' | 'date' | 'regexp' | 'module';
-    export type CustomInspectFunction = (depth: number, options: InspectOptionsStylized) => string;
+    export type CustomInspectFunction = (depth: number, options: InspectOptionsStylized) => any; // TODO: , inspect: inspect
     export interface InspectOptionsStylized extends InspectOptions {
         stylize(text: string, styleType: Style): string;
     }
@@ -899,7 +941,7 @@ declare module 'util' {
      * });
      * ```
      * @since v8.2.0
-     * @param original An `async` function
+     * @param fn An `async` function
      * @return a callback style function
      */
     export function callbackify(fn: () => Promise<void>): (callback: (err: NodeJS.ErrnoException) => void) => void;
@@ -1198,16 +1240,31 @@ declare module 'util' {
      *   - `tokens` Detailed parse information (only if `tokens` was specified).
      *
      */
-    export function parseArgs<T extends ParseArgsConfig>(config: T): ParsedResults<T>;
+    export function parseArgs<T extends ParseArgsConfig>(config?: T): ParsedResults<T>;
 
     interface ParseArgsOptionConfig {
-        type: 'string' | 'boolean';
-        short?: string;
-        multiple?: boolean;
         /**
+         * Type of argument.
+         */
+        type: 'string' | 'boolean';
+        /**
+         * Whether this option can be provided multiple times.
+         * If `true`, all values will be collected in an array.
+         * If `false`, values for the option are last-wins.
+         * @default false.
+         */
+        multiple?: boolean | undefined;
+        /**
+         * A single character alias for the option.
+         */
+        short?: string | undefined;
+        /**
+         * The default option value when it is not set by args.
+         * It must be of the same type as the the `type` property.
+         * When `multiple` is `true`, it must be an array.
          * @since v18.11.0
          */
-        default?: string | boolean | string[] | boolean[];
+        default?: string | boolean | string[] | boolean[] | undefined;
     }
 
     interface ParseArgsOptionsConfig {
@@ -1215,11 +1272,30 @@ declare module 'util' {
     }
 
     export interface ParseArgsConfig {
-        strict?: boolean;
-        allowPositionals?: boolean;
-        tokens?: boolean;
-        options?: ParseArgsOptionsConfig;
-        args?: string[];
+        /**
+         * Array of argument strings.
+         */
+        args?: string[] | undefined;
+        /**
+         * Used to describe arguments known to the parser.
+         */
+        options?: ParseArgsOptionsConfig | undefined;
+        /**
+         * Should an error be thrown when unknown arguments are encountered,
+         * or when arguments are passed that do not match the `type` configured in `options`.
+         * @default true
+         */
+        strict?: boolean | undefined;
+        /**
+         * Whether this command accepts positional arguments.
+         */
+        allowPositionals?: boolean | undefined;
+        /**
+         * Return the parsed tokens. This is useful for extending the built-in behavior,
+         * from adding additional checks through to reprocessing the tokens in different ways.
+         * @default false
+         */
+        tokens?: boolean | undefined;
     }
 
     /*

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -6,28 +6,44 @@
  * ```js
  * const util = require('util');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/util.js)
+ * @see [source](https://github.com/nodejs/node/blob/v18.x/lib/util.js)
  */
 declare module 'util' {
     import * as types from 'node:util/types';
     export interface InspectOptions {
         /**
-         * If set to `true`, getters are going to be
-         * inspected as well. If set to `'get'` only getters without setter are going
-         * to be inspected. If set to `'set'` only getters having a corresponding
-         * setter are going to be inspected. This might cause side effects depending on
-         * the getter function.
-         * @default `false`
+         * If `true`, object's non-enumerable symbols and properties are included in the formatted result.
+         * `WeakMap` and `WeakSet` entries are also included as well as user defined prototype properties (excluding method properties).
+         * @default false
          */
-        getters?: 'get' | 'set' | boolean | undefined;
         showHidden?: boolean | undefined;
         /**
+         * Specifies the number of times to recurse while formatting object.
+         * This is useful for inspecting large objects.
+         * To recurse up to the maximum call stack size pass `Infinity` or `null`.
          * @default 2
          */
         depth?: number | null | undefined;
+        /**
+         * If `true`, the output is styled with ANSI color codes. Colors are customizable.
+         */
         colors?: boolean | undefined;
+        /**
+         * If `false`, `[util.inspect.custom](depth, opts, inspect)` functions are not invoked.
+         * @default true
+         */
         customInspect?: boolean | undefined;
+        /**
+         * If `true`, `Proxy` inspection includes the target and handler objects.
+         * @default false
+         */
         showProxy?: boolean | undefined;
+        /**
+         * Specifies the maximum number of `Array`, `TypedArray`, `WeakMap`, and `WeakSet` elements
+         * to include when formatting. Set to `null` or `Infinity` to show all elements.
+         * Set to `0` or negative to show no elements.
+         * @default 100
+         */
         maxArrayLength?: number | null | undefined;
         /**
          * Specifies the maximum number of characters to
@@ -36,6 +52,12 @@ declare module 'util' {
          * @default 10000
          */
         maxStringLength?: number | null | undefined;
+        /**
+         * The length at which input values are split across multiple lines.
+         * Set to `Infinity` to format the input as a single line
+         * (in combination with `compact` set to `true` or any number >= `1`).
+         * @default 80
+         */
         breakLength?: number | undefined;
         /**
          * Setting this to `false` causes each object key
@@ -45,13 +67,33 @@ declare module 'util' {
          * `breakLength`. Short array elements are also grouped together. Note that no
          * text will be reduced below 16 characters, no matter the `breakLength` size.
          * For more information, see the example below.
-         * @default `true`
+         * @default true
          */
         compact?: boolean | number | undefined;
+        /**
+         * If set to `true` or a function, all properties of an object, and `Set` and `Map`
+         * entries are sorted in the resulting string.
+         * If set to `true` the default sort is used.
+         * If set to a function, it is used as a compare function.
+         */
         sorted?: boolean | ((a: string, b: string) => number) | undefined;
+        /**
+         * If set to `true`, getters are going to be
+         * inspected as well. If set to `'get'` only getters without setter are going
+         * to be inspected. If set to `'set'` only getters having a corresponding
+         * setter are going to be inspected. This might cause side effects depending on
+         * the getter function.
+         * @default false
+         */
+        getters?: 'get' | 'set' | boolean | undefined;
+        /**
+         * If set to `true`, an underscore is used to separate every three digits in all bigints and numbers.
+         * @default false
+         */
+        numericSeparator?: boolean | undefined;
     }
     export type Style = 'special' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null' | 'string' | 'symbol' | 'date' | 'regexp' | 'module';
-    export type CustomInspectFunction = (depth: number, options: InspectOptionsStylized) => string;
+    export type CustomInspectFunction = (depth: number, options: InspectOptionsStylized) => any; // TODO: , inspect: inspect
     export interface InspectOptionsStylized extends InspectOptions {
         stylize(text: string, styleType: Style): string;
     }
@@ -899,7 +941,7 @@ declare module 'util' {
      * });
      * ```
      * @since v8.2.0
-     * @param original An `async` function
+     * @param fn An `async` function
      * @return a callback style function
      */
     export function callbackify(fn: () => Promise<void>): (callback: (err: NodeJS.ErrnoException) => void) => void;
@@ -1198,16 +1240,31 @@ declare module 'util' {
      *   - `tokens` Detailed parse information (only if `tokens` was specified).
      *
      */
-    export function parseArgs<T extends ParseArgsConfig>(config: T): ParsedResults<T>;
+    export function parseArgs<T extends ParseArgsConfig>(config?: T): ParsedResults<T>;
 
     interface ParseArgsOptionConfig {
-        type: 'string' | 'boolean';
-        short?: string;
-        multiple?: boolean;
         /**
+         * Type of argument.
+         */
+        type: 'string' | 'boolean';
+        /**
+         * Whether this option can be provided multiple times.
+         * If `true`, all values will be collected in an array.
+         * If `false`, values for the option are last-wins.
+         * @default false.
+         */
+        multiple?: boolean | undefined;
+        /**
+         * A single character alias for the option.
+         */
+        short?: string | undefined;
+        /**
+         * The default option value when it is not set by args.
+         * It must be of the same type as the the `type` property.
+         * When `multiple` is `true`, it must be an array.
          * @since v18.11.0
          */
-        default?: string | boolean | string[] | boolean[];
+        default?: string | boolean | string[] | boolean[] | undefined;
     }
 
     interface ParseArgsOptionsConfig {
@@ -1215,11 +1272,30 @@ declare module 'util' {
     }
 
     export interface ParseArgsConfig {
-        strict?: boolean;
-        allowPositionals?: boolean;
-        tokens?: boolean;
-        options?: ParseArgsOptionsConfig;
-        args?: string[];
+        /**
+         * Array of argument strings.
+         */
+        args?: string[] | undefined;
+        /**
+         * Used to describe arguments known to the parser.
+         */
+        options?: ParseArgsOptionsConfig | undefined;
+        /**
+         * Should an error be thrown when unknown arguments are encountered,
+         * or when arguments are passed that do not match the `type` configured in `options`.
+         * @default true
+         */
+        strict?: boolean | undefined;
+        /**
+         * Whether this command accepts positional arguments.
+         */
+        allowPositionals?: boolean | undefined;
+        /**
+         * Return the parsed tokens. This is useful for extending the built-in behavior,
+         * from adding additional checks through to reprocessing the tokens in different ways.
+         * @default false
+         */
+        tokens?: boolean | undefined;
     }
 
     /*


### PR DESCRIPTION
- Add missed `numericSeparator` option to `InspectOptions`
- Make `config` is optional in `parseArgs`
- Fix `CustomInspectFunction` return type: it may return a value of any type that will be formatted accordingly by util.inspect().

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v18.x/api/util.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
