### PR TITLE
Feature: Add CreateTask serviceTime

### DIFF
--- a/types/onfleet__node-onfleet/Resources/Tasks.d.ts
+++ b/types/onfleet__node-onfleet/Resources/Tasks.d.ts
@@ -118,6 +118,7 @@ declare namespace Task {
         recipientSkipSMSNotifications?: boolean | undefined;
         requirements?: TaskCompletionRequirements | undefined;
         barcodes?: Barcode[] | undefined;
+        serviceTime?: number | undefined;
     }
 
     interface TaskAutoAssign {


### PR DESCRIPTION
CreateTask definition in Onfleet includes a `serviceTime` property

https://docs.onfleet.com/reference/create-task