### PR TITLE
meteor: Use mongodb driver types for Selector=>Filter, Modifier=>UpdateFilter, SortSpecifier=>Sort instead of homebuilt types

### DIFF
--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -71,13 +71,15 @@ declare module 'meteor/mongo' {
             $comment?: string | undefined;
         };
 
+        /**
+         * @deprecated, use NestedPaths from the Mongo driver types instead
+         */
         type Flatten<T> = T extends any[] ? T[0] : T;
 
-        type Query<T> = { [P in keyof T]?: Flatten<T[P]> | RegExp | FieldExpression<Flatten<T[P]>> } & {
-            $or?: Query<T>[] | undefined;
-            $and?: Query<T>[] | undefined;
-            $nor?: Query<T>[] | undefined;
-        } & Dictionary<any>;
+        /**
+         * Alias for the driver Filter type
+         */
+        type Query<T> = MongoNpmModule.Filter<T>;
 
         type QueryWithModifiers<T> = {
             $query: Query<T>;
@@ -117,30 +119,12 @@ declare module 'meteor/mongo' {
             [P in keyof T]?: OnlyElementsOfArrays<T[P]> | { $each: T[P] };
         };
         type CurrentDateModifier = { $type: 'timestamp' | 'date' } | true;
-        type Modifier<T> =
-            | T
-            | {
-                  $currentDate?:
-                      | (Partial<Record<keyof T, CurrentDateModifier>> & Dictionary<CurrentDateModifier>)
-                      | undefined;
-                  $inc?: (PartialMapTo<T, number> & Dictionary<number>) | undefined;
-                  $min?: (PartialMapTo<T, Date | number> & Dictionary<Date | number>) | undefined;
-                  $max?: (PartialMapTo<T, Date | number> & Dictionary<Date | number>) | undefined;
-                  $mul?: (PartialMapTo<T, number> & Dictionary<number>) | undefined;
-                  $rename?: (PartialMapTo<T, string> & Dictionary<string>) | undefined;
-                  $set?: (Partial<T> & Dictionary<any>) | undefined;
-                  $setOnInsert?: (Partial<T> & Dictionary<any>) | undefined;
-                  $unset?: (PartialMapTo<T, string | boolean | 1 | 0> & Dictionary<any>) | undefined;
-                  $addToSet?: (ArraysOrEach<T> & Dictionary<any>) | undefined;
-                  $push?: (PushModifier<T> & Dictionary<any>) | undefined;
-                  $pull?: (ElementsOf<T> & Dictionary<any>) | undefined;
-                  $pullAll?: (Partial<T> & Dictionary<any>) | undefined;
-                  $pop?: (PartialMapTo<T, 1 | -1> & Dictionary<1 | -1>) | undefined;
-              };
+        type Modifier<T> = MongoNpmModule.UpdateFilter<T>;
 
         type OptionalId<TSchema> = UnionOmit<TSchema, '_id'> & { _id?: any };
 
-        interface SortSpecifier {}
+        type SortSpecifier = MongoNpmModule.Sort;
+        
         interface FieldSpecifier {
             [id: string]: Number;
         }

--- a/types/meteor/test/meteor-mongo-tests.ts
+++ b/types/meteor/test/meteor-mongo-tests.ts
@@ -55,6 +55,31 @@ Users.find({}).mapAsync(doc => {
     return doc;
 });
 
+const selector: Mongo.Selector<DBUser> = {
+    surname: "My Surname"
+}
+
+// $ExpectType Promise<DBUser | undefined>
+Users.findOneAsync(selector);
+
+const ids = ["abc-123"] as const;
+
+const withReadonlyArray: Mongo.Selector<DBUser> = {    
+    _id: { $in: ids }
+}
+Users.findOneAsync(withReadonlyArray);
+
+const updateModifier: Mongo.Modifier<DBUser> = {
+    $set: { surname: "new-name" }
+}
+Users.updateAsync({_id: "abc-123"}, updateModifier);
+
+const sortSpecifier: Mongo.Options<DBUser>["sort"] = {
+    surname: -1
+};
+
+Users.findOneAsync({}, { sort: sortSpecifier })
+
 Users.deny({
     update: (userId, doc) => {
         // $ExpectType string
@@ -535,6 +560,7 @@ Attachment.find({}, { transform: null }).observe({
         return false;
     },
 });
+
 
 // Test MongoInternals
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[MongoDB driver v4 now contains good types to use](https://www.npmjs.com/package/mongodb)
