### PR TITLE
fix(sortablejs): Add avoidImplicitDeselect to MultiDragOptions

### DIFF
--- a/types/sortablejs/plugins.d.ts
+++ b/types/sortablejs/plugins.d.ts
@@ -71,6 +71,11 @@ export interface MultiDragOptions {
     multiDragKey?: null | undefined;
 
     /**
+     * If you don't want to deselect items on outside click
+     */
+    avoidImplicitDeselect?: boolean | undefined;
+
+    /**
      * Called when an item is selected
      */
     onSelect?: ((event: SortableEvent) => void) | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/SortableJS/Sortable/tree/master/plugins/MultiDrag>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.