### PR TITLE
mssql: Add Request.toReadableStream method

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -15,6 +15,7 @@
 
 
 import events = require('events');
+import { Readable, ReadableOptions } from 'stream';
 import tds = require('tedious');
 import { Pool } from 'tarn';
 import { CallbackOrPromise, PoolOptions } from 'tarn/dist/Pool';
@@ -342,6 +343,7 @@ export declare class Request extends events.EventEmitter {
     public cancel(): void;
     public pause(): boolean;
     public resume(): boolean;
+    public toReadableStream(streamOptions?: ReadableOptions): Readable;
 }
 
 export declare class RequestError extends MSSQLError {

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -1,5 +1,6 @@
 import * as sql from 'mssql';
 import * as msnodesqlv8 from 'mssql/msnodesqlv8';
+import { Readable } from 'stream';
 
 interface Entity {
     value: number;
@@ -458,4 +459,14 @@ function test_connection_options() {
     }).then(() => {
         // noop
     });
+}
+
+function test_request_to_readable_stream() {
+    const request = new sql.Request();
+
+    // toReadableStream returns a Readable stream.
+    const stream: Readable = request.toReadableStream();
+
+    // You can optionally specify ReadableOptions.
+    request.toReadableStream({ highWaterMark: 10 });
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). **Won't run before my changes. The reported errors seem unrelated to this.**

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/mssql#toReadableStream
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. **I did not verify that this brings the typings fully up to date. I am just adding a missing method.**
