### PR TITLE
[cytoscape-fcose] Update definitions for v2.2.0

### DIFF
--- a/types/cytoscape-fcose/cytoscape-fcose-tests.ts
+++ b/types/cytoscape-fcose/cytoscape-fcose-tests.ts
@@ -28,6 +28,7 @@ const fcoseLayout: fcose.FcoseLayoutOptions = {
     nestingFactor: 0,
     numIter: 1,
     tile: true,
+    tilingCompareBy: (nodeId1: string, nodeId2: string) => nodeId1.localeCompare(nodeId2),
     tilingPaddingVertical: 1,
     tilingPaddingHorizontal: 1,
     gravity: 1,

--- a/types/cytoscape-fcose/index.d.ts
+++ b/types/cytoscape-fcose/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cytoscape-fcose 2.1
+// Type definitions for cytoscape-fcose 2.2
 // Project: https://github.com/iVis-at-Bilkent/cytoscape.js-fcose
 // Definitions by: Paul Paulsen <https://github.com/Phpaulsen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -92,6 +92,13 @@ declare namespace cytoscapeFcose {
         numIter?: number;
         // For enabling tiling
         tile?: boolean;
+        // The comparison function to be used while sorting nodes during tiling operation.
+        // Takes the ids of 2 nodes that will be compared as a parameter and the default tiling operation is performed when this option is not set.
+        // It works similar to ``compareFunction`` parameter of ``Array.prototype.sort()``
+        // If node1 is less then node2 by some ordering criterion ``tilingCompareBy(nodeId1, nodeId2)`` must return a negative value
+        // If node1 is greater then node2 by some ordering criterion ``tilingCompareBy(nodeId1, nodeId2)`` must return a positive value
+        // If node1 is equal to node2 by some ordering criterion ``tilingCompareBy(nodeId1, nodeId2)`` must return 0
+        tilingCompareBy?: (nodeId1: string, nodeId2: string) => number;
         // Represents the amount of the vertical space to put between the zero degree members during the tiling operation(can also be a function)
         tilingPaddingVertical?: number;
         // Represents the amount of the horizontal space to put between the zero degree members during the tiling operation(can also be a function)


### PR DESCRIPTION
Update type definitions for `cytoscape-fcose` to reflect version 2.2.0.
- Add `tilingCompareBy?: (a: string, b: string) => number` to layout options ([doc](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose#api), [usage in code](https://github.com/iVis-at-Bilkent/cose-base/compare/v2.1.0...v2.2.0#diff-b047529a22041e7299de2b611e391c9f44178444bce4f933770bdd2393a158bdR1579)).

See [release notes ](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose/releases/tag/v2.2.0)of v2.2.0.

