### PR TITLE
Add missing type for `histnorm` to `PlotData` in `plotly.js`

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1195,6 +1195,7 @@ export interface PlotData {
         | 'gauge+number+delta'
         | 'gauge+delta';
     histfunc: 'count' | 'sum' | 'avg' | 'min' | 'max';
+    histnorm: '' | 'percent' | 'probability' | 'density' | 'probability density';
     hoveron: 'points' | 'fills';
     hoverinfo:
         | 'all'


### PR DESCRIPTION
This type is specified in the docs but missing in the types here.

https://plotly.com/javascript/reference/#histogram-histnorm

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). (running tests failed with `Error: Cannot find module '/Users/[username]/.dts/typescript-installs/4.2/node_modules/typescript'`.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://plotly.com/javascript/reference/#histogram-histnorm