### PR TITLE
blessed: ListElement.setItems allows string[]

### DIFF
--- a/types/blessed/blessed-tests.ts
+++ b/types/blessed/blessed-tests.ts
@@ -784,6 +784,27 @@ blessed.escape('{bold}{/bold}');
 blessed.parseTags('{bold}hi{/bold}');
 blessed.generateTags({ fg: 'red' }, 'red text');
 
+// https://github.com/chjj/blessed#list-from-box
+
+const list = blessed.list({
+  keys: true,
+  fg: 'white',
+  style: {
+    selected: {
+      fg: 'white',
+      bg: 'blue',
+    },
+  },
+  interactive: true,
+  label: 'Active Requests',
+  width: '100%',
+  height: '100%',
+  tags: true,
+  border: { type: 'line', fg: 1 },
+});
+
+list.setItems(['string1', 'string2', 'string3']);
+
 // https://github.com/chjj/blessed/blob/master/test/program-mouse.js
 
 const program = blessed.program({

--- a/types/blessed/index.d.ts
+++ b/types/blessed/index.d.ts
@@ -2386,7 +2386,7 @@ export namespace Widgets {
         /**
          * Sets the list items to multiple strings.
          */
-        setItems(items: BlessedElement[]): void;
+        setItems(items: BlessedElement[] | string[]): void;
 
         /**
          * Returns the item index from the list. Child can be an element, index, or string.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [search for setItems from this point](https://www.npmjs.com/package/blessed#list-from-box)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.