### PR TITLE
Add type definitions for `js-crc` npm package

### DIFF
--- a/types/js-crc/index.d.ts
+++ b/types/js-crc/index.d.ts
@@ -6,5 +6,3 @@
 export function crc32(message: string | ArrayBuffer | Uint8Array | ReadonlyArray<number>): string;
 
 export function crc16(message: string | ArrayBuffer | Uint8Array | ReadonlyArray<number>): string;
-
-export as namespace jsCrc;

--- a/types/js-crc/index.d.ts
+++ b/types/js-crc/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for js-crc 0.2
+// Project: https://github.com/emn178/js-crc
+// Definitions by: Anders Kjeldsen <https://github.com/and3k5>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function crc32(message: string | ArrayBuffer | Uint8Array | ReadonlyArray<number>): string;
+
+export function crc16(message: string | ArrayBuffer | Uint8Array | ReadonlyArray<number>): string;
+
+export as namespace jsCrc;

--- a/types/js-crc/js-crc-tests.ts
+++ b/types/js-crc/js-crc-tests.ts
@@ -1,0 +1,6 @@
+import { crc32, crc16 } from "js-crc";
+
+// $ExpectType string
+const crc32value = crc32("test");
+// $ExpectType string
+const crc16value = crc16("test");

--- a/types/js-crc/tsconfig.json
+++ b/types/js-crc/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "js-crc-tests.ts"
+    ]
+}

--- a/types/js-crc/tslint.json
+++ b/types/js-crc/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.