### PR TITLE
[react-native]: Add inputMode prop to TextInput

### DIFF
--- a/types/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/types/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -114,7 +114,6 @@ export interface DocumentSelectionState extends EventEmitter {
  */
 export interface TextInputIOSProps {
   /**
-   * enum('never', 'while-editing', 'unless-editing', 'always')
    * When the clear button should appear on the right side of the text view
    */
   clearButtonMode?:
@@ -580,8 +579,6 @@ export interface TextInputProps
   editable?: boolean | undefined;
 
   /**
-   * enum("default", 'numeric', 'email-address', "ascii-capable", 'numbers-and-punctuation', 'url', 'number-pad', 'phone-pad', 'name-phone-pad',
-   * 'decimal-pad', 'twitter', 'web-search', 'visible-password')
    * Determines which keyboard to open, e.g.numeric.
    * The following values work across platforms: - default - numeric - email-address - phone-pad
    * The following values work on iOS: - ascii-capable - numbers-and-punctuation - url - number-pad - name-phone-pad - decimal-pad - twitter - web-search
@@ -590,7 +587,6 @@ export interface TextInputProps
   keyboardType?: KeyboardTypeOptions | undefined;
 
   /**
-   * enum('decimal', 'email', 'none', 'numeric', 'search', 'tel', 'text', 'url')
    * Works like the inputmode attribute in HTML, it determines which keyboard to open, e.g. numeric and has precedence over keyboardType.
    */
   inputMode?: InputModeOptions | undefined;
@@ -721,7 +717,6 @@ export interface TextInputProps
   placeholderTextColor?: ColorValue | undefined;
 
   /**
-   * enum('default', 'go', 'google', 'join', 'next', 'route', 'search', 'send', 'yahoo', 'done', 'emergency-call')
    * Determines how the return key should look.
    */
   returnKeyType?: ReturnKeyTypeOptions | undefined;

--- a/types/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/types/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -36,6 +36,16 @@ export type KeyboardTypeOptions =
   | KeyboardTypeAndroid
   | KeyboardTypeIOS;
 
+export type InputModeOptions =
+  | 'none'
+  | 'text'
+  | 'decimal'
+  | 'numeric'
+  | 'tel'
+  | 'search'
+  | 'email'
+  | 'url';
+
 export type ReturnKeyType = 'done' | 'go' | 'next' | 'search' | 'send';
 export type ReturnKeyTypeAndroid = 'none' | 'previous';
 export type ReturnKeyTypeIOS =
@@ -578,6 +588,12 @@ export interface TextInputProps
    * The following values work on Android: - visible-password
    */
   keyboardType?: KeyboardTypeOptions | undefined;
+
+  /**
+   * enum('decimal', 'email', 'none', 'numeric', 'search', 'tel', 'text', 'url')
+   * Works like the inputmode attribute in HTML, it determines which keyboard to open, e.g. numeric and has precedence over keyboardType.
+   */
+  inputMode?: InputModeOptions | undefined;
 
   /**
    * Limits the maximum number of characters that can be entered.

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -1114,6 +1114,8 @@ class TextInputTest extends React.Component<{}, {username: string}> {
         <TextInput contextMenuHidden={true} textAlignVertical="top" />
 
         <TextInput textAlign="center" />
+
+        <TextInput inputMode="numeric"/>
       </View>
     );
   }


### PR DESCRIPTION
In v0.71, React Native adds an `inputMode` prop to the `TextInput` component:

https://github.com/facebook/react-native/pull/34460

This prop is present in v0.71 
https://reactnative.dev/docs/textinput#inputmode

But not present in v0.70 and earlier versions
https://reactnative.dev/docs/0.70/textinput

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactnative.dev/docs/textinput#inputmode
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
