### PR TITLE
graphviz: Account for `undefined` in getter return values

### DIFF
--- a/types/graphviz/graphviz-tests.ts
+++ b/types/graphviz/graphviz-tests.ts
@@ -7,15 +7,31 @@ const g: graphviz.Graph = graphviz.digraph("G");
 const n1: graphviz.Node = g.addNode("Hello", { color: "blue" });
 n1.set("style", "filled");
 
+// @ts-expect-error
+const getAttributeError: graphviz.PossibleValue = n1.get('foo');
+
+const attribute: graphviz.PossibleValue | undefined = n1.get('foo');
+
 // Add node (ID: World)
 g.addNode("World");
 
-const g_h: graphviz.Node = g.getNode("Hello");
-g_h.set("shape", "star");
+// @ts-expect-error
+const getNodeError: graphviz.Node = g.getNode("Hello");
+
+const g_h: graphviz.Node | undefined = g.getNode("Hello");
+g_h?.set("shape", "star");
 
 // Add edge between the two nodes
 const e: graphviz.Edge = g.addEdge(n1, "World");
 e.set("color", "red");
+
+// Add subgraph.
+const subgraph1: graphviz.Graph = g.addCluster("subgraph1");
+
+// @ts-expect-error
+const getSubgraphError: graphviz.Graph = g.getCluster("subgraph2");
+
+const subgraph2: graphviz.Graph | undefined = g.getCluster("subgraph2");
 
 // Print the dot script
 console.log(g.to_dot());

--- a/types/graphviz/index.d.ts
+++ b/types/graphviz/index.d.ts
@@ -19,7 +19,7 @@ export interface Options {
 
 export interface HasAttributes {
     set(name: string, value: PossibleValue): void;
-    get(name: string): PossibleValue;
+    get(name: string): PossibleValue | undefined;
 }
 
 export interface Node extends HasAttributes {
@@ -75,14 +75,14 @@ export interface Graph extends HasAttributes {
     use: RenderEngine;
 
     addNode(id: string, attrs?: any): Node;
-    getNode(id: string): Node;
+    getNode(id: string): Node | undefined;
     nodeCount(): number;
 
     addEdge(nodeOne: string | Node, nodeTwo: string | Node, attrs?: Options): Edge;
 
     // Subgraph (cluster) API
     addCluster(id: string): Graph;
-    getCluster(id: string): Graph;
+    getCluster(id: string): Graph | undefined;
     clusterCount(): number;
 
     setNodeAttribut(name: string, value: any): void;


### PR DESCRIPTION
# PR Description

## Goal

All graphviz getters ultimately invoke an indexer on instances of the `Hash` class, which will return `undefined` for keys not present in those instances. This PR accounts for this eventuality by adding `| undefined` to getter return values for improved type checking.

## Not Addressed

Getters that are defined to return `any` are not modified, because `any | undefined` is consolidated to just `any` by the compiler.

The latest published version number of graphviz is 0.0.9. The version of these type definitions 0.0. These changes could be considered breaking changes, but updating the major or minor version here puts it out of sync with the graphviz library. 

## Template

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/glejeune/node-graphviz/blob/master/lib/deps/core_ext/hash.js>

