### PR TITLE
[chrome] Update chrome.identity.getAuthToken for the Promise version

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4705,6 +4705,19 @@ declare namespace chrome.identity {
         ANY = 'ANY',
     }
 
+    export interface GetAuthTokenResult {
+        /**
+         * Optional.
+         * A list of OAuth2 scopes granted to the extension.
+         */
+        grantedScopes?: string[]
+        /**
+         * Optional.
+         * The specific token associated with the request.
+         */
+        token?: string
+    }
+
     export interface ProfileDetails {
         /**
          * Optional.
@@ -4786,11 +4799,11 @@ declare namespace chrome.identity {
      * The Identity API caches access tokens in memory, so it's ok to call getAuthToken non-interactively any time a token is required. The token cache automatically handles expiration.
      * For a good user experience it is important interactive token requests are initiated by UI in your app explaining what the authorization is for. Failing to do this will cause your users to get authorization requests, or Chrome sign in screens if they are not signed in, with with no context. In particular, do not use getAuthToken interactively when your app is first launched.
      * @param details Token options.
-     * @param callback Called with an OAuth2 access token as specified by the manifest, or undefined if there was an error.
-     * If you specify the callback parameter, it should be a function that looks like this:
-     * function(string token) {...};
+     * @param callback The callback parameter looks like:
+     * (token?: string, grantedScopes?: string[]) => void
      */
-    export function getAuthToken(details: TokenDetails, callback?: (token: string) => void): void;
+    export function getAuthToken(details: TokenDetails, callback: (token?: string, grantedScopes?: string[]) => void): void;
+    export function getAuthToken(details: TokenDetails): Promise<GetAuthTokenResult>;
 
     /**
      * Retrieves email address and obfuscated gaia id of the user signed into a profile.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1637,12 +1637,14 @@ async function testHistoryForPromise() {
 async function testIdentity() {
     // $ExpectType void
     chrome.identity.launchWebAuthFlow({ url: 'https://example.com '}, () => {});
+    chrome.identity.getAuthToken({ interactive: false }, () => {});
 }
 
 // https://developer.chrome.com/docs/extensions/reference/identity/
 async function testIdentityForPromise() {
     // $ExpectType string | undefined
     await chrome.identity.launchWebAuthFlow({ url: 'https://example.com '});
+    await chrome.identity.getAuthToken({ interactive: false });
 }
 
 // https://developer.chrome.com/docs/extensions/reference/topSites/


### PR DESCRIPTION
When this API gets a promise support for the manifest version 3, it gets a special treatment to make it backward compatible. For details, see https://chromium-review.googlesource.com/c/chromium/src/+/3764170.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/identity/#method-getAuthToken and https://chromium-review.googlesource.com/c/chromium/src/+/3764170
- [x] (Not Applicable) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
