### PR TITLE
[cytoscape-fcose] Fix #64468: Node- & edge-specific options as functions or constants

### DIFF
--- a/types/cytoscape-fcose/cytoscape-fcose-tests.ts
+++ b/types/cytoscape-fcose/cytoscape-fcose-tests.ts
@@ -44,6 +44,19 @@ const fcoseLayout: fcose.FcoseLayoutOptions = {
     stop: () => {},
 };
 
+// Some layout parameters are node- or edge-specific and can be specified as either a function or a constant.
+// Type-check both approaches:
+const objectSpecificsAsFunctions: Partial<fcose.FcoseLayoutOptions> = {
+    nodeRepulsion: node => 4500,
+    idealEdgeLength: edge => 50,
+    edgeElasticity: edge => 0.45,
+};
+const objectSpecificsAsConstants: Partial<fcose.FcoseLayoutOptions> = {
+    nodeRepulsion: 4500,
+    idealEdgeLength: 50,
+    edgeElasticity: 0.45,
+};
+
 const cy = cytoscape({
     container: document.getElementById('cy'),
     layout: fcoseLayout,

--- a/types/cytoscape-fcose/index.d.ts
+++ b/types/cytoscape-fcose/index.d.ts
@@ -81,11 +81,11 @@ declare namespace cytoscapeFcose {
         /* incremental layout options */
 
         // Node repulsion (non overlapping) multiplier
-        nodeRepulsion?: number;
+        nodeRepulsion?: ((node: any) => number) | number;
         // Ideal edge (non nested) length
-        idealEdgeLength?(edge: any): number;
+        idealEdgeLength?: ((edge: any) => number) | number;
         // Divisor to compute edge forces
-        edgeElasticity?(edge: any): number;
+        edgeElasticity?: ((edge: any) => number) | number;
         // Nesting factor (multiplier) to compute ideal edge length for nested edges
         nestingFactor?: number;
         // Maximum number of iterations to perform - this is a suggested value and might be adjusted by the algorithm as required


### PR DESCRIPTION
Resolve #64468 by marking `nodeRepulsion`, `idealEdgeLength`, and `edgeElasticity` as either functions or constant numbers.

#### Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: *See [usage examples](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose/search?q=repulsion) and the [definition of `optFn`](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose/blob/78afcf96512a409abc903699277ad616c02dfad9/src/fcose/cose.js#L35), which is used for the three addressed options*.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header. -- *It doesn't*.
