### PR TITLE
Fix wrong typed values for cytoscape-context-menu

### DIFF
--- a/types/cytoscape-context-menus/cytoscape-context-menus-tests.ts
+++ b/types/cytoscape-context-menus/cytoscape-context-menus-tests.ts
@@ -18,7 +18,6 @@ const menuItem: contextMenus.MenuItem = {
     content: 'Test',
     selector: 'node',
     show: true,
-    submenu: false,
     coreAsWell: true,
     onClickFunction: () => {
         console.log('test');

--- a/types/cytoscape-context-menus/index.d.ts
+++ b/types/cytoscape-context-menus/index.d.ts
@@ -64,8 +64,8 @@ declare namespace contextMenus {
             src: string;
             width: number;
             height: number;
-            y: string;
-            x: string;
+            y: number;
+            x: number;
         };
         /**
          * Display content of the menu item.
@@ -84,7 +84,7 @@ declare namespace contextMenus {
          * Shows the listed menu items as a submenu for this item.
          * An item must have either a submenu or onClickFunction or both.
          */
-        submenu?: boolean;
+        submenu?: MenuItem[];
         /**
          * Whether the core instance will have this item on context menu event.
          */
@@ -92,7 +92,7 @@ declare namespace contextMenus {
         /**
          * The function to be executed when the menu item is clicked.
          */
-        onClickFunction?: any;
+        onClickFunction?: (event: cytoscape.EventObject | cytoscape.EventObjectCore | cytoscape.EventObjectNode | cytoscape.EventObjectEdge) => void;
         /**
          * Whether the menu item will have a trailing divider.
          */


### PR DESCRIPTION
Fix wrong typed for cytoscape-context-menu

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

-- Can't provide documentation, API haven't changed, initial typed were already wrong when merged.
