### PR TITLE
Add types for agnostic-http-error-handler

### DIFF
--- a/types/agnostic-http-error-handler/agnostic-http-error-handler-tests.ts
+++ b/types/agnostic-http-error-handler/agnostic-http-error-handler-tests.ts
@@ -1,0 +1,12 @@
+import errorHandler = require('agnostic-http-error-handler');
+import { Request, Response } from 'express';
+
+/* $ExpectType {
+  express: (err: Error, req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, Record<string, any>>, next: any) => void;
+  restana: (err: Error, req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, Record<string, any>>) => void;
+  native: (err: Error, req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, Record<string, any>>) => void;
+} */
+errorHandler(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (err: Error, _responsePayload, req: Request, _res: Response) => {},
+);

--- a/types/agnostic-http-error-handler/index.d.ts
+++ b/types/agnostic-http-error-handler/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for agnostic-http-error-handler 1.0
+// Project: https://github.com/jkyberneees/http-error-handler#readme
+// Definitions by: Arian Meidow <https://github.com/sPaCeMoNk3yIam>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.7
+
+type Falsy = false | 0 | '' | null | undefined;
+
+interface Data<T> {
+    pipe: (res: T) => any;
+}
+
+declare function errorHandler<Err, Req, Res, P, T>(
+    preErrorHandler: (err: Err, responsePayload: P, req: Req, res: Res) => T,
+): {
+    express: (
+        err: Err,
+        req: Req,
+        res: Res,
+        next: any,
+    ) => ReturnType<
+        (
+            err: Err,
+            req: Req,
+            res: Res,
+        ) => T extends Falsy ? (P extends Data<Res> ? ReturnType<Data<Res>['pipe']> : undefined) : T
+    >;
+
+    restana: (
+        err: Err,
+        req: Req,
+        res: Res,
+    ) => ReturnType<
+        (
+            err: Err,
+            req: Req,
+            res: Res,
+        ) => T extends Falsy ? (P extends Data<Res> ? ReturnType<Data<Res>['pipe']> : undefined) : T
+    >;
+
+    native: (
+        err: Err,
+        req: Req,
+        res: Res,
+    ) => ReturnType<
+        (
+            err: Err,
+            req: Req,
+            res: Res,
+        ) => T extends Falsy ? (P extends Data<Res> ? ReturnType<Data<Res>['pipe']> : undefined) : T
+    >;
+};
+
+export = errorHandler;

--- a/types/agnostic-http-error-handler/tsconfig.json
+++ b/types/agnostic-http-error-handler/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "agnostic-http-error-handler-tests.ts"
+    ]
+}

--- a/types/agnostic-http-error-handler/tslint.json
+++ b/types/agnostic-http-error-handler/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
