### PR TITLE
fix(reveal.js): make static Reveal inherit the api

### DIFF
--- a/types/reveal.js/index.d.ts
+++ b/types/reveal.js/index.d.ts
@@ -17,12 +17,13 @@ export = Reveal;
  *
  * @see {@link https://revealjs.com}
  * @see {@link https://github.com/hakimel/reveal.js/blob/master/js/reveal.js}
+ * @see {@link https://revealjs.com/api/}
  */
 declare const Reveal: {
     new (options?: Reveal.Options): Reveal.Api;
     new (revealElement: Element, options: Reveal.Options): Reveal.Api;
     initialize(options?: Reveal.Options): Promise<Reveal.Api>;
-};
+} & Reveal.Api;
 
 declare namespace Reveal {
     /**

--- a/types/reveal.js/index.d.ts
+++ b/types/reveal.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Reveal 4.3
+// Type definitions for Reveal 4.4
 // Project: https://github.com/hakimel/reveal.js/
 // Definitions by: robertop87 <https://github.com/robertop87>,
 //                 Nava2 <https://github.com/Nava2>,

--- a/types/reveal.js/reveal.js-tests.ts
+++ b/types/reveal.js/reveal.js-tests.ts
@@ -481,39 +481,63 @@ deck.slide(0, 1, 2, 1);
 
 // $ExpectType void
 deck.left();
+// $ExpectType void
+Reveal.left();
 
 // $ExpectType void
 deck.right();
+// $ExpectType void
+Reveal.right();
 
 // $ExpectType void
 deck.up();
+// $ExpectType void
+Reveal.up();
 
 // $ExpectType void
 deck.down();
+// $ExpectType void
+Reveal.down();
 
 // $ExpectType void
 deck.prev();
+// $ExpectType void
+Reveal.prev();
 
 // $ExpectType void
 deck.next();
+// $ExpectType void
+Reveal.next();
 
 // $ExpectType void
 deck.navigateLeft();
+// $ExpectType void
+Reveal.navigateLeft();
 
 // $ExpectType void
 deck.navigateRight();
+// $ExpectType void
+Reveal.navigateRight();
 
 // $ExpectType void
 deck.navigateUp();
+// $ExpectType void
+Reveal.navigateUp();
 
 // $ExpectType void
 deck.navigateDown();
+// $ExpectType void
+Reveal.navigateDown();
 
 // $ExpectType void
 deck.navigatePrev();
+// $ExpectType void
+Reveal.navigatePrev();
 
 // $ExpectType void
 deck.navigateNext();
+// $ExpectType void
+Reveal.navigateNext();
 
 // ---------------- //
 // fragment methods //
@@ -539,9 +563,17 @@ deck.on('click', el.click, false);
 deck.on('slidetransitionend', event => {
     console.log(event);
 });
+// $ExpectType void
+Reveal.on('slidetransitionend', event => {
+    console.log(event);
+});
+
 
 // $ExpectType void
 deck.off('click', el.click, false);
+// $ExpectType void
+Reveal.off('click', el.click, false);
+
 
 // $ExpectType void
 deck.addEventListener('click', el.click);
@@ -585,9 +617,11 @@ deck.toggleAutoSlide();
 
 // $ExpectType boolean
 deck.isFirstSlide();
+Reveal.isFirstSlide();
 
 // $ExpectType boolean
 deck.isLastSlide();
+Reveal.isLastSlide();
 
 // $ExpectType boolean
 deck.isLastVerticalSlide();

--- a/types/reveal.js/reveal.js-tests.ts
+++ b/types/reveal.js/reveal.js-tests.ts
@@ -617,10 +617,12 @@ deck.toggleAutoSlide();
 
 // $ExpectType boolean
 deck.isFirstSlide();
+// $ExpectType boolean
 Reveal.isFirstSlide();
 
 // $ExpectType boolean
 deck.isLastSlide();
+// $ExpectType boolean
 Reveal.isLastSlide();
 
 // $ExpectType boolean


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
