### PR TITLE
[google-spreadsheet] make PaginationOptions properties optional

### DIFF
--- a/types/google-spreadsheet/index.d.ts
+++ b/types/google-spreadsheet/index.d.ts
@@ -70,8 +70,8 @@ export type DeveloperMetadataLocationType = 'ROW' | 'COLUMN' | 'SHEET' | 'SPREAD
 // #region OPTIONS / CONFIG
 
 export interface PaginationOptions {
-    limit: number;
-    offset: number;
+    limit?: number | undefined;
+    offset?: number | undefined;
 }
 
 export interface WorksheetGridRange {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://theoephraim.github.io/node-google-spreadsheet/#/classes/google-spreadsheet-worksheet?id=fn-getrows
Please see the above URL. PaginationOptions (the type passed to `getRows`) has both properties optional, as per this PR.