### PR TITLE
[mui-datatables] use correct type for customBodyRender tableMeta.currentTableData

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -32,9 +32,9 @@ export interface MUIDataTableData {
     index: number;
 }
 
-export interface MUIDataTableCurrentData {
-    rowIndex: number;
-    dataIndex: number;
+export interface MUIDataTableCurrentData<T = any> {
+    index: number;
+    data: T[];
 }
 
 export interface MUIDataTableStateRows {

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -78,15 +78,13 @@ const MuiCustomTable: React.FC<Props> = props => {
             label: 'Score',
             options: {
                 customBodyRender: (value, tableMeta, updateValue) => {
-                    const testIndex = tableMeta.currentTableData.map((item) => item.index);
-                    const testData = tableMeta.currentTableData.map((item) => item.data);
-                    
-                    return (
-                        <div>{value}</div>
-                    );
+                    const testIndex = tableMeta.currentTableData.map(item => item.index);
+                    const testData = tableMeta.currentTableData.map(item => item.data);
+
+                    return <div>{value}</div>;
                 },
             },
-        }
+        },
     ];
 
     const TableOptions: MUIDataTableOptions = {
@@ -202,7 +200,7 @@ const MuiCustomTable: React.FC<Props> = props => {
                 deleteAria: 'Delete Selected Rows',
             },
         },
-        storageKey: 'SavedToLocalStorage'
+        storageKey: 'SavedToLocalStorage',
     };
 
     return (
@@ -287,12 +285,12 @@ const MuiTheme = createTheme({
                 root: {
                     fontWeight: 300,
                 },
-            }
+            },
         },
         MUIDataTableBody: {
             styleOverrides: {
                 emptyTitle: {},
-            }
+            },
         },
     },
 } as unknown as ThemeOptions);

--- a/types/mui-datatables/mui-datatables-tests.tsx
+++ b/types/mui-datatables/mui-datatables-tests.tsx
@@ -73,6 +73,20 @@ const MuiCustomTable: React.FC<Props> = props => {
                 },
             },
         },
+        {
+            name: 'score',
+            label: 'Score',
+            options: {
+                customBodyRender: (value, tableMeta, updateValue) => {
+                    const testIndex = tableMeta.currentTableData.map((item) => item.index);
+                    const testData = tableMeta.currentTableData.map((item) => item.data);
+                    
+                    return (
+                        <div>{value}</div>
+                    );
+                },
+            },
+        }
     ];
 
     const TableOptions: MUIDataTableOptions = {


### PR DESCRIPTION
When using a customBodyRenderer, the tables' data can be accessed through tableMeta.currentTableData. The types for currentTableData seem to be outdated. I updated them to match what mui-datatables actually returns. I also added a small example in the tests file showcasing this feature working correctly.

Here is a [codesandbox](https://codesandbox.io/p/sandbox/divine-https-vbckmk?) that shows the returned data from tableMeta.currentTableData.

- open codesandbox, open browser console
- you will see console.logs of arrays of objects with index and data properties, not rowIndex and dataIndex


Related, but regarding a different property of tableMeta: [https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64352](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64352)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/gregnb/mui-datatables/pull/1404](https://github.com/gregnb/mui-datatables/pull/1404)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
