### PR TITLE
[memjs] fix: correct get Promise return type to include null

### DIFF
--- a/types/memjs/index.d.ts
+++ b/types/memjs/index.d.ts
@@ -137,7 +137,7 @@ export class Client {
      * @param key
      * @param callback
      */
-    get(key: string): Promise<{ value: Buffer; flags: Buffer }>;
+    get(key: string): Promise<{ value: Buffer | null; flags: Buffer | null }>;
     get(
         key: string,
         callback: (err: Error | null, value: Buffer | null, flags: Buffer | null) => void

--- a/types/memjs/memjs-tests.ts
+++ b/types/memjs/memjs-tests.ts
@@ -9,7 +9,7 @@ client.set('hello', 'world', { expires: 600 }); // $ExpectType Promise<boolean>
 client.get('hello', (err, val) => {
     console.log(err, val);
 });
-client.get('hello'); // $ExpectType Promise<{ value: Buffer; flags: Buffer; }>
+client.get('hello'); // $ExpectType Promise<{ value: Buffer | null; flags: Buffer | null; }>
 
 // Can initialize clients with client and server options
 memjs.Client.create('12345', { username: 'hello' }); // $ExpectType Client


### PR DESCRIPTION
The Promise style signature for the client get method is a direct Promisification of the callback signature. As such, it may return the same types as the callback (Buffer | null).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/memcachier/memjs/blob/647a2e1c26b9a85b2f134ef332aeb669eb5cc023/lib/memjs/memjs.js#L157-L192
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
