### PR TITLE
Fix scopes prop in google.accounts TokenResponse

### DIFF
--- a/types/google.accounts/google.accounts-tests.ts
+++ b/types/google.accounts/google.accounts-tests.ts
@@ -23,7 +23,7 @@ google.accounts.oauth2.initCodeClient({
         error.stack;
         // $ExpectType "unknown" | "popup_closed" | "popup_failed_to_open"
         error.type;
-    }
+    },
 });
 
 // $ExpectType TokenClient
@@ -41,7 +41,7 @@ google.accounts.oauth2.initTokenClient({
         // $ExpectType string
         response.token_type;
         // $ExpectType string
-        response.scopes;
+        response.scope;
         // $ExpectType string
         response.state;
         // $ExpectType string
@@ -58,7 +58,7 @@ google.accounts.oauth2.initTokenClient({
         error.stack;
         // $ExpectType "unknown" | "popup_closed" | "popup_failed_to_open"
         error.type;
-    }
+    },
 });
 
 // $ExpectType boolean
@@ -69,7 +69,7 @@ google.accounts.oauth2.hasGrantedAllScopes(
         hd: '',
         prompt: '',
         token_type: '',
-        scopes: '',
+        scope: '',
         state: '',
         error: '',
         error_description: '',
@@ -87,7 +87,7 @@ google.accounts.oauth2.hasGrantedAnyScope(
         hd: '',
         prompt: '',
         token_type: '',
-        scopes: '',
+        scope: '',
         state: '',
         error: '',
         error_description: '',

--- a/types/google.accounts/index.d.ts
+++ b/types/google.accounts/index.d.ts
@@ -123,7 +123,7 @@ declare namespace google.accounts {
             /**
              * A space-delimited list of scopes that are approved by the user.
              */
-            scopes: string;
+            scope: string;
 
             /**
              * The string value that your application uses to maintain state


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

Hard to find good docs, but see https://googleapis.dev/dotnet/Google.Apis.Auth/latest/api/Google.Apis.Auth.OAuth2.Responses.TokenResponse.html#Google_Apis_Auth_OAuth2_Responses_TokenResponse_Scope. Also confirmed in real-world usage.