### PR TITLE
add(karma-rollup-preprocessor): new types

### DIFF
--- a/types/karma-rollup-preprocessor/index.d.ts
+++ b/types/karma-rollup-preprocessor/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for karma-rollup-preprocessor 7.0
+// Project: https://github.com/jlmakes/karma-rollup-preprocessor
+// Definitions by: Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import karma = require('karma');
+import { RollupOptions } from 'rollup';
+
+declare module 'karma' {
+    interface ConfigOptions {
+        /**
+         * see {@link https://github.com/jlmakes/karma-rollup-preprocessor#configured-preprocessors}
+         */
+        rollupPreprocessor?: RollupPreprocessorOptions | undefined;
+    }
+
+    /**
+     * Default global variable name is by default `__json__`,
+     * but you can override it with your own name in karma configuration:
+     */
+    interface RollupPreprocessorOptions extends Exclude<RollupOptions, 'input'> {}
+}

--- a/types/karma-rollup-preprocessor/karma-rollup-preprocessor-tests.ts
+++ b/types/karma-rollup-preprocessor/karma-rollup-preprocessor-tests.ts
@@ -1,0 +1,20 @@
+import karma = require('karma');
+
+module.exports = (config: karma.Config) => {
+    config.set({
+        files: [{ pattern: 'test/**/*.spec.js', watched: false }],
+        preprocessors: {
+            'test/**/*.spec.js': ['rollup'],
+        },
+
+        // $ExpectType { output: { format: "iife"; name: string; sourcemap: "inline"; }; }
+        rollupPreprocessor: {
+            // plugins: [require('rollup-plugin-buble')()],
+            output: {
+                format: 'iife',
+                name: '<your_project>',
+                sourcemap: 'inline',
+            },
+        },
+    });
+};

--- a/types/karma-rollup-preprocessor/package.json
+++ b/types/karma-rollup-preprocessor/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "rollup": ">=1.0.0"
+    }
+}

--- a/types/karma-rollup-preprocessor/tsconfig.json
+++ b/types/karma-rollup-preprocessor/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "karma-rollup-preprocessor-tests.ts"
+    ]
+}

--- a/types/karma-rollup-preprocessor/tslint.json
+++ b/types/karma-rollup-preprocessor/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
This adds support for agumenting Rollup options within Karma runner configuration (this is how Karma TS confgiration support is implmeneted by the community):
https://github.com/jlmakes/karma-rollup-preprocessor

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.