### PR TITLE
[dockerode] Use response stream types from 'stream' package instead of NodeJS

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -128,7 +128,7 @@ container.logs({}, (err, logs) => {
 });
 
 container.logs({ follow: true }, (err, logs) => {
-    // $ExpectType ReadableStream
+    // $ExpectType Readable
     logs;
 });
 
@@ -143,7 +143,7 @@ container.logs({ since: 0, until: 10, stdout: true, stderr: true });
 // $ExpectType Promise<Buffer>
 container.logs({ since: '12345.987654321', until: '54321.123456789', stdout: true, stderr: true });
 
-// $ExpectType Promise<ReadableStream>
+// $ExpectType Promise<Readable>
 container.logs({ follow: true });
 
 // $ExpectType Promise<Buffer>
@@ -160,7 +160,7 @@ container.stats({}, (err, logs) => {
 });
 
 container.stats({ stream: true }, (err, logs) => {
-    // $ExpectType ReadableStream
+    // $ExpectType Readable
     logs;
 });
 
@@ -178,7 +178,7 @@ container.stats({});
 // $ExpectType Promise<ContainerStats>
 container.stats({ 'one-shot': true });
 
-// $ExpectType Promise<ReadableStream>
+// $ExpectType Promise<Readable>
 container.stats({ stream: true });
 
 // $ExpectType Promise<ContainerStats>

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -44,9 +44,9 @@ declare namespace Dockerode {
         changes(callback: Callback<any>): void;
         changes(options?: {}): Promise<any>;
 
-        export(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-        export(callback: Callback<NodeJS.ReadableStream>): void;
-        export(options?: {}): Promise<NodeJS.ReadableStream>;
+        export(options: {}, callback: Callback<stream.Readable>): void;
+        export(callback: Callback<stream.Readable>): void;
+        export(options?: {}): Promise<stream.Readable>;
 
         start(options: {}, callback: Callback<any>): void;
         start(callback: Callback<any>): void;
@@ -98,8 +98,8 @@ declare namespace Dockerode {
         /** Deprecated since RAPI v1.20 */
         copy(options?: {}): Promise<any>;
 
-        getArchive(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-        getArchive(options: {}): Promise<NodeJS.ReadableStream>;
+        getArchive(options: {}, callback: Callback<stream.Readable>): void;
+        getArchive(options: {}): Promise<stream.Readable>;
 
         infoArchive(options: {}, callback: Callback<any>): void;
         infoArchive(options: {}): Promise<any>;
@@ -108,24 +108,24 @@ declare namespace Dockerode {
         putArchive(
             file: string | Buffer | NodeJS.ReadableStream,
             options: {},
-            callback: Callback<NodeJS.WritableStream>,
+            callback: Callback<stream.Writable>,
         ): void;
-        putArchive(file: string | Buffer | NodeJS.ReadableStream, options: {}): Promise<NodeJS.ReadWriteStream>;
+        putArchive(file: string | Buffer | NodeJS.ReadableStream, options: {}): Promise<stream.Duplex>;
 
         logs(options: ContainerLogsOptions & { follow?: false }, callback: Callback<Buffer>): void;
-        logs(options: ContainerLogsOptions & { follow: true }, callback: Callback<NodeJS.ReadableStream>): void;
+        logs(options: ContainerLogsOptions & { follow: true }, callback: Callback<stream.Readable>): void;
         logs(callback: Callback<Buffer>): void;
         logs(options?: ContainerLogsOptions & { follow?: false }): Promise<Buffer>;
-        logs(options?: ContainerLogsOptions & { follow: true }): Promise<NodeJS.ReadableStream>;
+        logs(options?: ContainerLogsOptions & { follow: true }): Promise<stream.Readable>;
 
         stats(options: { stream?: false; 'one-shot'?: boolean }, callback: Callback<ContainerStats>): void;
-        stats(options: { stream: true }, callback: Callback<NodeJS.ReadableStream>): void;
+        stats(options: { stream: true }, callback: Callback<stream.Readable>): void;
         stats(callback: Callback<ContainerStats>): void;
         stats(options?: { stream?: false; 'one-shot'?: boolean }): Promise<ContainerStats>;
-        stats(options?: { stream: true }): Promise<NodeJS.ReadableStream>;
+        stats(options?: { stream: true }): Promise<stream.Readable>;
 
-        attach(options: {}, callback: Callback<NodeJS.ReadWriteStream>): void;
-        attach(options: {}): Promise<NodeJS.ReadWriteStream>;
+        attach(options: {}, callback: Callback<stream.Duplex>): void;
+        attach(options: {}): Promise<stream.Duplex>;
     }
 
     class Image {
@@ -140,12 +140,12 @@ declare namespace Dockerode {
         history(callback: Callback<any>): void;
         history(): Promise<any>;
 
-        get(callback: Callback<NodeJS.ReadableStream>): void;
-        get(): Promise<NodeJS.ReadableStream>;
+        get(callback: Callback<stream.Readable>): void;
+        get(): Promise<stream.Readable>;
 
-        push(options: ImagePushOptions, callback: Callback<NodeJS.ReadableStream>): void;
-        push(callback: Callback<NodeJS.ReadableStream>): void;
-        push(options?: ImagePushOptions): Promise<NodeJS.ReadableStream>;
+        push(options: ImagePushOptions, callback: Callback<stream.Readable>): void;
+        push(callback: Callback<stream.Readable>): void;
+        push(options?: ImagePushOptions): Promise<stream.Readable>;
 
         tag(options: {}, callback: Callback<any>): void;
         tag(callback: Callback<any>): void;
@@ -192,9 +192,9 @@ declare namespace Dockerode {
         update(options: {}, callback: Callback<any>): void;
         update(options: {}): Promise<any>;
 
-        logs(options: ContainerLogsOptions, callback: Callback<NodeJS.ReadableStream>): void;
-        logs(callback: Callback<NodeJS.ReadableStream>): void;
-        logs(options?: ContainerLogsOptions): Promise<NodeJS.ReadableStream>;
+        logs(options: ContainerLogsOptions, callback: Callback<stream.Readable>): void;
+        logs(callback: Callback<stream.Readable>): void;
+        logs(options?: ContainerLogsOptions): Promise<stream.Readable>;
     }
 
     class Task {
@@ -1848,18 +1848,18 @@ declare class Dockerode {
     createContainer(options: Dockerode.ContainerCreateOptions, callback: Callback<Dockerode.Container>): void;
     createContainer(options: Dockerode.ContainerCreateOptions): Promise<Dockerode.Container>;
 
-    createImage(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-    createImage(auth: any, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-    createImage(options: {}): Promise<NodeJS.ReadableStream>;
-    createImage(auth: any, options: {}): Promise<NodeJS.ReadableStream>;
+    createImage(options: {}, callback: Callback<stream.Readable>): void;
+    createImage(auth: any, options: {}, callback: Callback<stream.Readable>): void;
+    createImage(options: {}): Promise<stream.Readable>;
+    createImage(auth: any, options: {}): Promise<stream.Readable>;
 
-    loadImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-    loadImage(file: string | NodeJS.ReadableStream, callback: Callback<NodeJS.ReadableStream>): void;
-    loadImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<NodeJS.ReadableStream>;
+    loadImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<stream.Readable>): void;
+    loadImage(file: string | NodeJS.ReadableStream, callback: Callback<stream.Readable>): void;
+    loadImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<stream.Readable>;
 
-    importImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
-    importImage(file: string | NodeJS.ReadableStream, callback: Callback<NodeJS.ReadableStream>): void;
-    importImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<NodeJS.ReadableStream>;
+    importImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<stream.Readable>): void;
+    importImage(file: string | NodeJS.ReadableStream, callback: Callback<stream.Readable>): void;
+    importImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<stream.Readable>;
 
     checkAuth(options: any, callback: Callback<any>): void;
     checkAuth(options: any): Promise<any>;
@@ -1867,16 +1867,16 @@ declare class Dockerode {
     buildImage(
         file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext,
         options: Dockerode.ImageBuildOptions,
-        callback: Callback<NodeJS.ReadableStream>,
+        callback: Callback<stream.Readable>,
     ): void;
     buildImage(
         file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext,
-        callback: Callback<NodeJS.ReadableStream>,
+        callback: Callback<stream.Readable>,
     ): void;
     buildImage(
         file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext,
         options?: Dockerode.ImageBuildOptions,
-    ): Promise<NodeJS.ReadableStream>;
+    ): Promise<stream.Readable>;
 
     getContainer(id: string): Dockerode.Container;
 
@@ -2005,9 +2005,9 @@ declare class Dockerode {
     ping(callback: Callback<any>): void;
     ping(): Promise<any>;
 
-    getEvents(options: Dockerode.GetEventsOptions, callback: Callback<NodeJS.ReadableStream>): void;
-    getEvents(callback: Callback<NodeJS.ReadableStream>): void;
-    getEvents(options?: Dockerode.GetEventsOptions): Promise<NodeJS.ReadableStream>;
+    getEvents(options: Dockerode.GetEventsOptions, callback: Callback<stream.Readable>): void;
+    getEvents(callback: Callback<stream.Readable>): void;
+    getEvents(options?: Dockerode.GetEventsOptions): Promise<stream.Readable>;
 
     pull(repoTag: string, options: {}, callback: Callback<any>, auth?: {}): Dockerode.Image;
     pull(repoTag: string, options?: {}): Promise<any>;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -108,9 +108,9 @@ declare namespace Dockerode {
         putArchive(
             file: string | Buffer | NodeJS.ReadableStream,
             options: {},
-            callback: Callback<stream.Writable>,
+            callback: Callback<stream.Readable>,
         ): void;
-        putArchive(file: string | Buffer | NodeJS.ReadableStream, options: {}): Promise<stream.Duplex>;
+        putArchive(file: string | Buffer | NodeJS.ReadableStream, options: {}): Promise<stream.Readable>;
 
         logs(options: ContainerLogsOptions & { follow?: false }, callback: Callback<Buffer>): void;
         logs(options: ContainerLogsOptions & { follow: true }, callback: Callback<stream.Readable>): void;
@@ -127,8 +127,8 @@ declare namespace Dockerode {
         stats(options?: ContainerStatsOptions & { stream?: false }): Promise<ContainerStats>;
         stats(options?: ContainerStatsOptions & { stream: true; 'one-shot'?: never }): Promise<stream.Readable>;
 
-        attach(options: {}, callback: Callback<stream.Duplex>): void;
-        attach(options: {}): Promise<stream.Duplex>;
+        attach(options: {}, callback: Callback<NodeJS.ReadWriteStream>): void;
+        attach(options: {}): Promise<NodeJS.ReadWriteStream>;
     }
 
     class Image {
@@ -324,8 +324,8 @@ declare namespace Dockerode {
         inspect(callback: Callback<ExecInspectInfo>): void;
         inspect(options?: ExecInspectOptions): Promise<ExecInspectInfo>;
 
-        start(options: ExecStartOptions, callback: Callback<stream.Duplex>): void;
-        start(options: ExecStartOptions): Promise<stream.Duplex>;
+        start(options: ExecStartOptions, callback: Callback<NodeJS.ReadWriteStream>): void;
+        start(options: ExecStartOptions): Promise<NodeJS.ReadWriteStream>;
 
         resize(options: {}, callback: Callback<any>): void;
         resize(options: {}): Promise<any>;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -118,11 +118,14 @@ declare namespace Dockerode {
         logs(options?: ContainerLogsOptions & { follow?: false }): Promise<Buffer>;
         logs(options?: ContainerLogsOptions & { follow: true }): Promise<stream.Readable>;
 
-        stats(options: { stream?: false; 'one-shot'?: boolean }, callback: Callback<ContainerStats>): void;
-        stats(options: { stream: true }, callback: Callback<stream.Readable>): void;
+        stats(options: ContainerStatsOptions & { stream?: false }, callback: Callback<ContainerStats>): void;
+        stats(
+            options: ContainerStatsOptions & { stream: true; 'one-shot'?: never },
+            callback: Callback<stream.Readable>,
+        ): void;
         stats(callback: Callback<ContainerStats>): void;
-        stats(options?: { stream?: false; 'one-shot'?: boolean }): Promise<ContainerStats>;
-        stats(options?: { stream: true }): Promise<stream.Readable>;
+        stats(options?: ContainerStatsOptions & { stream?: false }): Promise<ContainerStats>;
+        stats(options?: ContainerStatsOptions & { stream: true; 'one-shot'?: never }): Promise<stream.Readable>;
 
         attach(options: {}, callback: Callback<stream.Duplex>): void;
         attach(options: {}): Promise<stream.Duplex>;
@@ -1802,6 +1805,12 @@ declare namespace Dockerode {
         details?: boolean | undefined;
         tail?: number | undefined;
         timestamps?: boolean | undefined;
+        abortSignal?: AbortSignal;
+    }
+
+    interface ContainerStatsOptions {
+        stream?: boolean | undefined;
+        'one-shot'?: boolean | undefined;
         abortSignal?: AbortSignal;
     }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apocas/docker-modem/blob/master/lib/modem.js#L365-L366

Under the hood docker-modem returns a `http.IncomingMessage` (which extends `stream.Readable`) but I think it makes more sense to return the `stream.Readable` as the purpose of dockerode is to abstract the http layer.

Also I have some doubts about the typings of the `Container.putArchive` method. Currently it provides a `NodeJS.WritableStream` (replaced by a `stream.Writable` in this PR) as a callback parameter or returns a promised `NodeJS.ReadWriteStream` (replaced by a `stream.Duplex` in this PR).
But I think docker-modem returns by default a `http.IncomingMessage` or a `Duplex` if `openStdin` option is `true` (see this [docker-modem snippet](https://github.com/apocas/docker-modem/blob/master/lib/modem.js#L354-L360)) which is `false` for `putArchive` (see the [dockerode function](https://github.com/apocas/dockerode/blob/master/lib/container.js#L971-L1005)). I verified by logging the type, and it's indeed a `http.IncomingMessage`. Should we return a `stream.Readable` ?
Though I neither understand why dockerode is passing the option `stream: true` because the docker API returns a 200 OK with no body (see [doc](https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/PutContainerArchive)), but that's an issue for the dockerode repository.

