### PR TITLE
[node] Add a JSDoc description to setTimeout

### DIFF
--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -62,7 +62,13 @@ declare module 'timers' {
                 [Symbol.toPrimitive](): number;
             }
         }
-        /** Sets a timer which executes a function or specified piece of code once the timer expires. **/
+        /**
+         * Schedules execution of a one-time `callback` after `delay` milliseconds. The `callback` will likely not be invoked in precisely `delay` milliseconds.
+         * Node.js makes no guarantees about the exact timing of when callbacks will fire, nor of their ordering. The callback will be called as close as possible to the time specified.
+         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be set to `1`. Non-integer delays are truncated to an integer.
+         * If `callback` is not a function, a [TypeError](https://nodejs.org/api/errors.html#class-typeerror) will be thrown.
+         * @since v0.0.1
+         */
         function setTimeout<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timeout;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -62,6 +62,7 @@ declare module 'timers' {
                 [Symbol.toPrimitive](): number;
             }
         }
+        /** Sets a timer which executes a function or specified piece of code once the timer expires. **/
         function setTimeout<TArgs extends any[]>(callback: (...args: TArgs) => void, ms?: number, ...args: TArgs): NodeJS.Timeout;
         // util.promisify no rest args compability
         // tslint:disable-next-line void-return


### PR DESCRIPTION
I regularly get this mixed up with `setInterval`!

There's a lot of places where this fn is defined, but this is the place which seems to show up in my editor 
![image](https://user-images.githubusercontent.com/49038/213401595-abdbd415-322a-4ce9-8ed0-66ba8d8ce2cb.png)


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/setTimeout
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
