### PR TITLE
Updated wordpress__rich-text to 6.0

### DIFF
--- a/types/wordpress__rich-text/component/index.d.ts
+++ b/types/wordpress__rich-text/component/index.d.ts
@@ -1,0 +1,2 @@
+export { useAnchor } from './use-anchor';
+export { useAnchorRef } from './use-anchor-ref';

--- a/types/wordpress__rich-text/component/use-anchor-ref.d.ts
+++ b/types/wordpress__rich-text/component/use-anchor-ref.d.ts
@@ -1,0 +1,22 @@
+import { RefObject } from 'react';
+
+import { NamedFormatConfiguration } from '..';
+import { Value } from '../create';
+
+/**
+ * This hook, to be used in a format type's Edit component, returns the active
+ * element that is formatted, or the selection range if no format is active.
+ * The returned value is meant to be used for positioning UI, e.g. by passing it
+ * to the `Popover` component.
+ *
+ * @param $1          Named parameters.
+ * @param $1.ref      React ref of the element
+ *                                             containing  the editable content.
+ * @param $1.value    Value to check for selection.
+ * @param $1.settings The format type's settings.
+ *
+ * @return The active element or selection range.
+ *
+ * @deprecated since 5.16.0. Use `useAnchor` instead.
+ */
+export function useAnchorRef(param: { ref: RefObject<HTMLElement>, value: Value, settings?: NamedFormatConfiguration }): Element | Range;

--- a/types/wordpress__rich-text/component/use-anchor.d.ts
+++ b/types/wordpress__rich-text/component/use-anchor.d.ts
@@ -1,0 +1,8 @@
+import { Format, Value } from "../create";
+
+export interface VirtualAnchorElement {
+    getBoundingClientRect(): DOMRect;
+    ownerDocument: Document;
+}
+
+export function useAnchor(param: {editableContentElement: HTMLElement|null, value: Value, settings?: Format}): Element|VirtualAnchorElement|undefined|null;

