### PR TITLE
Fix issues in @vimeo/player types

### DIFF
--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -11,27 +11,27 @@
 
 declare namespace Vimeo {
     namespace Player {
-        type TrackKind = 'captions' | 'subtitles';
+        export type TrackKind = 'captions' | 'subtitles';
 
-        interface Error {
+        export interface Error {
             name: string;
             message: string;
             method: string;
         }
 
-        interface TimeEvent {
+        export interface TimeEvent {
             duration: number;
             percent: number;
             seconds: number;
         }
 
-        interface TextTrackChangeEvent {
+        export interface TextTrackChangeEvent {
             kind: TrackKind | null;
             label: string | null;
             language: string | null;
         }
 
-        interface VimeoChapter {
+        export interface VimeoChapter {
             startTime: number;
             title: string;
 
@@ -41,7 +41,7 @@ declare namespace Vimeo {
             index: number;
         }
 
-        interface Cue {
+        export interface Cue {
             /**
              * The `html` property contains the HTML that the Player renders for that cue.
              */
@@ -53,14 +53,14 @@ declare namespace Vimeo {
             text: string;
         }
 
-        interface CueChangeEvent {
+        export interface CueChangeEvent {
             cues: Cue[];
             kind: TrackKind;
             label: string;
             language: string;
         }
 
-        interface CuePointEvent {
+        export interface CuePointEvent {
             time: number;
 
             /**
@@ -70,49 +70,49 @@ declare namespace Vimeo {
             id: string;
         }
 
-        interface VolumeChangeEvent {
+        export interface VolumeChangeEvent {
             volume: number;
         }
 
-        interface PlaybackRateEvent {
+        export interface PlaybackRateEvent {
             playbackRate: number;
         }
 
-        interface LoadedEvent {
+        export interface LoadedEvent {
             id: number;
         }
 
-        interface DurationChangeEvent {
+        export interface DurationChangeEvent {
             duration: number;
         }
 
-        interface FullScreenChangeEvent {
+        export interface FullScreenChangeEvent {
             fullscreen: boolean;
         }
 
-        interface VimeoVideoQualityObject {
+        export interface VimeoVideoQualityObject {
             label: string;
             id: string;
             active: boolean;
         }
 
-        interface QualityChangeEvent {
+        export interface QualityChangeEvent {
             quality: VimeoVideoQuality;
         }
 
-        interface VimeoCameraProps {
+        export interface VimeoCameraProps {
             yaw: number;
             pitch: number;
             roll: number;
             fov: number;
         }
 
-        interface ResizeEvent {
+        export interface ResizeEvent {
             videoWidth: number;
             videoHeight: number;
         }
 
-        interface EventMap {
+        export interface EventMap {
             /**
              * Triggered when video playback is initiated.
              */
@@ -244,29 +244,29 @@ declare namespace Vimeo {
             leavepictureinpicture: never;
         }
 
-        type EventCallback<Data = any> = (data: Data) => any;
+        export type EventCallback<Data = any> = (data: Data) => any;
 
-        type VimeoTimeRange = [number, number];
-        type VimeoVideoQuality = 'auto' | '4K' | '2K' | '1080p' | '720p' | '540p' | '360p' | '240p';
+        export type VimeoTimeRange = [number, number];
+        export type VimeoVideoQuality = 'auto' | '4K' | '2K' | '1080p' | '720p' | '540p' | '360p' | '240p';
 
-        interface VimeoCuePoint {
+        export interface VimeoCuePoint {
             time: number;
             data: VimeoCuePointData;
             id: string;
         }
 
-        interface VimeoCuePointData {
+        export interface VimeoCuePointData {
             [key: string]: any;
         }
 
-        interface VimeoTextTrack {
+        export interface VimeoTextTrack {
             language: string;
             kind: TrackKind;
             label: string;
             mode?: string | undefined;
         }
 
-        interface Options {
+        export interface Options {
             id?: number | undefined;
             url?: string | undefined;
             autopause?: boolean | undefined;
@@ -294,14 +294,14 @@ declare namespace Vimeo {
             transparent?: boolean | undefined;
             width?: number | undefined;
         }
+
+        // This property doesn’t actually exist.
+        // It’s defined for backwards compatibility with older versions of the type definitions.
+        export { Player as default };
     }
 
     class Player {
         constructor(element: HTMLIFrameElement | HTMLElement | string, options?: Player.Options);
-
-        // This property doesn’t actually exist.
-        // It’s defined for backwards compatibility with older versions of the type definitions.
-        static default: typeof Player;
 
         on<EventName extends keyof Player.EventMap>(
             event: EventName,

--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -180,8 +180,8 @@ declare namespace Vimeo {
             volumechange: VolumeChangeEvent;
 
             /**
-             * Triggered when the playback rate of the video in the player changes. The ability to change rate can be disabled by the creator and the event will not fire for those videos. The new playback
-             * rate is returned with the event.
+             * Triggered when the playback rate of the video in the player changes. The ability to change rate can be disabled by the creator and the event will not fire for those videos. The new
+             * playback rate is returned with the event.
              */
             playbackratechange: PlaybackRateEvent;
 
@@ -196,8 +196,8 @@ declare namespace Vimeo {
             bufferend: never;
 
             /**
-             * Triggered when some kind of error is generated in the player. In general if you are using this API library, you should use `.catch()` on each method call instead of globally listening for
-             * error events.
+             * Triggered when some kind of error is generated in the player. In general if you are using this API library, you should use `.catch()` on each method call instead of globally listening
+             * for error events.
              *
              * If the error was generated from a method call, the name of that method will be included.
              */

--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -9,359 +9,363 @@
 //                 Michael Markey <https://github.com/mikeamarkey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace Player {
-    type TrackKind = 'captions' | 'subtitles';
+declare namespace Vimeo {
+    namespace Player {
+        type TrackKind = 'captions' | 'subtitles';
 
-    interface Error {
-        name: string;
-        message: string;
-        method: string;
+        interface Error {
+            name: string;
+            message: string;
+            method: string;
+        }
+
+        interface TimeEvent {
+            duration: number;
+            percent: number;
+            seconds: number;
+        }
+
+        interface TextTrackChangeEvent {
+            kind: TrackKind | null;
+            label: string | null;
+            language: string | null;
+        }
+
+        interface VimeoChapter {
+            startTime: number;
+            title: string;
+
+            /**
+             * The `index` property of each chapter is the place it holds in the order of all the chapters. It starts at 1.
+             */
+            index: number;
+        }
+
+        interface Cue {
+            /**
+             * The `html` property contains the HTML that the Player renders for that cue.
+             */
+            html: string;
+
+            /**
+             * The `text` property of each cue is the raw value parsed from the caption or subtitle file.
+             */
+            text: string;
+        }
+
+        interface CueChangeEvent {
+            cues: Cue[];
+            kind: TrackKind;
+            label: string;
+            language: string;
+        }
+
+        interface CuePointEvent {
+            time: number;
+
+            /**
+             * The `data` property will be the custom data provided in the `addCuePoint()` call, or an empty object if none was provided.
+             */
+            data: VimeoCuePointData;
+            id: string;
+        }
+
+        interface VolumeChangeEvent {
+            volume: number;
+        }
+
+        interface PlaybackRateEvent {
+            playbackRate: number;
+        }
+
+        interface LoadedEvent {
+            id: number;
+        }
+
+        interface DurationChangeEvent {
+            duration: number;
+        }
+
+        interface FullScreenChangeEvent {
+            fullscreen: boolean;
+        }
+
+        interface VimeoVideoQualityObject {
+            label: string;
+            id: string;
+            active: boolean;
+        }
+
+        interface QualityChangeEvent {
+            quality: VimeoVideoQuality;
+        }
+
+        interface VimeoCameraProps {
+            yaw: number;
+            pitch: number;
+            roll: number;
+            fov: number;
+        }
+
+        interface ResizeEvent {
+            videoWidth: number;
+            videoHeight: number;
+        }
+
+        interface EventMap {
+            /**
+             * Triggered when video playback is initiated.
+             */
+            play: TimeEvent;
+
+            /**
+             * Triggered when the video starts playing.
+             */
+            playing: TimeEvent;
+
+            /**
+             * Triggered when the video pauses.
+             */
+            pause: TimeEvent;
+
+            /**
+             * Triggered any time the video playback reaches the end. _Note_: when loop is turned on, the ended `event` will not fire.
+             */
+            ended: TimeEvent;
+
+            /**
+             * Triggered as the `currentTime` of the video updates. It generally fires every 250ms, but it may vary depending on the browser.
+             */
+            timeupdate: TimeEvent;
+
+            /**
+             * Triggered as the video is loaded. Reports back the amount of the video that has been buffered.
+             */
+            progress: TimeEvent;
+
+            /**
+             * Triggered when the player starts seeking to a specific time. A `timeupdate` event will also be fired at the same time.
+             */
+            seeking: TimeEvent;
+
+            /**
+             * Triggered when the player seeks to a specific time. A `timeupdate` event will also be fired at the same time.
+             */
+            seeked: TimeEvent;
+
+            /**
+             * Triggered when the active text track (captions/subtitles) changes. The values will be null if text tracks are turned off.
+             */
+            texttrackchange: TextTrackChangeEvent;
+
+            /**
+             * Triggered when the current chapter changes.
+             */
+            chapterchange: VimeoChapter;
+
+            /**
+             * Triggered when the active cue for the current text track changes. It also fires when the active text track changes. There may be multiple cues active.
+             */
+            cuechange: CueChangeEvent;
+
+            /**
+             * Triggered when the current time hits a registered cue point.
+             */
+            cuepoint: CuePointEvent;
+
+            /**
+             * Triggered when the volume in the player changes. Some devices do not support setting the volume of the video independently from the system volume, so this event will never fire on those
+             * devices.
+             */
+            volumechange: VolumeChangeEvent;
+
+            /**
+             * Triggered when the playback rate of the video in the player changes. The ability to change rate can be disabled by the creator and the event will not fire for those videos. The new playback
+             * rate is returned with the event.
+             */
+            playbackratechange: PlaybackRateEvent;
+
+            /**
+             * Triggered when buffering starts in the player. This is also triggered during preload and while seeking. There is no associated data with this event.
+             */
+            bufferstart: never;
+
+            /**
+             * Triggered when buffering ends in the player. This is also triggered at the end of preload and seeking. There is no associated data with this event.
+             */
+            bufferend: never;
+
+            /**
+             * Triggered when some kind of error is generated in the player. In general if you are using this API library, you should use `.catch()` on each method call instead of globally listening for
+             * error events.
+             *
+             * If the error was generated from a method call, the name of that method will be included.
+             */
+            error: Error;
+
+            /**
+             * Triggered when a new video is loaded in the player.
+             */
+            loaded: LoadedEvent;
+
+            /**
+             * Triggered when the duration attribute has been updated.
+             */
+            durationchange: DurationChangeEvent;
+
+            /**
+             * Triggered when the player enters or exits fullscreen.
+             */
+            fullscreenchange: FullScreenChangeEvent;
+
+            /**
+             * Triggered when the set quality changes.
+             */
+            qualitychange: QualityChangeEvent;
+
+            /**
+             * Triggered when any of the camera properties change for 360° videos.
+             */
+            camerachange: VimeoCameraProps;
+
+            /**
+             * Triggered when the intrinsic size of the media changes.
+             */
+            resize: ResizeEvent;
+
+            /**
+             * Triggered when the player enters picture-in-picture.
+             */
+            enterpictureinpicture: never;
+
+            /**
+             * Triggered when the player leaves picture-in-picture.
+             */
+            leavepictureinpicture: never;
+        }
+
+        type EventCallback<Data = any> = (data: Data) => any;
+
+        type VimeoTimeRange = [number, number];
+        type VimeoVideoQuality = 'auto' | '4K' | '2K' | '1080p' | '720p' | '540p' | '360p' | '240p';
+
+        interface VimeoCuePoint {
+            time: number;
+            data: VimeoCuePointData;
+            id: string;
+        }
+
+        interface VimeoCuePointData {
+            [key: string]: any;
+        }
+
+        interface VimeoTextTrack {
+            language: string;
+            kind: TrackKind;
+            label: string;
+            mode?: string | undefined;
+        }
+
+        interface Options {
+            id?: number | undefined;
+            url?: string | undefined;
+            autopause?: boolean | undefined;
+            autoplay?: boolean | undefined;
+            background?: boolean | undefined;
+            byline?: boolean | undefined;
+            color?: string | undefined;
+            controls?: boolean | undefined;
+            dnt?: boolean | undefined;
+            height?: number | undefined;
+            interactive_params?: string | undefined;
+            keyboard?: boolean | undefined;
+            loop?: boolean | undefined;
+            maxheight?: number | undefined;
+            maxwidth?: number | undefined;
+            muted?: boolean | undefined;
+            pip?: boolean | undefined;
+            playsinline?: boolean | undefined;
+            portrait?: boolean | undefined;
+            responsive?: boolean | undefined;
+            speed?: boolean | undefined;
+            quality?: VimeoVideoQuality | undefined;
+            texttrack?: string | undefined;
+            title?: boolean | undefined;
+            transparent?: boolean | undefined;
+            width?: number | undefined;
+        }
     }
 
-    interface TimeEvent {
-        duration: number;
-        percent: number;
-        seconds: number;
-    }
+    class Player {
+        constructor(element: HTMLIFrameElement | HTMLElement | string, options?: Player.Options);
 
-    interface TextTrackChangeEvent {
-        kind: TrackKind | null;
-        label: string | null;
-        language: string | null;
-    }
-
-    interface VimeoChapter {
-        startTime: number;
-        title: string;
-
-        /**
-         * The `index` property of each chapter is the place it holds in the order of all the chapters. It starts at 1.
-         */
-        index: number;
-    }
-
-    interface Cue {
-        /**
-         * The `html` property contains the HTML that the Player renders for that cue.
-         */
-        html: string;
-
-        /**
-         * The `text` property of each cue is the raw value parsed from the caption or subtitle file.
-         */
-        text: string;
-    }
-
-    interface CueChangeEvent {
-        cues: Cue[];
-        kind: TrackKind;
-        label: string;
-        language: string;
-    }
-
-    interface CuePointEvent {
-        time: number;
-
-        /**
-         * The `data` property will be the custom data provided in the `addCuePoint()` call, or an empty object if none was provided.
-         */
-        data: VimeoCuePointData;
-        id: string;
-    }
-
-    interface VolumeChangeEvent {
-        volume: number;
-    }
-
-    interface PlaybackRateEvent {
-        playbackRate: number;
-    }
-
-    interface LoadedEvent {
-        id: number;
-    }
-
-    interface DurationChangeEvent {
-        duration: number;
-    }
-
-    interface FullScreenChangeEvent {
-        fullscreen: boolean;
-    }
-
-    interface VimeoVideoQualityObject {
-        label: string;
-        id: string;
-        active: boolean;
-    }
-
-    interface QualityChangeEvent {
-        quality: VimeoVideoQuality;
-    }
-
-    interface VimeoCameraProps {
-        yaw: number;
-        pitch: number;
-        roll: number;
-        fov: number;
-    }
-
-    interface ResizeEvent {
-        videoWidth: number;
-        videoHeight: number;
-    }
-
-    interface EventMap {
-        /**
-         * Triggered when video playback is initiated.
-         */
-        play: TimeEvent;
-
-        /**
-         * Triggered when the video starts playing.
-         */
-        playing: TimeEvent;
-
-        /**
-         * Triggered when the video pauses.
-         */
-        pause: TimeEvent;
-
-        /**
-         * Triggered any time the video playback reaches the end. _Note_: when loop is turned on, the ended `event` will not fire.
-         */
-        ended: TimeEvent;
-
-        /**
-         * Triggered as the `currentTime` of the video updates. It generally fires every 250ms, but it may vary depending on the browser.
-         */
-        timeupdate: TimeEvent;
-
-        /**
-         * Triggered as the video is loaded. Reports back the amount of the video that has been buffered.
-         */
-        progress: TimeEvent;
-
-        /**
-         * Triggered when the player starts seeking to a specific time. A `timeupdate` event will also be fired at the same time.
-         */
-        seeking: TimeEvent;
-
-        /**
-         * Triggered when the player seeks to a specific time. A `timeupdate` event will also be fired at the same time.
-         */
-        seeked: TimeEvent;
-
-        /**
-         * Triggered when the active text track (captions/subtitles) changes. The values will be null if text tracks are turned off.
-         */
-        texttrackchange: TextTrackChangeEvent;
-
-        /**
-         * Triggered when the current chapter changes.
-         */
-        chapterchange: VimeoChapter;
-
-        /**
-         * Triggered when the active cue for the current text track changes. It also fires when the active text track changes. There may be multiple cues active.
-         */
-        cuechange: CueChangeEvent;
-
-        /**
-         * Triggered when the current time hits a registered cue point.
-         */
-        cuepoint: CuePointEvent;
-
-        /**
-         * Triggered when the volume in the player changes. Some devices do not support setting the volume of the video independently from the system volume, so this event will never fire on those
-         * devices.
-         */
-        volumechange: VolumeChangeEvent;
-
-        /**
-         * Triggered when the playback rate of the video in the player changes. The ability to change rate can be disabled by the creator and the event will not fire for those videos. The new playback
-         * rate is returned with the event.
-         */
-        playbackratechange: PlaybackRateEvent;
-
-        /**
-         * Triggered when buffering starts in the player. This is also triggered during preload and while seeking. There is no associated data with this event.
-         */
-        bufferstart: never;
-
-        /**
-         * Triggered when buffering ends in the player. This is also triggered at the end of preload and seeking. There is no associated data with this event.
-         */
-        bufferend: never;
-
-        /**
-         * Triggered when some kind of error is generated in the player. In general if you are using this API library, you should use `.catch()` on each method call instead of globally listening for
-         * error events.
-         *
-         * If the error was generated from a method call, the name of that method will be included.
-         */
-        error: Error;
-
-        /**
-         * Triggered when a new video is loaded in the player.
-         */
-        loaded: LoadedEvent;
-
-        /**
-         * Triggered when the duration attribute has been updated.
-         */
-        durationchange: DurationChangeEvent;
-
-        /**
-         * Triggered when the player enters or exits fullscreen.
-         */
-        fullscreenchange: FullScreenChangeEvent;
-
-        /**
-         * Triggered when the set quality changes.
-         */
-        qualitychange: QualityChangeEvent;
-
-        /**
-         * Triggered when any of the camera properties change for 360° videos.
-         */
-        camerachange: VimeoCameraProps;
-
-        /**
-         * Triggered when the intrinsic size of the media changes.
-         */
-        resize: ResizeEvent;
-
-        /**
-         * Triggered when the player enters picture-in-picture.
-         */
-        enterpictureinpicture: never;
-
-        /**
-         * Triggered when the player leaves picture-in-picture.
-         */
-        leavepictureinpicture: never;
-    }
-
-    type EventCallback<Data = any> = (data: Data) => any;
-
-    type VimeoTimeRange = [number, number];
-    type VimeoVideoQuality = 'auto' | '4K' | '2K' | '1080p' | '720p' | '540p' | '360p' | '240p';
-
-    interface VimeoCuePoint {
-        time: number;
-        data: VimeoCuePointData;
-        id: string;
-    }
-
-    interface VimeoCuePointData {
-        [key: string]: any;
-    }
-
-    interface VimeoTextTrack {
-        language: string;
-        kind: TrackKind;
-        label: string;
-        mode?: string | undefined;
-    }
-
-    interface Options {
-        id?: number | undefined;
-        url?: string | undefined;
-        autopause?: boolean | undefined;
-        autoplay?: boolean | undefined;
-        background?: boolean | undefined;
-        byline?: boolean | undefined;
-        color?: string | undefined;
-        controls?: boolean | undefined;
-        dnt?: boolean | undefined;
-        height?: number | undefined;
-        interactive_params?: string | undefined;
-        keyboard?: boolean | undefined;
-        loop?: boolean | undefined;
-        maxheight?: number | undefined;
-        maxwidth?: number | undefined;
-        muted?: boolean | undefined;
-        pip?: boolean | undefined;
-        playsinline?: boolean | undefined;
-        portrait?: boolean | undefined;
-        responsive?: boolean | undefined;
-        speed?: boolean | undefined;
-        quality?: VimeoVideoQuality | undefined;
-        texttrack?: string | undefined;
-        title?: boolean | undefined;
-        transparent?: boolean | undefined;
-        width?: number | undefined;
+        on<EventName extends keyof Player.EventMap>(
+            event: EventName,
+            callback: Player.EventCallback<Player.EventMap[EventName]>,
+        ): void;
+        on(event: string, callback: Player.EventCallback): void;
+        off<EventName extends keyof Player.EventMap>(
+            event: EventName,
+            callback: Player.EventCallback<Player.EventMap[EventName]>,
+        ): void;
+        off(event: string, callback?: Player.EventCallback): void;
+        loadVideo(id: number): Promise<number>;
+        loadVideo(url: string): Promise<string>;
+        loadVideo(options: Player.Options): Promise<{ [prop: string]: any }>;
+        ready(): Promise<void>;
+        enableTextTrack(language: string, kind?: Player.TrackKind): Promise<Player.VimeoTextTrack>;
+        disableTextTrack(): Promise<void>;
+        pause(): Promise<void>;
+        play(): Promise<void>;
+        unload(): Promise<void>;
+        requestFullscreen(): Promise<void>;
+        exitFullscreen(): Promise<void>;
+        getFullscreen(): Promise<boolean>;
+        requestPictureInPicture(): Promise<void>;
+        exitPictureInPicture(): Promise<void>;
+        getPictureInPicture(): Promise<boolean>;
+        getAutopause(): Promise<boolean>;
+        setAutopause(autopause: boolean): Promise<boolean>;
+        getColor(): Promise<string>;
+        setColor(color: string): Promise<string>;
+        getChapters(): Promise<Player.VimeoChapter[]>;
+        getCurrentChapter(): Promise<Player.VimeoChapter>;
+        addCuePoint(time: number, data: Player.VimeoCuePointData): Promise<string>;
+        removeCuePoint(id: string): Promise<string>;
+        getCuePoints(): Promise<Player.VimeoCuePoint[]>;
+        getBuffered(): Promise<Player.VimeoTimeRange[]>;
+        getCurrentTime(): Promise<number>;
+        setCurrentTime(seconds: number): Promise<number>;
+        getDuration(): Promise<number>;
+        getEnded(): Promise<boolean>;
+        getLoop(): Promise<boolean>;
+        setLoop(loop: boolean): Promise<boolean>;
+        getMuted(): Promise<boolean>;
+        setMuted(muted: boolean): Promise<boolean>;
+        getPaused(): Promise<boolean>;
+        getPlayed(): Promise<Player.VimeoTimeRange[]>;
+        getSeekable(): Promise<Player.VimeoTimeRange[]>;
+        getSeeking(): Promise<boolean>;
+        getPlaybackRate(): Promise<number>;
+        setPlaybackRate(playbackRate: number): Promise<number>;
+        getTextTracks(): Promise<Player.VimeoTextTrack[]>;
+        getVideoEmbedCode(): Promise<string>;
+        getVideoId(): Promise<number>;
+        getVideoTitle(): Promise<string>;
+        getVideoWidth(): Promise<number>;
+        getVideoHeight(): Promise<number>;
+        getVideoUrl(): Promise<string>;
+        getVolume(): Promise<number>;
+        setVolume(volume: number): Promise<number>;
+        getQualities(): Promise<Player.VimeoVideoQualityObject[]>;
+        getQuality(): Promise<Player.VimeoVideoQuality>;
+        setQuality(quality: Player.VimeoVideoQuality): Promise<Player.VimeoVideoQuality>;
+        getCameraProps(): Promise<Player.VimeoCameraProps>;
+        setCameraProps(cameraProps: Player.VimeoCameraProps): Promise<Player.VimeoCameraProps>;
+        destroy(): Promise<void>;
     }
 }
 
-declare class Player {
-    constructor(element: HTMLIFrameElement | HTMLElement | string, options?: Player.Options);
+export as namespace Vimeo;
 
-    on<EventName extends keyof Player.EventMap>(
-        event: EventName,
-        callback: Player.EventCallback<Player.EventMap[EventName]>,
-    ): void;
-    on(event: string, callback: Player.EventCallback): void;
-    off<EventName extends keyof Player.EventMap>(
-        event: EventName,
-        callback: Player.EventCallback<Player.EventMap[EventName]>,
-    ): void;
-    off(event: string, callback?: Player.EventCallback): void;
-    loadVideo(id: number): Promise<number>;
-    loadVideo(url: string): Promise<string>;
-    loadVideo(options: Player.Options): Promise<{ [prop: string]: any }>;
-    ready(): Promise<void>;
-    enableTextTrack(language: string, kind?: Player.TrackKind): Promise<Player.VimeoTextTrack>;
-    disableTextTrack(): Promise<void>;
-    pause(): Promise<void>;
-    play(): Promise<void>;
-    unload(): Promise<void>;
-    requestFullscreen(): Promise<void>;
-    exitFullscreen(): Promise<void>;
-    getFullscreen(): Promise<boolean>;
-    requestPictureInPicture(): Promise<void>;
-    exitPictureInPicture(): Promise<void>;
-    getPictureInPicture(): Promise<boolean>;
-    getAutopause(): Promise<boolean>;
-    setAutopause(autopause: boolean): Promise<boolean>;
-    getColor(): Promise<string>;
-    setColor(color: string): Promise<string>;
-    getChapters(): Promise<Player.VimeoChapter[]>;
-    getCurrentChapter(): Promise<Player.VimeoChapter>;
-    addCuePoint(time: number, data: Player.VimeoCuePointData): Promise<string>;
-    removeCuePoint(id: string): Promise<string>;
-    getCuePoints(): Promise<Player.VimeoCuePoint[]>;
-    getBuffered(): Promise<Player.VimeoTimeRange[]>;
-    getCurrentTime(): Promise<number>;
-    setCurrentTime(seconds: number): Promise<number>;
-    getDuration(): Promise<number>;
-    getEnded(): Promise<boolean>;
-    getLoop(): Promise<boolean>;
-    setLoop(loop: boolean): Promise<boolean>;
-    getMuted(): Promise<boolean>;
-    setMuted(muted: boolean): Promise<boolean>;
-    getPaused(): Promise<boolean>;
-    getPlayed(): Promise<Player.VimeoTimeRange[]>;
-    getSeekable(): Promise<Player.VimeoTimeRange[]>;
-    getSeeking(): Promise<boolean>;
-    getPlaybackRate(): Promise<number>;
-    setPlaybackRate(playbackRate: number): Promise<number>;
-    getTextTracks(): Promise<Player.VimeoTextTrack[]>;
-    getVideoEmbedCode(): Promise<string>;
-    getVideoId(): Promise<number>;
-    getVideoTitle(): Promise<string>;
-    getVideoWidth(): Promise<number>;
-    getVideoHeight(): Promise<number>;
-    getVideoUrl(): Promise<string>;
-    getVolume(): Promise<number>;
-    setVolume(volume: number): Promise<number>;
-    getQualities(): Promise<Player.VimeoVideoQualityObject[]>;
-    getQuality(): Promise<Player.VimeoVideoQuality>;
-    setQuality(quality: Player.VimeoVideoQuality): Promise<Player.VimeoVideoQuality>;
-    getCameraProps(): Promise<Player.VimeoCameraProps>;
-    setCameraProps(cameraProps: Player.VimeoCameraProps): Promise<Player.VimeoCameraProps>;
-    destroy(): Promise<void>;
-}
-
-export = Player;
+export = Vimeo.Player;

--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @vimeo/player 2.16.4
+// Type definitions for @vimeo/player 2.18
 // Project: https://github.com/vimeo/player.js
 // Definitions by: Denis Yılmaz <https://github.com/denisyilmaz>
 //                 Felix Albert <f.albert.work@icloud.com>
@@ -9,409 +9,359 @@
 //                 Michael Markey <https://github.com/mikeamarkey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export type TrackKind = 'captions' | 'subtitles';
+declare namespace Player {
+    type TrackKind = 'captions' | 'subtitles';
 
-export type CallbackFunction = (...args: any[]) => any;
+    interface Error {
+        name: string;
+        message: string;
+        method: string;
+    }
 
-export interface Error {
-    name: string;
-    message: string;
-    method: string;
+    interface TimeEvent {
+        duration: number;
+        percent: number;
+        seconds: number;
+    }
+
+    interface TextTrackChangeEvent {
+        kind: TrackKind | null;
+        label: string | null;
+        language: string | null;
+    }
+
+    interface VimeoChapter {
+        startTime: number;
+        title: string;
+
+        /**
+         * The `index` property of each chapter is the place it holds in the order of all the chapters. It starts at 1.
+         */
+        index: number;
+    }
+
+    interface Cue {
+        /**
+         * The `html` property contains the HTML that the Player renders for that cue.
+         */
+        html: string;
+
+        /**
+         * The `text` property of each cue is the raw value parsed from the caption or subtitle file.
+         */
+        text: string;
+    }
+
+    interface CueChangeEvent {
+        cues: Cue[];
+        kind: TrackKind;
+        label: string;
+        language: string;
+    }
+
+    interface CuePointEvent {
+        time: number;
+
+        /**
+         * The `data` property will be the custom data provided in the `addCuePoint()` call, or an empty object if none was provided.
+         */
+        data: VimeoCuePointData;
+        id: string;
+    }
+
+    interface VolumeChangeEvent {
+        volume: number;
+    }
+
+    interface PlaybackRateEvent {
+        playbackRate: number;
+    }
+
+    interface LoadedEvent {
+        id: number;
+    }
+
+    interface DurationChangeEvent {
+        duration: number;
+    }
+
+    interface FullScreenChangeEvent {
+        fullscreen: boolean;
+    }
+
+    interface VimeoVideoQualityObject {
+        label: string;
+        id: string;
+        active: boolean;
+    }
+
+    interface QualityChangeEvent {
+        quality: VimeoVideoQuality;
+    }
+
+    interface VimeoCameraProps {
+        yaw: number;
+        pitch: number;
+        roll: number;
+        fov: number;
+    }
+
+    interface ResizeEvent {
+        videoWidth: number;
+        videoHeight: number;
+    }
+
+    interface EventMap {
+        /**
+         * Triggered when video playback is initiated.
+         */
+        play: TimeEvent;
+
+        /**
+         * Triggered when the video starts playing.
+         */
+        playing: TimeEvent;
+
+        /**
+         * Triggered when the video pauses.
+         */
+        pause: TimeEvent;
+
+        /**
+         * Triggered any time the video playback reaches the end. _Note_: when loop is turned on, the ended `event` will not fire.
+         */
+        ended: TimeEvent;
+
+        /**
+         * Triggered as the `currentTime` of the video updates. It generally fires every 250ms, but it may vary depending on the browser.
+         */
+        timeupdate: TimeEvent;
+
+        /**
+         * Triggered as the video is loaded. Reports back the amount of the video that has been buffered.
+         */
+        progress: TimeEvent;
+
+        /**
+         * Triggered when the player starts seeking to a specific time. A `timeupdate` event will also be fired at the same time.
+         */
+        seeking: TimeEvent;
+
+        /**
+         * Triggered when the player seeks to a specific time. A `timeupdate` event will also be fired at the same time.
+         */
+        seeked: TimeEvent;
+
+        /**
+         * Triggered when the active text track (captions/subtitles) changes. The values will be null if text tracks are turned off.
+         */
+        texttrackchange: TextTrackChangeEvent;
+
+        /**
+         * Triggered when the current chapter changes.
+         */
+        chapterchange: VimeoChapter;
+
+        /**
+         * Triggered when the active cue for the current text track changes. It also fires when the active text track changes. There may be multiple cues active.
+         */
+        cuechange: CueChangeEvent;
+
+        /**
+         * Triggered when the current time hits a registered cue point.
+         */
+        cuepoint: CuePointEvent;
+
+        /**
+         * Triggered when the volume in the player changes. Some devices do not support setting the volume of the video independently from the system volume, so this event will never fire on those
+         * devices.
+         */
+        volumechange: VolumeChangeEvent;
+
+        /**
+         * Triggered when the playback rate of the video in the player changes. The ability to change rate can be disabled by the creator and the event will not fire for those videos. The new playback
+         * rate is returned with the event.
+         */
+        playbackratechange: PlaybackRateEvent;
+
+        /**
+         * Triggered when buffering starts in the player. This is also triggered during preload and while seeking. There is no associated data with this event.
+         */
+        bufferstart: never;
+
+        /**
+         * Triggered when buffering ends in the player. This is also triggered at the end of preload and seeking. There is no associated data with this event.
+         */
+        bufferend: never;
+
+        /**
+         * Triggered when some kind of error is generated in the player. In general if you are using this API library, you should use `.catch()` on each method call instead of globally listening for
+         * error events.
+         *
+         * If the error was generated from a method call, the name of that method will be included.
+         */
+        error: Error;
+
+        /**
+         * Triggered when a new video is loaded in the player.
+         */
+        loaded: LoadedEvent;
+
+        /**
+         * Triggered when the duration attribute has been updated.
+         */
+        durationchange: DurationChangeEvent;
+
+        /**
+         * Triggered when the player enters or exits fullscreen.
+         */
+        fullscreenchange: FullScreenChangeEvent;
+
+        /**
+         * Triggered when the set quality changes.
+         */
+        qualitychange: QualityChangeEvent;
+
+        /**
+         * Triggered when any of the camera properties change for 360° videos.
+         */
+        camerachange: VimeoCameraProps;
+
+        /**
+         * Triggered when the intrinsic size of the media changes.
+         */
+        resize: ResizeEvent;
+
+        /**
+         * Triggered when the player enters picture-in-picture.
+         */
+        enterpictureinpicture: never;
+
+        /**
+         * Triggered when the player leaves picture-in-picture.
+         */
+        leavepictureinpicture: never;
+    }
+
+    type EventCallback<Data = any> = (data: Data) => any;
+
+    type VimeoTimeRange = [number, number];
+    type VimeoVideoQuality = 'auto' | '4K' | '2K' | '1080p' | '720p' | '540p' | '360p' | '240p';
+
+    interface VimeoCuePoint {
+        time: number;
+        data: VimeoCuePointData;
+        id: string;
+    }
+
+    interface VimeoCuePointData {
+        [key: string]: any;
+    }
+
+    interface VimeoTextTrack {
+        language: string;
+        kind: TrackKind;
+        label: string;
+        mode?: string | undefined;
+    }
+
+    interface Options {
+        id?: number | undefined;
+        url?: string | undefined;
+        autopause?: boolean | undefined;
+        autoplay?: boolean | undefined;
+        background?: boolean | undefined;
+        byline?: boolean | undefined;
+        color?: string | undefined;
+        controls?: boolean | undefined;
+        dnt?: boolean | undefined;
+        height?: number | undefined;
+        interactive_params?: string | undefined;
+        keyboard?: boolean | undefined;
+        loop?: boolean | undefined;
+        maxheight?: number | undefined;
+        maxwidth?: number | undefined;
+        muted?: boolean | undefined;
+        pip?: boolean | undefined;
+        playsinline?: boolean | undefined;
+        portrait?: boolean | undefined;
+        responsive?: boolean | undefined;
+        speed?: boolean | undefined;
+        quality?: VimeoVideoQuality | undefined;
+        texttrack?: string | undefined;
+        title?: boolean | undefined;
+        transparent?: boolean | undefined;
+        width?: number | undefined;
+    }
 }
 
-export interface PasswordError extends Error {
-    name: 'PasswordError';
-    message: string;
-    method: string;
-}
-export interface PrivacyError extends Error {
-    name: 'PrivacyError';
-    message: string;
-    method: string;
-}
-export interface InvalidTrackLanguageError extends Error {
-    name: 'InvalidTrackLanguageError';
-    message: string;
-    method: string;
-}
-export interface InvalidTrackError extends Error {
-    name: 'InvalidTrackError';
-    message: string;
-    method: string;
-}
-export interface UnsupportedError extends Error {
-    name: 'UnsupportedError';
-    message: string;
-    method: string;
-}
-export interface ContrastError extends Error {
-    name: 'ContrastError';
-    message: string;
-    method: string;
-}
-export interface InvalidCuePoint extends Error {
-    name: 'InvalidCuePoint';
-    message: string;
-    method: string;
-}
-export interface RangeError extends Error {
-    name: 'RangeError';
-    message: string;
-    method: string;
-}
-export interface TypeError extends Error {
-    name: 'TypeError';
-    message: string;
-    method: string;
-}
+declare class Player {
+    constructor(element: HTMLIFrameElement | HTMLElement | string, options?: Player.Options);
 
-export interface TimeEvent {
-    duration: number;
-    percent: number;
-    seconds: number;
-}
-
-export interface TextTrackChangeEvent {
-    kind: TrackKind | null;
-    label: string | null;
-    language: string | null;
-}
-
-export interface VimeoChapter {
-    startTime: number;
-    title: string;
-
-    /**
-     * The `index` property of each chapter is the place it holds in the order of all the chapters. It starts at 1.
-     */
-    index: number;
-}
-
-export interface Cue {
-    /**
-     * The `html` property contains the HTML that the Player renders for that cue.
-     */
-    html: string;
-
-    /**
-     * The `text` property of each cue is the raw value parsed from the caption or subtitle file.
-     */
-    text: string;
+    on<EventName extends keyof Player.EventMap>(
+        event: EventName,
+        callback: Player.EventCallback<Player.EventMap[EventName]>,
+    ): void;
+    on(event: string, callback: Player.EventCallback): void;
+    off<EventName extends keyof Player.EventMap>(
+        event: EventName,
+        callback: Player.EventCallback<Player.EventMap[EventName]>,
+    ): void;
+    off(event: string, callback?: Player.EventCallback): void;
+    loadVideo(id: number): Promise<number>;
+    loadVideo(url: string): Promise<string>;
+    loadVideo(options: Player.Options): Promise<{ [prop: string]: any }>;
+    ready(): Promise<void>;
+    enableTextTrack(language: string, kind?: Player.TrackKind): Promise<Player.VimeoTextTrack>;
+    disableTextTrack(): Promise<void>;
+    pause(): Promise<void>;
+    play(): Promise<void>;
+    unload(): Promise<void>;
+    requestFullscreen(): Promise<void>;
+    exitFullscreen(): Promise<void>;
+    getFullscreen(): Promise<boolean>;
+    requestPictureInPicture(): Promise<void>;
+    exitPictureInPicture(): Promise<void>;
+    getPictureInPicture(): Promise<boolean>;
+    getAutopause(): Promise<boolean>;
+    setAutopause(autopause: boolean): Promise<boolean>;
+    getColor(): Promise<string>;
+    setColor(color: string): Promise<string>;
+    getChapters(): Promise<Player.VimeoChapter[]>;
+    getCurrentChapter(): Promise<Player.VimeoChapter>;
+    addCuePoint(time: number, data: Player.VimeoCuePointData): Promise<string>;
+    removeCuePoint(id: string): Promise<string>;
+    getCuePoints(): Promise<Player.VimeoCuePoint[]>;
+    getBuffered(): Promise<Player.VimeoTimeRange[]>;
+    getCurrentTime(): Promise<number>;
+    setCurrentTime(seconds: number): Promise<number>;
+    getDuration(): Promise<number>;
+    getEnded(): Promise<boolean>;
+    getLoop(): Promise<boolean>;
+    setLoop(loop: boolean): Promise<boolean>;
+    getMuted(): Promise<boolean>;
+    setMuted(muted: boolean): Promise<boolean>;
+    getPaused(): Promise<boolean>;
+    getPlayed(): Promise<Player.VimeoTimeRange[]>;
+    getSeekable(): Promise<Player.VimeoTimeRange[]>;
+    getSeeking(): Promise<boolean>;
+    getPlaybackRate(): Promise<number>;
+    setPlaybackRate(playbackRate: number): Promise<number>;
+    getTextTracks(): Promise<Player.VimeoTextTrack[]>;
+    getVideoEmbedCode(): Promise<string>;
+    getVideoId(): Promise<number>;
+    getVideoTitle(): Promise<string>;
+    getVideoWidth(): Promise<number>;
+    getVideoHeight(): Promise<number>;
+    getVideoUrl(): Promise<string>;
+    getVolume(): Promise<number>;
+    setVolume(volume: number): Promise<number>;
+    getQualities(): Promise<Player.VimeoVideoQualityObject[]>;
+    getQuality(): Promise<Player.VimeoVideoQuality>;
+    setQuality(quality: Player.VimeoVideoQuality): Promise<Player.VimeoVideoQuality>;
+    getCameraProps(): Promise<Player.VimeoCameraProps>;
+    setCameraProps(cameraProps: Player.VimeoCameraProps): Promise<Player.VimeoCameraProps>;
+    destroy(): Promise<void>;
 }
 
-export interface CueChangeEvent {
-    cues: Cue[];
-    kind: TrackKind;
-    label: string;
-    language: string;
-}
-
-export interface CuePointEvent {
-    time: number;
-
-    /**
-     * The `data` property will be the custom data provided in the `addCuePoint()` call, or an empty object if none was provided.
-     */
-    data: VimeoCuePointData;
-    id: string;
-}
-
-export interface VolumeChangeEvent {
-    volume: number;
-}
-
-export interface PlaybackRateEvent {
-    playbackRate: number;
-}
-
-export interface LoadedEvent {
-    id: number;
-}
-
-export interface DurationChangeEvent {
-    duration: number;
-}
-
-export interface FullScreenChangeEvent {
-    fullscreen: boolean;
-}
-
-export interface VimeoVideoQualityObject {
-    label: string;
-    id: string;
-    active: boolean;
-}
-
-export interface QualityChangeEvent {
-    quality: VimeoVideoQuality;
-}
-
-export interface VimeoCameraProps {
-    yaw: number;
-    pitch: number;
-    roll: number;
-    fov: number;
-}
-
-export interface ResizeEvent {
-    videoWidth: number;
-    videoHeight: number;
-}
-
-export interface EventMap {
-    /**
-     * Triggered when video playback is initiated.
-     */
-    play: TimeEvent;
-
-    /**
-     * Triggered when the video starts playing.
-     */
-    playing: TimeEvent;
-
-    /**
-     * Triggered when the video pauses.
-     */
-    pause: TimeEvent;
-
-    /**
-     * Triggered any time the video playback reaches the end. _Note_: when loop is turned on, the ended `event` will not fire.
-     */
-    ended: TimeEvent;
-
-    /**
-     * Triggered as the `currentTime` of the video updates. It generally fires every 250ms, but it may vary depending on the browser.
-     */
-    timeupdate: TimeEvent;
-
-    /**
-     * Triggered as the video is loaded. Reports back the amount of the video that has been buffered.
-     */
-    progress: TimeEvent;
-
-    /**
-     * Triggered when the player starts seeking to a specific time. A `timeupdate` event will also be fired at the same time.
-     */
-    seeking: TimeEvent;
-
-    /**
-     * Triggered when the player seeks to a specific time. A `timeupdate` event will also be fired at the same time.
-     */
-    seeked: TimeEvent;
-
-    /**
-     * Triggered when the active text track (captions/subtitles) changes. The values will be null if text tracks are turned off.
-     */
-    texttrackchange: TextTrackChangeEvent;
-
-    /**
-     * Triggered when the current chapter changes.
-     */
-    chapterchange: VimeoChapter;
-
-    /**
-     * Triggered when the active cue for the current text track changes. It also fires when the active text track changes. There may be multiple cues active.
-     */
-    cuechange: CueChangeEvent;
-
-    /**
-     * Triggered when the current time hits a registered cue point.
-     */
-    cuepoint: CuePointEvent;
-
-    /**
-     * Triggered when the volume in the player changes. Some devices do not support setting the volume of the video independently from the system volume, so this event will never fire on those
-     * devices.
-     */
-    volumechange: VolumeChangeEvent;
-
-    /**
-     * Triggered when the playback rate of the video in the player changes. The ability to change rate can be disabled by the creator and the event will not fire for those videos. The new playback
-     * rate is returned with the event.
-     */
-    playbackratechange: PlaybackRateEvent;
-
-    /**
-     * Triggered when buffering starts in the player. This is also triggered during preload and while seeking. There is no associated data with this event.
-     */
-    bufferstart: never;
-
-    /**
-     * Triggered when buffering ends in the player. This is also triggered at the end of preload and seeking. There is no associated data with this event.
-     */
-    bufferend: never;
-
-    /**
-     * Triggered when some kind of error is generated in the player. In general if you are using this API library, you should use `.catch()` on each method call instead of globally listening for
-     * error events.
-     *
-     * If the error was generated from a method call, the name of that method will be included.
-     */
-    error: Error;
-
-    /**
-     * Triggered when a new video is loaded in the player.
-     */
-    loaded: LoadedEvent;
-
-    /**
-     * Triggered when the duration attribute has been updated.
-     */
-    durationchange: DurationChangeEvent;
-
-    /**
-     * Triggered when the player enters or exits fullscreen.
-     */
-    fullscreenchange: FullScreenChangeEvent;
-
-    /**
-     * Triggered when the set quality changes.
-     */
-    qualitychange: QualityChangeEvent;
-
-    /**
-     * Triggered when any of the camera properties change for 360° videos.
-     */
-    camerachange: VimeoCameraProps;
-
-    /**
-     * Triggered when the intrinsic size of the media changes.
-     */
-    resize: ResizeEvent;
-
-    /**
-     * Triggered when the player enters picture-in-picture.
-     */
-    enterpictureinpicture: never;
-
-    /**
-     * Triggered when the player leaves picture-in-picture.
-     */
-    leavepictureinpicture: never;
-}
-
-export type EventCallback<Data = any> = (data: Data) => any;
-
-export type VimeoTimeRange = [number, number];
-export type VimeoVideoQuality = 'auto' | '4K' | '2K' | '1080p' | '720p' | '540p' | '360p' | '240p';
-
-export class Player {
-    constructor(element: HTMLIFrameElement | HTMLElement | string, options?: Options);
-
-    on<EventName extends keyof EventMap>(event: EventName, callback: EventCallback<EventMap[EventName]>): void;
-    on(event: string, callback: EventCallback): void;
-    off<EventName extends keyof EventMap>(event: EventName, callback: EventCallback<EventMap[EventName]>): void;
-    off(event: string, callback?: EventCallback): void;
-    loadVideo(id: number): VimeoPromise<number, TypeError | PasswordError | PrivacyError | Error>;
-    loadVideo(url: string): VimeoPromise<string, TypeError | PasswordError | PrivacyError | Error>;
-    loadVideo(
-        options: Options,
-    ): VimeoPromise<{ [prop: string]: any }, TypeError | PasswordError | PrivacyError | Error>;
-    ready(): VimeoPromise<void, Error>;
-    enableTextTrack(
-        language: string,
-        kind?: TrackKind,
-    ): VimeoPromise<VimeoTextTrack, InvalidTrackLanguageError | InvalidTrackError | Error>;
-    disableTextTrack(): VimeoPromise<void, Error>;
-    pause(): VimeoPromise<void, PasswordError | PrivacyError | Error>;
-    play(): VimeoPromise<void, PasswordError | PrivacyError | Error>;
-    unload(): VimeoPromise<void, Error>;
-    requestFullscreen(): VimeoPromise<void, Error>;
-    exitFullscreen(): VimeoPromise<void, Error>;
-    getFullscreen(): VimeoPromise<boolean, Error>;
-    requestPictureInPicture(): VimeoPromise<void, Error>;
-    exitPictureInPicture(): VimeoPromise<void, Error>;
-    getPictureInPicture(): VimeoPromise<boolean, Error>;
-    getAutopause(): VimeoPromise<boolean, UnsupportedError | Error>;
-    setAutopause(autopause: boolean): VimeoPromise<boolean, UnsupportedError | Error>;
-    getColor(): VimeoPromise<string, Error>;
-    setColor(color: string): VimeoPromise<string, ContrastError | TypeError | Error>;
-    getChapters(): VimeoPromise<VimeoChapter[], Error>;
-    getCurrentChapter(): VimeoPromise<VimeoChapter, Error>;
-    addCuePoint(time: number, data: VimeoCuePointData): VimeoPromise<string, UnsupportedError | RangeError | Error>;
-    removeCuePoint(id: string): VimeoPromise<string, UnsupportedError | InvalidCuePoint | Error>;
-    getCuePoints(): VimeoPromise<VimeoCuePoint[], UnsupportedError | Error>;
-    getBuffered(): VimeoPromise<VimeoTimeRange[], Error>;
-    getCurrentTime(): VimeoPromise<number, Error>;
-    setCurrentTime(seconds: number): VimeoPromise<number, RangeError | Error>;
-    getDuration(): VimeoPromise<number, Error>;
-    getEnded(): VimeoPromise<boolean, Error>;
-    getLoop(): VimeoPromise<boolean, Error>;
-    setLoop(loop: boolean): VimeoPromise<boolean, Error>;
-    getMuted(): VimeoPromise<boolean, Error>;
-    setMuted(muted: boolean): VimeoPromise<boolean, Error>;
-    getPaused(): VimeoPromise<boolean, Error>;
-    getPlayed(): VimeoPromise<VimeoTimeRange[], Error>;
-    getSeekable(): VimeoPromise<VimeoTimeRange[], Error>;
-    getSeeking(): VimeoPromise<boolean, Error>;
-    getPlaybackRate(): VimeoPromise<number, Error>;
-    setPlaybackRate(playbackRate: number): VimeoPromise<number, RangeError | Error>;
-    getTextTracks(): VimeoPromise<VimeoTextTrack[], Error>;
-    getVideoEmbedCode(): VimeoPromise<string, Error>;
-    getVideoId(): VimeoPromise<number, Error>;
-    getVideoTitle(): VimeoPromise<string, Error>;
-    getVideoWidth(): VimeoPromise<number, Error>;
-    getVideoHeight(): VimeoPromise<number, Error>;
-    getVideoUrl(): VimeoPromise<string, PrivacyError | Error>;
-    getVolume(): VimeoPromise<number, Error>;
-    setVolume(volume: number): VimeoPromise<number, RangeError | Error>;
-    getQualities(): VimeoPromise<VimeoVideoQualityObject[], Error>;
-    getQuality(): VimeoPromise<VimeoVideoQuality, Error>;
-    setQuality(quality: VimeoVideoQuality): VimeoPromise<VimeoVideoQuality, TypeError | Error>;
-    getCameraProps(): VimeoPromise<VimeoCameraProps, Error>;
-    setCameraProps(cameraProps: VimeoCameraProps): VimeoPromise<VimeoCameraProps, RangeError | Error>;
-    destroy(): VimeoPromise<void, Error>;
-}
-
-export interface VimeoCuePoint {
-    time: number;
-    data: VimeoCuePointData;
-    id: string;
-}
-
-export interface VimeoCuePointData {
-    [key: string]: any;
-}
-
-export interface VimeoTextTrack {
-    language: string;
-    kind: TrackKind;
-    label: string;
-    mode?: string | undefined;
-}
-
-export interface Options {
-    id?: number | undefined;
-    url?: string | undefined;
-    autopause?: boolean | undefined;
-    autoplay?: boolean | undefined;
-    background?: boolean | undefined;
-    byline?: boolean | undefined;
-    color?: string | undefined;
-    controls?: boolean | undefined;
-    dnt?: boolean | undefined;
-    height?: number | undefined;
-    interactive_params?: string | undefined;
-    keyboard?: boolean | undefined;
-    loop?: boolean | undefined;
-    maxheight?: number | undefined;
-    maxwidth?: number | undefined;
-    muted?: boolean | undefined;
-    pip?: boolean | undefined;
-    playsinline?: boolean | undefined;
-    portrait?: boolean | undefined;
-    responsive?: boolean | undefined;
-    speed?: boolean | undefined;
-    quality?: VimeoVideoQuality | undefined;
-    texttrack?: string | undefined;
-    title?: boolean | undefined;
-    transparent?: boolean | undefined;
-    width?: number | undefined;
-}
-
-export interface VimeoPromise<Result, Reason> extends Promise<Result> {
-    (successCallback?: (promiseValue: Result) => void, rejectCallback?: (reasonValue: Reason) => void): Promise<Result>;
-}
-
-/*~ You can declare properties of the module using const, let, or var */
-export default Player;
+export = Player;

--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -299,6 +299,10 @@ declare namespace Vimeo {
     class Player {
         constructor(element: HTMLIFrameElement | HTMLElement | string, options?: Player.Options);
 
+        // This property doesn’t actually exist.
+        // It’s defined for backwards compatibility with older versions of the type definitions.
+        static default: typeof Player;
+
         on<EventName extends keyof Player.EventMap>(
             event: EventName,
             callback: Player.EventCallback<Player.EventMap[EventName]>,

--- a/types/vimeo__player/vimeo__player-tests.ts
+++ b/types/vimeo__player/vimeo__player-tests.ts
@@ -3,6 +3,7 @@ import Player = require('@vimeo/player');
 // based on README.md of @vimeo/player >> https://github.com/vimeo/player.js
 
 let player: Player;
+let defaultPlayer: Player.default;
 
 player = new Player('handstick', {
     id: 19231868,

--- a/types/vimeo__player/vimeo__player-tests.ts
+++ b/types/vimeo__player/vimeo__player-tests.ts
@@ -30,6 +30,8 @@ player = new Player('handstick', {
     transparent: true,
 });
 
+player = new Player.default('handstick');
+
 const onPlay = (data: any) => {
     // data is an object containing properties specific to that event
 };

--- a/types/vimeo__player/vimeo__player-tests.ts
+++ b/types/vimeo__player/vimeo__player-tests.ts
@@ -32,6 +32,8 @@ player = new Player('handstick', {
 });
 
 player = new Player.default('handstick');
+defaultPlayer = new Player('handstick');
+defaultPlayer = new Player.default('handstick');
 
 const onPlay = (data: any) => {
     // data is an object containing properties specific to that event

--- a/types/vimeo__player/vimeo__player-tests.ts
+++ b/types/vimeo__player/vimeo__player-tests.ts
@@ -1,4 +1,4 @@
-import Player from '@vimeo/player';
+import Player = require('@vimeo/player');
 
 // based on README.md of @vimeo/player >> https://github.com/vimeo/player.js
 


### PR DESCRIPTION
This fixes two issues in the type definitions for `@vimeo/player`.

Firstly, the main export of `@vimeo/player` uses `module.exports =`. This means the correct way to write type definitions, is using `export =`. A namespace was used to export additional types.

Secondly, the package loads `native-promise-only`, and returns native promises. Before this change, there was a special promise type `VimeoPromise` that has a call expression, but this call expression doesn’t exist at runtime. This has been replaced with native `Promise` return values.

There were some specific error types that were used in conjunction with `VimeoPromise`. These errors have been removed. The package does document a specific error type that has a `method` property. This is unused by the type definitions, but it’s kept so users can use it for custom checks.

Also the minor version has been updated.

Hint for the reviewer: A lot of indentation changed due to the namespace, hide whitespace changes.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vimeo/player.js/blob/master/src/player.js#L4, https://github.com/vimeo/player.js/blob/master/dist/player.js#L3
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.