### PR TITLE
[selenium-webdriver] Use string literals for browser name types

### DIFF
--- a/types/selenium-webdriver/lib/capabilities.d.ts
+++ b/types/selenium-webdriver/lib/capabilities.d.ts
@@ -6,12 +6,11 @@ import { logging, ProxyConfig } from '../';
  * @enum {string}
  */
 export interface IBrowser {
-    CHROME: string;
-    EDGE: string;
-    FIREFOX: string;
-    IE: string;
-    INTERNET_EXPLORER: string;
-    SAFARI: string;
+    CHROME: 'chrome';
+    EDGE: 'MicrosoftEdge';
+    FIREFOX: 'firefox';
+    INTERNET_EXPLORER: 'internet explorer';
+    SAFARI: 'safari';
 }
 
 /**

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -83,7 +83,6 @@ function TestBrowser() {
     browser = webdriver.Browser.CHROME;
     browser = webdriver.Browser.EDGE;
     browser = webdriver.Browser.FIREFOX;
-    browser = webdriver.Browser.IE;
     browser = webdriver.Browser.INTERNET_EXPLORER;
     browser = webdriver.Browser.SAFARI;
 }


### PR DESCRIPTION
Browser names are stable constants with known values so the types can be narrowed to string literals instead of just strings.

Also, remove the type for `Browser.IE` which was removed from `selenium-webdriver` in v4.0.0-alpha. See https://github.com/SeleniumHQ/selenium/commit/dccf4dd92d38e95a7966cf92e5cc7f5558b4ea6f

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes
  - https://github.com/SeleniumHQ/selenium/commit/dccf4dd92d38e95a7966cf92e5cc7f5558b4ea6f (removes `Browser.IE`)
  -  [source file](https://github.com/SeleniumHQ/selenium/blob/trunk/javascript/node/selenium-webdriver/lib/capabilities.js#L31) defining `Browser` constants
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. 
  - These types apply even for `selenium-webdriver@4.0.0`
