### PR TITLE
fix: ListElement style not support the basic node style

### DIFF
--- a/types/blessed/blessed-tests.ts
+++ b/types/blessed/blessed-tests.ts
@@ -202,6 +202,33 @@ blessed.box({
   content: "Foo"
 });
 
+blessed.list({
+  parent: screen,
+  left: -1,
+  top: "50%-1",
+  width: "50%+1",
+  height: "50%+3",
+  border: "line",
+  content: "List",
+  style: {
+    selected: {
+      bg: 'red'
+    },
+    item: {
+      bg: 'blue'
+    },
+    bg: "blue",
+    border: {
+      fg: '#000000',
+    },
+    focus: {
+      border: {
+        fg: 'white',
+      },
+    }
+  }
+});
+
 blessed
   .listtable({
     parent: screen,

--- a/types/blessed/index.d.ts
+++ b/types/blessed/index.d.ts
@@ -448,8 +448,18 @@ export namespace Widgets {
 
         type TMouseAction = "mousedown" | "mouseup" | "mousemove";
 
+        interface TStyleBorder  {
+            bg?: string | undefined;
+            fg?: string | undefined;
+        }
+
+        interface Effects {
+            bg?: string;
+            fg?: string;
+            border?: TStyleBorder | undefined;
+        }
+
         interface TStyle {
-            type?: string | undefined;
             bg?: string | undefined;
             fg?: string | undefined;
             ch?: string | undefined;
@@ -459,9 +469,9 @@ export namespace Widgets {
             inverse?: boolean | undefined;
             invisible?: boolean | undefined;
             transparent?: boolean | undefined;
-            border?: "line" | "bg" | TBorder | undefined;
-            hover?: boolean | undefined;
-            focus?: boolean | undefined;
+            border?: TStyleBorder;
+            hover?: Effects | undefined;
+            focus?: Effects | undefined;
             label?: string | undefined;
             track?: { bg?: string | undefined; fg?: string | undefined } | undefined;
             scrollbar?: { bg?: string | undefined; fg?: string | undefined } | undefined;
@@ -2270,10 +2280,10 @@ export namespace Widgets {
         options: BigTextOptions;
     }
 
-    interface ListElementStyle {
+    type ListElementStyle = {
         selected?: any;
         item?: any;
-    }
+    } & Types.TStyle;
 
     interface ListOptions<TStyle extends ListElementStyle> extends BoxOptions {
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [follow the List style property definition](https://github.com/chjj/blessed#list-from-box) and the usage exaples that the docs mentioned, such as [style](https://github.com/chjj/blessed#style), [effects](https://github.com/chjj/blessed#effects), etc.

