### PR TITLE
spotify-api: Add missing 'is_private_session' property to 'UserDevice' interface.

### DIFF
--- a/types/spotify-api/index.d.ts
+++ b/types/spotify-api/index.d.ts
@@ -1831,6 +1831,7 @@ declare namespace SpotifyApi {
         id: string | null;
         is_active: boolean;
         is_restricted: boolean;
+        is_private_session: boolean;
         name: string;
         type: string;
         volume_percent: number | null;

--- a/types/spotify-api/spotify-api-tests.ts
+++ b/types/spotify-api/spotify-api-tests.ts
@@ -18,7 +18,7 @@
  * Get the User's Currently Playing (Track)
  *
  * GET /v1/me/player/currently-playing
- * https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-the-users-currently-playing-track
+ * https://developer.spotify.com/documentation/web-api/reference/#/operations/get-the-users-currently-playing-track
  */
 const playingNowTrack: SpotifyApi.CurrentlyPlayingResponse = {
     timestamp: 1614523995043,
@@ -26,6 +26,7 @@ const playingNowTrack: SpotifyApi.CurrentlyPlayingResponse = {
         id: '123456789',
         is_active: true,
         is_restricted: false,
+        is_private_session: false,
         name: 'Name Test',
         type: 'Computer',
         volume_percent: 48,
@@ -134,7 +135,7 @@ const playingNowTrack: SpotifyApi.CurrentlyPlayingResponse = {
  * Get the User's Currently Playing (Episode)
  *
  * GET /v1/me/player/currently-playing
- * https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-the-users-currently-playing-track
+ * https://developer.spotify.com/documentation/web-api/reference/#/operations/get-the-users-currently-playing-track
  */
 const playingNowEpisode: SpotifyApi.CurrentlyPlayingResponse = {
     timestamp: 1614525764500,
@@ -142,6 +143,7 @@ const playingNowEpisode: SpotifyApi.CurrentlyPlayingResponse = {
         id: '123456789',
         is_active: true,
         is_restricted: false,
+        is_private_session: false,
         name: 'Name Test',
         type: 'Computer',
         volume_percent: 48,

--- a/types/spotify-api/spotify-api-tests.ts
+++ b/types/spotify-api/spotify-api-tests.ts
@@ -10591,3 +10591,68 @@ const usersQueue: SpotifyApi.UsersQueueResponse = {
         },
     ],
 };
+
+/**
+ * Get information about a user’s available devices.
+ *
+ * GET /v1/me/player/devices
+ * https://developer.spotify.com/documentation/web-api/reference/#/operations/get-a-users-available-devices
+ */
+const usersDevices: SpotifyApi.UserDevicesResponse = {
+    devices: [
+        {
+            id: '0123456789abcdef0123456789abcdef01234567',
+            is_active: true,
+            is_private_session: true,
+            is_restricted: false,
+            name: 'iPhone',
+            type: 'Smartphone',
+            volume_percent: 100,
+        },
+        {
+            id: '123456789abcdef0123456789abcdef012345678',
+            is_active: false,
+            is_private_session: false,
+            is_restricted: false,
+            name: 'PS4',
+            type: 'GameConsole',
+            volume_percent: 75,
+        },
+        {
+            id: '23456789abcdef0123456789abcdef0123456789',
+            is_active: false,
+            is_private_session: false,
+            is_restricted: false,
+            name: 'Living Room',
+            type: 'AVR',
+            volume_percent: 44,
+        },
+        {
+            id: '3456789abcdef0123456789abcdef01234567890',
+            is_active: false,
+            is_private_session: false,
+            is_restricted: false,
+            name: 'FireTV',
+            type: 'TV',
+            volume_percent: 0,
+        },
+        {
+            id: '456789abcdef0123456789abcdef01234567890a',
+            is_active: false,
+            is_private_session: false,
+            is_restricted: false,
+            name: 'Bedroom',
+            type: 'Speaker',
+            volume_percent: 42,
+        },
+        {
+            id: '6789abcdef0123456789abcdef01234567890abc',
+            is_active: false,
+            is_private_session: false,
+            is_restricted: false,
+            name: 'Some Computer',
+            type: 'Computer',
+            volume_percent: 100,
+        },
+    ],
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.spotify.com/documentation/web-api/reference/#/operations/get-a-users-available-devices
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

