### PR TITLE
react: Make value returned by useState Readonly

### DIFF
--- a/types/react/package.json
+++ b/types/react/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "dependencies": {
-    "csstype": "^3.0.2"
+    "csstype": "^3.0.2",
+    "utility-types": "^3.10.0"
   },
   "exports": {
     ".": {

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -34,6 +34,7 @@
 import * as CSS from 'csstype';
 import * as PropTypes from 'prop-types';
 import { Interaction as SchedulerInteraction } from 'scheduler/tracing';
+import { DeepReadonly } from "utility-types";
 
 type NativeAnimationEvent = AnimationEvent;
 type NativeClipboardEvent = ClipboardEvent;
@@ -918,7 +919,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usestate
      */
-    function useState<S>(initialState: S | (() => S)): [Readonly<S>, Dispatch<SetStateAction<S>>];
+    function useState<S>(initialState: S | (() => S)): [DeepReadonly<S>, Dispatch<SetStateAction<S>>];
     // convenience overload when first argument is omitted
     /**
      * Returns a stateful value, and a function to update it.
@@ -926,7 +927,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usestate
      */
-    function useState<S = undefined>(): [Readonly<S> | undefined, Dispatch<SetStateAction<S | undefined>>];
+    function useState<S = undefined>(): [DeepReadonly<S> | undefined, Dispatch<SetStateAction<S | undefined>>];
     /**
      * An alternative to `useState`.
      *

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -918,7 +918,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usestate
      */
-    function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
+    function useState<S>(initialState: S | (() => S)): [Readonly<S>, Dispatch<SetStateAction<S>>];
     // convenience overload when first argument is omitted
     /**
      * Returns a stateful value, and a function to update it.
@@ -926,7 +926,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usestate
      */
-    function useState<S = undefined>(): [S | undefined, Dispatch<SetStateAction<S | undefined>>];
+    function useState<S = undefined>(): [Readonly<S> | undefined, Dispatch<SetStateAction<S | undefined>>];
     /**
      * An alternative to `useState`.
      *


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
  - Not sure what to add as a test for this; this change is intended to make mutation of state impossible
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

State is immutable, so the return value of useState should be wrapped in the `DeepReadonly` utility type which can prevent accidental mutation.

https://github.com/piotrwitek/utility-types/blob/master/src/mapped-types.ts#L396

This will prevent accidental mutation of state. E.g.

```
const [arr, setArr] = useState(['a', 'b']);
arr.push('c')
```
