### PR TITLE
Type definition for react-editable-label

### DIFF
--- a/types/react-editable-label/index.d.ts
+++ b/types/react-editable-label/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for react-editable-label 1.3
+// Project: https://github.com/markbiek/react-editable-label
+// Definitions by: markbiek <https://github.com/markbiek>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.1
+
+import { Component } from 'react';
+
+export type LabelSaveFunction = (value: string) => void;
+
+export interface EditableLabelProps {
+    initialValue: string;
+    save: LabelSaveFunction;
+    labelClass?: string;
+    inputClass?: string;
+    inputName?: string;
+    inputId?: string;
+    disableKeys?: boolean;
+}
+
+export default class EditableLabel extends Component<EditableLabelProps, any> {}

--- a/types/react-editable-label/react-editable-label-tests.ts
+++ b/types/react-editable-label/react-editable-label-tests.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import EditableLabel from 'react-editable-label';
+
+function checkCreateEditableLabel() {
+    const container = document.createElement('div');
+    container.id = 'react-editable-label-container';
+
+    document.body.appendChild(container);
+
+    const editableLabel = new EditableLabel(container, {});
+}

--- a/types/react-editable-label/tsconfig.json
+++ b/types/react-editable-label/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+	"react-editable-label-tests.ts"
+    ]
+}

--- a/types/react-editable-label/tslint.json
+++ b/types/react-editable-label/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "@definitelytyped/dtslint/dt.json"
+}


### PR DESCRIPTION
This adds types for https://www.npmjs.com/package/react-editable-label (owned by me). Eventually, I'd like to convert the package to Typescript and have the type definitions hosted internally. But, for now, this is the quickest way to make the package functional for TS users.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.