### PR TITLE
Correct shell option type for ExecOptions and ExecSyncOptions

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -791,7 +791,7 @@ declare module 'child_process' {
     function spawn(command: string, args: ReadonlyArray<string>, options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioNull>): ChildProcessByStdio<null, null, null>;
     function spawn(command: string, args: ReadonlyArray<string>, options: SpawnOptions): ChildProcess;
     interface ExecOptions extends CommonOptions {
-        shell?: string | undefined;
+        shell?: boolean | string | undefined;
         signal?: AbortSignal | undefined;
         maxBuffer?: number | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
@@ -1298,7 +1298,7 @@ declare module 'child_process' {
         encoding?: BufferEncoding | 'buffer' | null | undefined;
     }
     interface ExecSyncOptions extends CommonExecOptions {
-        shell?: string | undefined;
+        shell?: boolean | string | undefined;
     }
     interface ExecSyncOptionsWithStringEncoding extends ExecSyncOptions {
         encoding: BufferEncoding;


### PR DESCRIPTION
While other types for shell options are correct (there is boolean instead of string only), ExecOptions and ExecSyncOptions does not have the correct type. String type is preserved for non-breaking change (can be changed again if wanted)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
