### PR TITLE
Update numeric comparison for TS 5.0

### DIFF
--- a/types/chrome-apps/test/index.ts
+++ b/types/chrome-apps/test/index.ts
@@ -1645,9 +1645,7 @@ chrome.storage.managed.getBytesInUse((bytesInUse) => {
 
 // EVENT
 chrome.storage.onChanged.addListener((changes, areaName) => {
-    if (changes.length > 0) {
-        return areaName === 'managed';
-    }
+    return areaName === changes.areaName.newValue;
 });
 
 // #endregion

--- a/types/react-vis/react-vis-tests.tsx
+++ b/types/react-vis/react-vis-tests.tsx
@@ -229,12 +229,14 @@ export const HighlightDragExample: React.FC = () => {
                     if (!selection) {
                         return '#1E96BE';
                     }
-                    const inX = d.x >= selection.start && d.x <= selection.end;
-                    const inX0 = d.x0 >= selection.start && d.x0 <= selection.end;
-                    const inStart = selection.start >= d.x0 && selection.start <= d.x;
-                    const inEnd = selection.end >= d.x0 && selection.end <= d.x;
-
-                    return inStart || inEnd || inX || inX0 ? '#12939A' : '#1E96BE';
+                    if (typeof d.x === 'number' && typeof d.x0 === 'number') {
+                        const inX = d.x >= selection.start && d.x <= selection.end;
+                        const inX0 = d.x0 >= selection.start && d.x0 <= selection.end;
+                        const inStart = selection.start >= d.x0 && selection.start <= d.x;
+                        const inEnd = selection.end >= d.x0 && selection.end <= d.x;
+                        return inStart || inEnd || inX || inX0 ? '#12939A' : '#1E96BE';
+                    }
+                    return '#1E96BE';
                 }}
             />
             <Highlight color="#829AE3" drag enableY={false} onDrag={updateDragState} onDragEnd={updateDragState} />

--- a/types/transducers-js/transducers-js-tests.ts
+++ b/types/transducers-js/transducers-js-tests.ts
@@ -53,7 +53,7 @@ function takeExample() {
 }
 
 function takeWhileExample() {
-  const xf = t.takeWhile(n => n < 3);
+  const xf = t.takeWhile((n: number) => n < 3);
   t.into([], xf, [0, 1, 2, 3, 4, 5]); // [0, 1, 2];
 }
 
@@ -79,7 +79,7 @@ function dropExample() {
 }
 
 function dropWhileExample() {
-  const xf = t.dropWhile(n => n < 3);
+  const xf = t.dropWhile((n: number) => n < 3);
   t.into([], xf, [0, 1, 2, 3, 4, 5]); // [3, 4, 5];
 }
 


### PR DESCRIPTION
Some tests incorrectly compare non-numeric types against a number. Typescript 5.0 is better at catching this error than before, so this PR makes the test code avoid those new errors.
