### PR TITLE
change required field backblaze-b2

### DIFF
--- a/types/backblaze-b2/index.d.ts
+++ b/types/backblaze-b2/index.d.ts
@@ -109,7 +109,7 @@ interface GetDownloadAuthorizationOpts extends CommonArgs {
      * Authorization validity : 0 to 604800
      */
     validDurationInSeconds: number;
-    b2ContentDisposition: string;
+    b2ContentDisposition?: string;
 }
 
 interface DownloadFileOpts extends CommonArgs {


### PR DESCRIPTION
b2ContentDisposition is optional now [doc](https://www.backblaze.com/b2/docs/b2_download_file_by_name.html)
