### PR TITLE
fix(glob): use build in minimatch types

### DIFF
--- a/types/glob/index.d.ts
+++ b/types/glob/index.d.ts
@@ -26,7 +26,7 @@ declare namespace G {
     let Glob: IGlobStatic;
     let GlobSync: IGlobSyncStatic;
 
-    interface IOptions extends minimatch.IOptions {
+    interface IOptions extends minimatch.MinimatchOptions {
         cwd?: string | undefined;
         root?: string | undefined;
         dot?: boolean | undefined;
@@ -71,7 +71,7 @@ declare namespace G {
     }
 
     interface IGlobBase {
-        minimatch: minimatch.IMinimatch;
+        minimatch: minimatch.Minimatch;
         options: IOptions;
         aborted: boolean;
         cache: { [path: string]: boolean | 'DIR' | 'FILE' | ReadonlyArray<string> };

--- a/types/glob/package.json
+++ b/types/glob/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "@types/minimatch": "^5.1.2"
+        "minimatch": "^6.1.6"
     }
 }

--- a/types/glob/v5/index.d.ts
+++ b/types/glob/v5/index.d.ts
@@ -23,7 +23,7 @@ declare namespace G {
     let Glob: IGlobStatic;
     let GlobSync: IGlobSyncStatic;
 
-    interface IOptions extends minimatch.IOptions {
+    interface IOptions extends minimatch.MinimatchOptions {
         cwd?: string | undefined;
         root?: string | undefined;
         dot?: boolean | undefined;
@@ -69,7 +69,7 @@ declare namespace G {
     }
 
     interface IGlobBase {
-        minimatch: minimatch.IMinimatch;
+        minimatch: minimatch.Minimatch;
         options: IOptions;
         aborted: boolean;
         cache: { [path: string]: any /* boolean | string | string[] */ };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64079
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
