### PR TITLE
fix(fluent-ffmpeg): mergeToFile signature

### DIFF
--- a/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
+++ b/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
@@ -4,12 +4,9 @@ import { createWriteStream } from 'fs';
 const stream = createWriteStream('outputfile.divx');
 
 // Set the CWD
-ffmpeg('file.avi', { cwd: '/path/to' })
-    .output('ouptutfile.mp4');
+ffmpeg('file.avi', { cwd: '/path/to' }).output('ouptutfile.mp4');
 
-ffmpeg('/path/to/file.avi')
-    .output('outputfile.mp4')
-    .output(stream);
+ffmpeg('/path/to/file.avi').output('outputfile.mp4').output(stream);
 
 ffmpeg('/path/to/file.avi')
     // You may pass a pipe() options object when using a stream
@@ -17,7 +14,6 @@ ffmpeg('/path/to/file.avi')
 
 // Output-related methods apply to the last output added
 ffmpeg('/path/to/file.avi')
-
     .output('outputfile.mp4')
     .audioCodec('libfaac')
     .videoCodec('libx264')
@@ -28,20 +24,20 @@ ffmpeg('/path/to/file.avi')
     .size('640x480');
 
 // get arguments
-ffmpeg('/path/to/file.avi')
-
-    ._getArguments();
+ffmpeg('/path/to/file.avi')._getArguments();
 
 // ComplexFilter
 ffmpeg('/path/to/file.avi')
-
     .output('outputfile.mp4')
-    .complexFilter([
-      { inputs: '0:v', filter: 'scale', options: { w: 1920, h: 1080, interl: 1 }, outputs: [] },
-      { inputs: '0:a', filter: 'amerge', options: { inputs: 2 }, outputs: 'am'},
-      '[am]aresample=48000:async=1[are]',
-      { inputs: 'are', filter: 'channelsplit' , options: { channel_layout: 'stereo'}, outputs: [] }
-    ], [])
+    .complexFilter(
+        [
+            { inputs: '0:v', filter: 'scale', options: { w: 1920, h: 1080, interl: 1 }, outputs: [] },
+            { inputs: '0:a', filter: 'amerge', options: { inputs: 2 }, outputs: 'am' },
+            '[am]aresample=48000:async=1[are]',
+            { inputs: 'are', filter: 'channelsplit', options: { channel_layout: 'stereo' }, outputs: [] },
+        ],
+        [],
+    )
     .audioCodec('libfaac')
     .videoCodec('libx264')
     .size('320x200');
@@ -56,20 +52,13 @@ ffmpeg('/path/to/file.avi')
     .run();
 
 // Create a command to convert source.avi to MP4
-const command = ffmpeg('/path/to/source.avi')
-    .audioCodec('libfaac')
-    .videoCodec('libx264')
-    .format('mp4');
+const command = ffmpeg('/path/to/source.avi').audioCodec('libfaac').videoCodec('libx264').format('mp4');
 
 // Create a clone to save a small resized version
-command.clone()
-    .size('320x200')
-    .save('/path/to/output-small.mp4');
+command.clone().size('320x200').save('/path/to/output-small.mp4');
 
 // Create a clone to save a medium resized version
-command.clone()
-    .size('640x400')
-    .save('/path/to/output-medium.mp4');
+command.clone().size('640x400').save('/path/to/output-medium.mp4');
 
 // Save a converted version with the original size
 command.save('/path/to/output-original-size.mp4');
