### PR TITLE
jscodeshift: Improve types

### DIFF
--- a/types/jscodeshift/src/Collection.d.ts
+++ b/types/jscodeshift/src/Collection.d.ts
@@ -4,8 +4,10 @@ import recast = require("recast");
 import JSXElement = require("./collections/JSXElement");
 import NodeCollection = require("./collections/Node");
 import VariableDeclarator = require("./collections/VariableDeclarator");
+import Core = require("./core");
 
 type ASTPath<N> = nodePath.NodePath<N, N>;
+type Method<N extends Core.ASTNode> = (this: Collection<N>) => void;
 
 export interface Collection<N>
     extends NodeCollection.TraversalMethods,
@@ -124,7 +126,7 @@ export function fromNodes(...args: any[]): any;
  * @param methods Methods to add to the prototype
  * @param type Optional type to add the methods to
  */
-export function registerMethods(methods: object, type?: types.Type<any>): void;
+export function registerMethods<N extends Core.ASTNode>(methods: Record<string, Method<N>>, type?: types.Type<N>): void;
 
 export function hasConflictingRegistration(...args: any[]): any;
 

--- a/types/jscodeshift/src/core.d.ts
+++ b/types/jscodeshift/src/core.d.ts
@@ -22,7 +22,7 @@ declare namespace core {
     }
 
     interface Plugin {
-        (core: Core): void;
+        (jscodeshift: JSCodeshift): void;
     }
 
     interface FileInfo {

--- a/types/jscodeshift/test/jscodeshift-tests.ts
+++ b/types/jscodeshift/test/jscodeshift-tests.ts
@@ -1,4 +1,4 @@
-import { ASTNode, FileInfo, API, Transform, Parser, JSCodeshift, Collection, ImportDeclaration } from 'jscodeshift';
+import { ASTNode, FileInfo, API, Transform, Parser, Plugin, JSCodeshift, Collection, ImportDeclaration } from 'jscodeshift';
 import * as testUtils from 'jscodeshift/src/testUtils';
 import { run } from 'jscodeshift/src/Runner';
 
@@ -33,6 +33,28 @@ const parser: Parser = {
         // return estree compatible AST
         return { type: 'root' };
     },
+};
+
+// Can define a plugin.
+const plugin: Plugin = (jscodeshift) => {
+    // Adding a method to all Identifiers
+    jscodeshift.registerMethods({
+        logNames() {
+            return this.forEach((path) => {
+                // $ExpectType ASTPath<Identifier>
+                path;
+            });
+        }
+    }, jscodeshift.Identifier);
+
+    // Adding a method to all collections
+    jscodeshift.registerMethods({
+        findIdentifiers() {
+            // $ExpectType Collection<ASTNode>
+            this;
+            return this.find(jscodeshift.Identifier);
+        }
+    });
 };
 
 // Can pass options to recast
@@ -153,18 +175,18 @@ testUtils.runTest('dirname', 'transformName', {});
 
 // Can define an inline test with transform passed as module
 testUtils.defineInlineTest(
-    { default: () => {}, parser: 'babel' },
+    { default: () => { }, parser: 'babel' },
     { opt: true },
     "import test from 'test';",
     "import test from './test';",
 );
 
 // Can define an inline test with transform passed as function
-testUtils.defineInlineTest(() => {}, { opt: true }, "import test from 'test';", "import test from './test';");
+testUtils.defineInlineTest(() => { }, { opt: true }, "import test from 'test';", "import test from './test';");
 
 // Can run an inline test with transform passed as module
 testUtils.runInlineTest(
-    { default: () => {}, parser: 'babel' },
+    { default: () => { }, parser: 'babel' },
     { opt: true },
     { source: "import test from 'test';" },
     "import test from './test';",
@@ -173,7 +195,7 @@ testUtils.runInlineTest(
 
 // Can run an inline test with transform passed as function
 testUtils.runInlineTest(
-    () => {},
+    () => { },
     { opt: true },
     { source: "import test from 'test';" },
     "import test from './test';",


### PR DESCRIPTION
registerMethods infers the method's collection type from registerMethod's type-parameter

Plugin uses JSCodeshift. It was using Core-type before, which didn't contain the types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jscodeshift#examples
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
