### PR TITLE
[minio] Change type of `setRequestOptions` parameter

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -12,7 +12,7 @@
 // Import from dependencies
 import { Readable as ReadableStream } from 'stream';
 import { EventEmitter } from 'events';
-import { AgentOptions } from 'https';
+import { RequestOptions } from 'https';
 
 // Exports only from typings
 export type Region = 'us-east-1' |
@@ -438,7 +438,7 @@ export class Client {
 
     // Other
     newPostPolicy(): PostPolicy;
-    setRequestOptions(options: AgentOptions): void;
+    setRequestOptions(options: RequestOptions): void;
 
     // Minio extensions that aren't necessary present for Amazon S3 compatible storage servers
     extensions: {

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -370,3 +370,7 @@ minio.extensions.listObjectsV2WithMetadata('testBucket');
 minio.extensions.listObjectsV2WithMetadata('testBucket', 'test_');
 minio.extensions.listObjectsV2WithMetadata('testBucket', 'test_', true);
 minio.extensions.listObjectsV2WithMetadata('testBucket', 'test_', true, 'some_object.jpg');
+
+// @ts-expect-error
+minio.setRequestOptions();
+minio.setRequestOptions({ auth: 'foo', port: 12345 });


### PR DESCRIPTION
Related discussion: #63966

Changes the type of the `options` parameter on `setRequestOptions` from `AgentOptions` to `RequestOptions`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Code calling `request` function with request options: <https://github.com/minio/minio-js/blob/4fce54bd81188aaa86fe6927786877cd71c2b79b/src/main/minio.js#L474>
  - Validation selecting fields from `RequestOptions`: <https://github.com/minio/minio-js/blob/4fce54bd81188aaa86fe6927786877cd71c2b79b/src/main/minio.js#L205-L210>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
