### PR TITLE
[relay-runtime] Add cacheConfig to subscription config

### DIFF
--- a/types/relay-runtime/lib/subscription/requestSubscription.d.ts
+++ b/types/relay-runtime/lib/subscription/requestSubscription.d.ts
@@ -1,9 +1,10 @@
 import { DeclarativeMutationConfig } from '../mutations/RelayDeclarativeMutationConfig';
 import { GraphQLTaggedNode } from '../query/RelayModernGraphQLTag';
-import { Disposable, OperationType } from '../util/RelayRuntimeTypes';
+import { CacheConfig, Disposable, OperationType } from '../util/RelayRuntimeTypes';
 import { SelectorStoreUpdater, Environment } from '../store/RelayStoreTypes';
 
 export interface GraphQLSubscriptionConfig<TSubscription extends OperationType> {
+    cacheConfig?: CacheConfig | undefined;
     configs?: ReadonlyArray<DeclarativeMutationConfig> | undefined;
     subscription: GraphQLTaggedNode;
     variables: TSubscription['variables'];

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -23,6 +23,8 @@ import {
     createOperationDescriptor,
     FragmentRefs,
     readInlineData,
+    requestSubscription,
+    fetchQuery,
 } from 'relay-runtime';
 
 import * as multiActorEnvironment from 'relay-runtime/multi-actor-environment';
@@ -50,7 +52,7 @@ const storeWithOptions = new Store(source, {
 // ~~~~~~~~~~~~~~~~~~~~~
 // Define a function that fetches the results of an operation (query/mutation/etc)
 // and returns its results as a Promise:
-function fetchQuery(operation: any, variables: { [key: string]: string }, cacheConfig: {}) {
+function fetchFunction(operation: any, variables: { [key: string]: string }, cacheConfig: {}) {
     return fetch('/graphql', {
         method: 'POST',
         body: JSON.stringify({
@@ -63,7 +65,7 @@ function fetchQuery(operation: any, variables: { [key: string]: string }, cacheC
 }
 
 // Create a network layer from the fetch function
-const network = Network.create(fetchQuery);
+const network = Network.create(fetchFunction);
 
 // Create a cache for storing query responses
 const cache = new QueryResponseCache({ size: 250, ttl: 60000 });
@@ -656,3 +658,31 @@ function ArrayOfNullableFragmentResolver(usersKey: ReadonlyArray<UserComponent_u
 
     return data?.map(thing => `${thing.id}: ${thing.name}, ${thing.profile_picture}`);
 }
+
+// ~~~~~~~~~~~~~~~~~~~~~
+// fetchQuery
+// ~~~~~~~~~~~~~~~~~~~~~
+
+fetchQuery(
+    environment,
+    node,
+    { variable: true },
+    {
+        networkCacheConfig: { force: true, poll: 1234 },
+        fetchPolicy: 'network-only',
+    },
+);
+
+// ~~~~~~~~~~~~~~~~~~~~~
+// requestSubscription
+// ~~~~~~~~~~~~~~~~~~~~~
+
+requestSubscription(environment, {
+    cacheConfig: { force: true, poll: 1234 },
+    subscription: node,
+    variables: { variable: true },
+    onCompleted: () => { return; },
+    onError: (_error) => { return; },
+    onNext: (_response) => { return; },
+    updater: (_store, _data) => { return; },
+});


### PR DESCRIPTION
Simple change to add the missing `cacheConfig` option to `GraphQLSubscriptionConfig`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/facebook/relay/blob/main/packages/relay-runtime/subscription/requestSubscription.js#L46>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (option has excited for several versions)
