### PR TITLE
mongo: Fix types of iterators and dropIndexAsync

### DIFF
--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -228,7 +228,7 @@ declare namespace Mongo {
             transform?: Fn | undefined;
         }): boolean;
         dropCollectionAsync(): Promise<void>;
-        dropIndexAsync(indexName: string): void;
+        dropIndexAsync(indexName: string): Promise<void>;
         /**
          * Find the documents in a collection that match the selector.
          * @param selector A query describing the documents to find
@@ -472,8 +472,8 @@ declare namespace Mongo {
             callbacks: ObserveChangesCallbacks<T>,
             options?: { nonMutatingCallbacks?: boolean | undefined },
         ): Meteor.LiveQueryHandle;
-        [Symbol.iterator](): Iterator<T, never, never>;
-        [Symbol.asyncIterator](): AsyncIterator<T, never, never>;
+        [Symbol.iterator](): Iterator<T>;
+        [Symbol.asyncIterator](): AsyncIterator<T>;
     }
 
     var ObjectID: ObjectIDStatic;

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -234,7 +234,7 @@ declare module 'meteor/mongo' {
                 transform?: Fn | undefined;
             }): boolean;
             dropCollectionAsync(): Promise<void>;
-            dropIndexAsync(indexName: string): void;
+            dropIndexAsync(indexName: string): Promise<void>;
             /**
              * Find the documents in a collection that match the selector.
              * @param selector A query describing the documents to find
@@ -478,8 +478,8 @@ declare module 'meteor/mongo' {
                 callbacks: ObserveChangesCallbacks<T>,
                 options?: { nonMutatingCallbacks?: boolean | undefined },
             ): Meteor.LiveQueryHandle;
-            [Symbol.iterator](): Iterator<T, never, never>;
-            [Symbol.asyncIterator](): AsyncIterator<T, never, never>;
+            [Symbol.iterator](): Iterator<T>;
+            [Symbol.asyncIterator](): AsyncIterator<T>;
         }
 
         var ObjectID: ObjectIDStatic;

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -519,6 +519,18 @@ namespace MeteorTests {
     Comments.update({ viewNumber: { $exists: false } }, { $set: { viewNumber: 0 } });
     Comments.update({ private: true }, { $unset: { tags: true } });
 
+    for (const comment of Comments.find({})) {
+        // $ExpectType CommentsDAO
+        comment;
+    }
+
+    (async function() {
+        for await (const comment of Comments.find({})) {
+            // $ExpectType CommentsDAO
+            comment;
+        }
+    })();
+
     /**
      * From Sessions, Session.set section
      */
@@ -1144,6 +1156,10 @@ namespace MeteorTests {
     if (Meteor.isDevelopment) {
         Rooms._dropIndex('indexName');
     }
+
+    (async function() {
+        await Rooms.dropIndexAsync('indexName');
+    })();
 
     // Covers https://github.com/meteor-typings/meteor/issues/20
     Rooms.find().count(true);

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -545,6 +545,18 @@ namespace MeteorTests {
     Comments.update({ viewNumber: { $exists: false } }, { $set: { viewNumber: 0 } });
     Comments.update({ private: true }, { $unset: { tags: true } });
 
+    for (const comment of Comments.find({})) {
+        // $ExpectType CommentsDAO
+        comment;
+    }
+
+    (async function() {
+        for await (const comment of Comments.find({})) {
+            // $ExpectType CommentsDAO
+            comment;
+        }
+    })();
+
     /**
      * From Sessions, Session.set section
      */
@@ -1170,6 +1182,10 @@ namespace MeteorTests {
     if (Meteor.isDevelopment) {
         Rooms._dropIndex('indexName');
     }
+
+    (async function() {
+        await Rooms.dropIndexAsync('indexName');
+    })();
 
     // Covers https://github.com/meteor-typings/meteor/issues/20
     Rooms.find().count(true);

--- a/types/meteor/tsconfig.json
+++ b/types/meteor/tsconfig.json
@@ -5,6 +5,7 @@
             "es6",
             "dom"
         ],
+        "target": "es2015",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/meteor/tslint.json
+++ b/types/meteor/tslint.json
@@ -39,6 +39,7 @@
         "triple-equals": false,
         "typedef-whitespace": false,
         "unified-signatures": false,
-        "void-return": false
+        "void-return": false,
+        "await-promise": false
     }
 }


### PR DESCRIPTION
Declaring iterators and async iterators with a "next" type of never makes them unusable with TypeScript, which throws an error:

> Cannot iterate value because the 'next' method of its iterator expects
> type 'never', but for-of will always send 'undefined'.ts(2763)

However, Meteor's iterators are agnostic to the value passed in, so leaving it with the default of undefined is reasonable.

Also, dropIndexAsync was missing a return type (it should return a promise, not void).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://guide.meteor.com/2.8-migration.html)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.