### PR TITLE
[mui-datatables] Typescript compatibility with mui-datatables 4.3 and React 18

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1054,7 +1054,7 @@ export interface MUIDataTableJumpToPage {
     count: number;
     page: number;
     rowsPerPage: number;
-    textLabels: Partial<MUIDataTableTextLabels>
+    textLabels: Partial<MUIDataTableTextLabels>;
 }
 
 export interface MUIDataTablePagination {
@@ -1175,116 +1175,115 @@ declare module '@mui/material/styles/components' {
             defaultProps?: ComponentsProps['MUIDataTable'];
             styleOverrides?: ComponentsOverrides['MUIDataTable'];
             variants?: ComponentsVariants['MUIDataTable'];
-        },
+        };
         MUIDataTableBody?: {
             defaultProps?: ComponentsProps['MUIDataTableBody'];
             styleOverrides?: ComponentsOverrides['MUIDataTableBody'];
             variants?: ComponentsVariants['MUIDataTableBody'];
-        },
+        };
         MUIDataTableBodyCell?: {
             defaultProps?: ComponentsProps['MUIDataTableBodyCell'];
             styleOverrides?: ComponentsOverrides['MUIDataTableBodyCell'];
             variants?: ComponentsVariants['MUIDataTableBodyCell'];
-        },
+        };
         MUIDataTableBodyRow?: {
             defaultProps?: ComponentsProps['MUIDataTableBodyRow'];
             styleOverrides?: ComponentsOverrides['MUIDataTableBodyRow'];
             variants?: ComponentsVariants['MUIDataTableBodyRow'];
-        },
+        };
         MUIDataTableFilter?: {
             defaultProps?: ComponentsProps['MUIDataTableFilter'];
             styleOverrides?: ComponentsOverrides['MUIDataTableFilter'];
             variants?: ComponentsVariants['MUIDataTableFilter'];
-        },
+        };
         MUIDataTableFilterList?: {
             defaultProps?: ComponentsProps['MUIDataTableFilterList'];
             styleOverrides?: ComponentsOverrides['MUIDataTableFilterList'];
             variants?: ComponentsVariants['MUIDataTableFilterList'];
-        },
+        };
         MUIDataTableFooter?: {
             defaultProps?: ComponentsProps['MUIDataTableFooter'];
             styleOverrides?: ComponentsOverrides['MUIDataTableFooter'];
             variants?: ComponentsVariants['MUIDataTableFooter'];
-        },
+        };
         MUIDataTableHead?: {
             defaultProps?: ComponentsProps['MUIDataTableHead'];
             styleOverrides?: ComponentsOverrides['MUIDataTableHead'];
             variants?: ComponentsVariants['MUIDataTableHead'];
-        },
+        };
         MUIDataTableHeadCell?: {
             defaultProps?: ComponentsProps['MUIDataTableHeadCell'];
             styleOverrides?: ComponentsOverrides['MUIDataTableHeadCell'];
             variants?: ComponentsVariants['MUIDataTableHeadCell'];
-        },
+        };
         MUIDataTableHeadRow?: {
             defaultProps?: ComponentsProps['MUIDataTableHeadRow'];
             styleOverrides?: ComponentsOverrides['MUIDataTableHeadRow'];
             variants?: ComponentsVariants['MUIDataTableHeadRow'];
-        },
+        };
         MUIDataTableJumpToPage?: {
             defaultProps?: ComponentsProps['MUIDataTableJumpToPage'];
             styleOverrides?: ComponentsOverrides['MUIDataTableJumpToPage'];
             variants?: ComponentsVariants['MUIDataTableJumpToPage'];
-        },
+        };
         MUIDataTablePagination?: {
             defaultProps?: ComponentsProps['MUIDataTablePagination'];
             styleOverrides?: ComponentsOverrides['MUIDataTablePagination'];
             variants?: ComponentsVariants['MUIDataTablePagination'];
-        },
+        };
         MUIDataTableResize?: {
             defaultProps?: ComponentsProps['MUIDataTableResize'];
             styleOverrides?: ComponentsOverrides['MUIDataTableResize'];
             variants?: ComponentsVariants['MUIDataTableResize'];
-        },
+        };
         MUIDataTableSearch?: {
             defaultProps?: ComponentsProps['MUIDataTableSearch'];
             styleOverrides?: ComponentsOverrides['MUIDataTableSearch'];
             variants?: ComponentsVariants['MUIDataTableSearch'];
-        },
+        };
         MUIDataTableSelectCell?: {
             defaultProps?: ComponentsProps['MUIDataTableSelectCell'];
             styleOverrides?: ComponentsOverrides['MUIDataTableSelectCell'];
             variants?: ComponentsVariants['MUIDataTableSelectCell'];
-        },
+        };
         MUIDataTableToolbar?: {
             defaultProps?: ComponentsProps['MUIDataTableToolbar'];
             styleOverrides?: ComponentsOverrides['MUIDataTableToolbar'];
             variants?: ComponentsVariants['MUIDataTableToolbar'];
-        },
+        };
         MUIDataTableToolbarSelect?: {
             defaultProps?: ComponentsProps['MUIDataTableToolbarSelect'];
             styleOverrides?: ComponentsOverrides['MUIDataTableToolbarSelect'];
             variants?: ComponentsVariants['MUIDataTableToolbarSelect'];
-        },
+        };
         MUIDataTableViewCol?: {
             defaultProps?: ComponentsProps['MUIDataTableViewCol'];
             styleOverrides?: ComponentsOverrides['MUIDataTableViewCol'];
             variants?: ComponentsVariants['MUIDataTableViewCol'];
-        },
+        };
     }
 }
 
