### PR TITLE
add handler to reject

### DIFF
--- a/types/lambda-tester/lambda-tester-tests.ts
+++ b/types/lambda-tester/lambda-tester-tests.ts
@@ -15,6 +15,8 @@ interface TResult {
 }
 
 const handler: Handler<any, TResult> = () => Promise.resolve({ data: '123' });
+const handlerReject: Handler<any, TResult> = () => Promise.reject({ data: '123' });
+
 const context: Context = {} as any;
 const clientContext: ClientContext = {} as any;
 
@@ -24,6 +26,10 @@ interface TError {
 
 function lambdaTesterInstance() {
     return lambdaTester(handler).event({ test: '123' });
+}
+
+function lambdaTesterInstanceReject() {
+    return lambdaTester(handlerReject).event({ test: '123' });
 }
 
 lambdaTesterInstance()
@@ -43,7 +49,7 @@ lambdaTesterInstance().expectResolve((result: TResult) => {
     const t: string = result.data;
 });
 
-lambdaTesterInstance().expectReject((error: TError) => {
+lambdaTesterInstanceReject().expectReject((error: TError) => {
     const t: string = error.message;
 });
 
@@ -51,7 +57,7 @@ lambdaTesterInstance().expectResult((result: TResult) => {
     const t: string = result.data;
 });
 
-lambdaTesterInstance().expectError((error: TError) => {
+lambdaTesterInstanceReject().expectError((error: TError) => {
     const t: string = error.message;
 });
 


### PR DESCRIPTION
A failing test in package `lambda-tester` blocks other PRs from being automatically merged:

- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63811
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63951

The original PR that implemented `lambda-tester` was this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63538

I couldn't find any check results on this PR, so maybe the check was already failing back then.

However, I investigated the test file and I think the test cases are not correct. The test fail because of this message:
> 2> lambda-tester passed, but was expected to fail.

I guess the reason is that the handler on line 17 always resolves and never rejects. I added a new handler that rejects and use this handler for the cases where `.expectFail()` and `.expectReject()` are expected to fail:

https://github.com/zirkelc/DefinitelyTyped/blob/a8c0fdf2df6c16801a0a3263fd8c6f7a31fa0218/types/lambda-tester/lambda-tester-tests.ts#L17-L18

After this change has been merged, we could trigger a new check run on both PRs that are blocked by this package.

