### PR TITLE
[jsonwebtoken] Add KeyObject to Secret type

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -16,6 +16,8 @@
 
 /// <reference types="node" />
 
+import { KeyObject } from 'crypto';
+
 export class JsonWebTokenError extends Error {
     inner: Error;
 
@@ -161,6 +163,7 @@ export type GetPublicKeyOrSecret = (
 export type Secret =
     | string
     | Buffer
+    | KeyObject
     | { key: string | Buffer; passphrase: string };
 
 /**

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -6,9 +6,11 @@
 
 import jwt = require("jsonwebtoken");
 import fs = require("fs");
+import { createSecretKey, KeyObject } from "crypto";
 
 let token: string;
 let cert: Buffer;
+let secretKey: KeyObject;
 
 interface TestObject {
     foo: string;
@@ -45,6 +47,10 @@ const secret = { key: privKey.toString(), passphrase: "keypwd" };
 token = jwt.sign(testObject, secret, { algorithm: "RS256" }); // the algorithm option is mandatory in this case
 token = jwt.sign(testObject, { key: privKey, passphrase: 'keypwd' }, { algorithm: "RS256" });
 
+// sign with secret key (KeyObject)
+secretKey = createSecretKey("shhhhh", "utf-8");
+token = jwt.sign(testObject, secretKey);
+
 // sign with insecure key size
 token = jwt.sign({ foo: 'bar' }, 'shhhhh', { algorithm: 'RS256', allowInsecureKeySizes: true });
 
@@ -68,6 +74,9 @@ jwt.sign(testObject, cert, { algorithm: "RS256" }, (
  * jwt.verify
  * https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback
  */
+// verify using secret key
+jwt.verify(token, secretKey);
+
 // verify a token symmetric
 jwt.verify(token, "shhhhh", (err, decoded) => {
     const result = decoded as TestObject;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test jsonwebtoken`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#class-keyobject https://github.com/auth0/node-jsonwebtoken#usage
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Description:
The `verify` and `sign` functions accept KeyObject as a secret. It's highly encourage to use the KeyObject API as per the Node.js docs:
> Most applications should consider using the new KeyObject API instead of passing keys as strings or Buffers due to improved security features.