### PR TITLE
[uuid] Return correct type for `parse` method

### DIFF
--- a/types/uuid/index.d.ts
+++ b/types/uuid/index.d.ts
@@ -63,7 +63,7 @@ type v5 = v5Buffer & v5String & v5Static;
 
 type NIL = string;
 
-type parse = (uuid: string) => OutputBuffer;
+type parse = (uuid: string) => Uint8Array;
 type stringify = (buffer: InputBuffer, offset?: number) => string;
 type validate = (uuid: string) => boolean;
 type version = (uuid: string) => number;

--- a/types/uuid/uuid-tests.ts
+++ b/types/uuid/uuid-tests.ts
@@ -87,7 +87,7 @@ uuidv4(null, h); // $ExpectType CustomBuffer
 const nil5: string = uuidv5('hello', NIL_UUID);
 
 const stringified: string = uuidStringify(bufferv4);
-const parsed: ArrayLike<number> = uuidParse(stringified);
+const parsed: Uint8Array = uuidParse(stringified);
 
 let valid: boolean = uuidValidate(stringv1);
 valid = uuidValidate(stringv4);


### PR DESCRIPTION
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/uuidjs/uuid/blob/main/src/parse.js – the only possible return from `parse` is a `Uint8Array`.