### PR TITLE
Fix css-font-loading-module types for TS 5.0 beta

### DIFF
--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://drafts.csswg.org/css-font-loading/
 // Definitions by: slikts <https://github.com/slikts>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 5.0
 
 export type FontFaceLoadStatus = 'unloaded' | 'loading' | 'loaded' | 'error';
 export type FontFaceSetLoadStatus = 'loading' | 'loaded';
@@ -19,7 +20,7 @@ export interface FontFaceSetCallbackMap {
 
 declare global {
     interface FontFaceDescriptors {
-        display?: string | undefined;
+        display?: FontDisplay | undefined;
         featureSettings?: string | undefined;
         stretch?: string | undefined;
         style?: string | undefined;
@@ -39,7 +40,7 @@ declare global {
         variant: string;
         featureSettings: string;
         variationSettings: string;
-        display: string;
+        display: FontDisplay;
         readonly status: FontFaceLoadStatus;
         readonly loaded: Promise<FontFace>;
     }


### PR DESCRIPTION
The type of `FontFace.display` is now a union of allowed literals instead of `string`.

The new code won't succeed until tomorrow. See microsoft/TypeScript#52328