### PR TITLE
jws support 'json' option for decode

### DIFF
--- a/types/jws/index.d.ts
+++ b/types/jws/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for jws 3.2
-// Project: https://github.com/brianloveswords/node-jws
+// Project: https://github.com/auth0/node-jws
 // Definitions by: Justin Beckwith <https://github.com/JustinBeckwith>, Denis Olsem <https://github.com/dolsem>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -28,7 +28,7 @@ export function verify(signature: string, algorithm: Algorithm, secretOrKey: str
  * (Synchronous) Returns the decoded header, decoded payload,
  * and signature parts of the JWS Signature.
  */
-export function decode(signature: string): Signature;
+export function decode(signature: string, options?: DecodeOptions): Signature;
 
 /**
  * (Synchronous) Validates that the signature seems to be a legitimate JWS signature.
@@ -138,6 +138,14 @@ export interface SignOptions {
     privateKey?: any;
 
     encoding?: string|Buffer|stream.Readable | undefined;
+}
+
+export interface DecodeOptions {
+    /**
+     * Whether to force {@link JSON.parse} on the payload
+     * even if the header doesn't contain "typ":"JWT".
+     */
+    json: boolean;
 }
 
 export interface VerifyOptions {

--- a/types/jws/jws-tests.ts
+++ b/types/jws/jws-tests.ts
@@ -1,10 +1,10 @@
 /**
  * Tests are built by copying samples from the github repository:
- * https://github.com/brianloveswords/node-jws
+ * https://github.com/auth0/node-jws
  */
 
 import * as jws from 'jws';
-import * as fs from "fs";
+import * as fs from 'fs';
 
 // set up mock objects
 const fakeStream = fs.createReadStream('fakefile');
@@ -29,6 +29,7 @@ const signatureWithHeaderParams = jws.sign({
 
 // jws.decode
 const message = jws.decode('djfakdid');
+const messageWithPayloadForcedToJson = jws.decode('djfakdid', { json: true });
 
 // $ExpectType boolean
 const isValid = jws.isValid('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c');


### PR DESCRIPTION
This is supported in the library but not by the types: https://github.com/auth0/node-jws/blob/master/index.js#L15

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [node-jws/index.js#L15](https://github.com/auth0/node-jws/blob/master/index.js#L15) > [node-jws/lib/verify-stream.js#L57](https://github.com/auth0/node-jws/blob/b9fb8d30e9c009ade6379f308590f1b0703eefc3/lib/verify-stream.js#L57)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.