-
 declare module '@mui/material/styles/props' {
     interface ComponentsPropsList {
-        MUIDataTable: MUIDataTableProps
-        MUIDataTableBody: MUIDataTableBody
-        MUIDataTableBodyCell: MUIDataTableBodyCell
-        MUIDataTableBodyRow: MUIDataTableBodyRow
-        MUIDataTableFilter: MUIDataTableFilter
-        MUIDataTableFilterList: MUIDataTableFilterList
-        MUIDataTableFooter: MUIDataTableFooter
-        MUIDataTableHead: MUIDataTableHead
-        MUIDataTableHeadCell: MUIDataTableHeadCell
-        MUIDataTableHeadRow: MUIDataTableHeadRow
-        MUIDataTableJumpToPage: MUIDataTableJumpToPage
-        MUIDataTablePagination: MUIDataTablePagination
-        MUIDataTableResize: MUIDataTableResize
-        MUIDataTableSearch: MUIDataTableSearch
-        MUIDataTableSelectCell: MUIDataTableSelectCell
-        MUIDataTableToolbar: MUIDataTableToolbar
-        MUIDataTableToolbarSelect: MUIDataTableToolbarSelect
-        MUIDataTableViewCol: MUIDataTableViewCol
+        MUIDataTable: MUIDataTableProps;
+        MUIDataTableBody: MUIDataTableBody;
+        MUIDataTableBodyCell: MUIDataTableBodyCell;
+        MUIDataTableBodyRow: MUIDataTableBodyRow;
+        MUIDataTableFilter: MUIDataTableFilter;
+        MUIDataTableFilterList: MUIDataTableFilterList;
+        MUIDataTableFooter: MUIDataTableFooter;
+        MUIDataTableHead: MUIDataTableHead;
+        MUIDataTableHeadCell: MUIDataTableHeadCell;
+        MUIDataTableHeadRow: MUIDataTableHeadRow;
+        MUIDataTableJumpToPage: MUIDataTableJumpToPage;
+        MUIDataTablePagination: MUIDataTablePagination;
+        MUIDataTableResize: MUIDataTableResize;
+        MUIDataTableSearch: MUIDataTableSearch;
+        MUIDataTableSelectCell: MUIDataTableSelectCell;
+        MUIDataTableToolbar: MUIDataTableToolbar;
+        MUIDataTableToolbarSelect: MUIDataTableToolbarSelect;
+        MUIDataTableViewCol: MUIDataTableViewCol;
     }
 }
 

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mui-datatables 3.7
+// Type definitions for mui-datatables 4.3
 // Project: https://github.com/gregnb/mui-datatables
 // Definitions by: Jeroen "Favna" Claassens <https://github.com/favna>
 //                 Ankith Konda <https://github.com/ankithkonda>
@@ -9,8 +9,8 @@
 //                 Patrick Erichsen <https://github.com/Patrick-Erichsen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.5
+import { ComponentsProps, ComponentsOverrides, ComponentsVariants } from '@mui/material';
 
-import '@material-ui/core/styles/overrides';
 import * as React from 'react';
 
 export type Display = boolean | 'true' | 'false' | 'excluded';
