### PR TITLE
fix: entryLabelFontFamily in PieChartProps

### DIFF
--- a/types/react-native-charts-wrapper/index.d.ts
+++ b/types/react-native-charts-wrapper/index.d.ts
@@ -523,6 +523,8 @@ export interface PieChartProps extends PieRadarChartBase {
 
     entryLabelColor?: Color | undefined;
     entryLabelTextSize?: number | undefined;
+    entryLabelFontFamily?: string | undefined;
+    
     maxAngle?: number | undefined;
 
     data?: PieData | undefined;


### PR DESCRIPTION
EntryLabelFontFamily is missing with PieChartProps. Add it accordingly.
[react-native-charts-wrapper](https://github.com/wuxudong/react-native-charts-wrapper)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/wuxudong/react-native-charts-wrapper/blob/master/lib/PieChart.js)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


