### PR TITLE
[ltijs] Allow database URL to be optional when plugin is specified

### DIFF
--- a/types/ltijs/lib/Utils/Database.d.ts
+++ b/types/ltijs/lib/Utils/Database.d.ts
@@ -1,4 +1,4 @@
-export interface DatabaseOptions {
+export interface DatabaseConnectionOptions {
     url: string;
     connection?: {
         user: string;
@@ -7,8 +7,16 @@ export interface DatabaseOptions {
         keepAlive?: boolean | undefined;
         keepAliveInitialDelay?: number | undefined;
     } | undefined;
-    plugin?: object | undefined;
+    plugin?: never;
 }
+
+export interface DatabasePluginOptions {
+    url?: never;
+    connection?: never;
+    plugin: object;
+}
+
+export type DatabaseOptions = DatabaseConnectionOptions | DatabasePluginOptions;
 
 export interface Database {
     setup(): Promise<true>;

--- a/types/ltijs/ltijs-tests.ts
+++ b/types/ltijs/ltijs-tests.ts
@@ -5,6 +5,17 @@ const ltiMinimal = Provider.setup('EXAMPLEKEY', {
     url: 'mongodb://localhost/database',
 });
 
+const ltiPlugin = Provider.setup('EXAMPLEKEY', {
+    plugin: {},
+});
+
+// @ts-expect-error
+const ltiInvalid = Provider.setup('EXAMPLEKEY', {
+    // Can't specify both DB and plugin.
+    url: 'mongodb://localhost/database',
+    plugin: {},
+});
+
 const idToken: IdToken = {
     iss: '',
     issuerCode: '',


### PR DESCRIPTION
Here's another small change that makes the database URL optional but only when you're passing in a plugin object instead.  This is because when passing in a plugin, the URL is unused but otherwise it is mandatory.  Unit tests updated.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Cvmcosta/ltijs-sequelize#usage
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
