### PR TITLE
[sourcemap-validator] Add types

### DIFF
--- a/types/sourcemap-validator/index.d.ts
+++ b/types/sourcemap-validator/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for sourcemap-validator 2.1
+// Project: https://github.com/ben-ng/sourcemap-validator#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = validate;
+
+/**
+ * Validate source maps.
+ *
+ * @param minifiedCode Your minified code.
+ * @param sourceMap Your sourcemap as a JSON string. If left empty, the inline sourcemap in `minifiedCode` will be used.
+ * @param sourceContent A map to the raw source files. If left empty, the inline `sourceContent` in `sourceMap` will be used.
+ *
+ * @example
+ * import validate = require('sourcemap-validator');
+ * import * as fs from 'fs';
+ * import * as assert from 'assert';
+ *
+ * const min = fs.readFileSync('jquery.min.js', 'utf-8');
+ * const map = fs.readFileSync('jquery.min.map', 'utf-8');
+ * const raw = fs.readFileSync('jquery.js', 'utf-8');
+ *
+ * assert.doesNotThrow(() => {
+ *   validate(min, map, {'jquery.js': raw});
+ * }, 'The sourcemap is not valid');
+ *
+ * const browserifyBundleMin = fs.readFileSync('bundle.min.js', 'utf-8');
+ * const browserifyBundleMap = fs.readFileSync('bundle.min.map', 'utf-8');
+ *
+ * // Browserify bundles have inline sourceContent in their maps
+ * // so no need to pass a `sourceContent` object.
+ * assert.doesNotThrow(() => {
+ *   validate(browserifyBundleMin, browserifyBundleMap);
+ * }, 'The sourcemap is not valid');
+ */
+declare function validate(minifiedCode: string, sourceMap?: string, sourceContent?: Record<string, string>): void;

--- a/types/sourcemap-validator/sourcemap-validator-tests.ts
+++ b/types/sourcemap-validator/sourcemap-validator-tests.ts
@@ -1,0 +1,5 @@
+import validate = require('sourcemap-validator');
+
+validate('foo'); // $ExpectType void
+validate('foo', 'bar'); // $ExpectType void
+validate('foo', 'bar', { 'foo.js': 'bar' }); // $ExpectType void

--- a/types/sourcemap-validator/tsconfig.json
+++ b/types/sourcemap-validator/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sourcemap-validator-tests.ts"
+    ]
+}

--- a/types/sourcemap-validator/tslint.json
+++ b/types/sourcemap-validator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.