--- a/types/wordpress__rich-text/component/use-anchor.d.ts
+++ b/types/wordpress__rich-text/component/use-anchor.d.ts
@@ -1,4 +1,4 @@
-import { Format, Value } from "../create";
+import { Format, Value } from '../create';
 
 export interface VirtualAnchorElement {
     getBoundingClientRect(): DOMRect;

--- a/types/wordpress__rich-text/create.d.ts
+++ b/types/wordpress__rich-text/create.d.ts
@@ -1,0 +1,55 @@
+export interface Format {
+    type: string;
+    attributes?: Record<string, string> | undefined;
+    unregisteredAttributes?: Record<string, string> | undefined;
+    object?: boolean | undefined;
+}
+
+export interface Value {
+    activeFormats?: readonly Format[] | undefined;
+    end?: number | undefined;
+    formats: ReadonlyArray<Format[] | undefined>;
+    replacements: ReadonlyArray<Format[] | undefined>;
+    start?: number | undefined;
+    text: string;
+}
+
+/**
+ * Create a `RichText` value from an `Element` tree (DOM), an HTML string or a
+ * plain text string, with optionally a `Range` object to set the selection.
+ *
+ * @remarks
+ * If called without any input, an empty value will be created.
+ *
+ * If `multilineTag` is provided, any content of direct children whose type matches
+ * `multilineTag` will be separated by two newlines. The optional functions can
+ * be used to filter out content.
+ *
+ * A value will have the following shape, which you are strongly encouraged not
+ * to modify without the use of helper functions:
+ *
+ * ```js
+ * {
+ *   text: string,
+ *   formats: Array,
+ *   replacements: Array,
+ *   ?start: number,
+ *   ?end: number,
+ * }
+ * ```
+ *
+ * As you can see, text and formatting are separated. `text` holds the text,
+ * including any replacement characters for objects and lines. `formats`,
+ * `objects` and `lines` are all sparse arrays of the same length as `text`. It
+ * holds information about the formatting at the relevant text indices. Finally
+ * `start` and `end` state which text indices are selected. They are only
+ * provided if a `Range` was given.
+ */
+export function create(args?: { text: string }): Value;
+export function create(args?: { html: string }): Value; // tslint:disable-line:unified-signatures
+export function create(args?: {
+    element: Element;
+    multilineTag?: keyof HTMLElementTagNameMap | undefined;
+    multilineWrapperTags?: ReadonlyArray<keyof HTMLElementTagNameMap> | undefined;
+    range?: Range | undefined;
+}): Value; // tslint:disable-line:unified-signatures

--- a/types/wordpress__rich-text/index.d.ts
+++ b/types/wordpress__rich-text/index.d.ts
@@ -1,11 +1,15 @@
-// Type definitions for @wordpress/rich-text 3.4
+// Type definitions for @wordpress/rich-text 6.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/rich-text/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
+import { create, Format, Value } from "./create";
 import { ComponentType } from 'react';
 import { dispatch, select } from '@wordpress/data';
+
+export { create, Format, Value };
+export { useAnchor } from "./component/use-anchor";
 
 declare module '@wordpress/data' {
     function dispatch(key: 'core/rich-text'): typeof import('./store/actions');
@@ -38,22 +42,6 @@ export interface NamedFormatConfiguration extends FormatConfiguration {
     name: string;
 }
 
-export interface Format {
-    type: string;
-    attributes?: Record<string, string> | undefined;
-    unregisteredAttributes?: Record<string, string> | undefined;
-    object?: boolean | undefined;
-}
-
-export interface Value {
-    activeFormats?: readonly Format[] | undefined;
-    end?: number | undefined;
-    formats: ReadonlyArray<Format[] | undefined>;
-    replacements: ReadonlyArray<Format[] | undefined>;
-    start?: number | undefined;
-    text: string;
-}
-
 /**
  * Apply a format object to a Rich Text value from the given `startIndex` to the
  * given `endIndex`. Indices are retrieved from the selection if none are
@@ -77,46 +65,6 @@ export function applyFormat(value: Value, format: Format, startIndex?: number, e
  * @returns A new value combining all given records.
  */
 export function concat(...values: readonly Value[]): Value;
-
-/**
- * Create a `RichText` value from an `Element` tree (DOM), an HTML string or a
- * plain text string, with optionally a `Range` object to set the selection.
- *
- * @remarks
- * If called without any input, an empty value will be created.
- *
- * If `multilineTag` is provided, any content of direct children whose type matches
- * `multilineTag` will be separated by two newlines. The optional functions can
- * be used to filter out content.
- *
- * A value will have the following shape, which you are strongly encouraged not
- * to modify without the use of helper functions:
- *
- * ```js
- * {
- *   text: string,
- *   formats: Array,
- *   replacements: Array,
- *   ?start: number,
- *   ?end: number,
- * }
- * ```
- *
- * As you can see, text and formatting are separated. `text` holds the text,
- * including any replacement characters for objects and lines. `formats`,
- * `objects` and `lines` are all sparse arrays of the same length as `text`. It
- * holds information about the formatting at the relevant text indices. Finally
- * `start` and `end` state which text indices are selected. They are only
- * provided if a `Range` was given.
- */
-export function create(args?: { text: string }): Value;
-export function create(args?: { html: string }): Value; // tslint:disable-line:unified-signatures
-export function create(args?: {
-    element: Element;
-    multilineTag?: keyof HTMLElementTagNameMap | undefined;
-    multilineWrapperTags?: ReadonlyArray<keyof HTMLElementTagNameMap> | undefined;
-    range?: Range | undefined;
-}): Value; // tslint:disable-line:unified-signatures
 
 /**
  * Gets the format object by type at the start of the selection. This can be

--- a/types/wordpress__rich-text/index.d.ts
+++ b/types/wordpress__rich-text/index.d.ts
@@ -4,12 +4,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
-import { create, Format, Value } from "./create";
+import { create, Format, Value } from './create';
 import { ComponentType } from 'react';
 import { dispatch, select } from '@wordpress/data';
 
 export { create, Format, Value };
-export { useAnchor } from "./component/use-anchor";
+export * from './component';
 
 declare module '@wordpress/data' {
     function dispatch(key: 'core/rich-text'): typeof import('./store/actions');

--- a/types/wordpress__rich-text/index.d.ts
+++ b/types/wordpress__rich-text/index.d.ts
@@ -79,6 +79,16 @@ export function concat(...values: readonly Value[]): Value;
 export function getActiveFormat(value: Value, formatType: string): Format | undefined;
 
 /**
+ * Gets the all format objects at the start of the selection.
+ *
+ * @param value Value to inspect.
+ * @param EMPTY_ACTIVE_FORMATS Array to return if there are no active formats.
+ *
+ * @return Active format objects.
+ */
+export function getActiveFormats(value: Value, EMPTY_ACTIVE_FORMATS?: Format[]): Format[];
+
+/**
  * Gets the active object, if there is any.
  *
  * @param value - `Value` to inspect.

--- a/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
+++ b/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
@@ -182,3 +182,7 @@ select('core/rich-text').getFormatTypes();
 
 // $ExpectType NamedFormatConfiguration | undefined
 select('core/rich-text').getFormatTypeForBareElement('a');
+
+// useAnchor
+RT.useAnchor({editableContentElement: new HTMLElement(), value: RT.create()});
+RT.useAnchor({editableContentElement: new HTMLElement(), value: RT.create(), settings: RT.create().formats[0]![0]});

--- a/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
+++ b/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
@@ -46,6 +46,12 @@ RT.create({
 RT.getActiveFormat(VALUE, 'foo');
 
 //
+// getActiveFormats
+//
+RT.getActiveFormats(VALUE);
+RT.getActiveFormats(VALUE, []);
+
+//
 // getActiveObject
 //
 RT.getActiveObject(VALUE);

--- a/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
+++ b/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { dispatch, select } from '@wordpress/data';
 import * as RT from '@wordpress/rich-text';
 
@@ -192,3 +193,7 @@ select('core/rich-text').getFormatTypeForBareElement('a');
 // useAnchor
 RT.useAnchor({editableContentElement: new HTMLElement(), value: RT.create()});
 RT.useAnchor({editableContentElement: new HTMLElement(), value: RT.create(), settings: RT.create().formats[0]![0]});
+
+// useAnchorRef
+RT.useAnchorRef({ref: createRef(), value: VALUE});
+RT.useAnchorRef({ref: createRef(), value: VALUE, settings: select('core/rich-text').getFormatTypeForBareElement('a')!});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/%40wordpress/rich-text%406.0.0/packages/rich-text/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

