### PR TITLE
[jsrsasign] add question mark for optional parameter on ASN1HEX.getString()

### DIFF
--- a/types/jsrsasign/jsrsasign-tests.ts
+++ b/types/jsrsasign/jsrsasign-tests.ts
@@ -123,6 +123,7 @@ new KJUR.asn1.x509.Certificate({ tbsobj: tbscert, sigalg: 'SHA256withRSA', cakey
 // ASN1HEX
 ASN1HEX.checkStrictDER('0203012345');
 ASN1HEX.oidname('551d25');
+ASN1HEX.getString('01020304', 0); 
 
 // X509CRL
 const x509crl = new X509CRL(`-----BEGIN X509 CRL-----

--- a/types/jsrsasign/jsrsasign-tests.ts
+++ b/types/jsrsasign/jsrsasign-tests.ts
@@ -123,7 +123,7 @@ new KJUR.asn1.x509.Certificate({ tbsobj: tbscert, sigalg: 'SHA256withRSA', cakey
 // ASN1HEX
 ASN1HEX.checkStrictDER('0203012345');
 ASN1HEX.oidname('551d25');
-ASN1HEX.getString('01020304', 0); 
+ASN1HEX.getString('01020304', 0);
 
 // X509CRL
 const x509crl = new X509CRL(`-----BEGIN X509 CRL-----

--- a/types/jsrsasign/modules/ASN1HEX.d.ts
+++ b/types/jsrsasign/modules/ASN1HEX.d.ts
@@ -457,7 +457,7 @@ declare namespace jsrsasign {
          * ASN1HEX.getString("xxxx1303616161xxxxxx", 4) &rarr "aaa"
          * ASN1HEX.getString("xxxx0c03616161xxxxxx", 4) &rarr "aaa"
          */
-        function getString(h: string, idx: number, errorReturn: ErrorReturn): string | ErrorReturn;
+        function getString(h: string, idx: number, errorReturn?: ErrorReturn): string | ErrorReturn;
 
         /**
          * get hexadecimal string of ASN.1 TLV at<br/>


### PR DESCRIPTION
The errorReturn parameter is optional.
Compared to the above method([getOIDName](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jsrsasign/modules/ASN1HEX.d.ts#L442)), it is as follows.

```typescript
/**
 * blah blah
 * @param errorReturn (OPTION) error return value (DEFAULT: null)
 * blah blah
 */
function getOIDName(h: string, idx: number, errorReturn?: ErrorReturn): string | ErrorReturn;

/**
 * blah blah
 * @param errorReturn (OPTION) error return value (DEFAULT: null)
 * blah blah
 * missing question mark for errorReturn parameter
 */
function getString(h: string, idx: number, errorReturn: ErrorReturn): string | ErrorReturn;
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kjur/jsrsasign/blob/f6b7916b551ff9962d6148f9a2a7720b144bb795/src/asn1hex-1.1.js#L691
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
