### PR TITLE
[tampermonkey] fix: update `GM_info` types from the official docs

### DIFF
--- a/types/tampermonkey/index.d.ts
+++ b/types/tampermonkey/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Steven Wang <https://github.com/silverwzw>
 //                 Nikolay Borzov <https://github.com/nikolay-borzov>
 //                 taozhiyu <https://github.com/taozhiyu>
+//                 double-beep <https://github.com/double-beep>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // This definition is based on the API reference of Tampermonkey
@@ -259,11 +260,16 @@ declare namespace Tampermonkey {
         comment: string | null;
         compat_foreach: boolean;
         compat_metadata: boolean;
+        compat_powerful_this: boolean | null;
         compat_prototypes: boolean;
         compat_wrappedjsobject: boolean;
         compatopts_for_requires: boolean;
         noframes: boolean | null;
         run_at: string;
+        sandbox: string | null;
+        tab_types: string | null;
+        unwrap: boolean | null;
+
         override: ScriptMetadataOverrides;
     }
 
@@ -273,9 +279,26 @@ declare namespace Tampermonkey {
      */
     interface ScriptResource {
         name: string;
-        url: string;
-        content: string;
-        meta: string;
+        url?: string;
+        content?: string;
+        meta?: string;
+        error?: string;
+    }
+
+    interface WebRequestRule {
+        selector: {
+            include?: string | string[],
+            match?: string | string[],
+            exclude?: string | string[]
+        } | string;
+        action: string | {
+            cancel?: boolean,
+            redirect?: {
+                url: string;
+                from?: string;
+                to?: string;
+            } | string;
+        };
     }
 
     /**
@@ -286,18 +309,17 @@ declare namespace Tampermonkey {
         antifeatures: Record<string, Record<string, string>>;
         author: string | null;
 
-        /**
-         * Idk what this is, nothing I did changed this from any empty array
-         * and it's not documented anywhere
-         */
-        blockers: any[];
+        blockers: string[];
 
         copyright: string | null;
+        deleted?: number | undefined;
         description: string | null;
-        description_i18n: Record<string, string>;
+        description_i18n: Record<string, string> | null;
         downloadURL: string | null;
+        enabled?: boolean;
         evilness: number;
         excludes: string[];
+        fileURL?: string | null;
         grant: string[];
         header: string;
         homepage: string | null;
@@ -307,7 +329,7 @@ declare namespace Tampermonkey {
         lastModified: number;
         matches: string[];
         name: string;
-        name_i18n: Record<string, string>;
+        name_i18n: Record<string, string> | null;
         namespace: string | null;
         options: ScriptSettings;
 
@@ -320,21 +342,23 @@ declare namespace Tampermonkey {
         'run-at': string;
 
         supportURL: string | null;
-        sync: {
-            imported: boolean;
+        sync?: {
+            imported?: number | undefined;
         };
+        system?: boolean | undefined;
         unwrap: boolean;
         updateURL: string | null;
         uuid: string;
         version: string;
-        webRequest: string[];
+        webRequest: WebRequestRule[] | null;
     }
 
     interface ScriptInfo {
         downloadMode: 'native' | 'browser' | 'disabled';
-        isFirstPartyIsolation: boolean | undefined;
+        isFirstPartyIsolation?: boolean;
         isIncognito: boolean;
         script: ScriptMetadata;
+        sandboxMode: 'js' | 'raw' | 'dom';
 
         /**
          * In tampermonkey it's "Tampermonkey"
@@ -343,13 +367,13 @@ declare namespace Tampermonkey {
          */
         scriptHandler: string;
 
-        scriptMetaStr: string;
+        scriptMetaStr: string | null;
         scriptSource: string;
-        scriptUpdateURL: string | undefined;
+        scriptUpdateURL: string | null;
         scriptWillUpdate: boolean;
 
         /** This refers to tampermonkey's version */
-        version: string;
+        version?: string;
     }
 
     type ContentType = string | { type?: string | undefined; mimetype?: string | undefined };

--- a/types/tampermonkey/tampermonkey-tests.ts
+++ b/types/tampermonkey/tampermonkey-tests.ts
@@ -343,6 +343,7 @@ const exampleInfo: Tampermonkey.ScriptInfo = {
         description_i18n: {},
         downloadURL: null,
         evilness: 0,
+        enabled: true,
         excludes: [],
         grant: ['GM_setValue', 'GM_getValue', 'GM_deleteValue'],
         header: 'headers',
@@ -360,6 +361,7 @@ const exampleInfo: Tampermonkey.ScriptInfo = {
             comment: '',
             compat_foreach: false,
             compat_metadata: false,
+            compat_powerful_this: false,
             compat_prototypes: false,
             compat_wrappedjsobject: false,
             compatopts_for_requires: true,
@@ -382,6 +384,9 @@ const exampleInfo: Tampermonkey.ScriptInfo = {
                 use_matches: [],
             },
             run_at: 'document-idle',
+            sandbox: null,
+            tab_types: null,
+            unwrap: null,
         },
         position: 1,
         resources: [
@@ -395,7 +400,7 @@ const exampleInfo: Tampermonkey.ScriptInfo = {
         'run-at': 'document-idle',
         supportURL: null,
         sync: {
-            imported: false,
+            imported: 9,
         },
         unwrap: false,
         updateURL: null,
@@ -405,12 +410,13 @@ const exampleInfo: Tampermonkey.ScriptInfo = {
     },
     scriptMetaStr: 'metadata',
     scriptSource: 'console.log(GM_info);',
-    scriptUpdateURL: undefined,
+    scriptUpdateURL: null,
     scriptWillUpdate: false,
     version: '4.13.6136',
     scriptHandler: 'Tampermonkey',
     isIncognito: false,
     downloadMode: 'native',
+    sandboxMode: 'raw',
 };
 
 // GM.*


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`GM_info`](https://www.tampermonkey.net/documentation.php#api:GM_info)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
