### PR TITLE
graphql-fields: Update graphql to 16.6.0.

### DIFF
--- a/types/graphql-fields/package.json
+++ b/types/graphql-fields/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "*"
   }
 }

--- a/types/graphql-fields/tsconfig.json
+++ b/types/graphql-fields/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "esnext.asynciterable"
+            "es2018"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Getting this error:

```
cdimino@cdimino-dev-mini DefinitelyTyped % npm test graphql-fields

> definitely-typed@0.0.3 test
> node --require source-map-support/register node_modules/@definitelytyped/dtslint/ types graphql-fields

dtslint@0.0.147
Error: Errors in typescript@5.0 for external dependencies:
node_modules/graphql/execution/subscribe.d.ts(29,12): error TS2583: Cannot find name 'AsyncGenerator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.

    at testTypesVersion (/Users/cdimino/git/github/DefinitelyTyped/node_modules/@definitelytyped/dtslint/src/index.ts:235:11)
    at runTests (/Users/cdimino/git/github/DefinitelyTyped/node_modules/@definitelytyped/dtslint/src/index.ts:197:7)
    at main (/Users/cdimino/git/github/DefinitelyTyped/node_modules/@definitelytyped/dtslint/src/index.ts:83:5)
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/blob/9706f1729e9c41c9af901c279367dec0ab1093d1/src/lib/esnext.d.ts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
