### PR TITLE
react-rte - add block alignment buttons to toolbar config

### DIFF
--- a/types/react-rte/index.d.ts
+++ b/types/react-rte/index.d.ts
@@ -114,6 +114,7 @@ type CustomControl = ReactNode | CustControlFunc;
 type GroupName =
     | "INLINE_STYLE_BUTTONS"
     | "BLOCK_TYPE_BUTTONS"
+    | "BLOCK_ALIGNMENT_BUTTONS"
     | "LINK_BUTTONS"
     | "BLOCK_TYPE_DROPDOWN"
     | "HISTORY_BUTTONS"
@@ -123,6 +124,7 @@ export interface ToolbarConfig {
     display: GroupName[];
     extraProps?: object | undefined;
     INLINE_STYLE_BUTTONS: StyleConfigList;
+    BLOCK_ALIGNMENT_BUTTONS: StyleConfigList;
     BLOCK_TYPE_DROPDOWN: StyleConfigList;
     BLOCK_TYPE_BUTTONS: StyleConfigList;
 }

--- a/types/react-rte/index.d.ts
+++ b/types/react-rte/index.d.ts
@@ -114,7 +114,6 @@ type CustomControl = ReactNode | CustControlFunc;
 type GroupName =
     | "INLINE_STYLE_BUTTONS"
     | "BLOCK_TYPE_BUTTONS"
-    | "BLOCK_ALIGNMENT_BUTTONS"
     | "LINK_BUTTONS"
     | "BLOCK_TYPE_DROPDOWN"
     | "HISTORY_BUTTONS"
@@ -124,7 +123,6 @@ export interface ToolbarConfig {
     display: GroupName[];
     extraProps?: object | undefined;
     INLINE_STYLE_BUTTONS: StyleConfigList;
-    BLOCK_ALIGNMENT_BUTTONS: StyleConfigList;
     BLOCK_TYPE_DROPDOWN: StyleConfigList;
     BLOCK_TYPE_BUTTONS: StyleConfigList;
 }


### PR DESCRIPTION
This PR updates react-rte's GroupName and ToolbarConfig in DefinitelyTyped with "BLOCK_ALIGNMENT_BUTTONS" which exists in react-rte but not in DefinitelyTyped.
You can find the types declared in react-rte here: https://github.com/sstur/react-rte/blob/master/src/lib/EditorToolbarConfig.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sstur/react-rte/blob/master/src/lib/EditorToolbarConfig.js
