### PR TITLE
Exempt amap-js-api from npm-naming

### DIFF
--- a/types/amap-js-api/tslint.json
+++ b/types/amap-js-api/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "npm-naming": false
+    }
 }


### PR DESCRIPTION
Somebody created a bogus amap-js-api package on npm, but it's a mistaken stub. Nothing to do with the types here.