### PR TITLE
[bidirectional-map] Mark undefined as a possible return type

### DIFF
--- a/types/bidirectional-map/bidirectional-map-tests.ts
+++ b/types/bidirectional-map/bidirectional-map-tests.ts
@@ -6,10 +6,12 @@ const bidirectionalMap = new BiMap({
 bidirectionalMap.size; // $ExpectType number
 bidirectionalMap.set("two", 2);
 bidirectionalMap.set("three", 3);
-bidirectionalMap.get("one"); // $ExpectType number
+bidirectionalMap.get("one"); // $ExpectType number | undefined
+bidirectionalMap.get("not-a-number"); // $ExpectType number | undefined
 // @ts-expect-error
 bidirectionalMap.get(true);
-bidirectionalMap.getKey(1); // $ExpectType string
+bidirectionalMap.getKey(1); // $ExpectType string | undefined
+bidirectionalMap.getKey(2); // $ExpectType string | undefined
 // @ts-expect-error
 bidirectionalMap.getKey("one");
 bidirectionalMap.delete("two");

--- a/types/bidirectional-map/index.d.ts
+++ b/types/bidirectional-map/index.d.ts
@@ -9,8 +9,8 @@ export default class BiMap<TValue> {
     size: number;
 
     set(key: string, value: TValue): void;
-    get(key: string): TValue;
-    getKey(value: TValue): string;
+    get(key: string): TValue | undefined;
+    getKey(value: TValue): string | undefined;
     clear(): void;
     delete(key: string): void;
     deleteValue(value: TValue): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/educastellano/bidirectional-map/blob/63b9cd42c848b74aa8b198c91dffe3ae95cd95ee/index.js#L30

The problem is that this implementation of a bidirectional map calls `.get` on an instance of the `Map` class, which can return undefined. Consider the following code:
```
const aMap = new BidirectionalMap();
aMap.set(3, 3);
const res = aMap.get(2);
console.log(res);
```

In this example, `res` is undefined because `BidirectionalMap` returns the result of using `.get` on a map.

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.