### PR TITLE
More accurate types for pg-copy-streams

### DIFF
--- a/types/pg-copy-streams/index.d.ts
+++ b/types/pg-copy-streams/index.d.ts
@@ -7,15 +7,19 @@
 /// <reference types="node" />
 
 import { Submittable, Connection } from "pg";
-import { Transform, TransformOptions } from "stream";
+import { Readable, ReadableOptions, Writable, WritableOptions } from "stream";
 
-export function from(txt: string, options?: TransformOptions): CopyStreamQuery;
-export function to(txt: string, options?: TransformOptions): CopyToStreamQuery;
+export function from(txt: string, options?: WritableOptions): CopyStreamQuery;
+export function to(txt: string, options?: ReadableOptions): CopyToStreamQuery;
 
-export class CopyStreamQuery extends Transform implements Submittable {
+export class CopyStreamQuery extends Writable implements Submittable {
+    text: string;
+    rowCount: number;
     submit(connection: Connection): void;
 }
 
-export class CopyToStreamQuery extends Transform implements Submittable {
+export class CopyToStreamQuery extends Readable implements Submittable {
+    text: string;
+    rowCount: number;
     submit(connection: Connection): void;
 }

--- a/types/pg-copy-streams/pg-copy-streams-tests.ts
+++ b/types/pg-copy-streams/pg-copy-streams-tests.ts
@@ -13,7 +13,9 @@ copyStream.write('', err => {
 
   copyStream.end();
 });
+const insertedRows = copyStream.rowCount;
 
-const readStream = client.query(to('copy data to stdout;'));
+const readStream = client.query(to('copy data to stdout csv header;'));
 
 readStream.pipe(process.stdout);
+const selectedRows = readStream.rowCount - 1;


### PR DESCRIPTION
See code of the [`CopyStreamQuery`](https://github.com/brianc/node-pg-copy-streams/blob/b185b88dd2e87ef99443a86a02067037c7df46db/copy-from.js#L10-L14) and [`CopyToStreamQuery`](https://github.com/brianc/node-pg-copy-streams/blob/543cd9a94a1a214c05c7b728eccbfdcade2642b6/copy-to.js#L17-L21) classes.

They do not inherit from `stream.Transform` since [v4.0](https://github.com/brianc/node-pg-copy-streams#version-400---published-2020-05-11) and [v5.0](https://github.com/brianc/node-pg-copy-streams#version-500---published-2020-05-14) respectively, and according to the documentation were never meant to be.
Also both do (and always did) expose a `.rowCount` field (see also https://github.com/brianc/node-pg-copy-streams/pull/37) and a `.text` field.

I don't think this warrants a major version?