### PR TITLE
[node] Adds isBuiltin method to Node Module

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -85,6 +85,7 @@ declare module 'module' {
         static wrap(code: string): string;
         static createRequire(path: string | URL): NodeRequire;
         static builtinModules: string[];
+        static isBuiltin(moduleName: string): boolean;
         static Module: typeof Module;
         constructor(id: string, parent?: Module);
     }

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -1,12 +1,12 @@
 import Module = require('node:module');
 import { URL } from 'node:url';
-require.extensions[".ts"] = () => "";
+require.extensions['.ts'] = () => '';
 
 Module.runMain();
-const s: string = Module.wrap("some code");
+const s: string = Module.wrap('some code');
 
-const m1: Module = new Module("moduleId");
-const m2: Module = new Module("moduleId");
+const m1: Module = new Module('moduleId');
+const m2: Module = new Module('moduleId');
 const b: string[] = Module.builtinModules;
 let paths: string[] = [];
 paths = m1.paths;
@@ -17,10 +17,11 @@ let rf: (m: string) => any;
 rf = Module.createRequire('mod');
 rf = Module.createRequire(new URL('file:///C:/path/'));
 
-const aModule: NodeModule = new Module("s");
-const bModule: NodeModule = new Module("b", aModule);
+const aModule: NodeModule = new Module('s');
+const bModule: NodeModule = new Module('b', aModule);
 
 const builtIn: string[] = Module.builtinModules;
+const builtinResult: boolean = Module.isBuiltin('node:fs');
 
 const customRequire2 = Module.createRequire('node:./test');
 
@@ -28,7 +29,7 @@ customRequire2('test');
 
 const resolved2: string = customRequire2.resolve('test');
 
-const paths2: string[] | null  = customRequire2.resolve.paths('test');
+const paths2: string[] | null = customRequire2.resolve.paths('test');
 
 const cachedModule2: Module | undefined = customRequire2.cache['/path/to/module.js'];
 

--- a/types/node/ts4.8/module.d.ts
+++ b/types/node/ts4.8/module.d.ts
@@ -85,6 +85,7 @@ declare module 'module' {
         static wrap(code: string): string;
         static createRequire(path: string | URL): NodeRequire;
         static builtinModules: string[];
+        static isBuiltin(moduleName: string): boolean;
         static Module: typeof Module;
         constructor(id: string, parent?: Module);
     }

--- a/types/node/ts4.8/test/module.ts
+++ b/types/node/ts4.8/test/module.ts
@@ -1,12 +1,12 @@
 import Module = require('node:module');
 import { URL } from 'node:url';
-require.extensions[".ts"] = () => "";
+require.extensions['.ts'] = () => '';
 
 Module.runMain();
-const s: string = Module.wrap("some code");
+const s: string = Module.wrap('some code');
 
-const m1: Module = new Module("moduleId");
-const m2: Module = new Module("moduleId");
+const m1: Module = new Module('moduleId');
+const m2: Module = new Module('moduleId');
 const b: string[] = Module.builtinModules;
 let paths: string[] = [];
 paths = m1.paths;
@@ -17,10 +17,11 @@ let rf: (m: string) => any;
 rf = Module.createRequire('mod');
 rf = Module.createRequire(new URL('file:///C:/path/'));
 
-const aModule: NodeModule = new Module("s");
-const bModule: NodeModule = new Module("b", aModule);
+const aModule: NodeModule = new Module('s');
+const bModule: NodeModule = new Module('b', aModule);
 
 const builtIn: string[] = Module.builtinModules;
+const builtinResult: boolean = Module.isBuiltin('node:fs');
 
 const customRequire2 = Module.createRequire('node:./test');
 
@@ -28,7 +29,7 @@ customRequire2('test');
 
 const resolved2: string = customRequire2.resolve('test');
 
-const paths2: string[] | null  = customRequire2.resolve.paths('test');
+const paths2: string[] | null = customRequire2.resolve.paths('test');
 
 const cachedModule2: Module | undefined = customRequire2.cache['/path/to/module.js'];
 

--- a/types/node/v16/module.d.ts
+++ b/types/node/v16/module.d.ts
@@ -85,6 +85,7 @@ declare module 'module' {
         static wrap(code: string): string;
         static createRequire(path: string | URL): NodeRequire;
         static builtinModules: string[];
+        static isBuiltin(moduleName: string): boolean;
         static Module: typeof Module;
         constructor(id: string, parent?: Module);
     }

