### PR TITLE
meteor: Improve specificity of types declared as "Object"

### DIFF
--- a/types/meteor/accounts-base.d.ts
+++ b/types/meteor/accounts-base.d.ts
@@ -28,7 +28,7 @@ declare module 'meteor/accounts-base' {
                 username?: string | undefined;
                 email?: string | undefined;
                 password?: string | undefined;
-                profile?: Object | undefined;
+                profile?: Meteor.UserProfile | undefined;
             },
             callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void,
         ): string;
@@ -38,7 +38,7 @@ declare module 'meteor/accounts-base' {
                 username?: string | undefined;
                 email?: string | undefined;
                 password?: string | undefined;
-                profile?: Object | undefined;
+                profile?: Meteor.UserProfile | undefined;
             },
             callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void,
         ): Promise<string>;
@@ -105,12 +105,16 @@ declare module 'meteor/accounts-base' {
 
         function logoutOtherClients(callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void): void;
 
+        type PasswordSignupField = 'USERNAME_AND_EMAIL' | 'USERNAME_AND_OPTIONAL_EMAIL' | 'USERNAME_ONLY' | 'EMAIL_ONLY';
+        type PasswordlessSignupField = 'USERNAME_AND_EMAIL' | 'EMAIL_ONLY';
+
         var ui: {
             config(options: {
-                requestPermissions?: Object | undefined;
-                requestOfflineToken?: Object | undefined;
-                forceApprovalPrompt?: Object | undefined;
-                passwordSignupFields?: string | undefined;
+                requestPermissions?: Record<string, string[]> | undefined;
+                requestOfflineToken?: Record<'google', boolean> | undefined;
+                forceApprovalPrompt?: Record<'google', boolean> | undefined;
+                passwordSignupFields?: PasswordSignupField | PasswordSignupField[] | undefined;
+                passwordlessSignupFields?: PasswordlessSignupField | PasswordlessSignupField[] | undefined;
             }): void;
         };
     }
