### PR TITLE
[css-tree] Add `Lexer#match*()` method types

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -711,6 +711,16 @@ csstree.url.encode('foo'); // $ExpectType string
 csstree.fork({}); // $ExpectType { lexer: Lexer; }
 const { lexer } = csstree.fork({ atrules: {}, properties: {}, types: { foo: '<length>' } });
 lexer; // $ExpectType Lexer
-
+lexer.matchAtruleDescriptor('foo', 'bar', ast); // $ExpectType LexerMatchResult
+lexer.matchAtruleDescriptor('foo', 'bar', 'baz'); // $ExpectType LexerMatchResult
+lexer.matchAtrulePrelude('foo', ast); // $ExpectType LexerMatchResult
+lexer.matchAtrulePrelude('foo', 'bar'); // $ExpectType LexerMatchResult
+lexer.matchDeclaration(ast); // $ExpectType LexerMatchResult
 lexer.matchProperty('foo', ast); // $ExpectType LexerMatchResult
 lexer.matchProperty('foo', 'bar'); // $ExpectType LexerMatchResult
+lexer.matchType('foo', ast); // $ExpectType LexerMatchResult
+lexer.matchType('foo', 'bar'); // $ExpectType LexerMatchResult
+lexer.match('foo', ast); // $ExpectType LexerMatchResult
+lexer.match('foo', 'bar'); // $ExpectType LexerMatchResult
+lexer.match(syntax, ast); // $ExpectType LexerMatchResult
+lexer.match(syntax, 'bar'); // $ExpectType LexerMatchResult

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -856,7 +856,12 @@ export interface LexerMatchResult {
 }
 
 export class Lexer {
+    matchAtruleDescriptor(atruleName: string, descriptorName: string, value: CssNode | string): LexerMatchResult;
+    matchAtrulePrelude(atruleName: string, prelude: CssNode | string): LexerMatchResult;
+    matchDeclaration(node: CssNode): LexerMatchResult;
     matchProperty(propertyName: string, value: CssNode | string): LexerMatchResult;
+    matchType(typeName: string, value: CssNode | string): LexerMatchResult;
+    match(syntax: DSNode | string, value: CssNode | string): LexerMatchResult;
 }
 
 export function fork(extension: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/csstree/csstree/blob/v2.3.1/lib/lexer/Lexer.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