@@ -83,23 +72,23 @@ ffmpeg.setFfprobePath('path/to/ffprobe');
 ffmpeg.setFfmpegPath('path/to/ffmpeg');
 
 ffmpeg.getAvailableFormats((err, formats) => {
-  console.log('Available formats:');
-  console.dir(formats);
+    console.log('Available formats:');
+    console.dir(formats);
 });
 
 ffmpeg.getAvailableCodecs((err, codecs) => {
-  console.log('Available codecs:');
-  console.dir(codecs);
+    console.log('Available codecs:');
+    console.dir(codecs);
 });
 
 ffmpeg.getAvailableEncoders((err, encoders) => {
-  console.log('Available encoders:');
-  console.dir(encoders);
+    console.log('Available encoders:');
+    console.dir(encoders);
 });
 
 ffmpeg.getAvailableFilters((err, filters) => {
-  console.log("Available filters:");
-  console.dir(filters);
+    console.log('Available filters:');
+    console.dir(filters);
 });
 
 ffmpeg.ffprobe('/path/to/file.mp4', (err, data) => {
@@ -107,12 +96,11 @@ ffmpeg.ffprobe('/path/to/file.mp4', (err, data) => {
     console.log(data.streams[0].bit_rate);
 });
 
-ffmpeg('/path/to.mp4')
-    .loop()
-    .videoBitrate(300, true);
+ffmpeg('/path/to.mp4').loop().videoBitrate(300, true);
 
-ffmpeg('/path/to/file.avi')
-    .preset((command) => { command.format('avi').size('720x?'); });
+ffmpeg('/path/to/file.avi').preset(command => {
+    command.format('avi').size('720x?');
+});
 
 ffmpeg('/path/to/part1.avi')
     .input('/path/to/part2.avi')

--- a/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
+++ b/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
@@ -113,3 +113,8 @@ ffmpeg('/path/to.mp4')
 
 ffmpeg('/path/to/file.avi')
     .preset((command) => { command.format('avi').size('720x?'); });
+
+ffmpeg('/path/to/part1.avi')
+    .input('/path/to/part2.avi')
+    .input('/path/to/part2.avi')
+    .mergeToFile('/path/to/merged.avi', '/path/to/tempDir');

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -9,8 +9,8 @@
 
 /// <reference types="node" />
 
-import * as events from "events";
-import * as stream from "stream";
+import * as events from 'events';
+import * as stream from 'stream';
 
 declare namespace Ffmpeg {
     interface FfmpegCommandLogger {
@@ -354,8 +354,14 @@ declare namespace Ffmpeg {
         outputOption(...options: string[]): FfmpegCommand;
         outputOptions(options: string[]): FfmpegCommand;
         outputOptions(...options: string[]): FfmpegCommand;
-        filterGraph(spec: string | FilterSpecification | Array<string | FilterSpecification>, map?: string[] | string): FfmpegCommand;
-        complexFilter(spec: string | FilterSpecification | Array<string | FilterSpecification>, map?: string[] | string): FfmpegCommand;
+        filterGraph(
+            spec: string | FilterSpecification | Array<string | FilterSpecification>,
+            map?: string[] | string,
+        ): FfmpegCommand;
+        complexFilter(
+            spec: string | FilterSpecification | Array<string | FilterSpecification>,
+            map?: string[] | string,
+        ): FfmpegCommand;
 
         // options/misc
         usingPreset(preset: string | PresetFunction): FfmpegCommand;
@@ -389,7 +395,7 @@ declare namespace Ffmpeg {
         saveToFile(output: string): FfmpegCommand;
         save(output: string): FfmpegCommand;
         writeToStream(stream: stream.Writable, options?: { end?: boolean | undefined }): stream.Writable;
-        pipe(stream?: stream.Writable, options?: { end?: boolean | undefined }): stream.Writable|stream.PassThrough;
+        pipe(stream?: stream.Writable, options?: { end?: boolean | undefined }): stream.Writable | stream.PassThrough;
         stream(stream: stream.Writable, options?: { end?: boolean | undefined }): stream.Writable;
         takeScreenshots(config: number | ScreenshotsConfig, folder?: string): FfmpegCommand;
         thumbnail(config: number | ScreenshotsConfig, folder?: string): FfmpegCommand;
@@ -406,7 +412,12 @@ declare namespace Ffmpeg {
     function ffprobe(file: string, callback: (err: any, data: FfprobeData) => void): void;
     function ffprobe(file: string, index: number, callback: (err: any, data: FfprobeData) => void): void;
     function ffprobe(file: string, options: string[], callback: (err: any, data: FfprobeData) => void): void; // tslint:disable-line unified-signatures
-    function ffprobe(file: string, index: number, options: string[], callback: (err: any, data: FfprobeData) => void): void;
+    function ffprobe(
+        file: string,
+        index: number,
+        options: string[],
+        callback: (err: any, data: FfprobeData) => void,
+    ): void;
 }
 declare function Ffmpeg(options?: Ffmpeg.FfmpegCommandOptions): Ffmpeg.FfmpegCommand;
 declare function Ffmpeg(input?: string | stream.Readable, options?: Ffmpeg.FfmpegCommandOptions): Ffmpeg.FfmpegCommand;

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -396,7 +396,7 @@ declare namespace Ffmpeg {
         thumbnails(config: number | ScreenshotsConfig, folder?: string): FfmpegCommand;
         screenshot(config: number | ScreenshotsConfig, folder?: string): FfmpegCommand;
         screenshots(config: number | ScreenshotsConfig, folder?: string): FfmpegCommand;
-        mergeToFile(target: string | stream.Writable, options?: { end?: boolean | undefined }): FfmpegCommand;
+        mergeToFile(target: string | stream.Writable, tmpFolder: string): FfmpegCommand;
         concatenate(target: string | stream.Writable, options?: { end?: boolean | undefined }): FfmpegCommand;
         concat(target: string | stream.Writable, options?: { end?: boolean | undefined }): FfmpegCommand;
         clone(): FfmpegCommand;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [npmjs.com/package/fluent-ffmpeg](https://www.npmjs.com/package/fluent-ffmpeg#mergetofilefilename-tmpdir-concatenate-multiple-inputs)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. (not needed)
