### PR TITLE
[navermaps] Fix typo in DrawingEvent and types of DrawingOptions

### DIFF
--- a/types/navermaps/index.d.ts
+++ b/types/navermaps/index.d.ts
@@ -1545,12 +1545,12 @@ declare namespace naver.maps {
             drawingControlOptions?: DrawingControlOptions;
             drawingMode?: DrawingMode;
             controlPointOptions?: ControlPointOptions;
-            rectangleOptions?: RectangleOptions;
-            ellipseOptions?: EllipseOptions;
-            polylineOptions?: PolylineOptions;
-            arrowlineOptions?: PolylineOptions;
-            polygonOptions?: PolygonOptions;
-            markerOptions?: MarkerOptions;
+            rectangleOptions?: Partial<RectangleOptions>;
+            ellipseOptions?: Partial<EllipseOptions>;
+            polylineOptions?: Partial<PolylineOptions>;
+            arrowlineOptions?: Partial<PolylineOptions>;
+            polygonOptions?: Partial<PolygonOptions>;
+            markerOptions?: Partial<MarkerOptions>;
         }
 
         interface DrawingControlOptions extends ControlOptions {

--- a/types/navermaps/index.d.ts
+++ b/types/navermaps/index.d.ts
@@ -1531,7 +1531,7 @@ declare namespace naver.maps {
             MARKER,
         }
 
-        enum DrawingEvent {
+        enum DrawingEvents {
             ADD = 'drawing_added',
             REMOVE = 'drawing_removed',
             SELECT = 'drawing_selected',
@@ -1569,7 +1569,7 @@ declare namespace naver.maps {
         class DrawingManager extends KVO {
             constructor(options?: DrawingOptions);
             addDrawing(overlay: DrawingOverlay, drawingMode: DrawingMode, id?: string): void;
-            addListener(eventName: DrawingEvent, listener: (overlay: DrawingOverlay) => void): MapEventListener;
+            addListener(eventName: DrawingEvents, listener: (overlay: DrawingOverlay) => void): MapEventListener;
             destroy(): void;
             getDrawing(id: string): DrawingOverlay;
             getDrawings(): { [key: string]: DrawingOverlay };

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -226,6 +226,43 @@ naver.maps.Service.reverseGeocode(
     },
 );
 
+/**
+ * Overlay define options Example
+ * See https://navermaps.github.io/maps.js.ncp/docs/tutorial-3-drawing-restore.example.html
+ */
+
+naver.maps.Event.once(map, 'init', function () {
+    const drawingManager = new naver.maps.drawing.DrawingManager({
+        map: map,
+        rectangleOptions: {
+            fillColor: '#ff0000',
+            fillOpacity: 0.5,
+            strokeWeight: 3,
+            strokeColor: '#ff0000',
+        },
+        ellipseOptions: {
+            fillColor: '#ff25dc',
+            fillOpacity: 0.5,
+            strokeWeight: 3,
+            strokeColor: '#ff25dc'
+        },
+        polylineOptions: {
+            strokeColor: '#222',
+            strokeWeight: 3,
+        },
+        arrowlineOptions: {
+            endIconSize: 16,
+            strokeWeight: 3,
+        },
+        polygonOptions: {
+            fillColor: '#ffc300',
+            fillOpacity: 0.5,
+            strokeWeight: 3,
+            strokeColor: '#ffc300',
+        }
+    });
+});
+
 /*
  * LatLng
  */

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -227,7 +227,7 @@ naver.maps.Service.reverseGeocode(
 );
 
 /**
- * Overlay define options Example
+ * Overlay define options and DrawingManager event Example
  * See https://navermaps.github.io/maps.js.ncp/docs/tutorial-3-drawing-restore.example.html
  */
 
@@ -261,6 +261,10 @@ naver.maps.Event.once(map, 'init', function () {
             strokeColor: '#ffc300',
         }
     });
+
+    drawingManager.addListener(naver.maps.drawing.DrawingEvents.ADD, function (e) {});
+    drawingManager.addListener(naver.maps.drawing.DrawingEvents.REMOVE, function (e) {});
+    drawingManager.addListener(naver.maps.drawing.DrawingEvents.SELECT, function (e) {});
 });
 
 /*


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://navermaps.github.io/maps.js.ncp/docs/tutorial-3-drawing-restore.example.html>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
