### PR TITLE
Added missing `style` property to ButtonsRenderer

### DIFF
--- a/types/paypal-checkout-components/modules/button.d.ts
+++ b/types/paypal-checkout-components/modules/button.d.ts
@@ -54,6 +54,7 @@ export interface ButtonRenderer {
 export interface ButtonsRenderer {
     (
         options: {
+            style?: ButtonStyle | undefined;
             fundingSource?: string | undefined;
             createOrder?: (() => Promise<string>) | undefined;
             createBillingAgreement?: (() => Promise<string>) | undefined;


### PR DESCRIPTION
This option allows users to modify the look and feel of the PayPal button. In my testing, including this property as an option in ButtonsRenderer behaves the same as including it in rendering a ButtonRenderer.

See more on the official PayPal SDK documentation: https://developer.paypal.com/sdk/js/reference/#link-style

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://developer.paypal.com/sdk/js/reference/#link-style)>>