--- a/types/node/v16/test/module.ts
+++ b/types/node/v16/test/module.ts
@@ -1,12 +1,12 @@
 import Module = require('node:module');
 import { URL } from 'node:url';
-require.extensions[".ts"] = () => "";
+require.extensions['.ts'] = () => '';
 
 Module.runMain();
-const s: string = Module.wrap("some code");
+const s: string = Module.wrap('some code');
 
-const m1: Module = new Module("moduleId");
-const m2: Module = new Module("moduleId");
+const m1: Module = new Module('moduleId');
+const m2: Module = new Module('moduleId');
 const b: string[] = Module.builtinModules;
 let paths: string[] = [];
 paths = m1.paths;
@@ -17,10 +17,11 @@ let rf: (m: string) => any;
 rf = Module.createRequire('mod');
 rf = Module.createRequire(new URL('file:///C:/path/'));
 
-const aModule: NodeModule = new Module("s");
-const bModule: NodeModule = new Module("b", aModule);
+const aModule: NodeModule = new Module('s');
+const bModule: NodeModule = new Module('b', aModule);
 
 const builtIn: string[] = Module.builtinModules;
+const builtinResult: boolean = Module.isBuiltin('node:fs');
 
 const customRequire2 = Module.createRequire('node:./test');
 
@@ -28,7 +29,7 @@ customRequire2('test');
 
 const resolved2: string = customRequire2.resolve('test');
 
-const paths2: string[] | null  = customRequire2.resolve.paths('test');
+const paths2: string[] | null = customRequire2.resolve.paths('test');
 
 const cachedModule2: Module | undefined = customRequire2.cache['/path/to/module.js'];
 

--- a/types/node/v16/ts4.8/module.d.ts
+++ b/types/node/v16/ts4.8/module.d.ts
@@ -85,6 +85,7 @@ declare module 'module' {
         static wrap(code: string): string;
         static createRequire(path: string | URL): NodeRequire;
         static builtinModules: string[];
+        static isBuiltin(moduleName: string): boolean;
         static Module: typeof Module;
         constructor(id: string, parent?: Module);
     }

--- a/types/node/v16/ts4.8/test/module.ts
+++ b/types/node/v16/ts4.8/test/module.ts
@@ -1,12 +1,12 @@
 import Module = require('node:module');
 import { URL } from 'node:url';
-require.extensions[".ts"] = () => "";
+require.extensions['.ts'] = () => '';
 
 Module.runMain();
-const s: string = Module.wrap("some code");
+const s: string = Module.wrap('some code');
 
-const m1: Module = new Module("moduleId");
-const m2: Module = new Module("moduleId");
+const m1: Module = new Module('moduleId');
+const m2: Module = new Module('moduleId');
 const b: string[] = Module.builtinModules;
 let paths: string[] = [];
 paths = m1.paths;
@@ -17,10 +17,11 @@ let rf: (m: string) => any;
 rf = Module.createRequire('mod');
 rf = Module.createRequire(new URL('file:///C:/path/'));
 
-const aModule: NodeModule = new Module("s");
-const bModule: NodeModule = new Module("b", aModule);
+const aModule: NodeModule = new Module('s');
+const bModule: NodeModule = new Module('b', aModule);
 
 const builtIn: string[] = Module.builtinModules;
+const builtinResult: boolean = Module.isBuiltin('node:fs');
 
 const customRequire2 = Module.createRequire('node:./test');
 
@@ -28,7 +29,7 @@ customRequire2('test');
 
 const resolved2: string = customRequire2.resolve('test');
 
-const paths2: string[] | null  = customRequire2.resolve.paths('test');
+const paths2: string[] | null = customRequire2.resolve.paths('test');
 
 const cachedModule2: Module | undefined = customRequire2.cache['/path/to/module.js'];
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/module.html#moduleisbuiltinmodulename
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 

This method was added in Node v18.6.0 and v16.17.0. I'm not sure what to do about version numbers.

My auto formatting in my IDE has changed double quotes to single quotes and fixes some whitespace in the test files. I have left this in the change since it follows the project's `.prettierrc.json`. Please let me know if you'd rather I revert those parts of the change.
