### PR TITLE
update "wordcloud" types to align upstream

### DIFF
--- a/types/wordcloud/index.d.ts
+++ b/types/wordcloud/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for wordcloud 1.1
+// Type definitions for wordcloud 1.2
 // Project: https://github.com/timdream/wordcloud2.js, http://timdream.org/wordcloud2.js
 // Definitions by: Joe Skeen <https://github.com/joeskeen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordcloud/index.d.ts
+++ b/types/wordcloud/index.d.ts
@@ -10,7 +10,7 @@ declare function WordCloud(elements: HTMLElement | HTMLElement[], options: WordC
 
 declare namespace WordCloud {
     const isSupported: boolean;
-    let minFontSize: number;
+    const minFontSize: number;
 
     /** Stop rendering. */
     function stop(): void;

--- a/types/wordcloud/index.d.ts
+++ b/types/wordcloud/index.d.ts
@@ -12,12 +12,15 @@ declare namespace WordCloud {
     const isSupported: boolean;
     let miniumFontSize: number;
 
+    /** Stop rendering. */
+    function stop(): void;
+
     interface Options {
         /**
          * List of words/text to paint on the canvas in a 2-d array, in the form of [word, size],
          * e.g. [['foo', 12] , ['bar', 6]].
          */
-        list?: ListEntry[] | any[] | undefined;
+        list?: ListEntry[] | undefined;
         /** font to use. */
         fontFamily?: string | undefined;
         /** font weight to use, e.g. normal, bold or 600 */
@@ -52,6 +55,8 @@ declare namespace WordCloud {
         origin?: [number, number] | undefined;
         /** set to true to allow word being draw partly outside of the canvas. Allow word bigger than the size of the canvas to be drawn. */
         drawOutOfBound?: boolean | undefined;
+        /** set to `true` to shrink the word so it will fit into canvas. Best if `drawOutOfBound` is set to false. This word will now have lower weight. */
+        shrinkToFit?: boolean | undefined;
 
         /** visualize the grid by draw squares to mask the drawn areas. */
         drawMask?: boolean | undefined;
@@ -74,6 +79,8 @@ declare namespace WordCloud {
          * to  keep all text in one angle.
          */
         maxRotation?: number | undefined;
+        /** Force the use of a defined number of angles. Set the value equal to 2 in a -90°/90° range means just -90, 0 or 90 will be used. */
+        rotationSteps?: number | undefined;
 
         /** Shuffle the points to draw so the result will be different each time for the same list and settings. */
         shuffle?: boolean | undefined;
@@ -111,6 +118,6 @@ declare namespace WordCloud {
         h: number;
     }
 
-    type ListEntry = [string, number];
+    type ListEntry = [string, number, ...any[]];
     type EventCallback = (item: ListEntry, dimension: Dimension, event: MouseEvent) => void;
 }

--- a/types/wordcloud/index.d.ts
+++ b/types/wordcloud/index.d.ts
@@ -10,7 +10,7 @@ declare function WordCloud(elements: HTMLElement | HTMLElement[], options: WordC
 
 declare namespace WordCloud {
     const isSupported: boolean;
-    let miniumFontSize: number;
+    let minFontSize: number;
 
     /** Stop rendering. */
     function stop(): void;
@@ -30,13 +30,19 @@ declare namespace WordCloud {
          * specifies  different color for each item in the list. You may also specify colors with built-in
          * keywords: random-dark and random-light.
          */
-        color?: string | ((word: string, weight: string | number, fontSize: number, distance: number, theta: number) => string) | undefined;
+        color?:
+            | string
+            | ((word: string, weight: string | number, fontSize: number, distance: number, theta: number) => string)
+            | undefined;
         /**
          * for DOM clouds, allows the user to define the class of the span elements.Can be a normal class
          * string, applying the same class to every span or a callback(word, weight, fontSize, distance, theta)
          * for per-span class definition. In canvas clouds or if equals null, this option has no effect.
          */
-        classes?: string | ((word: string, weight: string | number, fontSize: number, distance: number, theta: number) => string) | undefined;
+        classes?:
+            | string
+            | ((word: string, weight: string | number, fontSize: number, distance: number, theta: number) => string)
+            | undefined;
         /** minimum font size to draw on the canvas. */
         minSize?: number | undefined;
         /** function to call or number to multiply for size of each word in the list. */

--- a/types/wordcloud/wordcloud-tests.ts
+++ b/types/wordcloud/wordcloud-tests.ts
@@ -6,7 +6,7 @@ declare const element: HTMLElement | HTMLElement[];
 
 if (!WordCloud.isSupported) console.log('WordCloud is not supported.');
 
-WordCloud.miniumFontSize = 20;
+WordCloud.minFontSize = 20;
 
 WordCloud.stop();
 

--- a/types/wordcloud/wordcloud-tests.ts
+++ b/types/wordcloud/wordcloud-tests.ts
@@ -1,184 +1,187 @@
-import WordCloud = require("wordcloud");
+import WordCloud = require('wordcloud');
 
 declare function test(name: string, cb: () => void): void;
 
 declare const element: HTMLElement | HTMLElement[];
 
-if (!WordCloud.isSupported)
-  console.log('WordCloud is not supported.');
+if (!WordCloud.isSupported) console.log('WordCloud is not supported.');
 
 WordCloud.miniumFontSize = 20;
 
-const list = 'Grumpy wizards make toxic brew for the evil Queen and Jack'.split(' ').map(word => [word, word.length * 5]);
+WordCloud.stop();
+
+const list = 'Grumpy wizards make toxic brew for the evil Queen and Jack'
+    .split(' ')
+    .map<[string, number]>(word => [word, word.length * 5]);
 
 function getTestOptions(): WordCloud.Options {
-  return {
-    shuffle: false,
-    rotateRatio: 0,
-    color: '#000',
-    fontFamily: 'sans-serif',
-    list,
-  };
+    return {
+        shuffle: false,
+        rotateRatio: 0,
+        color: '#000',
+        fontFamily: 'sans-serif',
+        list,
+    };
 }
 
 test('Test runs without any extra parameters.', () => {
-  const options = getTestOptions();
-  WordCloud(element, options);
+    const options = getTestOptions();
+    WordCloud(element, options);
 });
 
 test('Empty list results no output.', () => {
-  const options = getTestOptions();
-  options.list = [];
+    const options = getTestOptions();
+    options.list = [];
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('gridSize can be set', () => {
-  const options = getTestOptions();
-  options.gridSize = 15;
+    const options = getTestOptions();
+    options.gridSize = 15;
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('ellipticity can be set', () => {
-  const options = getTestOptions();
-  options.ellipticity = 1.5;
+    const options = getTestOptions();
+    options.ellipticity = 1.5;
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('origin can be set', () => {
-  const options = getTestOptions();
-  options.origin = [300, 0];
+    const options = getTestOptions();
+    options.origin = [300, 0];
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('minSize can be set', () => {
-  const options = getTestOptions();
-  options.minSize = 10;
+    const options = getTestOptions();
+    options.minSize = 10;
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('rotation can be set and locked', () => {
-  const options = getTestOptions();
-  options.rotateRatio = 1;
-  options.minRotation = options.maxRotation = Math.PI / 6;
+    const options = getTestOptions();
+    options.rotateRatio = 1;
+    options.minRotation = options.maxRotation = Math.PI / 6;
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('drawMask can be set', () => {
-  const options = getTestOptions();
-  options.drawMask = true;
+    const options = getTestOptions();
+    options.drawMask = true;
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('maskColor can be set', () => {
-  const options = getTestOptions();
-  options.drawMask = true;
-  options.maskColor = 'rgba(0, 0, 255, 0.8)';
+    const options = getTestOptions();
+    options.drawMask = true;
+    options.maskColor = 'rgba(0, 0, 255, 0.8)';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('backgroundColor can be set', () => {
-  const options = getTestOptions();
-  options.backgroundColor = 'rgb(0, 0, 255)';
+    const options = getTestOptions();
+    options.backgroundColor = 'rgb(0, 0, 255)';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('semi-transparent backgroundColor can be set', () => {
-  const options = getTestOptions();
-  options.backgroundColor = 'rgba(0, 0, 255, 0.3)';
+    const options = getTestOptions();
+    options.backgroundColor = 'rgba(0, 0, 255, 0.3)';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('weightFactor can be set', () => {
-  const options = getTestOptions();
-  options.weightFactor = 2;
+    const options = getTestOptions();
+    options.weightFactor = 2;
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('weightFactor can be set as a function', () => {
-  const options = getTestOptions();
-  options.weightFactor = w => Math.sqrt(w);
+    const options = getTestOptions();
+    options.weightFactor = w => Math.sqrt(w);
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('color can be set as a function', () => {
-  const options = getTestOptions();
-  options.color = (word, weight, fontSize, radius, theta) => {
-    if (theta < 2 * Math.PI / 3) {
-      return '#600';
-    } else if (theta < 2 * Math.PI * 2 / 3) {
-      return '#060';
-    } else {
-      return '#006';
-    }
-  };
+    const options = getTestOptions();
+    options.color = (word, weight, fontSize, radius, theta) => {
+        if (theta < (2 * Math.PI) / 3) {
+            return '#600';
+        } else if (theta < (2 * Math.PI * 2) / 3) {
+            return '#060';
+        } else {
+            return '#006';
+        }
+    };
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('shape can be set to circle', () => {
-  const options = getTestOptions();
-  options.shape = 'circle';
+    const options = getTestOptions();
+    options.shape = 'circle';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('shape can be set to cardioid', () => {
-  const options = getTestOptions();
-  options.shape = 'cardioid';
+    const options = getTestOptions();
+    options.shape = 'cardioid';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('shape can be set to diamond', () => {
-  const options = getTestOptions();
-  options.shape = 'diamond';
+    const options = getTestOptions();
+    options.shape = 'diamond';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('shape can be set to triangle', () => {
-  const options = getTestOptions();
-  options.shape = 'triangle';
+    const options = getTestOptions();
+    options.shape = 'triangle';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('shape can be set to triangle-forward', () => {
-  const options = getTestOptions();
-  options.shape = 'triangle-forward';
+    const options = getTestOptions();
+    options.shape = 'triangle-forward';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('shape can be set to pentagon', () => {
-  const options = getTestOptions();
-  options.shape = 'pentagon';
+    const options = getTestOptions();
+    options.shape = 'pentagon';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('shape can be set to star', () => {
-  const options = getTestOptions();
-  options.shape = 'star';
+    const options = getTestOptions();
+    options.shape = 'star';
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });
 
 test('shape can be set to a given polar equation', () => {
-  const options = getTestOptions();
-  options.shape = theta => theta / (2 * Math.PI);
+    const options = getTestOptions();
+    options.shape = theta => theta / (2 * Math.PI);
 
-  WordCloud(element, options);
+    WordCloud(element, options);
 });

--- a/types/wordcloud/wordcloud-tests.ts
+++ b/types/wordcloud/wordcloud-tests.ts
@@ -5,8 +5,7 @@ declare function test(name: string, cb: () => void): void;
 declare const element: HTMLElement | HTMLElement[];
 
 if (!WordCloud.isSupported) console.log('WordCloud is not supported.');
-
-WordCloud.minFontSize = 20;
+console.log(WordCloud.minFontSize);
 
 WordCloud.stop();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test wordcloud`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/timdream/wordcloud2.js/blob/gh-pages/API.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Types of "wordcloud" are out of dated. This PR updated them.

Existing code doesn't match Prettier config, e.g. it originally uses 2-space indentation but Prettier is configured with 4-space indentation. When I save and format the files, file indentation was changed, so you may see unrelated changes.
