### PR TITLE
ramda - improve pick() output type readability

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3967,10 +3967,10 @@ export function pathSatisfies<T, U>(pred: (val: T) => boolean): _.F.Curry<(a: Pa
 export function pick<T, K extends string | number | symbol>(
     names: readonly K[],
     obj: T,
-): Pick<T, Exclude<keyof T, Exclude<keyof T, K>>>;
+): { [P in keyof T as P extends K ? P : never]: T[P] };
 export function pick<K extends string | number | symbol>(
     names: readonly K[],
-): <T>(obj: T) => Pick<T, Exclude<keyof T, Exclude<keyof T, K>>>;
+): <T>(obj: T) => { [P in keyof T as P extends K ? P : never]: T[P] };
 
 /**
  * Similar to `pick` except that this one includes a `key: undefined` pair for properties that don't exist.

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -3964,13 +3964,33 @@ export function pathSatisfies<T, U>(pred: (val: T) => boolean): _.F.Curry<(a: Pa
  * R.pick(['a', 'e', 'f'], {a: 1, b: 2, c: 3, d: 4}); //=> {a: 1}
  * ```
  */
+export function pick<T extends readonly [any, ...any], K extends string | number | symbol>(
+    names: readonly K[],
+    array: T,
+): {
+    [P in K as P extends string | number
+        ? _.N.Greater<`${T['length']}`, `${P}`> extends 1
+            ? P
+            : never
+        : never]: P extends keyof T ? T[P] : T[number];
+};
 export function pick<T, K extends string | number | symbol>(
     names: readonly K[],
     obj: T,
 ): { [P in keyof T as P extends K ? P : never]: T[P] };
 export function pick<K extends string | number | symbol>(
     names: readonly K[],
-): <T>(obj: T) => { [P in keyof T as P extends K ? P : never]: T[P] };
+): <T extends readonly [any, ...any] | object>(
+    obj: T,
+) => T extends readonly [any, ...any]
+    ? {
+          [P in K as P extends string | number
+              ? _.N.Greater<`${T['length']}`, `${P}`> extends 1
+                  ? P
+                  : never
+              : never]: P extends keyof T ? T[P] : T[number];
+      }
+    : { [P in keyof T as P extends K ? P : never]: T[P] };
 
 /**
  * Similar to `pick` except that this one includes a `key: undefined` pair for properties that don't exist.

--- a/types/ramda/test/pick-tests.ts
+++ b/types/ramda/test/pick-tests.ts
@@ -1,12 +1,28 @@
 import * as R from 'ramda';
 
 () => {
-    const a1 = R.pick(['a', 'd'], { a: 1, b: 2, c: 3, d: 4 }); // => {a: 1, d: 4}
-    const a2 = R.pick(['a', 'e', 'f'], { a: 1, b: 2, c: 3, d: 4 }); // => {a: 1}
-    const a3 = R.pick(['a', 'e', 'f'])({ a: 1, b: 2, c: 3, d: 4 }); // => {a: 1}
-    const a4 = R.pick(['a', 'e', 'f'], [1, 2, 3, 4]); // => {}
-    const a5 = R.pick([1, 2], ['a', 'b', 'c', 'd']); // => {1: 'b', 2: 'c'}
+    const a10: { a: number; d: number } = R.pick(['a', 'd'], { a: 1, b: 2, c: 3, d: 4 }); // => {a: 1, d: 4}
+    const a11: { a: 1; d: 4 } = R.pick(['a', 'd'], { a: 1, b: 2, c: 3, d: 4 } as const); // => {a: 1, d: 4}
+
+    const a20: { a: number } = R.pick(['a', 'e', 'f'], { a: 1, b: 2, c: 3, d: 4 }); // => {a: 1}
+    const a21_const: { a: 1 } = R.pick(['a', 'e', 'f'], { a: 1, b: 2, c: 3, d: 4 } as const); // => {a: 1}
+
+    const a30: { a: number } = R.pick(['a', 'e', 'f'])({ a: 1, b: 2, c: 3, d: 4 }); // => {a: 1}
+    const a31: { a: 1 } = R.pick(['a', 'e', 'f'])({ a: 1, b: 2, c: 3, d: 4 } as const); // => {a: 1}
+
+    const a40: {} = R.pick(['a', 'e', 'f'], [1, 2, 3, 4]); // => {}
+
+    const a50: { 1: string; 2: string } = R.pick([1, 2], ['a', 'b', 'c', 'd']); // => {1: 'b', 2: 'c'}
+    const a51: { 1: 'b'; 2: 'c' } = R.pick([1, 2], ['a', 'b', 'c', 'd'] as const); // => {1: 'b', 2: 'c'}
+    const a52: { 0: string } = R.pick([12, 0], ['a', 'b', 'c', 'd']); // => {0: 'a'}
+    const a53: { 0: 'a' } = R.pick([12, 0], ['a', 'b', 'c', 'd'] as const); // => {0: 'a'}
+
+    const a60: { 1: string; 2: string } = R.pick([1, 2])(['a', 'b', 'c', 'd']); // => {1: 'b', 2: 'c'}
+    const a61: { 1: 'b'; 2: 'c' } = R.pick([1, 2])(['a', 'b', 'c', 'd'] as const); // => {1: 'b', 2: 'c'}
+    const a62: { 0: string } = R.pick([12, 0])(['a', 'b', 'c', 'd']); // => {0: 'a'}
+    const a63: { 0: 'a' } = R.pick([12, 0])(['a', 'b', 'c', 'd'] as const); // => {0: 'a'}
 
     const s = Symbol('s');
-    const a6 = R.pick([s], { [s]: 'a' }); // => {Symbol(s): 'a'}
+    const a7: { [s]: string } = R.pick([s], { [s]: 'a' }); // => {Symbol(s): 'a'}
+    const a7_const: { [s]: 'a' } = R.pick([s], { [s]: 'a' } as const); // => {Symbol(s): 'a'}
 };

--- a/types/ramda/test/pick-tests.ts
+++ b/types/ramda/test/pick-tests.ts
@@ -1,28 +1,32 @@
 import * as R from 'ramda';
 
 () => {
+    const abcdObj: { a: 1; b: 2; c: 3; d: 4 } = { a: 1, b: 2, c: 3, d: 4 };
+
     const a10: { a: number; d: number } = R.pick(['a', 'd'], { a: 1, b: 2, c: 3, d: 4 }); // => {a: 1, d: 4}
-    const a11: { a: 1; d: 4 } = R.pick(['a', 'd'], { a: 1, b: 2, c: 3, d: 4 } as const); // => {a: 1, d: 4}
+    const a11: { a: 1; d: 4 } = R.pick(['a', 'd'], abcdObj); // => {a: 1, d: 4}
 
     const a20: { a: number } = R.pick(['a', 'e', 'f'], { a: 1, b: 2, c: 3, d: 4 }); // => {a: 1}
-    const a21_const: { a: 1 } = R.pick(['a', 'e', 'f'], { a: 1, b: 2, c: 3, d: 4 } as const); // => {a: 1}
+    const a21: { a: 1 } = R.pick(['a', 'e', 'f'], abcdObj); // => {a: 1}
 
     const a30: { a: number } = R.pick(['a', 'e', 'f'])({ a: 1, b: 2, c: 3, d: 4 }); // => {a: 1}
-    const a31: { a: 1 } = R.pick(['a', 'e', 'f'])({ a: 1, b: 2, c: 3, d: 4 } as const); // => {a: 1}
+    const a31: { a: 1 } = R.pick(['a', 'e', 'f'])(abcdObj); // => {a: 1}
 
     const a40: {} = R.pick(['a', 'e', 'f'], [1, 2, 3, 4]); // => {}
 
+    const abcdTuple: ['a', 'b', 'c', 'd'] = ['a', 'b', 'c', 'd'];
     const a50: { 1: string; 2: string } = R.pick([1, 2], ['a', 'b', 'c', 'd']); // => {1: 'b', 2: 'c'}
-    const a51: { 1: 'b'; 2: 'c' } = R.pick([1, 2], ['a', 'b', 'c', 'd'] as const); // => {1: 'b', 2: 'c'}
+    const a51: { 1: 'b'; 2: 'c' } = R.pick([1, 2], abcdTuple); // => {1: 'b', 2: 'c'}
     const a52: { 0: string } = R.pick([12, 0], ['a', 'b', 'c', 'd']); // => {0: 'a'}
-    const a53: { 0: 'a' } = R.pick([12, 0], ['a', 'b', 'c', 'd'] as const); // => {0: 'a'}
+    const a53: { 0: 'a' } = R.pick([12, 0], abcdTuple); // => {0: 'a'}
 
     const a60: { 1: string; 2: string } = R.pick([1, 2])(['a', 'b', 'c', 'd']); // => {1: 'b', 2: 'c'}
-    const a61: { 1: 'b'; 2: 'c' } = R.pick([1, 2])(['a', 'b', 'c', 'd'] as const); // => {1: 'b', 2: 'c'}
+    const a61: { 1: 'b'; 2: 'c' } = R.pick([1, 2])(abcdTuple); // => {1: 'b', 2: 'c'}
     const a62: { 0: string } = R.pick([12, 0])(['a', 'b', 'c', 'd']); // => {0: 'a'}
-    const a63: { 0: 'a' } = R.pick([12, 0])(['a', 'b', 'c', 'd'] as const); // => {0: 'a'}
+    const a63: { 0: 'a' } = R.pick([12, 0])(abcdTuple); // => {0: 'a'}
 
     const s = Symbol('s');
+    const sObj: { [s]: 'a' } = { [s]: 'a' };
     const a7: { [s]: string } = R.pick([s], { [s]: 'a' }); // => {Symbol(s): 'a'}
-    const a7_const: { [s]: 'a' } = R.pick([s], { [s]: 'a' } as const); // => {Symbol(s): 'a'}
+    const a7_const: { [s]: 'a' } = R.pick([s], sObj); // => {Symbol(s): 'a'}
 };


### PR DESCRIPTION
When reading a question about `pick()`:
https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63571
I saw an opportunity to improve output type readability.

For example, `pick(["annie"], { annie: true, bob: true })` currently outputs:
`Pick<{ annie: boolean, bob: boolean }, "annie">`
With this PR, it will now output:
`{ annie: boolean }`