### PR TITLE
Fix eventsource DOM shim for TS 5.0 beta

### DIFF
--- a/types/eventsource/dom-monkeypatch.d.ts
+++ b/types/eventsource/dom-monkeypatch.d.ts
@@ -39,10 +39,10 @@ interface Event {
    * "submit".
    */
   readonly type: string;
-  readonly AT_TARGET: number;
-  readonly BUBBLING_PHASE: number;
-  readonly CAPTURING_PHASE: number;
-  readonly NONE: number;
+  readonly AT_TARGET: 2;
+  readonly BUBBLING_PHASE: 3;
+  readonly CAPTURING_PHASE: 1;
+  readonly NONE: 0;
   composedPath(): any[];
   initEvent(type: string, bubbles?: boolean, cancelable?: boolean): void;
   preventDefault(): void;

--- a/types/eventsource/index.d.ts
+++ b/types/eventsource/index.d.ts
@@ -5,6 +5,7 @@
 //                 Pedro Gámez <https://github.com/snakedrak>
 //                 Akuukis <https://github.com/Akuukis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 5.0
 
 // eventsource uses DOM dependencies which are absent in a browserless environment like node.js.
 // to avoid compiler errors this monkey patch is used. See more details in:


### PR DESCRIPTION
The types that the DOM monkeypatch shims are now the precise literals instead of number.

The new code won't succeed until tomorrow. See microsoft/TypeScript#52328
