### PR TITLE
Add JSDoc comments from upstream to `@types/passport` for IntelliSence, and update typings accordingly.

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -24,17 +24,59 @@ declare global {
             user?: User | undefined;
 
             // These declarations are merged into express's Request type
+            /**
+             * Initiate a login session for `user`.
+             *
+             * Options:
+             *   - `session`  Save login state in session, defaults to `true`.
+             *
+             * Examples:
+             *
+             *     req.logIn(user, { session: false });
+             *
+             *     req.logIn(user, function(err) {
+             *       if (err) { throw err; }
+             *       // session saved
+             *     });
+             */
             login(user: User, done: (err: any) => void): void;
             login(user: User, options: any, done: (err: any) => void): void;
+            /**
+             * Initiate a login session for `user`.
+             *
+             * Options:IncomingMessage
+             *   - `session`  Save login state in session, defaults to `true`.
+             *
+             * Examples:
+             *
+             *     req.logIn(user, { session: false });
+             *
+             *     req.logIn(user, function(err) {
+             *       if (err) { throw err; }
+             *       // session saved
+             *     });
+             */
             logIn(user: User, done: (err: any) => void): void;
             logIn(user: User, options: any, done: (err: any) => void): void;
 
+            /**
+             * Terminate an existing login session.
+             */
             logout(options: { keepSessionInfo?: boolean }, done: (err: any) => void): void;
             logout(done: (err: any) => void): void;
+            /**
+             * Terminate an existing login session.
+             */
             logOut(options: { keepSessionInfo?: boolean }, done: (err: any) => void): void;
             logOut(done: (err: any) => void): void;
 
+            /**
+             * Test if request is authenticated.
+             */
             isAuthenticated(): this is AuthenticatedRequest;
+            /**
+             * Test if request is unauthenticated.
+             */
             isUnauthenticated(): this is UnauthenticatedRequest;
         }
 
