### PR TITLE
Fix assert function. The message attribute is of type string or error

### DIFF
--- a/types/assert/assert-tests.ts
+++ b/types/assert/assert-tests.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 
 assert(true, "it's working");
+assert(true, new Error("it keeps working"));
 
 assert.ok(true, 'inner functions work as well');
 

--- a/types/node/console.d.ts
+++ b/types/node/console.d.ts
@@ -84,8 +84,9 @@ declare module 'node:console' {
              * @since v0.1.101
              * @param value The value tested for being truthy.
              * @param message All arguments besides `value` are used as error message.
+             * @see https://nodejs.org/api/assert.html#assertvalue-message
              */
-            assert(value: any, message?: string, ...optionalParams: any[]): void;
+            assert(value: any, message?: string | Error, ...optionalParams: any[]): void;
             /**
              * When `stdout` is a TTY, calling `console.clear()` will attempt to clear the
              * TTY. When `stdout` is not a TTY, this method does nothing.


### PR DESCRIPTION
Compliance with nodejs documentation: https://nodejs.org/api/assert.html#assertvalue-message
Note that since version 10.x the message attribute already has this type: https://nodejs.org/docs/latest-v10.x/api/assert.html#assert_assert_value_message