### PR TITLE
[three] add generic arg for uniform class

### DIFF
--- a/types/three/src/core/Uniform.d.ts
+++ b/types/three/src/core/Uniform.d.ts
@@ -1,14 +1,14 @@
-export class Uniform {
-    constructor(value: any);
+export class Uniform<T = any> {
+    constructor(value: T);
     /**
      * @deprecated
      */
-    constructor(type: string, value: any);
+    constructor(type: string, value: T);
     /**
      * @deprecated
      */
     type: string;
-    value: any;
+    value: T;
     /**
      * @deprecated Use {@link Object3D#onBeforeRender object.onBeforeRender()} instead.
      */
@@ -17,5 +17,5 @@ export class Uniform {
     /**
      * @deprecated Use {@link Object3D#onBeforeRender object.onBeforeRender()} instead.
      */
-    onUpdate(callback: () => void): Uniform;
+    onUpdate(callback: () => void): Uniform<T>;
 }

--- a/types/three/test/core/uniform.ts
+++ b/types/three/test/core/uniform.ts
@@ -1,0 +1,5 @@
+import * as THREE from 'three';
+
+const unknownUniform = new THREE.Uniform('abc' as unknown);
+const genericUniform = new THREE.Uniform<number>(4);
+const inferredUniform = new THREE.Uniform(4);

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -26,6 +26,7 @@
         "test/controls/controls-pointercontrols.ts",
         "test/controls/controls-transformcontrols.ts",
         "test/core/core-eventDispatcher.ts",
+        "test/core/uniform.ts",
         "test/geometries/geometry-buffer.ts",
         "test/geometries/geometry-cube.ts",
         "test/geometries/geometry-parametric.ts",


### PR DESCRIPTION
Allows the value of a uniform to have a resolved type. Leaves `any` as as the default to avoid making a breaking change.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/blob/dev/src/core/Uniform.js#L3-L7
