### PR TITLE
fix(simple-oauth2): correct type for 'scope' field in PasswordTokenConfig

### DIFF
--- a/types/simple-oauth2/index.d.ts
+++ b/types/simple-oauth2/index.d.ts
@@ -281,7 +281,7 @@ export interface PasswordTokenConfig {
     /** A string that represents the registered password. */
     password: string;
     /** A string or array of strings that represents the application privileges */
-    scope: string | string[];
+    scope?: string | string[];
 
     /**
      * Additional options will be automatically serialized as params for the token request.

--- a/types/simple-oauth2/simple-oauth2-tests.ts
+++ b/types/simple-oauth2/simple-oauth2-tests.ts
@@ -73,15 +73,29 @@ const oauth2ResourceOwnerPassword = new oauth2lib.ResourceOwnerPassword(
 
 // #Password Credentials Flow
 (async () => {
-    const tokenConfig = {
+    const tokenConfig1 = {
+        username: "username",
+        password: "password",
+    };
+
+    const tokenConfig2 = {
         username: "username",
         password: "password",
         scope: ["<scope1>", "<scope2>"],
     };
 
+    const tokenConfig3 = {
+        username: "username",
+        password: "password",
+        scope: "<scope1>",
+    };
+
     // Save the access token
     try {
-        const result = await oauth2ResourceOwnerPassword.getToken(tokenConfig);
+        let result = await oauth2ResourceOwnerPassword.getToken(tokenConfig1);
+        result = await oauth2ResourceOwnerPassword.getToken(tokenConfig2);
+        result = await oauth2ResourceOwnerPassword.getToken(tokenConfig3);
+
         const accessToken = oauth2ResourceOwnerPassword.createToken(result.token);
     } catch (error) {
         console.log("Access Token Error", error.message);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [link](https://github.com/lelylan/simple-oauth2/blob/master/lib/resource-owner-password-grant-type.js#L21)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

