### PR TITLE
[eslint] Fix `reportUnusedDisableDirectives`

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -709,6 +709,8 @@ eslint = new ESLint({
     }
 });
 eslint = new ESLint({ reportUnusedDisableDirectives: "error" });
+// @ts-expect-error
+eslint = new ESLint({ reportUnusedDisableDirectives: 2 });
 eslint = new ESLint({ resolvePluginsRelativeTo: "test" });
 eslint = new ESLint({ rulePaths: ["foo"] });
 

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -712,8 +712,9 @@ export class Linter {
 
 export namespace Linter {
     type Severity = 0 | 1 | 2;
+    type StringSeverity = "off" | "warn" | "error";
 
-    type RuleLevel = Severity | "off" | "warn" | "error";
+    type RuleLevel = Severity | StringSeverity;
     type RuleLevelAndOptions<Options extends any[] = any[]> = Prepend<Partial<Options>, RuleLevel>;
 
     type RuleEntry<Options extends any[] = any[]> = RuleLevel | RuleLevelAndOptions<Options>;
@@ -985,7 +986,7 @@ export namespace ESLint {
         overrideConfig?: Linter.Config | undefined;
         overrideConfigFile?: string | undefined;
         plugins?: Record<string, Plugin> | undefined;
-        reportUnusedDisableDirectives?: "off" | "warn" | "error" | undefined;
+        reportUnusedDisableDirectives?: Linter.StringSeverity | undefined;
         resolvePluginsRelativeTo?: string | undefined;
         rulePaths?: string[] | undefined;
         useEslintrc?: boolean | undefined;

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -985,7 +985,7 @@ export namespace ESLint {
         overrideConfig?: Linter.Config | undefined;
         overrideConfigFile?: string | undefined;
         plugins?: Record<string, Plugin> | undefined;
-        reportUnusedDisableDirectives?: Linter.RuleLevel | undefined;
+        reportUnusedDisableDirectives?: "off" | "warn" | "error" | undefined;
         resolvePluginsRelativeTo?: string | undefined;
         rulePaths?: string[] | undefined;
         useEslintrc?: boolean | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - docs: https://eslint.org/docs/latest/integrate/nodejs-api#linting
  - JSDoc: https://github.com/eslint/eslint/blob/v8.34.0/lib/eslint/eslint.js#L66
  - runtime type check: https://github.com/eslint/eslint/blob/v8.34.0/lib/eslint/eslint.js#L260-L267 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The `ESLint` constructor option `reportUnusedDisableDirectives` does not accept the numeric severity values 0, 1 or 2 allowed for rules. Using an unsupported value will result in a runtime error.

This PR fixes the type of `reportUnusedDisableDirectives` to reflect the fact that only the values `"error"`, `"warn"` and `"off"` are allowed besides `null` (which for some reason is not consistently typed).