### PR TITLE
Fix fs-extra usage in scripts

### DIFF
--- a/scripts/ghostbuster.js
+++ b/scripts/ghostbuster.js
@@ -1,6 +1,5 @@
+import { writeFileSync, readFileSync, readdirSync, existsSync } from 'node:fs';
 import { flatMap, mapDefined } from "@definitelytyped/utils";
-import fsExtra from "fs-extra";
-const { writeFileSync, readFileSync, readdirSync, existsSync } = fsExtra;
 import hp from "@definitelytyped/header-parser";
 import { Octokit } from "@octokit/core";
 

--- a/scripts/update-codeowners.js
+++ b/scripts/update-codeowners.js
@@ -1,9 +1,8 @@
 import * as cp from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import { AllPackages, getDefinitelyTyped, parseDefinitions, clean } from '@definitelytyped/definitions-parser';
 import { loggerWithErrors } from '@definitelytyped/utils';
-import fsExtra from 'fs-extra';
-const { writeFile } = fsExtra;
 
 async function main() {
     const options = { definitelyTypedPath: '.', progress: false, parseInParallel: true };


### PR DESCRIPTION
`fs-extra` was not added as a dependency. Scripts that were using `fs-extra` relied on an indirect dependency on an older version of `fs-extra`. These scripts only used functions that `fs-extra` exports from `fs`. The latest version of `fs-extra` doesn’t even export these in the ESM export, only in the CJS export. So while my original idea was to update to the latest version of `fs-extra`, instead I removed the dependency entirely.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

