### PR TITLE
docs(README.md): correct/clarify how to reference scoped packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,8 +614,10 @@ When `dts-gen` is used to scaffold a scoped package, the `paths` property has to
 
 ```json
 {
-  "paths": {
-    "@foo/*": ["foo__*"]
+  "compilerOptions": {
+    "paths": {
+      "@foo/*": ["foo__*"]
+    }
   }
 }
 ```


### PR DESCRIPTION
Original documentation suggested `paths` at the root of tsconfig, which led to confusion like #64173. This clarifies/corrects the documentation.

fix #64185

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [#64173](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/64173)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.