### PR TITLE
[geometric] Add missing functions to bring up to date with version 2.5

### DIFF
--- a/types/geometric/geometric-tests.ts
+++ b/types/geometric/geometric-tests.ts
@@ -1,5 +1,5 @@
 import geometric = require('geometric');
-import { Line, LineInterpolator, Point, Polygon } from 'geometric';
+import { Line, LineInterpolator, Point, Polygon, PolygonInterpolator } from 'geometric';
 
 const polygon: Polygon = [
     [0, 0],
@@ -17,6 +17,7 @@ const line: Line = [
     [1, 2],
     [3, 4],
 ];
+const epsilon = 0.0001;
 const interpolator: LineInterpolator = geometric.lineInterpolate(line);
 const t0: Point = interpolator(0.5);
 const t1: number = geometric.angleReflect(0, 90);
@@ -58,3 +59,20 @@ const t36: Polygon = geometric.polygonTranslate(polygon, 45, 100);
 const t37: Line = geometric.lineRotate(line, 1);
 const t38: Polygon = geometric.polygonScaleX(polygon, 1.2);
 const t39: Polygon = geometric.polygonScaleY(polygon, 1.2);
+const t40: Line = geometric.lineTranslate(line, 75, 100);
+const t41: PolygonInterpolator = geometric.polygonInterpolate(polygon);
+const t42: Point = t41(0.5);
+const t43: Polygon = geometric.polygonRandom(5);
+const t44: Polygon = geometric.polygonRandom(5, 1);
+const t45: Polygon = geometric.polygonRandom(5, 1, [0, 0]);
+const t46: Polygon = geometric.polygonReflectX(polygon);
+const t47: Polygon = geometric.polygonReflectX(polygon, 0.5);
+const t48: Polygon = geometric.polygonReflectY(polygon);
+const t49: Polygon = geometric.polygonReflectY(polygon, 0.5);
+const t50: Polygon = geometric.polygonScaleArea(polygon, 1.5);
+const t51: Polygon = geometric.polygonScaleArea(polygon, 1.5, point);
+const t52: Polygon = geometric.polygonWind(polygon);
+const t53: Polygon = geometric.polygonWind(polygon, 'cw');
+const t54: boolean = geometric.pointOnLine(point, line, epsilon);
+const t55: boolean = geometric.pointOnPolygon(point, polygon, epsilon);
+const t56: boolean = geometric.pointWithLine(point, line, epsilon);

--- a/types/geometric/index.d.ts
+++ b/types/geometric/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for geometric 2.2
+// Type definitions for geometric 2.5
 // Project: https://github.com/HarryStevens/geometric#readme
 // Definitions by: Linda Paiste <https://github.com/lindapaiste>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -64,10 +64,15 @@ export function lineLength(line: Line): number;
 export function lineMidpoint(line: Line): Point;
 
 /**
- * Returns the vertices resulting from rotating a line about an origin by an angle in degrees. If origin is not
- * specified, the origin defaults to [0, 0].
+ * Returns the coordinates resulting from rotating a line about an origin by an angle in degrees.
+ * If origin is not specified, the origin defaults to the midpoint of the line.
  */
 export function lineRotate(line: Line, angle: number, origin?: Point): Line;
+
+/**
+ * Returns the coordinates resulting from translating a line by an angle in degrees and a distance.
+ */
+export function lineTranslate(line: Line, angle: number, distance: number): Line;
 
 // -------------------------------POLYGONS-------------------------------------------//
 
@@ -99,6 +104,15 @@ export function polygonCentroid(polygon: Polygon): Point;
 export function polygonHull(points: Point[]): Polygon;
 
 /**
+ * Returns an interpolator function given a polygon of vertices [a, ..., n].
+ * The returned interpolator function takes a single argument t, where t is a number ranging from 0 to 1;
+ * a value of 0 returns a, while a value of 1 returns n. Intermediate values interpolate from a to n along the polygon's perimeter.
+ */
+export function polygonInterpolate(polygon: Polygon): PolygonInterpolator;
+
+export type PolygonInterpolator = (t: number) => Point;
+
+/**
  * Returns the length of a polygon's perimeter.
  */
 export function polygonLength(polygon: Polygon): number;
@@ -107,8 +121,28 @@ export function polygonLength(polygon: Polygon): number;
  * Returns the arithmetic mean of the vertices of a polygon. Keeps duplicate vertices, resulting in different
  * values for open and closed polygons. Not to be confused with a centroid.
  */
-
 export function polygonMean(polygon: Polygon): Point;
+
+/**
+ * Returns the vertices of a random convex polygon of the specified number of sides, area, and centroid coordinates.
+ * If sides is not specified, defaults to 3. If area is not specified, defaults to 100.
+ * If centroid is not specified, defaults to [0, 0].
+ * The returned polygon's winding order will be counter-clockwise.
+ * Based on an algorithm by Pavel Valtr and an implementation by Maneesh Agrawala.
+ */
+export function polygonRandom(sides?: number, area?: number, centroid?: Point): Polygon;
+
+/**
+ * Reflects a polygon over its vertical midline. Pass an optional reflectFactor between 0 and 1, where 1 indicates
+ * a full reflection, 0 leaves the polygon unchanged, and 0.5 collapses the polygon on its vertical midline.
+ */
+export function polygonReflectX(polygon: Polygon, reflectFactor?: number): Polygon;
+
+/**
+ * Reflects a polygon over its horizontal midline. Pass an optional reflectFactor between 0 and 1, where 1 indicates
+ * a full reflection, 0 leaves the polygon unchanged, and 0.5 collapses the polygon on its horizontal midline.
+ */
+export function polygonReflectY(polygon: Polygon, reflectFactor?: number): Polygon;
 
 /**
  * Returns the vertices of a regular polygon of the specified number of sides, area, and center coordinates. If
@@ -126,8 +160,20 @@ export function polygonRotate(polygon: Polygon, angle: number, origin?: Point): 
 /**
  * Returns the vertices resulting from scaling a polygon by a scaleFactor (where 1 is the polygon's current size)
  * from an origin point. If origin is not specified, the origin defaults to the polygon's centroid.
+ *
+ * The returned polygon's area is equal to the input polygon's area multiplied by the square of the scaleFactor.
+ * To scale the polygon's area by the scaleFactor itself, see geometric.polygonScaleArea.
  */
 export function polygonScale(polygon: Polygon, scaleFactor: number, origin?: Point): Polygon;
+
+/**
+ * Returns the vertices resulting from scaling a polygon by a scaleFactor (where 1 is the polygon's current size)
+ * from an origin point. If origin is not specified, the origin defaults to the polygon's centroid.
+ *
+ * The returned polygon's area is equal to the input polygon's area multiplied by the scaleFactor.
+ * To scale the polygon's area by the square of the scaleFactor, see geometric.polygonScale.
+ */
+export function polygonScaleArea(polygon: Polygon, scaleFactor: number, origin?: Point): Polygon;
 
 /**
  * Returns the vertices resulting from scaling the horizontal coordinates of a
@@ -152,6 +198,16 @@ export function polygonScaleY(polygon: Polygon, scaleFactor: number, origin?: Po
  */
 export function polygonTranslate(polygon: Polygon, angle: number, distance: number): Polygon;
 
+/**
+ * Returns a polygon in the specified winding order. If an order string is passed as either "cw" or "clockwise",
+ * returns a polygon with a clockwise winding order. Otherwise, returns a polygon with a counter-clockwise winding order.
+ * Returns null if the polygon has fewer than three points.
+ *
+ * On computer screens where the top-left corner is at [0, 0], a polygon with a negative signed area has a
+ * counter-clockwise winding order.
+ */
+export function polygonWind(polygon: Polygon, order?: 'cw' | 'ccw' | 'clockwise'): Polygon;
+
 // -------------------------------RELATIONSHIPS-------------------------------------------//
 
 /**
@@ -171,19 +227,23 @@ export function pointInPolygon(point: Point, polygon: Polygon): boolean;
 
 /**
  * Returns a boolean representing whether a point is located on one of the edges of a polygon.
+ * An optional epsilon number, such as 1e-6, can be passed to reduce the precision with which the relationship is measured.
  */
-export function pointOnPolygon(point: Point, polygon: Polygon): boolean;
+export function pointOnPolygon(point: Point, polygon: Polygon, epsilon?: number): boolean;
 
 /**
  * Returns a boolean representing whether a point is collinear with a line and is also located on the line segment.
+ * An optional epsilon number, such as 1e-6, can be passed to reduce the precision with which the relationship is measured.
  * See also pointWithLine.
  */
-export function pointOnLine(point: Point, line: Line): boolean;
+export function pointOnLine(point: Point, line: Line, epsilon?: number): boolean;
 
 /**
- * Returns a boolean representing whether a point is collinear with a line. See also pointOnLine.
+ * Returns a boolean representing whether a point is collinear with a line.
+ * An optional epsilon number, such as 1e-6, can be passed to reduce the precision with which the relationship is measured.
+ * See also pointOnLine.
  */
-export function pointWithLine(point: Point, line: Line): boolean;
+export function pointWithLine(point: Point, line: Line, epsilon?: number): boolean;
 
 /**
  * Returns a boolean representing whether a point is to the left of a line.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/HarryStevens/geometric/releases
https://github.com/HarryStevens/geometric#api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

Adds optional `epsilon` argument (since [v2.2.5](https://github.com/HarryStevens/geometric/releases/tag/v2.2.5)) to functions:
* `pointOnLine`
* `pointOnPolygon` 
* `pointWithLine`

Creates types for new functions:
* `lineTranslate`
* `polygonInterpolate`
* `polygonRandom`
* `polygonReflectX`
* `polygonReflectY`
* `polygonScaleArea`
* `polygonWind`

Update comments to match package docs for functions:
* `lineRotate` (see PR #62388)
* `polygonScale`