### PR TITLE
[screeps]  v3.3.1 rollback breaking change on `Game.getObjectById(id:string)` and add `ConcreteStructureMap`

### DIFF
--- a/types/screeps/index.d.ts
+++ b/types/screeps/index.d.ts
@@ -8,6 +8,7 @@
 //                 Dominic Marcuse <https://github.com/dmarcuse>
 //                 Skyler Kehren <https://github.com/pyrodogg>
 //                 Kieran Carnegie <https://github.com/kotarou>
+//                 Mofeng <https://github.com/DiamondMofeng>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 4.6
 

--- a/types/screeps/index.d.ts
+++ b/types/screeps/index.d.ts
@@ -89,26 +89,26 @@ declare const CREEP_CLAIM_LIFE_TIME: 600;
 declare const CREEP_CORPSE_RATE: 0.2;
 
 declare const OBSTACLE_OBJECT_TYPES: [
-    "spawn",
-    "creep",
-    "powerCreep",
-    "source",
-    "mineral",
-    "deposit",
-    "controller",
-    "constructedWall",
-    "extension",
-    "link",
-    "storage",
-    "tower",
-    "observer",
-    "powerSpawn",
-    "powerBank",
-    "lab",
-    "terminal",
-    "nuker",
-    "factory",
-    "invaderCore",
+    'spawn',
+    'creep',
+    'powerCreep',
+    'source',
+    'mineral',
+    'deposit',
+    'controller',
+    'constructedWall',
+    'extension',
+    'link',
+    'storage',
+    'tower',
+    'observer',
+    'powerSpawn',
+    'powerBank',
+    'lab',
+    'terminal',
+    'nuker',
+    'factory',
+    'invaderCore',
 ];
 
 declare const ENERGY_REGEN_TIME: 300;
@@ -456,134 +456,134 @@ declare const NUKE_DAMAGE: {
 declare const REACTIONS: {
     [resource: string]: { [resource: string]: string };
     H: {
-        O: "OH";
-        L: "LH";
-        K: "KH";
-        U: "UH";
-        Z: "ZH";
-        G: "GH";
+        O: 'OH';
+        L: 'LH';
+        K: 'KH';
+        U: 'UH';
+        Z: 'ZH';
+        G: 'GH';
     };
     O: {
-        H: "OH";
-        L: "LO";
-        K: "KO";
-        U: "UO";
-        Z: "ZO";
-        G: "GO";
+        H: 'OH';
+        L: 'LO';
+        K: 'KO';
+        U: 'UO';
+        Z: 'ZO';
+        G: 'GO';
     };
     Z: {
-        K: "ZK";
-        H: "ZH";
-        O: "ZO";
+        K: 'ZK';
+        H: 'ZH';
+        O: 'ZO';
     };
     L: {
-        U: "UL";
-        H: "LH";
-        O: "LO";
+        U: 'UL';
+        H: 'LH';
+        O: 'LO';
     };
     K: {
-        Z: "ZK";
-        H: "KH";
-        O: "KO";
+        Z: 'ZK';
+        H: 'KH';
+        O: 'KO';
     };
     G: {
-        H: "GH";
-        O: "GO";
+        H: 'GH';
+        O: 'GO';
     };
     U: {
-        L: "UL";
-        H: "UH";
-        O: "UO";
+        L: 'UL';
+        H: 'UH';
+        O: 'UO';
     };
     OH: {
-        UH: "UH2O";
-        UO: "UHO2";
-        ZH: "ZH2O";
-        ZO: "ZHO2";
-        KH: "KH2O";
-        KO: "KHO2";
-        LH: "LH2O";
-        LO: "LHO2";
-        GH: "GH2O";
-        GO: "GHO2";
+        UH: 'UH2O';
+        UO: 'UHO2';
+        ZH: 'ZH2O';
+        ZO: 'ZHO2';
+        KH: 'KH2O';
+        KO: 'KHO2';
+        LH: 'LH2O';
+        LO: 'LHO2';
+        GH: 'GH2O';
+        GO: 'GHO2';
     };
     X: {
-        UH2O: "XUH2O";
-        UHO2: "XUHO2";
-        LH2O: "XLH2O";
-        LHO2: "XLHO2";
-        KH2O: "XKH2O";
-        KHO2: "XKHO2";
-        ZH2O: "XZH2O";
-        ZHO2: "XZHO2";
-        GH2O: "XGH2O";
-        GHO2: "XGHO2";
+        UH2O: 'XUH2O';
+        UHO2: 'XUHO2';
+        LH2O: 'XLH2O';
+        LHO2: 'XLHO2';
+        KH2O: 'XKH2O';
+        KHO2: 'XKHO2';
+        ZH2O: 'XZH2O';
+        ZHO2: 'XZHO2';
+        GH2O: 'XGH2O';
+        GHO2: 'XGHO2';
     };
     ZK: {
-        UL: "G";
+        UL: 'G';
     };
     UL: {
-        ZK: "G";
+        ZK: 'G';
     };
     LH: {
-        OH: "LH2O";
+        OH: 'LH2O';
     };
     ZH: {
-        OH: "ZH2O";
+        OH: 'ZH2O';
     };
     GH: {
-        OH: "GH2O";
+        OH: 'GH2O';
     };
     KH: {
-        OH: "KH2O";
+        OH: 'KH2O';
     };
     UH: {
-        OH: "UH2O";
+        OH: 'UH2O';
     };
     LO: {
-        OH: "LHO2";
+        OH: 'LHO2';
     };
     ZO: {
-        OH: "ZHO2";
+        OH: 'ZHO2';
     };
     KO: {
-        OH: "KHO2";
+        OH: 'KHO2';
     };
     UO: {
-        OH: "UHO2";
+        OH: 'UHO2';
     };
     GO: {
-        OH: "GHO2";
+        OH: 'GHO2';
     };
     LH2O: {
-        X: "XLH2O";
+        X: 'XLH2O';
     };
     KH2O: {
-        X: "XKH2O";
+        X: 'XKH2O';
     };
     ZH2O: {
-        X: "XZH2O";
+        X: 'XZH2O';
     };
     UH2O: {
-        X: "XUH2O";
+        X: 'XUH2O';
     };
     GH2O: {
-        X: "XGH2O";
+        X: 'XGH2O';
     };
     LHO2: {
-        X: "XLHO2";
+        X: 'XLHO2';
     };
     UHO2: {
-        X: "XUHO2";
+        X: 'XUHO2';
     };
     KHO2: {
-        X: "XKHO2";
+        X: 'XKHO2';
     };
     ZHO2: {
-        X: "XZHO2";
+        X: 'XZHO2';
     };
     GHO2: {
-        X: "XGHO2";
+        X: 'XGHO2';
     };
 };
 
@@ -749,7 +749,10 @@ declare const COMMODITIES: Record<
         level?: number;
         amount: number;
         cooldown: number;
-        components: Record<DepositConstant | CommodityConstant | MineralConstant | RESOURCE_ENERGY | RESOURCE_GHODIUM, number>;
+        components: Record<
+            DepositConstant | CommodityConstant | MineralConstant | RESOURCE_ENERGY | RESOURCE_GHODIUM,
+            number
+        >;
     }
 >;
 
@@ -817,7 +820,7 @@ declare const POWER_CREEP_MAX_LEVEL: 25;
 declare const POWER_CREEP_LIFE_TIME: 5000;
 
 declare const POWER_CLASS: {
-    OPERATOR: "operator";
+    OPERATOR: 'operator';
 };
 
 declare const PWR_GENERATE_OPS: PWR_GENERATE_OPS;
@@ -869,13 +872,13 @@ declare const POWER_INFO: {
         duration?: number | number[];
     };
     [PWR_GENERATE_OPS]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 50;
         effect: [1, 2, 4, 6, 8];
     };
     [PWR_OPERATE_SPAWN]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 300;
         duration: 1000;
@@ -884,7 +887,7 @@ declare const POWER_INFO: {
         effect: [0.9, 0.7, 0.5, 0.35, 0.2];
     };
     [PWR_OPERATE_TOWER]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 10;
         duration: 100;
@@ -893,7 +896,7 @@ declare const POWER_INFO: {
         effect: [1.1, 1.2, 1.3, 1.4, 1.5];
     };
     [PWR_OPERATE_STORAGE]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 800;
         duration: 1000;
@@ -902,7 +905,7 @@ declare const POWER_INFO: {
         effect: [500000, 1000000, 2000000, 4000000, 7000000];
     };
     [PWR_OPERATE_LAB]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 50;
         duration: 1000;
@@ -911,7 +914,7 @@ declare const POWER_INFO: {
         effect: [2, 4, 6, 8, 10];
     };
     [PWR_OPERATE_EXTENSION]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 50;
         range: 3;
@@ -919,7 +922,7 @@ declare const POWER_INFO: {
         effect: [0.2, 0.4, 0.6, 0.8, 1.0];
     };
     [PWR_OPERATE_OBSERVER]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 400;
         duration: [200, 400, 600, 800, 1000];
@@ -927,7 +930,7 @@ declare const POWER_INFO: {
         ops: 10;
     };
     [PWR_OPERATE_TERMINAL]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 500;
         duration: 1000;
@@ -936,7 +939,7 @@ declare const POWER_INFO: {
         effect: [0.9, 0.8, 0.7, 0.6, 0.5];
     };
     [PWR_DISRUPT_SPAWN]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 5;
         range: 20;
@@ -944,7 +947,7 @@ declare const POWER_INFO: {
         duration: [1, 2, 3, 4, 5];
     };
     [PWR_DISRUPT_TOWER]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 0;
         duration: 5;
@@ -953,7 +956,7 @@ declare const POWER_INFO: {
         effect: [0.9, 0.8, 0.7, 0.6, 0.5];
     };
     [PWR_DISRUPT_SOURCE]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 100;
         range: 3;
@@ -961,7 +964,7 @@ declare const POWER_INFO: {
         duration: [100, 200, 300, 400, 500];
     };
     [PWR_SHIELD]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         effect: [5000, 10000, 15000, 20000, 25000];
         duration: 50;
@@ -969,7 +972,7 @@ declare const POWER_INFO: {
         energy: 100;
     };
     [PWR_REGEN_SOURCE]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [10, 11, 12, 14, 22];
         cooldown: 100;
         duration: 300;
@@ -978,7 +981,7 @@ declare const POWER_INFO: {
         period: 15;
     };
     [PWR_REGEN_MINERAL]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [10, 11, 12, 14, 22];
         cooldown: 100;
         duration: 100;
@@ -987,7 +990,7 @@ declare const POWER_INFO: {
         period: 10;
     };
     [PWR_DISRUPT_TERMINAL]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [20, 21, 22, 23, 24];
         cooldown: 8;
         duration: 10;
@@ -995,7 +998,7 @@ declare const POWER_INFO: {
         ops: [50, 40, 30, 20, 10];
     };
     [PWR_FORTIFY]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 5;
         range: 3;
