### PR TITLE
3 small fixes to the recent tslint->eslint conversion

### DIFF
--- a/types/graphql-upload/graphqlUploadKoa.d.ts
+++ b/types/graphql-upload/graphqlUploadKoa.d.ts
@@ -8,4 +8,4 @@ export interface UploadOptions {
 
 export default function graphqlUploadKoa<StateT = DefaultState, ContextT = DefaultContext>(
     uploadOptions?: UploadOptions,
-): Middleware<StateT, ContextT>; // tslint:disable-line:no-unnecessary-generics
+): Middleware<StateT, ContextT>; // eslint-disable-line no-unnecessary-generics

--- a/types/jquery/JQueryStatic.d.ts
+++ b/types/jquery/JQueryStatic.d.ts
@@ -194,7 +194,7 @@ jQuery(function( $ ) {
 ```
      */
     /* eslint-disable no-unnecessary-generics */
-    // tslint-disable-next-line:unified-signatures
+    // tslint:disable-next-line:unified-signatures
     <TElement = HTMLElement>(callback: ((this: Document, $: JQueryStatic) => void)): JQuery<TElement>;
     /* eslint-enable no-unnecessary-generics */
     /**

--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -43,7 +43,7 @@ export function parse<T>(url: string, config: ParseRemoteConfig<T>): void;
  * @returns Doesn't return anything. Results are provided asynchronously to a callback function.
  */
 /* eslint-disable no-unnecessary-generics */
-// tslint-disable-next-line:unified-signatures
+// tslint:disable-next-line:unified-signatures
 export function parse<T>(csvString: string, config: ParseWorkerConfig<T> & { download?: false | undefined }): void;
 /* eslint-enable no-unnecessary-generics */
 /**


### PR DESCRIPTION
1. wrong tslint syntax in a couple of manual fixups.
2. missed conversion in one file (probably new in the last two days -- graphql-upload got updated recently).
