### PR TITLE
[@types/sdp-transform] parseSimulcastStreamList returns a nested array

### DIFF
--- a/types/sdp-transform/index.d.ts
+++ b/types/sdp-transform/index.d.ts
@@ -14,10 +14,10 @@ export function parseRemoteCandidates(candidates: string): Array<{
     ip: string;
     port: number;
 }>;
-export function parseSimulcastStreamList(streams: string): Array<{
+export function parseSimulcastStreamList(streams: string): Array<Array<{
     scid: number | string;
     paused: boolean;
-}>;
+}>>;
 export interface ParamMap {
     [paramName: string]: number | string;
 }

--- a/types/sdp-transform/sdp-transform-tests.ts
+++ b/types/sdp-transform/sdp-transform-tests.ts
@@ -2,6 +2,8 @@ import {
     SessionDescription,
     parse,
     write,
+    parseSimulcastStreamList,
+    parseImageAttributes,
 } from 'sdp-transform';
 
 function test_basic() {
@@ -31,4 +33,20 @@ function test_origin_fields() {
         address: '127.0.0.1'
     };
     const sdp: string = write(session);
+}
+
+function test_parse_simulcast_stream_list() {
+    const session: SessionDescription = parse('');
+    const simulcastList = session.media[0].simulcast?.list1;
+
+    if (!simulcastList) {
+        return;
+    }
+
+    for (const stream of parseSimulcastStreamList(simulcastList)) {
+        for (const format of stream) {
+            format.paused; // $ExpectType boolean
+            format.scid; // $ExpectType string | number
+        }
+    }
 }

--- a/types/sdp-transform/sdp-transform-tests.ts
+++ b/types/sdp-transform/sdp-transform-tests.ts
@@ -3,7 +3,6 @@ import {
     parse,
     write,
     parseSimulcastStreamList,
-    parseImageAttributes,
 } from 'sdp-transform';
 
 function test_basic() {


### PR DESCRIPTION
Refer to the example at https://github.com/clux/sdp-transform#parsesimulcaststreamlist

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/clux/sdp-transform#parsesimulcaststreamlist
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
