### PR TITLE
Add types to `@types/qunit` that are needed for `ember-qunit`

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -813,6 +813,10 @@ declare global {
          * QUnit version
          */
         version: string;
+
+        // https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/html-reporter/html.js#L256
+        // https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/test/reporter-urlparams.js#L11
+        urlParams: Record<string, unknown>;
     }
 
     /* QUnit */

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -391,6 +391,8 @@ declare global {
             tooltip?: string | undefined;
             value?: string | string[] | { [key: string]: string } | undefined;
         }[];
+        // timeout: https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L752
+        timeout?: ReturnType<typeof setTimeout> | null;
     }
 
     interface GlobalHooks {

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -256,7 +256,8 @@ declare global {
          *
          * @param assertionResult The assertion result
          */
-        pushResult(assertResult: { result: boolean; actual: any; expected: any; message?: string }): void;
+        // source: https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L572
+        pushResult(assertResult: { result: boolean; actual: any; expected: any; message?: string; source?: string }): void;
 
         /**
          * Test if the provided promise rejects, and optionally compare the rejection value.

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -256,7 +256,7 @@ declare global {
          *
          * @param assertionResult The assertion result
          */
-        pushResult(assertResult: { result: boolean; actual: any; expected: any; message?: string; source?: string }): void;
+        pushResult(assertResult: { result: boolean; actual: any; expected: any; message?: string | undefined; source?: string | undefined }): void;
 
         /**
          * Test if the provided promise rejects, and optionally compare the rejection value.

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -384,7 +384,6 @@ declare global {
         seed: string;
         testId: string[];
         testTimeout?: number | null;
-        timeout?: ReturnType<typeof setTimeout> | null;
         urlConfig: {
             id?: string | undefined;
             label?: string | undefined;

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -507,6 +507,72 @@ declare global {
             name: string;
             module: string;
         }
+
+        // https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/core/config.js#L84
+        interface Module {
+            name: string;
+            // tests: Array<{ name: string; id: string; skip: boolean }>;
+            // childModules: Module[];
+            // testsRun: number;
+            // testsIgnored: number;
+            // hooks: Hooks;
+            // skip?: boolean;
+            // ignored?: boolean;
+        }
+
+        // https://github.com/qunitjs/qunit/blob/main/src/test.js#L23
+        interface TestBase {
+            testId: string;
+            testName: string;
+            expected: null | number;
+            // assertions: Array<{ result: boolean; message: string }>;
+            module: Module;
+            // steps: unknown[];
+            // timeout: undefined;
+            // data: unknown;
+            // withData: boolean;
+            // pauses: Map<string, unknown>;
+            // nextPauseId: 1;
+            // stackOffset: 0 | 1 | 2 | 3 | 5;
+            // errorForStack: Error;
+            // testReport: unknown;
+            // stack: string;
+            // before: () => unknown;
+            // run: () => unknown;
+            // after: () => void;
+            // queueGlobalHook: (hook: unknown, hookName: unknown) => () => unknown;
+            // queueHook: (
+            //   hook: unknown,
+            //   hookName: unknown,
+            //   hookOwner: unknown
+            // ) => () => unknown;
+            // hooks: (handler: unknown) => unknown;
+            finish: () => unknown;
+            // preserveTestEnvironment: () => unknown;
+            // queue: () => void;
+            // pushResult: (resultInfo: unknown) => void;
+            pushFailure: (message: string, source: string, actual: unknown) => void;
+            skip?: true;
+            // callback: ((assert: Assert) => void) | ((assert: Assert) => Promise<void>);
+            todo?: boolean;
+            async?: boolean;
+        }
+
+        interface AssertionTest extends TestBase {
+            assert: Assert;
+        }
+
+        interface SkipTest extends TestBase {
+            skip: true;
+            async: false;
+        }
+
+        interface TodoTest extends TestBase {
+            todo: true;
+            assert: Assert;
+        }
+
+        type Test = AssertionTest | SkipTest | TodoTest;
     }
 
     interface QUnit {

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -256,7 +256,6 @@ declare global {
          *
          * @param assertionResult The assertion result
          */
-        // source: https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L572
         pushResult(assertResult: { result: boolean; actual: any; expected: any; message?: string; source?: string }): void;
 
         /**
@@ -384,18 +383,14 @@ declare global {
         scrolltop: boolean;
         seed: string;
         testId: string[];
-        // https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L733
-        // ember-qunit sets testTimeout to null in devMode. Code surrounding testTimeout seems to assume it can be
-        // something other than a number
         testTimeout?: number | null;
+        timeout?: ReturnType<typeof setTimeout> | null;
         urlConfig: {
             id?: string | undefined;
             label?: string | undefined;
             tooltip?: string | undefined;
             value?: string | string[] | { [key: string]: string } | undefined;
         }[];
-        // timeout: https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L752
-        timeout?: ReturnType<typeof setTimeout> | null;
     }
 
     interface GlobalHooks {
@@ -508,7 +503,6 @@ declare global {
             module: string;
         }
 
-        // https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/core/config.js#L84
         interface Module {
             name: string;
             // tests: Array<{ name: string; id: string; skip: boolean }>;
@@ -520,7 +514,6 @@ declare global {
             // ignored?: boolean;
         }
 
-        // https://github.com/qunitjs/qunit/blob/main/src/test.js#L23
         interface TestBase {
             testId: string;
             testName: string;
@@ -883,8 +876,6 @@ declare global {
          */
         version: string;
 
-        // https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/html-reporter/html.js#L256
-        // https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/test/reporter-urlparams.js#L11
         urlParams: Record<string, unknown>;
     }
 

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -384,7 +384,10 @@ declare global {
         scrolltop: boolean;
         seed: string;
         testId: string[];
-        testTimeout: number;
+        // https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L733
+        // ember-qunit sets testTimeout to null in devMode. Code surrounding testTimeout seems to assume it can be
+        // something other than a number
+        testTimeout?: number | null;
         urlConfig: {
             id?: string | undefined;
             label?: string | undefined;

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -840,5 +840,8 @@ QUnit.onUncaughtException = (error: unknown) => {
 
 const configTimeout: number | null | undefined = QUnit.config.timeout;
 
+QUnit.config.testTimeout = null;
+QUnit.config.testTimeout = 60000;
+
 const urlParams = QUnit.urlParams;
 urlParams.foo;

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -838,8 +838,6 @@ QUnit.onUncaughtException = (error: unknown) => {
   }
 };
 
-const configTimeout: number | null | undefined = QUnit.config.timeout;
-
 QUnit.config.testTimeout = null;
 QUnit.config.testTimeout = 60000;
 

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -837,3 +837,5 @@ QUnit.onUncaughtException = (error: unknown) => {
     console.log(error.message);
   }
 };
+
+const configTimeout: number | null | undefined = QUnit.config.timeout;

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -570,6 +570,15 @@ QUnit.test( "Assert plugin", function ( assert ) {
         actual: actual,
         expected: `between ${from} and ${to} inclusive`
     });
+
+    // with stack
+    assert.pushResult({
+        result: isBetween,
+        actual: actual,
+        expected: `between ${from} and ${to} inclusive`,
+        message: 'message',
+        source: new Error().stack
+    });
 });
 
 QUnit.test( "throws", function( assert ) {

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -839,3 +839,6 @@ QUnit.onUncaughtException = (error: unknown) => {
 };
 
 const configTimeout: number | null | undefined = QUnit.config.timeout;
+
+const urlParams = QUnit.urlParams;
+urlParams.foo;


### PR DESCRIPTION
Adds and fixes types used by `ember-qunit` in https://github.com/emberjs/ember-qunit/pull/994

Add optional `source` property to `Assert.pushResult` argument:
https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L572

Make `QUnit.config.testTimeout` optional:
https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L733
`ember-qunit` sets `testTimeout` to `null` in "dev mode." Additionally, code surrounding `testTimeout` seems to assume it can be something other than a number.

~Add `QUnit.config.timeout` type: https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L752~

Add `QUnit.urlParams` type:
https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/html-reporter/html.js#L256
https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/test/reporter-urlparams.js#L11

Adds `Module` interface:
https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/module.js#L45
I included only the properties needed for `ember-qunit` but left some commented out properties I discovered during my code reading but didn't need. Do you want to make any of these public?

Adds `Test` interface:
https://github.com/qunitjs/qunit/blob/fc278e8c0d7e90ec42e47b47eee1cc85c9a9efaf/src/test.js#L23
I included only the properties needed for `ember-qunit` but left some commented out properties I discovered during my code reading but didn't need. Do you want to make any of these public?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~


