### PR TITLE
logfmt: use stricter types for parse

### DIFF
--- a/types/logfmt/index.d.ts
+++ b/types/logfmt/index.d.ts
@@ -39,7 +39,7 @@ interface RequestLogger {
 
 interface Logfmt {
     stringify(data: object): string;
-    parse(line: string): object;
+    parse(line: string): Partial<Record<string, string | boolean | null>>;
 
     log(data?: object, stream?: WritableStream): void;
     time(label?: string): Logfmt;

--- a/types/logfmt/logfmt-tests.ts
+++ b/types/logfmt/logfmt-tests.ts
@@ -14,7 +14,9 @@ logfmt2.log({foo: 'bar'});
 logfmt.log({foo: 'bar'});
 
 logfmt.stringify({foo: "bar", a: 14, baz: 'hello kitty'});
-logfmt.parse("foo=bar a=14 baz=\"hello kitty\" cool%story=bro f %^asdf code=H12");
+const parsed = logfmt.parse("foo=bar a=14 baz=\"hello kitty\" cool%story=bro f %^asdf code=H12");
+
+parsed.something === true || false || "a string" || null || undefined;
 
 process.stdin.pipe(logfmt.streamParser());
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [the readme](https://github.com/csquared/node-logfmt#parsing) states the only conversion is done to `"true"` and `"false"` which are converted to booleans, everything else is returned as it is (`null` or `string`), this matches the [source](https://github.com/csquared/node-logfmt/blob/master/lib/logfmt_parser.js) (lines 24-27).
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header~.

