### PR TITLE
[jest] type done callback on each

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -494,7 +494,7 @@ declare namespace jest {
         // Exclusively arrays.
         <T extends any[] | [any]>(cases: ReadonlyArray<T>): (
             name: string,
-            fn: (...t: [...args: T, done: DoneCallback]) => any,
+            fn: (...args: T) => any,
             timeout?: number,
         ) => void;
         <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -494,7 +494,7 @@ declare namespace jest {
         // Exclusively arrays.
         <T extends any[] | [any]>(cases: ReadonlyArray<T>): (
             name: string,
-            fn: (...args: T) => any,
+            fn: (...t: [...args: T, done: DoneCallback]) => any,
             timeout?: number,
         ) => void;
         <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (
@@ -503,7 +503,7 @@ declare namespace jest {
             timeout?: number,
         ) => void;
         // Not arrays.
-        <T>(cases: ReadonlyArray<T>): (name: string, fn: (...args: T[]) => any, timeout?: number) => void;
+        <T>(cases: ReadonlyArray<T>): (name: string, fn: (arg: T, done: DoneCallback) => any, timeout?: number) => void;
         (cases: ReadonlyArray<ReadonlyArray<any>>): (
             name: string,
             fn: (...args: any[]) => any,
@@ -511,7 +511,7 @@ declare namespace jest {
         ) => void;
         (strings: TemplateStringsArray, ...placeholders: any[]): (
             name: string,
-            fn: (arg: any) => any,
+            fn: (arg: any, done: DoneCallback) => any,
             timeout?: number,
         ) => void;
     }

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1744,6 +1744,16 @@ test.each([
     5000,
 );
 
+test.each([
+    [
+        { prop1: true, prop2: true },
+        { prop1: true, prop2: true },
+    ],
+    [{ prop1: true }, { prop1: true, prop2: false }],
+])('%j -> %j', (input, output) => {
+    console.log(input, output);
+});
+
 declare const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']];
 test.each(constCases)('%s + %s', (...args) => {
     // following assertion is skipped because of flaky testing

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1646,10 +1646,9 @@ describe.each([
     [1, 1, 2],
     [1, 2, 3],
     [2, 1, 3],
-])('.add(%i, %i)', (a: number, b: number, expected: number, done) => {
+])('.add(%i, %i)', (a: number, b: number, expected: number) => {
     test(`returns ${expected}`, () => {
         expect(a + b).toBe(expected);
-        done();
     });
 });
 
@@ -1797,10 +1796,9 @@ test.each`
 test.each([
     [1, '1'],
     [2, '2'],
-])('', (a, b, done) => {
+])('', (a, b) => {
     a; // $ExpectType number
     b; // $ExpectType string
-    done; // $ExpectType DoneCallback
 });
 
 test.only.each([

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1646,10 +1646,22 @@ describe.each([
     [1, 1, 2],
     [1, 2, 3],
     [2, 1, 3],
-])('.add(%i, %i)', (a: number, b: number, expected: number) => {
+])('.add(%i, %i)', (a: number, b: number, expected: number, done) => {
     test(`returns ${expected}`, () => {
         expect(a + b).toBe(expected);
+        done();
     });
+});
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34617
+
+it.each<number>([1, 2, 3])('dummy: %d', (num, done) => {
+    done();
+});
+
+const casesReadonlyArray = [[1, 2, 3] as ReadonlyArray<number>] as ReadonlyArray<ReadonlyArray<number>>;
+it.each(casesReadonlyArray)('%d', (a, b, c) => {
+    expect(a + b).toBe(c);
 });
 
 interface Case {
@@ -1663,9 +1675,10 @@ describe.each`
     ${1} | ${1} | ${2}
     ${1} | ${2} | ${3}
     ${2} | ${1} | ${3}
-`('$a + $b', ({ a, b, expected }: Case) => {
+`('$a + $b', ({ a, b, expected }: Case, done) => {
     test(`returns ${expected}`, () => {
         expect(a + b).toBe(expected);
+        done();
     });
 });
 
@@ -1774,9 +1787,10 @@ test.each`
 test.each([
     [1, '1'],
     [2, '2'],
-])('', (a, b) => {
+])('', (a, b, done) => {
     a; // $ExpectType number
     b; // $ExpectType string
+    done; // $ExpectType DoneCallback
 });
 
 test.only.each([


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Docs don't appear to mention this, but an issue regarding this gap was raised here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34617

## Note

I also added a test case for `ReadonlyArray` declaration, however I was unable to fix it for the done callback as the variadic tuple approach doesn't appear to work there, ie:

```typescript
<T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (
            name: string,
            fn: (...t: [...args: T, done: DoneCallback) => any,  // results in arguments being typed T | DoneCallback
            timeout?: number,
        ) => void;
```
