### PR TITLE
Fix wordpress__components & wordpress__compose type mismatch after change to React v18

### DIFF
--- a/types/wordpress__components/index.d.ts
+++ b/types/wordpress__components/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/components 19.10
+// Type definitions for @wordpress/components 23.0
 // Project: https://github.com/WordPress/gutenberg/tree/trunk/packages/components
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 //                 Jon Surrell <https://github.com/sirreal>

--- a/types/wordpress__components/package.json
+++ b/types/wordpress__components/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^4.1.0",
+        "@wordpress/element": "^5.0.0",
         "downshift": "^6.0.15",
         "re-resizable": "^6.4.0"
     }

--- a/types/wordpress__components/package.json
+++ b/types/wordpress__components/package.json
@@ -1,7 +1,10 @@
 {
     "private": true,
     "dependencies": {
+        "@types/wordpress__rich-text": "^3.4.6",
         "@wordpress/element": "^5.0.0",
+        "@types/tinycolor2": "^1.4.3",
+        "@types/wordpress__notices": "3.5.0",
         "downshift": "^6.0.15",
         "re-resizable": "^6.4.0"
     }

--- a/types/wordpress__components/package.json
+++ b/types/wordpress__components/package.json
@@ -1,10 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@types/wordpress__rich-text": "^3.4.6",
         "@wordpress/element": "^5.0.0",
-        "@types/tinycolor2": "^1.4.3",
-        "@types/wordpress__notices": "3.5.0",
         "downshift": "^6.0.15",
         "re-resizable": "^6.4.0"
     }

--- a/types/wordpress__compose/index.d.ts
+++ b/types/wordpress__compose/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/compose 4.0
+// Type definitions for @wordpress/compose 6.0
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/compose/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__compose/package.json
+++ b/types/wordpress__compose/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/element": "^3.0.0"
+        "@wordpress/element": "^5.0.0"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/WordPress/gutenberg/pull/45235
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.