@@ -170,9 +174,9 @@ declare module 'meteor/accounts-base' {
 
         function setUsername(userId: string, newUsername: string): void;
 
-        function setPassword(userId: string, newPassword: string, options?: { logout?: Object | undefined }): void;
+        function setPassword(userId: string, newPassword: string, options?: { logout?: boolean | undefined }): void;
 
-        function setPasswordAsync(userId: string, newPassword: string, options?: { logout?: Object | undefined }): Promise<void>;
+        function setPasswordAsync(userId: string, newPassword: string, options?: { logout?: boolean | undefined }): Promise<void>;
 
         function validateNewUser(func: Function): boolean;
 
@@ -224,6 +228,13 @@ declare module 'meteor/accounts-base' {
             userCallback?: ((err?: any) => void) | undefined;
         }
 
+        type LoginMethodResult = { error: Error } | {
+            userId: string;
+            error?: Error;
+            stampedLoginToken?: StampedLoginToken;
+            options?: Record<string, any>;
+        };
+
         /**
          *
          * Call a login method on the server.
@@ -268,7 +279,8 @@ declare module 'meteor/accounts-base' {
          * - `undefined`, meaning don't handle;
          * - a login method result object
          **/
-        function registerLoginHandler(name: string, handler: (options: any) => undefined | Object): void;
+        function registerLoginHandler(handler: (options: any) => undefined | LoginMethodResult): void;
+        function registerLoginHandler(name: string, handler: (options: any) => undefined | LoginMethodResult): void;
 
         type Password =
             | string

--- a/types/meteor/email.d.ts
+++ b/types/meteor/email.d.ts
@@ -1,20 +1,19 @@
+import { SendMailOptions } from 'nodemailer';
+
 declare module 'meteor/email' {
     namespace Email {
-      interface EmailOptions {
-        from?: string | undefined;
-        to?: string | string[] | undefined;
-        cc?: string | string[] | undefined;
-        bcc?: string | string[] | undefined;
-        replyTo?: string | string[] | undefined;
-        subject?: string | undefined;
-        text?: string | undefined;
-        html?: string | undefined;
-        headers?: Object | undefined;
-        attachments?: Object[] | undefined;
-        mailComposer?: MailComposer | undefined;
-      }
+      /**
+       * ExtraMailOptions is intentionally left empty here, but can be
+       * overridden in your application if desired. This should not be necessary
+       * if you're using the default mail transport, but if you're using a
+       * custom transport or have configured hooks which accept additional
+       * options, you may need to define this interface to match your custom
+       * options.
+       */
+      interface ExtraMailOptions {}
+      type EmailOptions = { mailComposer: MailComposer } | (ExtraMailOptions & SendMailOptions)
 
-      interface CustomEmailOptions extends  EmailOptions {
+      type CustomEmailOptions = EmailOptions & {
         packageSettings?: unknown;
       }
 

--- a/types/meteor/globals/accounts-base.d.ts
+++ b/types/meteor/globals/accounts-base.d.ts
@@ -25,7 +25,7 @@ declare namespace Accounts {
             username?: string | undefined;
             email?: string | undefined;
             password?: string | undefined;
-            profile?: Object | undefined;
+            profile?: Meteor.UserProfile | undefined;
         },
         callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void,
     ): string;
@@ -35,7 +35,7 @@ declare namespace Accounts {
             username?: string | undefined;
             email?: string | undefined;
             password?: string | undefined;
-            profile?: Object | undefined;
+            profile?: Meteor.UserProfile | undefined;
         },
         callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void,
     ): Promise<string>;
@@ -102,12 +102,16 @@ declare namespace Accounts {
 
     function logoutOtherClients(callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void): void;
 
+    type PasswordSignupField = 'USERNAME_AND_EMAIL' | 'USERNAME_AND_OPTIONAL_EMAIL' | 'USERNAME_ONLY' | 'EMAIL_ONLY';
+    type PasswordlessSignupField = 'USERNAME_AND_EMAIL' | 'EMAIL_ONLY';
+
     var ui: {
         config(options: {
-            requestPermissions?: Object | undefined;
-            requestOfflineToken?: Object | undefined;
-            forceApprovalPrompt?: Object | undefined;
-            passwordSignupFields?: string | undefined;
+            requestPermissions?: Record<string, string[]> | undefined;
+            requestOfflineToken?: Record<'google', boolean> | undefined;
+            forceApprovalPrompt?: Record<'google', boolean> | undefined;
+            passwordSignupFields?: PasswordSignupField | PasswordSignupField[] | undefined;
+            passwordlessSignupFields?: PasswordlessSignupField | PasswordlessSignupField[] | undefined;
         }): void;
     };
 }
@@ -167,9 +171,9 @@ declare namespace Accounts {
 
     function setUsername(userId: string, newUsername: string): void;
 
-    function setPassword(userId: string, newPassword: string, options?: { logout?: Object | undefined }): void;
+    function setPassword(userId: string, newPassword: string, options?: { logout?: boolean | undefined }): void;
 
-    function setPasswordAsync(userId: string, newPassword: string, options?: { logout?: Object | undefined }): Promise<void>;
+    function setPasswordAsync(userId: string, newPassword: string, options?: { logout?: boolean | undefined }): Promise<void>;
 
     function validateNewUser(func: Function): boolean;
 
@@ -221,6 +225,13 @@ declare namespace Accounts {
         userCallback?: ((err?: any) => void) | undefined;
     }
 
+    type LoginMethodResult = { error: Error } | {
+        userId: string;
+        error?: Error;
+        stampedLoginToken?: StampedLoginToken;
+        options?: Record<string, any>;
+    };
+
     /**
      *
      * Call a login method on the server.
@@ -265,7 +276,8 @@ declare namespace Accounts {
      * - `undefined`, meaning don't handle;
      * - a login method result object
      **/
-    function registerLoginHandler(name: string, handler: (options: any) => undefined | Object): void;
+    function registerLoginHandler(handler: (options: any) => undefined | LoginMethodResult): void;
+    function registerLoginHandler(name: string, handler: (options: any) => undefined | LoginMethodResult): void;
 
     type Password =
         | string

--- a/types/meteor/globals/meteor.d.ts
+++ b/types/meteor/globals/meteor.d.ts
@@ -243,7 +243,7 @@ declare namespace Meteor {
      * @param func A function that takes a callback as its final parameter
      * @param context Optional `this` object against which the original function will be invoked
      */
-    function wrapAsync(func: Function, context?: Object): any;
+    function wrapAsync<T extends Function>(func: T, context?: ThisParameterType<T>): Function;
 
     function bindEnvironment<TFunc extends Function>(func: TFunc): TFunc;
 
@@ -275,7 +275,6 @@ declare namespace Meteor {
         requestPermissions?: ReadonlyArray<string> | undefined;
         requestOfflineToken?: Boolean | undefined;
         forceApprovalPrompt?: Boolean | undefined;
-        loginUrlParameters?: Object | undefined;
         redirectUrl?: string | undefined;
         loginHint?: string | undefined;
         loginStyle?: string | undefined;
@@ -297,7 +296,16 @@ declare namespace Meteor {
     ): void;
 
     function loginWithGoogle(
-        options?: Meteor.LoginWithExternalServiceOptions,
+        options?: Meteor.LoginWithExternalServiceOptions & {
+            /** Google login accepts additional login parameters based on
+             * https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters.
+             * However, there's only one parameter that must be set
+             * directly; all others can be set using Meteor's standard OAuth
+             * login parameters */
+            loginUrlParameters?: {
+                include_granted_scopes: boolean;
+            },
+        },
         callback?: (error?: global_Error | Meteor.Error | Meteor.TypedError) => void,
     ): void;
 
@@ -329,7 +337,7 @@ declare namespace Meteor {
     ): void;
 
     function loginWithPassword(
-        user: Object | string,
+        user: { username: string } | { email: string } | { id: string } | string,
         password: string,
         callback?: (error?: global_Error | Meteor.Error | Meteor.TypedError) => void,
     ): void;
@@ -403,7 +411,7 @@ declare namespace Meteor {
         close: () => void;
         onClose: (callback: () => void) => void;
         clientAddress: string;
-        httpHeaders: Object;
+        httpHeaders: Record<string, string>;
     }
 
     function onConnection(callback: (connection: Connection) => void): void;
@@ -431,7 +439,7 @@ declare interface Subscription {
      * @param id The new document's ID.
      * @param fields The fields in the new document.  If `_id` is present it is ignored.
      */
-    added(collection: string, id: string, fields: Object): void;
+    added(collection: string, id: string, fields: Record<string, unknown>): void;
     /**
      * Call inside the publish function. Informs the subscriber that a document in the record set has been modified.
      * @param collection The name of the collection that contains the changed document.
@@ -439,7 +447,7 @@ declare interface Subscription {
      * @param fields The fields in the document that have changed, together with their new values.  If a field is not present in `fields` it was left unchanged; if it is present in `fields` and
      * has a value of `undefined` it was removed from the document.  If `_id` is present it is ignored.
      */
-    changed(collection: string, id: string, fields: Object): void;
+    changed(collection: string, id: string, fields: Record<string, unknown>): void;
     /** Access inside the publish function. The incoming connection for this subscription. */
     connection: Meteor.Connection;
     /**

--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -177,7 +177,7 @@ declare namespace Mongo {
                  * The server connection that will manage this collection. Uses the default connection if not specified. Pass the return value of calling `DDP.connect` to specify a different
                  * server. Pass `null` to specify no connection. Unmanaged (`name` is null) collections cannot specify a connection.
                  */
-                connection?: Object | null | undefined;
+                connection?: DDP.DDPStatic | null | undefined;
                 /** The method of generating the `_id` fields of new documents in this collection.  Possible values:
                  * - **`'STRING'`**: random strings
                  * - **`'MONGO'`**:  random [`Mongo.ObjectID`](#mongo_object_id) values

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -248,7 +248,7 @@ declare module 'meteor/meteor' {
          * @param func A function that takes a callback as its final parameter
          * @param context Optional `this` object against which the original function will be invoked
          */
-        function wrapAsync(func: Function, context?: Object): any;
+        function wrapAsync<T extends Function>(func: T, context?: ThisParameterType<T>): Function;
 
         function bindEnvironment<TFunc extends Function>(func: TFunc): TFunc;
 
@@ -280,7 +280,6 @@ declare module 'meteor/meteor' {
             requestPermissions?: ReadonlyArray<string> | undefined;
             requestOfflineToken?: Boolean | undefined;
             forceApprovalPrompt?: Boolean | undefined;
-            loginUrlParameters?: Object | undefined;
             redirectUrl?: string | undefined;
             loginHint?: string | undefined;
             loginStyle?: string | undefined;
@@ -302,7 +301,16 @@ declare module 'meteor/meteor' {
         ): void;
 
         function loginWithGoogle(
-            options?: Meteor.LoginWithExternalServiceOptions,
+            options?: Meteor.LoginWithExternalServiceOptions & {
+                /** Google login accepts additional login parameters based on
+                 * https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters.
+                 * However, there's only one parameter that must be set
+                 * directly; all others can be set using Meteor's standard OAuth
+                 * login parameters */
+                loginUrlParameters?: {
+                    include_granted_scopes: boolean;
+                },
+            },
             callback?: (error?: global_Error | Meteor.Error | Meteor.TypedError) => void,
         ): void;
 
@@ -334,7 +342,7 @@ declare module 'meteor/meteor' {
         ): void;
 
         function loginWithPassword(
-            user: Object | string,
+            user: { username: string } | { email: string } | { id: string } | string,
             password: string,
             callback?: (error?: global_Error | Meteor.Error | Meteor.TypedError) => void,
         ): void;
@@ -408,7 +416,7 @@ declare module 'meteor/meteor' {
             close: () => void;
             onClose: (callback: () => void) => void;
             clientAddress: string;
-            httpHeaders: Object;
+            httpHeaders: Record<string, string>;
         }
 
         function onConnection(callback: (connection: Connection) => void): void;
@@ -436,7 +444,7 @@ declare module 'meteor/meteor' {
          * @param id The new document's ID.
          * @param fields The fields in the new document.  If `_id` is present it is ignored.
          */
-        added(collection: string, id: string, fields: Object): void;
+        added(collection: string, id: string, fields: Record<string, unknown>): void;
         /**
          * Call inside the publish function. Informs the subscriber that a document in the record set has been modified.
          * @param collection The name of the collection that contains the changed document.
@@ -444,7 +452,7 @@ declare module 'meteor/meteor' {
          * @param fields The fields in the document that have changed, together with their new values.  If a field is not present in `fields` it was left unchanged; if it is present in `fields` and
          * has a value of `undefined` it was removed from the document.  If `_id` is present it is ignored.
          */
-        changed(collection: string, id: string, fields: Object): void;
+        changed(collection: string, id: string, fields: Record<string, unknown>): void;
         /** Access inside the publish function. The incoming connection for this subscription. */
         connection: Meteor.Connection;
         /**

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -2,6 +2,7 @@ import * as MongoNpmModule from 'mongodb';
 // tslint:disable-next-line:no-duplicate-imports
 import { Collection as MongoCollection, CreateIndexesOptions, Db as MongoDb, Hint, IndexSpecification, MongoClient } from 'mongodb';
 import { Meteor } from 'meteor/meteor';
+import { DDP } from 'meteor/ddp';
 
 declare module 'meteor/mongo' {
     // Based on https://github.com/microsoft/TypeScript/issues/28791#issuecomment-443520161
@@ -183,7 +184,7 @@ declare module 'meteor/mongo' {
                      * The server connection that will manage this collection. Uses the default connection if not specified. Pass the return value of calling `DDP.connect` to specify a different
                      * server. Pass `null` to specify no connection. Unmanaged (`name` is null) collections cannot specify a connection.
                      */
-                    connection?: Object | null | undefined;
+                    connection?: DDP.DDPStatic | null | undefined;
                     /** The method of generating the `_id` fields of new documents in this collection.  Possible values:
                      * - **`'STRING'`**: random strings
                      * - **`'MONGO'`**:  random [`Mongo.ObjectID`](#mongo_object_id) values

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -128,6 +128,15 @@ namespace MeteorTests {
         Meteor.subscribe('counts-by-room', Session.get('roomId'));
     });
 
+    // Async publish function
+    Meteor.publish('userData', async function (userId: unknown) {
+        check(userId, String);
+        const user = await Meteor.users.findOneAsync(userId);
+        if (user) {
+            return Meteor.users.find(userId, { fields: { profile: 1 } });
+        }
+    });
+
     // Checking status
     let status: DDP.Status = 'connected';
 
@@ -1108,14 +1117,14 @@ namespace MeteorTests {
         Accounts.registerLoginHandler('impersonate', (options: { targetUserId: string }) => {
             const currentUser = Meteor.userId();
             if (!currentUser) {
-                return { error: 'No user was logged in' };
+                return { error: new Error('No user was logged in') };
             }
 
             const isSuperUser = (userId: string) => true;
 
             if (!isSuperUser(currentUser)) {
                 const errMsg = `User ${currentUser} tried to impersonate but is not allowed`;
-                return { error: errMsg };
+                return { error: new Error(errMsg) };
             }
             // By returning an object with userId, the session will now be logged in as that user
             return { userId: options.targetUserId };

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -1134,14 +1134,14 @@ namespace MeteorTests {
         Accounts.registerLoginHandler('impersonate', (options: { targetUserId: string }) => {
             const currentUser = Meteor.userId();
             if (!currentUser) {
-                return { error: 'No user was logged in' };
+                return { error: new Error('No user was logged in') };
             }
 
             const isSuperUser = (userId: string) => true;
 
             if (!isSuperUser(currentUser)) {
                 const errMsg = `User ${currentUser} tried to impersonate but is not allowed`;
-                return { error: errMsg };
+                return { error: new Error(errMsg) };
             }
             // By returning an object with userId, the session will now be logged in as that user
             return { userId: options.targetUserId };


### PR DESCRIPTION
In all of the cases where we previously had a type declared as "Object", it was possible to use something more specific and better capture the actual constraints of the type.

This PR is a followup to a request from #64249. I have a [corresponding change](https://github.com/meteor/meteor/compare/release-2.11...ebroder:meteor:object-type-improvements?expand=1) prepared for the core Meteor type definitions, but I'm waiting to open the PR until we have confidence the changes are correct from the testing infrastructure here.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
