### PR TITLE
pg: remove not supposed option from ClientConfig

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -23,7 +23,6 @@ export interface ClientConfig {
     keepAlive?: boolean | undefined;
     stream?: stream.Duplex | undefined;
     statement_timeout?: false | number | undefined;
-    parseInputDatesAsUTC?: boolean | undefined;
     ssl?: boolean | ConnectionOptions | undefined;
     query_timeout?: number | undefined;
     keepAliveInitialDelayMillis?: number | undefined;


### PR DESCRIPTION
parseInputDatesAsUTC does not work as an option for ClientConfig in any node-postgres version.

・I searched the source code, but there is no place where parseInputDatesAsUTC is overridden with the given arguments.
https://github.com/brianc/node-postgres
・There is no mention of this in the official documentation.
https://node-postgres.com/apis/client#new-client
・when I try to execute the following source code, parseInputDatesAsUTC is processed as false.
```
const client = new Client({
  host: 'localhost',
  port: 5332,
  user: 'database-user',
  password: 'password!!',
  parseInputDatesAsUTC: true,
})
```

I think it was added due to some misunderstand.

related: https://github.com/brianc/node-postgres/issues/1350


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).



