### PR TITLE
[chrome] Fix contextMenu id types

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1729,26 +1729,13 @@ declare namespace chrome.contextMenus {
      * @param updateProperties The properties to update. Accepts the same values as the create function.
      * @param callback Called when the context menu has been updated.
      */
-    export function update(id: string, updateProperties: UpdateProperties, callback?: () => void): void;
-    /**
-     * Updates a previously created context menu item.
-     * @param id The ID of the item to update.
-     * @param updateProperties The properties to update. Accepts the same values as the create function.
-     * @param callback Called when the context menu has been updated.
-     */
-    export function update(id: number, updateProperties: UpdateProperties, callback?: () => void): void;
+    export function update(id: string | number, updateProperties: UpdateProperties, callback?: () => void): void;
     /**
      * Removes a context menu item.
      * @param menuItemId The ID of the context menu item to remove.
      * @param callback Called when the context menu has been removed.
      */
-    export function remove(menuItemId: string, callback?: () => void): void;
-    /**
-     * Removes a context menu item.
-     * @param menuItemId The ID of the context menu item to remove.
-     * @param callback Called when the context menu has been removed.
-     */
-    export function remove(menuItemId: number, callback?: () => void): void;
+    export function remove(menuItemId: string | number, callback?: () => void): void;
 
     /**
      * Since Chrome 21.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1396,6 +1396,7 @@ function testContextMenusRemove() {
     chrome.contextMenus.remove('dummy-id', () => console.log('removed'));
     // @ts-expect-error
     chrome.contextMenus.remove('dummy-id', (invalid: any) => console.log('removed'));
+    chrome.contextMenus.remove(Math.random() > 0.5 ? "1" : 1)
 }
 
 function testContextMenusRemoveAll() {
@@ -1408,6 +1409,7 @@ function testContextMenusRemoveAll() {
 function testContextMenusUpdate() {
     chrome.contextMenus.update(1, { title: 'Hello World!' });
     chrome.contextMenus.update(1, { title: 'Hello World!' }, () => console.log('updated'));
+    chrome.contextMenus.update(Math.random() > 0.5 ? "1" : 1, { title: 'Hello World!' }, () => console.log('updated'));
     // @ts-expect-error
     chrome.contextMenus.update(1, { title: 'Hello World!' }, (invalid: any) => console.log('updated'));
     chrome.contextMenus.update('dummy-id', { title: 'Hello World!' });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/contextMenus
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

The types in `chrome.contextMenus` for `menuItemId` are `number | string`, but you can't currently pass a variable of this type. Eg, this is broken:

```js
const menuItemId = chrome.contextMenus.create(...)
chrome.contextMenus.remove(menuItemId)
```