### PR TITLE
Skip daily bot sync on forks

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   trigger_bot:
     runs-on: ubuntu-latest
+    if: github.repository == 'DefinitelyTyped/DefinitelyTyped'
 
     steps:
       - run: 'gh workflow run daily.yml -R DefinitelyTyped/dt-mergebot'


### PR DESCRIPTION
Forks don't have the credentials to run the sync script anyway.