### PR TITLE
[vuelidate] Fix max call stack size error in Vue 2.7.6-14

### DIFF
--- a/types/vuelidate/index.d.ts
+++ b/types/vuelidate/index.d.ts
@@ -5,7 +5,7 @@
 //                 Orblazer <https://github.com/orblazer>
 //                 Yuri Krylov <https://github.com/shadrus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 4.4
 
 import './vue'
 import './lib/validators'

--- a/types/vuelidate/vue.d.ts
+++ b/types/vuelidate/vue.d.ts
@@ -6,7 +6,7 @@ import { Validation } from './vuelidate'
 
 declare module 'vue/types/vue' {
     type ValidationProperties<V> = {
-        [P in Exclude<keyof V, '$v'>]?: Validation & ValidationProperties<V[P]> & ValidationEvaluation
+        [P in Exclude<keyof V, '$v' | '$parent' | '$root' | '$children'>]?: Validation & ValidationProperties<V[P]> & ValidationEvaluation
     }
 
     interface ValidationGroups {

--- a/types/vuelidate/vuelidate-tests.ts
+++ b/types/vuelidate/vuelidate-tests.ts
@@ -196,15 +196,15 @@ export class ValidComponent extends Vue {
         } else return false
     }
 
-	verifyNoTypeRecursion() {
-		const parent = this.$v.$parent;
-		const root = this.$v.$root;
-		const children = this.$v.$children;
+    verifyNoTypeRecursion() {
+        const parent = this.$v.$parent;
+        const root = this.$v.$root;
+        const children = this.$v.$children;
 
-		parent // $ExpectType Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, any>> | null
-		root // $ExpectType Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, any>>
-		children // $ExpectType Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, any>>[]
-	}
+        parent // $ExpectType Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, any>> | null
+        root // $ExpectType Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, any>>
+        children // $ExpectType Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, any>>[]
+    }
 }
 
 @Component({

--- a/types/vuelidate/vuelidate-tests.ts
+++ b/types/vuelidate/vuelidate-tests.ts
@@ -195,6 +195,16 @@ export class ValidComponent extends Vue {
             return !this.$v.password.minLength
         } else return false
     }
+
+	verifyNoTypeRecursion() {
+		const parent = this.$v.$parent;
+		const root = this.$v.$root;
+		const children = this.$v.$children;
+
+		parent // $ExpectType Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, any>> | null
+		root // $ExpectType Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, any>>
+		children // $ExpectType Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, any>>[]
+	}
 }
 
 @Component({


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vuejs/vue/issues/12750 and https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/61288
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.