@@ -53,16 +95,46 @@ import express = require('express');
 declare namespace passport {
     interface AuthenticateOptions {
         authInfo?: boolean | undefined;
+        /**
+         * Assign the object provided by the verify callback to given property.
+         */
         assignProperty?: string | undefined;
+        /**
+         * True to flash failure messages
+         * or a string to use as a flash message for failures
+         * (overrides any from the strategy itself).
+         */
         failureFlash?: string | boolean | undefined;
+        /**
+         * True to store failure message in `req.session.messages`, 
+         * or a string to use as override message for failure.
+         */
         failureMessage?: boolean | string | undefined;
+        /**
+         * After failed login, redirect to given URL.
+         */
         failureRedirect?: string | undefined;
         failWithError?: boolean | undefined;
         keepSessionInfo?: boolean | undefined;
+        /**
+         * Save login state in session, defaults to `true`.
+         */
         session?: boolean | undefined;
         scope?: string | string[] | undefined;
+        /**
+         * True to flash success messages
+         * or a string to use as a flash message for success
+         * (overrides any from the strategy itself).
+         */
         successFlash?: string | boolean | undefined;
+        /**
+         * True to store success message in `req.session.messages`,
+         * or a string to use as override message for success.
+         */
         successMessage?: boolean | string | undefined;
+        /**
+         * After successful login, redirect to given URL.
+         */
         successRedirect?: string | undefined;
         successReturnToOrRedirect?: string | undefined;
         state?: string | undefined;
@@ -73,35 +145,383 @@ declare namespace passport {
     }
 
     interface Authenticator<InitializeRet = express.Handler, AuthenticateRet = any, AuthorizeRet = AuthenticateRet, AuthorizeOptions = AuthenticateOptions> {
+        /**
+         * Register a strategy for later use when authenticating requests.  The name
+         * with which the strategy is registered is passed to {@link Authenticator.authenticate `authenticate()`}.
+         *
+         * @example <caption>Register strategy.</caption>
+         * passport.use(new GoogleStrategy(...));
+         *
+         * @example <caption>Register strategy and override name.</caption>
+         * passport.use('password', new LocalStrategy(function(username, password, cb) {
+         *   // ...
+         * }));
+         */
         use(strategy: Strategy): this;
         use(name: string, strategy: Strategy): this;
+        /**
+         * Deregister a strategy that was previously registered with the given name.
+         *
+         * In a typical application, the necessary authentication strategies are
+         * registered when initializing the app and, once registered, are always
+         * available.  As such, it is typically not necessary to call this function.
+         *
+         * @example
+         * passport.unuse('acme');
+         */
         unuse(name: string): this;
+        /**
+         * Adapt this `Authenticator` to work with a specific framework.
+         *
+         * By default, Passport works as {@link https://github.com/senchalabs/connect#readme Connect}-style
+         * middleware, which makes it compatible with {@link https://expressjs.com/ Express}.
+         * For any app built using Express, there is no need to call this function.
+         */
         framework<X, Y, Z>(fw: Framework<X, Y, Z>): Authenticator<X, Y, Z>;
-        initialize(options?: { userProperty: string; }): InitializeRet;
+        /**
+         * Passport initialization.
+         *
+         * Intializes Passport for incoming requests, allowing authentication strategies
+         * to be applied.
+         *
+         * As of v0.6.x, it is typically no longer necessary to use this middleware.  It
+         * exists for compatiblity with apps built using previous versions of Passport,
+         * in which this middleware was necessary.
+         *
+         * The primary exception to the above guidance is when using strategies that
+         * depend directly on `passport@0.4.x` or earlier.  These earlier versions of
+         * Passport monkeypatch Node.js `http.IncomingMessage` in a way that expects
+         * certain Passport-specific properties to be available.  This middleware
+         * provides a compatibility layer for this situation.
+         * 
+         * Options:
+         *  - `userProperty` Determines what property on
+         *                   `req` will be set to the authenticated user object.
+         *                   Default `'user'`
+         *  
+         *  - `compat`       When `true`, enables a compatibility
+         *                   layer for packages that depend on `passport@0.4.x` or earlier.
+         *                   Default `true`.
+         *
+         * Examples:
+         * 
+         *      app.use(passport.initialize());
+         * 
+         * If sessions are being utilized, applications must set up Passport with
+         * functions to serialize a user into and out of a session.  For example, a
+         * common pattern is to serialize just the user ID into the session (due to the
+         * fact that it is desirable to store the minimum amount of data in a session).
+         * When a subsequent request arrives for the session, the full User object can
+         * be loaded from the database by ID.
+         *
+         * Note that additional middleware is required to persist login state, so we
+         * must use the `connect.session()` middleware _before_ `passport.initialize()`.
+         *
+         * If sessions are being used, this middleware must be in use by the
+         * Connect/Express application for Passport to operate.  If the application is
+         * entirely stateless (not using sessions), this middleware is not necessary,
+         * but its use will not have any adverse impact.
+         *
+         * Examples:
+         *
+         *     app.use(connect.cookieParser());
+         *     app.use(connect.session({ secret: 'keyboard cat' }));
+         *     app.use(passport.initialize());
+         *     app.use(passport.session());
+         *
+         *     passport.serializeUser(function(user, done) {
+         *       done(null, user.id);
+         *     });
+         *
+         *     passport.deserializeUser(function(id, done) {
+         *       User.findById(id, function (err, user) {
+         *         done(err, user);
+         *       });
+         *     });
+         */
+        initialize(options?: { userProperty: string; compat: boolean; }): InitializeRet;
+        /**
+         * Middleware that will restore login state from a session.
+         *
+         * Web applications typically use sessions to maintain login state between
+         * requests.  For example, a user will authenticate by entering credentials into
+         * a form which is submitted to the server.  If the credentials are valid, a
+         * login session is established by setting a cookie containing a session
+         * identifier in the user's web browser.  The web browser will send this cookie
+         * in subsequent requests to the server, allowing a session to be maintained.
+         *
+         * If sessions are being utilized, and a login session has been established,
+         * this middleware will populate `req.user` with the current user.
+         *
+         * Note that sessions are not strictly required for Passport to operate.
+         * However, as a general rule, most web applications will make use of sessions.
+         * An exception to this rule would be an API server, which expects each HTTP
+         * request to provide credentials in an Authorization header.
+         *
+         * Examples:
+         * 
+         *     app.use(connect.cookieParser());
+         *     app.use(connect.session({ secret: 'keyboard cat' }));
+         *     app.use(passport.initialize());
+         *     app.use(passport.session());
+         *
+         * Options:
+         *   - `pauseStream`      Pause the request stream before deserializing the user
+         *                        object from the session.  Defaults to `false`.  Should
+         *                        be set to `true` in cases where middleware consuming the
+         *                        request body is configured after passport and the
+         *                        deserializeUser method is asynchronous.
+         */
         session(options?: { pauseStream: boolean; }): AuthenticateRet;
-
+        
+        /**
+         * Authenticates requests.
+         *
+         * Applies the `name`ed strategy (or strategies) to the incoming request, in
+         * order to authenticate the request.  If authentication is successful, the user
+         * will be logged in and populated at `req.user` and a session will be
+         * established by default.  If authentication fails, an unauthorized response
+         * will be sent.
+         *
+         * Options:
+         *   - `session`          Save login state in session, defaults to `true`.
+         *   - `successRedirect`  After successful login, redirect to given URL.
+         *   - `successMessage`   True to store success message in
+         *                        `req.session.messages`, or a string to use as override
+         *                        message for success.
+         *   - `successFlash`     True to flash success messages or a string to use as a flash
+         *                        message for success (overrides any from the strategy itself).
+         *   - `failureRedirect`  After failed login, redirect to given URL.
+         *   - `failureMessage`   True to store failure message in
+         *                        `req.session.messages`, or a string to use as override
+         *                        message for failure.
+         *   - `failureFlash`     True to flash failure messages or a string to use as a flash
+         *                        message for failures (overrides any from the strategy itself).
+         *   - `assignProperty`   Assign the object provided by the verify callback to given property.
+         *
+         * An optional `callback` can be supplied to allow the application to override
+         * the default manner in which authentication attempts are handled.  The
+         * callback has the following signature, where `user` will be set to the
+         * authenticated user on a successful authentication attempt, or `false`
+         * otherwise.  An optional `info` argument will be passed, containing additional
+         * details provided by the strategy's verify callback - this could be information about
+         * a successful authentication or a challenge message for a failed authentication.
+         * An optional `status` argument will be passed when authentication fails - this could
+         * be a HTTP response code for a remote authentication failure or similar.
+         *
+         *     app.get('/protected', function(req, res, next) {
+         *       passport.authenticate('local', function(err, user, info, status) {
+         *         if (err) { return next(err) }
+         *         if (!user) { return res.redirect('/signin') }
+         *         res.redirect('/account');
+         *       })(req, res, next);
+         *     });
+         *
+         * Note that if a callback is supplied, it becomes the application's
+         * responsibility to log-in the user, establish a session, and otherwise perform
+         * the desired operations.
+         *
+         * Examples:
+         *
+         *     passport.authenticate('local', { successRedirect: '/', failureRedirect: '/login' });
+         *
+         *     passport.authenticate('basic', { session: false });
+         *
+         *     passport.authenticate('twitter');
+         */
         authenticate(strategy: string | string[] | Strategy, callback?: (...args: any[]) => any): AuthenticateRet;
         authenticate(strategy: string | string[] | Strategy, options: AuthenticateOptions, callback?: (...args: any[]) => any): AuthenticateRet;
+        /**
+         * Create third-party service authorization middleware.
+         *
+         * Returns middleware that will authorize a connection to a third-party service.
+         *
+         * This middleware is identical to using {@link Authenticator.authenticate `authenticate()`}
+         * middleware with the `assignProperty` option set to `'account'`.  This is
+         * useful when a user is already authenticated (for example, using a username
+         * and password) and they want to connect their account with a third-party
+         * service.
+         *
+         * In this scenario, the user's third-party account will be set at
+         * `req.account`, and the existing `req.user` and login session data will be
+         * be left unmodified.  A route handler can then link the third-party account to
+         * the existing local account.
+         *
+         * All arguments to this function behave identically to those accepted by
+         * `{@link Authenticator.authenticate}`.
+         *
+         * @example
+         * app.get('/oauth/callback/twitter', passport.authorize('twitter'));
+         */
         authorize(strategy: string | string[], callback?: (...args: any[]) => any): AuthorizeRet;
         authorize(strategy: string | string[], options: AuthorizeOptions, callback?: (...args: any[]) => any): AuthorizeRet;
+        /**
+         * Registers a function used to serialize user objects into the session.
+         *
+         * Examples:
+         *
+         *     passport.serializeUser(function(user, done) {
+         *       done(null, user.id);
+         *     });
+         */
         serializeUser<TID>(fn: (user: Express.User, done: (err: any, id?: TID) => void) => void): void;
         serializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, user: Express.User, done: (err: any, id?: TID) => void) => void): void;
+        /**
+         * Registers a function used to deserialize user objects out of the session.
+         *
+         * Examples:
+         *
+         *     passport.deserializeUser(function(id, done) {
+         *       User.findById(id, function (err, user) {
+         *         done(err, user);
+         *       });
+         *     });
+         */
         deserializeUser<TID>(fn: (id: TID, done: (err: any, user?: Express.User | false | null) => void) => void): void;
         deserializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, id: TID, done: (err: any, user?: Express.User | false | null) => void) => void): void;
