### PR TITLE
Freeze version of @hapi/hapi temp. at 21.1.0

### DIFF
--- a/types/avocat/package.json
+++ b/types/avocat/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "dependencies": {
         "@hapi/boom": "^9.1.1",
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapi-auth-bearer-token/package.json
+++ b/types/hapi-auth-bearer-token/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@hapi/hapi": "^21.1.0",
+    "@hapi/hapi": "21.1.0",
     "joi": "^17.7.0"
   }
 }

--- a/types/hapi-server-session/package.json
+++ b/types/hapi-server-session/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@hapi/hapi": "^21.1.0",
+    "@hapi/hapi": "21.1.0",
     "joi": "^17.7.0"
   }
 }

--- a/types/hapi__basic/package.json
+++ b/types/hapi__basic/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapi__bell/package.json
+++ b/types/hapi__bell/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapi__catbox-memcached/package.json
+++ b/types/hapi__catbox-memcached/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapi__cookie/package.json
+++ b/types/hapi__cookie/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapi__crumb/package.json
+++ b/types/hapi__crumb/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapi__glue/package.json
+++ b/types/hapi__glue/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapi__h2o2/package.json
+++ b/types/hapi__h2o2/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "dependencies": {
         "@hapi/boom": "^10.0.0",
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "@hapi/wreck": "^18.0.0",
         "joi": "^17.7.0"
     }

--- a/types/hapi__hawk/package.json
+++ b/types/hapi__hawk/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "dependencies": {
         "@hapi/boom": "^9.0.0",
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapi__inert/package.json
+++ b/types/hapi__inert/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@hapi/hapi": "^21.1.0",
+    "@hapi/hapi": "21.1.0",
     "joi": "^17.7.0"
   }
 }

--- a/types/hapi__jwt/package.json
+++ b/types/hapi__jwt/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapi__nes/package.json
+++ b/types/hapi__nes/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@hapi/hapi": "^21.1.0",
+    "@hapi/hapi": "21.1.0",
     "joi": "^17.7.0"
   }
 }

--- a/types/hapi__vision/package.json
+++ b/types/hapi__vision/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "handlebars": "^4.1",
         "joi": "^17.7.0"
     }

--- a/types/hapi__yar/package.json
+++ b/types/hapi__yar/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@hapi/hapi": "^21.1.0",
+    "@hapi/hapi": "21.1.0",
     "joi": "^17.7.0"
   }
 }

--- a/types/hapipal__avocat/package.json
+++ b/types/hapipal__avocat/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "dependencies": {
         "@hapi/boom": "^9.1.1",
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/hapipal__schmervice/package.json
+++ b/types/hapipal__schmervice/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@hapi/hapi": "^21.1.0",
+    "@hapi/hapi": "21.1.0",
     "joi": "^17.7.0"
   }
 }

--- a/types/hapipal__toys/package.json
+++ b/types/hapipal__toys/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "dependencies": {
         "@hapi/boom": "^9.1.1",
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0"
     }
 }

--- a/types/schwifty/package.json
+++ b/types/schwifty/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@hapi/hapi": "^21.1.0",
+        "@hapi/hapi": "21.1.0",
         "joi": "^17.7.0",
         "knex": "^0.16.1",
         "objection": "^1.1.9"


### PR DESCRIPTION
Similarly to solution from #64018 this commit freezes version of @hapi/hapi at 21.1.0 to avoid unexpected impact on consuming packages and ecosystem after @hapi/hapi@21.2.0 types updates.

See also:
https://github.com/hapijs/hapi/pull/4419

Thanks!

/cc [Alexthemediocre](https://github.com/Alexthemediocre)