### PR TITLE
fix(googlefc): AdBlockerStatusEnum

### DIFF
--- a/types/googlefc/googlefc-tests.ts
+++ b/types/googlefc/googlefc-tests.ts
@@ -27,7 +27,7 @@ googlefc.callbackQueue.push({ CONSENT_DATA_READY: () => googlefc.showRevocationM
 googlefc.callbackQueue.push({
     AD_BLOCK_DATA_READY: () => {
         switch (googlefc.getAdBlockerStatus()) {
-            case googlefc.AdBlockerStatusEnum.EXTENSION_AD_BLOCKER:
+            case googlefc.AdBlockerStatusEnum.EXTENSION_LEVEL_AD_BLOCKER:
             case googlefc.AdBlockerStatusEnum.NETWORK_LEVEL_AD_BLOCKER:
                 // Insert handling for cases where the user is blocking ads.
                 break;

--- a/types/googlefc/index.d.ts
+++ b/types/googlefc/index.d.ts
@@ -45,7 +45,7 @@ declare namespace googlefc {
         /** Something failed, in an unknown state. */
         UNKNOWN: 0;
         /** The user was running an extension level ad blocker. */
-        EXTENSION_AD_BLOCKER: 1;
+        EXTENSION_LEVEL_AD_BLOCKER: 1;
         /** The user was running a network level ad blocker. */
         NETWORK_LEVEL_AD_BLOCKER: 2;
         /** The user was not blocking ads. */


### PR DESCRIPTION
Although their documentation states otherwise, the `googlefc.AdBlockerStatusEnum` doesn't contain the property `EXTENSION_AD_BLOCKER`, but `EXTENSION_LEVEL_AD_BLOCKER`. This is only documented in an example here: https://developers.google.com/funding-choices/fc-api-docs#googlefc-getAdBlockerStatus

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
