### PR TITLE
passport-oauth2: enable provider specific profile and results

### DIFF
--- a/types/passport-oauth2/index.d.ts
+++ b/types/passport-oauth2/index.d.ts
@@ -5,6 +5,7 @@
 //                 Eduardo AC <https://github.com/EduardoAC>
 //                 Ivan Fernandes <https://github.com/ivan94>
 //                 Daphne Smit <https://github.com/daphnesmit>
+//                 Joel Klint <https://github.com/JoelKlint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -54,12 +55,31 @@ declare namespace OAuth2Strategy {
 
     type VerifyCallback = (err?: Error | null, user?: Express.User, info?: object) => void;
 
-    type VerifyFunction =
-        ((accessToken: string, refreshToken: string, profile: any, verified: VerifyCallback) => void) |
-        ((accessToken: string, refreshToken: string, results: any, profile: any, verified: VerifyCallback) => void);
-    type VerifyFunctionWithRequest =
-        ((req: Request, accessToken: string, refreshToken: string, profile: any, verified: VerifyCallback) => void) |
-        ((req: Request, accessToken: string, refreshToken: string, results: any, profile: any, verified: VerifyCallback) => void);
+    type VerifyFunction<TProfile = any, TResults = any> =
+        | ((accessToken: string, refreshToken: string, profile: TProfile, verified: VerifyCallback) => void)
+        | ((
+              accessToken: string,
+              refreshToken: string,
+              results: TResults,
+              profile: TProfile,
+              verified: VerifyCallback,
+          ) => void);
+    type VerifyFunctionWithRequest<TProfile = any, TResults = any> =
+        | ((
+              req: Request,
+              accessToken: string,
+              refreshToken: string,
+              profile: TProfile,
+              verified: VerifyCallback,
+          ) => void)
+        | ((
+              req: Request,
+              accessToken: string,
+              refreshToken: string,
+              results: TResults,
+              profile: TProfile,
+              verified: VerifyCallback,
+          ) => void);
 
     interface _StrategyOptionsBase {
         authorizationURL: string;

--- a/types/passport-oauth2/passport-oauth2-tests.ts
+++ b/types/passport-oauth2/passport-oauth2-tests.ts
@@ -125,3 +125,24 @@ const strategyOptions3: StrategyOptions = {
 };
 
 const strategy5: Strategy = new Strategy(strategyOptions3, verifyFunction2);
+
+interface ProviderSpecificProfile {
+    someProviderProfileField: string;
+}
+interface ProviderSpecificResults {
+    someProviderResultField: string;
+}
+const providerSpecificVerifyFunction: OAuth2Strategy.VerifyFunction<
+    ProviderSpecificProfile,
+    ProviderSpecificResults
+> = (accessToken, refreshToken, results, profile, verified) => {
+    results.someProviderResultField;
+    profile.someProviderProfileField;
+};
+const providerSpecificVerifyFunctionWithRequest: OAuth2Strategy.VerifyFunctionWithRequest<
+    ProviderSpecificProfile,
+    ProviderSpecificResults
+> = (req, accessToken, refreshToken, results, profile, verified) => {
+    results.someProviderResultField;
+    profile.someProviderProfileField;
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Example of a provider-specific profile: https://github.com/seanfisher/passport-microsoft/blob/master/lib/strategy.js#L118
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
