### PR TITLE
Fix types for multipipe

### DIFF
--- a/types/multipipe/index.d.ts
+++ b/types/multipipe/index.d.ts
@@ -19,126 +19,145 @@ import stream = require("stream");
 declare function multipipe(callback?: (err?: Error) => any): stream.PassThrough;
 declare function multipipe(options?: stream.DuplexOptions, callback?: (err?: Error) => any): stream.PassThrough;
 
-declare function multipipe(stream: stream.Duplex | ReadonlyArray<stream.Stream>, callback?: (err?: Error) => any): stream.Duplex;
-declare function multipipe(stream: stream.Duplex | ReadonlyArray<stream.Stream>, options?: stream.DuplexOptions, callback?: (err?: Error) => any): stream.Duplex;
+declare function multipipe(stream: NodeJS.ReadWriteStream | ReadonlyArray<stream.Stream>, callback?: (err?: Error) => any): NodeJS.ReadWriteStream;
+declare function multipipe(stream: NodeJS.ReadWriteStream | ReadonlyArray<stream.Stream>, options?: stream.DuplexOptions, callback?: (err?: Error) => any): NodeJS.ReadWriteStream;
 
-declare function multipipe(source: stream.Readable, destination: stream.Writable, callback?: (err?: Error) => any): stream.Duplex;
-declare function multipipe(source: stream.Readable, destination: stream.Writable, options?: stream.DuplexOptions, callback?: (err?: Error) => any): stream.Duplex;
+declare function multipipe(source: NodeJS.ReadableStream, destination: NodeJS.WritableStream, callback?: (err?: Error) => any): NodeJS.ReadWriteStream;
+declare function multipipe(source: NodeJS.ReadableStream, destination: NodeJS.WritableStream, options?: stream.DuplexOptions, callback?: (err?: Error) => any): NodeJS.ReadWriteStream;
 
-declare function multipipe(source: stream.Readable, transform: stream.Duplex, destination: stream.Writable, callback?: (err?: Error) => any): stream.Duplex;
-declare function multipipe(source: stream.Readable, transform: stream.Duplex, destination: stream.Writable, options: stream.DuplexOptions, callback?: (err?: Error) => any): stream.Duplex;
-
-declare function multipipe(source: stream.Readable, t1: stream.Duplex, t2: stream.Duplex, destination: stream.Writable, callback?: (err?: Error) => any): stream.Duplex;
-declare function multipipe(source: stream.Readable, t1: stream.Duplex, t2: stream.Duplex, destination: stream.Writable, options: stream.DuplexOptions, callback?: (err?: Error) => any): stream.Duplex;
-
+declare function multipipe(source: NodeJS.ReadableStream, transform: NodeJS.ReadWriteStream, destination: NodeJS.WritableStream, callback?: (err?: Error) => any): NodeJS.ReadWriteStream;
 declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    destination: stream.Writable,
-    callback?: (err?: Error) => any
-): stream.Duplex;
-declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    destination: stream.Writable,
+    source: NodeJS.ReadableStream,
+    transform: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
     options: stream.DuplexOptions,
     callback?: (err?: Error) => any
-): stream.Duplex;
+): NodeJS.ReadWriteStream;
 
 declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    t4: stream.Duplex,
-    destination: stream.Writable,
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
     callback?: (err?: Error) => any
-): stream.Duplex;
+): NodeJS.ReadWriteStream;
 declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    t4: stream.Duplex,
-    destination: stream.Writable,
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
     options: stream.DuplexOptions,
     callback?: (err?: Error) => any
-): stream.Duplex;
+): NodeJS.ReadWriteStream;
 
 declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    t4: stream.Duplex,
-    t5: stream.Duplex,
-    destination: stream.Writable,
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
     callback?: (err?: Error) => any
-): stream.Duplex;
+): NodeJS.ReadWriteStream;
 declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    t4: stream.Duplex,
-    t5: stream.Duplex,
-    destination: stream.Writable,
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
     options: stream.DuplexOptions,
     callback?: (err?: Error) => any
