### PR TITLE
Add `setAttribute()` and `removeAttribute()` to `HostedFields` for `@types/braintree-web`

### DIFF
--- a/types/braintree-web/modules/hosted-fields.d.ts
+++ b/types/braintree-web/modules/hosted-fields.d.ts
@@ -182,6 +182,20 @@ export interface HostedFieldsTokenizePayload {
     };
 }
 
+/**
+ * @description The name of a HostedFields attribute.
+ */
+export type HostedFieldAttributeName = 'aria-invalid' | 'aria-required' | 'disabled' | 'placeholder';
+
+/**
+ * @description Fields used in setAttribute() and removeAttribute() for modifying a HostedFields instance's attributes.
+ */
+export interface HostedFieldAttributeOptions {
+    field: HostedFieldsHostedFieldsFieldName;
+    attribute: HostedFieldAttributeName;
+    value?: string | boolean;
+}
+
 export interface HostedFields {
     /**
      * braintree.hostedFields.create({
@@ -408,4 +422,62 @@ export interface HostedFields {
      * });
      */
     focus(field: HostedFieldsHostedFieldsFieldName, callback?: callback): void;
+
+    /**
+     * Sets an attribute of a {@link module:braintree-web/hosted-fields~field field}.
+     * Supported attributes are `aria-invalid`, `aria-required`, `disabled`, and `placeholder`.
+     *
+     * @param options The options for the attribute you wish to set.
+     * @param options.field The field to which you wish to add an attribute. Must be a valid {@link module:braintree-web/hosted-fields~fieldOptions fieldOption}.
+     * @param options.attribute The name of the attribute you wish to add to the field.
+     * @param options.value The value for the attribute.
+     * @param callback Callback executed on completion, containing an error if one occurred. No data is returned if the attribute is set successfully.
+     *
+     * @example <caption>Set the placeholder attribute of a field</caption>
+     * hostedFieldsInstance.setAttribute({
+     *   field: 'number',
+     *   attribute: 'placeholder',
+     *   value: '1111 1111 1111 1111'
+     * }, function (attributeErr) {
+     *   if (attributeErr) {
+     *     console.error(attributeErr);
+     *   }
+     * });
+     *
+     * @example <caption>Set the aria-required attribute of a field</caption>
+     * hostedFieldsInstance.setAttribute({
+     *   field: 'number',
+     *   attribute: 'aria-required',
+     *   value: true
+     * }, function (attributeErr) {
+     *   if (attributeErr) {
+     *     console.error(attributeErr);
+     *   }
+     * });
+     *
+     * @returns Returns a promise if no callback is provided.
+     */
+    setAttribute(options: HostedFieldAttributeOptions, callback?: callback): void;
+
+    /**
+     * Removes a supported attribute from a {@link module:braintree-web/hosted-fields~field field}.
+     *
+     * @param options The options for the attribute you wish to remove.
+     * @param options.field The field from which you wish to remove an attribute. Must be a valid {@link module:braintree-web/hosted-fields~fieldOptions fieldOption}.
+     * @param options.attribute The name of the attribute you wish to remove from the field.
+     * @param callback Callback executed on completion, containing an error if one occurred. No data is returned if the attribute is removed successfully.
+     *
+     * @example <caption>Remove the placeholder attribute of a field</caption>
+     * hostedFieldsInstance.removeAttribute({
+     *   field: 'number',
+     *   attribute: 'placeholder'
+     * }, function (attributeErr) {
+     *   if (attributeErr) {
+     *     console.error(attributeErr);
+     *   }
+     * });
+     *
+     * @returns Returns a promise if no callback is provided.
+     */
+    removeAttribute(options: HostedFieldAttributeOptions, callback?: callback): void;
 }

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -321,6 +321,25 @@ braintree.client.create(
 
                 hostedFieldsInstance.on('binAvailable', onBinAvailable);
                 hostedFieldsInstance.off('binAvailable', onBinAvailable);
+
+                hostedFieldsInstance.setAttribute({
+                    field: 'number',
+                    attribute: 'disabled',
+                    value: true
+                }, (attributeErr) => {
+                    if (attributeErr) {
+                        console.error(attributeErr);
+                    }
+                });
+
+                hostedFieldsInstance.removeAttribute({
+                    field: 'number',
+                    attribute: 'disabled'
+                }, (attributeErr) => {
+                    if (attributeErr) {
+                        console.error(attributeErr);
+                    }
+                });
             },
         );
 


### PR DESCRIPTION
The Braintree HostedFields API contains setAttribute() and removeAttribute() functions for modifying the attributes of a hosted fields instance. The possible attributes that can be modified within these functions are: aria-invalid, aria-requested, disabled and placeholder. 

This pull request adds these functions to `HostedFields`' types. The changes have been tested within the package and I have verified these changes as working in my own production code.

See the Braintree JS SDK for more: [setAttribute()](https://braintree.github.io/braintree-web/3.22.2/HostedFields.html#setAttribute), [removeAttribute()](https://braintree.github.io/braintree-web/3.22.2/HostedFields.html#setAttribute)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://braintree.github.io/braintree-web/3.22.2/HostedFields.html#setAttribute)>>