### PR TITLE
[effective-domain-name-parser] Create types

### DIFF
--- a/types/effective-domain-name-parser/effective-domain-name-parser-tests.ts
+++ b/types/effective-domain-name-parser/effective-domain-name-parser-tests.ts
@@ -1,0 +1,15 @@
+import { parse } from 'effective-domain-name-parser';
+
+const parsedTest = parse('www.us.test.com'); // { tld: 'com', sld: 'test', subdomain: 'www.us' }
+
+// $ExpectType string
+parsedTest.tld;
+
+// $ExpectType string
+parsedTest.sld;
+
+// $ExpectType string
+parsedTest.subdomain;
+
+// @ts-expect-error
+parse(['www.us.test.com']);

--- a/types/effective-domain-name-parser/index.d.ts
+++ b/types/effective-domain-name-parser/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for effective-domain-name-parser 0.0
+// Project: https://github.com/dontcallmedom/node-domain-name-parser#readme
+// Definitions by: David Reed <https://github.com/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface ParsedDomain {
+    tld: string;
+    sld: string;
+    subdomain: string;
+}
+
+export function parse(name: string): ParsedDomain;

--- a/types/effective-domain-name-parser/tsconfig.json
+++ b/types/effective-domain-name-parser/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "effective-domain-name-parser-tests.ts"]
+}

--- a/types/effective-domain-name-parser/tslint.json
+++ b/types/effective-domain-name-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.