### PR TITLE
[chrome] Promisify remaining `chrome.identity` APIs

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4790,11 +4790,13 @@ declare namespace chrome.identity {
      *  * Removes all OAuth2 access tokens from the token cache
      *  * Removes user's account preferences
      *  * De-authorizes the user from all auth flows
+     * If `callback` is not provided, the function returns a Promise when the state has been cleared.
      * @since Chrome 87.
      * @param callback Called when the state has been cleared.
      * The parameter should be a function that looks like this:
      * () => {...};
      */
+    export function clearAllCachedAuthTokens(): Promise<void>;
     export function clearAllCachedAuthTokens(callback: () => void): void;
 
     /**
@@ -4802,18 +4804,21 @@ declare namespace chrome.identity {
      * getAccounts is only supported on dev channel.
      * Dev channel only.
      */
+    export function getAccounts(): Promise<AccountInfo[]>;
     export function getAccounts(callback: (accounts: AccountInfo[]) => void): void;
 
     /**
      * Gets an OAuth2 access token using the client ID and scopes specified in the oauth2 section of manifest.json.
      * The Identity API caches access tokens in memory, so it's ok to call getAuthToken non-interactively any time a token is required. The token cache automatically handles expiration.
      * For a good user experience it is important interactive token requests are initiated by UI in your app explaining what the authorization is for. Failing to do this will cause your users to get authorization requests, or Chrome sign in screens if they are not signed in, with with no context. In particular, do not use getAuthToken interactively when your app is first launched.
+     * If `callback` is not provided, the function returns a Promise that resolves with the token.
      * @param details Token options.
      * @param callback Called with an OAuth2 access token as specified by the manifest, or undefined if there was an error.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function(string token) {...};
      */
-    export function getAuthToken(details: TokenDetails, callback?: (token: string) => void): void;
+    export function getAuthToken(details: TokenDetails): Promise<string>;
+    export function getAuthToken(details: TokenDetails, callback: (token: string) => void): void;
 
     /**
      * Retrieves email address and obfuscated gaia id of the user signed into a profile.
@@ -4831,12 +4836,14 @@ declare namespace chrome.identity {
     /**
      * Removes an OAuth2 access token from the Identity API's token cache.
      * If an access token is discovered to be invalid, it should be passed to removeCachedAuthToken to remove it from the cache. The app may then retrieve a fresh token with getAuthToken.
+     * If `callback` is not provided, the function returns a Promise when the state has been removed from the cache.
      * @param details Token information.
      * @param callback Called when the token has been removed from the cache.
      * If you specify the callback parameter, it should be a function that looks like this:
      * function() {...};
      */
-    export function removeCachedAuthToken(details: TokenInformation, callback?: () => void): void;
+    export function removeCachedAuthToken(details: TokenInformation): Promise<void>;
+    export function removeCachedAuthToken(details: TokenInformation, callback: () => void): void;
 
     /**
      * Starts an auth flow at the specified URL.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -14,6 +14,7 @@
 //                 Idan Zeierman <https://github.com/idan315>
 //                 Nicolas Rodriguez <https://github.com/nicolas377>
 //                 Ido Salomon <https://github.com/idosal>
+//                 Federico Brigante <https://github.com/fregante>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4784,6 +4784,19 @@ declare namespace chrome.identity {
 
     export interface SignInChangeEvent extends chrome.events.Event<(account: AccountInfo, signedIn: boolean) => void> { }
 
+    export interface GetAuthTokenResult {
+        /**
+         * Optional.
+         * A list of OAuth2 scopes granted to the extension.
+         */
+        grantedScopes?: string[]
+        /**
+         * Optional.
+         * The specific token associated with the request.
+         */
+        token?: string
+    }
+
     /**
      * Resets the state of the Identity API:
      *
@@ -4817,8 +4830,8 @@ declare namespace chrome.identity {
      * If you specify the callback parameter, it should be a function that looks like this:
      * function(string token) {...};
      */
-    export function getAuthToken(details: TokenDetails): Promise<string>;
-    export function getAuthToken(details: TokenDetails, callback: (token: string) => void): void;
+    export function getAuthToken(details: TokenDetails): Promise<GetAuthTokenResult>;
+    export function getAuthToken(details: TokenDetails, callback: (token?: string, grantedScopes?: string[]) => void): void;
 
     /**
      * Retrieves email address and obfuscated gaia id of the user signed into a profile.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1663,12 +1663,22 @@ async function testHistoryForPromise() {
 async function testIdentity() {
     // $ExpectType void
     chrome.identity.launchWebAuthFlow({ url: 'https://example.com ' }, () => { });
+
+    chrome.identity.clearAllCachedAuthTokens(() => {})
+    getAccounts((accounts: chrome.identity.AccountInfo[]) => { })
+    getAuthToken({}, (token: string) => { })
+    removeCachedAuthToken({token: '1234'}, () => { })
 }
 
 // https://developer.chrome.com/docs/extensions/reference/identity/
 async function testIdentityForPromise() {
     // $ExpectType string | undefined
     await chrome.identity.launchWebAuthFlow({ url: 'https://example.com ' });
+
+    await chrome.identity.clearAllCachedAuthTokens()
+    const accounts: chrome.identity.AccountInfo[] = await getAccounts()
+    const token = await getAuthToken({})
+    await removeCachedAuthToken({token: '1234'})
 }
 
 // https://developer.chrome.com/docs/extensions/reference/topSites/

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1666,7 +1666,7 @@ async function testIdentity() {
 
     chrome.identity.clearAllCachedAuthTokens(() => {})
     chrome.identity.getAccounts((accounts: chrome.identity.AccountInfo[]) => { })
-    chrome.identity.getAuthToken({}, (token: string) => { })
+    chrome.identity.getAuthToken({}, (token?: string, grantedScopes?: string[]) => { })
     chrome.identity.removeCachedAuthToken({token: '1234'}, () => { })
 }
 

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1665,9 +1665,9 @@ async function testIdentity() {
     chrome.identity.launchWebAuthFlow({ url: 'https://example.com ' }, () => { });
 
     chrome.identity.clearAllCachedAuthTokens(() => {})
-    getAccounts((accounts: chrome.identity.AccountInfo[]) => { })
-    getAuthToken({}, (token: string) => { })
-    removeCachedAuthToken({token: '1234'}, () => { })
+    chrome.identity.getAccounts((accounts: chrome.identity.AccountInfo[]) => { })
+    chrome.identity.getAuthToken({}, (token: string) => { })
+    chrome.identity.removeCachedAuthToken({token: '1234'}, () => { })
 }
 
 // https://developer.chrome.com/docs/extensions/reference/identity/
@@ -1676,9 +1676,9 @@ async function testIdentityForPromise() {
     await chrome.identity.launchWebAuthFlow({ url: 'https://example.com ' });
 
     await chrome.identity.clearAllCachedAuthTokens()
-    const accounts: chrome.identity.AccountInfo[] = await getAccounts()
-    const token = await getAuthToken({})
-    await removeCachedAuthToken({token: '1234'})
+    const accounts: chrome.identity.AccountInfo[] = await chrome.identity.getAccounts()
+    const token = await chrome.identity.getAuthToken({})
+    await chrome.identity.removeCachedAuthToken({token: '1234'})
 }
 
 // https://developer.chrome.com/docs/extensions/reference/topSites/


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/identity/#method-getAccounts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
