### PR TITLE
[polygon] Fix to allow optional arguments on `scale` and `rotate`, and add tests

### DIFF
--- a/types/polygon/index.d.ts
+++ b/types/polygon/index.d.ts
@@ -93,7 +93,7 @@ declare class Polygon {
     /**
      * Scales this polygon around `origin` (default is `this.center()`) and will return a new polygon if requested with `returnNew`
      */
-    scale(amount: number, origin: Vec2, returnNew?: boolean): Polygon;
+    scale(amount: number, origin?: Vec2, returnNew?: boolean): Polygon;
 
     /**
      * Returns true if `vec2` is inside the polygon
@@ -143,7 +143,7 @@ declare class Polygon {
     /**
      * Rotate by origin `vec2` (default `this.center()`) by radians `rads` and return a clone if `returnNew` is specified
      */
-    rotate(rads: number, vec2: Vec2, returnNew?: boolean): Polygon;
+    rotate(rads: number, vec2?: Vec2, returnNew?: boolean): Polygon;
 
     /**
      * Translate by `vec2` and return a clone if `returnNew` is specified

--- a/types/polygon/index.d.ts
+++ b/types/polygon/index.d.ts
@@ -143,7 +143,7 @@ declare class Polygon {
     /**
      * Rotate by origin `vec2` (default `this.center()`) by radians `rads` and return a clone if `returnNew` is specified
      */
-    rotate(rads: number, vec2?: Vec2, returnNew?: boolean): Polygon;
+    rotate(rads: number, vec2?: Vec2 | null, returnNew?: boolean): Polygon;
 
     /**
      * Translate by `vec2` and return a clone if `returnNew` is specified

--- a/types/polygon/index.d.ts
+++ b/types/polygon/index.d.ts
@@ -143,7 +143,7 @@ declare class Polygon {
     /**
      * Rotate by origin `vec2` (default `this.center()`) by radians `rads` and return a clone if `returnNew` is specified
      */
-    rotate(rads: number, vec2?: Vec2 | null, returnNew?: boolean): Polygon;
+    rotate(rads: number, origin?: Vec2 | null, returnNew?: boolean): Polygon;
 
     /**
      * Translate by `vec2` and return a clone if `returnNew` is specified

--- a/types/polygon/index.d.ts
+++ b/types/polygon/index.d.ts
@@ -93,7 +93,7 @@ declare class Polygon {
     /**
      * Scales this polygon around `origin` (default is `this.center()`) and will return a new polygon if requested with `returnNew`
      */
-    scale(amount: number, origin?: Vec2, returnNew?: boolean): Polygon;
+    scale(amount: number, origin?: Vec2 | null, returnNew?: boolean): Polygon;
 
     /**
      * Returns true if `vec2` is inside the polygon

--- a/types/polygon/polygon-tests.ts
+++ b/types/polygon/polygon-tests.ts
@@ -105,6 +105,9 @@ p.rotate(Math.PI, new Vec2(0, 0));
 // $ExpectType Polygon
 p.rotate(Math.PI, new Vec2(0, 0), true);
 
+// $ExpectType Polygon
+p.rotate(Math.PI, null, true);
+
 // $ExpectType boolean
 p.equal(p2);
 

--- a/types/polygon/polygon-tests.ts
+++ b/types/polygon/polygon-tests.ts
@@ -1,16 +1,127 @@
-// no tests yet
 import Polygon = require('polygon');
+import Vec2 = require('vec2');
 
-const polygon1 = new Polygon([
+// $ExpectType Polygon
+const p = new Polygon([
     [0, 0],
     [5, 0],
     [5, 5],
     [0, 5],
     [0, 0],
 ]);
-const shouldBeTrue = polygon1.contains({
-    x: 3,
-    y: 3,
-    w: 4,
-    h: 3,
-});
+
+const p2 = new Polygon([
+    [0, 0],
+    [5, 0],
+    [5, 5],
+    [0, 5],
+    [0, 0],
+]);
+
+// $ExpectType boolean
+p.contains({ x: 3, y: 3, w: 4, h: 3 });
+
+// $ExpectType Vec2[]
+p.points;
+
+// $ExpectType number
+p.length;
+
+// $ExpectType Polygon
+p.each((prev, current, next, idx) => {});
+
+// $ExpectType void
+p.insert(new Vec2(1, 2), 1);
+
+// $ExpectType number
+p.area();
+
+// $ExpectType boolean
+p.winding();
+
+// $ExpectType Polygon
+p.rewind(true);
+
+// $ExpectType Vec2
+p.closestPointTo(new Vec2(300, 300));
+
+// $ExpectType Polygon
+p.dedupe();
+
+// $ExpectType boolean
+p.containsPoint(new Vec2(5, 5));
+
+// $ExpectType Polygon
+p.remove(new Vec2(5, 5));
+
+// $ExpectType Polygon
+p.remove(0);
+
+// $ExpectType Polygon
+p.clean();
+
+// $ExpectType Polygon
+p.clone();
+
+// $ExpectType { x: number; y: number; w: number; h: number; }
+p.aabb();
+
+// $ExpectType boolean
+p.containsPolygon(p2);
+
+// $ExpectType Polygon
+p.offset(-10);
+
+// $ExpectType Vec2
+p.point(0);
+
+// $ExpectType Vec2
+p.center();
+
+// $ExpectType Polygon
+p.scale(10);
+
+// $ExpectType Polygon
+p.scale(10, new Vec2(10, 1));
+
+// $ExpectType Polygon
+p.scale(10, new Vec2(10, 1), true);
+
+// $ExpectType Polygon
+p.scale(10, null, true);
+
+// $ExpectType Polygon
+p.lines((start, end, idx) => {});
+
+// $ExpectType [Vec2, Vec2]
+p.line(0);
+
+// $ExpectType Polygon
+p.rotate(Math.PI);
+
+// $ExpectType Polygon
+p.rotate(Math.PI, new Vec2(0, 0));
+
+// $ExpectType Polygon
+p.rotate(Math.PI, new Vec2(0, 0), true);
+
+// $ExpectType boolean
+p.equal(p2);
+
+// $ExpectType Polygon
+p.translate(new Vec2(10, 10));
+
+// $ExpectType Polygon
+p.translate(new Vec2(10, 10), true);
+
+// $ExpectType Polygon
+p.selfIntersections();
+
+// $ExpectType number[][]
+p.toArray();
+
+// $ExpectType Polygon
+p.union(p2);
+
+// $ExpectType Polygon
+p.cut(p2);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test polygon`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tmpvar/polygon.js#supported-methods

Both of these arguments are optional. Default values are actually mentioned right in the documentation comments above both definitions, as well as in the documentation. https://github.com/tmpvar/polygon.js#supported-methods

I also added tests for all methods based on the official Polygon tests. 🎉

Thanks!