### PR TITLE
[webpack-node-external] Indicate the types are compatible with v3

### DIFF
--- a/types/webpack-node-externals/index.d.ts
+++ b/types/webpack-node-externals/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack-node-externals 2.5
+// Type definitions for webpack-node-externals 3.0
 // Project: https://github.com/liady/webpack-node-externals
 // Definitions by: Matt Traynham <https://github.com/mtraynham>
 //                 Manuel Pogge <https://github.com/MrSpoocy>

--- a/types/webpack-node-externals/index.d.ts
+++ b/types/webpack-node-externals/index.d.ts
@@ -4,7 +4,7 @@
 //                 Manuel Pogge <https://github.com/MrSpoocy>
 //                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.7
+// TypeScript Version: 4.4
 
 /// <reference types="node" />
 import { ExternalsPlugin } from 'webpack';

--- a/types/webpack-node-externals/tslint.json
+++ b/types/webpack-node-externals/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+  "extends": "@definitelytyped/dtslint/dt.json",
+  "rules": {
+    "no-outside-dependencies": false
+  }
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/liady/webpack-node-externals/compare/v2.5.2..v3.0.0
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.