### PR TITLE
[eslint] Add es2022 nodes from estree

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -1,4 +1,4 @@
-import { Comment, WhileStatement } from 'estree';
+import { Comment, PrivateIdentifier, PropertyDefinition, StaticBlock, WhileStatement } from 'estree';
 import { AST, SourceCode, Rule, Linter, ESLint, RuleTester, Scope } from 'eslint';
 import { ESLintRules } from 'eslint/rules';
 
@@ -480,6 +480,18 @@ rule = {
             'Program:exit'() {},
             'MemberExpression[object.name="req"]': (node: Rule.Node) => {
                 node.parent;
+            },
+            PrivateIdentifier(node) {
+                const expected: PrivateIdentifier & Rule.NodeParentExtension = node;
+                expected.parent;
+            },
+            PropertyDefinition(node) {
+                const expected: PropertyDefinition & Rule.NodeParentExtension = node;
+                expected.parent;
+            },
+            StaticBlock(node) {
+                const expected: StaticBlock & Rule.NodeParentExtension = node;
+                expected.parent;
             },
         };
     },

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -483,12 +483,15 @@ export namespace Rule {
         NewExpression?: ((node: ESTree.NewExpression & NodeParentExtension) => void) | undefined;
         ObjectExpression?: ((node: ESTree.ObjectExpression & NodeParentExtension) => void) | undefined;
         ObjectPattern?: ((node: ESTree.ObjectPattern & NodeParentExtension) => void) | undefined;
+        PrivateIdentifier?: ((node: ESTree.PrivateIdentifier & NodeParentExtension) => void) | undefined;
         Program?: ((node: ESTree.Program) => void) | undefined;
         Property?: ((node: ESTree.Property & NodeParentExtension) => void) | undefined;
+        PropertyDefinition?: ((node: ESTree.PropertyDefinition & NodeParentExtension) => void) | undefined;
         RestElement?: ((node: ESTree.RestElement & NodeParentExtension) => void) | undefined;
         ReturnStatement?: ((node: ESTree.ReturnStatement & NodeParentExtension) => void) | undefined;
         SequenceExpression?: ((node: ESTree.SequenceExpression & NodeParentExtension) => void) | undefined;
         SpreadElement?: ((node: ESTree.SpreadElement & NodeParentExtension) => void) | undefined;
+        StaticBlock?: ((node: ESTree.StaticBlock & NodeParentExtension) => void) | undefined;
         Super?: ((node: ESTree.Super & NodeParentExtension) => void) | undefined;
         SwitchCase?: ((node: ESTree.SwitchCase & NodeParentExtension) => void) | undefined;
         SwitchStatement?: ((node: ESTree.SwitchStatement & NodeParentExtension) => void) | undefined;


### PR DESCRIPTION
These nodes specifically:

- `PrivateIdentifier`: `#prop`
- `PropertyDefinition`: `prop = value;`
- `StaticBlock`: `static { … }`

Types for these nodes are already in estree. This PR just adds them to eslint.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [ESLint v8.0.0 release notes](https://eslint.org/blog/2021/10/eslint-v8.0.0-released/)
  - [ESTree es2022 docs](https://github.com/estree/estree/blob/master/es2022.md)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