+        /**
+         * Registers a function used to transform auth info.
+         *
+         * In some circumstances authorization details are contained in authentication
+         * credentials or loaded as part of verification.
+         *
+         * For example, when using bearer tokens for API authentication, the tokens may
+         * encode (either directly or indirectly in a database), details such as scope
+         * of access or the client to which the token was issued.
+         *
+         * Such authorization details should be enforced separately from authentication.
+         * Because Passport deals only with the latter, this is the responsiblity of
+         * middleware or routes further along the chain.  However, it is not optimal to
+         * decode the same data or execute the same database query later.  To avoid
+         * this, Passport accepts optional `info` along with the authenticated `user`
+         * in a strategy's `success()` action.  This info is set at `req.authInfo`,
+         * where said later middlware or routes can access it.
+         *
+         * Optionally, applications can register transforms to proccess this info,
+         * which take effect prior to `req.authInfo` being set.  This is useful, for
+         * example, when the info contains a client ID.  The transform can load the
+         * client from the database and include the instance in the transformed info,
+         * allowing the full set of client properties to be convieniently accessed.
+         *
+         * If no transforms are registered, `info` supplied by the strategy will be left
+         * unmodified.
+         *
+         * Examples:
+         *
+         *     passport.transformAuthInfo(function(info, done) {
+         *       Client.findById(info.clientID, function (err, client) {
+         *         info.client = client;
+         *         done(err, info);
+         *       });
+         *     });
+         */
         transformAuthInfo(fn: (info: any, done: (err: any, info: any) => void) => void): void;
     }
 
     interface PassportStatic extends Authenticator {
+        /**
+         * Create a new `Authenticator` object.
+         */
         Authenticator: { new(): Authenticator };
+        /**
+         * Create a new `Authenticator` object.
+         */
         Passport: PassportStatic["Authenticator"];
+        /**
+         * Creates an instance of `Strategy`.
+         */
         Strategy: { new(): Strategy & StrategyCreatedStatic };
+        strategies: {
+            /**
+             *  Create a new `SessionStrategy` object.
+             *
+             * An instance of this strategy is automatically used when creating an
+             * {@link Authenticator `Authenticator`}.  As such, it is typically unnecessary to create an
+             * instance using this constructor.
+             *
+             * This `Strategy` authenticates HTTP requests based on the contents
+             * of session data.
+             *
+             * The login session must have been previously initiated, typically upon the
+             * user interactively logging in using a HTML form.  During session initiation,
+             * the logged-in user's information is persisted to the session so that it can
+             * be restored on subsequent requests.
+             *
+             * Note that this strategy merely restores the authentication state from the
+             * session, it does not authenticate the session itself.  Authenticating the
+             * underlying session is assumed to have been done by the middleware
+             * implementing session support.  This is typically accomplished by setting a
+             * signed cookie, and verifying the signature of that cookie on incoming
+             * requests.
+             *
+             * In {@link https://expressjs.com/ Express}-based apps, session support is
+             * commonly provided by {@link https://github.com/expressjs/session `express-session`}
+             * or {@link https://github.com/expressjs/cookie-session `cookie-session`}.
+             * 
+             * Options:
+             * 
+             *  - `key` Determines what property ("key") on
+             *          the session data where login session data is located.  The login
+             *          session is stored and read from `req.session[key]`.
+             *          Default `'passport'`.
+             */
+            SessionStrategy: SessionStrategy
+        }
     }
-
+    
     interface Strategy {
         name?: string | undefined;
+        /**
+         * Authenticate request.
+         *
+         * This function must be overridden by subclasses.  In abstract form, it always
+         * throws an exception.
+         */
         authenticate(this: StrategyCreated<this>, req: express.Request, options?: any): any;
     }
