### PR TITLE
Fix TS4058 on EventEmitter classes

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -77,11 +77,11 @@ declare module 'events' {
         captureRejections?: boolean | undefined;
     }
     // Any EventTarget with a Node-style `once` function
-    interface _NodeEventTarget {
+    export interface _NodeEventTarget {
         once(eventName: string | symbol, listener: (...args: any[]) => void): this;
     }
     // Any EventTarget with a DOM-style `addEventListener`
-    interface _DOMEventTarget {
+    export interface _DOMEventTarget {
         addEventListener(
             eventName: string,
             listener: (...args: any[]) => void,
@@ -90,7 +90,7 @@ declare module 'events' {
             }
         ): any;
     }
-    interface StaticEventEmitterOptions {
+    export interface StaticEventEmitterOptions {
         signal?: AbortSignal | undefined;
     }
     interface EventEmitter extends NodeJS.EventEmitter {}

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -670,7 +670,7 @@ declare module 'events' {
             }
         }
     }
-    export = EventEmitter;
+    export default EventEmitter;
 }
 declare module 'node:events' {
     import events = require('events');


### PR DESCRIPTION
Creating a function that returns an anonymous class extends a class itself extending `EventEmitter` causes several TS4058 errors unless events.d.ts is appropriately modified to export the interfaces `_NodeEventTarget`, `_DOMEventTarget`, and `StaticEventEmitterOptions`.
