### PR TITLE
Change the Extrafield type in checkout capture from array to an object

### DIFF
--- a/types/chec__commerce.js/types/checkout-capture.d.ts
+++ b/types/chec__commerce.js/types/checkout-capture.d.ts
@@ -1,10 +1,10 @@
-import { Extrafield } from './extrafield';
+import { Extrafields } from './extrafields';
 import { Address } from './address';
 
 export interface CheckoutCapture {
     line_items?: any;
     discount_code?: string;
-    extra_fields?: Extrafield[];
+    extra_fields?: Extrafields;
     customer: {
         id?: string;
         firstname?: string;

--- a/types/chec__commerce.js/types/checkout-token.d.ts
+++ b/types/chec__commerce.js/types/checkout-token.d.ts
@@ -1,5 +1,5 @@
 import { Merchant } from './merchant';
-import { Extrafield } from './extrafield';
+import { Extrafields } from './extrafields';
 import { ShippingMethod } from './shipping-method';
 import { Gateway } from './gateway';
 import { Live } from './live';
@@ -40,7 +40,7 @@ export interface CheckoutToken {
     };
     line_items: CheckoutTokenLineItem[];
     merchant: Merchant;
-    extra_fields: Extrafield[];
+    extra_fields: Extrafields;
     gateways: Gateway[];
     shipping_methods: ShippingMethod[];
     live: Live;

--- a/types/chec__commerce.js/types/extrafield.d.ts
+++ b/types/chec__commerce.js/types/extrafield.d.ts
@@ -1,9 +1,0 @@
-export type ExtrafieldType = 'text';
-
-export interface Extrafield {
-    id: string;
-    name: string;
-    type: ExtrafieldType;
-    required: boolean;
-    options: any; // todo
-}

--- a/types/chec__commerce.js/types/extrafields.d.ts
+++ b/types/chec__commerce.js/types/extrafields.d.ts
@@ -1,0 +1,5 @@
+export type ExtrafieldType = 'text';
+
+export interface Extrafields {
+    [key: string]: string // The [key: string represents each extrfield id]
+}

--- a/types/chec__commerce.js/types/extrafields.d.ts
+++ b/types/chec__commerce.js/types/extrafields.d.ts
@@ -1,5 +1,5 @@
 export type ExtrafieldType = 'text';
 
 export interface Extrafields {
-    [key: string]: string // The [key: string represents each extrfield id]
+    [key: string]: string; // The [key: string represents each extrfield id]
 }


### PR DESCRIPTION
This is a fix for the Extrafield Type in the checkout capture
The type is referenced here in the API documentation https://commercejs.com/docs/api/?shell#checkout in capture order