-): stream.Duplex;
+): NodeJS.ReadWriteStream;
 
 declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    t4: stream.Duplex,
-    t5: stream.Duplex,
-    t6: stream.Duplex,
-    destination: stream.Writable,
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    t4: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
     callback?: (err?: Error) => any
-): stream.Duplex;
+): NodeJS.ReadWriteStream;
 declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    t4: stream.Duplex,
-    t5: stream.Duplex,
-    t6: stream.Duplex,
-    destination: stream.Writable,
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    t4: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
     options: stream.DuplexOptions,
     callback?: (err?: Error) => any
-): stream.Duplex;
+): NodeJS.ReadWriteStream;
 
 declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    t4: stream.Duplex,
-    t5: stream.Duplex,
-    t6: stream.Duplex,
-    t7: stream.Duplex,
-    destination: stream.Writable,
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    t4: NodeJS.ReadWriteStream,
+    t5: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
     callback?: (err?: Error) => any
-): stream.Duplex;
+): NodeJS.ReadWriteStream;
 declare function multipipe(
-    source: stream.Readable,
-    t1: stream.Duplex,
-    t2: stream.Duplex,
-    t3: stream.Duplex,
-    t4: stream.Duplex,
-    t5: stream.Duplex,
-    t6: stream.Duplex,
-    t7: stream.Duplex,
-    destination: stream.Writable,
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    t4: NodeJS.ReadWriteStream,
+    t5: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
     options: stream.DuplexOptions,
     callback?: (err?: Error) => any
-): stream.Duplex;
+): NodeJS.ReadWriteStream;
+
+declare function multipipe(
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    t4: NodeJS.ReadWriteStream,
+    t5: NodeJS.ReadWriteStream,
+    t6: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
+    callback?: (err?: Error) => any
+): NodeJS.ReadWriteStream;
+declare function multipipe(
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    t4: NodeJS.ReadWriteStream,
+    t5: NodeJS.ReadWriteStream,
+    t6: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
+    options: stream.DuplexOptions,
+    callback?: (err?: Error) => any
+): NodeJS.ReadWriteStream;
+
+declare function multipipe(
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    t4: NodeJS.ReadWriteStream,
+    t5: NodeJS.ReadWriteStream,
+    t6: NodeJS.ReadWriteStream,
+    t7: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
+    callback?: (err?: Error) => any
+): NodeJS.ReadWriteStream;
+declare function multipipe(
+    source: NodeJS.ReadableStream,
+    t1: NodeJS.ReadWriteStream,
+    t2: NodeJS.ReadWriteStream,
+    t3: NodeJS.ReadWriteStream,
+    t4: NodeJS.ReadWriteStream,
+    t5: NodeJS.ReadWriteStream,
+    t6: NodeJS.ReadWriteStream,
+    t7: NodeJS.ReadWriteStream,
+    destination: NodeJS.WritableStream,
+    options: stream.DuplexOptions,
+    callback?: (err?: Error) => any
+): NodeJS.ReadWriteStream;
 
 export = multipipe;

--- a/types/multipipe/multipipe-tests.ts
+++ b/types/multipipe/multipipe-tests.ts
@@ -1,7 +1,7 @@
 import stream = require('stream');
 import multipipe = require('multipipe');
 
-let rws: stream.Duplex;
+let rws: NodeJS.ReadWriteStream;
 
 const rs = new stream.Readable();
 const ws = new stream.Writable();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/juliangruber/multipipe/blob/be2f86eb159101170d4be0438cf67d3b7a4cc61c/index.js#L54
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

`multipipe` uses `duplexer2`, which has `NodeJS.ReadWriteStream` as return type in [its type definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0437cec30bdf403820b13a1a4985f4be37b659ac/types/duplexer2/index.d.ts#L17), not `stream.Duplex` (which has additional properties).
And its logic supports any `NodeJS.ReadWriteStream` and not just `stream.Duplex` in the input. Declaring arguments with the appropriate interface makes it easier to use it alongside other libraries.