### PR TITLE
add missing connect method in superagent request object

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -145,6 +145,7 @@ declare namespace request {
         ca(cert: string | string[] | Buffer | Buffer[]): this;
         cert(cert: string | string[] | Buffer | Buffer[]): this;
         clearTimeout(): this;
+        connect(override: string | { [hostname: string]: string }): this;
         disableTLSCerts(): this;
         end(callback?: CallbackHandler): void;
         field(name: string, val: MultipartValue): this;

--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -145,7 +145,7 @@ declare namespace request {
         ca(cert: string | string[] | Buffer | Buffer[]): this;
         cert(cert: string | string[] | Buffer | Buffer[]): this;
         clearTimeout(): this;
-        connect(override: string | { [hostname: string]: string }): this;
+        connect(override: string | { [hostname: string]: false | string | { host: string, port: number} }): this;
         disableTLSCerts(): this;
         end(callback?: CallbackHandler): void;
         field(name: string, val: MultipartValue): this;

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -272,8 +272,9 @@ request
     })
     .end(callback);
 
-//DNS override (tests based on documentation examples)
+// DNS override (tests based on documentation examples)
 request.get("http://example.com").connect("127.0.0.1").end(callback);
+
 request.get("http://redir.example.com:555")
       .connect({
         "redir.example.com": "127.0.0.1", // redir.example.com:555 will use 127.0.0.1:555

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -272,6 +272,16 @@ request
     })
     .end(callback);
 
+//DNS override (tests based on documentation examples)
+request.get("http://example.com").connect("127.0.0.1").end(callback);
+request.get("http://redir.example.com:555")
+      .connect({
+        "redir.example.com": "127.0.0.1", // redir.example.com:555 will use 127.0.0.1:555
+        "www.example.com": false, // don't override this one; use DNS as normal
+        "mapped.example.com": { host: "127.0.0.1", port: 8080}, // mapped.example.com:* will use 127.0.0.1:8080
+        "*": "proxy.example.com", // all other requests will go to this host
+      }).end(callback);
+
 // Promise
 request
     .get("/search")


### PR DESCRIPTION
superagent allows for overriding DNS. See [Request.prototype.connect](https://github.com/ladjs/superagent/blob/cd094f523f8c02808e00ee65bf3ac1624c9300a8/src/node/index.js#L1308). Documentation [here](https://github.com/ladjs/superagent/blob/master/docs/index.md#forcing-specific-connection-ip-address). This pull requests adds that missing method to the type definitions.
