### PR TITLE
[css-tree] Update Url type

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -432,7 +432,7 @@ switch (ast.type) {
         break;
 
     case 'Url':
-        ast.value; // $ExpectType Raw | StringNode
+        ast.value; // $ExpectType string
         break;
 
     case 'Value':
@@ -611,7 +611,7 @@ switch (toPlain.type) {
         break;
 
     case 'Url':
-        toPlain.value; // $ExpectType Raw | StringNode
+        toPlain.value; // $ExpectType string
         break;
 
     case 'Value':

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -379,7 +379,7 @@ export interface UnicodeRange extends CssNodeCommon {
 
 export interface Url extends CssNodeCommon {
     type: 'Url';
-    value: StringNode | Raw;
+    value: string;
 }
 
 export interface Value extends CssNodeCommon {


### PR DESCRIPTION
The type was [changed in 2.0.0](https://github.com/csstree/csstree/blob/master/CHANGELOG.md#:~:text=Changed%20Url%20node%20type%20to%20store%20decoded%20url%20value%20as%20a%20string%20instead%20of%20String%20or%20Raw%20node%2C%20i.e.%20with%20no%20quotes%2C%20escape%20sequences%20and%20url()%20wrapper).

> Changed `Url` node type to store decoded url value as a `string` instead of `String` or `Raw` node, i.e. with no quotes, escape sequences and `url()` wrapper

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/csstree/csstree/blob/master/CHANGELOG.md#:~:text=Changed%20Url%20node%20type%20to%20store%20decoded%20url%20value%20as%20a%20string%20instead%20of%20String%20or%20Raw%20node%2C%20i.e.%20with%20no%20quotes%2C%20escape%20sequences%20and%20url()%20wrapper>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
