### PR TITLE
[auth0] Add `telemetry` to client's option

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -401,6 +401,17 @@ management.assignPermissionsToUser(
     },
 );
 
+// Without telemetry
+new auth0.ManagementClient({
+    domain: 'xxx.auth0.com',
+    telemetry: false,
+});
+
+new auth0.AuthenticationClient({
+    domain: 'xxx.auth0.com',
+    telemetry: false,
+});
+
 // Using different client settings.
 const retryableManagementClient = new auth0.ManagementClient({
     clientId: '',

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -22,6 +22,7 @@ export interface ManagementClientOptions {
     scope?: string | undefined;
     tokenProvider?: TokenProvider | undefined;
     retry?: RetryOptions | undefined;
+    telemetry?: boolean | undefined;
 }
 
 export interface TokenProvider {
@@ -616,6 +617,7 @@ export interface AuthenticationClientOptions {
     clientId?: string | undefined;
     clientSecret?: string | undefined;
     domain: string;
+    telemetry?: boolean | undefined;
 }
 
 interface Environment {


### PR DESCRIPTION
This PR add `telemetry?: boolean | undefined` to `ManagementClientOptions` and `AuthenticationClientOptions`.
`telemetry` is not documented, but actually used and mentioned in [README.md](https://github.com/auth0/node-auth0/blob/v3.1.1/README.md?plain=1#L51).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [AuthenticationClient](https://github.com/auth0/node-auth0/blob/v3.1.1/src/auth/index.js#LL72C10-L72C10)
  - [ManagementClient](https://github.com/auth0/node-auth0/blob/v3.1.1/src/management/index.js#L160)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
