### PR TITLE
[Nunjucks] Add `dev` argument to `ConfigureOptions`

### DIFF
--- a/types/nunjucks/index.d.ts
+++ b/types/nunjucks/index.d.ts
@@ -44,6 +44,7 @@ export interface ConfigureOptions {
     lstripBlocks?: boolean | undefined;
     watch?: boolean | undefined;
     noCache?: boolean | undefined;
+    dev?: boolean | undefined;
     web?:
         | {
               useCache?: boolean | undefined;

--- a/types/nunjucks/nunjucks-tests.ts
+++ b/types/nunjucks/nunjucks-tests.ts
@@ -30,6 +30,7 @@ nunjucks.configure('views', {
     autoescape: true,
     watch: true,
 });
+nunjucks.configure({ dev: true });
 rendered = env.renderString(src, ctx);
 
 env.on('load', (name, source, loader) => {});
@@ -40,6 +41,7 @@ let extension: nunjucks.Extension = {
         return 'The parser api is complicated';
     },
 };
+
 env = env.addExtension('SpawnGlitter', extension);
 const hasExtension: boolean = env.hasExtension('SpawnGlitter');
 extension = env.getExtension('SpawnGlitter');


### PR DESCRIPTION
There is an undocumented `dev` argument that can be sent to `nunjucks.configure`, which allows a full error trace to the thrown

(See: https://github.com/mozilla/nunjucks/issues/1430)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
