### PR TITLE
Bump JSDOM types to 21.x

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jsdom 20.0
+// Type definitions for jsdom 21.1
 // Project: https://github.com/jsdom/jsdom
 // Definitions by: Leonard Thieu <https://github.com/leonard-thieu>
 //                 Johan Palmfjord <https://github.com/palmfjord>


### PR DESCRIPTION
21.x did not change any JSDOM APIs. Only changes to its DOM implementation which isn't typed here (lib.dom.d.ts makes no assumptions about the particular implementation).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [xx] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsdom/jsdom/blob/master/Changelog.md#2100
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

