### PR TITLE
[which] fix: general Options were not included in types for the async methods

### DIFF
--- a/types/which/index.d.ts
+++ b/types/which/index.d.ts
@@ -8,22 +8,22 @@
 /** Finds all instances of a specified executable in the PATH environment variable */
 declare function which(
     cmd: string,
-    options: which.AsyncOptions & which.OptionsAll,
+    options: which.Options & which.AsyncOptions & which.OptionsAll,
     cb: (err: Error | null, paths: ReadonlyArray<string> | undefined) => void,
 ): void;
 declare function which(
     cmd: string,
-    options: which.AsyncOptions & which.OptionsFirst,
+    options: which.Options & which.AsyncOptions & which.OptionsFirst,
     cb: (err: Error | null, path: string | undefined) => void,
 ): void;
 declare function which(
     cmd: string,
-    options: which.AsyncOptions,
+    options: which.Options & which.AsyncOptions,
     cb: (err: Error | null, path: string | ReadonlyArray<string> | undefined) => void,
 ): void;
 declare function which(cmd: string, cb: (err: Error | null, path: string | undefined) => void): void;
-declare function which(cmd: string, options: which.AsyncOptions & which.OptionsAll): Promise<string[]>;
-declare function which(cmd: string, options?: which.AsyncOptions & which.OptionsFirst): Promise<string>;
+declare function which(cmd: string, options: which.Options & which.AsyncOptions & which.OptionsAll): Promise<string[]>;
+declare function which(cmd: string, options?: which.Options & which.AsyncOptions & which.OptionsFirst): Promise<string>;
 
 declare namespace which {
     /** Finds all instances of a specified executable in the PATH environment variable */

--- a/types/which/which-tests.ts
+++ b/types/which/which-tests.ts
@@ -18,12 +18,13 @@ which('cat', { all: true }, (err, paths) => {
 const promise: Promise<string> = which('cat');
 const promise1: Promise<string> = which('cat', { all: false });
 const promise2: Promise<string[]> = which('cat', { all: true });
+const promise3: Promise<string> = which('cat', { nothrow: true });
 
 which('node')
     .then(resolvedPath => {
         resolvedPath; // $ExpectType string
     })
-    .catch(er => {});
+    .catch(er => { });
 
 async () => {
     const path = await which('cat');

--- a/types/which/which-tests.ts
+++ b/types/which/which-tests.ts
@@ -24,7 +24,7 @@ which('node')
     .then(resolvedPath => {
         resolvedPath; // $ExpectType string
     })
-    .catch(er => { });
+    .catch(er => {});
 
 async () => {
     const path = await which('cat');


### PR DESCRIPTION
fix: general Options were not included in types for the async methods. This resulted in an error on {nothrow: true}. Fixed this and added a test for it.)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [na] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [na] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [na] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [na] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [na] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [na] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
```
// this should not result in a type error
await which(command, { nothrow: true });
```
Library documentation that supports this: https://github.com/npm/node-which#USAGE
- [na] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ na] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [na] Delete the package's directory.
- [na] Add it to `notNeededPackages.json`.
