### PR TITLE
[yargs] support string `alias` property in `option()`

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -442,9 +442,9 @@ declare namespace yargs {
          * This method can be used to make yargs aware of options that could exist.
          * You can also pass an opt object which can hold further customization, like `.alias()`, `.demandOption()` etc. for that option.
          */
-        option<K extends keyof T, O extends Options>(key: K, options: O): Argv<Omit<T, K> & { [key in K]: InferredOptionType<O> }>;
-        option<K extends string, O extends Options>(key: K, options: O): Argv<T & { [key in K]: InferredOptionType<O> }>;
-        option<O extends { [key: string]: Options }>(options: O): Argv<Omit<T, keyof O> & InferredOptionTypes<O>>;
+        option<K extends keyof T, O extends Options>(key: K, options: O): Argv<Omit<T, K> & { [key in K]: InferredOptionType<O> } & Alias<O>>;
+        option<K extends string, O extends Options>(key: K, options: O): Argv<T & { [key in K]: InferredOptionType<O> } & Alias<O>>;
+        option<O extends { [key: string]: Options }>(options: O): Argv<Omit<T, keyof O> & InferredOptionTypes<O> & Alias<O>>;
 
         /**
          * This method can be used to make yargs aware of options that could exist.
@@ -855,6 +855,9 @@ declare namespace yargs {
         O extends (
             | { default: infer D }
         ) ? Exclude<D, undefined> : unknown;
+
+    type Alias<O extends Options | PositionalOptions> =
+        O extends { alias: infer T } ? T extends Exclude<string, T> ? { [key in T]: InferredOptionType<O> } : {} : {};
 
     // prettier-ignore
     type IsRequiredOrHasDefault<O extends Options | PositionalOptions> =

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -1243,6 +1243,11 @@ function Argv$inferOptionTypesForAliases() {
         .alias("n", "count")
         .alias("num", ["n", "count"])
         .parseSync();
+
+    // $ExpectType { [x: string]: unknown; u: string | undefined; url: string | undefined; _: (string | number)[]; $0: string; }
+    yargs
+        // tslint:disable-next-line:no-object-literal-type-assertion
+        .option("u", { type: "string", alias: "url" } as const).parseSync();
 }
 
 async function Argv$inferArrayOptionTypes() {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://yargs.js.org/docs/#api-reference-optionkey-opt ... example in [test code](https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...kazarmy:DefinitelyTyped:yargs-string-alias-option?expand=1#diff-68379c677eef47abe34460c219eaa9dc6857a510d0a686da417e927c610f8c76)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
