### PR TITLE
Make dynamodb-lock-client config types more accurate

### DIFF
--- a/types/dynamodb-lock-client/dynamodb-lock-client-tests.ts
+++ b/types/dynamodb-lock-client/dynamodb-lock-client-tests.ts
@@ -1,9 +1,10 @@
-import * as AWS from "aws-sdk";
 import * as DynamoDBLockClient from "dynamodb-lock-client";
 
-const dynamodb = new AWS.DynamoDB.DocumentClient({
-    region: "us-east-1",
-});
+const dynamodb = {
+    get: () => {},
+    put: () => {},
+    delete: () => {},
+};
 
 const failClosedClient = new DynamoDBLockClient.FailClosed({
     dynamodb,

--- a/types/dynamodb-lock-client/index.d.ts
+++ b/types/dynamodb-lock-client/index.d.ts
@@ -5,7 +5,6 @@
 
 /// <reference types="node" />
 
-import { DynamoDB } from "aws-sdk";
 import { EventEmitter } from "events";
 
 export interface Lock extends EventEmitter {
@@ -14,7 +13,11 @@ export interface Lock extends EventEmitter {
 }
 
 interface GenericConfig {
-    dynamodb: DynamoDB.DocumentClient;
+    dynamodb: {
+        delete: (...args: any[]) => any;
+        get: (...args: any[]) => any;
+        put: (...args: any[]) => any;
+    };
     lockTable: string;
     partitionKey: string;
     sortKey?: string | undefined;

--- a/types/dynamodb-lock-client/package.json
+++ b/types/dynamodb-lock-client/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "aws-sdk": "^2.865.0"
-    }
-}


### PR DESCRIPTION
The config type's dynamodb property doesn't *actually* have to be an AWS DynamoDB object. It accepts anything with delete/get/put methods.

This is important for DT because aws-sdk@2 uses so much memory that it overwhelms its testing infrastructure, so it's helpful to remove dependencies on aws-sdk@2.