### PR TITLE
[react-onsenui] Add children prop to Button

### DIFF
--- a/types/react-onsenui/index.d.ts
+++ b/types/react-onsenui/index.d.ts
@@ -338,6 +338,7 @@ export class Fab extends Component<{
 }, any> {}
 
 export class Button extends Component<{
+    children?: React.ReactNode,
     modifier?: string | undefined,
     disabled?: boolean | undefined,
     ripple?: boolean | undefined,

--- a/types/react-onsenui/react-onsenui-tests.tsx
+++ b/types/react-onsenui/react-onsenui-tests.tsx
@@ -72,7 +72,7 @@ export class App extends React.Component<AppProps, AppState> {
                             <option value="3">Option #3</option>
                         </Select>
                         <Switch className='left' modifier='material' checked={true} inputId='switchId' name='switchTest' />
-                        <Button name='someButton' onClick={this.onClick} />
+                        <Button name='someButton' onClick={this.onClick}>Button label</Button>
                         <SearchInput
                             modifier='material'
                             inputId='searchInputId'


### PR DESCRIPTION
As in the [Hello World with React](https://onsen.io/v2/guide/react/#hello-world-with-react) example from Onsen UI documentation, the Button component should accept children which is rendered as the button label.
I believe it is related to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://onsen.io/v2/api/react/Button.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
