### PR TITLE
[aws-lambda] Add AsyncHandler

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -81,7 +81,9 @@ untypedCallback(null, { bar: 123 });
 // @ts-expect-error
 untypedCallback(null, anyObj, anyObj);
 
-interface TestResult { foo: number; }
+interface TestResult {
+    foo: number;
+}
 declare const typedCallback: AWSLambda.Callback<TestResult>;
 typedCallback();
 typedCallback(undefined);
@@ -200,11 +202,44 @@ const mixedUntypedCallbackTypedHandler: CustomHandler = (
     cb: AWSLambda.Callback,
 ) => {};
 
+// Test AsyncHandler default types
+const asyncHandler: AWSLambda.AsyncHandler = async (
+    // $ExpectType unknown
+    event,
+    // $ExpectType Context
+    context,
+) => {};
+
 // Test that AsyncHandler is compatible with Handler
-const asyncHandler: AWSLambda.AsyncHandler = async (event, context) => {};
-const asyncHandlerTest: AWSLambda.Handler = asyncHandler;
+const asyncHandlerToHandler: AWSLambda.Handler = asyncHandler;
+
+// Test correct event type inference
+const asyncHandler2: AWSLambda.AsyncHandler<string, boolean> = async (
+    // $ExpectType string
+    event,
+    // $ExpectType Context
+    context,
+) => {
+    return true;
+};
+
+// Test correct result type checking
+// @ts-expect-error
+const asyncHandler3: AWSLambda.AsyncHandler<string, boolean> = async (event, context) => 'abc';
+
+// Test that you can't assign a Handler to an AsyncHandler
+// @ts-expect-error
+const handler: AWSLambda.AsyncHandler = asyncHandlerToHandler;
 
 // Test that you cannot pass a callback to AsyncHandler
 // @see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63474
 // @ts-expect-error
-const asyncHandler4: AWSLambda.AsyncHandler = async (event, context, callback) => { return 1 }
+const asyncHandler4: AWSLambda.AsyncHandler = async (event, context, callback) => {};
+
+// Test that you cannot pass some other thing as a callback to AsyncHandler
+// @ts-expect-error
+const asyncHandler7: AWSLambda.AsyncHandler = async (event: unknown, context: unknown, isTest?: boolean) => {};
+
+const handler8 = async (event: unknown, context: unknown, isTest?: boolean) => {};
+// @ts-expect-error
+const asyncHandler8: AWSLambda.AsyncHandler = handler8;

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -200,11 +200,11 @@ const mixedUntypedCallbackTypedHandler: CustomHandler = (
     cb: AWSLambda.Callback,
 ) => {};
 
-const promiseBasedHandler: AWSLambda.PromiseBasedHandler = async (event, context) => {};
-const promiseBasedHandlerTest: AWSLambda.Handler = promiseBasedHandler;
+// Test that AsyncHandler is compatible with Handler
+const asyncHandler: AWSLambda.AsyncHandler = async (event, context) => {};
+const asyncHandlerTest: AWSLambda.Handler = asyncHandler;
 
-const contextBasedHandler: AWSLambda.ContextBasedHandler = async (event, context) => {};
-const contextBasedHandlerTest: AWSLambda.Handler = contextBasedHandler;
-
-const callbackBasedHandler: AWSLambda.CallbackBasedHandler = async (event, context) => {};
-const callbackBasedHandlerTest: AWSLambda.Handler = callbackBasedHandler;
+// Test that you cannot pass a callback to AsyncHandler
+// @see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63474
+// @ts-expect-error
+const asyncHandler4: AWSLambda.AsyncHandler = async (event, context, callback) => { return 1 }

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -199,3 +199,12 @@ const mixedUntypedCallbackTypedHandler: CustomHandler = (
     context: AWSLambda.Context,
     cb: AWSLambda.Callback,
 ) => {};
+
+const promiseBasedHandler: AWSLambda.PromiseBasedHandler = async (event, context) => {};
+const promiseBasedHandlerTest: AWSLambda.Handler = promiseBasedHandler;
+
+const contextBasedHandler: AWSLambda.ContextBasedHandler = async (event, context) => {};
+const contextBasedHandlerTest: AWSLambda.Handler = contextBasedHandler;
+
+const callbackBasedHandler: AWSLambda.CallbackBasedHandler = async (event, context) => {};
+const callbackBasedHandlerTest: AWSLambda.Handler = callbackBasedHandler;

