### PR TITLE
feat(mapbox-gl): backport DragPanOptions and InteractiveOptions to v1

### DIFF
--- a/types/mapbox-gl/v1/index.d.ts
+++ b/types/mapbox-gl/v1/index.d.ts
@@ -187,6 +187,15 @@ declare namespace mapboxgl {
         | 'bottom-left'
         | 'bottom-right';
 
+    type DragPanOptions = {
+        linearity?: number;
+        easing?: (t: number) => number;
+        deceleration?: number;
+        maxSpeed?: number;
+    };
+
+    type InteractiveOptions = { around?: 'center' };
+
     /**
      * Map
      */
@@ -574,7 +583,7 @@ declare namespace mapboxgl {
         customAttribution?: string | string[] | undefined;
 
         /** If true, enable the "drag to pan" interaction (see DragPanHandler). */
-        dragPan?: boolean | undefined;
+        dragPan?: boolean | DragPanOptions | undefined;
 
         /** If true, enable the "drag to rotate" interaction (see DragRotateHandler). */
         dragRotate?: boolean | undefined;
@@ -685,7 +694,7 @@ declare namespace mapboxgl {
         renderWorldCopies?: boolean | undefined;
 
         /** If true, enable the "scroll to zoom" interaction */
-        scrollZoom?: boolean | undefined;
+        scrollZoom?: boolean | InteractiveOptions | undefined;
 
         /** stylesheet location */
         style?: mapboxgl.Style | string | undefined;
@@ -702,10 +711,10 @@ declare namespace mapboxgl {
         transformRequest?: TransformRequestFunction | undefined;
 
         /** If true, enable the "pinch to rotate and zoom" interaction (see TouchZoomRotateHandler). */
-        touchZoomRotate?: boolean | undefined;
+        touchZoomRotate?: boolean | InteractiveOptions | undefined;
 
         /** If true, the "drag to pitch" interaction is enabled */
-        touchPitch?: boolean | undefined;
+        touchPitch?: boolean | InteractiveOptions | undefined;
 
         /** Initial zoom level */
         zoom?: number | undefined;
@@ -795,7 +804,7 @@ declare namespace mapboxgl {
 
         isEnabled(): boolean;
 
-        enable(): void;
+        enable(options?: InteractiveOptions): void;
 
         disable(): void;
 
@@ -814,7 +823,7 @@ declare namespace mapboxgl {
 
         isActive(): boolean;
 
-        enable(): void;
+        enable(options?: DragPanOptions): void;
 
         disable(): void;
     }
@@ -898,7 +907,7 @@ declare namespace mapboxgl {
 
         isEnabled(): boolean;
 
-        enable(): void;
+        enable(options?: InteractiveOptions): void;
 
         disable(): void;
 
@@ -910,7 +919,7 @@ declare namespace mapboxgl {
     export class TouchPitchHandler {
         constructor(map: mapboxgl.Map);
 
-        enable(): void;
+        enable(options?: InteractiveOptions): void;
 
         isActive(): boolean;
 

--- a/types/mapbox-gl/v1/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/v1/mapbox-gl-tests.ts
@@ -112,6 +112,29 @@ expectType<mapboxgl.MapboxOptions>({
 });
 
 /**
+ * Check `touchPitch`, `touchZoomRotate`, `scrollZoom` to accept Object
+ */
+expectType<mapboxgl.MapboxOptions>({
+    container: 'map',
+    touchPitch: { around: 'center' },
+    touchZoomRotate: { around: 'center' },
+    scrollZoom: { around: 'center' },
+});
+
+/**
+ * Check `dragPan` to accept Object
+ */
+expectType<mapboxgl.MapboxOptions>({
+    container: 'map',
+    dragPan: {
+        linearity: 0.3,
+        easing: t => t,
+        maxSpeed: 1400,
+        deceleration: 2500,
+    },
+});
+
+/**
  * Create and style marker clusters
  */
 map.on('load', function () {
@@ -1316,10 +1339,12 @@ new mapboxgl.Map().scrollZoom.setZoomRate(1);
 
 // $ExpectType void
 new mapboxgl.Map().scrollZoom.setWheelZoomRate(1);
+new mapboxgl.Map().scrollZoom.enable({ around: 'center' });
 
 const touchPitchHandler = new mapboxgl.TouchPitchHandler(map);
 // $ExpectType void
 touchPitchHandler.enable();
+touchPitchHandler.enable({ around: 'center' });
 // $ExpectType boolean
 touchPitchHandler.isActive();
 // $ExpectType boolean
@@ -1328,6 +1353,30 @@ touchPitchHandler.isEnabled();
 touchPitchHandler.disable();
 
 new mapboxgl.Map().touchPitch = touchPitchHandler;
+
+/**
+ * `dragPan`
+ */
+// $ExpectType void
+new mapboxgl.Map().dragPan.enable({
+    linearity: 0.3,
+    easing: t => t,
+    maxSpeed: 1400,
+    deceleration: 2500,
+});
+
+/**
+ * `touchZoomRotate`
+ */
+// $ExpectType void
+new mapboxgl.Map().touchZoomRotate.enable({
+    around: 'center',
+});
+// $ExpectType void
+new mapboxgl.Map().touchZoomRotate.enable();
+
+// $ExpectType void
+new mapboxgl.Map().touchZoomRotate.enable({});
 
 /*
  * Visibility


### PR DESCRIPTION
Backport the `DragPanOptions` and `InteractiveOptions` types from the main branch of `mapbox-gl` to the v1 branch. Code copied from #57193.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - documentation (not v1-specific): <https://docs.mapbox.com/mapbox-gl-js/api/map/#map>
  - `DragPanHandler` source code on v1 branch: <https://github.com/mapbox/mapbox-gl-js/blob/v1.13.3/src/ui/handler/shim/drag_pan.js#L6>
  - `scrollZoom` source code on v1 branch: <https://github.com/mapbox/mapbox-gl-js/blob/v1.13.3/src/ui/handler/scroll_zoom.js#L131>
  - `TwoTouchHandler` source code on v1 branch: <https://github.com/mapbox/mapbox-gl-js/blob/v1.13.3/src/ui/handler/touch_zoom_rotate.js#L74>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.