### PR TITLE
Fix return type of setInterval in experimental/timers package

### DIFF
--- a/types/k6/experimental/timers.d.ts
+++ b/types/k6/experimental/timers.d.ts
@@ -27,7 +27,7 @@ export function clearTimeout(timeoutID: TimeoutID): void;
  * @param args - The arguments to be passed to the function.
  * @returns The interval id.
  */
-export function setInterval(functionRef: (...args: any[]) => void, delay: number, ...args: any[]): number;
+export function setInterval(functionRef: (...args: any[]) => void, delay: number, ...args: any[]): IntervalID;
 
 /**
  * Cancels a interval previously set with setInterval().

--- a/types/k6/experimental/timers.d.ts
+++ b/types/k6/experimental/timers.d.ts
@@ -27,7 +27,7 @@ export function clearTimeout(timeoutID: TimeoutID): void;
  * @param args - The arguments to be passed to the function.
  * @returns The interval id.
  */
-export function setInterval(functionRef: (...args: any[]) => void, delay: number, ...args: any[]): void;
+export function setInterval(functionRef: (...args: any[]) => void, delay: number, ...args: any[]): number;
 
 /**
  * Cancels a interval previously set with setInterval().

--- a/types/k6/test/timers.ts
+++ b/types/k6/test/timers.ts
@@ -39,7 +39,6 @@ const intervalId = setInterval(() => {}, 5);
 
 clearInterval(intervalId);
 
-// @ts-expect-no-error
 clearInterval(5);
 
 // @ts-expect-error

--- a/types/k6/test/timers.ts
+++ b/types/k6/test/timers.ts
@@ -38,7 +38,6 @@ const intervalId = setInterval(function(){}, 5);
 
 // clearInterval
 
-// @ts-expect-no-error
 clearInterval(intervalId)
 
 // @ts-expect-no-error

--- a/types/k6/test/timers.ts
+++ b/types/k6/test/timers.ts
@@ -33,11 +33,11 @@ setInterval('functionRef', 5);
 // @ts-expect-error
 setInterval('functionRef', 5, 'arg');
 
-const intervalId = setInterval(function(){}, 5);
+const intervalId = setInterval(() => {}, 5);
 
 // clearInterval
 
-clearInterval(intervalId)
+clearInterval(intervalId);
 
 // @ts-expect-no-error
 clearInterval(5);

--- a/types/k6/test/timers.ts
+++ b/types/k6/test/timers.ts
@@ -33,7 +33,16 @@ setInterval('functionRef', 5);
 // @ts-expect-error
 setInterval('functionRef', 5, 'arg');
 
+// @ts-expect-no-error
+const intervalId = setInterval(function(){}, 5);
+
 // clearInterval
+
+// @ts-expect-no-error
+clearInterval(intervalId)
+
+// @ts-expect-no-error
+clearInterval(5);
 
 // @ts-expect-error
 clearInterval();

--- a/types/k6/test/timers.ts
+++ b/types/k6/test/timers.ts
@@ -33,7 +33,6 @@ setInterval('functionRef', 5);
 // @ts-expect-error
 setInterval('functionRef', 5, 'arg');
 
-// @ts-expect-no-error
 const intervalId = setInterval(function(){}, 5);
 
 // clearInterval


### PR DESCRIPTION
setInterval function returns the interval id, It is also stated in the jsdoc above the function. It was wrongly typed as void which causes type errors.

Please fill in this template.

- [+] Use a meaningful title for the pull request. Include the name of the package modified.
- [-] Test the change in your own code. (Compile and run.)
- [-] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [+] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [+] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [-] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [+] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [-] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
