### PR TITLE
[wordpress__data] Add storeNameOrDescriptor to Subscriber type definition

### DIFF
--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -38,7 +38,7 @@ export type DispatcherMap = Record<string, <T = void, DoEnsurePromise extends bo
  * unsubscribe();
  *
  */
-export type Subscriber = (callback: () => void) => () => void;
+export type Subscriber = (callback: () => void, storeNameOrDescriptor?: string | StoreDescriptor) => () => void;
 
 export function dispatch(storeNameOrDescriptor: string|StoreDescriptor): DispatcherMap;
 export function select(storeNameOrDescriptor: string|StoreDescriptor): SelectorMap;

--- a/types/wordpress__data/index.d.ts
+++ b/types/wordpress__data/index.d.ts
@@ -19,7 +19,12 @@ export { Action, combineReducers };
 export type ResolveSelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => Promise<T>>;
 export type SelectorMap = Record<string, <T = unknown>(...args: readonly any[]) => T>;
 type EnsurePromise<T> = T extends Promise<any> ? T : Promise<T>;
-export type DispatcherMap = Record<string, <T = void, DoEnsurePromise extends boolean = true>(...args: readonly any[]) => DoEnsurePromise extends true ? EnsurePromise<T> : T>;
+export type DispatcherMap = Record<
+    string,
+    <T = void, DoEnsurePromise extends boolean = true>(
+        ...args: readonly any[]
+    ) => DoEnsurePromise extends true ? EnsurePromise<T> : T
+>;
 
 /**
  * Subscribe to any changes to the store
@@ -40,9 +45,9 @@ export type DispatcherMap = Record<string, <T = void, DoEnsurePromise extends bo
  */
 export type Subscriber = (callback: () => void, storeNameOrDescriptor?: string | StoreDescriptor) => () => void;
 
-export function dispatch(storeNameOrDescriptor: string|StoreDescriptor): DispatcherMap;
-export function select(storeNameOrDescriptor: string|StoreDescriptor): SelectorMap;
-export function resolveSelect(storeNameOrDescriptor: string|StoreDescriptor): ResolveSelectorMap;
+export function dispatch(storeNameOrDescriptor: string | StoreDescriptor): DispatcherMap;
+export function select(storeNameOrDescriptor: string | StoreDescriptor): SelectorMap;
+export function resolveSelect(storeNameOrDescriptor: string | StoreDescriptor): ResolveSelectorMap;
 
 export const subscribe: Subscriber;
 
@@ -57,18 +62,26 @@ export interface GenericStoreConfig {
 
 export interface StoreConfig<S> {
     reducer: Reducer<S>;
-    actions?: {
-        [k: string]: (...args: readonly any[]) => Action | Generator<any>;
-    } | undefined;
-    selectors?: {
-        [k: string]: (state: S, ...args: readonly any[]) => any;
-    } | undefined;
-    resolvers?: {
-        [k: string]: (...args: readonly any[]) => any;
-    } | undefined;
-    controls?: {
-        [k: string]: (action: Action) => any;
-    } | undefined;
+    actions?:
+        | {
+              [k: string]: (...args: readonly any[]) => Action | Generator<any>;
+          }
+        | undefined;
+    selectors?:
+        | {
+              [k: string]: (state: S, ...args: readonly any[]) => any;
+          }
+        | undefined;
+    resolvers?:
+        | {
+              [k: string]: (...args: readonly any[]) => any;
+          }
+        | undefined;
+    controls?:
+        | {
+              [k: string]: (action: Action) => any;
+          }
+        | undefined;
     initialState?: S | undefined;
 
     /**
@@ -159,7 +172,7 @@ export type Plugin<T extends Record<string, any>> = (registry: DataRegistry, opt
 
 export const plugins: {
     persistence: Plugin<{
-        storage?: Pick<Storage, 'getItem' | 'setItem'> & Partial<Storage> | undefined;
+        storage?: (Pick<Storage, 'getItem' | 'setItem'> & Partial<Storage>) | undefined;
         storageKey?: string | undefined;
     }>;
 };


### PR DESCRIPTION
This PR adds the `storeNameOrDescriptor` parameter to the `Subscriber` type definition ([02b10e4](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64177/commits/02b10e413b57c1500f1d4965eab58c3541d95c81)). 

Also, I fixed how the code is formatted in the commit b8cf6b5743a1dc31264dc97bcc5486312102ac59. I ran the command:
```
npm run prettier -- --write types/wordpress__data/index.d.ts
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/09052a2bf9b48928e92ccf1bd6b69ebf5506421e/packages/data/src/index.js/#L160-L184
