### PR TITLE
[cytoscape-fcose] Fix alignment constraint types

### DIFF
--- a/types/cytoscape-fcose/cytoscape-fcose-tests.ts
+++ b/types/cytoscape-fcose/cytoscape-fcose-tests.ts
@@ -37,7 +37,7 @@ const fcoseLayout: fcose.FcoseLayoutOptions = {
     initialEnergyOnIncremental: 1,
 
     fixedNodeConstraint: [{nodeId: 'n1', position: {x: 100, y: 200}}],
-    alignmentConstraint: {vertical: [['n1', 'n2']], horizontal: [['n2', 'n4']]},
+    alignmentConstraint: {vertical: [['n1', 'n2', 'n3'], ['n4', 'n5']], horizontal: [['n2', 'n4']]},
     relativePlacementConstraint: [{top: 'n1', bottom: 'n2', gap: 100}, {left: 'n3', right: 'n4', gap: 75}],
 
     ready: () => {},

--- a/types/cytoscape-fcose/index.d.ts
+++ b/types/cytoscape-fcose/index.d.ts
@@ -17,8 +17,8 @@ declare namespace cytoscapeFcose {
     }
 
     interface FcoseAlignmentConstraint {
-        vertical: Array<[string, string]>;
-        horizontal: Array<[string, string]>;
+        vertical: string[][];
+        horizontal: string[][];
     }
 
     interface FcoseRelativeVerticalPlacementConstraint {


### PR DESCRIPTION
#### Description
Fix the type definitions for horizontal and vertical alignment constraints in `cytoscape-fcose`.

This is a non-breaking change as it only generalizes the affected types (i.e. replaces them with a supertype).

#### Checklist
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [See usage example of alignment constraints in the official documentation here](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose#documentation)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -- *It doesn't; cytoscape-fcose version 2.2.0 adds a new feature that is not typed with this PR*.
