### PR TITLE
[ltijs] Also export other types in `Provider.ts`

### DIFF
--- a/types/ltijs/index.d.ts
+++ b/types/ltijs/index.d.ts
@@ -18,6 +18,7 @@ declare module 'express' {
 }
 
 export { default as Provider } from './lib/Provider/Provider';
+export * from './lib/Provider/Provider';
 export * from './lib/Provider/Services/DeepLinking';
 export * from './lib/Provider/Services/GradeService';
 export * from './lib/Provider/Services/NamesAndRoles';

--- a/types/ltijs/ltijs-tests.ts
+++ b/types/ltijs/ltijs-tests.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { Provider, IdToken } from 'ltijs';
+import { Provider, IdToken, DeploymentOptions } from 'ltijs';
 
 const ltiMinimal = Provider.setup('EXAMPLEKEY', {
     url: 'mongodb://localhost/database',
@@ -86,8 +86,9 @@ ltiAdvanced.onDeepLinking((connection, request, response) => {
     ltiAdvanced.redirect(response, '/deeplink');
 });
 
+const deploymentOptions: DeploymentOptions = { serverless: true };
 // $ExpectType Promise<true | undefined>
-ltiMinimal.deploy({ serverless: true });
+ltiMinimal.deploy(deploymentOptions);
 
 // $ExpectType Promise<true | undefined>
 ltiAdvanced.deploy({ port: 4040, silent: true });


### PR DESCRIPTION
The previous change accidentally un-exported some types, but the unit tests didn't pick this up.  This change re-exports those, and has the units tests check one of the types (`DeploymentOptions`) to ensure it doesn't happen again with any future updates.

Sorry @paulschwoerer for not testing the previous change more thoroughly.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64145
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
