### PR TITLE
Use GH_DT_MERGEBOT_TOKEN for starting action on dt-mergebot

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - run: 'gh workflow run daily.yml -R DefinitelyTyped/dt-mergebot'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_DT_MERGEBOT_TOKEN }}


### PR DESCRIPTION
I'm not sure whether the permissions are set up correctly yet.