### PR TITLE
Update http-aws-es to depend on aws-sdk2-types

### DIFF
--- a/types/http-aws-es/http-aws-es-tests.ts
+++ b/types/http-aws-es/http-aws-es-tests.ts
@@ -1,4 +1,4 @@
-import * as AWS from "aws-sdk";
+import * as AWS from "aws-sdk2-types";
 import { Client } from "elasticsearch";
 import HttpAmazonESConnector = require("http-aws-es");
 

--- a/types/http-aws-es/index.d.ts
+++ b/types/http-aws-es/index.d.ts
@@ -7,7 +7,7 @@
 /// <reference types="node" />
 
 import * as e from "elasticsearch";
-import * as AWS from "aws-sdk";
+import * as AWS from "aws-sdk2-types";
 
 declare module "elasticsearch" {
     interface ConfigOptions {

--- a/types/http-aws-es/package.json
+++ b/types/http-aws-es/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "aws-sdk": "^2.814.0"
-    }
-}


### PR DESCRIPTION
I missed another dependent of aws-sdk@2 which should use the DT clone of the types.