### PR TITLE
async - waterfall returns a promise when callback is omitted

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -391,6 +391,7 @@ export function doUntil<T, R, E = Error>(
 export function during<E = Error>(test: (testCallback: AsyncBooleanResultCallback<E>) => void, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
 export function doDuring<E = Error>(fn: AsyncVoidFunction<E>, test: (testCallback: AsyncBooleanResultCallback<E>) => void, callback: ErrorCallback<E>): void;
 export function forever<E = Error>(next: (next: ErrorCallback<E>) => void, errBack: ErrorCallback<E>): void;
+export function waterfall<T>(tasks: Function[]): Promise<T>;
 export function waterfall<T, E = Error>(tasks: Function[], callback?: AsyncResultCallback<T, E>): void;
 export function compose(...fns: Function[]): Function;
 export function seq(...fns: Function[]): Function;

--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -392,7 +392,7 @@ export function during<E = Error>(test: (testCallback: AsyncBooleanResultCallbac
 export function doDuring<E = Error>(fn: AsyncVoidFunction<E>, test: (testCallback: AsyncBooleanResultCallback<E>) => void, callback: ErrorCallback<E>): void;
 export function forever<E = Error>(next: (next: ErrorCallback<E>) => void, errBack: ErrorCallback<E>): void;
 export function waterfall<T>(tasks: Function[]): Promise<T>;
-export function waterfall<T, E = Error>(tasks: Function[], callback?: AsyncResultCallback<T, E>): void;
+export function waterfall<T, E = Error>(tasks: Function[], callback: AsyncResultCallback<T, E>): void;
 export function compose(...fns: Function[]): Function;
 export function seq(...fns: Function[]): Function;
 export function applyEach(fns: Function[], ...argsAndCallback: any[]): void;           // applyEach(fns, args..., callback). TS does not support ... for a middle argument. Callback is optional.

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -186,12 +186,20 @@ async.during(testCallback => { testCallback(new Error(), false); }, callback => 
 async.doDuring(callback => { callback(); }, testCallback => { testCallback(new Error(), false); }, error => { console.log(error); });
 async.forever(errBack => { errBack(new Error("Not going on forever.")); }, error => { console.log(error); });
 
+// $ExpectType void
 async.waterfall([
         (callback: any) => { callback(null, 'one', 'two'); },
         (arg1: any, arg2: any, callback: any) => { callback(null, 'three'); },
         (arg1: any, callback: any) => { callback(null, 'done'); }
     ],
     (err, result) => { });
+
+// $ExpectType Promise<A>
+async.waterfall<A>([
+    (callback: any) => { callback(null, 'one', 'two'); },
+    (arg1: any, arg2: any, callback: any) => { callback(null, 'three'); },
+    (arg1: any, callback: any) => { callback(null, 'done'); }
+]);
 
 const q = async.queue<any>((task: any, callback: (err?: Error, msg?: string) => void) => {
     console.log('hello ' + task.name);


### PR DESCRIPTION
The waterfall function returns a promise when callback is omitted

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://caolan.github.io/async/v3/docs.html#waterfall
