### PR TITLE
[seedrandom] Stricter types around states and options, more tests, big refactor

### DIFF
--- a/types/seedrandom/index.d.ts
+++ b/types/seedrandom/index.d.ts
@@ -3,51 +3,80 @@
 // Definitions by: Kern Handa <https://github.com/kernhanda>
 //                 Eugene Zaretskiy <https://github.com/EugeneZ>
 //                 Martin Badin <https://github.com/martin-badin>
+//                 Martijn van der Ven <https://github.com/Zegnat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+type StateBuilder<S extends string> = Record<S, number>;
+type ComplexStateBuilder<S extends string, M extends string> = StateBuilder<S> & Record<M, number[]>;
+
+interface OtherAlgorithm<State> {
+    (seed?: string, options?: { state?: false }): seedrandom.PRNG;
+    (seed?: string, options?: { state: State | true }): seedrandom.StatefulPRNG<State>;
+}
+
+type Callback<callbackReturnType> = (
+    prng: seedrandom.PRNG,
+    seed: string,
+    is_math_call: boolean,
+    state: undefined | boolean | seedrandom.State.Arc4,
+) => callbackReturnType;
+
+interface callbackOption<callbackReturnType> {
+    pass: Callback<callbackReturnType>;
+}
+interface stateOptionEnabled {
+    state: true | seedrandom.State.Arc4;
+}
+interface seedrandomOptions<callbackReturnType> {
+    global?: boolean;
+    state?: boolean | seedrandom.State.Arc4;
+    entropy?: boolean;
+    pass?: Callback<callbackReturnType>;
+}
+
 declare namespace seedrandom {
-    type State = object;
-
-    interface Callback {
-        (prng?: PRNG, shortseed?: string, global?: boolean, state?: State): PRNG;
-    }
-
-    interface Options {
-        entropy?: boolean | undefined;
-        global?: boolean | undefined;
-        pass?: Callback | undefined;
-        state?: boolean | State | undefined;
-    }
-
     interface PRNG {
         (): number;
         double(): number;
         int32(): number;
         quick(): number;
     }
-
-    interface StatefulPRNG extends PRNG {
+    interface StatefulPRNG<State> extends PRNG {
         state(): State;
+    }
+    namespace State {
+        type Arc4 = ComplexStateBuilder<'i' | 'j', 'S'>;
+        type Alea = StateBuilder<'c' | 's0' | 's1' | 's2'>;
+        type Xor128 = StateBuilder<'x' | 'y' | 'z' | 'w'>;
+        type Xorwow = StateBuilder<'x' | 'y' | 'z' | 'w' | 'v' | 'd'>;
+        type Xorshift7 = ComplexStateBuilder<'i', 'x'>;
+        type Xor4096 = ComplexStateBuilder<'i' | 'w', 'X'>;
+        type Tychei = StateBuilder<'a' | 'b' | 'c' | 'd'>;
     }
 }
 
-type ReturnedPRNG<O extends seedrandom.Options = {}> = O extends { state: true | seedrandom.State }
-    ? seedrandom.StatefulPRNG
-    : seedrandom.PRNG;
-
-interface BaseInterface {
-    <O extends seedrandom.Options>(seed?: string, options?: O): ReturnedPRNG<O>;
-    new (seed?: string): seedrandom.PRNG;
-}
-
 interface seedrandom {
-    <O extends seedrandom.Options>(seed?: string, options?: O, callback?: seedrandom.Callback): ReturnedPRNG<O>;
-    alea: BaseInterface;
-    tychei: BaseInterface;
-    xor128: BaseInterface;
-    xor4096: BaseInterface;
-    xorshift7: BaseInterface;
-    xorwow: BaseInterface;
+    // Arc4 Algorithm, default seedrandom
+    <O extends seedrandomOptions<any>>(seed?: string, options?: O | boolean): O extends callbackOption<
+        infer callbackReturnType
+    >
+        ? callbackReturnType
+        : O extends stateOptionEnabled
+        ? seedrandom.StatefulPRNG<seedrandom.State.Arc4>
+        : seedrandom.PRNG;
+    <O extends seedrandomOptions<any>, callbackReturnType>(
+        seed: string | undefined,
+        options: O | boolean | undefined,
+        callback: Callback<callbackReturnType>,
+    ): O extends callbackOption<infer callbackReturnType> ? callbackReturnType : callbackReturnType;
+
+    // Other Algorithms
+    alea: OtherAlgorithm<seedrandom.State.Alea>;
+    xor128: OtherAlgorithm<seedrandom.State.Xor128>;
+    xorwow: OtherAlgorithm<seedrandom.State.Xorwow>;
+    xorshift7: OtherAlgorithm<seedrandom.State.Xorshift7>;
+    xor4096: OtherAlgorithm<seedrandom.State.Xor4096>;
+    tychei: OtherAlgorithm<seedrandom.State.Tychei>;
 }
 
 declare const seedrandom: seedrandom;

--- a/types/seedrandom/seedrandom-tests.ts
+++ b/types/seedrandom/seedrandom-tests.ts
@@ -9,40 +9,99 @@ prng.quick(); // $ExpectType number
 prng.state;
 prng(); // $ExpectType number
 
-const prngWithState = seedrandom('added entropy.', { entropy: true, state: true }); // $ExpectType StatefulPRNG
+const prngWithState = seedrandom('added entropy.', { entropy: true, state: true }); // $ExpectType StatefulPRNG<Arc4>
 prngWithState.double(); // $ExpectType number
 prngWithState.int32(); // $ExpectType number
 prngWithState.quick(); // $ExpectType number
-prngWithState.state(); // $ExpectType object
+prngWithState.state(); // $ExpectType Arc4
 prngWithState(); // $ExpectType number
 
-seedrandom('hello.', { state: {} }); // $ExpectType StatefulPRNG
+const aleaState = {
+    c: 1,
+    s0: 0.8760416533332318,
+    s1: 0.8980805180035532,
+    s2: 0.8814748537261039,
+};
+
+const arc4State = {
+    i: 0,
+    j: 230,
+    S: [
+        61, 249, 52, 85, 86, 251, 19, 50, 60, 17, 104, 57, 156, 123, 26, 172, 143, 31, 187, 1, 161, 201, 222, 66, 252,
+        106, 100, 227, 113, 63, 239, 4, 20, 128, 228, 9, 133, 152, 2, 7, 173, 219, 37, 44, 192, 150, 47, 25, 117, 62,
+        72, 111, 30, 45, 32, 39, 211, 181, 0, 223, 132, 207, 112, 184, 55, 168, 154, 115, 250, 98, 149, 247, 202, 75,
+        118, 127, 208, 119, 189, 125, 28, 238, 217, 99, 197, 141, 244, 185, 24, 170, 218, 27, 6, 162, 231, 22, 232, 180,
+        38, 171, 93, 226, 213, 129, 110, 3, 5, 225, 120, 15, 140, 175, 236, 84, 183, 116, 78, 224, 16, 65, 53, 174, 64,
+        96, 253, 89, 206, 148, 210, 233, 41, 71, 59, 235, 80, 14, 23, 34, 216, 193, 142, 108, 177, 212, 139, 56, 134,
+        138, 33, 87, 159, 51, 237, 88, 241, 83, 69, 191, 48, 145, 92, 70, 126, 196, 121, 12, 131, 205, 103, 74, 8, 155,
+        215, 124, 169, 122, 67, 166, 209, 229, 163, 147, 243, 10, 36, 167, 186, 107, 11, 214, 73, 54, 136, 102, 95, 254,
+        94, 234, 245, 246, 179, 230, 194, 105, 144, 43, 157, 198, 195, 109, 221, 220, 97, 176, 165, 77, 178, 204, 58,
+        151, 137, 190, 200, 18, 35, 79, 29, 158, 199, 135, 21, 146, 188, 153, 42, 49, 40, 182, 242, 82, 203, 240, 90,
+        81, 248, 68, 164, 76, 101, 160, 91, 13, 114, 130, 255, 46,
+    ],
+};
+
+seedrandom(undefined, { state: arc4State }); // $ExpectType StatefulPRNG<Arc4>
+seedrandom('hello.', { state: arc4State }); // $ExpectType StatefulPRNG<Arc4>
+// @ts-expect-error protect against using states from different algorithms
+seedrandom('hello.', { state: aleaState });
 seedrandom('hello.', { global: true }); // $ExpectType PRNG
+seedrandom('hello.', true); // $ExpectType PRNG
 seedrandom('hello.'); // $ExpectType PRNG
 seedrandom(); // $ExpectType PRNG
 
-new seedrandom.alea('hello.'); // $ExpectType PRNG
-new seedrandom.tychei('hello.'); // $ExpectType PRNG
-new seedrandom.xor128('hello.'); // $ExpectType PRNG
-new seedrandom.xor4096('hello.'); // $ExpectType PRNG
-new seedrandom.xorshift7('hello.'); // $ExpectType PRNG
-new seedrandom.xorwow('hello.'); // $ExpectType PRNG
-seedrandom.alea('hello.', { entropy: true }); // $ExpectType PRNG
-seedrandom.tychei('hello.', { entropy: true }); // $ExpectType PRNG
-seedrandom.xor128('hello.', { entropy: true }); // $ExpectType PRNG
-seedrandom.xor4096('hello.', { entropy: true }); // $ExpectType PRNG
-seedrandom.xorshift7('hello.', { entropy: true }); // $ExpectType PRNG
-seedrandom.xorwow('hello.', { entropy: true }); // $ExpectType PRNG
+// $ExpectType { prng: PRNG; seed: string; }
+seedrandom('hello', {
+    pass(prng, seed, is_math_call, state) {
+        return { prng, seed };
+    },
+});
+// $ExpectType number
+seedrandom(
+    'hello',
+    {
+        pass(prng, seed, is_math_call, state) {
+            return 1;
+        },
+    },
+    (prng, seed, is_math_call, state) => {
+        return 'a';
+    },
+);
+// $ExpectType string
+seedrandom('hello', {}, (prng, seed, is_math_call, state) => {
+    return 'a';
+});
+// $ExpectType string
+seedrandom(undefined, undefined, (prng, seed, is_math_call, state) => {
+    return 'a';
+});
 
-new alea('hello.'); // $ExpectType PRNG
-new tychei('hello.'); // $ExpectType PRNG
-new xor128('hello.'); // $ExpectType PRNG
-new xor4096('hello.'); // $ExpectType PRNG
-new xorshift7('hello.'); // $ExpectType PRNG
-new xorwow('hello.'); // $ExpectType PRNG
-alea('hello.', { entropy: true }); // $ExpectType PRNG
-tychei('hello.', { entropy: true }); // $ExpectType PRNG
-xor128('hello.', { entropy: true }); // $ExpectType PRNG
-xor4096('hello.', { entropy: true }); // $ExpectType PRNG
-xorshift7('hello.', { entropy: true }); // $ExpectType PRNG
-xorwow('hello.', { entropy: true }); // $ExpectType PRNG
+seedrandom.alea('hello.'); // $ExpectType PRNG
+seedrandom.alea('hello.', { state: true }); // $ExpectType StatefulPRNG<Alea>
+seedrandom.alea('hello.', { state: aleaState }); // $ExpectType StatefulPRNG<Alea>
+// @ts-expect-error protect against using states from different algorithms
+seedrandom.alea('hello.', { state: arc4State });
+seedrandom.tychei('hello.'); // $ExpectType PRNG
+seedrandom.tychei('hello.', { state: true }); // $ExpectType StatefulPRNG<Tychei>
+seedrandom.xor128('hello.'); // $ExpectType PRNG
+seedrandom.xor128('hello.', { state: true }); // $ExpectType StatefulPRNG<Xor128>
+seedrandom.xor4096('hello.'); // $ExpectType PRNG
+seedrandom.xor4096('hello.', { state: true }); // $ExpectType StatefulPRNG<Xor4096>
+seedrandom.xorshift7('hello.'); // $ExpectType PRNG
+seedrandom.xorshift7('hello.', { state: true }); // $ExpectType StatefulPRNG<Xorshift7>
+seedrandom.xorwow('hello.'); // $ExpectType PRNG
+seedrandom.xorwow('hello.', { state: true }); // $ExpectType StatefulPRNG<Xorwow>
+
+alea('hello.'); // $ExpectType PRNG
+alea('hello.', { state: true }); // $ExpectType StatefulPRNG<Alea>
+tychei('hello.'); // $ExpectType PRNG
+tychei('hello.', { state: true }); // $ExpectType StatefulPRNG<Tychei>
+xor128('hello.'); // $ExpectType PRNG
+xor128('hello.', { state: true }); // $ExpectType StatefulPRNG<Xor128>
+xor4096('hello.'); // $ExpectType PRNG
+xor4096('hello.', { state: true }); // $ExpectType StatefulPRNG<Xor4096>
+xorshift7('hello.'); // $ExpectType PRNG
+xorshift7('hello.', { state: true }); // $ExpectType StatefulPRNG<Xorshift7>
+xorwow('hello.'); // $ExpectType PRNG
+xorwow('hello.', { state: true }); // $ExpectType StatefulPRNG<Xorwow>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test seedrandom`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

After hitting some pitfalls this morning and filing #63760 to remove some properties from the types that were not available, I still found it extremely hard to navigate the seedrandom package by the types alone. Quickly figured out that the types were more of a suggestion than a rule. This fixes a lot of things, but I may very well have missed some things. Please let me know if you can come up with more tests to add!

* The other algorithms shipped inside seedrandom do not use the full options object and only allow passing state, e.g. [in Alea’s case](https://github.com/davidbau/seedrandom/blob/4460ad325a0a15273a211e509f03ae0beb99511a/lib/alea.js#L64).
  
* Callback can return anything, not just a PRNG. This is the specific example [in the seedrandom README](https://github.com/davidbau/seedrandom/blob/4460ad325a0a15273a211e509f03ae0beb99511a/README.md?plain=1#L220-L222).
  
* @martin-badin in #63473 you added `new`, but looking at the seedrandom code I do not see any use of `this` or other hints of instantiation being required. I have removed this again.
  
  Note that the library is always exposing a function `impl` (e.g. [Alea’s exports](https://github.com/davidbau/seedrandom/blob/4460ad325a0a15273a211e509f03ae0beb99511a/lib/alea.js#L100-L106)) which wraps the actual user-defined object (e.g. [`new Alea` within `impl`](https://github.com/davidbau/seedrandom/blob/4460ad325a0a15273a211e509f03ae0beb99511a/lib/alea.js#L63)). For the root `seedrandom` it is the same (that is: [wrapping `new ARC4`](https://github.com/davidbau/seedrandom/blob/4460ad325a0a15273a211e509f03ae0beb99511a/seedrandom.js#L54).)
    
  The currently exposed functions are basically [factories](https://en.wikipedia.org/wiki/Factory_%28object-oriented_programming%29) and should not be using `new`.
  
* My jostling of the types moved some stuff outside of the exported `seedrandom` namespace. Currently it exposes only the `PRNG`, `StatefulPRNG`, and different `State.*` types. This should be enough to cover usecases such as @xmakina’s #58222 but might possible be a BC break by no longer exposing `Callback`?
  
  1. Do we need to make more types publicly available? I could not find any good guidance for this here on DefinitelyTyped.
  2. Is there a way to dts-test which types/interfaces/namespaces are exposed so BC can be tested?

**Any and all feedback greatly appreciated** as today is my first day writing a .d.ts file 👋