### PR TITLE
feat: compatibility fix for eslint >=v8.21.0

### DIFF
--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -840,6 +840,90 @@ export namespace Linter {
         preprocess?(text: string, filename: string): T[];
         postprocess?(messages: LintMessage[][], filename: string): LintMessage[];
     }
+    interface FlatConfig {
+      /**
+       * An array of glob patterns indicating the files that the configuration
+       * object should apply to. If not specified, the configuration object applies
+       * to all files
+       */
+      files?: string | string[];
+      /**
+       * An array of glob patterns indicating the files that the configuration
+       * object should not apply to. If not specified, the configuration object
+       * applies to all files matched by files
+       */
+      ignores?: string | string[];
+      /**
+       * An object containing settings related to how JavaScript is configured for
+       * linting.
+       */
+      languageOptions?: {
+        /**
+         * The version of ECMAScript to support. May be any year (i.e., 2022) or
+         * version (i.e., 5). Set to "latest" for the most recent supported version.
+         * @default "latest"
+         */
+        ecmaVersion?: ParserOptions["ecmaVersion"],
+        /**
+         * The type of JavaScript source code. Possible values are "script" for
+         * traditional script files, "module" for ECMAScript modules (ESM), and
+         * "commonjs" for CommonJS files. (default: "module" for .js and .mjs
+         * files; "commonjs" for .cjs files)
+         */
+        sourceType?: "script" | "module" | "commonjs",
+        /**
+         * An object specifying additional objects that should be added to the
+         * global scope during linting.
+         */
+        globals?: ESLint.Environment["globals"],
+        /**
+         * Either an object containing a parse() method or a string indicating the
+         * name of a parser inside of a plugin (i.e., "pluginName/parserName").
+         * @default "@/espree"
+         */
+        parser?: string,
+        /**
+         * An object specifying additional options that are passed directly to the
+         * parser() method on the parser. The available options are parser-dependent
+         */
+        parserOptions?: ESLint.Environment["parserOptions"],
+      };
+      /**
+       * An object containing settings related to the linting process
+       */
+      linterOptions?: {
+        /**
+         * A Boolean value indicating if inline configuration is allowed.
+         */
+        noInlineConfig?: boolean,
+        /**
+         * A Boolean value indicating if unused disable directives should be
+         * tracked and reported.
+         */
+        reportUnusedDisableDirectives?: boolean,
+      };
+      /**
+       * Either an object containing preprocess() and postprocess() methods or a
+       * string indicating the name of a processor inside of a plugin
+       * (i.e., "pluginName/processorName").
+       */
+      processor?: string | Processor;
+      /**
+       * An object containing a name-value mapping of plugin names to plugin objects.
+       * When files is specified, these plugins are only available to the matching files.
+       */
+      plugins?: Record<string, ESLint.Plugin>;
+      /**
+       * An object containing the configured rules. When files or ignores are specified,
+       * these rule configurations are only available to the matching files.
+       */
+      rules?: RulesRecord;
+      /**
+       * An object containing name-value pairs of information that should be
+       * available to all rules.
+       */
+      settings?: Record<string, unknown>;
+    }
 }
 
 //#endregion

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for eslint 8.21.0
+// Type definitions for eslint 8.21
 // Project: https://eslint.org
 // Definitions by: Pierre-Marie Dartus <https://github.com/pmdartus>
 //                 Jed Fox <https://github.com/j-f1>

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for eslint 8.4
+// Type definitions for eslint 8.21.0
 // Project: https://eslint.org
 // Definitions by: Pierre-Marie Dartus <https://github.com/pmdartus>
 //                 Jed Fox <https://github.com/j-f1>


### PR DESCRIPTION
Add interface for the flat config specification introduced half a year ago.

`@types/eslint` is now only 6 months behind `eslint` instead of 12 months behind.

See discussion for more information.
https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63230

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://eslint.org/docs/latest/use/configure/configuration-files-new>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. ***There are likely to be other definitions to be added, however as the previous version was v8.4 (a year ago), and this is upgrading to v8.21 (6 months ago), I don't believe completeness to be required.***


