### PR TITLE
Add types for junit-report-builder

### DIFF
--- a/types/junit-report-builder/index.d.ts
+++ b/types/junit-report-builder/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace builder {
-    interface Builder {
+    interface JUnitReportBuilder {
         /**
          * Writes report to disk synchronously
          */
@@ -24,7 +24,7 @@ declare namespace builder {
         /**
          * Creates a new builder for a separate report
          */
-        newBuilder(): Builder;
+        newBuilder(): JUnitReportBuilder;
     }
 
     interface TestSuite {
@@ -98,6 +98,6 @@ declare namespace builder {
     }
 }
 
-declare const builder: builder.Builder;
+declare const builder: builder.JUnitReportBuilder;
 
 export = builder;

--- a/types/junit-report-builder/index.d.ts
+++ b/types/junit-report-builder/index.d.ts
@@ -1,0 +1,103 @@
+// Type definitions for junit-report-builder 3.0
+// Project: https://github.com/davidparsson/junit-report-builder
+// Definitions by: Daniel König <https://github.com/dakoenig>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace builder {
+    interface Builder {
+        /**
+         * Writes report to disk synchronously
+         */
+        writeTo(reportPath: string): void;
+        /**
+         * Returns report as string
+         */
+        build(): string;
+        /**
+         * Adds a test suite to the report
+         */
+        testSuite(): TestSuite;
+        /**
+         * Adds a test case outside of any test suite to the report
+         */
+        testCase(): TestCase;
+        /**
+         * Creates a new builder for a separate report
+         */
+        newBuilder(): Builder;
+    }
+
+    interface TestSuite {
+        /**
+         * Sets the label of the test suite
+         */
+        name(name: string | number): TestSuite;
+        /**
+         * Sets the elapsed time for all test cases within the test suite
+         */
+        time(timeInSeconds: number): TestSuite;
+        /**
+         * Sets the timestamp denoting the start of the test suite
+         */
+        timestamp(timestamp: string | number | Date): TestSuite;
+        /**
+         * Adds a custom property to the test suite
+         */
+        property(name: string | number, value: string | number): TestSuite;
+        /**
+         * Adds a test case to the test suite
+         */
+        testCase(): TestCase;
+    }
+
+    interface TestCase {
+        /**
+         * Adds the class name associated with the test case
+         */
+        className(className: string): TestCase;
+        /**
+         * Sets the label of the test case
+         */
+        name(name: string | number): TestCase;
+        /**
+         * Sets the elapsed time for the test case
+         */
+        time(timeInSeconds: number): TestCase;
+        /**
+         * Adds the path to the file associated with the test case
+         */
+        file(filePath: string): TestCase;
+        /**
+         * Marks the test case as a failure
+         */
+        failure(message?: string, type?: string): TestCase;
+        /**
+         * Marks the test case as erroneous
+         */
+        error(message?: string, type?: string, content?: string): TestCase;
+        /**
+         * Adds the stack trace associated with test case failure or error
+         */
+        stacktrace(stackTrace: string): TestCase;
+        /**
+         * Marks the test case as skipped
+         */
+        skipped(): TestCase;
+        /**
+         * Adds the text written to stdout during test case execution
+         */
+        standardOutput(log: string): TestCase;
+        /**
+         * Adds the text written to stderr during test case execution
+         */
+        standardError(log: string): TestCase;
+        /**
+         * Adds the path to an attachment associated with test case failure or error
+         */
+        errorAttachment(filePath: string): TestCase;
+    }
+}
+
+declare const builder: builder.Builder;
+
+export = builder;

--- a/types/junit-report-builder/junit-report-builder-tests.ts
+++ b/types/junit-report-builder/junit-report-builder-tests.ts
@@ -50,5 +50,5 @@ builder.build();
 // $ExpectType void
 builder.writeTo('test-report.xml');
 
-// $ExpectType Builder
+// $ExpectType JUnitReportBuilder
 builder.newBuilder();

--- a/types/junit-report-builder/junit-report-builder-tests.ts
+++ b/types/junit-report-builder/junit-report-builder-tests.ts
@@ -1,0 +1,54 @@
+import * as builder from 'junit-report-builder';
+
+// $ExpectType TestSuite
+const testSuite = builder
+    .testSuite()
+    .name(1)
+    .name('test suite')
+    .time(42)
+    .timestamp('1970-01-01T00:00:00.000Z')
+    .timestamp(Date.now())
+    .timestamp(new Date())
+    .property(1, 'first value')
+    .property('second property', 2);
+
+// $ExpectType TestCase
+testSuite
+    .testCase()
+    .className('TestClass')
+    .name('failed test case in test suite')
+    .time(42)
+    .file('/path/to/test')
+    .failure()
+    .failure('failure reason')
+    .failure('failure reason', 'failure type');
+
+// $ExpectType TestCase
+testSuite
+    .testCase()
+    .name('erroneous test case in test suite')
+    .error()
+    .error('error message')
+    .error('error message', 'error type')
+    .error('error message', 'error type', 'error content')
+    .stacktrace('stack trace');
+
+// $ExpectType TestCase
+testSuite.testCase().name('skipped test case in test suite').skipped();
+
+// $ExpectType TestCase
+builder
+    .testCase()
+    .name(1)
+    .name('test case outside of test suite')
+    .standardOutput('output written to stdout')
+    .standardError('output written to stderr')
+    .errorAttachment('/path/to/attachment');
+
+// $ExpectType string
+builder.build();
+// $ExpectType void
+builder.writeTo('test-report.xml');
+
+// $ExpectType Builder
+builder.newBuilder();

--- a/types/junit-report-builder/tsconfig.json
+++ b/types/junit-report-builder/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "junit-report-builder-tests.ts"
+    ]
+}

--- a/types/junit-report-builder/tslint.json
+++ b/types/junit-report-builder/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
This PR adds types for the previously untyped junit-report-builder package.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
