### PR TITLE
[tampermonkey] allow accessing globals in window/unsafeWindow

### DIFF
--- a/types/tampermonkey/index.d.ts
+++ b/types/tampermonkey/index.d.ts
@@ -383,7 +383,34 @@ declare namespace Tampermonkey {
  * The unsafeWindow object provides full access to the pages javascript
  * functions and variables
  */
-declare var unsafeWindow: Window;
+declare var unsafeWindow: Window &
+    Omit<
+        typeof globalThis,
+        | 'GM_addStyle'
+        | 'GM_addValueChangeListener'
+        | 'GM_deleteValue'
+        | 'GM_download'
+        | 'GM_download'
+        | 'GM_getResourceText'
+        | 'GM_getResourceURL'
+        | 'GM_getTab'
+        | 'GM_getTabs'
+        | 'GM_getValue'
+        | 'GM_info'
+        | 'GM_listValues'
+        | 'GM_log'
+        | 'GM_notification'
+        | 'GM_notification'
+        | 'GM_openInTab'
+        | 'GM_registerMenuCommand'
+        | 'GM_removeValueChangeListener'
+        | 'GM_saveTab'
+        | 'GM_setClipboard'
+        | 'GM_setValue'
+        | 'GM_unregisterMenuCommand'
+        | 'GM_xmlhttpRequest'
+        | 'GM'
+    >;
 
 /**
  *
@@ -488,7 +515,7 @@ declare function GM_getTabs(callback: (tabsMap: { [tabId: number]: any }) => voi
 
 // Utils
 
-declare const GM_info: Tampermonkey.ScriptInfo;
+declare var GM_info: Tampermonkey.ScriptInfo;
 
 /** Log a message to the console */
 declare function GM_log(...message: any[]): void;
@@ -546,7 +573,7 @@ declare function GM_setClipboard(data: string, info?: Tampermonkey.ContentType):
 /**
  * `GM` has all the `GM_*` apis in promisified form
  */
-declare const GM: Readonly<{
+declare var GM: Readonly<{
     // Styles
 
     /**

--- a/types/tampermonkey/tampermonkey-tests.ts
+++ b/types/tampermonkey/tampermonkey-tests.ts
@@ -2,6 +2,9 @@
 
 let title: string = unsafeWindow.document.title;
 
+// $ExpectType Console
+unsafeWindow.console;
+
 // window.onurlchange
 
 if (window.onurlchange === null) {
@@ -333,6 +336,12 @@ GM_setClipboard('<b>Some text in clipboard</b>', {
 
 // GM_info
 
+// $ExpectType ScriptInfo
+window.GM_info;
+
+// @ts-expect-error
+unsafeWindow.GM_info;
+
 // I created a basic userscript and copied GM_info from there for testing if the real thing fits the types
 // I don't think there's a real way of testing this other than testing if it fits the original
 const exampleInfo: Tampermonkey.ScriptInfo = {
@@ -427,6 +436,11 @@ const exampleInfo: Tampermonkey.ScriptInfo = {
 // GM.info
 
 const exampleInfo1: Tampermonkey.ScriptInfo = GM.info;
+
+const exampleInfo2: Tampermonkey.ScriptInfo = window.GM.info;
+
+// @ts-expect-error
+unsafeWindow.GM;
 
 async () => {
     // GM.addStyle


### PR DESCRIPTION
Use-case: e.g. hooking/overwriting globals of the page (`unsafeWindow.console.log =`) or simply accessing them.

const to var is needed to make GM and GM_info available in globalThis and thus window.
unsafeWindow includes all globals except the `GM.*` and `GM_*` apis.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.tampermonkey.net/documentation.php#api:unsafeWindow, 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
