### PR TITLE
Add onBlur on react-rte props

### DIFF
--- a/types/react-rte/index.d.ts
+++ b/types/react-rte/index.d.ts
@@ -148,7 +148,7 @@ interface Props {
     rootStyle?: object | undefined;
     editorStyle?: object | undefined;
     toolbarStyle?: object | undefined;
-    onBlur?: (event: Object) => void;
+    onBlur?: (event: object) => void;
 }
 
 declare class RichTextEditor extends Component<Props, any> {

--- a/types/react-rte/index.d.ts
+++ b/types/react-rte/index.d.ts
@@ -148,6 +148,7 @@ interface Props {
     rootStyle?: object | undefined;
     editorStyle?: object | undefined;
     toolbarStyle?: object | undefined;
+    onBlur?: (event: Object) => void;
 }
 
 declare class RichTextEditor extends Component<Props, any> {


### PR DESCRIPTION
The main lib already have this prop, but @types does not, so i am adding this prop to make sure the lib work properly in typescript

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`


