### PR TITLE
Update lodash tests for TS 5.0

### DIFF
--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3895,9 +3895,9 @@ fp.now(); // $ExpectType number
             = anything;
 
         if (_.isArrayLike(value)) {
-            const result: string | string[] | { [index: number]: boolean, length: number } | [number, boolean] = value;
+            const result: string | string[] | { length: number } | [number, boolean] = value;
         } else {
-            const result: number | { length: string } | { a: string; } | null | undefined = value;
+            const result: number | { [index: number]: boolean, length: number } | { length: string } | { a: string; } | null | undefined = value;
         }
 
         if (fp.isArrayLike(value)) {
@@ -3985,9 +3985,9 @@ fp.now(); // $ExpectType number
             = anything;
 
         if (_.isArrayLikeObject(value)) {
-            const result: string[] | { [index: number]: boolean, length: number } | [number, boolean] = value;
+            const result: string[] | { length: number } | [number, boolean] = value;
         } else {
-            const result: string | number | { length: string; } | { a: string; } | null | undefined = value;
+            const result: string | number | { length: string; } | { [index: number]: boolean, length: number } | { a: string; } | null | undefined = value;
         }
 
         if (fp.isArrayLikeObject(value)) {


### PR DESCRIPTION
Type guards now remove from a union any type that includes numeric index signatures when the guarded type does not. This changes lodash tests of `isArray` and `isArrayObject`; the true branch now inserts a `{ length: number }` into the union, and the false branch now has `{ [n: number]: boolean; length: number }` instead of the true branch.
