### PR TITLE
[mui-datatables] use correct type for customBodyRender tableMeta.tableData

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -70,7 +70,7 @@ export interface MUIDataTableMeta {
     columnIndex: number;
     rowData: any[];
     rowIndex: number;
-    tableData: MUIDataTableData[];
+    tableData: any[];
     tableState: MUIDataTableState;
 }
 

--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -64,13 +64,13 @@ export interface MUIDataTableState {
     sortOrder: MUISortOptions;
 }
 
-export interface MUIDataTableMeta {
+export interface MUIDataTableMeta<T = any> {
     currentTableData: MUIDataTableCurrentData[];
     columnData: MUIDataTableColumnState;
     columnIndex: number;
     rowData: any[];
     rowIndex: number;
-    tableData: any[];
+    tableData: T[];
     tableState: MUIDataTableState;
 }
 


### PR DESCRIPTION
As of now, when using a customBodyRender, there is a tableMeta object returned with a property named tableData. This property turns out to be an array of the tables' data. The typings indicate a different structure. This PR fixes this issue.

This behaviour can be observed when supplying a [customBodyRender](https://github.com/gregnb/mui-datatables#column-options) for a column that makes use of [tableMeta.tableData](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mui-datatables/index.d.ts#L73). When actually logging tableMeta.tableData the output is just a plain array of the tables' rows. There are no data and index properties.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gregnb/mui-datatables/blob/master/src/MUIDataTable.js#L1127
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mui-datatables/index.d.ts#L73
