### PR TITLE
[sanitize-html] Added missing `mediaChildren` property to IFrame

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -48,6 +48,7 @@ declare namespace sanitize {
     attribs: { [index: string]: string };
     text: string;
     tagPosition: number;
+    mediaChildren: string[];
   }
 
   // tslint:disable-next-line:interface-name


### PR DESCRIPTION
As described in the documentation https://github.com/apostrophecms/sanitize-html#filters IFilter has a property called `mediaChildren` that was missing. It was apparently always there in the docs even in 1 major version before.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[<url here>](https://github.com/apostrophecms/sanitize-html#filters)>
