### PR TITLE
fix(swagger-stats): freeze @hapi/hapi version

### DIFF
--- a/types/swagger-stats/package.json
+++ b/types/swagger-stats/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "fastify": "^3.0.0",
         "joi": "^17.7.0",
         "prom-client": ">=11.5.3"


### PR DESCRIPTION
It looks upstream @hapi/hapi update to 21.2.0 broken broken imports in @hapi/* ecosystem, impacting e.g. @types/node checks on DT. This change should be temporary

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

Kind of error(s) seen in DT:

> Error: node_modules/@hapi/hapi/lib/types/server/server.d.ts(5,10): error TS2617: 'Mimos' can only be imported by using 'import Mimos = require("@hapi/mimos")' or by turning on the 'esModuleInterop' flag and using a default import.

x-ref: https://github.com/hapijs/hapi/issues/4418