### PR TITLE
[google-apps-script] Add missing `setHelpText` definitions to the validation builders.

### DIFF
--- a/types/google-apps-script/google-apps-script.forms.d.ts
+++ b/types/google-apps-script/google-apps-script.forms.d.ts
@@ -86,6 +86,7 @@ declare namespace GoogleAppsScript {
     interface CheckboxGridValidationBuilder {
       requireLimitOneResponsePerColumn(): CheckboxGridValidationBuilder;
       build(): CheckboxGridValidation;
+      setHelpText(text: string): CheckboxGridValidationBuilder;
     }
     /**
      * A question item that allows the respondent to select one or more checkboxes, as well as an
@@ -175,6 +176,7 @@ declare namespace GoogleAppsScript {
       requireSelectAtMost(number: Integer): CheckboxValidationBuilder;
       requireSelectExactly(number: Integer): CheckboxValidationBuilder;
       build(): CheckboxValidation;
+      setHelpText(text: string): CheckboxValidationBuilder;
     }
     /**
      * A single choice associated with a type of Item that supports choices, like CheckboxItem, ListItem, or MultipleChoiceItem.
@@ -537,6 +539,7 @@ declare namespace GoogleAppsScript {
     interface GridValidationBuilder {
       requireLimitOneResponsePerColumn(): GridValidationBuilder;
       build(): GridValidation;
+      setHelpText(text: string): GridValidationBuilder;
     }
     /**
      * A layout item that displays an image. Items can be accessed or created from a Form.
@@ -852,6 +855,7 @@ declare namespace GoogleAppsScript {
       requireTextLengthLessThanOrEqualTo(number: Integer): ParagraphTextValidationBuilder;
       requireTextMatchesPattern(pattern: string): ParagraphTextValidationBuilder;
       build(): ParagraphTextValidation;
+      setHelpText(text: string): ParagraphTextValidationBuilder;
     }
     /**
      * The bean implementation of a Feedback, which contains properties common to all feedback, such as
@@ -1018,6 +1022,7 @@ declare namespace GoogleAppsScript {
       requireTextMatchesPattern(pattern: string): TextValidationBuilder;
       requireWholeNumber(): TextValidationBuilder;
       build(): TextValidation;
+      setHelpText(text: string): TextValidationBuilder;
     }
     /**
      * A question item that allows the respondent to indicate a time of day. Items can be accessed or

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -651,26 +651,31 @@ SlidesApp.getActivePresentation().getSlides()[0].setSkipped(true);
 // Example of building a text validation
 const formAppTextValidation = FormApp.createTextValidation()
     .requireNumberBetween(1, 100)
+    .setHelpText('Please be between 1 and 100')
     .build();
 
 // Example of building a grid validation
 const formAppGridValidation = FormApp.createGridValidation()
     .requireLimitOneResponsePerColumn()
+    .setHelpText('You did it wrong')
     .build();
 
 // Example of building a grid validation
 const formAppCheckboxGridValidation = FormApp.createCheckboxGridValidation()
     .requireLimitOneResponsePerColumn()
+    .setHelpText('This is not fine')
     .build();
 
 // Example of building a checkbox validation
 const formAppCheckboxValidation = FormApp.createCheckboxValidation()
     .requireSelectAtLeast(1)
+    .setHelpText('Select one pls')
     .build();
 
 // Example of building a paragraph text validation
 const formAppParagraphTextValidation = FormApp.createParagraphTextValidation()
     .requireTextDoesNotContainPattern('string')
+    .setHelpText('Hey! You put a string in your string!')
     .build();
 
 const mimeTypes: string[] = [


### PR DESCRIPTION
Similarly to the `build` methods added in #61785, these methods are used in the examples given and exist in real Google Apps Script, but for some reason their existence
isn't explicitly documented at, for example: https://developers.google.com/apps-script/reference/forms/text-validation-builder

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/apps-script/reference/forms/text-validation-builder
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (**N/A**)