### PR TITLE
[@types/react] Refer to string for the download attribute

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1946,7 +1946,7 @@ declare namespace React {
         default?: boolean | undefined;
         defer?: boolean | undefined;
         disabled?: boolean | undefined;
-        download?: any;
+        download?: string | undefined;
         encType?: string | undefined;
         form?: string | undefined;
         formAction?: string | undefined;
@@ -2042,7 +2042,7 @@ declare namespace React {
         | (string & {});
 
     interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
-        download?: any;
+        download?: string | undefined;
         href?: string | undefined;
         hrefLang?: string | undefined;
         media?: string | undefined;
@@ -2058,7 +2058,7 @@ declare namespace React {
     interface AreaHTMLAttributes<T> extends HTMLAttributes<T> {
         alt?: string | undefined;
         coords?: string | undefined;
-        download?: any;
+        download?: string | undefined;
         href?: string | undefined;
         hrefLang?: string | undefined;
         media?: string | undefined;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -49,6 +49,8 @@ const testCases = [
     <svg role="treeitem" />,
     <a target="_blank"></a>,
     <a target="some-frame"></a>,
+    <a download="anchor-example-filename.txt"></a>,
+    <area download="area-example-filename.txt" />,
     <input type="button" />,
     <input type="some-type" />,
     // @ts-expect-error

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -2680,7 +2680,7 @@ declare namespace React {
         default?: boolean | undefined;
         defer?: boolean | undefined;
         disabled?: boolean | undefined;
-        download?: any;
+        download?: string | undefined;
         encType?: string | undefined;
         form?: string | undefined;
         formAction?: string | undefined;
@@ -2759,7 +2759,7 @@ declare namespace React {
     }
 
     interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
-        download?: any;
+        download?: string | undefined;
         href?: string | undefined;
         hrefLang?: string | undefined;
         media?: string | undefined;
@@ -2772,7 +2772,7 @@ declare namespace React {
     interface AreaHTMLAttributes<T> extends HTMLAttributes<T> {
         alt?: string | undefined;
         coords?: string | undefined;
-        download?: any;
+        download?: string | undefined;
         href?: string | undefined;
         hrefLang?: string | undefined;
         media?: string | undefined;

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1911,7 +1911,7 @@ declare namespace React {
         default?: boolean | undefined;
         defer?: boolean | undefined;
         disabled?: boolean | undefined;
-        download?: any;
+        download?: string | undefined;
         encType?: string | undefined;
         form?: string | undefined;
         formAction?: string | undefined;
@@ -2007,7 +2007,7 @@ declare namespace React {
         | (string & {});
 
     interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
-        download?: any;
+        download?: string | undefined;
         href?: string | undefined;
         hrefLang?: string | undefined;
         media?: string | undefined;
@@ -2024,7 +2024,7 @@ declare namespace React {
     interface AreaHTMLAttributes<T> extends HTMLAttributes<T> {
         alt?: string | undefined;
         coords?: string | undefined;
-        download?: any;
+        download?: string | undefined;
         href?: string | undefined;
         hrefLang?: string | undefined;
         media?: string | undefined;

--- a/types/react/v16/test/elementAttributes.tsx
+++ b/types/react/v16/test/elementAttributes.tsx
@@ -38,6 +38,8 @@ const testCases = [
     <svg role="treeitem" />,
     <a target="_blank"></a>,
     <a target="some-frame"></a>,
+    <a download="anchor-example-filename.txt"></a>,
+    <area download="area-example-filename.txt" />,
     <input type="button" />,
     <input type="some-type" />,
     <picture>

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1910,7 +1910,7 @@ declare namespace React {
         default?: boolean | undefined;
         defer?: boolean | undefined;
         disabled?: boolean | undefined;
-        download?: any;
+        download?: string | undefined;
         encType?: string | undefined;
         form?: string | undefined;
         formAction?: string | undefined;
@@ -2006,7 +2006,7 @@ declare namespace React {
         | (string & {});
 
     interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
-        download?: any;
+        download?: string | undefined;
         href?: string | undefined;
         hrefLang?: string | undefined;
         media?: string | undefined;
@@ -2022,7 +2022,7 @@ declare namespace React {
     interface AreaHTMLAttributes<T> extends HTMLAttributes<T> {
         alt?: string | undefined;
         coords?: string | undefined;
-        download?: any;
+        download?: string | undefined;
         href?: string | undefined;
         hrefLang?: string | undefined;
         media?: string | undefined;

--- a/types/react/v17/test/elementAttributes.tsx
+++ b/types/react/v17/test/elementAttributes.tsx
@@ -49,6 +49,8 @@ const testCases = [
     <svg role="treeitem" />,
     <a target="_blank"></a>,
     <a target="some-frame"></a>,
+    <a download="anchor-example-filename.txt"></a>,
+    <area download="area-example-filename.txt" />,
     <input type="button" />,
     <input type="some-type" />,
     // @ts-expect-error


### PR DESCRIPTION
# Pull Request

## Description 

Currently the `download` attribute of anchor elements and derived ones are specified as optional or `any`. Based on [the  HTML specification](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-download) and [common references](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download) the value is expected to be a `string` if it is set. The adjustment helps to guide the usage while also easing the integration at environments which enforce a stricter policy (no `any`).

## Template Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
