### PR TITLE
fix(image-blob-reduce): correct type for init options

### DIFF
--- a/types/image-blob-reduce/image-blob-reduce-tests.ts
+++ b/types/image-blob-reduce/image-blob-reduce-tests.ts
@@ -1,10 +1,22 @@
-import * as pica from 'pica';
 import * as imageBlobReduce from 'image-blob-reduce';
 
+// no options
+// $ExpectType ImageBlobReduce
+imageBlobReduce();
+
+// $ExpectType Pica
+imageBlobReduce.pica();
+
+// with incorrect options
+// @ts-expect-error
+imageBlobReduce({ pica: imageBlobReduce.pica });
+
+// with options
 const createOptions: imageBlobReduce.Options = {
-    pica,
+    pica: imageBlobReduce.pica(),
 };
 
+// $ExpectType ImageBlobReduce
 const imageReducer = imageBlobReduce(createOptions);
 
 imageReducer.use(

--- a/types/image-blob-reduce/index.d.ts
+++ b/types/image-blob-reduce/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Matthias Fischer <https://github.com/dotnetautor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import type { PicaStatic } from 'pica';
+import type { Pica, PicaStatic } from 'pica';
 
 interface InternalProperties {
     image: HTMLImageElement;
@@ -28,7 +28,7 @@ declare namespace imageBlobReduce {
     }
 
     interface Options {
-        pica?: PicaStatic;
+        pica?: Pica;
     }
 
     interface Env extends InternalProperties {
@@ -48,6 +48,7 @@ declare namespace imageBlobReduce {
     interface ImageBlobReduceStatic {
         new (options?: Options): ImageBlobReduce;
         (options?: Options): ImageBlobReduce;
+        pica: PicaStatic;
     }
 }
 


### PR DESCRIPTION
image-blob-reduce in fact [accepts an instance of `Pica`](https://github.com/nodeca/image-blob-reduce/blob/0e974bb9dac8e47121bdb4bbb736b5b965c79b70/index.js#L12) — not `PicaStatic`.

Additional change: added `pica` static field to `ImageBlobReduceStatic` [which reexports `PicaStatic` from pica](https://github.com/nodeca/image-blob-reduce/blob/master/README.md#reexports).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/image-blob-reduce/blob/0e974bb9dac8e47121bdb4bbb736b5b965c79b70/index.js#L12
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
