### PR TITLE
Adds isUtf8 to Node.js Buffer

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -46,6 +46,8 @@
 declare module 'buffer' {
     import { BinaryLike } from 'node:crypto';
     import { ReadableStream as WebReadableStream } from 'node:stream/web';
+    export function isAscii(input: Buffer | ArrayBuffer | NodeJS.TypedArray): boolean;
+    export function isUtf8(input: Buffer | ArrayBuffer | NodeJS.TypedArray): boolean;
     export const INSPECT_MAX_BYTES: number;
     export const kMaxLength: number;
     export const kStringMaxLength: number;
@@ -169,11 +171,21 @@ declare module 'buffer' {
     import { Blob as NodeBlob } from 'buffer';
     // This conditional type will be the existing global Blob in a browser, or
     // the copy below in a Node environment.
-    type __Blob = typeof globalThis extends { onmessage: any, Blob: infer T }
-        ? T : NodeBlob;
+    type __Blob = typeof globalThis extends { onmessage: any; Blob: infer T } ? T : NodeBlob;
     global {
         // Buffer class
-        type BufferEncoding = 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'base64url' | 'latin1' | 'binary' | 'hex';
+        type BufferEncoding =
+            | 'ascii'
+            | 'utf8'
+            | 'utf-8'
+            | 'utf16le'
+            | 'ucs2'
+            | 'ucs-2'
+            | 'base64'
+            | 'base64url'
+            | 'latin1'
+            | 'binary'
+            | 'hex';
         type WithImplicitCoercion<T> =
             | T
             | {
@@ -247,7 +259,11 @@ declare module 'buffer' {
              * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal`Buffer` pool like `Buffer.allocUnsafe()` does.
              * @since v5.10.0
              */
-            from(arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>, byteOffset?: number, length?: number): Buffer;
+            from(
+                arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
+                byteOffset?: number,
+                length?: number,
+            ): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param data data to create a new Buffer
@@ -265,7 +281,7 @@ declare module 'buffer' {
                     | {
                           [Symbol.toPrimitive](hint: 'string'): string;
                       },
-                encoding?: BufferEncoding
+                encoding?: BufferEncoding,
             ): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
@@ -339,7 +355,10 @@ declare module 'buffer' {
              * @param [encoding='utf8'] If `string` is a string, this is its encoding.
              * @return The number of bytes contained within `string`.
              */
-            byteLength(string: string | NodeJS.ArrayBufferView | ArrayBuffer | SharedArrayBuffer, encoding?: BufferEncoding): number;
+            byteLength(
+                string: string | NodeJS.ArrayBufferView | ArrayBuffer | SharedArrayBuffer,
+                encoding?: BufferEncoding,
+            ): number;
             /**
              * Returns a new `Buffer` which is the result of concatenating all the `Buffer`instances in the `list` together.
              *
@@ -710,7 +729,13 @@ declare module 'buffer' {
              * @param [sourceStart=0] The offset within `buf` at which to begin comparison.
              * @param [sourceEnd=buf.length] The offset within `buf` at which to end comparison (not inclusive).
              */
-            compare(target: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): -1 | 0 | 1;
+            compare(
+                target: Uint8Array,
+                targetStart?: number,
+                targetEnd?: number,
+                sourceStart?: number,
+                sourceEnd?: number,
+            ): -1 | 0 | 1;
             /**
              * Copies data from a region of `buf` to a region in `target`, even if the `target`memory region overlaps with `buf`.
              *

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -46,7 +46,6 @@
 declare module 'buffer' {
     import { BinaryLike } from 'node:crypto';
     import { ReadableStream as WebReadableStream } from 'node:stream/web';
-    export function isAscii(input: Buffer | ArrayBuffer | NodeJS.TypedArray): boolean;
     export function isUtf8(input: Buffer | ArrayBuffer | NodeJS.TypedArray): boolean;
     export const INSPECT_MAX_BYTES: number;
     export const kMaxLength: number;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for non-npm package Node.js 18.13
+// Type definitions for non-npm package Node.js 18.14
 // Project: https://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -3,6 +3,8 @@ import {
     Blob as NodeBlob,
     Buffer as ImportedBuffer,
     constants,
+    isAscii,
+    isUtf8,
     kMaxLength,
     kStringMaxLength,
     resolveObjectURL,
@@ -32,6 +34,16 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const value2: number = constants.MAX_STRING_LENGTH;
     const value3: number = kMaxLength;
     const value4: number = kStringMaxLength;
+}
+
+// Module methods
+{
+    const bool1: boolean = isAscii(new Buffer('hello'));
+    const bool2: boolean = isAscii(new ArrayBuffer(0));
+    const bool3: boolean = isAscii(new Uint8Array());
+    const bool4: boolean = isUtf8(new Buffer('hello'));
+    const bool5: boolean = isUtf8(new ArrayBuffer(0));
+    const bool6: boolean = isUtf8(new Uint8Array());
 }
 
 // Class Methods: Buffer.swap16(), Buffer.swa32(), Buffer.swap64()
@@ -75,7 +87,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     buf = Buffer.from(arr.buffer, 0, 1);
 
     // @ts-expect-error
-    Buffer.from("this is a test", 1, 1);
+    Buffer.from('this is a test', 1, 1);
     // Ideally passing a normal Buffer would be a type error too, but it's not
     //  since Buffer is assignable to ArrayBuffer currently
 }
@@ -84,21 +96,33 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
 {
     const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
     /* tslint:disable-next-line no-construct */
-    Buffer.from(new String("DEADBEEF"), "hex");
+    Buffer.from(new String('DEADBEEF'), 'hex');
     // @ts-expect-error
     Buffer.from(buf2, 'hex');
 }
 
 // Class Method: Buffer.from(object, [, byteOffset[, length]])  (Implicit coercion)
 {
-    const pseudoBuf = { valueOf() { return Buffer.from([1, 2, 3]); } };
+    const pseudoBuf = {
+        valueOf() {
+            return Buffer.from([1, 2, 3]);
+        },
+    };
     let buf: Buffer = Buffer.from(pseudoBuf);
-    const pseudoString = { valueOf() { return "Hello"; }};
+    const pseudoString = {
+        valueOf() {
+            return 'Hello';
+        },
+    };
     buf = Buffer.from(pseudoString);
-    buf = Buffer.from(pseudoString, "utf-8");
+    buf = Buffer.from(pseudoString, 'utf-8');
     // @ts-expect-error
     Buffer.from(pseudoString, 1, 2);
-    const pseudoArrayBuf = { valueOf() { return new Uint16Array(2); } };
+    const pseudoArrayBuf = {
+        valueOf() {
+            return new Uint16Array(2);
+        },
+    };
     buf = Buffer.from(pseudoArrayBuf, 1, 1);
 }
 
@@ -121,20 +145,20 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
 // Class Method byteLenght
 {
     let len: number;
-    len = Buffer.byteLength("foo");
-    len = Buffer.byteLength("foo", "utf8");
+    len = Buffer.byteLength('foo');
+    len = Buffer.byteLength('foo', 'utf8');
 
-    const b = Buffer.from("bar");
+    const b = Buffer.from('bar');
     len = Buffer.byteLength(b);
-    len = Buffer.byteLength(b, "utf16le");
+    len = Buffer.byteLength(b, 'utf16le');
 
     const ab = new ArrayBuffer(15);
     len = Buffer.byteLength(ab);
-    len = Buffer.byteLength(ab, "ascii");
+    len = Buffer.byteLength(ab, 'ascii');
 
     const dv = new DataView(ab);
     len = Buffer.byteLength(dv);
-    len = Buffer.byteLength(dv, "utf16le");
+    len = Buffer.byteLength(dv, 'utf16le');
 }
 
 // Class Method poolSize
@@ -170,9 +194,9 @@ b.fill('a').fill('b');
 {
     const buffer = new Buffer('123');
     let index: number;
-    index = buffer.indexOf("23");
-    index = buffer.indexOf("23", 1);
-    index = buffer.indexOf("23", 1, "utf8");
+    index = buffer.indexOf('23');
+    index = buffer.indexOf('23', 1);
+    index = buffer.indexOf('23', 1, 'utf8');
     index = buffer.indexOf(23);
     index = buffer.indexOf(buffer);
 }
@@ -180,9 +204,9 @@ b.fill('a').fill('b');
 {
     const buffer = new Buffer('123');
     let index: number;
-    index = buffer.lastIndexOf("23");
-    index = buffer.lastIndexOf("23", 1);
-    index = buffer.lastIndexOf("23", 1, "utf8");
+    index = buffer.lastIndexOf('23');
+    index = buffer.lastIndexOf('23', 1);
+    index = buffer.lastIndexOf('23', 1, 'utf8');
     index = buffer.lastIndexOf(23);
     index = buffer.lastIndexOf(buffer);
 }
@@ -201,15 +225,15 @@ b.fill('a').fill('b');
 {
     const buffer = new Buffer('123');
     let includes: boolean;
-    includes = buffer.includes("23");
-    includes = buffer.includes("23", 1);
-    includes = buffer.includes("23", 1, "utf8");
+    includes = buffer.includes('23');
+    includes = buffer.includes('23', 1);
+    includes = buffer.includes('23', 1, 'utf8');
     includes = buffer.includes(23);
     includes = buffer.includes(23, 1);
-    includes = buffer.includes(23, 1, "utf8");
+    includes = buffer.includes(23, 1, 'utf8');
     includes = buffer.includes(buffer);
     includes = buffer.includes(buffer, 1);
-    includes = buffer.includes(buffer, 1, "utf8");
+    includes = buffer.includes(buffer, 1, 'utf8');
 }
 
 {
@@ -343,15 +367,15 @@ const c: NodeJS.TypedArray = new Buffer(123);
 }
 
 {
-  const obj = {
-    valueOf() {
-      return 'hello';
-    }
-  };
-  Buffer.from(obj);
+    const obj = {
+        valueOf() {
+            return 'hello';
+        },
+    };
+    Buffer.from(obj);
 }
 
-const buff = Buffer.from("Hello World!");
+const buff = Buffer.from('Hello World!');
 
 // reads
 

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -3,7 +3,6 @@ import {
     Blob as NodeBlob,
     Buffer as ImportedBuffer,
     constants,
-    isAscii,
     isUtf8,
     kMaxLength,
     kStringMaxLength,
@@ -38,12 +37,9 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
 
 // Module methods
 {
-    const bool1: boolean = isAscii(new Buffer('hello'));
-    const bool2: boolean = isAscii(new ArrayBuffer(0));
-    const bool3: boolean = isAscii(new Uint8Array());
-    const bool4: boolean = isUtf8(new Buffer('hello'));
-    const bool5: boolean = isUtf8(new ArrayBuffer(0));
-    const bool6: boolean = isUtf8(new Uint8Array());
+    const bool1: boolean = isUtf8(new Buffer('hello'));
+    const bool2: boolean = isUtf8(new ArrayBuffer(0));
+    const bool3: boolean = isUtf8(new Uint8Array());
 }
 
 // Class Methods: Buffer.swap16(), Buffer.swa32(), Buffer.swap64()

--- a/types/node/ts4.8/buffer.d.ts
+++ b/types/node/ts4.8/buffer.d.ts
@@ -46,6 +46,7 @@
 declare module 'buffer' {
     import { BinaryLike } from 'node:crypto';
     import { ReadableStream as WebReadableStream } from 'node:stream/web';
+    export function isUtf8(input: Buffer | ArrayBuffer | NodeJS.TypedArray): boolean;
     export const INSPECT_MAX_BYTES: number;
     export const kMaxLength: number;
     export const kStringMaxLength: number;
@@ -169,12 +170,22 @@ declare module 'buffer' {
     import { Blob as NodeBlob } from 'buffer';
     // This conditional type will be the existing global Blob in a browser, or
     // the copy below in a Node environment.
-    type __Blob = typeof globalThis extends { onmessage: any, Blob: any }
-        ? {} : NodeBlob;
+    type __Blob = typeof globalThis extends { onmessage: any; Blob: any } ? {} : NodeBlob;
 
     global {
         // Buffer class
-        type BufferEncoding = 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'base64url' | 'latin1' | 'binary' | 'hex';
+        type BufferEncoding =
+            | 'ascii'
+            | 'utf8'
+            | 'utf-8'
+            | 'utf16le'
+            | 'ucs2'
+            | 'ucs-2'
+            | 'base64'
+            | 'base64url'
+            | 'latin1'
+            | 'binary'
+            | 'hex';
         type WithImplicitCoercion<T> =
             | T
             | {
@@ -248,7 +259,11 @@ declare module 'buffer' {
              * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal`Buffer` pool like `Buffer.allocUnsafe()` does.
              * @since v5.10.0
              */
-            from(arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>, byteOffset?: number, length?: number): Buffer;
+            from(
+                arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
+                byteOffset?: number,
+                length?: number,
+            ): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param data data to create a new Buffer
@@ -266,7 +281,7 @@ declare module 'buffer' {
                     | {
                           [Symbol.toPrimitive](hint: 'string'): string;
                       },
-                encoding?: BufferEncoding
+                encoding?: BufferEncoding,
             ): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
@@ -340,7 +355,10 @@ declare module 'buffer' {
              * @param [encoding='utf8'] If `string` is a string, this is its encoding.
              * @return The number of bytes contained within `string`.
              */
-            byteLength(string: string | NodeJS.ArrayBufferView | ArrayBuffer | SharedArrayBuffer, encoding?: BufferEncoding): number;
+            byteLength(
+                string: string | NodeJS.ArrayBufferView | ArrayBuffer | SharedArrayBuffer,
+                encoding?: BufferEncoding,
+            ): number;
             /**
              * Returns a new `Buffer` which is the result of concatenating all the `Buffer`instances in the `list` together.
              *
@@ -711,7 +729,13 @@ declare module 'buffer' {
              * @param [sourceStart=0] The offset within `buf` at which to begin comparison.
              * @param [sourceEnd=buf.length] The offset within `buf` at which to end comparison (not inclusive).
              */
-            compare(target: Uint8Array, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): -1 | 0 | 1;
+            compare(
+                target: Uint8Array,
+                targetStart?: number,
+                targetEnd?: number,
+                sourceStart?: number,
+                sourceEnd?: number,
+            ): -1 | 0 | 1;
             /**
              * Copies data from a region of `buf` to a region in `target`, even if the `target`memory region overlaps with `buf`.
              *

--- a/types/node/ts4.8/test/buffer.ts
+++ b/types/node/ts4.8/test/buffer.ts
@@ -3,6 +3,7 @@ import {
     Blob as NodeBlob,
     Buffer as ImportedBuffer,
     constants,
+    isUtf8,
     kMaxLength,
     kStringMaxLength,
     resolveObjectURL,
@@ -32,6 +33,13 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     const value2: number = constants.MAX_STRING_LENGTH;
     const value3: number = kMaxLength;
     const value4: number = kStringMaxLength;
+}
+
+// Module methods
+{
+    const bool1: boolean = isUtf8(new Buffer('hello'));
+    const bool2: boolean = isUtf8(new ArrayBuffer(0));
+    const bool3: boolean = isUtf8(new Uint8Array());
 }
 
 // Class Methods: Buffer.swap16(), Buffer.swa32(), Buffer.swap64()
@@ -75,7 +83,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
     buf = Buffer.from(arr.buffer, 0, 1);
 
     // @ts-expect-error
-    Buffer.from("this is a test", 1, 1);
+    Buffer.from('this is a test', 1, 1);
     // Ideally passing a normal Buffer would be a type error too, but it's not
     //  since Buffer is assignable to ArrayBuffer currently
 }
@@ -84,21 +92,33 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
 {
     const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
     /* tslint:disable-next-line no-construct */
-    Buffer.from(new String("DEADBEEF"), "hex");
+    Buffer.from(new String('DEADBEEF'), 'hex');
     // @ts-expect-error
     Buffer.from(buf2, 'hex');
 }
 
 // Class Method: Buffer.from(object, [, byteOffset[, length]])  (Implicit coercion)
 {
-    const pseudoBuf = { valueOf() { return Buffer.from([1, 2, 3]); } };
+    const pseudoBuf = {
+        valueOf() {
+            return Buffer.from([1, 2, 3]);
+        },
+    };
     let buf: Buffer = Buffer.from(pseudoBuf);
-    const pseudoString = { valueOf() { return "Hello"; }};
+    const pseudoString = {
+        valueOf() {
+            return 'Hello';
+        },
+    };
     buf = Buffer.from(pseudoString);
-    buf = Buffer.from(pseudoString, "utf-8");
+    buf = Buffer.from(pseudoString, 'utf-8');
     // @ts-expect-error
     Buffer.from(pseudoString, 1, 2);
-    const pseudoArrayBuf = { valueOf() { return new Uint16Array(2); } };
+    const pseudoArrayBuf = {
+        valueOf() {
+            return new Uint16Array(2);
+        },
+    };
     buf = Buffer.from(pseudoArrayBuf, 1, 1);
 }
 
@@ -121,20 +141,20 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as ReadonlyArray<Uint8A
 // Class Method byteLenght
 {
     let len: number;
-    len = Buffer.byteLength("foo");
-    len = Buffer.byteLength("foo", "utf8");
+    len = Buffer.byteLength('foo');
+    len = Buffer.byteLength('foo', 'utf8');
 
-    const b = Buffer.from("bar");
+    const b = Buffer.from('bar');
     len = Buffer.byteLength(b);
-    len = Buffer.byteLength(b, "utf16le");
+    len = Buffer.byteLength(b, 'utf16le');
 
     const ab = new ArrayBuffer(15);
     len = Buffer.byteLength(ab);
-    len = Buffer.byteLength(ab, "ascii");
+    len = Buffer.byteLength(ab, 'ascii');
 
     const dv = new DataView(ab);
     len = Buffer.byteLength(dv);
-    len = Buffer.byteLength(dv, "utf16le");
+    len = Buffer.byteLength(dv, 'utf16le');
 }
 
 // Class Method poolSize
@@ -170,9 +190,9 @@ b.fill('a').fill('b');
 {
     const buffer = new Buffer('123');
     let index: number;
-    index = buffer.indexOf("23");
-    index = buffer.indexOf("23", 1);
-    index = buffer.indexOf("23", 1, "utf8");
+    index = buffer.indexOf('23');
+    index = buffer.indexOf('23', 1);
+    index = buffer.indexOf('23', 1, 'utf8');
     index = buffer.indexOf(23);
     index = buffer.indexOf(buffer);
 }
@@ -180,9 +200,9 @@ b.fill('a').fill('b');
 {
     const buffer = new Buffer('123');
     let index: number;
-    index = buffer.lastIndexOf("23");
-    index = buffer.lastIndexOf("23", 1);
-    index = buffer.lastIndexOf("23", 1, "utf8");
+    index = buffer.lastIndexOf('23');
+    index = buffer.lastIndexOf('23', 1);
+    index = buffer.lastIndexOf('23', 1, 'utf8');
     index = buffer.lastIndexOf(23);
     index = buffer.lastIndexOf(buffer);
 }
@@ -201,15 +221,15 @@ b.fill('a').fill('b');
 {
     const buffer = new Buffer('123');
     let includes: boolean;
-    includes = buffer.includes("23");
-    includes = buffer.includes("23", 1);
-    includes = buffer.includes("23", 1, "utf8");
+    includes = buffer.includes('23');
+    includes = buffer.includes('23', 1);
+    includes = buffer.includes('23', 1, 'utf8');
     includes = buffer.includes(23);
     includes = buffer.includes(23, 1);
-    includes = buffer.includes(23, 1, "utf8");
+    includes = buffer.includes(23, 1, 'utf8');
     includes = buffer.includes(buffer);
     includes = buffer.includes(buffer, 1);
-    includes = buffer.includes(buffer, 1, "utf8");
+    includes = buffer.includes(buffer, 1, 'utf8');
 }
 
 {
@@ -343,15 +363,15 @@ const c: NodeJS.TypedArray = new Buffer(123);
 }
 
 {
-  const obj = {
-    valueOf() {
-      return 'hello';
-    }
-  };
-  Buffer.from(obj);
+    const obj = {
+        valueOf() {
+            return 'hello';
+        },
+    };
+    Buffer.from(obj);
 }
 
-const buff = Buffer.from("Hello World!");
+const buff = Buffer.from('Hello World!');
 
 // reads
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/buffer.html#bufferisasciiinput
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

I have a question about the last check box. These functions were added to Node in 19.4 (`isUtf8`) and 19.6 (`isAscii`), since version 18 is the LTS, do we still add types for Node 19, or should they wait until 20?