### PR TITLE
react-native: Use number literals for `FileReader` and `XMLHttpRequest` states

### DIFF
--- a/types/react-native/v0.63/globals.d.ts
+++ b/types/react-native/v0.63/globals.d.ts
@@ -203,11 +203,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     overrideMimeType(mime: string): void;
     send(data?: any): void;
     setRequestHeader(header: string, value: string): void;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
     addEventListener<K extends keyof XMLHttpRequestEventMap>(
         type: K,
         listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
@@ -223,11 +223,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
 declare var XMLHttpRequest: {
     prototype: XMLHttpRequest;
     new (): XMLHttpRequest;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
 };
 
 interface XMLHttpRequestEventTargetEventMap {
@@ -426,9 +426,9 @@ interface FileReader extends EventTarget {
     // readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(
         type: K,
         listener: (this: FileReader, ev: FileReaderEventMap[K]) => any,
@@ -446,7 +446,7 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new (): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };

--- a/types/react-native/v0.64/globals.d.ts
+++ b/types/react-native/v0.64/globals.d.ts
@@ -203,11 +203,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     overrideMimeType(mime: string): void;
     send(data?: any): void;
     setRequestHeader(header: string, value: string): void;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
     addEventListener<K extends keyof XMLHttpRequestEventMap>(
         type: K,
         listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
@@ -223,11 +223,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
 declare var XMLHttpRequest: {
     prototype: XMLHttpRequest;
     new (): XMLHttpRequest;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
 };
 
 interface XMLHttpRequestEventTargetEventMap {
@@ -448,9 +448,9 @@ interface FileReader extends EventTarget {
     // readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(
         type: K,
         listener: (this: FileReader, ev: FileReaderEventMap[K]) => any,
@@ -468,7 +468,7 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new (): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };

--- a/types/react-native/v0.65/globals.d.ts
+++ b/types/react-native/v0.65/globals.d.ts
@@ -214,11 +214,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     overrideMimeType(mime: string): void;
     send(data?: any): void;
     setRequestHeader(header: string, value: string): void;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
     addEventListener<K extends keyof XMLHttpRequestEventMap>(
         type: K,
         listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
@@ -234,11 +234,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
 declare var XMLHttpRequest: {
     prototype: XMLHttpRequest;
     new (): XMLHttpRequest;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
 };
 
 interface XMLHttpRequestEventTargetEventMap {
@@ -471,9 +471,9 @@ interface FileReader extends EventTarget {
     // readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(
         type: K,
         listener: (this: FileReader, ev: FileReaderEventMap[K]) => any,
@@ -491,7 +491,7 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new (): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };

--- a/types/react-native/v0.66/globals.d.ts
+++ b/types/react-native/v0.66/globals.d.ts
@@ -214,11 +214,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     overrideMimeType(mime: string): void;
     send(data?: any): void;
     setRequestHeader(header: string, value: string): void;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
     addEventListener<K extends keyof XMLHttpRequestEventMap>(
         type: K,
         listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
@@ -234,11 +234,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
 declare var XMLHttpRequest: {
     prototype: XMLHttpRequest;
     new (): XMLHttpRequest;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
 };
 
 interface XMLHttpRequestEventTargetEventMap {
@@ -471,9 +471,9 @@ interface FileReader extends EventTarget {
     // readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(
         type: K,
         listener: (this: FileReader, ev: FileReaderEventMap[K]) => any,
@@ -491,7 +491,7 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new (): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };

--- a/types/react-native/v0.67/globals.d.ts
+++ b/types/react-native/v0.67/globals.d.ts
@@ -214,11 +214,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     overrideMimeType(mime: string): void;
     send(data?: any): void;
     setRequestHeader(header: string, value: string): void;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
     addEventListener<K extends keyof XMLHttpRequestEventMap>(
         type: K,
         listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
@@ -234,11 +234,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
 declare var XMLHttpRequest: {
     prototype: XMLHttpRequest;
     new (): XMLHttpRequest;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
 };
 
 interface XMLHttpRequestEventTargetEventMap {
@@ -471,9 +471,9 @@ interface FileReader extends EventTarget {
     // readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(
         type: K,
         listener: (this: FileReader, ev: FileReaderEventMap[K]) => any,
@@ -491,7 +491,7 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new (): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };

--- a/types/react-native/v0.68/globals.d.ts
+++ b/types/react-native/v0.68/globals.d.ts
@@ -214,11 +214,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     overrideMimeType(mime: string): void;
     send(data?: any): void;
     setRequestHeader(header: string, value: string): void;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
     addEventListener<K extends keyof XMLHttpRequestEventMap>(
         type: K,
         listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
@@ -234,11 +234,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
 declare var XMLHttpRequest: {
     prototype: XMLHttpRequest;
     new (): XMLHttpRequest;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
 };
 
 interface XMLHttpRequestEventTargetEventMap {
@@ -471,9 +471,9 @@ interface FileReader extends EventTarget {
     // readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(
         type: K,
         listener: (this: FileReader, ev: FileReaderEventMap[K]) => any,
@@ -491,7 +491,7 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new (): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };

--- a/types/react-native/v0.69/globals.d.ts
+++ b/types/react-native/v0.69/globals.d.ts
@@ -227,11 +227,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     overrideMimeType(mime: string): void;
     send(data?: any): void;
     setRequestHeader(header: string, value: string): void;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
     addEventListener<K extends keyof XMLHttpRequestEventMap>(
         type: K,
         listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
@@ -247,11 +247,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
 declare var XMLHttpRequest: {
     prototype: XMLHttpRequest;
     new (): XMLHttpRequest;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
 };
 
 interface XMLHttpRequestEventTargetEventMap {
@@ -484,9 +484,9 @@ interface FileReader extends EventTarget {
     // readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(
         type: K,
         listener: (this: FileReader, ev: FileReaderEventMap[K]) => any,
@@ -504,7 +504,7 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new (): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };

--- a/types/react-native/v0.70/globals.d.ts
+++ b/types/react-native/v0.70/globals.d.ts
@@ -227,11 +227,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     overrideMimeType(mime: string): void;
     send(data?: any): void;
     setRequestHeader(header: string, value: string): void;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
     addEventListener<K extends keyof XMLHttpRequestEventMap>(
         type: K,
         listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
@@ -247,11 +247,11 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
 declare var XMLHttpRequest: {
     prototype: XMLHttpRequest;
     new (): XMLHttpRequest;
-    readonly DONE: number;
-    readonly HEADERS_RECEIVED: number;
-    readonly LOADING: number;
-    readonly OPENED: number;
-    readonly UNSENT: number;
+    readonly DONE: 4;
+    readonly HEADERS_RECEIVED: 2;
+    readonly LOADING: 3;
+    readonly OPENED: 1;
+    readonly UNSENT: 0;
 };
 
 interface XMLHttpRequestEventTargetEventMap {
@@ -484,9 +484,9 @@ interface FileReader extends EventTarget {
     // readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(
         type: K,
         listener: (this: FileReader, ev: FileReaderEventMap[K]) => any,
@@ -504,7 +504,7 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new (): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };


### PR DESCRIPTION
Forward-port: https://github.com/facebook/react-native/pull/36000

Mostly to improve compat in codebases where `lib.dom.d.ts` is loaded alongside RN. TS 5.0 updates to `lib.dom.d.ts` added number literals for these states as well so the abstract `number` type from RN was no longer compatible

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://github.com/facebook/react-native/blob/v0.63.5/Libraries/Blob/FileReader.js#L34-L36
   - https://github.com/facebook/react-native/blob/v0.63.5/Libraries/Network/XMLHttpRequest.js#L53-L57
   - https://github.com/facebook/react-native/blob/v0.71.1/Libraries/Blob/FileReader.js#L33-L35
   - https://github.com/facebook/react-native/blob/v0.71.1/Libraries/Network/XMLHttpRequest.js#L54-L58
- ~[ ]~ If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

