### PR TITLE
fix skmeans typings and distinguish between mono/multi array

### DIFF
--- a/types/skmeans/index.d.ts
+++ b/types/skmeans/index.d.ts
@@ -3,14 +3,14 @@
 // Definitions by: DefinitelyTyped <https://github.com/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type CentroidValues = number[] | number[][] | 'kmrand' | 'kmpp' | null;
+type CentroidValues<TPoint extends number | number[]> = TPoint[] | 'kmrand' | 'kmpp';
 
-interface Data {
+interface DataResult<TPoint extends number | number[]> {
     it: number;
     k: number;
-    centroids: number[] | number[][];
+    centroids: TPoint[];
     idxs: number[];
-    test: (x: number, point?: (x1: number, x2: number) => number) => void;
+    test: (x: number, distance?: (x: TPoint, y: TPoint) => number) => void;
 }
 
 /**
@@ -22,12 +22,12 @@ interface Data {
  * @param iterations Maximum number of iterations. If not provided, it will be set to 10000.
  * @param distance Custom distance function. Takes two points as arguments and returns a scalar number.
  */
-declare function skmeans(
-    data: number[] | number[][],
+declare function skmeans<TPoint extends number | number[]>(
+    data: TPoint[],
     k: number,
-    centroids?: CentroidValues,
+    centroids?: CentroidValues<TPoint> | null,
     iterations?: number | null,
-    distance?: (x: number, y: number) => number
-): Data;
+    distance?: (x: TPoint, y: TPoint) => number | null,
+): DataResult<TPoint>;
 
 export = skmeans;

--- a/types/skmeans/index.d.ts
+++ b/types/skmeans/index.d.ts
@@ -10,7 +10,7 @@ interface DataResult<TPoint extends number | number[]> {
     k: number;
     centroids: TPoint[];
     idxs: number[];
-    test: (x: number, distance?: (x: TPoint, y: TPoint) => number) => void;
+    test: (x: TPoint, distance?: (x: TPoint, y: TPoint) => number) => void;
 }
 
 /**

--- a/types/skmeans/skmeans-tests.ts
+++ b/types/skmeans/skmeans-tests.ts
@@ -33,7 +33,7 @@ res.centroids.forEach(i => () => {
 });
 
 const res2 = skmeans(dataMulti, 3, null, 10);
-res2.test(6, distance3d);
+res2.test([6, 1, 3], distance3d);
 res2.centroids.forEach(i => () => {
     i[0] + i[1];
 });
@@ -59,6 +59,6 @@ skmeans(dataUni, 3, null, null, distance3d);
     skmeans(dataMulti, 3).centroids;
 }
 
-// we should NOT be able to use scalar-based distance function in mono-dimensions
+// we should NOT be able to use scalar-based distance function in multi-dimensions
 // @ts-expect-error
 skmeans(dataMulti, 3, null, null, distance1d);

--- a/types/skmeans/skmeans-tests.ts
+++ b/types/skmeans/skmeans-tests.ts
@@ -2,11 +2,19 @@ import skmeans = require('skmeans');
 
 const dataUni = [0, 1, 3, 6, 8, 3];
 
-const dataMulti = [[0, 3, 4], [5, 4, 9]];
+const dataMulti = [
+    [0, 3, 4],
+    [5, 4, 9],
+];
 
-skmeans(dataUni, 4, "kmrand");
+const distance3d = ([x1, y1, z1]: number[], [x2, y2, z2]: number[]) =>
+    Math.abs(x1 - x2) + Math.abs(y1 - y2) + Math.abs(z1 - z2);
 
-skmeans(dataUni, 3, "kmpp");
+const distance1d = (x1: number, x2: number) => Math.abs(x1 - x2);
+
+skmeans(dataUni, 4, 'kmrand');
+
+skmeans(dataUni, 3, 'kmpp');
 
 skmeans(dataUni, 3, [3]);
 
@@ -14,14 +22,43 @@ skmeans(dataMulti, 6);
 
 skmeans(dataMulti, 3, null, 10);
 
-skmeans(dataMulti, 3, [0, 0]);
+skmeans(dataMulti, 3, [[0, 0, 0]]);
 
-skmeans(dataMulti, 3, null, null, (x1, x2) => Math.abs(x1 - x2));
+skmeans(dataMulti, 3, null, null, distance3d);
 
-const res = skmeans(dataMulti, 3, null, 10);
+const res = skmeans(dataUni, 3, null, 10);
 res.test(6);
-(res.centroids as number[]).forEach(i => () => { i + 1; });
+res.centroids.forEach(i => () => {
+    i + 1;
+});
 
 const res2 = skmeans(dataMulti, 3, null, 10);
-res2.test(6, (x1, x2) => Math.abs(x1 - x2));
-(res.centroids as number[][]).forEach(i => () => { i[0] + i[1]; });
+res2.test(6, distance3d);
+res2.centroids.forEach(i => () => {
+    i[0] + i[1];
+});
+
+// we should NOT be able to use arrays-centroid in mono-dimensions
+{
+    // @ts-expect-error
+    skmeans(dataUni, 3, [[3]]);
+    // $ExpectType number[]
+    skmeans(dataUni, 3).centroids;
+}
+
+// we should NOT be able to use arrays-based distance function in mono-dimensions
+// @ts-expect-error
+skmeans(dataUni, 3, null, null, distance3d);
+
+// we should be NOT able to use scalar-centroid in multi-dimensions
+{
+    // @ts-expect-error
+    skmeans(dataMulti, 3, [3]);
+
+    // $ExpectType number[][]
+    skmeans(dataMulti, 3).centroids;
+}
+
+// we should NOT be able to use scalar-based distance function in mono-dimensions
+// @ts-expect-error
+skmeans(dataMulti, 3, null, null, distance1d);


### PR DESCRIPTION
## tl-dr of the pull request

[skmeans](https://www.npmjs.com/package/skmeans) is a package to do [k-mean clustering](https://en.wikipedia.org/wiki/K-means_clustering). 

It operates on a data set. This data set is either an array of 1-dimension (`number[]`), or an array of vectors ( `number[][]`)

This MR:
- Differentiates data set (mono and multi dimensions)
- Fixes the typing of the `test` distance on multi-dimensional data
- Fixes the typing on the `distance` method that was wrong on multi-dimensional data


## Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

## Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/solzimer/skmeans/blob/0.11.1/main.js


## Improvement I failed to achieve
Typescript can differentiate `number[][]` and `[number,number,number][]`. In theory, we could make the number of dimensions known to this lib typing, to avoid doing mistakes.

However this is not convenient at all: it is difficult to specify better types on such expressions:
```typescript
const data = [
 [ 1, 1, 1]
]
```
I am open to ideas about safety vs convenience ..


