### PR TITLE
[animejs] Add  missing optional `unit` parameter to `get()` helper function

### DIFF
--- a/types/animejs/animejs-tests.ts
+++ b/types/animejs/animejs-tests.ts
@@ -110,6 +110,9 @@ anime.set(
     }
 );
 
+anime.get('.test-div', 'height');
+anime.get('.test-div', 'height', 'rem');
+
 // test importing from lib/ files
 import animeCJS = require('animejs/lib/anime');
 import animeMin = require('animejs/lib/anime.min');

--- a/types/animejs/index.d.ts
+++ b/types/animejs/index.d.ts
@@ -151,7 +151,7 @@ declare namespace anime {
     const running: AnimeInstance[];
     const easings: { [EasingFunction: string]: (t: number) => any };
     function remove(targets: AnimeTarget | ReadonlyArray<AnimeTarget>): void;
-    function get(targets: AnimeTarget, prop: string): string | number;
+    function get(targets: AnimeTarget, prop: string, unit?: string): string | number;
     function path(path: string | HTMLElement | SVGElement | null, percent?: number): (prop: string) => {
         el: HTMLElement | SVGElement,
         property: string,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [anime.js Documentation – `get()` Helper](https://animejs.com/documentation/#get)
