### PR TITLE
[ember__component] add an export for `setComponentTemplate`

### DIFF
--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -121,7 +121,7 @@ export function setComponentManager<T>(managerFactory: (owner: unknown) => Compo
  */
  export function getComponentTemplate(obj: object): TemplateFactory | undefined;
 
-export function setComponentTemplate(factory: TemplateFactory, obj: object): object;
+export function setComponentTemplate<T>(factory: TemplateFactory, obj: T): T;
 
 // In normal TypeScript, these built-in components are essentially opaque tokens
 // that just need to be importable. Declaring them with unique interfaces

--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -121,6 +121,8 @@ export function setComponentManager<T>(managerFactory: (owner: unknown) => Compo
  */
  export function getComponentTemplate(obj: object): TemplateFactory | undefined;
 
+export function setComponentTemplate(factory: TemplateFactory, obj: object): object;
+
 // In normal TypeScript, these built-in components are essentially opaque tokens
 // that just need to be importable. Declaring them with unique interfaces
 // like this, however, gives tools like Glint (that DO have a richer

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -1,4 +1,4 @@
-import Component, { getComponentTemplate } from '@ember/component';
+import Component, { getComponentTemplate, setComponentTemplate } from '@ember/component';
 import Object, { computed, get } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import { assertType } from './lib/assert';
@@ -144,7 +144,7 @@ interface MySig {
 type GetWithFallback<T, K, Fallback> = K extends keyof T ? T[K] : Fallback;
 type NamedArgsFor<T> = GetWithFallback<GetWithFallback<T, 'Args', {}>, 'Named', object>;
 
-interface SigExample extends NamedArgsFor<MySig> {}
+interface SigExample extends NamedArgsFor<MySig> { }
 class SigExample extends Component<MySig> {
     get accessArgs() {
         const {
@@ -161,3 +161,9 @@ getComponentTemplate(component1);
 
 // @ts-expect-error
 getComponentTemplate('foo');
+
+// $ExpectType typeof Component
+setComponentTemplate(hbs`foo`, Component);
+
+// @ts-expect-error
+setComponentTemplate('foo', Component);


### PR DESCRIPTION
It's exported here https://github.com/emberjs/ember.js/blob/3f89e156f612fc0ed79caea9a0b087ac8c0caef3/types/preview/%40ember/component/index.d.ts#L118