### PR TITLE
Phoenix callbacks can be async

### DIFF
--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -27,11 +27,11 @@ export class Channel {
   join(timeout?: number): Push;
   leave(timeout?: number): Push;
 
-  onClose(callback: (payload: any, ref: any, joinRef: any) => void): void;
-  onError(callback: (reason?: any) => void): void;
+  onClose(callback: (payload: any, ref: any, joinRef: any) => void | Promise<void>): void;
+  onError(callback: (reason?: any) => void | Promise<void>): void;
   onMessage(event: string, payload: any, ref: any): any;
 
-  on(event: string, callback: (response?: any) => void): number;
+  on(event: string, callback: (response?: any) => void | Promise<void>): number;
   off(event: string, ref?: number): void;
 
   push(event: string, payload: object, timeout?: number): Push;
@@ -47,8 +47,8 @@ export interface SocketConnectOption {
   timeout: number;
   heartbeatIntervalMs: number;
   longpollerTimeout: number;
-  encode: (payload: object, callback: (encoded: any) => void) => void;
-  decode: (payload: string, callback: (decoded: any) => void) => void;
+  encode: (payload: object, callback: (encoded: any) => void | Promise<void>) => void;
+  decode: (payload: string, callback: (decoded: any) => void | Promise<void>) => void;
   logger: (kind: string, message: string, data: any) => void;
   reconnectAfterMs: (tries: number) => number;
   rejoinAfterMs: (tries: number) => number;
@@ -64,7 +64,7 @@ export class Socket {
   endPointURL(): string;
 
   connect(params?: any): void;
-  disconnect(callback?: () => void, code?: number, reason?: string): void;
+  disconnect(callback?: () => void | Promise<void>, code?: number, reason?: string): void;
   connectionState(): ConnectionState;
   isConnected(): boolean;
 
@@ -75,10 +75,10 @@ export class Socket {
   log(kind: string, message: string, data: any): void;
   hasLogger(): boolean;
 
-  onOpen(callback: (cb: any) => void): MessageRef;
-  onClose(callback: (cb: any) => void): MessageRef;
-  onError(callback: (cb: any) => void): MessageRef;
-  onMessage(callback: (cb: any) => void): MessageRef;
+  onOpen(callback: (cb: any) => void | Promise<void>): MessageRef;
+  onClose(callback: (cb: any) => void | Promise<void>): MessageRef;
+  onError(callback: (cb: any) => void | Promise<void>): MessageRef;
+  onMessage(callback: (cb: any) => void | Promise<void>): MessageRef;
 
   makeRef(): MessageRef;
   off(refs: MessageRef[]): void;
@@ -110,7 +110,7 @@ export class Ajax {
     body: any,
     timeout?: number,
     ontimeout?: any,
-    callback?: (response?: any) => void,
+    callback?: (response?: any) => void | Promise<void>,
   ): void;
 
   static xdomainRequest(
@@ -120,7 +120,7 @@ export class Ajax {
     body: any,
     timeout?: number,
     ontimeout?: any,
-    callback?: (response?: any) => void,
+    callback?: (response?: any) => void | Promise<void>,
   ): void;
 
   static xhrRequest(
@@ -131,7 +131,7 @@ export class Ajax {
     body: any,
     timeout?: number,
     ontimeout?: any,
-    callback?: (response?: any) => void,
+    callback?: (response?: any) => void | Promise<void>,
   ): void;
 
   static parseJSON(resp: string): JSON;
@@ -144,7 +144,7 @@ export class Presence {
 
   onJoin(callback: PresenceOnJoinCallback): void;
   onLeave(callback: PresenceOnLeaveCallback): void;
-  onSync(callback: () => void): void;
+  onSync(callback: () => void | Promise<void>): void;
   list<T = any>(chooser?: (key: string, presence: any) => T): T[];
   inPendingSyncState(): boolean;
 
@@ -174,7 +174,7 @@ export interface PresenceOpts {
 }
 
 export class Timer {
-  constructor(callback: () => void, timerCalc: (tries: number) => number);
+  constructor(callback: () => void | Promise<void>, timerCalc: (tries: number) => number);
 
   reset(): void;
   scheduleTimeout(): void;

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -95,3 +95,12 @@ function test_timer() {
   reconnectTimer.scheduleTimeout(); // fires after 5000
   reconnectTimer.reset();
 }
+
+function test_async_callback() {
+  const socket = new Socket('/ws', { params: { userToken: '123' } });
+  socket.connect();
+
+  const channel = socket.channel('room:123', { token: '123' });
+
+  channel.on('new_msg', async msg => console.log('Got message', msg));
+}


### PR DESCRIPTION
All callback arguments can now return `T | Promise<T>`, to fix annoying eslint errors like:

    Promise returned in function argument where a void return was expected. (eslint @typescript-eslint/no-misused-promises)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
  > N/A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  > nothing changed on the Phoenix side, just authorizing async callbacks