### PR TITLE
[ssh2] Update styles and add additional SFTP status codes

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ssh2 v1.11
+// Type definitions for ssh2 1.11
 // Project: https://github.com/mscdex/ssh2
 // Definitions by: Qubo <https://github.com/tkQubo>
 //                 Ron Buckton <https://github.com/rbuckton>
@@ -12,11 +12,11 @@
 
 /// <reference types="node" />
 
-import { Duplex, Writable, Readable, ReadableOptions, WritableOptions } from "stream";
-import { EventEmitter } from "events";
-import { Socket, Server as NetServer } from "net";
-import { Agent as BaseHTTPAgent, AgentOptions } from "http";
-import { Agent as BaseHTTPSAgent } from "https";
+import { Duplex, Writable, Readable, ReadableOptions, WritableOptions } from 'stream';
+import { EventEmitter } from 'events';
+import { Socket, Server as NetServer } from 'net';
+import { Agent as BaseHTTPAgent, AgentOptions } from 'http';
+import { Agent as BaseHTTPSAgent } from 'https';
 
 export interface Prompt {
     prompt: string;
@@ -26,68 +26,72 @@ export interface Prompt {
 /**
  * Possible Key Exchange Algorithms
  */
-export type KexAlgorithm = "curve25519-sha256"
-    | "curve25519-sha256@libssh.org"
-    | "ecdh-sha2-nistp256"
-    | "ecdh-sha2-nistp384"
-    | "ecdh-sha2-nistp521"
-    | "diffie-hellman-group-exchange-sha256"
-    | "diffie-hellman-group14-sha256"
-    | "diffie-hellman-group15-sha512"
-    | "diffie-hellman-group16-sha512"
-    | "diffie-hellman-group17-sha512"
-    | "diffie-hellman-group18-sha512"
-    | "diffie-hellman-group-exchange-sha1"
-    | "diffie-hellman-group14-sha1"
-    | "diffie-hellman-group1-sha1";
+export type KexAlgorithm =
+    | 'curve25519-sha256'
+    | 'curve25519-sha256@libssh.org'
+    | 'ecdh-sha2-nistp256'
+    | 'ecdh-sha2-nistp384'
+    | 'ecdh-sha2-nistp521'
+    | 'diffie-hellman-group-exchange-sha256'
+    | 'diffie-hellman-group14-sha256'
+    | 'diffie-hellman-group15-sha512'
+    | 'diffie-hellman-group16-sha512'
+    | 'diffie-hellman-group17-sha512'
+    | 'diffie-hellman-group18-sha512'
+    | 'diffie-hellman-group-exchange-sha1'
+    | 'diffie-hellman-group14-sha1'
+    | 'diffie-hellman-group1-sha1';
 
-export type ServerHostKeyAlgorithm = "ssh-ed25519"
-    | "ecdsa-sha2-nistp256"
-    | "ecdsa-sha2-nistp384"
-    | "ecdsa-sha2-nistp521"
-    | "rsa-sha2-512"
-    | "rsa-sha2-256"
-    | "ssh-rsa"
-    | "ssh-dss";
+export type ServerHostKeyAlgorithm =
+    | 'ssh-ed25519'
+    | 'ecdsa-sha2-nistp256'
+    | 'ecdsa-sha2-nistp384'
+    | 'ecdsa-sha2-nistp521'
+    | 'rsa-sha2-512'
+    | 'rsa-sha2-256'
+    | 'ssh-rsa'
+    | 'ssh-dss';
 
-export type CompressionAlgorithm = "none" | "zlib" | "zlib@openssh.com";
+export type CompressionAlgorithm = 'none' | 'zlib' | 'zlib@openssh.com';
 
-export type CipherAlgorithm = "chacha20-poly1305@openssh.com"
-    | "aes128-gcm"
-    | "aes128-gcm@openssh.com"
-    | "aes256-gcm"
-    | "aes256-gcm@openssh.com"
-    | "aes128-ctr"
-    | "aes192-ctr"
-    | "aes256-ctr"
-    | "aes256-cbc"
-    | "aes192-cbc"
-    | "aes128-cbc"
-    | "blowfish-cbc"
-    | "3des-cbc"
-    | "arcfour256"
-    | "arcfour128"
-    | "cast128-cbc"
-    | "arcfour";
+export type CipherAlgorithm =
+    | 'chacha20-poly1305@openssh.com'
+    | 'aes128-gcm'
+    | 'aes128-gcm@openssh.com'
+    | 'aes256-gcm'
+    | 'aes256-gcm@openssh.com'
+    | 'aes128-ctr'
+    | 'aes192-ctr'
+    | 'aes256-ctr'
+    | 'aes256-cbc'
+    | 'aes192-cbc'
+    | 'aes128-cbc'
+    | 'blowfish-cbc'
+    | '3des-cbc'
+    | 'arcfour256'
+    | 'arcfour128'
+    | 'cast128-cbc'
+    | 'arcfour';
 
-export type MacAlgorithm = "hmac-sha2-256-etm@openssh.com"
-    | "hmac-sha2-512-etm@openssh.com"
-    | "hmac-sha1-etm@openssh.com"
-    | "hmac-sha2-256"
-    | "hmac-sha2-512"
-    | "hmac-sha1"
-    | "hmac-md5"
-    | "hmac-sha2-256-96"
-    | "hmac-sha2-512-96"
-    | "hmac-ripemd160"
-    | "hmac-sha1-96"
-    | "hmac-md5-96"
+export type MacAlgorithm =
+    | 'hmac-sha2-256-etm@openssh.com'
+    | 'hmac-sha2-512-etm@openssh.com'
+    | 'hmac-sha1-etm@openssh.com'
+    | 'hmac-sha2-256'
+    | 'hmac-sha2-512'
+    | 'hmac-sha1'
+    | 'hmac-md5'
+    | 'hmac-sha2-256-96'
+    | 'hmac-sha2-512-96'
+    | 'hmac-ripemd160'
+    | 'hmac-sha1-96'
+    | 'hmac-md5-96';
 
 /**
  * Lists of supported algorithms can either be an ordered array of all supported algorithms,
  * OR a map of algorithms to manipulate the default list
  */
-export type AlgorithmList<T> = T[] | Record<"append" | "prepend" | "remove", T | T[]>;
+export type AlgorithmList<T> = T[] | Record<'append' | 'prepend' | 'remove', T | T[]>;
 
 /**
  * Overrides for the default transport layer algorithms used for the connection.
@@ -102,7 +106,13 @@ export interface Algorithms {
     compress?: AlgorithmList<CompressionAlgorithm>;
 }
 
-export type KeyType = 'ssh-rsa' | 'ssh-dss' | 'ssh-ed25519' | 'ecdsa-sha2-nistp256' | 'ecdsa-sha2-nistp384' | 'ecdsa-sha2-nistp521';
+export type KeyType =
+    | 'ssh-rsa'
+    | 'ssh-dss'
+    | 'ssh-ed25519'
+    | 'ecdsa-sha2-nistp256'
+    | 'ecdsa-sha2-nistp384'
+    | 'ecdsa-sha2-nistp521';
 
 export interface ParsedKey {
     type: KeyType;
@@ -150,7 +160,7 @@ export interface Header {
     greeting?: string;
 }
 
-export type OpenMode = "r" | "r+" | "w" | "wx" | "xw" | "w+" | "xw+" | "a" | "ax" | "xa" | "a+" | "ax+" | "xa+";
+export type OpenMode = 'r' | 'r+' | 'w' | 'wx' | 'xw' | 'w+' | 'xw+' | 'a' | 'ax' | 'xa' | 'a+' | 'ax+' | 'xa+';
 
 export namespace utils {
     function parseKey(data: Buffer | string | ParsedKey, passphrase?: Buffer | string): ParsedKey | Error;
@@ -161,7 +171,7 @@ export namespace utils {
             APPEND = 0x00000004,
             CREAT = 0x00000008,
             TRUNC = 0x00000010,
-            EXCL = 0x00000020
+            EXCL = 0x00000020,
         }
 
         enum STATUS_CODE {
@@ -196,7 +206,7 @@ export namespace utils {
             FILE_CORRUPT = 28,
             OWNER_INVALID = 29,
             GROUP_INVALID = 30,
-            NO_MATCHING_BYTE_RANGE_LOCK = 31
+            NO_MATCHING_BYTE_RANGE_LOCK = 31,
         }
 
         function stringToFlags(str: OpenMode): number | null;
@@ -204,9 +214,9 @@ export namespace utils {
     }
 }
 
-export type ChannelType = "session" | "sftp" | "direct-tcpip" | "direct-streamlocal@openssh.com";
+export type ChannelType = 'session' | 'sftp' | 'direct-tcpip' | 'direct-streamlocal@openssh.com';
 
-export type ChannelSubType = "exec" | "shell";
+export type ChannelSubType = 'exec' | 'shell';
 
 export interface Channel extends Duplex {
     /** Standard input for the Channel. */
@@ -250,9 +260,9 @@ export interface Channel extends Duplex {
     /**
      * Emitted once the channel is completely closed on both the client and the server.
      */
-    on(event: "close", listener: () => void): this;
-    on(event: "eof", listener: () => void): this;
-    on(event: "end", listener: () => void): this;
+    on(event: 'close', listener: () => void): this;
+    on(event: 'eof', listener: () => void): this;
+    on(event: 'end', listener: () => void): this;
     on(event: string | symbol, listener: Function): this;
 }
 
@@ -267,8 +277,8 @@ export interface ClientChannel extends Channel {
      * finishes. If the process finished normally, the process's return value is passed to
      * the `exit` callback.
      */
-    on(event: "exit", listener: (code: string) => void): this;
-    on(event: "exit", listener: (code: null, signal: string, dump: string, desc: string) => void): this;
+    on(event: 'exit', listener: (code: string) => void): this;
+    on(event: 'exit', listener: (code: null, signal: string, dump: string, desc: string) => void): this;
     on(event: string | symbol, listener: Function): this;
 }
 
@@ -289,12 +299,12 @@ export class Client extends EventEmitter {
     /**
      * Emitted when a notice was sent by the server upon connection.
      */
-    on(event: "banner", listener: (message: string) => void): this;
+    on(event: 'banner', listener: (message: string) => void): this;
 
     /**
      * Emitted when authentication was successful.
      */
-    on(event: "ready", listener: () => void): this;
+    on(event: 'ready', listener: () => void): this;
 
     /**
      * Emitted when an incoming forwarded TCP connection is being requested.
@@ -302,7 +312,14 @@ export class Client extends EventEmitter {
      * Calling `accept()` accepts the connection and returns a `Channel` object.
      * Calling `reject()` rejects the connection and no further action is needed.
      */
-    on(event: "tcp connection", listener: (details: TcpConnectionDetails, accept: AcceptConnection<ClientChannel>, reject: RejectConnection) => void): this;
+    on(
+        event: 'tcp connection',
+        listener: (
+            details: TcpConnectionDetails,
+            accept: AcceptConnection<ClientChannel>,
+            reject: RejectConnection,
+        ) => void,
+    ): this;
 
     /**
      * Emitted when an incoming X11 connection is being requested.
@@ -310,7 +327,10 @@ export class Client extends EventEmitter {
      * Calling `accept()` accepts the connection and returns a `Channel` object.
      * Calling `reject()` rejects the connection and no further action is needed.
      */
-    on(event: "x11", listener: (details: X11Details, accept: AcceptConnection<ClientChannel>, reject: RejectConnection) => void): this;
+    on(
+        event: 'x11',
+        listener: (details: X11Details, accept: AcceptConnection<ClientChannel>, reject: RejectConnection) => void,
+    ): this;
 
     /**
      * Emitted when the server is asking for replies to the given `prompts` for keyboard-
@@ -324,7 +344,16 @@ export class Client extends EventEmitter {
      *
      * NOTE: It's possible for the server to come back and ask more questions.
      */
-    on(event: "keyboard-interactive", listener: (name: string, instructions: string, lang: string, prompts: Prompt[], finish: KeyboardInteractiveCallback) => void): this;
+    on(
+        event: 'keyboard-interactive',
+        listener: (
+            name: string,
+            instructions: string,
+            lang: string,
+            prompts: Prompt[],
+            finish: KeyboardInteractiveCallback,
+        ) => void,
+    ): this;
 
     /**
      * Emitted when the server has requested that the user's password be changed, if using
@@ -332,52 +361,55 @@ export class Client extends EventEmitter {
      *
      * Call `done` with the new password.
      */
-    on(event: "change password", listener: (message: string, done: ChangePasswordCallback) => void): this;
+    on(event: 'change password', listener: (message: string, done: ChangePasswordCallback) => void): this;
 
     /**
      * Emitted when an error occurred.
      */
-    on(event: "error", listener: (err: Error & ClientErrorExtensions) => void): this;
+    on(event: 'error', listener: (err: Error & ClientErrorExtensions) => void): this;
 
     /**
      * Emitted when the socket was disconnected.
      */
-    on(event: "end", listener: () => void): this;
+    on(event: 'end', listener: () => void): this;
 
     /**
      * Emitted when the socket was closed.
      */
-    on(event: "close", listener: () => void): this;
+    on(event: 'close', listener: () => void): this;
 
     /**
      * Emitted when the socket has timed out.
      */
-    on(event: "timeout", listener: () => void): this;
+    on(event: 'timeout', listener: () => void): this;
 
     /**
      * Emitted when the socket has connected.
      */
-    on(event: "connect", listener: () => void): this;
+    on(event: 'connect', listener: () => void): this;
 
     /**
      * Emitted when the server responds with a greeting message.
      */
-    on(event: "greeting", listener: (greeting: string) => void): this;
+    on(event: 'greeting', listener: (greeting: string) => void): this;
 
     /**
      * Emitted when a handshake has completed (either initial or rekey).
      */
-    on(event: "handshake", listener: (negotiated: NegotiatedAlgorithms) => void): this;
+    on(event: 'handshake', listener: (negotiated: NegotiatedAlgorithms) => void): this;
 
     /**
      * Emitted when the server announces its available host keys.
      */
-    on(event: "hostkeys", listener: (keys: ParsedKey[]) => void): this;
+    on(event: 'hostkeys', listener: (keys: ParsedKey[]) => void): this;
 
     /**
      * An incoming forwarded UNIX socket connection is being requested.
      */
-    on(event: "unix connection", listener: (info: UNIXConnectionDetails, accept: AcceptConnection, reject: RejectConnection) => void): this;
+    on(
+        event: 'unix connection',
+        listener: (info: UNIXConnectionDetails, accept: AcceptConnection, reject: RejectConnection) => void,
+    ): this;
 
     /**
      * Attempts a connection to a server.
@@ -529,7 +561,7 @@ export type SyncHostVerifier = (key: Buffer) => boolean;
 export type HostFingerprintVerifier = (fingerprint: string, verify: VerifyCallback) => boolean;
 export type SyncHostFingerprintVerifier = (fingerprint: string) => boolean;
 export type DebugFunction = (message: string) => void;
-export type AuthenticationType = "password" | "publickey" | "hostbased" | "agent" | "keyboard-interactive" | "none";
+export type AuthenticationType = 'password' | 'publickey' | 'hostbased' | 'agent' | 'keyboard-interactive' | 'none';
 
 export interface ConnectConfig {
     /** Hostname or IP address of the server. */
@@ -597,14 +629,14 @@ export interface AuthMethod {
  * Strategy returned from the {@link ConnectConfig.authHandler} to connect without authentication.
  */
 export interface NoAuthMethod extends AuthMethod {
-    type: "none";
+    type: 'none';
 }
 
 /**
  * Strategy returned from the {@link ConnectConfig.authHandler} to connect with a password.
  */
 export interface PasswordAuthMethod extends AuthMethod {
-    type: "password";
+    type: 'password';
     password: string;
 }
 
@@ -612,7 +644,7 @@ export interface PasswordAuthMethod extends AuthMethod {
  * Strategy returned from the {@link ConnectConfig.authHandler} to connect with a public key.
  */
 export interface PublicKeyAuthMethod extends AuthMethod {
-    type: "publickey";
+    type: 'publickey';
     key: ParsedKey | Buffer | string;
     passphrase?: Buffer | string;
 }
@@ -621,7 +653,7 @@ export interface PublicKeyAuthMethod extends AuthMethod {
  * Strategy returned from the {@link ConnectConfig.authHandler} to connect with host-based authentication.
  */
 export interface HostBasedAuthMethod extends AuthMethod {
-    type: "hostbased";
+    type: 'hostbased';
     localHostname: string;
     localUsername: string;
     /**
@@ -638,7 +670,7 @@ export interface HostBasedAuthMethod extends AuthMethod {
  * Strategy returned from the {@link ConnectConfig.authHandler} to connect with an agent.
  */
 export interface AgentAuthMethod extends AuthMethod {
-    type: "agent";
+    type: 'agent';
     /**
      * Can be a string that is interpreted exactly like the `agent` connection config
      * option or can be a custom agent object/instance that extends and implements `BaseAgent`
@@ -649,19 +681,35 @@ export interface AgentAuthMethod extends AuthMethod {
 /**
  * Strategy returned from the {@link ConnectConfig.authHandler} to connect with an agent.
  */
-export interface KeyboardInteractiveAuthMethod  extends AuthMethod {
-    type: "keyboard-interactive";
+export interface KeyboardInteractiveAuthMethod extends AuthMethod {
+    type: 'keyboard-interactive';
     /**
      * This works exactly the same way as a 'keyboard-interactive' client event handler
      */
-    prompt(name: string, instructions: string, lang: string, prompts: Prompt[], finish: KeyboardInteractiveCallback): void;
+    prompt(
+        name: string,
+        instructions: string,
+        lang: string,
+        prompts: Prompt[],
+        finish: KeyboardInteractiveCallback,
+    ): void;
 }
 
-export type AnyAuthMethod = NoAuthMethod | PasswordAuthMethod | HostBasedAuthMethod | PublicKeyAuthMethod | AgentAuthMethod | KeyboardInteractiveAuthMethod;
+export type AnyAuthMethod =
+    | NoAuthMethod
+    | PasswordAuthMethod
+    | HostBasedAuthMethod
+    | PublicKeyAuthMethod
+    | AgentAuthMethod
+    | KeyboardInteractiveAuthMethod;
 
 export type NextAuthHandler = (authName: AuthenticationType | AnyAuthMethod) => void;
 
-export type AuthHandlerMiddleware = (authsLeft: AuthenticationType[], partialSuccess: boolean, next: NextAuthHandler) => void;
+export type AuthHandlerMiddleware = (
+    authsLeft: AuthenticationType[],
+    partialSuccess: boolean,
+    next: NextAuthHandler,
+) => void;
 
 export interface TcpConnectionDetails {
     /** The originating IP of the connection. */
@@ -738,7 +786,7 @@ export class Server extends NetServer {
     static KEEPALIVE_CLIENT_COUNT_MAX: number;
     constructor(cfg: ServerConfig, listener?: ServerConnectionListener);
     injectSocket(socket: Socket): void;
-    on(event: "connection", listener: ServerConnectionListener): this;
+    on(event: 'connection', listener: ServerConnectionListener): this;
     on(event: string | symbol, listener: Function): this;
 }
 
@@ -785,69 +833,91 @@ export interface Connection extends EventEmitter {
     /**
      * Emitted when the client has requested authentication.
      */
-    on(event: "authentication", listener: (context: AuthContext) => void): this;
+    on(event: 'authentication', listener: (context: AuthContext) => void): this;
 
     /**
      * Emitted when the client has been successfully authenticated.
      */
-    on(event: "ready", listener: () => void): this;
+    on(event: 'ready', listener: () => void): this;
 
     /**
      * Emitted when the client has requested a new session.
      * Sessions are used to start interactive shells, execute commands, request X11 forwarding, etc.
      */
-    on(event: "session", listener: (accept: AcceptConnection<Session>, reject: RejectConnection) => void): this;
+    on(event: 'session', listener: (accept: AcceptConnection<Session>, reject: RejectConnection) => void): this;
 
     /**
      * Emitted when the client has requested an outbound (TCP) connection.
      */
-    on(event: "tcpip", listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection, info: TcpipRequestInfo) => void): this;
+    on(
+        event: 'tcpip',
+        listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection, info: TcpipRequestInfo) => void,
+    ): this;
 
     /**
      * Emitted when the client has requested a connection to a UNIX domain socket.
      */
-    on(event: "openssh.streamlocal", listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection, info: SocketRequestInfo) => void): this;
+    on(
+        event: 'openssh.streamlocal',
+        listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection, info: SocketRequestInfo) => void,
+    ): this;
 
     /**
      * Emitted when the client has sent a global request for name.
      * If info.bindPort === 0, you should pass the chosen port to accept so that the client will know what port was bound.
      */
-    on(event: "request", listener: (accept: ((chosenPort?: number) => void) | undefined, reject: (() => void) | undefined, name: "tcpip-forward" | "cancel-tcpip-forward", info: TcpipBindInfo) => void): this;
+    on(
+        event: 'request',
+        listener: (
+            accept: ((chosenPort?: number) => void) | undefined,
+            reject: (() => void) | undefined,
+            name: 'tcpip-forward' | 'cancel-tcpip-forward',
+            info: TcpipBindInfo,
+        ) => void,
+    ): this;
 
     /**
      * Emitted when the client has sent a global request for name.
      */
-    on(event: "request", listener: (accept: (() => void) | undefined, reject: () => void, name: "streamlocal-forward@openssh.com" | "cancel-streamlocal-forward@openssh.com", info: SocketBindInfo) => void): this;
+    on(
+        event: 'request',
+        listener: (
+            accept: (() => void) | undefined,
+            reject: () => void,
+            name: 'streamlocal-forward@openssh.com' | 'cancel-streamlocal-forward@openssh.com',
+            info: SocketBindInfo,
+        ) => void,
+    ): this;
 
     /**
      * Emitted when the client has finished rekeying (either client or server initiated).
      */
-    on(event: "rekey", listener: () => void): this;
+    on(event: 'rekey', listener: () => void): this;
 
     /**
      * Emitted when an error occurrs.
      */
-    on(event: "error", listener: ErrorCallback): this;
+    on(event: 'error', listener: ErrorCallback): this;
 
     /**
      * Emitted when the socket has disconnected.
      */
-    on(event: "end", listener: () => void): this;
+    on(event: 'end', listener: () => void): this;
 
     /**
      * Emitted when the client socket was closed.
      */
-    on(event: "close", listener: () => void): this;
+    on(event: 'close', listener: () => void): this;
 
     /**
      * Emitted when the Alogrithms have been negotiated; emitted every time there is a rekey
      */
-    on(event: "handshake", listener: (negotiated: NegotiatedAlgorithms) => void): this;
+    on(event: 'handshake', listener: (negotiated: NegotiatedAlgorithms) => void): this;
 
     /**
      * Emitted if the server sends a greeting header
      */
-    on(event: "greeting", listener: (greeting: string) => void): this;
+    on(event: 'greeting', listener: (greeting: string) => void): this;
 
     noMoreSessions: boolean;
     authenticated: boolean;
@@ -868,7 +938,13 @@ export interface Connection extends EventEmitter {
      * Alert the client of an incoming TCP connection on `boundAddr` on port `boundPort` from
      * `remoteAddr` on port `remotePort`.
      */
-    forwardOut(boundAddr: string, boundPort: number, remoteAddr: string, remotePort: number, callback: ServerCallback): this;
+    forwardOut(
+        boundAddr: string,
+        boundPort: number,
+        remoteAddr: string,
+        remotePort: number,
+        callback: ServerCallback,
+    ): this;
 
     /**
      * Initiates a rekeying with the client.
@@ -908,12 +984,12 @@ export interface AuthContextBase extends EventEmitter {
     /**
      * Emitted when the client aborts the authentication request.
      */
-    on(event: "abort", listener: () => void): this;
+    on(event: 'abort', listener: () => void): this;
 }
 
 export interface KeyboardAuthContext extends AuthContextBase {
     /** The method of authentication. */
-    method: "keyboard-interactive";
+    method: 'keyboard-interactive';
 
     /** A list of preferred authentication "sub-methods" sent by the client. */
     submethods: string[];
@@ -940,12 +1016,17 @@ export interface KeyboardAuthContext extends AuthContextBase {
      * @param instructions Instructions for the client.
      * @param callback A callback to call with the responses from the client.
      */
-    prompt(prompts: string | Prompt | (string | Prompt)[], title: string, instructions: string, callback: KeyboardInteractiveCallback): void;
+    prompt(
+        prompts: string | Prompt | (string | Prompt)[],
+        title: string,
+        instructions: string,
+        callback: KeyboardInteractiveCallback,
+    ): void;
 }
 
 export interface PublicKeyAuthContext extends AuthContextBase {
     /** The method of authentication. */
-    method: "publickey";
+    method: 'publickey';
     /** The public key sent by the client. */
     key: PublicKey;
     /** The signature to verify, or `undefined` if the client is only checking the validity of the key. */
@@ -963,7 +1044,7 @@ export interface PublicKey {
 
 export interface HostbasedAuthContext extends AuthContextBase {
     /** The method of authentication. */
-    method: "hostbased";
+    method: 'hostbased';
     /** The public key sent by the client. */
     key: PublicKey;
     /** The signature to verify, or `undefined` if the client is only checking the validity of the key. */
@@ -978,7 +1059,7 @@ export interface HostbasedAuthContext extends AuthContextBase {
 
 export interface PasswordAuthContext extends AuthContextBase {
     /** The method of authentication. */
-    method: "password";
+    method: 'password';
     /** The password sent by the client. */
     password: string;
     requestChange(prompt: string, cb: ChangePasswordCallback): void;
@@ -986,10 +1067,15 @@ export interface PasswordAuthContext extends AuthContextBase {
 
 export interface NoneAuthContext extends AuthContextBase {
     /** The method of authentication. */
-    method: "none";
+    method: 'none';
 }
 
-export type AuthContext = KeyboardAuthContext | PublicKeyAuthContext | HostbasedAuthContext | PasswordAuthContext | NoneAuthContext;
+export type AuthContext =
+    | KeyboardAuthContext
+    | PublicKeyAuthContext
+    | HostbasedAuthContext
+    | PasswordAuthContext
+    | NoneAuthContext;
 
 export interface TcpipRequestInfo {
     /** Source IP address of outgoing connection. */
@@ -1030,52 +1116,61 @@ export interface Session extends ServerChannel {
     /**
      * Emitted when the client requested allocation of a pseudo-TTY for this session.
      */
-    on(event: "pty", listener: (accept: SessionAccept, reject: RejectConnection, info: PseudoTtyInfo) => void): this;
+    on(event: 'pty', listener: (accept: SessionAccept, reject: RejectConnection, info: PseudoTtyInfo) => void): this;
 
     /**
      * Emitted when the client reported a change in window dimensions during this session.
      */
-    on(event: "window-change", listener: (accept: SessionAccept, reject: RejectConnection, info: WindowChangeInfo) => void): this;
+    on(
+        event: 'window-change',
+        listener: (accept: SessionAccept, reject: RejectConnection, info: WindowChangeInfo) => void,
+    ): this;
 
     /**
      * Emitted when the client requested X11 forwarding.
      */
-    on(event: "x11", listener: (accept: SessionAccept, reject: RejectConnection, info: X11Info) => void): this;
+    on(event: 'x11', listener: (accept: SessionAccept, reject: RejectConnection, info: X11Info) => void): this;
 
     /**
      * Emitted when the client requested an environment variable to be set for this session.
      */
-    on(event: "env", listener: (accept: SessionAccept, reject: RejectConnection, info: SetEnvInfo) => void): this;
+    on(event: 'env', listener: (accept: SessionAccept, reject: RejectConnection, info: SetEnvInfo) => void): this;
 
     /**
      * Emitted when the client has sent a POSIX signal.
      */
-    on(event: "signal", listener: (accept: SessionAccept, reject: RejectConnection, info: SignalInfo) => void): this;
+    on(event: 'signal', listener: (accept: SessionAccept, reject: RejectConnection, info: SignalInfo) => void): this;
 
     /**
      * Emitted when the client has requested incoming ssh-agent requests be forwarded to them.
      */
-    on(event: "auth-agent", listener: (accept: SessionAccept, reject: RejectConnection) => void): this;
+    on(event: 'auth-agent', listener: (accept: SessionAccept, reject: RejectConnection) => void): this;
 
     /**
      * Emitted when the client has requested an interactive shell.
      */
-    on(event: "shell", listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection) => void): this;
+    on(event: 'shell', listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection) => void): this;
 
     /**
      * Emitted when the client has requested execution of a command string.
      */
-    on(event: "exec", listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection, info: ExecInfo) => void): this;
+    on(
+        event: 'exec',
+        listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection, info: ExecInfo) => void,
+    ): this;
 
     /**
      * Emitted when the client has requested the SFTP subsystem.
      */
-    on(event: "sftp", listener: (accept: AcceptSftpConnection, reject: RejectConnection) => void): this;
+    on(event: 'sftp', listener: (accept: AcceptSftpConnection, reject: RejectConnection) => void): this;
 
     /**
      * Emitted when the client has requested an arbitrary subsystem.
      */
-    on(event: "subsystem", listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection, info: SubsystemInfo) => void): this;
+    on(
+        event: 'subsystem',
+        listener: (accept: AcceptConnection<ServerChannel>, reject: RejectConnection, info: SubsystemInfo) => void,
+    ): this;
 
     on(event: string | symbol, listener: Function): this;
 }
@@ -1332,13 +1427,21 @@ export interface SFTPWrapper extends EventEmitter {
      * (Client-only)
      * Reads a file in memory and returns its contents
      */
-    readFile(remotePath: string, options: ReadFileOptions, callback: (err: Error | undefined, handle: Buffer) => void): void;
+    readFile(
+        remotePath: string,
+        options: ReadFileOptions,
+        callback: (err: Error | undefined, handle: Buffer) => void,
+    ): void;
 
     /**
      * (Client-only)
      * Reads a file in memory and returns its contents
      */
-    readFile(remotePath: string, encoding: BufferEncoding, callback: (err: Error | undefined, handle: Buffer) => void): void;
+    readFile(
+        remotePath: string,
+        encoding: BufferEncoding,
+        callback: (err: Error | undefined, handle: Buffer) => void,
+    ): void;
 
     /**
      * (Client-only)
@@ -1392,8 +1495,18 @@ export interface SFTPWrapper extends EventEmitter {
      * (Client-only)
      * Opens a file `filename` for `mode` with optional `attributes`.
      */
-    open(filename: string, mode: number | OpenMode, attributes: InputAttributes, callback: (err: Error | undefined, handle: Buffer) => void): void;
-    open(filename: string, mode: number | OpenMode, attributes: string | number, callback: (err: Error | undefined, handle: Buffer) => void): void;
+    open(
+        filename: string,
+        mode: number | OpenMode,
+        attributes: InputAttributes,
+        callback: (err: Error | undefined, handle: Buffer) => void,
+    ): void;
+    open(
+        filename: string,
+        mode: number | OpenMode,
+        attributes: string | number,
+        callback: (err: Error | undefined, handle: Buffer) => void,
+    ): void;
 
     /**
      * (Client-only)
@@ -1412,7 +1525,14 @@ export interface SFTPWrapper extends EventEmitter {
      * Reads `length` bytes from the resource associated with `handle` starting at `position`
      * and stores the bytes in `buffer` starting at `offset`.
      */
-    read(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number, callback: (err: Error | undefined, bytesRead: number, buffer: Buffer, position: number) => void): void;
+    read(
+        handle: Buffer,
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number,
+        callback: (err: Error | undefined, bytesRead: number, buffer: Buffer, position: number) => void,
+    ): void;
 
     /**
      * (Client-only)
@@ -1599,31 +1719,38 @@ export interface SFTPWrapper extends EventEmitter {
      * (Client-only)
      * Performs a remote file copy. If length is 0, then the server will read from srcHandle until EOF is reached.
      */
-    ext_copy_data(handle: Buffer, srcOffset: number, len: number, dstHandle: Buffer, dstOffset: number, callback: Callback): void;
+    ext_copy_data(
+        handle: Buffer,
+        srcOffset: number,
+        len: number,
+        dstHandle: Buffer,
+        dstOffset: number,
+        callback: Callback,
+    ): void;
 
     /**
      * Emitted after initial protocol version check has passed
      */
-    on(event: "ready", listener: () => void): this;
-    on(event: "OPEN", listener: (reqId: number, filename: string, flags: number, attrs: Attributes) => void): this;
-    on(event: "READ", listener: (reqId: number, handle: Buffer, offset: number, len: number) => void): this;
-    on(event: "WRITE", listener: (reqId: number, handle: Buffer, offset: number, data: Buffer) => void): this;
-    on(event: "FSTAT", listener: (reqId: number, handle: Buffer) => void): this;
-    on(event: "FSETSTAT", listener: (reqId: number, handle: Buffer, attrs: Attributes) => void): this;
-    on(event: "CLOSE", listener: (reqId: number, handle: Buffer) => void): this;
-    on(event: "OPENDIR", listener: (reqId: number, path: string) => void): this;
-    on(event: "READDIR", listener: (reqId: number, handle: Buffer) => void): this;
-    on(event: "LSTAT", listener: (reqId: number, path: string) => void): this;
-    on(event: "STAT", listener: (reqId: number, path: string) => void): this;
-    on(event: "REMOVE", listener: (reqId: number, path: string) => void): this;
-    on(event: "RMDIR", listener: (reqId: number, path: string) => void): this;
-    on(event: "REALPATH", listener: (reqId: number, path: string) => void): this;
-    on(event: "READLINK", listener: (reqId: number, path: string) => void): this;
-    on(event: "SETSTAT", listener: (reqId: number, path: string, attrs: Attributes) => void): this;
-    on(event: "MKDIR", listener: (reqId: number, path: string, attrs: Attributes) => void): this;
-    on(event: "RENAME", listener: (reqId: number, oldPath: string, newPath: string) => void): this;
-    on(event: "SYMLINK", listener: (reqId: number, targetPath: string, linkPath: string) => void): this;
-    on(event: "EXTENDED", listener: (reqId: number, extName: string, extData: Buffer) => void): this;
+    on(event: 'ready', listener: () => void): this;
+    on(event: 'OPEN', listener: (reqId: number, filename: string, flags: number, attrs: Attributes) => void): this;
+    on(event: 'READ', listener: (reqId: number, handle: Buffer, offset: number, len: number) => void): this;
+    on(event: 'WRITE', listener: (reqId: number, handle: Buffer, offset: number, data: Buffer) => void): this;
+    on(event: 'FSTAT', listener: (reqId: number, handle: Buffer) => void): this;
+    on(event: 'FSETSTAT', listener: (reqId: number, handle: Buffer, attrs: Attributes) => void): this;
+    on(event: 'CLOSE', listener: (reqId: number, handle: Buffer) => void): this;
+    on(event: 'OPENDIR', listener: (reqId: number, path: string) => void): this;
+    on(event: 'READDIR', listener: (reqId: number, handle: Buffer) => void): this;
+    on(event: 'LSTAT', listener: (reqId: number, path: string) => void): this;
+    on(event: 'STAT', listener: (reqId: number, path: string) => void): this;
+    on(event: 'REMOVE', listener: (reqId: number, path: string) => void): this;
+    on(event: 'RMDIR', listener: (reqId: number, path: string) => void): this;
+    on(event: 'REALPATH', listener: (reqId: number, path: string) => void): this;
+    on(event: 'READLINK', listener: (reqId: number, path: string) => void): this;
+    on(event: 'SETSTAT', listener: (reqId: number, path: string, attrs: Attributes) => void): this;
+    on(event: 'MKDIR', listener: (reqId: number, path: string, attrs: Attributes) => void): this;
+    on(event: 'RENAME', listener: (reqId: number, oldPath: string, newPath: string) => void): this;
+    on(event: 'SYMLINK', listener: (reqId: number, targetPath: string, linkPath: string) => void): this;
+    on(event: 'EXTENDED', listener: (reqId: number, extName: string, extData: Buffer) => void): this;
     on(event: string | symbol, listener: Function): this;
 
     /**
@@ -1656,13 +1783,18 @@ export interface SFTPWrapper extends EventEmitter {
 }
 
 export interface PublicKeyEntry {
-    pubKey: ParsedKey | {
-        pubKey: ParsedKey | Buffer | string;
-        comment?: string;
-    }
+    pubKey:
+        | ParsedKey
+        | {
+              pubKey: ParsedKey | Buffer | string;
+              comment?: string;
+          };
 }
 
-export type KnownPublicKeys<T extends string | Buffer | ParsedKey = string | Buffer | ParsedKey> = (T | PublicKeyEntry)[]
+export type KnownPublicKeys<T extends string | Buffer | ParsedKey = string | Buffer | ParsedKey> = (
+    | T
+    | PublicKeyEntry
+)[];
 
 export type PrivateKeys = (Buffer | ParsedKey | EncryptedPrivateKey | string)[];
 
@@ -1670,7 +1802,10 @@ export type Callback = (err?: Error | null) => void;
 
 export type ErrorCallback = (err: Error) => void;
 
-export type IdentityCallback<T extends string | Buffer | ParsedKey = string | Buffer | ParsedKey> = (err?: Error | null, keys?: KnownPublicKeys<T>) => void;
+export type IdentityCallback<T extends string | Buffer | ParsedKey = string | Buffer | ParsedKey> = (
+    err?: Error | null,
+    keys?: KnownPublicKeys<T>,
+) => void;
 
 export type SignCallback = (err?: Error | null, signature?: Buffer) => void;
 
@@ -1682,10 +1817,10 @@ export type GetStreamCallback = (err?: Error | null, stream?: Duplex) => void;
  * for correlation, not introspected.
  */
 export interface AgentInboundRequest {
-    __opaque_type: never
+    __opaque_type: never;
 }
 
-export interface SigningRequestOptions  {
+export interface SigningRequestOptions {
     hash: 'sha256' | 'sha512';
 }
 
@@ -1720,7 +1855,12 @@ export class AgentProtocol extends Duplex {
      * (Client mode only)
      * Signs the datawith the given public key, and calls back with its signature.
      */
-    sign(pubKey: ParsedKey | Buffer | string, data: Buffer, options?: SigningRequestOptions, callback?: SignCallback): boolean;
+    sign(
+        pubKey: ParsedKey | Buffer | string,
+        data: Buffer,
+        options?: SigningRequestOptions,
+        callback?: SignCallback,
+    ): boolean;
     sign(pubKey: ParsedKey | Buffer | string, data: Buffer, callback?: SignCallback): boolean;
 
     /**
@@ -1734,14 +1874,17 @@ export class AgentProtocol extends Duplex {
      * The client has requested a list of public keys stored in the agent.
      * Use `failureReply()` or `getIdentitiesReply()` to reply appropriately.
      */
-    on(event: "identities", listener: (req: AgentInboundRequest) => void): this;
+    on(event: 'identities', listener: (req: AgentInboundRequest) => void): this;
 
     /**
      * (Server mode only)
      * The client has requested `data` to be signed using the key identified
      * by `pubKey`. Use `failureReply()` or `signReply()` to reply appropriately.
      */
-    on(event: "sign", listener: (req: AgentInboundRequest, pubKey: ParsedKey, data: Buffer, options: SigningRequestOptions) => void): this;
+    on(
+        event: 'sign',
+        listener: (req: AgentInboundRequest, pubKey: ParsedKey, data: Buffer, options: SigningRequestOptions) => void,
+    ): this;
 
     on(event: string | symbol, listener: Function): this;
 }
@@ -1789,7 +1932,12 @@ export class OpenSSHAgent extends BaseAgent<ParsedKey> {
     getIdentities(cb: IdentityCallback<ParsedKey>): void;
 
     /** @inheritdoc */
-    sign(pubKey: ParsedKey | Buffer | string, data: Buffer, options?: SigningRequestOptions, cb?: SignCallback): boolean;
+    sign(
+        pubKey: ParsedKey | Buffer | string,
+        data: Buffer,
+        options?: SigningRequestOptions,
+        cb?: SignCallback,
+    ): boolean;
     sign(pubKey: ParsedKey | Buffer | string, data: Buffer, cb?: SignCallback): boolean;
 
     /** @inheritdoc */
@@ -1814,13 +1962,13 @@ export interface NegotiatedAlgorithms {
         mac: MacAlgorithm | '';
         compress: CompressionAlgorithm;
         lang: string;
-    },
+    };
     sc: {
         cipher: CipherAlgorithm;
         mac: MacAlgorithm | '';
         compress: CompressionAlgorithm;
         lang: string;
-    },
+    };
 }
 
 export type VerifyCallback = (valid: boolean) => void;
@@ -1873,7 +2021,6 @@ export type ClientSFTPCallback = (err: Error | undefined, sftp: SFTPWrapper) => 
 export type ChangePasswordCallback = (newPassword: string) => void;
 
 export type KeyboardInteractiveCallback = (answers: string[]) => void;
-
 
 export interface UNIXConnectionDetails {
     socketPath: string;

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -173,7 +173,30 @@ export namespace utils {
             BAD_MESSAGE = 5,
             NO_CONNECTION = 6,
             CONNECTION_LOST = 7,
-            OP_UNSUPPORTED = 8
+            OP_UNSUPPORTED = 8,
+            INVALID_HANDLE = 9,
+            NO_SUCH_PATH = 10,
+            FILE_ALREADY_EXISTS = 11,
+            WRITE_PROTECT = 12,
+            NO_MEDIA = 13,
+            NO_SPACE_ON_FILESYSTEM = 14,
+            QUOTA_EXCEEDED = 15,
+            UNKNOWN_PRINCIPAL = 16,
+            LOCK_CONFLICT = 17,
+            DIR_NOT_EMPTY = 18,
+            NOT_A_DIRECTORY = 19,
+            INVALID_FILENAME = 20,
+            LINK_LOOP = 21,
+            CANNOT_DELETE = 22,
+            INVALID_PARAMETER = 23,
+            FILE_IS_A_DIRECTORY = 24,
+            BYTE_RANGE_LOCK_CONFLICT = 25,
+            BYTE_RANGE_LOCK_REFUSED = 26,
+            DELETE_PENDING = 27,
+            FILE_CORRUPT = 28,
+            OWNER_INVALID = 29,
+            GROUP_INVALID = 30,
+            NO_MATCHING_BYTE_RANGE_LOCK = 31
         }
 
         function stringToFlags(str: OpenMode): number | null;

--- a/types/ssh2/package.json
+++ b/types/ssh2/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@types/node": "^18.11.18"
+    }
+}


### PR DESCRIPTION
[The SFTP specification](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-9.1) defines 31 valid error codes. The list of codes previously defined was incomplete.

This PR also updates the type definitions to conform with the current linting and testing rules for the DefinitelyTyped project.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-9.1
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
