### PR TITLE
Add a scheduled workflow to trigger the daily run of the mergebot

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,14 @@
+name: Daily Open PR sync
+
+on:
+  schedule:
+    - cron: "37 */6 * * *"
+
+jobs:
+  trigger_bot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'gh workflow run daily.yml -R DefinitelyTyped/dt-mergebot'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Scheduled workflows are automatically disabled for repositories without recent activity. So this scheduled workflow does not work well when configured in the dt-mergebot repository.
To keep things self-contained, this workflow only triggers a workflow in the dt-mergebot repository, where all the logic still lives.

Closes https://github.com/DefinitelyTyped/dt-mergebot/issues/452
Needs https://github.com/DefinitelyTyped/dt-mergebot/pull/457 to be merged first.