@@ -1050,6 +1050,12 @@ export interface MUIDataTableHeadCell {
 export interface MUIDataTableHeadRow {
     classes?: object | undefined;
 }
+export interface MUIDataTableJumpToPage {
+    count: number;
+    page: number;
+    rowsPerPage: number;
+    textLabels: Partial<MUIDataTableTextLabels>
+}
 
 export interface MUIDataTablePagination {
     changeRowsPerPage: (...args: any) => any;
@@ -1163,7 +1169,126 @@ export function debounceSearchRender(debounceWait?: number): MUIDataTableOptions
 
 export default MUIDataTable;
 
-declare module '@material-ui/core/styles/overrides' {
+declare module '@mui/material/styles/components' {
+    interface Components {
+        MUIDataTable?: {
+            defaultProps?: ComponentsProps['MUIDataTable'];
+            styleOverrides?: ComponentsOverrides['MUIDataTable'];
+            variants?: ComponentsVariants['MUIDataTable'];
+        },
+        MUIDataTableBody?: {
+            defaultProps?: ComponentsProps['MUIDataTableBody'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableBody'];
+            variants?: ComponentsVariants['MUIDataTableBody'];
+        },
+        MUIDataTableBodyCell?: {
+            defaultProps?: ComponentsProps['MUIDataTableBodyCell'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableBodyCell'];
+            variants?: ComponentsVariants['MUIDataTableBodyCell'];
+        },
+        MUIDataTableBodyRow?: {
+            defaultProps?: ComponentsProps['MUIDataTableBodyRow'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableBodyRow'];
+            variants?: ComponentsVariants['MUIDataTableBodyRow'];
+        },
+        MUIDataTableFilter?: {
+            defaultProps?: ComponentsProps['MUIDataTableFilter'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableFilter'];
+            variants?: ComponentsVariants['MUIDataTableFilter'];
+        },
+        MUIDataTableFilterList?: {
+            defaultProps?: ComponentsProps['MUIDataTableFilterList'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableFilterList'];
+            variants?: ComponentsVariants['MUIDataTableFilterList'];
+        },
+        MUIDataTableFooter?: {
+            defaultProps?: ComponentsProps['MUIDataTableFooter'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableFooter'];
+            variants?: ComponentsVariants['MUIDataTableFooter'];
+        },
+        MUIDataTableHead?: {
+            defaultProps?: ComponentsProps['MUIDataTableHead'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableHead'];
+            variants?: ComponentsVariants['MUIDataTableHead'];
+        },
+        MUIDataTableHeadCell?: {
+            defaultProps?: ComponentsProps['MUIDataTableHeadCell'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableHeadCell'];
+            variants?: ComponentsVariants['MUIDataTableHeadCell'];
+        },
+        MUIDataTableHeadRow?: {
+            defaultProps?: ComponentsProps['MUIDataTableHeadRow'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableHeadRow'];
+            variants?: ComponentsVariants['MUIDataTableHeadRow'];
+        },
+        MUIDataTableJumpToPage?: {
+            defaultProps?: ComponentsProps['MUIDataTableJumpToPage'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableJumpToPage'];
+            variants?: ComponentsVariants['MUIDataTableJumpToPage'];
+        },
+        MUIDataTablePagination?: {
+            defaultProps?: ComponentsProps['MUIDataTablePagination'];
+            styleOverrides?: ComponentsOverrides['MUIDataTablePagination'];
+            variants?: ComponentsVariants['MUIDataTablePagination'];
+        },
+        MUIDataTableResize?: {
+            defaultProps?: ComponentsProps['MUIDataTableResize'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableResize'];
+            variants?: ComponentsVariants['MUIDataTableResize'];
+        },
+        MUIDataTableSearch?: {
+            defaultProps?: ComponentsProps['MUIDataTableSearch'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableSearch'];
+            variants?: ComponentsVariants['MUIDataTableSearch'];
+        },
+        MUIDataTableSelectCell?: {
+            defaultProps?: ComponentsProps['MUIDataTableSelectCell'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableSelectCell'];
+            variants?: ComponentsVariants['MUIDataTableSelectCell'];
+        },
+        MUIDataTableToolbar?: {
+            defaultProps?: ComponentsProps['MUIDataTableToolbar'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableToolbar'];
+            variants?: ComponentsVariants['MUIDataTableToolbar'];
+        },
+        MUIDataTableToolbarSelect?: {
+            defaultProps?: ComponentsProps['MUIDataTableToolbarSelect'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableToolbarSelect'];
+            variants?: ComponentsVariants['MUIDataTableToolbarSelect'];
+        },
+        MUIDataTableViewCol?: {
+            defaultProps?: ComponentsProps['MUIDataTableViewCol'];
+            styleOverrides?: ComponentsOverrides['MUIDataTableViewCol'];
+            variants?: ComponentsVariants['MUIDataTableViewCol'];
+        },
+    }
+}
+
+
+declare module '@mui/material/styles/props' {
+    interface ComponentsPropsList {
+        MUIDataTable: MUIDataTableProps
+        MUIDataTableBody: MUIDataTableBody
+        MUIDataTableBodyCell: MUIDataTableBodyCell
+        MUIDataTableBodyRow: MUIDataTableBodyRow
+        MUIDataTableFilter: MUIDataTableFilter
+        MUIDataTableFilterList: MUIDataTableFilterList
+        MUIDataTableFooter: MUIDataTableFooter
+        MUIDataTableHead: MUIDataTableHead
+        MUIDataTableHeadCell: MUIDataTableHeadCell
+        MUIDataTableHeadRow: MUIDataTableHeadRow
+        MUIDataTableJumpToPage: MUIDataTableJumpToPage
+        MUIDataTablePagination: MUIDataTablePagination
+        MUIDataTableResize: MUIDataTableResize
+        MUIDataTableSearch: MUIDataTableSearch
+        MUIDataTableSelectCell: MUIDataTableSelectCell
+        MUIDataTableToolbar: MUIDataTableToolbar
+        MUIDataTableToolbarSelect: MUIDataTableToolbarSelect
+        MUIDataTableViewCol: MUIDataTableViewCol
+    }
+}
+
+declare module '@mui/material/styles/overrides' {
     interface ComponentNameToClassKey {
         MUIDataTable: 'root' | 'caption' | 'liveAnnounce' | 'paper' | 'responsiveScroll' | 'tableRoot';
 

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -8,7 +8,9 @@ import MUIDataTable, {
     Popover,
 } from 'mui-datatables';
 import * as React from 'react';
-import { createMuiTheme, Checkbox, Radio } from '@material-ui/core';
+import { Checkbox, Radio, ThemeOptions } from '@mui/material';
+import { createTheme } from '@mui/material/styles';
+
 
 interface Props extends Omit<MUIDataTableProps, 'columns'> {
     columns?: MUIDataTableColumn[] | undefined;
@@ -265,18 +267,22 @@ const disabledOptions: MUIDataTableOptions = {
 
 <MuiCustomTable title="Disabled Buttons" data={Todos} options={disabledOptions} />;
 
-const MuiTheme = createMuiTheme({
-    overrides: {
+const MuiTheme = createTheme({
+    components: {
         MUIDataTable: {
-            root: {
-                fontWeight: 300,
-            },
+            styleOverrides: {
+                root: {
+                    fontWeight: 300,
+                },
+            }
         },
         MUIDataTableBody: {
-            emptyTitle: {},
+            styleOverrides: {
+                emptyTitle: {},
+            }
         },
     },
-});
+} as ThemeOptions);
 
 <Popover
     classes={{ icon: 'icon_class' }}

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -11,7 +11,6 @@ import * as React from 'react';
 import { Checkbox, Radio, ThemeOptions } from '@mui/material';
 import { createTheme } from '@mui/material/styles';
 
-
 interface Props extends Omit<MUIDataTableProps, 'columns'> {
     columns?: MUIDataTableColumn[] | undefined;
 }
@@ -282,7 +281,7 @@ const MuiTheme = createTheme({
             }
         },
     },
-} as ThemeOptions);
+} as unknown as ThemeOptions);
 
 <Popover
     classes={{ icon: 'icon_class' }}

--- a/types/mui-datatables/package.json
+++ b/types/mui-datatables/package.json
@@ -1,7 +1,9 @@
 {
     "private": true,
     "dependencies": {
-       "@material-ui/core": "^4.11.3",
-       "@material-ui/types": "5.1.0"
+        "@emotion/react": "^11.10.5",
+        "@emotion/styled": "^11.10.5",
+        "@mui/material": "^5.11.4",
+        "csstype": "^3.1.1"
     }
 }

--- a/types/mui-datatables/tsconfig.json
+++ b/types/mui-datatables/tsconfig.json
@@ -17,7 +17,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [mui-datatables v4.3](https://github.com/gregnb/mui-datatables/releases/tag/4.3.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

