### PR TITLE
Added getMyQueue endpoint for spotify-web-api-node

### DIFF
--- a/types/spotify-web-api-node/index.d.ts
+++ b/types/spotify-web-api-node/index.d.ts
@@ -593,6 +593,15 @@ declare class SpotifyWebApi {
     addToQueue(uri: string, options?: DeviceOptions): Promise<Response<SpotifyApi.AddToQueueResponse>>;
 
     /**
+     * Get the list of objects that make up the user's queue.
+     * @param callback Optional callback method to be called instead of the promise.
+     * @returns A promise that if successful, resolves into an object containing the current playing song
+     *          and the queue, otherwise an error. Not returned if a callback is given.
+     */
+    getMyQueue(callback: Callback<SpotifyApi.UsersQueueResponse>): void;
+    getMyQueue(): Promise<Response<SpotifyApi.UsersQueueResponse>>;
+
+    /**
      * Get the Current User's Connect Devices
      * @param callback Optional callback method to be called instead of the promise.
      * @returns A promise that if successful, resolves into a paging object of tracks,

--- a/types/spotify-web-api-node/spotify-web-api-node-tests.ts
+++ b/types/spotify-web-api-node/spotify-web-api-node-tests.ts
@@ -526,6 +526,15 @@ spotifyApi.getAvailableGenreSeeds()
 // Add an Item to the User's Playback Queue
 // TBD
 
+// Get a User's Queue
+spotifyApi.getMyQueue()
+  .then((data) => {
+    const queue = data.body.queue;
+    console.log(queue);
+  }, (err) => {
+    console.log('Something went wrong!', err);
+  });
+
 // Get a User's Available Devices
 spotifyApi.getMyDevices()
   .then((data) => {


### PR DESCRIPTION
There is an pending pull request at the spotify-web-api-node which adds the new getMyQueue endpoint. The spotify-web-api library received queue response type declarations which can now be used in the node variant.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/thelinmichael/spotify-web-api-node/pull/465

