### PR TITLE
[fontkit]: Add types for getGlyph, hhea, name in glyph and params in bbox

### DIFF
--- a/types/fontkit/fontkit-tests.ts
+++ b/types/fontkit/fontkit-tests.ts
@@ -40,3 +40,21 @@ for (let i = 0; i < glyphs.length; i++) {
 }
 
 res.join('|');
+
+const dims = [];
+for (const glyph of glyphs) {
+    const bbox = glyph.bbox;
+    let dim = `${glyph.id}`;
+    dim += ` w:${bbox.width} h:${bbox.height}`;
+    dims.push(dim);
+}
+dims.join('|');
+
+// -----------------
+// API: Font['hhea']
+// -----------------
+openV2.then(font => {
+    font['hhea'].version; // $ExpectType number
+    font.getGlyph; // $ExpectType (glyphId: number, codePoints?: number[] | undefined) => Glyph
+    font.getGlyph(0); // $ExpectType Glyph
+});

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -40,7 +40,7 @@ export interface Font {
     bbox: BBOX;
     /** the font metric table consisting of a set of metrics and other data required for OpenType fonts */
     'OS/2': Os2Table;
-    /** the font's horizontal header table consisting of intformation needed to layout fonts with horizontal characters    */
+    /** the font's horizontal header table consisting of information needed to layout fonts with horizontal characters    */
     hhea: HHEA;
 
     /** the number of glyphs in the font */

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -40,6 +40,8 @@ export interface Font {
     bbox: BBOX;
     /** the font metric table consisting of a set of metrics and other data required for OpenType fonts */
     'OS/2': Os2Table;
+    /** the font's horizontal header table consisting of intformation needed to layout fonts with horizontal characters    */
+    hhea: HHEA;
 
     /** the number of glyphs in the font */
     numGlyphs: number;
@@ -87,6 +89,13 @@ export interface Font {
         language?: string,
         direction?: string,
     ): GlyphRun;
+
+    /**
+     * Returns a glyph object for the given glyph id. You can pass the array of
+     * code points this glyph represents for your use later, and it will be
+     * stored in the glyph object.
+     */
+    getGlyph(glyphId: number, codePoints?: number[]): Glyph;
 }
 
 export interface GlyphRun {
@@ -203,6 +212,9 @@ export interface Glyph {
 
     /** Renders the glyph to the given graphics context, at the specified font size. */
     render(ctx: CanvasRenderingContext2D, size: number): void;
+
+    /**  The glyph's name. Commonly the character, or 'space' or UTF**** */
+    name: string;
 }
 
 /**
@@ -260,6 +272,8 @@ export interface BBOX {
     minY: number;
     maxX: number;
     maxY: number;
+    width: number;
+    height: number;
 }
 
 export interface Os2Table {
@@ -310,6 +324,22 @@ export interface Os2Table {
     ySuperscriptXSize: number;
     ySuperscriptYOffset: number;
     ySuperscriptYSize: number;
+}
+
+export interface HHEA {
+    version: number;
+    ascent: number;
+    descent: number;
+    lineGap: number;
+    advanceWidthMax: number;
+    minLeftSideBearing: number;
+    minRightSideBearing: number;
+    xMaxExtent: number;
+    caretSlopeRise: number;
+    caretSlopeRun: number;
+    caretOffset: number;
+    metricDataFormat: number;
+    numberOfMetrics: number;
 }
 
 /**


### PR DESCRIPTION
Some minor types that are missing

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

-   https://github.com/foliojs/fontkit/blob/master/src/TTFFont.js#L409
- 