### PR TITLE
Remove aws-sdk dependency from @mapbox/aws-sdk-jest

### DIFF
--- a/types/mapbox__aws-sdk-jest/package.json
+++ b/types/mapbox__aws-sdk-jest/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "aws-sdk": "^2.814.0"
-    }
-}


### PR DESCRIPTION
It's not needed for the types to work, and removing the aws-sdk@2 dependency helps DT infrastructure, which often runs out of memory on packages that depend on aws-sdk@2.

The only reason to include the dependency is to make sure that aws-sdk changes don't break it, but (1) the changes are purely additive (2) aws-sdk@2 is deprecated and unlikely to change much in the future.

