### PR TITLE
Update select2 Options.dropdownParent to allow additional types

### DIFF
--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -211,7 +211,7 @@ export interface Options<Result = DataFormat | GroupedDataFormat, RemoteResult =
     dropdownAutoWidth?: boolean | undefined;
     dropdownCss?: any;
     dropdownCssClass?: string | undefined;
-    dropdownParent?: JQuery | undefined;
+    dropdownParent?: HTMLElement | JQuery | string | undefined;
     escapeMarkup?: ((markup: string) => string) | undefined;
     initSelection?: ((element: JQuery, callback: (data: any) => void) => void) | undefined;
     language?: string | Translation | undefined;

--- a/types/select2/select2-tests.ts
+++ b/types/select2/select2-tests.ts
@@ -313,7 +313,15 @@ $("#mySelect2").select2({
 // Dropdown placement
 
 $("#mySelect2").select2({
+    dropdownParent: document.getElementById("myModal")!
+});
+
+$("#mySelect2").select2({
     dropdownParent: $("#myModal")
+});
+
+$("#mySelect2").select2({
+    dropdownParent: "#myModal"
 });
 
 // =====================================================


### PR DESCRIPTION
Per the docs at: https://select2.org/configuration/options-api dropdownParent is allowed to be of type "jQuery selector or DOM node".

This can be further seen by the select2 code at:
https://github.com/select2/select2/blob/0a30b0b3e67843c09b0bcc4d01e65b72d9b1279f/src/js/select2/dropdown/attachBody.js#L6

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://select2.org/configuration/options-api
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
