### PR TITLE
Add generic geometry to geoJSON

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1752,7 +1752,7 @@ export function featureGroup(layers?: Layer[], options?: LayerOptions): FeatureG
 
 export type StyleFunction<P = any> = (feature?: geojson.Feature<geojson.GeometryObject, P>) => PathOptions;
 
-export interface GeoJSONOptions<P = any> extends InteractiveLayerOptions {
+export interface GeoJSONOptions<P = any, G extends geojson.GeometryObject = geojson.GeometryObject> extends InteractiveLayerOptions {
     /**
      * A Function defining how GeoJSON points spawn Leaflet layers.
      * It is internally called when data is added, passing the GeoJSON point
@@ -1792,7 +1792,7 @@ export interface GeoJSONOptions<P = any> extends InteractiveLayerOptions {
      * function (feature, layer) {}
      * ```
      */
-    onEachFeature?(feature: geojson.Feature<geojson.GeometryObject, P>, layer: Layer): void;
+    onEachFeature?(feature: geojson.Feature<G, P>, layer: Layer): void;
 
     /**
      * A Function that will be used to decide whether to show a feature or not.
@@ -1805,7 +1805,7 @@ export interface GeoJSONOptions<P = any> extends InteractiveLayerOptions {
      * }
      * ```
      */
-    filter?(geoJsonFeature: geojson.Feature<geojson.GeometryObject, P>): boolean;
+    filter?(geoJsonFeature: geojson.Feature<G, P>): boolean;
 
     /**
      * A Function that will be used for converting GeoJSON coordinates to LatLngs.
@@ -1821,17 +1821,17 @@ export interface GeoJSONOptions<P = any> extends InteractiveLayerOptions {
  * Represents a GeoJSON object or an array of GeoJSON objects.
  * Allows you to parse GeoJSON data and display it on the map. Extends FeatureGroup.
  */
-export class GeoJSON<P = any> extends FeatureGroup<P> {
+export class GeoJSON<P = any, G extends geojson.GeometryObject = geojson.GeometryObject> extends FeatureGroup<P> {
     /**
      * Convert layer into GeoJSON feature
      */
-    static getFeature<P = any>(layer: Layer, newGeometry: geojson.Feature<geojson.GeometryObject, P> | geojson.GeometryObject): geojson.Feature<geojson.GeometryObject, P>;
+    static getFeature<P = any, G extends geojson.GeometryObject = geojson.GeometryObject>(layer: Layer, newGeometry: geojson.Feature<G, P> | G): geojson.Feature<G, P>;
 
     /**
      * Creates a Layer from a given GeoJSON feature. Can use a custom pointToLayer
      * and/or coordsToLatLng functions if provided as options.
      */
-    static geometryToLayer<P = any>(featureData: geojson.Feature<geojson.GeometryObject, P>, options?: GeoJSONOptions<P>): Layer;
+    static geometryToLayer<P = any, G extends geojson.GeometryObject = geojson.GeometryObject>(featureData: geojson.Feature<G, P>, options?: GeoJSONOptions<P, G>): Layer;
 
     /**
      * Creates a LatLng object from an array of 2 numbers (longitude, latitude) or
@@ -1865,9 +1865,9 @@ export class GeoJSON<P = any> extends FeatureGroup<P> {
     /**
      * Normalize GeoJSON geometries/features into GeoJSON features.
      */
-    static asFeature<P = any>(geojson: geojson.Feature<geojson.GeometryObject, P> | geojson.GeometryObject): geojson.Feature<geojson.GeometryObject, P>;
+    static asFeature<P = any, G extends geojson.GeometryObject = geojson.GeometryObject>(geojson: geojson.Feature<G, P> | G): geojson.Feature<G, P>;
 
-    constructor(geojson?: geojson.GeoJsonObject, options?: GeoJSONOptions<P>)
+    constructor(geojson?: geojson.GeoJsonObject, options?: GeoJSONOptions<P, G>)
     /**
      * Adds a GeoJSON object to the layer.
      */
@@ -1885,7 +1885,7 @@ export class GeoJSON<P = any> extends FeatureGroup<P> {
      */
     setStyle(style: PathOptions | StyleFunction<P>): this;
 
-    options: GeoJSONOptions<P>;
+    options: GeoJSONOptions<P, G>;
 }
 
 /**
@@ -1895,8 +1895,8 @@ export class GeoJSON<P = any> extends FeatureGroup<P> {
  * map (you can alternatively add it later with addData method) and
  * an options object.
  */
-export function geoJSON<P = any>(geojson?: geojson.GeoJsonObject | geojson.GeoJsonObject[], options?: GeoJSONOptions<P>): GeoJSON<P>;
-export function geoJson<P = any>(geojson?: geojson.GeoJsonObject | geojson.GeoJsonObject[], options?: GeoJSONOptions<P>): GeoJSON<P>;
+export function geoJSON<P = any, G extends geojson.GeometryObject = geojson.GeometryObject>(geojson?: geojson.GeoJsonObject | geojson.GeoJsonObject[], options?: GeoJSONOptions<P, G>): GeoJSON<P, G>;
+export function geoJson<P = any, G extends geojson.GeometryObject = geojson.GeometryObject>(geojson?: geojson.GeoJsonObject | geojson.GeoJsonObject[], options?: GeoJSONOptions<P, G>): GeoJSON<P, G>;
 
 export type Zoom = boolean | 'center';
 

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -1,4 +1,5 @@
 import * as L from 'leaflet';
+import * as geojson_types from 'geojson';
 
 const version = L.version;
 
@@ -882,3 +883,34 @@ export class ExtendedTileLayer extends L.TileLayer {
         }
     }
 }
+
+const polygonGeoJson = L.geoJSON<any, geojson_types.Polygon>(null, {
+    onEachFeature(polygonFeature, layer) {
+        // $ExpectType Polygon
+        polygonFeature.geometry;
+    }
+});
+
+const pointGeoJson = L.geoJSON<any, geojson_types.Point>(null, {
+    onEachFeature(polygonFeature, layer) {
+        // $ExpectType Point
+        polygonFeature.geometry;
+    }
+});
+
+// $ExpectType Polygon
+L.GeoJSON.getFeature(new L.Layer(), {} as geojson_types.Polygon).geometry;
+
+// $ExpectType Point
+L.GeoJSON.asFeature({} as geojson_types.Point).geometry;
+
+L.GeoJSON.geometryToLayer(
+    {} as geojson_types.Feature<geojson_types.MultiPolygon>,
+    {
+        filter(multiPolygon) {
+            // $ExpectType MultiPolygon
+            multiPolygon.geometry;
+            return true;
+        }
+    }
+);


### PR DESCRIPTION
This PR adds a generic geometry type (`G`) to leaflet's `GeoJSON` and `GeoJSONOptions` objects. The generic type must extend `geojson.GeometryObject` and defaults to that for backwards compatibility.

This is helpful when you know the specific geometry of the geoJSON you're adding and want to access properties of that geometry in the `filter` or `onEachFeature` functions. With just `geojson.GeometryObject`, you are limited to the common features of all geometries.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - Not applicable because these are changes that affect only typing
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - Not applicable because these are changes that affect only typing
