### PR TITLE
[css-tree] Fix `find*()` return types and add `fork()` type

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -35,26 +35,29 @@ csstree.walk(ast, {
     reverse: false,
 });
 
-csstree.find(ast, (node, item, list) => {
+const findResult = csstree.find(ast, (node, item, list) => {
     node; // $ExpectType CssNode
     item; // $ExpectType ListItem<CssNode>
     list; // $ExpectType List<CssNode>
     return true;
 });
+findResult; // $ExpectType CssNode | null
 
-csstree.findLast(ast, (node, item, list) => {
+const findLastResult = csstree.findLast(ast, (node, item, list) => {
     node; // $ExpectType CssNode
     item; // $ExpectType ListItem<CssNode>
     list; // $ExpectType List<CssNode>
     return true;
 });
+findLastResult; // $ExpectType CssNode | null
 
-csstree.findAll(ast, (node, item, list) => {
+const findAllResult = csstree.findAll(ast, (node, item, list) => {
     node; // $ExpectType CssNode
     item; // $ExpectType ListItem<CssNode>
     list; // $ExpectType List<CssNode>
     return true;
 });
+findAllResult; // $ExpectType CssNode[]
 
 csstree.generate(ast); // $ExpectType string
 
@@ -82,13 +85,9 @@ csstree.generate(ast, {
     }),
 });
 
-const property = csstree.property('*-vendor-property');
-// @ts-expect-error
-property.name = 'test';
+const property = csstree.property('*-vendor-property'); // $ExpectType Property
 
-const keyword = csstree.keyword('-vendor-keyword');
-// @ts-expect-error
-keyword.name = 'test';
+const keyword = csstree.keyword('-vendor-keyword'); // $ExpectType Keyword
 
 csstree.clone(ast); // $ExpectType CssNode
 
@@ -708,3 +707,10 @@ csstree.string.encode('foo'); // $ExpectType string
 csstree.string.encode('foo', true); // $ExpectType string
 csstree.url.decode('foo'); // $ExpectType string
 csstree.url.encode('foo'); // $ExpectType string
+
+csstree.fork({}); // $ExpectType { lexer: Lexer; }
+const { lexer } = csstree.fork({ atrules: {}, properties: {}, types: { foo: '<length>' } });
+lexer; // $ExpectType Lexer
+
+lexer.matchProperty('foo', ast); // $ExpectType LexerMatchResult
+lexer.matchProperty('foo', 'bar'); // $ExpectType LexerMatchResult

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for css-tree 2.0
+// Type definitions for css-tree 2.3
 // Project: https://github.com/csstree/csstree
 // Definitions by: Erik Källén <https://github.com/erik-kallen>
 //                 Jason Kratzer <https://github.com/pyoor>
@@ -593,8 +593,8 @@ export function walk(ast: CssNode, options: EnterOrLeaveFn | WalkOptions): void;
 
 export type FindFn = (this: WalkContext, node: CssNode, item: ListItem<CssNode>, list: List<CssNode>) => boolean;
 
-export function find(ast: CssNode, fn: FindFn): CssNode;
-export function findLast(ast: CssNode, fn: FindFn): CssNode;
+export function find(ast: CssNode, fn: FindFn): CssNode | null;
+export function findLast(ast: CssNode, fn: FindFn): CssNode | null;
 export function findAll(ast: CssNode, fn: FindFn): CssNode[];
 
 export interface Property {
@@ -830,3 +830,37 @@ export const url: {
     decode(input: string): string;
     encode(input: string): string;
 };
+
+export class SyntaxMatchError extends SyntaxError {
+    rawMessage: string;
+    syntax: string;
+    css: string;
+    mismatchOffset: number;
+    mismatchLength: number;
+    offset: number;
+    line: number;
+    column: number;
+    loc: {
+        source: string;
+        start: { offset: number; line: number; column: number };
+        end: { offset: number; line: number; column: number };
+    };
+}
+
+export class SyntaxReferenceError extends SyntaxError {
+    reference: string;
+}
+
+export interface LexerMatchResult {
+    error: Error | SyntaxMatchError | SyntaxReferenceError | null;
+}
+
+export class Lexer {
+    matchProperty(propertyName: string, value: CssNode | string): LexerMatchResult;
+}
+
+export function fork(extension: {
+    atrules?: Record<string, string> | undefined,
+    properties?: Record<string, string> | undefined,
+    types?: Record<string, string> | undefined,
+}): { lexer: Lexer };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/csstree/csstree/blob/v2.3.1/lib/syntax/create.js#L31-L39>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Notes:
- Please note that this PR does NOT cover all types around the `fork()` function; it is just the first step.
- To provide built-in type definitions has been considered in <https://github.com/csstree/csstree/issues/240>. If it came, this definition would no longer be necessary.
