### PR TITLE
[ffprobe] Add missing side data and side data list types

### DIFF
--- a/types/ffprobe/ffprobe-tests.ts
+++ b/types/ffprobe/ffprobe-tests.ts
@@ -1,9 +1,53 @@
 import ffprobe = require('ffprobe');
 import ffprobeStatic = require('ffprobe-static');
 
+const handleSideData = (side_data: ffprobe.SideData) => {
+    if ('rotation' in side_data) {
+        side_data.rotation;
+        side_data.displaymatrix;
+    } else if (side_data.side_data_type === 'Spherical Mapping') {
+        if (side_data.projection === 'cubemap') {
+            side_data.padding;
+        } else if (side_data.projection === 'tiled equirectangular') {
+            side_data.bound_bottom;
+            side_data.bound_top;
+        }
+    } else if (side_data.side_data_type === 'Mastering display metadata') {
+        if ('red_x' in side_data) {
+            side_data.red_x;
+            side_data.blue_x;
+            side_data.green_x;
+            side_data.white_point_x;
+
+            if ('max_luminance' in side_data) {
+                side_data.min_luminance;
+            }
+        }
+
+        if ('min_luminance' in side_data) {
+            side_data.max_luminance;
+
+            if ('red_y' in side_data) {
+                side_data.red_y;
+                side_data.blue_y;
+                side_data.green_y;
+                side_data.white_point_y;
+            }
+        }
+    }
+};
+
 ffprobe('./file.mp4', { path: ffprobeStatic.path })
     .then(info => {
         info; // $ExpectType FFProbeResult
+
+        for (const stream of info.streams) {
+            if (!stream.side_data_list) continue;
+
+            for (const side_data of stream.side_data_list) {
+                handleSideData(side_data);
+            }
+        }
     })
     .catch((err: Error) => {
         err; // $ExpectType Error

--- a/types/ffprobe/index.d.ts
+++ b/types/ffprobe/index.d.ts
@@ -6,6 +6,249 @@
 declare namespace getInfo {
     type FFProbeBoolean = '0' | '1';
 
+    interface BaseSideData {
+        side_data_type: string;
+    }
+
+    interface UnknownSideData extends BaseSideData {
+        /**
+         * Based on the C code related to the default side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2298}
+         */
+        side_data_type: 'unknown';
+    }
+
+    interface DisplayMatrixSideData extends BaseSideData {
+        /**
+         * Based on the C code related to Display Matrix side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2300-L2304}
+         */
+        side_data_type: 'Display Matrix';
+        /**
+         * Mismatches the type linked earlier because ffprobe JSON output
+         * reads the printed integers for the display matrix as a string
+         */
+        displaymatrix: string;
+        rotation: number;
+    }
+
+    interface Stereo3dSideData extends BaseSideData {
+        /**
+         * Based on the C code related to Stereo 3D side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2306-L2308}
+         */
+        side_data_type: 'Stereo 3D';
+        /**
+         * Based on the C code of the libauvutil stereo3d file
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/libavutil/stereo3d.c#L47-L56}
+         */
+        type:
+            | 'unknown'
+            | '2D'
+            | 'side by side'
+            | 'top and bottom'
+            | 'frame alternate'
+            | 'checkerboard'
+            | 'side by side (quincunx subsampling)'
+            | 'interleaved lines'
+            | 'interleaved columns';
+        inverted: number;
+    }
+
+    interface BaseSphericalMappingSideData extends BaseSideData {
+        /**
+         * Based on the C code related to Spherical Mapping side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2310-L2326}
+         */
+        side_data_type: 'Spherical Mapping';
+        /**
+         * Based on the C code of the libauvutil spherical file
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/libavutil/spherical.c#L55-L59}
+         */
+        projection: string;
+        yaw: number;
+        pitch: number;
+        roll: number;
+    }
+
+    interface UnknownSphericalMappingSideData extends BaseSphericalMappingSideData {
+        projection: 'unknown';
+    }
+
+    interface EquirectangularSphericalMappingSideData extends BaseSphericalMappingSideData {
+        projection: 'equirectangular';
+    }
+
+    interface CubeMapSphericalMappingSideData extends BaseSphericalMappingSideData {
+        projection: 'cubemap';
+        /**
+         * Based on the C code related to Cube Map Spherical Mapping side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2313}
+         */
+        padding: number;
+    }
+
+    interface TiltedEquirectangularSphericalMappingSideData extends BaseSphericalMappingSideData {
+        projection: 'tiled equirectangular';
+        /**
+         * Based on the C code related to Cube Map Spherical Mapping side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2315-L2321}
+         */
+        bound_left: number;
+        bound_top: number;
+        bound_right: number;
+        bound_bottom: number;
+    }
+
+    type SphericalMappingSideData =
+        | UnknownSphericalMappingSideData
+        | EquirectangularSphericalMappingSideData
+        | CubeMapSphericalMappingSideData
+        | TiltedEquirectangularSphericalMappingSideData;
+
+    interface SkipSamplesSideData extends BaseSideData {
+        /**
+         * Based on the C code related to Skip Samples side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2328-L2331}
+         */
+        side_data_type: 'Skip Samples';
+        skip_samples: number;
+        discard_padding: number;
+        skip_reason: number;
+        discard_reason: number;
+    }
+
+    interface BaseMasteringDisplayMetadataSideData extends BaseSideData {
+        /**
+         * Based on the C code related to Mastering display metadata side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2333-L2350}
+         */
+        side_data_type: 'Mastering display metadata';
+    }
+
+    interface PrimariesMasteringDisplayMetadataSideData extends BaseMasteringDisplayMetadataSideData {
+        /**
+         * Based on the C code related to Primaries Mastering display metadata side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2336-L2344}
+         */
+        red_x: string;
+        red_y: string;
+        green_x: string;
+        green_y: string;
+        blue_x: string;
+        blue_y: string;
+
+        white_point_x: string;
+        white_point_y: string;
+    }
+
+    interface LuminanceMasteringDisplayMetadataSideData extends BaseMasteringDisplayMetadataSideData {
+        /**
+         * Based on the C code related to Luminance Mastering display metadata side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2348-L2349}
+         */
+        min_luminance: string;
+        max_luminance: string;
+    }
+
+    type MasteringDisplayMetadataSideData =
+        | PrimariesMasteringDisplayMetadataSideData
+        | LuminanceMasteringDisplayMetadataSideData
+        | (PrimariesMasteringDisplayMetadataSideData & LuminanceMasteringDisplayMetadataSideData);
+
+    interface ContentLightLevelMetadataSideData extends BaseSideData {
+        /**
+         * Based on the C code related to Content light level metadata side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2352-L2354}
+         */
+        side_data_type: 'Content light level metadata';
+        max_content: number;
+        max_average: number;
+    }
+
+    interface DoviConfigurationRecordSideData extends BaseSideData {
+        /**
+         * Based on the C code related to DOVI configuration record side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2356-L2364}
+         */
+        side_data_type: 'DOVI configuration record';
+        dv_version_major: number;
+        dv_version_minor: number;
+        dv_profile: number;
+        dv_level: number;
+        rpu_present_flag: number;
+        el_present_flag: number;
+        bl_present_flag: number;
+        dv_bl_signal_compatibility_id: number;
+    }
+
+    interface AudioServiceTypeSideData extends BaseSideData {
+        /**
+         * Based on the C code related to Audio Service Type side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2366-L2367}
+         */
+        side_data_type: 'Audio Service Type';
+        service_type: number;
+    }
+
+    interface MpegtsStreamIdSideData extends BaseSideData {
+        /**
+         * Based on the C code related to MPEGTS Stream ID side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2369}
+         */
+        side_data_type: 'MPEGTS Stream ID';
+        id: number;
+    }
+
+    interface CpbPropertiesSideData extends BaseSideData {
+        /**
+         * Based on the C code related to CPB properties side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2371-L2376}
+         */
+        side_data_type: 'CPB properties';
+        max_bitrate: number;
+        min_bitrate: number;
+        avg_bitrate: number;
+        buffer_size: number;
+        vbv_delay: number;
+    }
+
+    interface WebvttSideData extends BaseSideData {
+        /**
+         * Based on the C code related to Webvtt side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2379-L2381}
+         */
+        side_data_type: 'WebVTT ID' | 'WebVTT Settings';
+        data?: string | undefined;
+        data_hash: string;
+    }
+
+    interface ActiveFormatDescriptionSideData extends BaseSideData {
+        /**
+         * Based on the C code related to Active format description side data section
+         * {@see https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2383}
+         */
+        side_data_type: 'Active format description';
+        active_format?: number;
+    }
+
+    type SideData =
+        | UnknownSideData
+        | DisplayMatrixSideData
+        | Stereo3dSideData
+        | SphericalMappingSideData
+        | SkipSamplesSideData
+        | MasteringDisplayMetadataSideData
+        | ContentLightLevelMetadataSideData
+        | DoviConfigurationRecordSideData
+        | AudioServiceTypeSideData
+        | MpegtsStreamIdSideData
+        | AudioServiceTypeSideData
+        | MpegtsStreamIdSideData
+        | CpbPropertiesSideData
+        | WebvttSideData
+        | ActiveFormatDescriptionSideData;
+
     interface Options {
         path: string;
     }
@@ -91,6 +334,8 @@ declare namespace getInfo {
             creation_time?: string | undefined;
             [tag: string]: string | undefined;
         };
+
+        side_data_list?: SideData[] | undefined;
     }
 
     interface FFProbeResult {


### PR DESCRIPTION
Hello 👋🏼 

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [FFmpeg/doc/ffprobe.xsd#L209](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/doc/ffprobe.xsd#L209)
  - [FFmpeg/fftools/ffprobe.c#L2283-L2388](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/fftools/ffprobe.c#L2283-L2388)
    - Note: The PR has comments associating each C condition block to a certain type with `@see`
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - It does not

---

<details>
<summary><strong>Useful Examples of Side Data Types</strong></summary>
<br />

- [Display Matrix](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/mov-displaymatrix#L5-L11)
- [Stereo 3D](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/mov-spherical-mono#L3-L5)
- [Spherical Mapping](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/mov-spherical-mono#L8-L16)
- [Skip Samples](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/mov-aac-2048-priming#L1)
- [Mastering display metadata](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/mxf-probe-applehdr10#L59-L69)
- [Content light level metadata](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/mxf-probe-applehdr10#L72-L74)
- [DOVI configuration record](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/matroska-dovi-write-config8#L49-L57)
- [Audio Service Type](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/hls-fmp4_ac3#L7-L8)
- [MPEGTS Stream ID](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/ts-demux#L1)
- [CPB properties](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/mxf-probe-d10#L60-L65)
- [WebVTT ID](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/webm-webvtt-remux#L123-L124)
- [WebVTT Settings](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/webm-webvtt-remux#L203-L204)
- [Active format description](https://github.com/FFmpeg/FFmpeg/blob/b37795688a9bfa6d5a2e9b2535c4b10ebc14ac5d/tests/ref/fate/h264-afd#L3-L4)
</details>