### PR TITLE
twitter-text: fix extractUrls function parameters

### DIFF
--- a/types/twitter-text/index.d.ts
+++ b/types/twitter-text/index.d.ts
@@ -44,7 +44,10 @@ export function splitTags(text: string): string[];
 
 export function extractHashtags(text: string): string[];
 export function extractHashtagsWithIndices(text: string): HashtagWithIndices[];
-export function extractUrls(text: string): string[];
+export function extractUrls(
+    text: string,
+    options?: { extractUrlsWithoutProtocol: boolean },
+): string[];
 export function extractUrlsWithIndices(
     text: string,
     options?: { extractUrlsWithoutProtocol: boolean },


### PR DESCRIPTION
extractUrls function accepts an optional second parameter with options, as extractUrlsWithIndices does. See:

https://github.com/twitter/twitter-text/blob/master/js/src/extractUrls.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/twitter/twitter-text/blob/master/js/src/extractUrls.js>