-
+    
+    interface SessionStrategy extends Strategy {
+        new(deserializeUser: (serializedUser: unknown, req: express.Request, callback: (err: any, user?: Express.User | false | null) => void) => any): SessionStrategy;
+        new(options: { key: string }, deserializeUser: (serializedUser: unknown, req: express.Request, callback: (err: any, user?: Express.User | false | null) => void) => any): SessionStrategy;
+        /** 
+         * The name of the strategy, set to `'session'`.
+         */
+        readonly name: "session";
+        /**
+         * Authenticate request based on current session data.
+         *
+         * When login session data is present in the session, that data will be used to
+         * restore login state across across requests by calling the deserialize user
+         * function.
+         *
+         * If login session data is not present, the request will be passed to the next
+         * middleware, rather than failing authentication - which is the behavior of
+         * most other strategies.  This deviation allows session authentication to be
+         * performed at the application-level, rather than the individual route level,
+         * while allowing both authenticated and unauthenticated requests and rendering
+         * responses accordingly.  Routes that require authentication will need to guard
+         * that condition.
+         *
+         * This function is **protected**, and should _not_ be called directly.  Instead,
+         * use `passport.authenticate()` middleware and specify the {@link SessionStrategy.name `name`}
+         * of this strategy and any options.
+         *
+         * Options:
+         * - `pauseStream` When `true`, data events on
+         *                 the request will be paused, and then resumed after the asynchronous
+         *                 `deserializeUser` function has completed.  This is only necessary in
+         *                 cases where later middleware in the stack are listening for events,
+         *                 and ensures that those events are not missed.
+         *                 Default `false`.
+         *
+         * @example
+         * passport.authenticate('session');
+         * 
+         * @protected
+         */
+        authenticate(req: IncomingMessage, options?: { pauseStream: boolean }): void
+    }
+    
     interface StrategyCreatedStatic {
         /**
          * Authenticate `user`, with optional `info`.

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -93,8 +93,8 @@ declare global {
 import express = require('express');
 
 declare namespace passport {
-    type DoneCallback = (err: any, user?: Express.User | false | null) => void
-    type DeserializeUserFunction = (serializedUser: unknown, req: express.Request, done: DoneCallback) => void
+    type DoneCallback = (err: any, user?: Express.User | false | null) => void;
+    type DeserializeUserFunction = (serializedUser: unknown, req: express.Request, done: DoneCallback) => void;
     /**
      * An optional callback supplied to allow the application to override
      * the default manner in which authentication attempts are handled.  The
@@ -118,8 +118,13 @@ declare namespace passport {
      * responsibility to log-in the user, establish a session, and otherwise perform
      * the desired operations.
      */
-    type AuthenticateCallback = (err: any, user?: Express.User | false | null | undefined, info?: object | string | Array<string | undefined> | undefined, status?: number | undefined | Array<number | undefined>) => any
-    type AuthorizeCallback = AuthenticateCallback
+    type AuthenticateCallback = (
+        err: any,
+        user?: Express.User | false | null,
+        info?: object | string | Array<string | undefined>,
+        status?: number | Array<number | undefined>,
+    ) => any;
+    type AuthorizeCallback = AuthenticateCallback;
 
     interface AuthenticateOptions {
         authInfo?: boolean | undefined;
@@ -134,7 +139,7 @@ declare namespace passport {
          */
         failureFlash?: string | boolean | undefined;
         /**
-         * True to store failure message in `req.session.messages`, 
+         * True to store failure message in `req.session.messages`,
          * or a string to use as override message for failure.
          */
         failureMessage?: boolean | string | undefined;
@@ -175,7 +180,7 @@ declare namespace passport {
          */
         pauseStream?: boolean | undefined;
         /**
-         * Determines what property on `req` 
+         * Determines what property on `req`
          * will be set to the authenticated user object.
          * Default `'user'`.
          */
@@ -186,13 +191,13 @@ declare namespace passport {
 
     interface InitializeOptions {
         /**
-         * Determines what property on `req` 
+         * Determines what property on `req`
          * will be set to the authenticated user object.
          * Default `'user'`.
          */
         userProperty?: string;
         /**
-         * When `true`, enables a compatibility layer 
+         * When `true`, enables a compatibility layer
          * for packages that depend on `passport@0.4.x` or earlier.
          * Default `true`.
          */
@@ -209,7 +214,7 @@ declare namespace passport {
          */
         pauseStream: boolean;
     }
-    
+
     interface SessionStrategyOptions {
         /**
          * Determines what property ("key") on
@@ -224,11 +229,11 @@ declare namespace passport {
         /**
          * Save login state in session, defaults to `true`.
          */
-        session: boolean
+        session: boolean;
     }
 
     interface LogOutOptions {
-        keepSessionInfo?: boolean
+        keepSessionInfo?: boolean;
     }
 
     interface StrategyFailure {
@@ -236,7 +241,12 @@ declare namespace passport {
         [key: string]: any;
     }
 
-    interface Authenticator<InitializeRet = express.Handler, AuthenticateRet = any, AuthorizeRet = AuthenticateRet, AuthorizeOptions = AuthenticateOptions> {
+    interface Authenticator<
+        InitializeRet = express.Handler,
+        AuthenticateRet = any,
+        AuthorizeRet = AuthenticateRet,
+        AuthorizeOptions = AuthenticateOptions,
+    > {
         /**
          * Register a strategy for later use when authenticating requests.  The name
          * with which the strategy is registered is passed to {@link Authenticator.authenticate `authenticate()`}.
@@ -285,20 +295,20 @@ declare namespace passport {
          * Passport monkeypatch Node.js `http.IncomingMessage` in a way that expects
          * certain Passport-specific properties to be available.  This middleware
          * provides a compatibility layer for this situation.
-         * 
+         *
          * Options:
          *  - `userProperty` Determines what property on
          *                   `req` will be set to the authenticated user object.
          *                   Default `'user'`.
-         *  
+         *
          *  - `compat`       When `true`, enables a compatibility
          *                   layer for packages that depend on `passport@0.4.x` or earlier.
          *                   Default `true`.
          *
          * Examples:
-         * 
+         *
          *      app.use(passport.initialize());
-         * 
+         *
          * If sessions are being utilized, applications must set up Passport with
          * functions to serialize a user into and out of a session.  For example, a
          * common pattern is to serialize just the user ID into the session (due to the
@@ -351,7 +361,7 @@ declare namespace passport {
          * request to provide credentials in an Authorization header.
          *
          * Examples:
-         * 
+         *
          *     app.use(connect.cookieParser());
          *     app.use(connect.session({ secret: 'keyboard cat' }));
          *     app.use(passport.initialize());
@@ -365,7 +375,7 @@ declare namespace passport {
          *                        deserializeUser method is asynchronous.
          */
         session(options?: SessionOptions): AuthenticateRet;
-        
+
         /**
          * Authenticates requests.
          *
@@ -421,10 +431,15 @@ declare namespace passport {
          *
          *     passport.authenticate('twitter');
          */
-        authenticate(strategy: string | string[] | Strategy, callback?: AuthenticateCallback): AuthenticateRet;
-        authenticate(strategy: string | string[] | Strategy, callback?: (...args: any[]) => any): AuthenticateRet;
-        authenticate(strategy: string | string[] | Strategy, options: AuthenticateOptions, callback?: AuthenticateCallback): AuthenticateRet;
-        authenticate(strategy: string | string[] | Strategy, options: AuthenticateOptions, callback?: (...args: any[]) => any): AuthenticateRet;
+        authenticate(
+            strategy: string | string[] | Strategy,
+            callback?: AuthenticateCallback | ((...args: any[]) => any),
+        ): AuthenticateRet;
+        authenticate(
+            strategy: string | string[] | Strategy,
+            options: AuthenticateOptions,
+            callback?: AuthenticateCallback | ((...args: any[]) => any),
+        ): AuthenticateRet;
         /**
          * Create third-party service authorization middleware.
          *
@@ -447,10 +462,12 @@ declare namespace passport {
          * @example
          * app.get('/oauth/callback/twitter', passport.authorize('twitter'));
          */
-        authorize(strategy: string | string[], callback?: AuthorizeCallback): AuthorizeRet;
-        authorize(strategy: string | string[], callback?: (...args: any[]) => any): AuthorizeRet;
-        authorize(strategy: string | string[], options: AuthorizeOptions, callback?: AuthorizeCallback): AuthorizeRet;
-        authorize(strategy: string | string[], options: AuthorizeOptions, callback?: (...args: any[]) => any): AuthorizeRet;
+        authorize(strategy: string | string[], callback?: AuthorizeCallback | ((...args: any[]) => any)): AuthorizeRet;
+        authorize(
+            strategy: string | string[],
+            options: AuthorizeOptions,
+            callback?: AuthorizeCallback | ((...args: any[]) => any),
+        ): AuthorizeRet;
         /**
          * Registers a function used to serialize user objects into the session.
          *
@@ -470,19 +487,28 @@ declare namespace passport {
          *       done(null, user.id);
          *     });
          */
-        serializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, user: Express.User, done: (err: any, id?: TID) => void) => void): void;
+        serializeUser<TID, TR extends IncomingMessage = express.Request>(
+            fn: (req: TR, user: Express.User, done: (err: any, id?: TID) => void) => void,
+        ): void;
         /**
          * Private implementation that traverses the chain of serializers,
          * attempting to serialize a user.
          */
-        serializeUser<User extends Express.User = Express.User, Request extends IncomingMessage = express.Request>(user: User, req: Request, done: (err: any, serializedUser?: number | NonNullable<unknown> | undefined) => any): void;
+        serializeUser<User extends Express.User = Express.User, Request extends IncomingMessage = express.Request>(
+            user: User,
+            req: Request,
+            done: (err: any, serializedUser?: number | NonNullable<unknown>) => any,
+        ): void;
         /**
          * Private implementation that traverses the chain of serializers,
          * attempting to serialize a user.
-         * 
+         *
          * For backwards compatibility.
          */
-        serializeUser<User extends Express.User = Express.User>(user: User, done: (err: any, serializedUser: number | NonNullable<unknown> | undefined) => any): void;
+        serializeUser<User extends Express.User = Express.User>(
+            user: User,
+            done: (err: any, serializedUser: number | NonNullable<unknown> | undefined) => any,
+        ): void;
         /**
          * Registers a function used to deserialize user objects out of the session.
          *
@@ -506,19 +532,28 @@ declare namespace passport {
          *       });
          *     });
          */
-        deserializeUser<TID, TR extends IncomingMessage = express.Request>(fn: (req: TR, id: TID, done: (err: any, user?: Express.User | false | null) => void) => void): void;
+        deserializeUser<TID, TR extends IncomingMessage = express.Request>(
+            fn: (req: TR, id: TID, done: (err: any, user?: Express.User | false | null) => void) => void,
+        ): void;
         /**
          * Private implementation that traverses the chain of deserializers,
          * attempting to deserialize a user.
          */
-        deserializeUser<User extends Express.User = Express.User, Request extends IncomingMessage = express.Request>(serializedUser: NonNullable<unknown>, req: Request, done: (err: any, user?: User | false | undefined) => any): void;
+        deserializeUser<User extends Express.User = Express.User, Request extends IncomingMessage = express.Request>(
+            serializedUser: NonNullable<unknown>,
+            req: Request,
+            done: (err: any, user?: User | false) => any,
+        ): void;
         /**
          * Private implementation that traverses the chain of deserializers,
          * attempting to deserialize a user.
-         * 
+         *
          * For backwards compatibility.
          */
-        deserializeUser<User extends Express.User = Express.User>(serializedUser: NonNullable<unknown>, done: (err: any, user?: User | false | undefined) => any): void;
+        deserializeUser<User extends Express.User = Express.User>(
+            serializedUser: NonNullable<unknown>,
+            done: (err: any, user?: User | false) => any,
+        ): void;
         /**
          * Registers a function used to transform auth info.
          *
@@ -559,36 +594,43 @@ declare namespace passport {
         /**
          * Private implementation that traverses the chain of transformers,
          * attempting to transform auth info.
-         * 
+         *
          * If no transformers are registered (or they all pass),
          * the default behavior is to use the un-transformed info as-is.
          */
-        transformAuthInfo<InitialInfo = unknown, Request extends IncomingMessage = express.Request>(info: unknown, req: Request, done: (err: any, transformedAuthInfo: InitialInfo | NonNullable<unknown> | undefined) => any): void;
+        transformAuthInfo<InitialInfo = unknown, Request extends IncomingMessage = express.Request>(
+            info: unknown,
+            req: Request,
+            done: (err: any, transformedAuthInfo: InitialInfo | NonNullable<unknown> | undefined) => any,
+        ): void;
         /**
          * Private implementation that traverses the chain of transformers,
          * attempting to transform auth info.
-         * 
+         *
          * If no transformers are registered (or they all pass),
          * the default behavior is to use the un-transformed info as-is.
-         * 
+         *
          * For backwards compatibility.
          */
-        transformAuthInfo<InitialInfo = unknown>(info: unknown, done: (err: any, transformedAuthInfo: InitialInfo | NonNullable<unknown> | undefined) => any): void;
+        transformAuthInfo<InitialInfo = unknown>(
+            info: unknown,
+            done: (err: any, transformedAuthInfo: InitialInfo | NonNullable<unknown> | undefined) => any,
+        ): void;
     }
 
     interface PassportStatic extends Authenticator {
         /**
          * Create a new `Authenticator` object.
          */
-        Authenticator: { new(): Authenticator };
+        Authenticator: { new (): Authenticator };
         /**
          * Create a new `Authenticator` object.
          */
-        Passport: PassportStatic["Authenticator"];
+        Passport: PassportStatic['Authenticator'];
         /**
          * Creates an instance of `Strategy`.
          */
-        Strategy: { new(): Strategy & StrategyCreatedStatic };
+        Strategy: { new (): Strategy & StrategyCreatedStatic };
         strategies: {
             /**
              *  Create a new `SessionStrategy` object.
@@ -615,16 +657,19 @@ declare namespace passport {
              * In {@link https://expressjs.com/ Express}-based apps, session support is
              * commonly provided by {@link https://github.com/expressjs/session `express-session`}
              * or {@link https://github.com/expressjs/cookie-session `cookie-session`}.
-             * 
+             *
              * Options:
-             * 
+             *
              *  - `key` Determines what property ("key") on
              *          the session data where login session data is located.  The login
              *          session is stored and read from `req.session[key]`.
              *          Default `'passport'`.
              */
-            SessionStrategy: SessionStrategy
-        }
+            SessionStrategy: {
+                new (deserializeUser: DeserializeUserFunction): SessionStrategy;
+                new (options: SessionStrategyOptions, deserializeUser: DeserializeUserFunction): SessionStrategy;
+            };
+        };
     }
 
     interface Strategy {
@@ -639,12 +684,10 @@ declare namespace passport {
     }
 
     interface SessionStrategy extends Strategy {
-        new(deserializeUser: DeserializeUserFunction): SessionStrategy;
-        new(options: SessionStrategyOptions, deserializeUser: DeserializeUserFunction): SessionStrategy;
-        /** 
+        /**
          * The name of the strategy, set to `'session'`.
          */
-        readonly name: "session";
+        readonly name: 'session';
         /**
          * Authenticate request based on current session data.
          *
@@ -674,46 +717,10 @@ declare namespace passport {
          *
          * @example
          * passport.authenticate('session');
-         * 
-         * @protected
          */
-        authenticate(req: IncomingMessage): void
-        /**
-         * Authenticate request based on current session data.
-         *
-         * When login session data is present in the session, that data will be used to
-         * restore login state across across requests by calling the deserialize user
-         * function.
-         *
-         * If login session data is not present, the request will be passed to the next
-         * middleware, rather than failing authentication - which is the behavior of
-         * most other strategies.  This deviation allows session authentication to be
-         * performed at the application-level, rather than the individual route level,
-         * while allowing both authenticated and unauthenticated requests and rendering
-         * responses accordingly.  Routes that require authentication will need to guard
-         * that condition.
-         *
-         * This function is **protected**, and should _not_ be called directly.  Instead,
-         * use `passport.authenticate()` middleware and specify the {@link SessionStrategy.name `name`}
-         * of this strategy and any options.
-         *
-         * Options:
-         * - `pauseStream` When `true`, data events on
-         *                 the request will be paused, and then resumed after the asynchronous
-         *                 `deserializeUser` function has completed.  This is only necessary in
-         *                 cases where later middleware in the stack are listening for events,
-         *                 and ensures that those events are not missed.
-         *                 Default `false`.
-         *
-         * @example
-         * passport.authenticate('session');
-         * 
-         * @protected
-         */
-        authenticate(req: IncomingMessage, options: Pick<AuthenticateOptions, "pauseStream">): void
+        authenticate(req: IncomingMessage, options?: Pick<AuthenticateOptions, 'pauseStream'>): void;
     }
-    
-    
+
     interface StrategyCreatedStatic {
         /**
          * Authenticate `user`, with optional `info`.
@@ -767,18 +774,24 @@ declare namespace passport {
         id: string;
         displayName: string;
         username?: string | undefined;
-        name?: {
-            familyName: string;
-            givenName: string;
-            middleName?: string | undefined;
-        } | undefined;
-        emails?: Array<{
-            value: string;
-            type?: string | undefined;
-        }> | undefined;
-        photos?: Array<{
-            value: string;
-        }> | undefined;
+        name?:
+            | {
+                  familyName: string;
+                  givenName: string;
+                  middleName?: string | undefined;
+              }
+            | undefined;
+        emails?:
+            | Array<{
+                  value: string;
+                  type?: string | undefined;
+              }>
+            | undefined;
+        photos?:
+            | Array<{
+                  value: string;
+              }>
+            | undefined;
     }
 
     interface Framework<InitializeRet = any, AuthenticateRet = any, AuthorizeRet = AuthenticateRet> {
@@ -820,7 +833,10 @@ declare namespace passport {
          *       });
          *     });
          */
-        initialize(passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>, options?: any): (...args: any[]) => InitializeRet;
+        initialize(
+            passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>,
+            options?: any,
+        ): (...args: any[]) => InitializeRet;
         /**
          * Authenticates requests.
          *
@@ -876,7 +892,12 @@ declare namespace passport {
          *
          *     passport.authenticate('twitter');
          */
-        authenticate(passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>, name: string, options?: any, callback?: (...args: any[]) => any): (...args: any[]) => AuthenticateRet;
+        authenticate(
+            passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>,
+            name: string,
+            options?: any,
+            callback?: (...args: any[]) => any,
+        ): (...args: any[]) => AuthenticateRet;
         /**
          * Create third-party service authorization middleware.
          *
@@ -899,7 +920,12 @@ declare namespace passport {
          * @example
          * app.get('/oauth/callback/twitter', passport.authorize('twitter'));
          */
-        authorize?(passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>, name: string, options?: any, callback?: (...args: any[]) => any): (...args: any[]) => AuthorizeRet;
+        authorize?(
+            passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>,
+            name: string,
+            options?: any,
+            callback?: (...args: any[]) => any,
+        ): (...args: any[]) => AuthorizeRet;
     }
 }
 

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -507,7 +507,7 @@ declare namespace passport {
          */
         serializeUser<User extends Express.User = Express.User>(
             user: User,
-            done: (err: any, serializedUser: number | NonNullable<unknown> | undefined) => any,
+            done: (err: any, serializedUser?: number | NonNullable<unknown>) => any,
         ): void;
         /**
          * Registers a function used to deserialize user objects out of the session.

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -601,7 +601,7 @@ declare namespace passport {
         transformAuthInfo<InitialInfo = unknown, Request extends IncomingMessage = express.Request>(
             info: unknown,
             req: Request,
-            done: (err: any, transformedAuthInfo: InitialInfo | NonNullable<unknown> | undefined) => any,
+            done: (err: any, transformedAuthInfo?: InitialInfo | NonNullable<unknown>) => any,
         ): void;
         /**
          * Private implementation that traverses the chain of transformers,
@@ -614,7 +614,7 @@ declare namespace passport {
          */
         transformAuthInfo<InitialInfo = unknown>(
             info: unknown,
-            done: (err: any, transformedAuthInfo: InitialInfo | NonNullable<unknown> | undefined) => any,
+            done: (err: any, transformedAuthInfo?: InitialInfo | NonNullable<unknown>) => any,
         ): void;
     }
 

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -248,22 +248,6 @@ app.use((req: express.Request, res: express.Response, next: (err?: any) => void)
 app.use((req, _res, next) => {
     const user: Express.User = { username: '', id: 0 };
 
-    passport.serializeUser({ username: '', id: 0 }, req, (err, serializedUser) => {
-        // $ExpectType unknown
-        serializedUser;
-    });
-    passport.serializeUser(user, req, (err, serializedUser) => {
-        // $ExpectType unknown
-        serializedUser;
-    });
-    passport.serializeUser({ username: '', id: 0 }, (err, serializedUser) => {
-        // $ExpectType unknown
-        serializedUser;
-    });
-    passport.serializeUser(user, (err, serializedUser) => {
-        // $ExpectType unknown
-        serializedUser;
-    });
     passport.deserializeUser(0, req, (err, user) => {
         // $ExpectType false | User | undefined
         user;
@@ -276,15 +260,7 @@ app.use((req, _res, next) => {
         // $ExpectType unknown
         info;
     });
-    passport.transformAuthInfo<Express.User>(user, (err, info) => {
-        // $ExpectType unknown
-        info;
-    });
     passport.transformAuthInfo({}, req, (err, info) => {
-        // $ExpectType unknown
-        info;
-    });
-    passport.transformAuthInfo<Express.User>(user, req, (err, info) => {
         // $ExpectType unknown
         info;
     });

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -26,8 +26,8 @@ class TestStrategy extends passport.Strategy {
             this.fail();
             this.fail(403);
             this.fail('challenge string', 403);
-            this.fail({message: 'hello'}, 403);
-            this.fail({message: 'hello', other: 123}, 123);
+            this.fail({ message: 'hello' }, 403);
+            this.fail({ message: 'hello', other: 123 }, 123);
         } else {
             this.success(user);
         }
@@ -36,7 +36,7 @@ class TestStrategy extends passport.Strategy {
 
 const newFramework: passport.Framework = {
     initialize() {
-        return () => { };
+        return () => {};
     },
     authenticate(passport, name, options) {
         return () => {
@@ -47,30 +47,34 @@ const newFramework: passport.Framework = {
         return () => {
             return `authorize(): ${name} ${options}`;
         };
-    }
+    },
 };
-passport.use(new passport.strategies.SessionStrategy((serializedUser, req, done) => {
-    done(null, false)
-    done(null, null)
-    done(undefined, undefined)
-    done(new Error(), undefined)
-    done(undefined, { username: "test", id: 0 })
-}));
+passport.use(
+    new passport.strategies.SessionStrategy((serializedUser, req, done) => {
+        done(null, false);
+        done(null, null);
+        done(undefined, undefined);
+        done(new Error(), undefined);
+        done(undefined, { username: 'test', id: 0 });
+    }),
+);
 
-passport.use(new passport.strategies.SessionStrategy({ key: "passport" }, (serializedUser, req, done) => {
-    done(null, false)
-    done(null, null)
-    done(undefined, undefined)
-    done(new Error(), undefined)
-    done(undefined, { username: "test", id: 0 })
-}));
+passport.use(
+    new passport.strategies.SessionStrategy({ key: 'passport' }, (serializedUser, req, done) => {
+        done(null, false);
+        done(null, null);
+        done(undefined, undefined);
+        done(new Error(), undefined);
+        done(undefined, { username: 'test', id: 0 });
+    }),
+);
 
-const sesStratOpts: passport.SessionStrategyOptions = { key: "passport" }
-const sesStratFn: passport.DeserializeUserFunction = (serializedUser, req, done) => {}
+const sesStratOpts: passport.SessionStrategyOptions = { key: 'passport' };
+const sesStratFn: passport.DeserializeUserFunction = (serializedUser, req, done) => {};
 
 passport.use(new passport.strategies.SessionStrategy(sesStratFn));
 passport.use(new passport.strategies.SessionStrategy(sesStratOpts, sesStratFn));
-passport.use(new passport.strategies.SessionStrategy({ key: "passport" }, sesStratFn));
+passport.use(new passport.strategies.SessionStrategy({ key: 'passport' }, sesStratFn));
 passport.use(new passport.strategies.SessionStrategy(sesStratOpts, (serializedUser, req, done) => {}));
 
 passport.use(new TestStrategy());
@@ -107,69 +111,70 @@ passport.deserializeUser<number>((id, done) => {
     };
 
     fetchUser(id)
-        .then((user) => done(null, user))
+        .then(user => done(null, user))
         .catch(done);
 });
 
-passport.use(new TestStrategy())
-    .unuse('test')
-    .use(new TestStrategy())
-    .framework(newFramework);
+passport.use(new TestStrategy()).unuse('test').use(new TestStrategy()).framework(newFramework);
 
 const app = express();
 app.use(passport.initialize());
 app.use(passport.initialize({ compat: false }));
-app.use(passport.initialize({ userProperty: "user" }));
-app.use(passport.initialize({ compat: true, userProperty: "user" }));
+app.use(passport.initialize({ userProperty: 'user' }));
+app.use(passport.initialize({ compat: true, userProperty: 'user' }));
 app.use(passport.session());
 app.use(passport.session({ pauseStream: false }));
 
-app.post('/login',
-    passport.authenticate('local', { failureRedirect: '/login', failureFlash: true }),
-    (req, res) => {
-        res.redirect('/');
-    });
+app.post('/login', passport.authenticate('local', { failureRedirect: '/login', failureFlash: true }), (req, res) => {
+    res.redirect('/');
+});
 
-app.post('/login',
-    passport.authorize('local', { failureRedirect: '/login', failureFlash: true }),
-    (req, res) => {
-        res.redirect('/');
-    });
+app.post('/login', passport.authorize('local', { failureRedirect: '/login', failureFlash: true }), (req, res) => {
+    res.redirect('/');
+});
 
 app.post('/login', (req, res, next) => {
-    passport.authenticate('local', (err: any, user: { username: string; }, info: { message: string; }) => {
-        if (err) { return next(err); }
+    passport.authenticate('local', (err: any, user: { username: string }, info: { message: string }) => {
+        if (err) {
+            return next(err);
+        }
         if (!user) {
             if (req.session) {
                 req.session.error = info.message;
             }
             return res.redirect('/login');
         }
-        req.logIn(user, (err) => {
-            if (err) { return next(err); }
+        req.logIn(user, err => {
+            if (err) {
+                return next(err);
+            }
             return res.redirect('/users/' + user.username);
         });
     })(req, res, next);
 });
 
 app.post('/login', (req, res, next) => {
-    passport.authenticate('local', (err: any, user: { username: string; }, info: { message: string; }) => {
-        if (err) { return next(err); }
+    passport.authenticate('local', (err: any, user: { username: string }, info: { message: string }) => {
+        if (err) {
+            return next(err);
+        }
         if (!user) {
             if (req.session) {
                 req.session.error = info.message;
             }
             return res.redirect('/login');
         }
-        req.logIn(user, { session: true, keepSessionInfo: false }, (err) => {
-            if (err) { return next(err); }
+        req.logIn(user, { session: true, keepSessionInfo: false }, err => {
+            if (err) {
+                return next(err);
+            }
             return res.redirect('/users/' + user.username);
         });
     })(req, res, next);
 });
 
 app.post('/logout', (req, res, next) => {
-    req.logout((err) => {
+    req.logout(err => {
         if (err) {
             return next(err);
         }
@@ -178,7 +183,7 @@ app.post('/logout', (req, res, next) => {
 });
 
 app.post('/logout', (req, res, next) => {
-    req.logout({ keepSessionInfo: false }, (err) => {
+    req.logout({ keepSessionInfo: false }, err => {
         if (err) {
             return next(err);
         }
@@ -197,23 +202,19 @@ function authSetting(): void {
         res.redirect('/');
     };
 
-    app.get('/auth/facebook',
-        passport.authenticate('facebook'));
-    app.get('/auth/facebook/callback',
-        passport.authenticate('facebook', authOption), successCallback);
+    app.get('/auth/facebook', passport.authenticate('facebook'));
+    app.get('/auth/facebook/callback', passport.authenticate('facebook', authOption), successCallback);
 
-    app.get('/auth/twitter',
-        passport.authenticate('twitter'));
-    app.get('/auth/twitter/callback',
-        passport.authenticate('twitter', authOption));
+    app.get('/auth/twitter', passport.authenticate('twitter'));
+    app.get('/auth/twitter/callback', passport.authenticate('twitter', authOption));
 
-    app.get('/auth/google',
+    app.get(
+        '/auth/google',
         passport.authenticate('google', {
-            scope:
-                ['https://www.googleapis.com/auth/userinfo.profile']
-        }));
-    app.get('/auth/google/callback',
-        passport.authenticate('google', authOption), successCallback);
+            scope: ['https://www.googleapis.com/auth/userinfo.profile'],
+        }),
+    );
+    app.get('/auth/google/callback', passport.authenticate('google', authOption), successCallback);
 }
 
 function ensureAuthenticated(req: express.Request, res: express.Response, next: (err?: any) => void) {
@@ -235,7 +236,7 @@ authenticator.use(new TestStrategy());
 app.use((req: express.Request, res: express.Response, next: (err?: any) => void) => {
     if (req.user) {
         if (req.user.username) {
-            req.user.username = "hello user";
+            req.user.username = 'hello user';
         }
         if (req.user.id) {
             req.user.id = 123;
@@ -245,48 +246,48 @@ app.use((req: express.Request, res: express.Response, next: (err?: any) => void)
 });
 
 app.use((req, _res, next) => {
-    const user: Express.User = { username: "", id: 0 }
+    const user: Express.User = { username: '', id: 0 };
 
-    passport.serializeUser({ username: "", id: 0 }, req, (err, serializedUser) => {
+    passport.serializeUser({ username: '', id: 0 }, req, (err, serializedUser) => {
         // $ExpectType number | {} | undefined
-        serializedUser
-    })
+        serializedUser;
+    });
     passport.serializeUser(user, req, (err, serializedUser) => {
         // $ExpectType number | {} | undefined
-        serializedUser
-    })
-    passport.serializeUser({ username: "", id: 0 }, (err, serializedUser) => {
+        serializedUser;
+    });
+    passport.serializeUser({ username: '', id: 0 }, (err, serializedUser) => {
         // $ExpectType number | {} | undefined
-        serializedUser
-    })
+        serializedUser;
+    });
     passport.serializeUser(user, (err, serializedUser) => {
         // $ExpectType number | {} | undefined
-        serializedUser
-    })
+        serializedUser;
+    });
     passport.deserializeUser(0, req, (err, user) => {
-        // $ExpectType false | Express.User | undefined
-        user
-    })
+        // $ExpectType false | User | undefined
+        user;
+    });
     passport.deserializeUser(0, (err, user) => {
-        // $ExpectType false | Express.User | undefined
-        user
-    })
+        // $ExpectType false | User | undefined
+        user;
+    });
     passport.transformAuthInfo({}, (err, info) => {
         // $ExpectType unknown
-        info
-    })
+        info;
+    });
     passport.transformAuthInfo<Express.User>(user, (err, info) => {
-        // $ExpectType {} | Express.User | undefined
-        info
-    })
+        // $ExpectType {} | User | undefined
+        info;
+    });
     passport.transformAuthInfo({}, req, (err, info) => {
         // $ExpectType unknown
-        info
-    })
+        info;
+    });
     passport.transformAuthInfo<Express.User>(user, req, (err, info) => {
-        // $ExpectType {} | Express.User | undefined
-        info
-    })
+        // $ExpectType {} | User | undefined
+        info;
+    });
 
-    next()
-})
+    next();
+});

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -249,19 +249,19 @@ app.use((req, _res, next) => {
     const user: Express.User = { username: '', id: 0 };
 
     passport.serializeUser({ username: '', id: 0 }, req, (err, serializedUser) => {
-        // $ExpectType number | {} | undefined
+        // $ExpectType unknown
         serializedUser;
     });
     passport.serializeUser(user, req, (err, serializedUser) => {
-        // $ExpectType number | {} | undefined
+        // $ExpectType unknown
         serializedUser;
     });
     passport.serializeUser({ username: '', id: 0 }, (err, serializedUser) => {
-        // $ExpectType number | {} | undefined
+        // $ExpectType unknown
         serializedUser;
     });
     passport.serializeUser(user, (err, serializedUser) => {
-        // $ExpectType number | {} | undefined
+        // $ExpectType unknown
         serializedUser;
     });
     passport.deserializeUser(0, req, (err, user) => {
@@ -277,7 +277,7 @@ app.use((req, _res, next) => {
         info;
     });
     passport.transformAuthInfo<Express.User>(user, (err, info) => {
-        // $ExpectType {} | User | undefined
+        // $ExpectType unknown
         info;
     });
     passport.transformAuthInfo({}, req, (err, info) => {
@@ -285,7 +285,7 @@ app.use((req, _res, next) => {
         info;
     });
     passport.transformAuthInfo<Express.User>(user, req, (err, info) => {
-        // $ExpectType {} | User | undefined
+        // $ExpectType unknown
         info;
     });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jaredhanson/passport/blob/master/lib/authenticator.js>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

### Reason for changes:

The in-editor IntelliSence for the Passport.js (`passport`) library was not displaying the JSDoc comments present in the Passport source code. So while the `@types/passport` package added the typescript typings for Passport, it removed the ability to see the JSDoc documentation comments.

![Before](https://user-images.githubusercontent.com/80650685/211314487-7f6f63bf-b51f-4c94-a2c5-0e6faf8f8d65.png)
    
### Proposed changes:
 
#### In types/passport/index.d.ts:
 - Add the JSDoc comments from the upstream https://github.com/jaredhanson/passport repo to get the documentation only found in the Passport source code JSDoc comments. With the JSDoc comments for the `.d.ts` types, the integrated JSDoc IntelliSence viewer will now display the JSDoc documentation correctly.

![After](https://user-images.githubusercontent.com/80650685/211314465-21134efc-f9b5-4878-b1b1-13d199025253.png)

 - Also add the missing typing for the built-in passport authentication strategy `SessionStrategy`, which was not present previously.
 - And update some missing options for some functions according to the documentation.
    
### Need for review:
 - The `SessionStrategy.authenicate` method is a `@protected` member of the `SessionStrategy` class.  However, I could not find a way to properly express that type while using an `interface`, because only the typescript `class` has the ability to use the `protected` modifier. However, using `class` anywhere in the declaration file (in the `passport` namespace, top-level declaration scope, or a nested namespace inside the `passport` namespace) will cause problems with the way the `passport` namespace is exported. And would require a larger change to the entire declaration file.
    
#### Request for maintainers:
 - Please see if it is reasonable to keep the JSDoc comments for the Passport.js (`passport`) library package up to date with the upstream documentation. I would be open to see how I could help.