### PR TITLE
[reveal.js] Fix plugin typings

### DIFF
--- a/types/reveal.js/index.d.ts
+++ b/types/reveal.js/index.d.ts
@@ -218,7 +218,6 @@ declare namespace Reveal {
          */
         nextFragment(): boolean;
 
-
         // TODO - These functions are used for handling custom events defined by reveal.js on the `revealElement`.
         // The `dispatchEvent` function can help finding the correct event names, but library users can dispatch any synthetic events.
         /**
@@ -657,7 +656,10 @@ declare namespace Reveal {
          * @param binding
          * @param callback
          */
-        addKeyBinding(binding: string | { keyCode: number; key: string; description: string }, callback: (event: KeyboardEvent) => void): void;
+        addKeyBinding(
+            binding: string | { keyCode: number; key: string; description: string },
+            callback: (event: KeyboardEvent) => void,
+        ): void;
 
         /**
          * Removes the specified custom key binding.
@@ -711,7 +713,7 @@ declare namespace Reveal {
          *
          * @returns a key:value hash of all query params
          */
-        getQueryHash(): Record<string,string>;
+        getQueryHash(): Record<string, string>;
 
         /**
          * Return a hash URL that will resolve to the given slide location.
@@ -1522,7 +1524,7 @@ declare namespace Reveal {
         sanitizer?: (...args: any) => any;
         silent?: boolean;
         smartLists?: boolean;
-        smartpants?: boolean;
+        smartypants?: boolean;
         tokenizer?: object;
         walkTokens?: (...args: any) => any;
         xhtml?: boolean;
@@ -1550,10 +1552,13 @@ declare namespace Reveal {
     // NOTE: it is possible to extend type definitions depend on the plugin
     /**
      * Reveal Plugin
+     *
+     * @see {@link https://revealjs.com/creating-plugins/}
      */
     interface Plugin {
         id: string;
-        init(reveal: Api): Promise<any>;
+        init?(reveal: Api): void | Promise<any>;
+        destroy?(): void;
     }
 
     interface PluginFunction {

--- a/types/reveal.js/plugin/highlight/highlight/index.d.ts
+++ b/types/reveal.js/plugin/highlight/highlight/index.d.ts
@@ -1,4 +1,3 @@
-
 import Reveal = require('../../../.');
 
 /**

--- a/types/reveal.js/plugin/markdown/markdown/index.d.ts
+++ b/types/reveal.js/plugin/markdown/markdown/index.d.ts
@@ -1,4 +1,3 @@
-
 import Reveal = require('../../../.');
 
 /**

--- a/types/reveal.js/plugin/math/math/index.d.ts
+++ b/types/reveal.js/plugin/math/math/index.d.ts
@@ -1,5 +1,3 @@
-
-
 import Reveal = require('../../../.');
 
 /**
@@ -7,6 +5,10 @@ import Reveal = require('../../../.');
  *
  * @see {@link https://github.com/hakimel/reveal.js/tree/master/plugin/math}
  */
-declare const RevealMath: Reveal.PluginFunction;
+declare const RevealMath: Reveal.PluginFunction & {
+    KaTeX: Reveal.PluginFunction;
+    MathJax2: Reveal.PluginFunction;
+    MathJax3: Reveal.PluginFunction;
+};
 
 export = RevealMath;

--- a/types/reveal.js/plugin/notes/notes/index.d.ts
+++ b/types/reveal.js/plugin/notes/notes/index.d.ts
@@ -1,4 +1,3 @@
-
 import Reveal = require('../../../.');
 
 /**

--- a/types/reveal.js/plugin/search/search/index.d.ts
+++ b/types/reveal.js/plugin/search/search/index.d.ts
@@ -1,4 +1,3 @@
-
 import Reveal = require('../../../.');
 
 /**

--- a/types/reveal.js/plugin/zoom/zoom/index.d.ts
+++ b/types/reveal.js/plugin/zoom/zoom/index.d.ts
@@ -1,6 +1,4 @@
-
 import Reveal = require('../../../.');
-
 
 /**
  * Reveal plugin zoom

--- a/types/reveal.js/reveal.js-tests.ts
+++ b/types/reveal.js/reveal.js-tests.ts
@@ -25,6 +25,12 @@ new Reveal({
     plugins: [RevealMarkdown, RevealHighlight, RevealNotes, RevealSearch, RevealMath, RevealZoom],
 });
 
+// math sub-plugins
+// $ExpectType Api
+new Reveal({
+    plugins: [RevealMath.KaTeX, RevealMath.MathJax2, RevealMath.MathJax3],
+});
+
 // with options
 // $ExpectType Api
 new Reveal({ width: 960, height: 700 });
@@ -357,7 +363,7 @@ deck.initialize({
         sanitizer: () => {},
         silent: true,
         smartLists: true,
-        smartpants: true,
+        smartypants: true,
         tokenizer: { key: 'value' },
         walkTokens: () => {},
         xhtml: true,
@@ -568,12 +574,10 @@ Reveal.on('slidetransitionend', event => {
     console.log(event);
 });
 
-
 // $ExpectType void
 deck.off('click', el.click, false);
 // $ExpectType void
 Reveal.off('click', el.click, false);
-
 
 // $ExpectType void
 deck.addEventListener('click', el.click);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://revealjs.com/creating-plugins/
  - https://revealjs.com/math/
  - https://marked.js.org/using_advanced
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - I doesn't, its fixing existing issues with the typings themselves.

---

This fixes a few issues with the current typing. this isn't due to a change on the reveal.js side, just matching the library better.

- The RevealMath plugin has 3 "sub-plugins" to choose from: `KaTeX` `MathJax2` and `MathJax3`. see https://github.com/hakimel/reveal.js/blob/master/plugin/math/plugin.js

- On plugins the `init()` function is optional, and doesn't have to return anything. Technically the return value isn't looked at beside checking whether it's a promise, but I figured `void | Promise<any>` was better than `any` or `any | Promise<any>`. See https://revealjs.com/creating-plugins/.

- Plugins can have an optional `destroy()` method.

There was a typo in a `marked` options that's forwarded, `smartpants` instead of `smartypants`. see https://github.com/markedjs/marked. **This is technically a breacking change from the previous types, even if it fixes an bug.**

(Also, I took the liberty to run prettier on it, hence a bunch of whitespace changes.)

For the sake of referencing I'm also tagging https://github.com/hakimel/reveal.js/issues/2496.