### PR TITLE
docs(@types/node): misleading jsdoc value for windowsHide

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -624,7 +624,7 @@ declare module 'child_process' {
     }
     interface CommonOptions extends ProcessEnvOptions {
         /**
-         * @default true
+         * @default false
          */
         windowsHide?: boolean | undefined;
         /**

--- a/types/node/ts4.8/child_process.d.ts
+++ b/types/node/ts4.8/child_process.d.ts
@@ -624,7 +624,7 @@ declare module 'child_process' {
     }
     interface CommonOptions extends ProcessEnvOptions {
         /**
-         * @default true
+         * @default false
          */
         windowsHide?: boolean | undefined;
         /**

--- a/types/node/v14/child_process.d.ts
+++ b/types/node/v14/child_process.d.ts
@@ -143,7 +143,7 @@ declare module 'child_process' {
 
     interface CommonOptions extends ProcessEnvOptions {
         /**
-         * @default true
+         * @default false
          */
         windowsHide?: boolean | undefined;
         /**

--- a/types/node/v14/ts4.8/child_process.d.ts
+++ b/types/node/v14/ts4.8/child_process.d.ts
@@ -143,7 +143,7 @@ declare module 'child_process' {
 
     interface CommonOptions extends ProcessEnvOptions {
         /**
-         * @default true
+         * @default false
          */
         windowsHide?: boolean | undefined;
         /**

--- a/types/node/v16/child_process.d.ts
+++ b/types/node/v16/child_process.d.ts
@@ -621,7 +621,7 @@ declare module 'child_process' {
     }
     interface CommonOptions extends ProcessEnvOptions {
         /**
-         * @default true
+         * @default false
          */
         windowsHide?: boolean | undefined;
         /**

--- a/types/node/v16/ts4.8/child_process.d.ts
+++ b/types/node/v16/ts4.8/child_process.d.ts
@@ -621,7 +621,7 @@ declare module 'child_process' {
     }
     interface CommonOptions extends ProcessEnvOptions {
         /**
-         * @default true
+         * @default false
          */
         windowsHide?: boolean | undefined;
         /**


### PR DESCRIPTION
per https://nodejs.org/dist/latest-v18.x/docs/api/child_process.html#child_processspawncommand-args-options
also checked older docs of node 14/16... was always `false`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v18.x/docs/api/child_process.html#child_processspawncommand-args-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
