### PR TITLE
fix(ramda): improve intersperse types

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -2393,8 +2393,8 @@ export function intersection<T>(list1: readonly T[]): (list2: readonly T[]) => T
  * R.intersperse('a', ['b', 'n', 'n', 's']); //=> ['b', 'a', 'n', 'a', 'n', 'a', 's']
  * ```
  */
-export function intersperse<T>(separator: T, list: readonly T[]): T[];
-export function intersperse<T>(separator: T): (list: readonly T[]) => T[];
+export function intersperse<S, T>(separator: S, list: readonly T[]): Array<S | T>;
+export function intersperse<S, T>(separator: S): (list: readonly T[]) => Array<S | T>;
 
 /**
  * Transforms the items of the list with the transducer

--- a/types/ramda/test/intersperse-tests.ts
+++ b/types/ramda/test/intersperse-tests.ts
@@ -4,4 +4,5 @@ import * as R from 'ramda';
     R.intersperse(',', ['foo', 'bar']); // => ['foo', ',', 'bar']
     R.intersperse(0, [1, 2]); // => [1, 0, 2]
     R.intersperse(0, [1]); // => [1]
+    R.intersperse('a', [1, 2]); // => [1, 'a', 2]
 };


### PR DESCRIPTION
Intersperse return type to be a union of the seperator and list.

For example in use in TSX we may want to intersperce an array of elements with a JSX seperator:

Before: 
```tsx
import { intersperse } from 'ramda'

interperse<JSX.Element | string>(<br />, ['a', 'b'])
```

After:
```tsx
import { intersperse } from 'ramda'

interperse(<br />, ['a', 'b'])
```


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
