### PR TITLE
[@type/react-syntax-highlighter] add missing one-dark/one-light styles in cjs/styles/prism

### DIFF
--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -3682,6 +3682,8 @@ declare module 'react-syntax-highlighter/dist/cjs/styles/prism' {
     export { default as nightOwl } from 'react-syntax-highlighter/dist/cjs/styles/prism/night-owl';
     export { default as nord } from 'react-syntax-highlighter/dist/cjs/styles/prism/nord';
     export { default as okaidia } from 'react-syntax-highlighter/dist/cjs/styles/prism/okaidia';
+    export { default as oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism/one-dark';
+    export { default as oneLight } from 'react-syntax-highlighter/dist/cjs/styles/prism/one-light';
     export { default as pojoaque } from 'react-syntax-highlighter/dist/cjs/styles/prism/pojoaque';
     export { default as prism } from 'react-syntax-highlighter/dist/cjs/styles/prism/prism';
     export { default as shadesOfPurple } from 'react-syntax-highlighter/dist/cjs/styles/prism/shades-of-purple';
@@ -3806,8 +3808,8 @@ declare module 'react-syntax-highlighter/dist/cjs/styles/prism/material-oceanic'
 }
 
 declare module 'react-syntax-highlighter/dist/cjs/styles/prism/night-owl' {
-  const style: { [key: string]: React.CSSProperties };
-  export default style;
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
 }
 
 declare module 'react-syntax-highlighter/dist/cjs/styles/prism/nord' {
@@ -3816,6 +3818,16 @@ declare module 'react-syntax-highlighter/dist/cjs/styles/prism/nord' {
 }
 
 declare module 'react-syntax-highlighter/dist/cjs/styles/prism/okaidia' {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module 'react-syntax-highlighter/dist/cjs/styles/prism/one-dark' {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module 'react-syntax-highlighter/dist/cjs/styles/prism/one-light' {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }

--- a/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
+++ b/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
@@ -5,6 +5,7 @@ import PrismLightHighlighter from "react-syntax-highlighter/dist/cjs/prism-light
 import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript";
 import jsx from "react-syntax-highlighter/dist/cjs/languages/prism/jsx";
 import { docco } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { oneLight as oneLightCjs, oneDark as oneDarkCjs } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { coldarkCold, coldarkDark, oneLight, oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import createElement from "react-syntax-highlighter/dist/esm/create-element";
 
@@ -120,7 +121,9 @@ const TestComponent: React.FC = () => <div>Hello world</div>;
 <PrismLightHighlighter style={docco}>{codeString}</PrismLightHighlighter>;
 <PrismLightHighlighter style={oneDark}>{codeString}</PrismLightHighlighter>;
 <PrismLightHighlighter style={oneLight}>{codeString}</PrismLightHighlighter>;
-<PrismLightHighlighter style={{ keyword: { color: "red" } }}>{codeString}</PrismLightHighlighter>;
+<PrismLightHighlighter style={oneDarkCjs}>{codeString}</PrismLightHighlighter>;
+<PrismLightHighlighter style={oneLightCjs}>{codeString}</PrismLightHighlighter>;
+<PrismLightHighlighter style={{ keyword: { color: 'red' } }}>{codeString}</PrismLightHighlighter>;
 // @ts-expect-error
 <PrismLightHighlighter style={{ color: "red" }}>{codeString}</PrismLightHighlighter>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [one-dark](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/prism/one-dark.js)
  - [one-light](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/prism/one-light.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.