### PR TITLE
Add types to Report for @adobe/aio-lib-analytics

### DIFF
--- a/types/adobe__aio-lib-analytics/index.d.ts
+++ b/types/adobe__aio-lib-analytics/index.d.ts
@@ -6,8 +6,27 @@
 
 export interface Report {
   body: {
-    rows: any[];
-    lastPage: boolean;
+    firstPage?: boolean;
+    lastPage?: boolean;
+    numberOfElements?: number;
+    number?: number;
+    totalElements?: number;
+    message?: string;
+    reportId?: string;
+    rows?: {
+      itemId?: string;
+      value?: string;
+      rowId?: string;
+      data?: (number)[];
+      dataExpected?: (number)[];
+      dataUpperBound?: (number)[];
+      dataLowerBound?: (number)[];
+      dataAnomalyDetected?: (boolean)[];
+      percentChange?: (number)[];
+      latitude?: number;
+      longitude?: number;
+    }[];
+    summaryData?: Record<string, never>;
   };
 }
 


### PR DESCRIPTION
I derived the types of the report from https://github.com/adobe/aio-lib-analytics/blob/master/spec/analytics_api.json
I couldn't add tests as the report results are the response of a private API.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
