### PR TITLE
yargs: Fix incorrect type propagation of argv options by commands

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -150,7 +150,7 @@ declare namespace yargs {
             handler?: (args: ArgumentsCamelCase<U>) => void | Promise<void>,
             middlewares?: MiddlewareFunction[],
             deprecated?: boolean | string,
-        ): Argv<U>;
+        ): Argv<T>;
         command<O extends { [key: string]: Options }>(
             command: string | ReadonlyArray<string>,
             description: string,
@@ -159,7 +159,7 @@ declare namespace yargs {
             middlewares?: MiddlewareFunction[],
             deprecated?: boolean | string,
         ): Argv<T>;
-        command<U>(command: string | ReadonlyArray<string>, description: string, module: CommandModule<T, U>): Argv<U>;
+        command<U>(command: string | ReadonlyArray<string>, description: string, module: CommandModule<T, U>): Argv<T>;
         command<U = T>(
             command: string | ReadonlyArray<string>,
             showInHelp: false,
@@ -174,8 +174,8 @@ declare namespace yargs {
             builder?: O,
             handler?: (args: ArgumentsCamelCase<InferredOptionTypes<O>>) => void | Promise<void>,
         ): Argv<T>;
-        command<U>(command: string | ReadonlyArray<string>, showInHelp: false, module: CommandModule<T, U>): Argv<U>;
-        command<U>(module: CommandModule<T, U>): Argv<U>;
+        command<U>(command: string | ReadonlyArray<string>, showInHelp: false, module: CommandModule<T, U>): Argv<T>;
+        command<U>(module: CommandModule<T, U>): Argv<T>;
 
         // Advanced API
         /** Apply command modules from a directory relative to the module calling this method. */

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -159,7 +159,7 @@ declare namespace yargs {
             middlewares?: MiddlewareFunction[],
             deprecated?: boolean | string,
         ): Argv<T>;
-        command<U>(command: string | ReadonlyArray<string>, description: string, module: CommandModule<T, U>): Argv<T>;
+        command(command: string | ReadonlyArray<string>, description: string, module: CommandModule<T, any>): Argv<T>;
         command<U = T>(
             command: string | ReadonlyArray<string>,
             showInHelp: false,
@@ -174,8 +174,8 @@ declare namespace yargs {
             builder?: O,
             handler?: (args: ArgumentsCamelCase<InferredOptionTypes<O>>) => void | Promise<void>,
         ): Argv<T>;
-        command<U>(command: string | ReadonlyArray<string>, showInHelp: false, module: CommandModule<T, U>): Argv<T>;
-        command<U>(module: CommandModule<T, U>): Argv<T>;
+        command(command: string | ReadonlyArray<string>, showInHelp: false, module: CommandModule<T, any>): Argv<T>;
+        command(module: CommandModule<T, any>): Argv<T>;
 
         // Advanced API
         /** Apply command modules from a directory relative to the module calling this method. */

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -1340,7 +1340,7 @@ function Argv$parsed() {
     const parsedArgs = yargs.parsed;
 }
 
-async function Argv$defaultCommandWithPositional(): Promise<string> {
+async function Argv$defaultCommandWithPositional() {
     const argv = yargs.command(
         "$0 <arg>",
         "default command",
@@ -1350,9 +1350,7 @@ async function Argv$defaultCommandWithPositional(): Promise<string> {
                 describe: "argument",
                 type: "string",
             }),
-        () => { }).argv;
-
-    return (await argv).arg;
+        (argv) => { const arg = argv.arg; }).parseSync();
 }
 
 function Argv$commandsWithAsynchronousBuilders() {
@@ -1366,9 +1364,7 @@ function Argv$commandsWithAsynchronousBuilders() {
                     describe: "argument",
                     type: "string",
                 })),
-        () => { }).parseSync();
-
-    const arg1: string = argv1.arg;
+        (argv) => { const arg1: string = argv.arg; }).parseSync();
 
     const argv2 = yargs.command({
         command: "command <arg>",
@@ -1380,10 +1376,8 @@ function Argv$commandsWithAsynchronousBuilders() {
                     describe: "argument",
                     type: "string",
                 })),
-        handler: () => {}
+        handler: (argv) => { const arg2: string = argv.arg; }
     }).parseSync();
-
-    const arg2: string = argv2.arg;
 }
 
 const wait = (n: number) => new Promise(resolve => setTimeout(resolve, n));

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -1340,7 +1340,25 @@ function Argv$parsed() {
     const parsedArgs = yargs.parsed;
 }
 
-async function Argv$defaultCommandWithPositional() {
+function Argv$optionsOfTwoCommandsDoNotCollide() {
+    return yargs
+    .command(
+        ["foo"],
+        "foo command",
+        (yargs) => yargs.option("a", { type: "string", required: true }),
+        (argv) => { const a: string = argv.a; })
+    .command(
+        ["bar"],
+        "bar command",
+        (yargs) => yargs.option("b", { type: "number", required: true }),
+        (argv) => {
+            // @ts-expect-error
+            const a: string = argv.a;
+            const b: number = argv.b;
+        }).parseSync();
+}
+
+function Argv$defaultCommandWithPositional() {
     const argv = yargs.command(
         "$0 <arg>",
         "default command",
@@ -1351,6 +1369,8 @@ async function Argv$defaultCommandWithPositional() {
                 type: "string",
             }),
         (argv) => { const arg = argv.arg; }).parseSync();
+    // @ts-expect-error
+    const a: string = argv.arg;
 }
 
 function Argv$commandsWithAsynchronousBuilders() {
@@ -1365,6 +1385,8 @@ function Argv$commandsWithAsynchronousBuilders() {
                     type: "string",
                 })),
         (argv) => { const arg1: string = argv.arg; }).parseSync();
+    // @ts-expect-error
+    const arg1: string = argv1.arg;
 
     const argv2 = yargs.command({
         command: "command <arg>",
@@ -1378,6 +1400,8 @@ function Argv$commandsWithAsynchronousBuilders() {
                 })),
         handler: (argv) => { const arg2: string = argv.arg; }
     }).parseSync();
+    // @ts-expect-error
+    const arg2: string = argv2.arg;
 }
 
 const wait = (n: number) => new Promise(resolve => setTimeout(resolve, n));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gerben-stavenga/DefinitelyTyped/blob/45d54334fa561a8a6c4e6575848417b7e65c8171/types/yargs/yargs-tests.ts#L1370
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
