### PR TITLE
[seedrandom] do not show nonexistent properties (quick and state)

### DIFF
--- a/types/seedrandom/index.d.ts
+++ b/types/seedrandom/index.d.ts
@@ -24,17 +24,24 @@ declare namespace seedrandom {
         double(): number;
         int32(): number;
         quick(): number;
+    }
+
+    interface StatefulPRNG extends PRNG {
         state(): State;
     }
 }
 
+type ReturnedPRNG<O extends seedrandom.Options = {}> = O extends { state: true | seedrandom.State }
+    ? seedrandom.StatefulPRNG
+    : seedrandom.PRNG;
+
 interface BaseInterface {
-    (seed?: string, options?: seedrandom.Options): seedrandom.PRNG;
+    <O extends seedrandom.Options>(seed?: string, options?: O): ReturnedPRNG<O>;
     new (seed?: string): seedrandom.PRNG;
 }
 
 interface seedrandom {
-    (seed?: string, options?: seedrandom.Options, callback?: seedrandom.Callback): seedrandom.PRNG;
+    <O extends seedrandom.Options>(seed?: string, options?: O, callback?: seedrandom.Callback): ReturnedPRNG<O>;
     alea: BaseInterface;
     tychei: BaseInterface;
     xor128: BaseInterface;

--- a/types/seedrandom/index.d.ts
+++ b/types/seedrandom/index.d.ts
@@ -36,7 +36,6 @@ interface BaseInterface {
 interface seedrandom {
     (seed?: string, options?: seedrandom.Options, callback?: seedrandom.Callback): seedrandom.PRNG;
     alea: BaseInterface;
-    quick: BaseInterface;
     tychei: BaseInterface;
     xor128: BaseInterface;
     xor4096: BaseInterface;

--- a/types/seedrandom/seedrandom-tests.ts
+++ b/types/seedrandom/seedrandom-tests.ts
@@ -5,9 +5,18 @@ const prng = seedrandom('added entropy.', { entropy: true }); // $ExpectType PRN
 prng.double(); // $ExpectType number
 prng.int32(); // $ExpectType number
 prng.quick(); // $ExpectType number
-prng.state(); // $ExpectType object
+// @ts-expect-error seedrandom only provides internal state when explicitly requested
+prng.state;
 prng(); // $ExpectType number
 
+const prngWithState = seedrandom('added entropy.', { entropy: true, state: true }); // $ExpectType StatefulPRNG
+prngWithState.double(); // $ExpectType number
+prngWithState.int32(); // $ExpectType number
+prngWithState.quick(); // $ExpectType number
+prngWithState.state(); // $ExpectType object
+prngWithState(); // $ExpectType number
+
+seedrandom('hello.', { state: {} }); // $ExpectType StatefulPRNG
 seedrandom('hello.', { global: true }); // $ExpectType PRNG
 seedrandom('hello.'); // $ExpectType PRNG
 seedrandom(); // $ExpectType PRNG

--- a/types/seedrandom/seedrandom-tests.ts
+++ b/types/seedrandom/seedrandom-tests.ts
@@ -1,5 +1,5 @@
 import seedrandom = require('seedrandom');
-import { alea, tychei, xor128, xor4096, xorshift7, xorwow, quick } from 'seedrandom';
+import { alea, tychei, xor128, xor4096, xorshift7, xorwow } from 'seedrandom';
 
 const prng = seedrandom('added entropy.', { entropy: true }); // $ExpectType PRNG
 prng.double(); // $ExpectType number
@@ -13,14 +13,12 @@ seedrandom('hello.'); // $ExpectType PRNG
 seedrandom(); // $ExpectType PRNG
 
 new seedrandom.alea('hello.'); // $ExpectType PRNG
-new seedrandom.quick('hello.'); // $ExpectType PRNG
 new seedrandom.tychei('hello.'); // $ExpectType PRNG
 new seedrandom.xor128('hello.'); // $ExpectType PRNG
 new seedrandom.xor4096('hello.'); // $ExpectType PRNG
 new seedrandom.xorshift7('hello.'); // $ExpectType PRNG
 new seedrandom.xorwow('hello.'); // $ExpectType PRNG
 seedrandom.alea('hello.', { entropy: true }); // $ExpectType PRNG
-seedrandom.quick('hello.', { entropy: true }); // $ExpectType PRNG
 seedrandom.tychei('hello.', { entropy: true }); // $ExpectType PRNG
 seedrandom.xor128('hello.', { entropy: true }); // $ExpectType PRNG
 seedrandom.xor4096('hello.', { entropy: true }); // $ExpectType PRNG
@@ -28,14 +26,12 @@ seedrandom.xorshift7('hello.', { entropy: true }); // $ExpectType PRNG
 seedrandom.xorwow('hello.', { entropy: true }); // $ExpectType PRNG
 
 new alea('hello.'); // $ExpectType PRNG
-new quick('hello.'); // $ExpectType PRNG
 new tychei('hello.'); // $ExpectType PRNG
 new xor128('hello.'); // $ExpectType PRNG
 new xor4096('hello.'); // $ExpectType PRNG
 new xorshift7('hello.'); // $ExpectType PRNG
 new xorwow('hello.'); // $ExpectType PRNG
 alea('hello.', { entropy: true }); // $ExpectType PRNG
-quick('hello.', { entropy: true }); // $ExpectType PRNG
 tychei('hello.', { entropy: true }); // $ExpectType PRNG
 xor128('hello.', { entropy: true }); // $ExpectType PRNG
 xor4096('hello.', { entropy: true }); // $ExpectType PRNG


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

I noticed the types exposing properties that simply do not exist in the source.

1. `quick` is not its own PRNG and [is never exposed on the top level object](https://github.com/davidbau/seedrandom/blob/4460ad325a0a15273a211e509f03ae0beb99511a/index.js#L51-L60).
2. `state` is only available if a `state` was passed to `options`, e.g. [code for ARC4 PRNG](https://github.com/davidbau/seedrandom/blob/4460ad325a0a15273a211e509f03ae0beb99511a/seedrandom.js#L88-L89).

This PR addresses this as it can lead to broken code when accessing `undefined`.