### PR TITLE
Export ParseError as a part of katex default export

### DIFF
--- a/types/katex/index.d.ts
+++ b/types/katex/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for KaTeX 0.14
+// Type definitions for KaTeX 0.16
 // Project: http://khan.github.io/KaTeX/
 // Definitions by: Michael Randolph <https://github.com/mrand01>
 //                 Kevin Nguyen <https://github.com/knguyen0125>
@@ -155,4 +155,9 @@ export default class katex {
      * @param options KaTeX options
      */
     static renderToString(tex: string, options?: KatexOptions): string;
+
+    /**
+     * KaTeX error, usually during parsing.
+     */
+    static ParseError: typeof ParseError;
 }

--- a/types/katex/katex-tests.ts
+++ b/types/katex/katex-tests.ts
@@ -1,4 +1,4 @@
-import katex, { KatexOptions, ParseError } from 'katex';
+import katex, { KatexOptions } from 'katex';
 import renderMathInElement, { RenderMathInElementOptions } from 'katex/contrib/auto-render';
 import katexReplaceWithTex from 'katex/contrib/katex2tex';
 
@@ -12,7 +12,7 @@ class KatexTest {
             };
             let value: string = katex.renderToString('My Latex String', options);
         } catch (error) {
-            if (error instanceof ParseError) {
+            if (error instanceof katex.ParseError) {
                 //do something with this error
             }
         }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://katex.org/docs/error.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


Currently, `ParseError` is named-exported in the type definition but not in the actual library implementation. `ParseError` should be exported as a property of `katex` default export.
This is not changed in recent updates to the library. Just a long-standing bug of this definition.