@@ -1003,7 +1006,7 @@ declare const POWER_INFO: {
         duration: [1, 2, 3, 4, 5];
     };
     [PWR_OPERATE_POWER]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [10, 11, 12, 14, 22];
         cooldown: 800;
         range: 3;
@@ -1012,7 +1015,7 @@ declare const POWER_INFO: {
         effect: [1, 2, 3, 4, 5];
     };
     [PWR_OPERATE_CONTROLLER]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [20, 21, 22, 23, 24];
         cooldown: 800;
         range: 3;
@@ -1021,7 +1024,7 @@ declare const POWER_INFO: {
         effect: [10, 20, 30, 40, 50];
     };
     [PWR_OPERATE_FACTORY]: {
-        className: POWER_CLASS["OPERATOR"];
+        className: POWER_CLASS['OPERATOR'];
         level: [0, 2, 7, 14, 22];
         cooldown: 1000;
         range: 3;
@@ -1488,7 +1491,14 @@ interface Flag extends RoomObject {
 }
 
 interface FlagConstructor extends _Constructor<Flag> {
-    new (name: string, color: ColorConstant, secondaryColor: ColorConstant, roomName: string, x: number, y: number): Flag;
+    new (
+        name: string,
+        color: ColorConstant,
+        secondaryColor: ColorConstant,
+        roomName: string,
+        x: number,
+        y: number,
+    ): Flag;
     (name: string, color: ColorConstant, secondaryColor: ColorConstant, roomName: string, x: number, y: number): Flag;
 }
 
@@ -1639,7 +1649,7 @@ interface Shard {
     /**
      * Currently always equals to normal.
      */
-    type: "normal";
+    type: 'normal';
     /**
      * Whether this shard belongs to the PTR.
      */
@@ -1742,7 +1752,7 @@ type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T exten
            *
            * If the body part is boosted, this property specifies the mineral type which is used for boosting.
            */
-          boost?: keyof typeof BOOSTS[T];
+          boost?: keyof (typeof BOOSTS)[T];
           /**
            * One of the body part types constants.
            */
@@ -1829,9 +1839,14 @@ interface LookForAtAreaResultMatrix<T, K extends keyof LookAtTypes = keyof LookA
 
 type LookForAtAreaResult<T, K extends keyof LookAtTypes = keyof LookAtTypes> = { type: K } & { [P in K]: T };
 
-type LookForAtAreaResultWithPos<T, K extends keyof LookAtTypes = keyof LookAtTypes> = LookForAtAreaResult<T, K> & { x: number; y: number };
+type LookForAtAreaResultWithPos<T, K extends keyof LookAtTypes = keyof LookAtTypes> = LookForAtAreaResult<T, K> & {
+    x: number;
+    y: number;
+};
 
-type LookForAtAreaResultArray<T, K extends keyof LookAtTypes = keyof LookAtTypes> = Array<LookForAtAreaResultWithPos<T, K>>;
+type LookForAtAreaResultArray<T, K extends keyof LookAtTypes = keyof LookAtTypes> = Array<
+    LookForAtAreaResultWithPos<T, K>
+>;
 
 interface FindTypes {
     [key: number]:
@@ -2067,13 +2082,13 @@ declare const InterShardMemory: InterShardMemory;
 
 // Extras
 
-type Terrain = "plain" | "swamp" | "wall";
+type Terrain = 'plain' | 'swamp' | 'wall';
 
-type ExitKey = "1" | "3" | "5" | "7";
+type ExitKey = '1' | '3' | '5' | '7';
 
 type AnyCreep = Creep | PowerCreep;
 
-type FindClosestByPathAlgorithm = "astar" | "dijkstra";
+type FindClosestByPathAlgorithm = 'astar' | 'dijkstra';
 
 // Return Codes
 
@@ -2114,7 +2129,14 @@ type ERR_NOT_ENOUGH_EXTENSIONS = -6;
 type ERR_RCL_NOT_ENOUGH = -14;
 type ERR_GCL_NOT_ENOUGH = -15;
 
-type CreepActionReturnCode = OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART | ERR_TIRED;
+type CreepActionReturnCode =
+    | OK
+    | ERR_NOT_OWNER
+    | ERR_BUSY
+    | ERR_INVALID_TARGET
+    | ERR_NOT_IN_RANGE
+    | ERR_NO_BODYPART
+    | ERR_TIRED;
 
 type CreepMoveReturnCode = OK | ERR_NOT_OWNER | ERR_BUSY | ERR_TIRED | ERR_NO_BODYPART;
 
@@ -2195,14 +2217,14 @@ interface FilterObject {
 
 type BodyPartConstant = MOVE | WORK | CARRY | ATTACK | RANGED_ATTACK | TOUGH | HEAL | CLAIM;
 
-type MOVE = "move";
-type WORK = "work";
-type CARRY = "carry";
-type ATTACK = "attack";
-type RANGED_ATTACK = "ranged_attack";
-type TOUGH = "tough";
-type HEAL = "heal";
-type CLAIM = "claim";
+type MOVE = 'move';
+type WORK = 'work';
+type CARRY = 'carry';
+type ATTACK = 'attack';
+type RANGED_ATTACK = 'ranged_attack';
+type TOUGH = 'tough';
+type HEAL = 'heal';
+type CLAIM = 'claim';
 
 // Look Constants
 
@@ -2222,23 +2244,23 @@ type LookConstant =
     | LOOK_POWER_CREEPS
     | LOOK_RUINS;
 
-type LOOK_CONSTRUCTION_SITES = "constructionSite";
-type LOOK_CREEPS = "creep";
-type LOOK_ENERGY = "energy";
-type LOOK_FLAGS = "flag";
-type LOOK_MINERALS = "mineral";
-type LOOK_DEPOSITS = "deposit";
-type LOOK_NUKES = "nuke";
-type LOOK_RESOURCES = "resource";
-type LOOK_SOURCES = "source";
-type LOOK_STRUCTURES = "structure";
-type LOOK_TERRAIN = "terrain";
-type LOOK_TOMBSTONES = "tombstone";
-type LOOK_POWER_CREEPS = "powerCreep";
-type LOOK_RUINS = "ruin";
+type LOOK_CONSTRUCTION_SITES = 'constructionSite';
+type LOOK_CREEPS = 'creep';
+type LOOK_ENERGY = 'energy';
+type LOOK_FLAGS = 'flag';
+type LOOK_MINERALS = 'mineral';
+type LOOK_DEPOSITS = 'deposit';
+type LOOK_NUKES = 'nuke';
+type LOOK_RESOURCES = 'resource';
+type LOOK_SOURCES = 'source';
+type LOOK_STRUCTURES = 'structure';
+type LOOK_TERRAIN = 'terrain';
+type LOOK_TOMBSTONES = 'tombstone';
+type LOOK_POWER_CREEPS = 'powerCreep';
+type LOOK_RUINS = 'ruin';
 
-type ORDER_SELL = "sell";
-type ORDER_BUY = "buy";
+type ORDER_SELL = 'sell';
+type ORDER_BUY = 'buy';
 
 // Direction Constants
 
@@ -2306,27 +2328,27 @@ type StructureConstant =
     | STRUCTURE_PORTAL
     | STRUCTURE_INVADER_CORE;
 
-type STRUCTURE_EXTENSION = "extension";
-type STRUCTURE_RAMPART = "rampart";
-type STRUCTURE_ROAD = "road";
-type STRUCTURE_SPAWN = "spawn";
-type STRUCTURE_LINK = "link";
-type STRUCTURE_WALL = "constructedWall";
-type STRUCTURE_KEEPER_LAIR = "keeperLair";
-type STRUCTURE_CONTROLLER = "controller";
-type STRUCTURE_STORAGE = "storage";
-type STRUCTURE_TOWER = "tower";
-type STRUCTURE_OBSERVER = "observer";
-type STRUCTURE_POWER_BANK = "powerBank";
-type STRUCTURE_POWER_SPAWN = "powerSpawn";
-type STRUCTURE_EXTRACTOR = "extractor";
-type STRUCTURE_LAB = "lab";
-type STRUCTURE_TERMINAL = "terminal";
-type STRUCTURE_CONTAINER = "container";
-type STRUCTURE_NUKER = "nuker";
-type STRUCTURE_FACTORY = "factory";
-type STRUCTURE_INVADER_CORE = "invaderCore";
-type STRUCTURE_PORTAL = "portal";
+type STRUCTURE_EXTENSION = 'extension';
+type STRUCTURE_RAMPART = 'rampart';
+type STRUCTURE_ROAD = 'road';
+type STRUCTURE_SPAWN = 'spawn';
+type STRUCTURE_LINK = 'link';
+type STRUCTURE_WALL = 'constructedWall';
+type STRUCTURE_KEEPER_LAIR = 'keeperLair';
+type STRUCTURE_CONTROLLER = 'controller';
+type STRUCTURE_STORAGE = 'storage';
+type STRUCTURE_TOWER = 'tower';
+type STRUCTURE_OBSERVER = 'observer';
+type STRUCTURE_POWER_BANK = 'powerBank';
+type STRUCTURE_POWER_SPAWN = 'powerSpawn';
+type STRUCTURE_EXTRACTOR = 'extractor';
+type STRUCTURE_LAB = 'lab';
+type STRUCTURE_TERMINAL = 'terminal';
+type STRUCTURE_CONTAINER = 'container';
+type STRUCTURE_NUKER = 'nuker';
+type STRUCTURE_FACTORY = 'factory';
+type STRUCTURE_INVADER_CORE = 'invaderCore';
+type STRUCTURE_PORTAL = 'portal';
 
 // Terrain mask constants
 type TERRAIN_MASK_WALL = 1;
@@ -2357,7 +2379,11 @@ type MineralConstant =
     | RESOURCE_CATALYST;
 
 /** The compounds which can't boost */
-type MineralBaseCompoundsConstant = RESOURCE_HYDROXIDE | RESOURCE_ZYNTHIUM_KEANITE | RESOURCE_UTRIUM_LEMERGITE | RESOURCE_GHODIUM;
+type MineralBaseCompoundsConstant =
+    | RESOURCE_HYDROXIDE
+    | RESOURCE_ZYNTHIUM_KEANITE
+    | RESOURCE_UTRIUM_LEMERGITE
+    | RESOURCE_GHODIUM;
 
 /** The boosts (from tier 1 to tier 3) */
 type MineralBoostConstant =
@@ -2440,107 +2466,107 @@ type CommodityConstant =
 type InterShardResourceConstant = SUBSCRIPTION_TOKEN | CPU_UNLOCK | PIXEL | ACCESS_KEY;
 type MarketResourceConstant = ResourceConstant | InterShardResourceConstant;
 
-type RESOURCE_ENERGY = "energy";
-type RESOURCE_POWER = "power";
-type RESOURCE_OPS = "ops";
+type RESOURCE_ENERGY = 'energy';
+type RESOURCE_POWER = 'power';
+type RESOURCE_OPS = 'ops';
 
-type RESOURCE_BIOMASS = "biomass";
-type RESOURCE_METAL = "metal";
-type RESOURCE_MIST = "mist";
-type RESOURCE_SILICON = "silicon";
+type RESOURCE_BIOMASS = 'biomass';
+type RESOURCE_METAL = 'metal';
+type RESOURCE_MIST = 'mist';
+type RESOURCE_SILICON = 'silicon';
 
-type RESOURCE_UTRIUM = "U";
-type RESOURCE_LEMERGIUM = "L";
-type RESOURCE_KEANIUM = "K";
-type RESOURCE_ZYNTHIUM = "Z";
-type RESOURCE_OXYGEN = "O";
-type RESOURCE_HYDROGEN = "H";
-type RESOURCE_CATALYST = "X";
+type RESOURCE_UTRIUM = 'U';
+type RESOURCE_LEMERGIUM = 'L';
+type RESOURCE_KEANIUM = 'K';
+type RESOURCE_ZYNTHIUM = 'Z';
+type RESOURCE_OXYGEN = 'O';
+type RESOURCE_HYDROGEN = 'H';
+type RESOURCE_CATALYST = 'X';
 
-type RESOURCE_HYDROXIDE = "OH";
-type RESOURCE_ZYNTHIUM_KEANITE = "ZK";
-type RESOURCE_UTRIUM_LEMERGITE = "UL";
-type RESOURCE_GHODIUM = "G";
+type RESOURCE_HYDROXIDE = 'OH';
+type RESOURCE_ZYNTHIUM_KEANITE = 'ZK';
+type RESOURCE_UTRIUM_LEMERGITE = 'UL';
+type RESOURCE_GHODIUM = 'G';
 
-type RESOURCE_UTRIUM_HYDRIDE = "UH";
-type RESOURCE_UTRIUM_OXIDE = "UO";
-type RESOURCE_KEANIUM_HYDRIDE = "KH";
-type RESOURCE_KEANIUM_OXIDE = "KO";
-type RESOURCE_LEMERGIUM_HYDRIDE = "LH";
-type RESOURCE_LEMERGIUM_OXIDE = "LO";
-type RESOURCE_ZYNTHIUM_HYDRIDE = "ZH";
-type RESOURCE_ZYNTHIUM_OXIDE = "ZO";
-type RESOURCE_GHODIUM_HYDRIDE = "GH";
-type RESOURCE_GHODIUM_OXIDE = "GO";
+type RESOURCE_UTRIUM_HYDRIDE = 'UH';
+type RESOURCE_UTRIUM_OXIDE = 'UO';
+type RESOURCE_KEANIUM_HYDRIDE = 'KH';
+type RESOURCE_KEANIUM_OXIDE = 'KO';
+type RESOURCE_LEMERGIUM_HYDRIDE = 'LH';
+type RESOURCE_LEMERGIUM_OXIDE = 'LO';
+type RESOURCE_ZYNTHIUM_HYDRIDE = 'ZH';
+type RESOURCE_ZYNTHIUM_OXIDE = 'ZO';
+type RESOURCE_GHODIUM_HYDRIDE = 'GH';
+type RESOURCE_GHODIUM_OXIDE = 'GO';
 
-type RESOURCE_UTRIUM_ACID = "UH2O";
-type RESOURCE_UTRIUM_ALKALIDE = "UHO2";
-type RESOURCE_KEANIUM_ACID = "KH2O";
-type RESOURCE_KEANIUM_ALKALIDE = "KHO2";
-type RESOURCE_LEMERGIUM_ACID = "LH2O";
-type RESOURCE_LEMERGIUM_ALKALIDE = "LHO2";
-type RESOURCE_ZYNTHIUM_ACID = "ZH2O";
-type RESOURCE_ZYNTHIUM_ALKALIDE = "ZHO2";
-type RESOURCE_GHODIUM_ACID = "GH2O";
-type RESOURCE_GHODIUM_ALKALIDE = "GHO2";
+type RESOURCE_UTRIUM_ACID = 'UH2O';
+type RESOURCE_UTRIUM_ALKALIDE = 'UHO2';
+type RESOURCE_KEANIUM_ACID = 'KH2O';
+type RESOURCE_KEANIUM_ALKALIDE = 'KHO2';
+type RESOURCE_LEMERGIUM_ACID = 'LH2O';
+type RESOURCE_LEMERGIUM_ALKALIDE = 'LHO2';
+type RESOURCE_ZYNTHIUM_ACID = 'ZH2O';
+type RESOURCE_ZYNTHIUM_ALKALIDE = 'ZHO2';
+type RESOURCE_GHODIUM_ACID = 'GH2O';
+type RESOURCE_GHODIUM_ALKALIDE = 'GHO2';
 
-type RESOURCE_CATALYZED_UTRIUM_ACID = "XUH2O";
-type RESOURCE_CATALYZED_UTRIUM_ALKALIDE = "XUHO2";
-type RESOURCE_CATALYZED_KEANIUM_ACID = "XKH2O";
-type RESOURCE_CATALYZED_KEANIUM_ALKALIDE = "XKHO2";
-type RESOURCE_CATALYZED_LEMERGIUM_ACID = "XLH2O";
-type RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE = "XLHO2";
-type RESOURCE_CATALYZED_ZYNTHIUM_ACID = "XZH2O";
-type RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE = "XZHO2";
-type RESOURCE_CATALYZED_GHODIUM_ACID = "XGH2O";
-type RESOURCE_CATALYZED_GHODIUM_ALKALIDE = "XGHO2";
+type RESOURCE_CATALYZED_UTRIUM_ACID = 'XUH2O';
+type RESOURCE_CATALYZED_UTRIUM_ALKALIDE = 'XUHO2';
+type RESOURCE_CATALYZED_KEANIUM_ACID = 'XKH2O';
+type RESOURCE_CATALYZED_KEANIUM_ALKALIDE = 'XKHO2';
+type RESOURCE_CATALYZED_LEMERGIUM_ACID = 'XLH2O';
+type RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE = 'XLHO2';
+type RESOURCE_CATALYZED_ZYNTHIUM_ACID = 'XZH2O';
+type RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE = 'XZHO2';
+type RESOURCE_CATALYZED_GHODIUM_ACID = 'XGH2O';
+type RESOURCE_CATALYZED_GHODIUM_ALKALIDE = 'XGHO2';
 
-type RESOURCE_UTRIUM_BAR = "utrium_bar";
-type RESOURCE_LEMERGIUM_BAR = "lemergium_bar";
-type RESOURCE_ZYNTHIUM_BAR = "zynthium_bar";
-type RESOURCE_KEANIUM_BAR = "keanium_bar";
-type RESOURCE_GHODIUM_MELT = "ghodium_melt";
-type RESOURCE_OXIDANT = "oxidant";
-type RESOURCE_REDUCTANT = "reductant";
-type RESOURCE_PURIFIER = "purifier";
-type RESOURCE_BATTERY = "battery";
+type RESOURCE_UTRIUM_BAR = 'utrium_bar';
+type RESOURCE_LEMERGIUM_BAR = 'lemergium_bar';
+type RESOURCE_ZYNTHIUM_BAR = 'zynthium_bar';
+type RESOURCE_KEANIUM_BAR = 'keanium_bar';
+type RESOURCE_GHODIUM_MELT = 'ghodium_melt';
+type RESOURCE_OXIDANT = 'oxidant';
+type RESOURCE_REDUCTANT = 'reductant';
+type RESOURCE_PURIFIER = 'purifier';
+type RESOURCE_BATTERY = 'battery';
 
-type RESOURCE_COMPOSITE = "composite";
-type RESOURCE_CRYSTAL = "crystal";
-type RESOURCE_LIQUID = "liquid";
+type RESOURCE_COMPOSITE = 'composite';
+type RESOURCE_CRYSTAL = 'crystal';
+type RESOURCE_LIQUID = 'liquid';
 
-type RESOURCE_WIRE = "wire";
-type RESOURCE_SWITCH = "switch";
-type RESOURCE_TRANSISTOR = "transistor";
-type RESOURCE_MICROCHIP = "microchip";
-type RESOURCE_CIRCUIT = "circuit";
-type RESOURCE_DEVICE = "device";
+type RESOURCE_WIRE = 'wire';
+type RESOURCE_SWITCH = 'switch';
+type RESOURCE_TRANSISTOR = 'transistor';
+type RESOURCE_MICROCHIP = 'microchip';
+type RESOURCE_CIRCUIT = 'circuit';
+type RESOURCE_DEVICE = 'device';
 
-type RESOURCE_CELL = "cell";
-type RESOURCE_PHLEGM = "phlegm";
-type RESOURCE_TISSUE = "tissue";
-type RESOURCE_MUSCLE = "muscle";
-type RESOURCE_ORGANOID = "organoid";
-type RESOURCE_ORGANISM = "organism";
+type RESOURCE_CELL = 'cell';
+type RESOURCE_PHLEGM = 'phlegm';
+type RESOURCE_TISSUE = 'tissue';
+type RESOURCE_MUSCLE = 'muscle';
+type RESOURCE_ORGANOID = 'organoid';
+type RESOURCE_ORGANISM = 'organism';
 
-type RESOURCE_ALLOY = "alloy";
-type RESOURCE_TUBE = "tube";
-type RESOURCE_FIXTURES = "fixtures";
-type RESOURCE_FRAME = "frame";
-type RESOURCE_HYDRAULICS = "hydraulics";
-type RESOURCE_MACHINE = "machine";
+type RESOURCE_ALLOY = 'alloy';
+type RESOURCE_TUBE = 'tube';
+type RESOURCE_FIXTURES = 'fixtures';
+type RESOURCE_FRAME = 'frame';
+type RESOURCE_HYDRAULICS = 'hydraulics';
+type RESOURCE_MACHINE = 'machine';
 
-type RESOURCE_CONDENSATE = "condensate";
-type RESOURCE_CONCENTRATE = "concentrate";
-type RESOURCE_EXTRACT = "extract";
-type RESOURCE_SPIRIT = "spirit";
-type RESOURCE_EMANATION = "emanation";
-type RESOURCE_ESSENCE = "essence";
+type RESOURCE_CONDENSATE = 'condensate';
+type RESOURCE_CONCENTRATE = 'concentrate';
+type RESOURCE_EXTRACT = 'extract';
+type RESOURCE_SPIRIT = 'spirit';
+type RESOURCE_EMANATION = 'emanation';
+type RESOURCE_ESSENCE = 'essence';
 
-type SUBSCRIPTION_TOKEN = "token";
-type CPU_UNLOCK = "cpuUnlock";
-type PIXEL = "pixel";
-type ACCESS_KEY = "accessKey";
+type SUBSCRIPTION_TOKEN = 'token';
+type CPU_UNLOCK = 'cpuUnlock';
+type PIXEL = 'pixel';
+type ACCESS_KEY = 'accessKey';
 
 type TOMBSTONE_DECAY_PER_PART = 5;
 
@@ -2591,7 +2617,7 @@ type EventHealType = EVENT_HEAL_TYPE_MELEE | EVENT_HEAL_TYPE_RANGED;
 type EVENT_HEAL_TYPE_MELEE = 1;
 type EVENT_HEAL_TYPE_RANGED = 2;
 
-type EventDestroyType = "creep" | StructureConstant;
+type EventDestroyType = 'creep' | StructureConstant;
 
 type EventItem =
     | {
@@ -2707,10 +2733,10 @@ interface EventData {
     };
 }
 
-type PowerClassConstant = POWER_CLASS["OPERATOR"];
+type PowerClassConstant = POWER_CLASS['OPERATOR'];
 
 interface POWER_CLASS {
-    OPERATOR: "operator";
+    OPERATOR: 'operator';
 }
 
 type PowerConstant =
@@ -2768,12 +2794,12 @@ interface RouteOptions {
 }
 
 interface RoomStatusPermanent {
-    status: "normal" | "closed";
+    status: 'normal' | 'closed';
     timestamp: null;
 }
 
 interface RoomStatusTemporary {
-    status: "novice" | "respawn";
+    status: 'novice' | 'respawn';
     timestamp: number;
 }
 
@@ -2799,7 +2825,11 @@ interface GameMap {
      * Or one of the following Result codes:
      * ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExit(fromRoom: string | Room, toRoom: string | Room, opts?: RouteOptions): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
+    findExit(
+        fromRoom: string | Room,
+        toRoom: string | Room,
+        opts?: RouteOptions,
+    ): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
     /**
      * Find route from the given room to another room.
      * @param fromRoom Start room name or room object.
@@ -2968,7 +2998,7 @@ interface MapLineStyle {
     /**
      * Either undefined (solid line), dashed, or dotted. Default is undefined.
      */
-    lineStyle?: "dashed" | "dotted" | "solid" | undefined;
+    lineStyle?: 'dashed' | 'dotted' | 'solid' | undefined;
 }
 
 interface MapPolyStyle {
@@ -2991,7 +3021,7 @@ interface MapPolyStyle {
     /**
      * Either undefined (solid line), dashed, or dotted. Default is undefined.
      */
-    lineStyle?: "dashed" | "dotted" | "solid" | undefined;
+    lineStyle?: 'dashed' | 'dotted' | 'solid' | undefined;
 }
 
 interface MapCircleStyle extends MapPolyStyle {
@@ -3041,7 +3071,7 @@ interface MapTextStyle {
     /**
      * Text align, either center, left, or right. Default is center.
      */
-    align?: "center" | "left" | "right";
+    align?: 'center' | 'left' | 'right';
     /**
      * Opacity value, default is 0.5.
      */
@@ -3290,7 +3320,10 @@ interface PathFinder {
      */
     search(
         origin: RoomPosition,
-        goal: RoomPosition | { pos: RoomPosition; range: number } | Array<RoomPosition | { pos: RoomPosition; range: number }>,
+        goal:
+            | RoomPosition
+            | { pos: RoomPosition; range: number }
+            | Array<RoomPosition | { pos: RoomPosition; range: number }>,
         opts?: PathFinderOpts,
     ): PathFinderPath;
     /**
@@ -3577,7 +3610,9 @@ interface PowerCreep extends RoomObject {
      * Instantly restore time to live to the maximum using a Power Spawn or a Power Bank nearby. It has to be at adjacent tile.
      * @param target The target structure
      */
-    renew(target: StructurePowerBank | StructurePowerSpawn): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
+    renew(
+        target: StructurePowerBank | StructurePowerSpawn,
+    ): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
     /**
      * Display a visual speech balloon above the creep with the specified message.
      *
@@ -3592,7 +3627,9 @@ interface PowerCreep extends RoomObject {
      * Spawn this power creep in the specified Power Spawn.
      * @param powerSpawn Your Power Spawn structure
      */
-    spawn(powerSpawn: StructurePowerSpawn): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_TIRED | ERR_RCL_NOT_ENOUGH;
+    spawn(
+        powerSpawn: StructurePowerSpawn,
+    ): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_TIRED | ERR_RCL_NOT_ENOUGH;
     /**
      * Kill the power creep immediately. It will not be destroyed permanently, but will become unspawned, so that you can `spawn` it again.
      */
@@ -3879,7 +3916,11 @@ interface RoomPosition {
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
      * @returns The name of the flag if created, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
      */
-    createFlag(name?: string, color?: ColorConstant, secondaryColor?: ColorConstant): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
+    createFlag(
+        name?: string,
+        color?: ColorConstant,
+        secondaryColor?: ColorConstant,
+    ): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
     /**
      * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param type Any of the FIND_* constants.
@@ -3902,7 +3943,10 @@ interface RoomPosition {
      */
     findClosestByPath<T extends _HasRoomPosition | RoomPosition>(
         objects: T[],
-        opts?: FindPathOpts & { filter?: ((object: T) => boolean) | FilterObject | string; algorithm?: FindClosestByPathAlgorithm },
+        opts?: FindPathOpts & {
+            filter?: ((object: T) => boolean) | FilterObject | string;
+            algorithm?: FindClosestByPathAlgorithm;
+        },
     ): T | null;
     /**
      * Find the object with the shortest linear distance from the given position.
@@ -3919,14 +3963,21 @@ interface RoomPosition {
      * @param objects An array of RoomPositions or objects with a RoomPosition.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<T extends _HasRoomPosition | RoomPosition>(objects: T[], opts?: { filter: any | string }): T | null;
+    findClosestByRange<T extends _HasRoomPosition | RoomPosition>(
+        objects: T[],
+        opts?: { filter: any | string },
+    ): T | null;
     /**
      * Find all objects in the specified linear range.
      * @param type Any of the FIND_* constants.
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<K extends FindConstant, S extends FindTypes[K]>(type: K, range: number, opts?: FilterOptions<K, S>): S[];
+    findInRange<K extends FindConstant, S extends FindTypes[K]>(
+        type: K,
+        range: number,
+        opts?: FilterOptions<K, S>,
+    ): S[];
     findInRange<S extends AnyStructure>(
         type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES,
         range: number,
@@ -3938,7 +3989,11 @@ interface RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T extends _HasRoomPosition | RoomPosition>(objects: T[], range: number, opts?: { filter?: any | string }): T[];
+    findInRange<T extends _HasRoomPosition | RoomPosition>(
+        objects: T[],
+        range: number,
+        opts?: { filter?: any | string },
+    ): T[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.
      *
@@ -4195,7 +4250,7 @@ interface LineStyle {
     /**
      * Either undefined (solid line), dashed, or dotted.Default is undefined.
      */
-    lineStyle?: "dashed" | "dotted" | "solid" | undefined;
+    lineStyle?: 'dashed' | 'dotted' | 'solid' | undefined;
 }
 
 interface PolyStyle {
@@ -4218,7 +4273,7 @@ interface PolyStyle {
     /**
      * Either undefined (solid line), dashed, or dotted. Default is undefined.
      */
-    lineStyle?: "dashed" | "dotted" | "solid" | undefined;
+    lineStyle?: 'dashed' | 'dotted' | 'solid' | undefined;
 }
 
 interface CircleStyle extends PolyStyle {
@@ -4258,7 +4313,7 @@ interface TextStyle {
      * Background rectangle padding, default is 0.3.
      */
     backgroundPadding?: number;
-    align?: "center" | "left" | "right";
+    align?: 'center' | 'left' | 'right';
     /**
      * Opacity value, default is 1.0.
      */
@@ -4345,7 +4400,11 @@ interface Room {
      * @param name The name of the structure, for structures that support it (currently only spawns).
      * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
      */
-    createConstructionSite(pos: RoomPosition | _HasRoomPosition, structureType: STRUCTURE_SPAWN, name?: string): ScreepsReturnCode;
+    createConstructionSite(
+        pos: RoomPosition | _HasRoomPosition,
+        structureType: STRUCTURE_SPAWN,
+        name?: string,
+    ): ScreepsReturnCode;
     /**
      * Create new Flag at the specified location.
      * @param x The X position.
@@ -4491,7 +4550,10 @@ interface Room {
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      * @returns An array of Creeps at the specified position if found.
      */
-    lookForAt<T extends keyof AllLookAtTypes>(type: T, target: RoomPosition | _HasRoomPosition): Array<AllLookAtTypes[T]>;
+    lookForAt<T extends keyof AllLookAtTypes>(
+        type: T,
+        target: RoomPosition | _HasRoomPosition,
+    ): Array<AllLookAtTypes[T]>;
     /**
      * Get the given objets in the supplied area.
      * @param type One of the LOOK_* constants
@@ -4864,7 +4926,13 @@ interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE
      */
     getUsedCapacity<R extends ResourceConstant | undefined = undefined>(
         resource?: R,
-    ): R extends undefined ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : R extends POSSIBLE_RESOURCES ? number : null;
+    ): R extends undefined
+        ? ResourceConstant extends POSSIBLE_RESOURCES
+            ? number
+            : null
+        : R extends POSSIBLE_RESOURCES
+        ? number
+        : null;
     /**
      * Returns free capacity for the store. For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
      * @param resource The type of the resource.
@@ -4872,7 +4940,13 @@ interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE
      */
     getFreeCapacity<R extends ResourceConstant | undefined = undefined>(
         resource?: R,
-    ): R extends undefined ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : R extends POSSIBLE_RESOURCES ? number : null;
+    ): R extends undefined
+        ? ResourceConstant extends POSSIBLE_RESOURCES
+            ? number
+            : null
+        : R extends POSSIBLE_RESOURCES
+        ? number
+        : null;
 }
 
 type Store<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends boolean> = StoreBase<
@@ -5038,7 +5112,9 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     unclaim(): ScreepsReturnCode;
 }
 
-interface StructureControllerConstructor extends _Constructor<StructureController>, _ConstructorById<StructureController> {}
+interface StructureControllerConstructor
+    extends _Constructor<StructureController>,
+        _ConstructorById<StructureController> {}
 
 declare const StructureController: StructureControllerConstructor;
 
@@ -5067,7 +5143,9 @@ interface StructureExtension extends OwnedStructure<STRUCTURE_EXTENSION> {
     store: Store<RESOURCE_ENERGY, false>;
 }
 
-interface StructureExtensionConstructor extends _Constructor<StructureExtension>, _ConstructorById<StructureExtension> {}
+interface StructureExtensionConstructor
+    extends _Constructor<StructureExtension>,
+        _ConstructorById<StructureExtension> {}
 
 declare const StructureExtension: StructureExtensionConstructor;
 
@@ -5126,7 +5204,9 @@ interface StructureKeeperLair extends OwnedStructure<STRUCTURE_KEEPER_LAIR> {
     ticksToSpawn?: number;
 }
 
-interface StructureKeeperLairConstructor extends _Constructor<StructureKeeperLair>, _ConstructorById<StructureKeeperLair> {}
+interface StructureKeeperLairConstructor
+    extends _Constructor<StructureKeeperLair>,
+        _ConstructorById<StructureKeeperLair> {}
 
 declare const StructureKeeperLair: StructureKeeperLairConstructor;
 
@@ -5163,7 +5243,9 @@ interface StructurePowerBank extends OwnedStructure<STRUCTURE_POWER_BANK> {
     ticksToDecay: number;
 }
 
-interface StructurePowerBankConstructor extends _Constructor<StructurePowerBank>, _ConstructorById<StructurePowerBank> {}
+interface StructurePowerBankConstructor
+    extends _Constructor<StructurePowerBank>,
+        _ConstructorById<StructurePowerBank> {}
 
 declare const StructurePowerBank: StructurePowerBankConstructor;
 
@@ -5204,7 +5286,9 @@ interface StructurePowerSpawn extends OwnedStructure<STRUCTURE_POWER_SPAWN> {
     processPower(): ScreepsReturnCode;
 }
 
-interface StructurePowerSpawnConstructor extends _Constructor<StructurePowerSpawn>, _ConstructorById<StructurePowerSpawn> {}
+interface StructurePowerSpawnConstructor
+    extends _Constructor<StructurePowerSpawn>,
+        _ConstructorById<StructurePowerSpawn> {}
 
 declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
 
@@ -5345,7 +5429,9 @@ interface StructureExtractor extends OwnedStructure<STRUCTURE_EXTRACTOR> {
     cooldown: number;
 }
 
-interface StructureExtractorConstructor extends _Constructor<StructureExtractor>, _ConstructorById<StructureExtractor> {}
+interface StructureExtractorConstructor
+    extends _Constructor<StructureExtractor>,
+        _ConstructorById<StructureExtractor> {}
 
 declare const StructureExtractor: StructureExtractorConstructor;
 
@@ -5475,7 +5561,9 @@ interface StructureContainer extends Structure<STRUCTURE_CONTAINER> {
     ticksToDecay: number;
 }
 
-interface StructureContainerConstructor extends _Constructor<StructureContainer>, _ConstructorById<StructureContainer> {}
+interface StructureContainerConstructor
+    extends _Constructor<StructureContainer>,
+        _ConstructorById<StructureContainer> {}
 
 declare const StructureContainer: StructureContainerConstructor;
 
@@ -5599,7 +5687,9 @@ interface StructureInvaderCore extends OwnedStructure<STRUCTURE_INVADER_CORE> {
     spawning: Spawning | null;
 }
 
-interface StructureInvaderCoreConstructor extends _Constructor<StructureInvaderCore>, _ConstructorById<StructureInvaderCore> {}
+interface StructureInvaderCoreConstructor
+    extends _Constructor<StructureInvaderCore>,
+        _ConstructorById<StructureInvaderCore> {}
 
 declare const StructureInvaderCore: StructureInvaderCoreConstructor;
 

--- a/types/screeps/index.d.ts
+++ b/types/screeps/index.d.ts
@@ -1571,6 +1571,15 @@ interface Game {
     getObjectById<T extends _HasId>(id: Id<T>): T | null;
 
     /**
+     * Get an object with the specified unique ID. It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
+     * @param id The unique identifier.
+     * @returns an object instance or null if it cannot be found.
+     * @deprecated Use Id<T>, instead of strings, to increase type safety
+     */
+    // tslint:disable-next-line:unified-signatures
+    getObjectById<T extends _HasId>(id: string): T | null;
+
+    /**
      * Send a custom message at your profile email.
      *
      * This way, you can set up notifications to yourself on any occasion within the game.
@@ -5635,52 +5644,37 @@ type AnyStoreStructure =
 type AnyStructure = AnyOwnedStructure | StructureContainer | StructurePortal | StructureRoad | StructureWall;
 
 /**
+ * Map of structure constant to the concrete structure class
+ */
+interface ConcreteStructureMap {
+    [STRUCTURE_EXTENSION]: StructureExtension;
+    [STRUCTURE_RAMPART]: StructureRampart;
+    [STRUCTURE_ROAD]: StructureRoad;
+    [STRUCTURE_SPAWN]: StructureSpawn;
+    [STRUCTURE_LINK]: StructureLink;
+    [STRUCTURE_WALL]: StructureWall;
+    [STRUCTURE_STORAGE]: StructureStorage;
+    [STRUCTURE_TOWER]: StructureTower;
+    [STRUCTURE_OBSERVER]: StructureObserver;
+    [STRUCTURE_POWER_SPAWN]: StructurePowerSpawn;
+    [STRUCTURE_EXTRACTOR]: StructureExtractor;
+    [STRUCTURE_LAB]: StructureLab;
+    [STRUCTURE_TERMINAL]: StructureTerminal;
+    [STRUCTURE_CONTAINER]: StructureContainer;
+    [STRUCTURE_NUKER]: StructureNuker;
+    [STRUCTURE_FACTORY]: StructureFactory;
+    [STRUCTURE_KEEPER_LAIR]: StructureKeeperLair;
+    [STRUCTURE_CONTROLLER]: StructureController;
+    [STRUCTURE_POWER_BANK]: StructurePowerBank;
+    [STRUCTURE_PORTAL]: StructurePortal;
+    [STRUCTURE_INVADER_CORE]: StructureInvaderCore;
+}
+
+/**
  * Conditional type for all concrete implementations of Structure.
  * Unlike Structure<T>, ConcreteStructure<T> gives you the actual concrete class that extends Structure<T>.
  */
-type ConcreteStructure<T extends StructureConstant> = T extends STRUCTURE_EXTENSION
-    ? StructureExtension
-    : T extends STRUCTURE_RAMPART
-    ? StructureRampart
-    : T extends STRUCTURE_ROAD
-    ? StructureRoad
-    : T extends STRUCTURE_SPAWN
-    ? StructureSpawn
-    : T extends STRUCTURE_LINK
-    ? StructureLink
-    : T extends STRUCTURE_WALL
-    ? StructureWall
-    : T extends STRUCTURE_STORAGE
-    ? StructureStorage
-    : T extends STRUCTURE_TOWER
-    ? StructureTower
-    : T extends STRUCTURE_OBSERVER
-    ? StructureObserver
-    : T extends STRUCTURE_POWER_SPAWN
-    ? StructurePowerSpawn
-    : T extends STRUCTURE_EXTRACTOR
-    ? StructureExtractor
-    : T extends STRUCTURE_LAB
-    ? StructureLab
-    : T extends STRUCTURE_TERMINAL
-    ? StructureTerminal
-    : T extends STRUCTURE_CONTAINER
-    ? StructureContainer
-    : T extends STRUCTURE_NUKER
-    ? StructureNuker
-    : T extends STRUCTURE_FACTORY
-    ? StructureFactory
-    : T extends STRUCTURE_KEEPER_LAIR
-    ? StructureKeeperLair
-    : T extends STRUCTURE_CONTROLLER
-    ? StructureController
-    : T extends STRUCTURE_POWER_BANK
-    ? StructurePowerBank
-    : T extends STRUCTURE_PORTAL
-    ? StructurePortal
-    : T extends STRUCTURE_INVADER_CORE
-    ? StructureInvaderCore
-    : never;
+type ConcreteStructure<T extends StructureConstant> = ConcreteStructureMap[T];
 /**
  * A remnant of dead creeps. This is a walkable structure.
  * <ul>

--- a/types/screeps/screeps-tests.ts
+++ b/types/screeps/screeps-tests.ts
@@ -40,7 +40,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 // Game object Id types
 {
-    const creepId: Id<Creep> = "1" as Id<Creep>;
+    const creepId: Id<Creep> = '1' as Id<Creep>;
     const creepOne: Creep | null = Game.getObjectById(creepId);
     const creepThree: Creep = new Creep(creepId); // Works with typed ID
 
@@ -50,8 +50,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     type StoreStructure = StructureContainer | StructureStorage | StructureLink;
-    const storeUnionID: Id<StoreStructure> = "1234" as Id<StoreStructure>; // Strict assertion required
-    const storeIdUnion: StoreStructure["id"] = "1234" as StoreStructure["id"];
+    const storeUnionID: Id<StoreStructure> = '1234' as Id<StoreStructure>; // Strict assertion required
+    const storeIdUnion: StoreStructure['id'] = '1234' as StoreStructure['id'];
     const stringID: string = storeUnionID; // Id<T> assignable implicitly to string
     const stringID2: string = storeIdUnion; // Id<T> assignable implicitly to string
     const storeObject = Game.getObjectById(storeUnionID)!;
@@ -60,11 +60,11 @@ function resources(o: GenericStore): ResourceConstant[] {
     // Object recognized
     switch (storeObject.structureType) {
         case STRUCTURE_CONTAINER:
-            storeObject.structureType === "container";
+            storeObject.structureType === 'container';
         case STRUCTURE_STORAGE:
-            storeObject.structureType === "storage";
+            storeObject.structureType === 'storage';
         default:
-            storeObject.structureType === "link";
+            storeObject.structureType === 'link';
     }
 }
 
@@ -85,14 +85,14 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.powerCreeps
 
 {
-    PowerCreep.create("steve", POWER_CLASS.OPERATOR) === OK;
+    PowerCreep.create('steve', POWER_CLASS.OPERATOR) === OK;
 
     for (const i of Object.keys(Game.powerCreeps)) {
         const powerCreep = Game.powerCreeps[i];
 
         if (powerCreep.ticksToLive === undefined) {
             // Not spawned in world; spawn creep
-            const spawn = Game.getObjectById("powerSpawnID" as Id<StructurePowerSpawn>)!;
+            const spawn = Game.getObjectById('powerSpawnID' as Id<StructurePowerSpawn>)!;
             powerCreep.spawn(spawn);
         } else {
             // Generate Ops
@@ -104,9 +104,15 @@ function resources(o: GenericStore): ResourceConstant[] {
                 Game.powerCreeps[i].usePower(PWR_GENERATE_OPS);
             } else {
                 // Boost resource
-                const targetSource = Game.getObjectById("targetSourceID" as Id<Source>)!;
-                const sourceEffect = targetSource.effects.find((effect) => effect.effect === PWR_REGEN_SOURCE && effect.level > 0);
-                if (!sourceEffect && powerCreep.powers[PWR_REGEN_SOURCE] && powerCreep.powers[PWR_REGEN_SOURCE].cooldown === 0) {
+                const targetSource = Game.getObjectById('targetSourceID' as Id<Source>)!;
+                const sourceEffect = targetSource.effects.find(
+                    effect => effect.effect === PWR_REGEN_SOURCE && effect.level > 0,
+                );
+                if (
+                    !sourceEffect &&
+                    powerCreep.powers[PWR_REGEN_SOURCE] &&
+                    powerCreep.powers[PWR_REGEN_SOURCE].cooldown === 0
+                ) {
                     powerCreep.usePower(PWR_REGEN_SOURCE, targetSource);
                 }
             }
@@ -128,7 +134,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     // Constant type checking
     POWER_INFO[PWR_GENERATE_OPS].className === POWER_CLASS.OPERATOR;
-    typeof POWER_INFO[PWR_GENERATE_OPS].level[0] === "number";
+    typeof POWER_INFO[PWR_GENERATE_OPS].level[0] === 'number';
 }
 
 // Game.spawns
@@ -146,10 +152,15 @@ function resources(o: GenericStore): ResourceConstant[] {
             const creepSpawn: StructureSpawn = creep.spawn;
 
             const cancelStatus: OK | ERR_NOT_OWNER = creep.cancel();
-            const setDirectionStatus: OK | ERR_NOT_OWNER | ERR_INVALID_ARGS = creep.setDirections([TOP, BOTTOM, LEFT, RIGHT]);
+            const setDirectionStatus: OK | ERR_NOT_OWNER | ERR_INVALID_ARGS = creep.setDirections([
+                TOP,
+                BOTTOM,
+                LEFT,
+                RIGHT,
+            ]);
         }
 
-        const invaderCore = new StructureInvaderCore("" as Id<StructureInvaderCore>);
+        const invaderCore = new StructureInvaderCore('' as Id<StructureInvaderCore>);
         const invader = invaderCore.spawning;
         if (invader) {
             const name = invader.name;
@@ -190,7 +201,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 // Game.cpu.halt()
 {
-    if (Game.cpu.hasOwnProperty("halt")) {
+    if (Game.cpu.hasOwnProperty('halt')) {
         Game.cpu.halt!();
     }
 }
@@ -224,9 +235,9 @@ function resources(o: GenericStore): ResourceConstant[] {
 }
 
 {
-    if (Game.spawns["Spawn1"].energy === 0) {
+    if (Game.spawns['Spawn1'].energy === 0) {
         Game.notify(
-            "Spawn1 is out of energy",
+            'Spawn1 is out of energy',
             180, // group these notifications for 3 hours
         );
     }
@@ -235,9 +246,9 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.map.describeExits()
 
 {
-    const exits = Game.map.describeExits("W8N3");
+    const exits = Game.map.describeExits('W8N3');
     // tslint:disable-next-line:newline-per-chained-call
-    keys(exits).map((exitKey) => {
+    keys(exits).map(exitKey => {
         const nextRoom = exits[exitKey];
         const exitDir = +exitKey as ExitConstant;
         const exitPos = creep.pos.findClosestByRange(exitDir);
@@ -281,7 +292,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 {
     const route = Game.map.findRoute(creep.room, anotherRoomName, {
         routeCallback(roomName, fromRoomName) {
-            if (roomName === "W10S10") {
+            if (roomName === 'W10S10') {
                 // avoid this room
                 return Infinity;
             }
@@ -291,8 +302,8 @@ function resources(o: GenericStore): ResourceConstant[] {
 }
 
 {
-    const from = new RoomPosition(25, 25, "E1N1");
-    const to = new RoomPosition(25, 25, "E4N1");
+    const from = new RoomPosition(25, 25, 'E1N1');
+    const to = new RoomPosition(25, 25, 'E4N1');
 
     // Use `findRoute` to calculate a high-level plan for this path,
     // prioritizing highways and owned rooms
@@ -302,7 +313,8 @@ function resources(o: GenericStore): ResourceConstant[] {
             const parsed = /^[WE]([0-9]+)[NS]([0-9]+)$/.exec(roomName);
             if (parsed !== null) {
                 const isHighway = parseInt(parsed[1], 10) % 10 === 0 || parseInt(parsed[2], 10) % 10 === 0;
-                const isMyRoom = Game.rooms[roomName] && Game.rooms[roomName].controller && Game.rooms[roomName].controller!.my;
+                const isMyRoom =
+                    Game.rooms[roomName] && Game.rooms[roomName].controller && Game.rooms[roomName].controller!.my;
                 if (isHighway || isMyRoom) {
                     return 1;
                 } else {
@@ -315,14 +327,14 @@ function resources(o: GenericStore): ResourceConstant[] {
     });
 
     if (route !== ERR_NO_PATH) {
-        route.forEach((info) => {
+        route.forEach(info => {
             allowedRooms[info.room] = true;
         });
     }
 
     // Invoke PathFinder, allowing access only to rooms from `findRoute`
     const ret = PathFinder.search(from, [to], {
-        roomCallback: (roomName) => {
+        roomCallback: roomName => {
             if (allowedRooms[roomName] === undefined) {
                 return false;
             } else {
@@ -335,27 +347,27 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.map.getRoomLinearDistance(roomName1, roomName2, [continuous])
 
 {
-    Game.map.getRoomLinearDistance("W1N1", "W4N2"); // 3
-    Game.map.getRoomLinearDistance("E65S55", "W65S55", false); // 131
-    Game.map.getRoomLinearDistance("E65S55", "W65S55", true); // 11
+    Game.map.getRoomLinearDistance('W1N1', 'W4N2'); // 3
+    Game.map.getRoomLinearDistance('E65S55', 'W65S55', false); // 131
+    Game.map.getRoomLinearDistance('E65S55', 'W65S55', true); // 11
 }
 
 // Game.map.getTerrainAt(x, y, roomName)
 // Game.map.getTerrainAt(pos)
 
 {
-    Game.map.getTerrainAt(25, 20, "W10N10");
+    Game.map.getTerrainAt(25, 20, 'W10N10');
 }
 
 {
-    Game.map.getTerrainAt(new RoomPosition(25, 20, "W10N10"));
+    Game.map.getTerrainAt(new RoomPosition(25, 20, 'W10N10'));
 }
 
 // Game.map.getRoomStatus(roomName)
 
 {
     const roomStatus = Game.map.getRoomStatus(room.name);
-    if (roomStatus.status === "normal") {
+    if (roomStatus.status === 'normal') {
         creep.moveTo(room.getPositionAt(25, 25)!);
     }
 }
@@ -364,7 +376,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     // Game.market.calcTransactionCost(amount, roomName1, roomName2)
-    const cost = Game.market.calcTransactionCost(1000, "W0N0", "W10N5");
+    const cost = Game.market.calcTransactionCost(1000, 'W0N0', 'W10N5');
 
     // Game.market.cancelOrder(orderId)
     for (const id of Object.keys(Game.market.orders)) {
@@ -372,14 +384,20 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     // Game.market.changeOrderPrice(orderId, newPrice)
-    Game.market.changeOrderPrice("57bec1bf77f4d17c4c011960", 9.95);
+    Game.market.changeOrderPrice('57bec1bf77f4d17c4c011960', 9.95);
 
     // Game.market.createOrder({type, resourceType, price, totalAmount, [roomName]})
-    Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000, roomName: "W1N1" });
+    Game.market.createOrder({
+        type: ORDER_SELL,
+        resourceType: RESOURCE_GHODIUM,
+        price: 9.95,
+        totalAmount: 10000,
+        roomName: 'W1N1',
+    });
     Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000 });
 
     // Game.market.deal(orderId, amount, [yourRoomName])
-    Game.market.deal("57cd2b12cda69a004ae223a3", 1000, "W1N1");
+    Game.market.deal('57cd2b12cda69a004ae223a3', 1000, 'W1N1');
 
     const amountToBuy = 2000;
     const maxTransferEnergyCost = 500;
@@ -387,32 +405,32 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     for (const i of orders) {
         if (i.roomName) {
-            const transferEnergyCost = Game.market.calcTransactionCost(amountToBuy, "W1N1", i.roomName);
+            const transferEnergyCost = Game.market.calcTransactionCost(amountToBuy, 'W1N1', i.roomName);
 
             if (transferEnergyCost < maxTransferEnergyCost) {
-                Game.market.deal(i.id, amountToBuy, "W1N1");
+                Game.market.deal(i.id, amountToBuy, 'W1N1');
                 break;
             }
         }
     }
 
     // Game.market.extendOrder(orderId, addAmount)
-    Game.market.extendOrder("57bec1bf77f4d17c4c011960", 10000);
+    Game.market.extendOrder('57bec1bf77f4d17c4c011960', 10000);
 
     // Game.market.getAllOrders([filter])
     Game.market.getAllOrders();
     Game.market.getAllOrders({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM });
 
-    const targetRoom = "W1N1";
+    const targetRoom = 'W1N1';
     Game.market.getAllOrders(
-        (currentOrder) =>
+        currentOrder =>
             currentOrder.resourceType === RESOURCE_GHODIUM &&
             currentOrder.type === ORDER_SELL &&
             Game.market.calcTransactionCost(1000, targetRoom, currentOrder.roomName!) < 500,
     );
 
     // Game.market.getOrderById(id)
-    const order = Game.market.getOrderById("55c34a6b5be41a0a6e80c123");
+    const order = Game.market.getOrderById('55c34a6b5be41a0a6e80c123');
 
     // Subscription tokens
     Game.market.getAllOrders({ type: ORDER_SELL, resourceType: SUBSCRIPTION_TOKEN });
@@ -435,7 +453,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     const pfCreep = Game.creeps.John;
 
     // tslint:disable-next-line:newline-per-chained-call
-    const goals = pfCreep.room.find(FIND_SOURCES).map((source) => {
+    const goals = pfCreep.room.find(FIND_SOURCES).map(source => {
         // We can't actually walk on sources-- set `range` to 1
         // so we path next to it.
         return { pos: source.pos, range: 1 };
@@ -458,7 +476,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             const costs = new PathFinder.CostMatrix();
 
             // tslint:disable-next-line:newline-per-chained-call
-            curRoom.find(FIND_STRUCTURES).forEach((struct) => {
+            curRoom.find(FIND_STRUCTURES).forEach(struct => {
                 if (struct.structureType === STRUCTURE_ROAD) {
                     // Favor roads over plain tiles
                     costs.set(struct.pos.x, struct.pos.y, 1);
@@ -473,7 +491,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
             // Avoid creeps in the room
             // tslint:disable-next-line:newline-per-chained-call
-            curRoom.find(FIND_CREEPS).forEach((thisCreep) => {
+            curRoom.find(FIND_CREEPS).forEach(thisCreep => {
                 costs.set(thisCreep.pos.x, thisCreep.pos.y, 0xff);
             });
 
@@ -497,7 +515,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     // RawMemory.foreignSegment
 
-    RawMemory.setActiveForeignSegment("player");
+    RawMemory.setActiveForeignSegment('player');
     // on the next tick
     const playerSegment = RawMemory.foreignSegment;
     // --> {"username": "player", "id": 40, "data": "Hello!"}
@@ -506,7 +524,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     RawMemory.interShardSegment = JSON.stringify({
         creeps: {
-            Bob: { role: "claimer" },
+            Bob: { role: 'claimer' },
         },
     });
 
@@ -528,8 +546,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     RawMemory.setActiveSegments([0, 3]);
 
     // RawMemory.setActiveForeignSegment(username, [id])
-    RawMemory.setActiveForeignSegment("player");
-    RawMemory.setActiveForeignSegment("player", 10);
+    RawMemory.setActiveForeignSegment('player');
+    RawMemory.setActiveForeignSegment('player', 10);
     RawMemory.setActiveForeignSegment(null);
 
     // RawMemory.setDefaultPublicSegment(id)
@@ -545,11 +563,11 @@ function resources(o: GenericStore): ResourceConstant[] {
 // InterShardMemory
 
 {
-    let localShardData = "";
+    let localShardData = '';
     InterShardMemory.setLocal(localShardData);
     localShardData = InterShardMemory.getLocal();
 
-    const remoteShardData: string = InterShardMemory.getRemote("shard2") || "";
+    const remoteShardData: string = InterShardMemory.getRemote('shard2') || '';
 }
 
 // Find Overloads
@@ -588,7 +606,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     creepsHere[0].getActiveBodyparts(ATTACK);
 
     const towers = room.find<StructureTower>(FIND_MY_STRUCTURES, {
-        filter: (structure) => {
+        filter: structure => {
             return structure.structureType === STRUCTURE_TOWER;
         },
     });
@@ -622,10 +640,10 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     const tower = creep.pos.findClosestByPath<StructureTower>(FIND_HOSTILE_STRUCTURES, {
-        filter: (structure) => {
+        filter: structure => {
             return structure.structureType === STRUCTURE_TOWER;
         },
-        algorithm: "astar",
+        algorithm: 'astar',
     });
     if (tower !== null) {
         tower.attack(creep);
@@ -641,24 +659,26 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     const tower2 = creep.pos.findClosestByPath(FIND_HOSTILE_STRUCTURES, {
         filter: isStructureType(STRUCTURE_TOWER),
-        algorithm: "astar",
+        algorithm: 'astar',
     });
     if (tower2 !== null) {
         tower2.attack(creep);
         tower2.attack(powerCreep);
     }
 
-    const creepWithEnergy = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS), { filter: (c) => c.store.energy > 0 });
+    const creepWithEnergy = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS), {
+        filter: c => c.store.energy > 0,
+    });
 
     const creepAbove = creep.pos.findClosestByPath(
-        creep.room.find(FIND_CREEPS).map((c) => c.pos),
+        creep.room.find(FIND_CREEPS).map(c => c.pos),
         {
-            filter: (p) => p.getDirectionTo(creep) === TOP,
+            filter: p => p.getDirectionTo(creep) === TOP,
         },
     );
 
     const rampart = creep.pos.findClosestByRange<StructureRampart>(FIND_HOSTILE_STRUCTURES, {
-        filter: (structure) => {
+        filter: structure => {
             return structure.structureType === STRUCTURE_RAMPART;
         },
     });
@@ -671,7 +691,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     hostileCreeps[0].saying;
 
     const labs = creep.pos.findInRange<StructureLab>(FIND_MY_STRUCTURES, 4, {
-        filter: (structure) => {
+        filter: structure => {
             return structure.structureType === STRUCTURE_LAB;
         },
     });
@@ -689,7 +709,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             const pos = new RoomPosition(+x, +y, room.name);
             const objects = row[x as unknown as number];
             if (objects.length > 0) {
-                objects.map((o) => o.type);
+                objects.map(o => o.type);
             }
         }
     }
@@ -720,7 +740,7 @@ function resources(o: GenericStore): ResourceConstant[] {
         creep.drop(resourceType, amount);
     }
 
-    const extension = new StructureExtension("" as Id<StructureExtension>);
+    const extension = new StructureExtension('' as Id<StructureExtension>);
 
     const e1: number = extension.store.getUsedCapacity(RESOURCE_ENERGY);
     const e2: number = extension.store[RESOURCE_ENERGY];
@@ -731,7 +751,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     const eg3: null = extension.store.getCapacity(RESOURCE_GHODIUM);
     const eg4: 0 = extension.store.G;
 
-    const storage = new StructureStorage("" as Id<StructureStorage>);
+    const storage = new StructureStorage('' as Id<StructureStorage>);
 
     const sg1: number = storage.store.getUsedCapacity(RESOURCE_GHODIUM);
     const sg2: number = storage.store.getFreeCapacity(RESOURCE_GHODIUM);
@@ -740,12 +760,12 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 // Advanced Structure types
 {
-    const owned = Game.getObjectById("blah" as Id<AnyOwnedStructure>)!;
+    const owned = Game.getObjectById('blah' as Id<AnyOwnedStructure>)!;
     const owner = owned.owner && owned.owner.username;
     owned.notifyWhenAttacked(false);
 
     const structs = room.find(FIND_MY_STRUCTURES);
-    structs.forEach((struct) => {
+    structs.forEach(struct => {
         switch (struct.structureType) {
             case STRUCTURE_CONTROLLER:
                 const usernameOptional: string | undefined = struct.owner && struct.owner.username;
@@ -756,7 +776,7 @@ function resources(o: GenericStore): ResourceConstant[] {
         }
     });
 
-    const unowned = Game.getObjectById("blah2" as Id<AnyStructure>)!;
+    const unowned = Game.getObjectById('blah2' as Id<AnyStructure>)!;
     const hp = unowned.hits / unowned.hitsMax;
 
     // test discriminated union
@@ -777,17 +797,20 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     // test discriminated union using filter functions on find
     const from = Game.rooms.myRoom.find(FIND_STRUCTURES, {
-        filter: (s) => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0,
+        filter: s =>
+            (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0,
     })[0];
     const to = from.pos.findClosestByPath(FIND_MY_STRUCTURES, {
-        filter: (s) => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity,
+        filter: s =>
+            (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) &&
+            s.energy < s.energyCapacity,
     });
 
     Game.rooms.myRoom
         .find(FIND_MY_STRUCTURES, {
-            filter: (s) => s.structureType === STRUCTURE_RAMPART,
+            filter: s => s.structureType === STRUCTURE_RAMPART,
         })
-        .forEach((r) => r.notifyWhenAttacked(false));
+        .forEach(r => r.notifyWhenAttacked(false));
 }
 
 {
@@ -811,7 +834,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     tombstone.id;
 
-    const creep = Game.creeps["dave"];
+    const creep = Game.creeps['dave'];
     creep.withdraw(tombstone, RESOURCE_ENERGY);
 }
 
@@ -825,7 +848,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 }
 
 {
-    if (Game.cpu.hasOwnProperty("getHeapStatistics")) {
+    if (Game.cpu.hasOwnProperty('getHeapStatistics')) {
         const heap = Game.cpu.getHeapStatistics!();
         heap.total_heap_size;
     }
@@ -834,9 +857,9 @@ function resources(o: GenericStore): ResourceConstant[] {
 // StructurePortal
 
 {
-    const portals = room.find<StructurePortal>(FIND_STRUCTURES, { filter: (s) => s.structureType === STRUCTURE_PORTAL });
+    const portals = room.find<StructurePortal>(FIND_STRUCTURES, { filter: s => s.structureType === STRUCTURE_PORTAL });
     portals.forEach((p: StructurePortal) => {
-        const state = p.ticksToDecay === undefined ? "stable" : "unstable";
+        const state = p.ticksToDecay === undefined ? 'stable' : 'unstable';
         if (p.destination instanceof RoomPosition) {
             Game.notify(`Found ${state} inter-room portal to ${p.destination.toString()}`);
         } else {
@@ -849,23 +872,27 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     room.createConstructionSite(10, 10, STRUCTURE_EXTENSION);
-    room.createConstructionSite(10, 11, STRUCTURE_SPAWN, "mySpawn");
+    room.createConstructionSite(10, 11, STRUCTURE_SPAWN, 'mySpawn');
 
     const pos = new RoomPosition(10, 10, room.name);
     room.createConstructionSite(pos, STRUCTURE_EXTENSION);
-    room.createConstructionSite(pos, STRUCTURE_SPAWN, "mySpawn");
+    room.createConstructionSite(pos, STRUCTURE_SPAWN, 'mySpawn');
     pos.createConstructionSite(STRUCTURE_EXTENSION);
-    pos.createConstructionSite(STRUCTURE_SPAWN, "mySpawn");
+    pos.createConstructionSite(STRUCTURE_SPAWN, 'mySpawn');
 }
 
 // StructureLab
 
 {
-    const lab0 = Game.getObjectById("lab" as Id<StructureLab>);
-    const lab1 = Game.getObjectById("lab" as Id<StructureLab>);
-    const lab2 = Game.getObjectById("lab" as Id<StructureLab>);
+    const lab0 = Game.getObjectById('lab' as Id<StructureLab>);
+    const lab1 = Game.getObjectById('lab' as Id<StructureLab>);
+    const lab2 = Game.getObjectById('lab' as Id<StructureLab>);
     if (lab0 !== null && lab1 !== null && lab2 !== null) {
-        if (lab1.mineralAmount >= LAB_REACTION_AMOUNT && lab2.mineralAmount >= LAB_REACTION_AMOUNT && lab0.mineralType === null) {
+        if (
+            lab1.mineralAmount >= LAB_REACTION_AMOUNT &&
+            lab2.mineralAmount >= LAB_REACTION_AMOUNT &&
+            lab0.mineralType === null
+        ) {
             lab0.runReaction(lab1, lab2);
         }
         // nevermind, reverse that
@@ -899,7 +926,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Room.Terrain
 
 {
-    const room = Game.rooms[""];
+    const room = Game.rooms[''];
 
     const myTerrain = room.getTerrain();
 
@@ -914,13 +941,13 @@ function resources(o: GenericStore): ResourceConstant[] {
         /*wall*/
     }
 
-    const enemyTerrain = new Room.Terrain("W2N5");
+    const enemyTerrain = new Room.Terrain('W2N5');
 }
 
 // Creep.body
 function atackPower(creep: Creep) {
     return creep.body
-        .map((part) => {
+        .map(part => {
             if (part.type === ATTACK) {
                 const multiplier = part.boost ? BOOSTS[part.type][part.boost].attack : 1;
                 return multiplier * ATTACK_POWER;
@@ -933,7 +960,7 @@ function atackPower(creep: Creep) {
 // Factories and Commodities
 
 {
-    const factory = new StructureFactory("" as Id<StructureFactory>);
+    const factory = new StructureFactory('' as Id<StructureFactory>);
 
     if (!factory.level) {
         powerCreep.usePower(PWR_OPERATE_FACTORY, factory);
@@ -1014,12 +1041,16 @@ function atackPower(creep: Creep) {
 // Game.map.visual
 {
     const mapVis = Game.map.visual;
-    const point1 = new RoomPosition(1, 1, "E1N1");
-    const point2 = new RoomPosition(1, 1, "E1N8");
-    const point3 = new RoomPosition(1, 1, "E8N8");
-    const point4 = new RoomPosition(1, 1, "E1N8");
+    const point1 = new RoomPosition(1, 1, 'E1N1');
+    const point2 = new RoomPosition(1, 1, 'E1N8');
+    const point3 = new RoomPosition(1, 1, 'E8N8');
+    const point4 = new RoomPosition(1, 1, 'E1N8');
 
-    mapVis.line(point1, point2).circle(point3, { fill: "#f2f2f2" }).poly([point1, point2, point3, point4]).rect(point3, 50, 50);
+    mapVis
+        .line(point1, point2)
+        .circle(point3, { fill: '#f2f2f2' })
+        .poly([point1, point2, point3, point4])
+        .rect(point3, 50, 50);
 
     const size: number = mapVis.getSize();
 
@@ -1030,7 +1061,8 @@ function atackPower(creep: Creep) {
 
 // Id
 {
-    const roomId = "" as Id<Room>; // $ExpectError
-    const creep = Game.getObjectById("" as Id<Creep>);
-    const foo = Game.getObjectById<StructureTower>("" as Id<Creep>); // expected to be an error in the next major release
+    // @ts-expect-error
+    const roomId = '' as Id<Room>;
+    const creep = Game.getObjectById('' as Id<Creep>);
+    const foo = Game.getObjectById<StructureTower>('' as Id<Creep>); // expected to be an error in the next major release
 }

--- a/types/screeps/screeps-tests.ts
+++ b/types/screeps/screeps-tests.ts
@@ -105,7 +105,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             } else {
                 // Boost resource
                 const targetSource = Game.getObjectById("targetSourceID" as Id<Source>)!;
-                const sourceEffect = targetSource.effects.find(effect => effect.effect === PWR_REGEN_SOURCE && effect.level > 0);
+                const sourceEffect = targetSource.effects.find((effect) => effect.effect === PWR_REGEN_SOURCE && effect.level > 0);
                 if (!sourceEffect && powerCreep.powers[PWR_REGEN_SOURCE] && powerCreep.powers[PWR_REGEN_SOURCE].cooldown === 0) {
                     powerCreep.usePower(PWR_REGEN_SOURCE, targetSource);
                 }
@@ -237,7 +237,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 {
     const exits = Game.map.describeExits("W8N3");
     // tslint:disable-next-line:newline-per-chained-call
-    keys(exits).map(exitKey => {
+    keys(exits).map((exitKey) => {
         const nextRoom = exits[exitKey];
         const exitDir = +exitKey as ExitConstant;
         const exitPos = creep.pos.findClosestByRange(exitDir);
@@ -315,14 +315,14 @@ function resources(o: GenericStore): ResourceConstant[] {
     });
 
     if (route !== ERR_NO_PATH) {
-        route.forEach(info => {
+        route.forEach((info) => {
             allowedRooms[info.room] = true;
         });
     }
 
     // Invoke PathFinder, allowing access only to rooms from `findRoute`
     const ret = PathFinder.search(from, [to], {
-        roomCallback: roomName => {
+        roomCallback: (roomName) => {
             if (allowedRooms[roomName] === undefined) {
                 return false;
             } else {
@@ -405,7 +405,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     const targetRoom = "W1N1";
     Game.market.getAllOrders(
-        currentOrder =>
+        (currentOrder) =>
             currentOrder.resourceType === RESOURCE_GHODIUM &&
             currentOrder.type === ORDER_SELL &&
             Game.market.calcTransactionCost(1000, targetRoom, currentOrder.roomName!) < 500,
@@ -435,7 +435,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     const pfCreep = Game.creeps.John;
 
     // tslint:disable-next-line:newline-per-chained-call
-    const goals = pfCreep.room.find(FIND_SOURCES).map(source => {
+    const goals = pfCreep.room.find(FIND_SOURCES).map((source) => {
         // We can't actually walk on sources-- set `range` to 1
         // so we path next to it.
         return { pos: source.pos, range: 1 };
@@ -458,7 +458,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             const costs = new PathFinder.CostMatrix();
 
             // tslint:disable-next-line:newline-per-chained-call
-            curRoom.find(FIND_STRUCTURES).forEach(struct => {
+            curRoom.find(FIND_STRUCTURES).forEach((struct) => {
                 if (struct.structureType === STRUCTURE_ROAD) {
                     // Favor roads over plain tiles
                     costs.set(struct.pos.x, struct.pos.y, 1);
@@ -473,7 +473,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
             // Avoid creeps in the room
             // tslint:disable-next-line:newline-per-chained-call
-            curRoom.find(FIND_CREEPS).forEach(thisCreep => {
+            curRoom.find(FIND_CREEPS).forEach((thisCreep) => {
                 costs.set(thisCreep.pos.x, thisCreep.pos.y, 0xff);
             });
 
@@ -588,7 +588,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     creepsHere[0].getActiveBodyparts(ATTACK);
 
     const towers = room.find<StructureTower>(FIND_MY_STRUCTURES, {
-        filter: structure => {
+        filter: (structure) => {
             return structure.structureType === STRUCTURE_TOWER;
         },
     });
@@ -622,7 +622,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     const tower = creep.pos.findClosestByPath<StructureTower>(FIND_HOSTILE_STRUCTURES, {
-        filter: structure => {
+        filter: (structure) => {
             return structure.structureType === STRUCTURE_TOWER;
         },
         algorithm: "astar",
@@ -635,7 +635,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     // Generic type predicate filter
     const isStructureType = <T extends StructureConstant, S extends ConcreteStructure<T>>(structureType: T) => {
         return (structure: AnyStructure): structure is S => {
-            return structure.structureType === structureType as string;
+            return structure.structureType === (structureType as string);
         };
     };
 
@@ -648,14 +648,17 @@ function resources(o: GenericStore): ResourceConstant[] {
         tower2.attack(powerCreep);
     }
 
-    const creepWithEnergy = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS), { filter: c => c.store.energy > 0 });
+    const creepWithEnergy = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS), { filter: (c) => c.store.energy > 0 });
 
-    const creepAbove = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS).map(c => c.pos), {
-        filter: p => p.getDirectionTo(creep) === TOP,
-    });
+    const creepAbove = creep.pos.findClosestByPath(
+        creep.room.find(FIND_CREEPS).map((c) => c.pos),
+        {
+            filter: (p) => p.getDirectionTo(creep) === TOP,
+        },
+    );
 
     const rampart = creep.pos.findClosestByRange<StructureRampart>(FIND_HOSTILE_STRUCTURES, {
-        filter: structure => {
+        filter: (structure) => {
             return structure.structureType === STRUCTURE_RAMPART;
         },
     });
@@ -668,7 +671,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     hostileCreeps[0].saying;
 
     const labs = creep.pos.findInRange<StructureLab>(FIND_MY_STRUCTURES, 4, {
-        filter: structure => {
+        filter: (structure) => {
             return structure.structureType === STRUCTURE_LAB;
         },
     });
@@ -686,7 +689,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             const pos = new RoomPosition(+x, +y, room.name);
             const objects = row[x as unknown as number];
             if (objects.length > 0) {
-                objects.map(o => o.type);
+                objects.map((o) => o.type);
             }
         }
     }
@@ -742,7 +745,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     owned.notifyWhenAttacked(false);
 
     const structs = room.find(FIND_MY_STRUCTURES);
-    structs.forEach(struct => {
+    structs.forEach((struct) => {
         switch (struct.structureType) {
             case STRUCTURE_CONTROLLER:
                 const usernameOptional: string | undefined = struct.owner && struct.owner.username;
@@ -774,17 +777,17 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     // test discriminated union using filter functions on find
     const from = Game.rooms.myRoom.find(FIND_STRUCTURES, {
-        filter: s => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0,
+        filter: (s) => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0,
     })[0];
     const to = from.pos.findClosestByPath(FIND_MY_STRUCTURES, {
-        filter: s => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity,
+        filter: (s) => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity,
     });
 
     Game.rooms.myRoom
         .find(FIND_MY_STRUCTURES, {
-            filter: s => s.structureType === STRUCTURE_RAMPART,
+            filter: (s) => s.structureType === STRUCTURE_RAMPART,
         })
-        .forEach(r => r.notifyWhenAttacked(false));
+        .forEach((r) => r.notifyWhenAttacked(false));
 }
 
 {
@@ -831,7 +834,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // StructurePortal
 
 {
-    const portals = room.find<StructurePortal>(FIND_STRUCTURES, { filter: s => s.structureType === STRUCTURE_PORTAL });
+    const portals = room.find<StructurePortal>(FIND_STRUCTURES, { filter: (s) => s.structureType === STRUCTURE_PORTAL });
     portals.forEach((p: StructurePortal) => {
         const state = p.ticksToDecay === undefined ? "stable" : "unstable";
         if (p.destination instanceof RoomPosition) {
@@ -917,7 +920,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Creep.body
 function atackPower(creep: Creep) {
     return creep.body
-        .map(part => {
+        .map((part) => {
             if (part.type === ATTACK) {
                 const multiplier = part.boost ? BOOSTS[part.type][part.boost].attack : 1;
                 return multiplier * ATTACK_POWER;
@@ -1016,11 +1019,7 @@ function atackPower(creep: Creep) {
     const point3 = new RoomPosition(1, 1, "E8N8");
     const point4 = new RoomPosition(1, 1, "E1N8");
 
-    mapVis
-        .line(point1, point2)
-        .circle(point3, { fill: "#f2f2f2" })
-        .poly([point1, point2, point3, point4])
-        .rect(point3, 50, 50);
+    mapVis.line(point1, point2).circle(point3, { fill: "#f2f2f2" }).poly([point1, point2, point3, point4]).rect(point3, 50, 50);
 
     const size: number = mapVis.getSize();
 
@@ -1031,9 +1030,7 @@ function atackPower(creep: Creep) {
 
 // Id
 {
-    // @ts-expect-error
-    const roomId = "" as Id<Room>;
+    const roomId = "" as Id<Room>; // $ExpectError
     const creep = Game.getObjectById("" as Id<Creep>);
-    // @ts-expect-error
-    const foo = Game.getObjectById<StructureTower>("" as Id<Creep>);
+    const foo = Game.getObjectById<StructureTower>("" as Id<Creep>); // expected to be an error in the next major release
 }


### PR DESCRIPTION
## Changlog

chore!: Add [myself](https://github.com/DiamondMofeng) to maintainers

feat: Update `ConcreteStructure` syntax to use map instead of conditional chain ([#209](https://github.com/screepers/typed-screeps/pull/209))
fix: Brings `Game.getObjectById(id:string)` back

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://github.com/screepers/typed-screeps/issues/223
    - https://github.com/screepers/typed-screeps/pull/209
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
