### PR TITLE
Make jsonstream-next return `Transform` streams.

### DIFF
--- a/types/jsonstream-next/index.d.ts
+++ b/types/jsonstream-next/index.d.ts
@@ -5,12 +5,14 @@
 
 /// <reference types="node" />
 
+import stream = require("stream");
+
 export interface Options {
     recurse: boolean;
 }
 
-export function parse(pattern: any): NodeJS.ReadWriteStream;
-export function parse(patterns: any[]): NodeJS.ReadWriteStream;
+export function parse(pattern: any): stream.Transform;
+export function parse(patterns: any[]): stream.Transform;
 
 /**
  * Create a writable stream.
@@ -18,18 +20,18 @@ export function parse(patterns: any[]): NodeJS.ReadWriteStream;
  * JSONStream.stringify() will create an array,
  * (with default options open='[\n', sep='\n,\n', close='\n]\n')
  */
-export function stringify(): NodeJS.ReadWriteStream;
+export function stringify(): stream.Transform;
 
 /**
  * Create a writable stream.
  * You may pass in custom open, close, and seperator strings.
  */
-export function stringify(open: string, sep: string, close: string): NodeJS.ReadWriteStream;
+export function stringify(open: string, sep: string, close: string): stream.Transform;
 
 /** Creates a writable stream where elements are only seperated by a newline. */
-export function stringify(newlineOnly: NewlineOnlyIndicator): NodeJS.ReadWriteStream;
+export function stringify(newlineOnly: NewlineOnlyIndicator): stream.Transform;
 export type NewlineOnlyIndicator = false;
 
-export function stringifyObject(): NodeJS.ReadWriteStream;
-export function stringifyObject(open: string, sep: string, close: string): NodeJS.ReadWriteStream;
-export function stringifyObject(newlineOnly: NewlineOnlyIndicator): NodeJS.ReadWriteStream;
+export function stringifyObject(): stream.Transform;
+export function stringifyObject(open: string, sep: string, close: string): stream.Transform;
+export function stringifyObject(newlineOnly: NewlineOnlyIndicator): stream.Transform;

--- a/types/jsonstream-next/jsonstream-next-tests.ts
+++ b/types/jsonstream-next/jsonstream-next-tests.ts
@@ -16,7 +16,7 @@ export function foo(read: NodeJS.ReadableStream) {
     const transform = json.parse('*');
     const oldFlush = (cb: (e: Error | null | undefined) => void) => transform._flush(cb);
     const newFlush: typeof oldFlush = cb => {
-        return oldFlush(err => {
+        oldFlush(err => {
             if (err) {
                 console.error("Parse error: " + err.message);
             }

--- a/types/jsonstream-next/jsonstream-next-tests.ts
+++ b/types/jsonstream-next/jsonstream-next-tests.ts
@@ -11,3 +11,17 @@ export function foo(read: NodeJS.ReadableStream) {
     read = json.stringifyObject();
     read = json.stringifyObject('{', ',', '}');
 }
+
+{
+    const transform = json.parse('*');
+    const oldFlush = (cb: (e: Error | null | undefined) => void) => transform._flush(cb);
+    const newFlush: typeof oldFlush = cb => {
+        return oldFlush(err => {
+            if (err) {
+                console.error("Parse error: " + err.message);
+            }
+            cb(err);
+        });
+    };
+    transform._flush = newFlush;
+}


### PR DESCRIPTION
https://unpkg.com/browse/jsonstream-next@3.0.0/index.js

If you notice, all of these functions use the `obj` export off of `through2`, and [the types for `through2`](https://unpkg.com/browse/@types/through2@2.0.38/index.d.ts) say that it returns `Transform` streams from Node's `stream` package.

