### PR TITLE
[@types/react] update PropsWithoutRef to use Omit

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -782,7 +782,7 @@ declare namespace React {
 
     /** Ensures that the props do not include ref at all */
     type PropsWithoutRef<P> =
-        // Pick would not be sufficient for this. We'd like to avoid unnecessary mapping and need a distributive conditional to support unions.
+        // Omit would not be sufficient for this. We'd like to avoid unnecessary mapping and need a distributive conditional to support unions.
         // see: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
         // https://github.com/Microsoft/TypeScript/issues/28339
         P extends any ? ('ref' extends keyof P ? Omit<P, 'ref'> : P) : P;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -785,7 +785,7 @@ declare namespace React {
         // Pick would not be sufficient for this. We'd like to avoid unnecessary mapping and need a distributive conditional to support unions.
         // see: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
         // https://github.com/Microsoft/TypeScript/issues/28339
-        P extends any ? ('ref' extends keyof P ? Pick<P, Exclude<keyof P, 'ref'>> : P) : P;
+        P extends any ? ('ref' extends keyof P ? Omit<P, 'ref'> : P) : P;
     /** Ensures that the props do not include string ref, which cannot be forwarded */
     type PropsWithRef<P> =
         // Just "P extends { ref?: infer R }" looks sufficient, but R will infer as {} if P is {}.


### PR DESCRIPTION
This improves over the current Pick-Exclude making the resulting type less restrictive.  See  https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64163

No new tests needed as this should be equivalent behavior.

I have tested this by manually changing react types in the expo-router. And the subsequent build emits a much cleaner type.

And I have also tested that an Omit used in my own project allows for the behavior I'm expecting.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64163
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.