### PR TITLE
[laravel-vapor] add `withBaseAssetUrl` declaration for vite support in v0.6.0

### DIFF
--- a/types/laravel-vapor/index.d.ts
+++ b/types/laravel-vapor/index.d.ts
@@ -20,6 +20,7 @@ interface VaporStoreOptions {
 
 declare class Vapor {
     store(file: File, options?: VaporStoreOptions): Promise<any>;
+    withBaseAssetUrl(url?: string | boolean): void;
     asset(path: string): string;
 }
 

--- a/types/laravel-vapor/index.d.ts
+++ b/types/laravel-vapor/index.d.ts
@@ -20,7 +20,7 @@ interface VaporStoreOptions {
 
 declare class Vapor {
     store(file: File, options?: VaporStoreOptions): Promise<any>;
-    withBaseAssetUrl(url?: string | boolean): void;
+    withBaseAssetUrl(url?: string): void;
     asset(path: string): string;
 }
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [repo](https://github.com/laravel/vapor-js/blob/master/src/index.js#L27), [docs](https://docs.vapor.build/1.0/projects/deployments.html#referencing-assets-from-javascript) 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

