### PR TITLE
[@wordpress/notices] Export `store` type

### DIFF
--- a/types/wordpress__notices/index.d.ts
+++ b/types/wordpress__notices/index.d.ts
@@ -5,6 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.6
 
+import { StoreDescriptor } from '@wordpress/data';
 import { MouseEventHandler } from 'react';
 
 declare module '@wordpress/data' {

--- a/types/wordpress__notices/index.d.ts
+++ b/types/wordpress__notices/index.d.ts
@@ -115,3 +115,11 @@ export interface Options {
      */
     onDismiss(): void;
 }
+
+export interface NoticesStoreDescriptor extends StoreDescriptor {
+    name: 'core/notices';
+}
+
+declare module "@wordpress/notices" {
+    const store: NoticesStoreDescriptor;
+}

--- a/types/wordpress__notices/index.d.ts
+++ b/types/wordpress__notices/index.d.ts
@@ -121,6 +121,6 @@ export interface NoticesStoreDescriptor extends StoreDescriptor {
     name: 'core/notices';
 }
 
-declare module "@wordpress/notices" {
+declare module '@wordpress/notices' {
     const store: NoticesStoreDescriptor;
 }

--- a/types/wordpress__notices/wordpress__notices-tests.tsx
+++ b/types/wordpress__notices/wordpress__notices-tests.tsx
@@ -1,5 +1,5 @@
 import { dispatch, select } from '@wordpress/data';
-import type { Notice, Action } from '@wordpress/notices';
+import { Notice, Action, store } from '@wordpress/notices';
 
 //
 // store
@@ -47,3 +47,9 @@ select('core/notices').getNotices('foo');
 
 // $ExpectType Notice
 const { type, id, actions } = select('core/notices').getNotices('foo')[0];
+
+// $ExpectType NoticesStoreDescriptor
+store;
+
+// $ExpectType "core/notices"
+store.name;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: the store exported from `@wordpress/notices` is not defined, so importing it in other codebases results in an error. https://github.com/WordPress/gutenberg/blob/trunk/packages/notices/src/index.js#L1
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.