### PR TITLE
Added missing parentheses to BlockVariation#isActive's signature in @wordpress/blocks

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -665,5 +665,5 @@ export interface BlockVariation<Attributes extends BlockAttributes = BlockAttrib
           };
     scope?: BlockVariationScope[];
     keywords?: string[];
-    isActive?: (blockAttributes: Attributes, variationAttributes: Attributes) => boolean | string[];
+    isActive?: ((blockAttributes: Attributes, variationAttributes: Attributes) => boolean) | string[];
 }


### PR DESCRIPTION
The proper signature for isActive is either a string array or a function that returns a boolean. The current definition is a function that returns a boolean or a string array, which prevents following WordPress' tutorial on extending the Query Loop Block.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [WordPress' Extending the Query Loop Block tutorial](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#making-gutenberg-recognize-your-variation)
