### PR TITLE
[markdown-pdf]: Fix the type for to.buffer callback

### DIFF
--- a/types/markdown-pdf/index.d.ts
+++ b/types/markdown-pdf/index.d.ts
@@ -77,7 +77,7 @@ declare namespace MarkdownPDF {
          */
         path(path: string, callback?: () => void): void;
         /** Create a concat-stream and pipe output from markdown-pdf to it. The callback function cb will be invoked when the buffer has been created. */
-        buffer(opts: any, callback?: () => void): void;
+        buffer(opts: any, callback?: (err: any, buffer: ArrayBuffer) => void): void;
         /** Create a concat-stream and pipe output from markdown-pdf to it. The callback function cb will be invoked when the string has been created. */
         string(opts: any, callback?: () => void): void;
     }

--- a/types/markdown-pdf/index.d.ts
+++ b/types/markdown-pdf/index.d.ts
@@ -35,8 +35,8 @@ declare namespace MarkdownPDF {
         /** A config object that is passed to remarkable, the underlying markdown parser */
         remarkable?: any; // FIXME: remarkable config types
     }
-    type PaperFormat = "A3" | "A4" | "A5" | "Legal" | "Letter" | "Tabloid";
-    type PaperOrientation = "portait" | "landscape";
+    type PaperFormat = 'A3' | 'A4' | 'A5' | 'Legal' | 'Letter' | 'Tabloid';
+    type PaperOrientation = 'portait' | 'landscape';
 
     interface OptionsBuilder {
         /** Create a readable stream and pipe it to markdown pdf. */

--- a/types/markdown-pdf/markdown-pdf-tests.ts
+++ b/types/markdown-pdf/markdown-pdf-tests.ts
@@ -8,5 +8,10 @@ mdPdf().concat.from.strings(['lol', 'lol'], {}).to('path', () => { }); // $Expec
 mdPdf().from('path').to.path('path', () => { }); // $ExpectType void
 mdPdf().from('path').to('path'); // $ExpectType void
 
+// $ExpectType void
+mdPdf().from.string('markdown').to.buffer(null, (err, buffer) => {
+    buffer; // $ExpectType ArrayBuffer
+});
+
 // @ts-expect-error
 mdPdf({ paperFormat: 'wrongFormat' });

--- a/types/markdown-pdf/markdown-pdf-tests.ts
+++ b/types/markdown-pdf/markdown-pdf-tests.ts
@@ -1,24 +1,31 @@
 import mdPdf = require('markdown-pdf');
 
+// $ExpectType void
 mdPdf()
     .from('path')
-    .to('path', () => {}); // $ExpectType void
+    .to('path', () => {});
+// $ExpectType void
 mdPdf()
     .from.string('markdown')
-    .to('path', () => {}); // $ExpectType void
+    .to('path', () => {});
+// $ExpectType void
 mdPdf({ paperOrientation: 'landscape', paperFormat: 'A3' })
     .from('lol')
-    .to('lol', () => {}); // $ExpectType void
+    .to('lol', () => {});
+// $ExpectType void
 mdPdf()
     .concat.from.paths(['lol', 'lol'], {})
-    .to('path', () => {}); // $ExpectType void
+    .to('path', () => {});
+// $ExpectType void
 mdPdf()
     .concat.from.strings(['lol', 'lol'], {})
-    .to('path', () => {}); // $ExpectType void
+    .to('path', () => {});
+// $ExpectType void
 mdPdf()
     .from('path')
-    .to.path('path', () => {}); // $ExpectType void
-mdPdf().from('path').to('path'); // $ExpectType void
+    .to.path('path', () => {});
+// $ExpectType void
+mdPdf().from('path').to('path');
 
 // $ExpectType void
 mdPdf()

--- a/types/markdown-pdf/markdown-pdf-tests.ts
+++ b/types/markdown-pdf/markdown-pdf-tests.ts
@@ -1,17 +1,31 @@
 import mdPdf = require('markdown-pdf');
 
-mdPdf().from('path').to('path', () => { }); // $ExpectType void
-mdPdf().from.string('markdown').to('path', () => { }); // $ExpectType void
-mdPdf({ paperOrientation: 'landscape', paperFormat: 'A3' }).from('lol').to('lol', () => { }); // $ExpectType void
-mdPdf().concat.from.paths(['lol', 'lol'], {}).to('path', () => { }); // $ExpectType void
-mdPdf().concat.from.strings(['lol', 'lol'], {}).to('path', () => { }); // $ExpectType void
-mdPdf().from('path').to.path('path', () => { }); // $ExpectType void
+mdPdf()
+    .from('path')
+    .to('path', () => {}); // $ExpectType void
+mdPdf()
+    .from.string('markdown')
+    .to('path', () => {}); // $ExpectType void
+mdPdf({ paperOrientation: 'landscape', paperFormat: 'A3' })
+    .from('lol')
+    .to('lol', () => {}); // $ExpectType void
+mdPdf()
+    .concat.from.paths(['lol', 'lol'], {})
+    .to('path', () => {}); // $ExpectType void
+mdPdf()
+    .concat.from.strings(['lol', 'lol'], {})
+    .to('path', () => {}); // $ExpectType void
+mdPdf()
+    .from('path')
+    .to.path('path', () => {}); // $ExpectType void
 mdPdf().from('path').to('path'); // $ExpectType void
 
 // $ExpectType void
-mdPdf().from.string('markdown').to.buffer(null, (err, buffer) => {
-    buffer; // $ExpectType ArrayBuffer
-});
+mdPdf()
+    .from.string('markdown')
+    .to.buffer(null, (err, buffer) => {
+        buffer; // $ExpectType ArrayBuffer
+    });
 
 // @ts-expect-error
 mdPdf({ paperFormat: 'wrongFormat' });


### PR DESCRIPTION
Fixing the types for to.buffer callback based on the discussion here [GitHub Issue](https://github.com/alanshaw/markdown-pdf/issues/143)  Added a test and also ran prettier to fix the formatting for the types.

Please fill in this template.
- [x]  Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [GitHub Issue](https://github.com/alanshaw/markdown-pdf/issues/143) 