### PR TITLE
[gulp-match] Expose the MatchCondition type of gulp-match

### DIFF
--- a/types/gulp-match/gulp-match-tests.ts
+++ b/types/gulp-match/gulp-match-tests.ts
@@ -13,3 +13,5 @@ a = _match(file, /\.css$/);
 a = _match(file, (file: vinyl) => file.isSymbolic());
 a = _match(file, {isDirectory: true});
 a = _match(file, {isFile: true});
+
+const b: _match.MatchCondition = '*.css';

--- a/types/gulp-match/index.d.ts
+++ b/types/gulp-match/index.d.ts
@@ -11,13 +11,15 @@ interface StatFilterCondition {
     isFile?: boolean | undefined;
 }
 
-type MatchCondition = boolean | ((fs: vinyl) => boolean) | RegExp | string | string[] | StatFilterCondition;
-
 /**
  * Does a vinyl file match a condition? This function checks the condition on the file.path of the vinyl-fs file passed to it.
  *
  * Condition can be a boolean, a function, a regular expression, a glob string (or array of glob strings), or a stat filter object.
  */
-declare function gulpMatch(file: vinyl, condition: MatchCondition, options?: minimatch.IOptions): boolean;
+declare function gulpMatch(file: vinyl, condition: gulpMatch.MatchCondition, options?: minimatch.IOptions): boolean;
+
+declare namespace gulpMatch {
+    type MatchCondition = boolean | ((fs: vinyl) => boolean) | RegExp | string | string[] | StatFilterCondition;
+}
 
 export = gulpMatch;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `gulp-if` package wraps `gulp-match` and takes a match condition as one of its arguments (to pass it to `gulp-match` internally). The existing type definitions for `gulp-if` are incomplete (they don't describe all supported types of the union). Exposing the MatchCondition type allows to reference it instead of having to duplicate it.