### PR TITLE
[express-session]: expand some existing types to match implementation

### DIFF
--- a/types/connect-sqlite3/index.d.ts
+++ b/types/connect-sqlite3/index.d.ts
@@ -56,7 +56,7 @@ declare namespace connect {
      * @deprecated The `expires` option should not be set directly; instead only use the `maxAge` option
      * @see maxAge
      */
-    expires?: Date | undefined;
+    expires?: Date | null | undefined;
 
     /**
      * Specifies the boolean value for the `HttpOnly Set-Cookie` attribute. When truthy, the `HttpOnly` attribute is set, otherwise it is not.
@@ -116,11 +116,11 @@ declare namespace connect {
 
   abstract class Cookie implements CookieOptions {
     /** Returns the original `maxAge` (time-to-live), in milliseconds, of the session cookie. */
-    originalMaxAge: number;
+    originalMaxAge: number | null;
 
     maxAge?: number | undefined;
     signed?: boolean | undefined;
-    expires?: Date | undefined;
+    expires?: Date | null | undefined;
     httpOnly?: boolean | undefined;
     path?: string | undefined;
     domain?: string | undefined;
@@ -151,7 +151,7 @@ declare namespace connect {
     // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38783, https://github.com/expressjs/session/pull/700#issuecomment-540855551
     all?(callback: (err: any, obj?: SessionData[] | { [sid: string]: SessionData; } | null) => void): void;
     /** Returns the amount of sessions in the store. */
-    length?(callback: (err: any, length: number) => void): void;
+    length?(callback: (err: any, length?: number) => void): void;
     /** Delete all sessions from the store. */
     clear?(callback?: (err?: any) => void): void;
     /** "Touches" a given session, resetting the idle timer. */

--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -60,6 +60,17 @@ app.use(
     }),
 );
 
+// When constructed without arguments, `expires` and `originalMaxAge` are null.
+const emptyCookie: SessionData['cookie'] = { expires: null, originalMaxAge: null };
+
+app.use(
+    session({
+        cookie: emptyCookie,
+        secret: 'keyboard cat',
+        unset: 'keep',
+    }),
+);
+
 // Example of adding additional properties to SessionData using declaration merging
 declare module 'express-session' {
     interface SessionData {
@@ -114,6 +125,14 @@ class MyStore extends Store {
         if (callback) callback();
     }
 
+    length = (callback?: (err?: any, length?: number) => void) => {
+        if (this.sessions == null && callback) {
+            callback(new Error('error to show that length is optional'));
+        }
+
+        if (callback) callback(null, Object.keys(this.sessions).length);
+    }
+
     destroy = (sid: string, callback?: (err?: any) => void): void => {
         this.sessions[sid] = undefined;
         this.sessions = JSON.parse(JSON.stringify(this.sessions));
@@ -131,11 +150,11 @@ app.use(
 app.use((req, res, next) => {
     let sess = req.session;
     const store = req.sessionStore;
-    store.get(sess.id, (err, session) => { });
-    store.set(sess.id, { views: 0, cookie: sess.cookie }, (err) => { });
+    store.get(sess.id, (err, session) => {});
+    store.set(sess.id, { views: 0, cookie: sess.cookie }, err => {});
     sess = store.createSession(req, { views: 0, cookie: sess.cookie });
-    store.destroy(sess.id, (err) => { });
+    store.destroy(sess.id, err => {});
     store.generate(req);
-    store.regenerate(req, (err) => { });
+    store.regenerate(req, err => {});
     res.end();
 });

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -246,7 +246,7 @@ declare namespace session {
          * @deprecated The `expires` option should not be set directly; instead only use the `maxAge` option
          * @see maxAge
          */
-        expires?: Date | undefined;
+        expires?: Date | null | undefined;
 
         /**
          * Specifies the boolean value for the `HttpOnly Set-Cookie` attribute. When truthy, the `HttpOnly` attribute is set, otherwise it is not.
@@ -306,11 +306,11 @@ declare namespace session {
 
     class Cookie implements CookieOptions {
         /** Returns the original `maxAge` (time-to-live), in milliseconds, of the session cookie. */
-        originalMaxAge: number;
+        originalMaxAge: number | null;
 
         maxAge?: number | undefined;
         signed?: boolean | undefined;
-        expires?: Date | undefined;
+        expires?: Date | null | undefined;
         httpOnly?: boolean | undefined;
         path?: string | undefined;
         domain?: string | undefined;
@@ -339,10 +339,10 @@ declare namespace session {
 
         /** Returns all sessions in the store */
         // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38783, https://github.com/expressjs/session/pull/700#issuecomment-540855551
-        all?(callback: (err: any, obj?: SessionData[] | { [sid: string]: SessionData; } | null) => void): void;
+        all?(callback: (err: any, obj?: SessionData[] | { [sid: string]: SessionData } | null) => void): void;
 
         /** Returns the amount of sessions in the store. */
-        length?(callback: (err: any, length: number) => void): void;
+        length?(callback: (err: any, length?: number) => void): void;
 
         /** Delete all sessions from the store. */
         clear?(callback?: (err?: any) => void): void;
@@ -360,8 +360,8 @@ declare namespace session {
         set(sid: string, session: SessionData, callback?: (err?: any) => void): void;
         destroy(sid: string, callback?: (err?: any) => void): void;
 
-        all(callback: (err: any, obj?: { [sid: string]: SessionData; } | null) => void): void;
-        length(callback: (err: any, length: number) => void): void;
+        all(callback: (err: any, obj?: { [sid: string]: SessionData } | null) => void): void;
+        length(callback: (err: any, length?: number) => void): void;
         clear(callback?: (err?: any) => void): void;
         touch(sid: string, session: SessionData, callback?: () => void): void;
     }


### PR DESCRIPTION
When a cookie is constructed without arguments, the `expires` and `originalMaxAge` fields are null. Existing tests within the `express-session` repo reflect this, along with other manual tests.

Additionally, the `Store` class's `length` method will conditionally call the given callback without the second `length` parameter when there is an error. This parameter has been made optional to reflect that.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/expressjs/session/blob/master/session/cookie.js#L27 (sets `maxAge` to `null`) 
  - https://github.com/expressjs/session/blob/master/session/cookie.js#L43 (sets `originalMaxAge` to `null` through `maxAge`)
  - https://github.com/expressjs/session/blob/master/session/cookie.js#L92:L94 (sets `expires` to `null` through `maxAge`)
  - https://github.com/expressjs/session/blob/master/session/memory.js#L133 (calls `length` callback with only `err`)
  - For future reference, SHA of `master` branch at this time is `1e3fc39a3fc3810772dfa00a7535a710042c42aa`.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - Version remains current.

