### PR TITLE
[@types/webmidi] Change map-like types to read-only

### DIFF
--- a/types/webmidi/index.d.ts
+++ b/types/webmidi/index.d.ts
@@ -24,13 +24,13 @@ declare namespace WebMidi {
      * This is a maplike interface whose value is a MIDIInput instance and key is its
      * ID.
      */
-    type MIDIInputMap = Map<string, MIDIInput>;
+    type MIDIInputMap = ReadonlyMap<string, MIDIInput>;
 
     /**
      * This is a maplike interface whose value is a MIDIOutput instance and key is its
      * ID.
      */
-    type MIDIOutputMap = Map<string, MIDIOutput>;
+    type MIDIOutputMap = ReadonlyMap<string, MIDIOutput>;
 
     interface MIDIAccess extends EventTarget {
         /**

--- a/types/webmidi/webmidi-tests.ts
+++ b/types/webmidi/webmidi-tests.ts
@@ -33,6 +33,11 @@ const onFulfilled = (item: WebMidi.MIDIAccess) => {
         // 'send' only available on outputs
         inputOrOutput.send([12345]);
     }
+
+    // @ts-expect-error MidiInputMap is read-only
+    item.inputs.clear();
+    // @ts-expect-error MidiOutputMap is read-only
+    item.outputs.clear();
 };
 
 const onRejected = (e: Error) => {


### PR DESCRIPTION

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test webmidi`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: *Per the spec, [`MIDIInputMap`](https://webaudio.github.io/web-midi-api/#MIDIInputMap) and [`MIDIOutputMap`](https://webaudio.github.io/web-midi-api/#MIDIOutputMap) are both [`readonly maplike`](https://webidl.spec.whatwg.org/#idl-maplike)s.*
