### PR TITLE
fix(@types/auth0): add okta as a value for Strategy

### DIFF
--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -464,6 +464,7 @@ export type Strategy =
     | 'oauth2'
     | 'office365'
     | 'oidc'
+    | 'okta'
     | 'paypal'
     | 'paypal-sandbox'
     | 'pingfederate'


### PR DESCRIPTION
`okta` is a value for Strategy. It is mentioned here in the docs https://auth0.com/docs/api/management/v2#!/Connections/post_connections

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: << https://auth0.com/docs/api/management/v2#!/Connections/post_connections>>