--- a/types/aws-lambda/handler.d.ts
+++ b/types/aws-lambda/handler.d.ts
@@ -87,6 +87,22 @@ export type Handler<TEvent = any, TResult = any> = (
     callback: Callback<TResult>,
 ) => void | Promise<TResult>;
 
+export type CallbackBasedHandler<TEvent = any, TResult = any> = (
+    event: TEvent,
+    context: Context,
+    callback: Callback<TResult>,
+) => void;
+
+export type PromiseBasedHandler<TEvent = any, TResult = any> = (
+    event: TEvent,
+    context: Context
+) => Promise<TResult>;
+
+export type ContextBasedHandler<TEvent = any, TResult = any> = (
+    event: TEvent,
+    context: Context
+) => void;
+
 /**
  * {@link Handler} context parameter.
  * See {@link https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html AWS documentation}.

--- a/types/aws-lambda/handler.d.ts
+++ b/types/aws-lambda/handler.d.ts
@@ -87,21 +87,10 @@ export type Handler<TEvent = any, TResult = any> = (
     callback: Callback<TResult>,
 ) => void | Promise<TResult>;
 
-export type CallbackBasedHandler<TEvent = any, TResult = any> = (
+export type AsyncHandler<TEvent = unknown, TResult = unknown> = (
     event: TEvent,
     context: Context,
-    callback: Callback<TResult>,
-) => void;
-
-export type PromiseBasedHandler<TEvent = any, TResult = any> = (
-    event: TEvent,
-    context: Context
 ) => Promise<TResult>;
-
-export type ContextBasedHandler<TEvent = any, TResult = any> = (
-    event: TEvent,
-    context: Context
-) => void;
 
 /**
  * {@link Handler} context parameter.

--- a/types/aws-lambda/handler.d.ts
+++ b/types/aws-lambda/handler.d.ts
@@ -87,10 +87,12 @@ export type Handler<TEvent = any, TResult = any> = (
     callback: Callback<TResult>,
 ) => void | Promise<TResult>;
 
-export type AsyncHandler<TEvent = unknown, TResult = unknown> = (
+export type AsyncHandler<TEvent = unknown, TResult = unknown> = ((
     event: TEvent,
     context: Context,
-) => Promise<TResult>;
+    callback: Callback<TResult>,
+) => Promise<TResult>) &
+    ((event: TEvent, context: Context) => Promise<TResult>);
 
 /**
  * {@link Handler} context parameter.

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -42,7 +42,7 @@
 //                 Ross Gerbasi <https://github.com/aphex>
 //                 Joey Kilpatrick <https://github.com/joeykilpatrick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 4.3
 
 export * from "./handler";
 export * from "./common/api-gateway";


### PR DESCRIPTION
This PR adds `AsyncHandler`, a subtype of `Handler`.

~This PR adds `PromiseBasedHandler`, `CallbackBasedHandler`, `ContextBasedHandler`, subtypes of `Handler`.~

Most modern AWS Lambda "handler wrapper" libraries export a `PromiseBasedHandler`.
e.g.:
- [@sentry/serverless](https://github.com/getsentry/sentry-javascript/blob/2794b6867a6971c2bad23f8b79544d4d7aff3a83/packages/serverless/src/awslambda.ts#L30)
- [@bugsnag/bugsnag-js](https://github.com/bugsnag/bugsnag-js/blob/0599faeb4019e571bfd7111c2663b5ddcbb78901/packages/plugin-aws-lambda/types/bugsnag-plugin-aws-lambda.d.ts#L6)
- [@vendia/serverless-express](https://github.com/vendia/serverless-express/blob/75cfbffeb3fd030695b9587a75300c7b8012ac6a/src/configure.js#L60)

They all define their own types for an `AsyncHandler` or similar. It would be great if we had a promise-only subtype for `Handler`, so we don't need to make our own types.

I added `AsyncHandler`. It is backwards compatible because I only added new type and ensured that it's compatible with `Handler`.

I know that there were already a lot of attempts to fix this, but I think this one is quite simple because it's completely backwards compatible and opt-in.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).