### PR TITLE
[maildev] fix: name of the function to stop the server

### DIFF
--- a/types/maildev/index.d.ts
+++ b/types/maildev/index.d.ts
@@ -130,7 +130,7 @@ declare module "maildev" {
          *
          * @param callback The error callback.
          */
-        end(callback?: (error: Error) => void): void;
+        close(callback?: (error: Error) => void): void;
 
         /**
          * Accepts e-mail identifier, returns email object.


### PR DESCRIPTION
The correct name of the function to stop the server is `close`.

The name used to be `end` but was renamed to `close` in 1.0.0-rc1, and this file already targets 1.0.0-rc3 (current version is 2.0.5).

You can find the `close` function mentionned in the [current code](https://github.com/maildev/maildev/blob/master/lib/mailserver.js#L268) and in the [documentation](https://github.com/maildev/maildev/blob/master/docs/api.md#api-methods).


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/maildev/maildev/commit/dac47a18103bb8bb20208913e627641144774690#diff-6904936ddfe12389ae0d9216c381431d9f8eeb488b5cf8510ce007a6a91cc523L268
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
