### PR TITLE
Update return value of Users.show method

### DIFF
--- a/types/node-zendesk/index.d.ts
+++ b/types/node-zendesk/index.d.ts
@@ -939,7 +939,7 @@ export namespace Users {
 
         /** Showing Users */
         show(userId: ZendeskID, cb: ZendeskCallback<unknown, unknown>): ResponsePayload;
-        show(userId: ZendeskID): Promise<ResponsePayload>;
+        show(userId: ZendeskID): Promise<ResponseModel>;
         showMany(userIds: ReadonlyArray<ZendeskID>, cb: ZendeskCallback<unknown, unknown>): ListPayload;
         showMany(userIds: ReadonlyArray<ZendeskID>): Promise<ListPayload>;
 


### PR DESCRIPTION
The return value here returns the model directly, not the ResponsePayload.

We see this in production while actually executing this code. We have to re-cast the result to ResponseModel and _not_ reference `result.user` as expected in ResponsePayload.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. N/A