### PR TITLE
serve-static: annotate missing acceptRanges property in options

### DIFF
--- a/types/serve-static/index.d.ts
+++ b/types/serve-static/index.d.ts
@@ -23,6 +23,12 @@ declare namespace serveStatic {
     var mime: typeof m;
     interface ServeStaticOptions<R extends http.ServerResponse = http.ServerResponse> {
         /**
+         * Enable or disable accepting ranged requests, defaults to true.
+         * Disabling this will not send Accept-Ranges and ignore the contents of the Range request header.
+         */
+        acceptRanges?: boolean | undefined;
+
+        /**
          * Enable or disable setting Cache-Control response header, defaults to true.
          * Disabling this will ignore the immutable and maxAge options.
          */

--- a/types/serve-static/serve-static-tests.ts
+++ b/types/serve-static/serve-static-tests.ts
@@ -6,6 +6,7 @@ var app = express();
 app.use(serveStatic('/1'));
 app.use(serveStatic('/2', { }));
 app.use(serveStatic('/3', {
+    acceptRanges: true,
     dotfiles: 'ignore',
     etag: true,
     extensions: ['html'],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://expressjs.com/en/resources/middleware/serve-static.html>> <<https://github.com/expressjs/serve-static#acceptranges>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
