### PR TITLE
[chrome-remote-interface] use `{}` instead of `Record<keyof any, never>`

### DIFF
--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -167,7 +167,7 @@ declare namespace CDP {
         [event in GetEvent<D>]:
             (listener: (params: GetReturnType<D, event>, sessionId?: string) => void) => () => Client
     };
-    type DoEventObj<D> = D extends string ? DoEventPromises<D> & DoEventListeners<D> : Record<keyof any, never>;
+    type DoEventObj<D> = D extends string ? DoEventPromises<D> & DoEventListeners<D> : {};
 
     type IsNullableObj<T> = Record<keyof T, undefined> extends T ? true : false;
     /**


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Oops ... `Record<keyof any, never>` adds 3 keys while `{}` adds none when used with `&`, with the latter being the original intention ... this is what happens when classes are treated like magic objects :sweat_smile: