### PR TITLE
[yargs] add missing types to esm from cjs

### DIFF
--- a/types/yargs/index.d.mts
+++ b/types/yargs/index.d.mts
@@ -20,6 +20,7 @@ export type {
     ParserConfigurationOptions,
     Argv,
     Arguments,
+    ArgumentsCamelCase,
     RequireDirectoryOptions,
     Options,
     PositionalOptions,
@@ -37,7 +38,9 @@ export type {
     SyncCompletionFunction,
     AsyncCompletionFunction,
     PromiseCompletionFunction,
+    FallbackCompletionFunction,
     MiddlewareFunction,
     Choices,
     PositionalOptionsType,
+    CompletionCallback,
 } from './index.js';


### PR DESCRIPTION
Some types who are available in cjs version are missing in esm version.
For the consistency, I'd like to import and export the types from cjs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
    - Since no tests for esm exist, there is nothing to be reflected.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - ArgumentsCamelCase: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/yargs/index.d.ts#L675-L683
   - FallbackCompletionFunction: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/yargs/index.d.ts#L928
   - CompletionCallback: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/yargs/index.d.ts#L932
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.