### PR TITLE
minio: region of `makeBucket`is optional and add missing `makeOpt`

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -255,6 +255,7 @@ export class Client {
         callback: NoResultCallback,
     ): void;
     makeBucket(bucketName: string, region: Region, callback: NoResultCallback): void;
+    makeBucket(bucketName: string, callback: NoResultCallback): void;
     makeBucket(bucketName: string, region?: Region, makeOpts?: { ObjectLocking: boolean }): Promise<void>;
 
     listBuckets(callback: ResultCallback<BucketItemFromList[]>): void;

--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -243,19 +243,19 @@ export class TargetConfig {
     addFilterPrefix(prefix: any): void;
 }
 
+export interface MakeBucketOpt {
+    ObjectLocking: boolean;
+}
+
 // Exports from library
 export class Client {
     constructor(options: ClientOptions);
 
     // Bucket operations
-    makeBucket(
-        bucketName: string,
-        region: Region,
-        makeOpts: { ObjectLocking: boolean },
-        callback: NoResultCallback,
-    ): void;
+    makeBucket(bucketName: string, region: Region, makeOpts: MakeBucketOpt, callback: NoResultCallback): void;
     makeBucket(bucketName: string, region: Region, callback: NoResultCallback): void;
-    makeBucket(bucketName: string, region?: Region, makeOpts?: { ObjectLocking: boolean }): Promise<void>;
+    makeBucket(bucketName: string, callback: NoResultCallback): void;
+    makeBucket(bucketName: string, region?: Region, makeOpts?: MakeBucketOpt): Promise<void>;
 
     listBuckets(callback: ResultCallback<BucketItemFromList[]>): void;
     listBuckets(): Promise<BucketItemFromList[]>;

--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -255,7 +255,6 @@ export class Client {
         callback: NoResultCallback,
     ): void;
     makeBucket(bucketName: string, region: Region, callback: NoResultCallback): void;
-    makeBucket(bucketName: string, callback: NoResultCallback): void;
     makeBucket(bucketName: string, region?: Region, makeOpts?: { ObjectLocking: boolean }): Promise<void>;
 
     listBuckets(callback: ResultCallback<BucketItemFromList[]>): void;

--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -15,34 +15,36 @@ import { EventEmitter } from 'events';
 import { RequestOptions } from 'https';
 
 // Exports only from typings
-export type Region = 'us-east-1' |
-    'us-west-1' |
-    'us-west-2' |
-    'eu-west-1' |
-    'eu-central-1' |
-    'ap-southeast-1' |
-    'ap-northeast-1' |
-    'ap-southeast-2' |
-    'sa-east-1' |
-    'cn-north-1' |
-    string;
-export type NotificationEvent = 's3:ObjectCreated:*' |
-    's3:ObjectCreated:Put' |
-    's3:ObjectCreated:Post' |
-    's3:ObjectCreated:Copy' |
-    's3:ObjectCreated:CompleteMultipartUpload' |
-    's3:ObjectRemoved:*' |
-    's3:ObjectRemoved:Delete' |
-    's3:ObjectRemoved:DeleteMarkerCreated' |
-    's3:ReducedRedundancyLostObject' |
-    's3:TestEvent' |
-    's3:ObjectRestore:Post' |
-    's3:ObjectRestore:Completed' |
-    's3:Replication:OperationFailedReplication' |
-    's3:Replication:OperationMissedThreshold' |
-    's3:Replication:OperationReplicatedAfterThreshold' |
-    's3:Replication:OperationNotTracked' |
-    string;
+export type Region =
+    | 'us-east-1'
+    | 'us-west-1'
+    | 'us-west-2'
+    | 'eu-west-1'
+    | 'eu-central-1'
+    | 'ap-southeast-1'
+    | 'ap-northeast-1'
+    | 'ap-southeast-2'
+    | 'sa-east-1'
+    | 'cn-north-1'
+    | string;
+export type NotificationEvent =
+    | 's3:ObjectCreated:*'
+    | 's3:ObjectCreated:Put'
+    | 's3:ObjectCreated:Post'
+    | 's3:ObjectCreated:Copy'
+    | 's3:ObjectCreated:CompleteMultipartUpload'
+    | 's3:ObjectRemoved:*'
+    | 's3:ObjectRemoved:Delete'
+    | 's3:ObjectRemoved:DeleteMarkerCreated'
+    | 's3:ReducedRedundancyLostObject'
+    | 's3:TestEvent'
+    | 's3:ObjectRestore:Post'
+    | 's3:ObjectRestore:Completed'
+    | 's3:Replication:OperationFailedReplication'
+    | 's3:Replication:OperationMissedThreshold'
+    | 's3:Replication:OperationReplicatedAfterThreshold'
+    | 's3:Replication:OperationNotTracked'
+    | string;
 export type Mode = 'COMPLIANCE' | 'GOVERNANCE';
 export type LockUnit = 'Days' | 'Years';
 export type LegalHoldStatus = 'ON' | 'OFF';
@@ -109,7 +111,7 @@ export interface IncompleteUploadedBucketItem {
 export interface BucketStream<T> extends ReadableStream {
     on(event: 'data', listener: (item: T) => void): this;
     on(event: 'end' | 'pause' | 'readable' | 'resume' | 'close', listener: () => void): this;
-    on(event: "error", listener: (err: Error) => void): this;
+    on(event: 'error', listener: (err: Error) => void): this;
     on(event: string | symbol, listener: (...args: any[]) => void): this;
 }
 
@@ -222,7 +224,7 @@ export interface SelectOptions {
     inputSerialization: InputSerialization;
     outputSerialization: OutputSerialization;
     requestProgress?: { Enabled: boolean };
-    scanRange?: { Start: number, End: number };
+    scanRange?: { Start: number; End: number };
 }
 
 export interface SourceObjectStats {
@@ -246,8 +248,14 @@ export class Client {
     constructor(options: ClientOptions);
 
     // Bucket operations
+    makeBucket(
+        bucketName: string,
+        region: Region,
+        makeOpts: { ObjectLocking: boolean },
+        callback: NoResultCallback,
+    ): void;
     makeBucket(bucketName: string, region: Region, callback: NoResultCallback): void;
-    makeBucket(bucketName: string, region?: Region): Promise<void>;
+    makeBucket(bucketName: string, region?: Region, makeOpts?: { ObjectLocking: boolean }): Promise<void>;
 
     listBuckets(callback: ResultCallback<BucketItemFromList[]>): void;
     listBuckets(): Promise<BucketItemFromList[]>;
@@ -260,9 +268,18 @@ export class Client {
 
     listObjects(bucketName: string, prefix?: string, recursive?: boolean): BucketStream<BucketItem>;
 
-    listObjectsV2(bucketName: string, prefix?: string, recursive?: boolean, startAfter?: string): BucketStream<BucketItem>;
+    listObjectsV2(
+        bucketName: string,
+        prefix?: string,
+        recursive?: boolean,
+        startAfter?: string,
+    ): BucketStream<BucketItem>;
 
-    listIncompleteUploads(bucketName: string, prefix?: string, recursive?: boolean): BucketStream<IncompleteUploadedBucketItem>;
+    listIncompleteUploads(
+        bucketName: string,
+        prefix?: string,
+        recursive?: boolean,
+    ): BucketStream<IncompleteUploadedBucketItem>;
 
     getBucketVersioning(bucketName: string, callback: ResultCallback<VersioningConfig>): void;
     getBucketVersioning(bucketName: string): Promise<VersioningConfig>;
@@ -317,24 +334,86 @@ export class Client {
     getObject(bucketName: string, objectName: string, callback: ResultCallback<ReadableStream>): void;
     getObject(bucketName: string, objectName: string): Promise<ReadableStream>;
 
-    getPartialObject(bucketName: string, objectName: string, offset: number, callback: ResultCallback<ReadableStream>): void;
-    getPartialObject(bucketName: string, objectName: string, offset: number, length: number, callback: ResultCallback<ReadableStream>): void;
+    getPartialObject(
+        bucketName: string,
+        objectName: string,
+        offset: number,
+        callback: ResultCallback<ReadableStream>,
+    ): void;
+    getPartialObject(
+        bucketName: string,
+        objectName: string,
+        offset: number,
+        length: number,
+        callback: ResultCallback<ReadableStream>,
+    ): void;
     getPartialObject(bucketName: string, objectName: string, offset: number, length?: number): Promise<ReadableStream>;
 
     fGetObject(bucketName: string, objectName: string, filePath: string, callback: NoResultCallback): void;
     fGetObject(bucketName: string, objectName: string, filePath: string): Promise<void>;
 
-    putObject(bucketName: string, objectName: string, stream: ReadableStream | Buffer | string, callback: ResultCallback<UploadedObjectInfo>): void;
-    putObject(bucketName: string, objectName: string, stream: ReadableStream | Buffer | string, size: number, callback: ResultCallback<UploadedObjectInfo>): void;
-    putObject(bucketName: string, objectName: string, stream: ReadableStream | Buffer | string, size: number, metaData: ItemBucketMetadata, callback: ResultCallback<UploadedObjectInfo>): void;
-    putObject(bucketName: string, objectName: string, stream: ReadableStream | Buffer | string, size?: number, metaData?: ItemBucketMetadata): Promise<UploadedObjectInfo>;
-    putObject(bucketName: string, objectName: string, stream: ReadableStream | Buffer | string, metaData?: ItemBucketMetadata): Promise<UploadedObjectInfo>;
+    putObject(
+        bucketName: string,
+        objectName: string,
+        stream: ReadableStream | Buffer | string,
+        callback: ResultCallback<UploadedObjectInfo>,
+    ): void;
+    putObject(
+        bucketName: string,
+        objectName: string,
+        stream: ReadableStream | Buffer | string,
+        size: number,
+        callback: ResultCallback<UploadedObjectInfo>,
+    ): void;
+    putObject(
+        bucketName: string,
+        objectName: string,
+        stream: ReadableStream | Buffer | string,
+        size: number,
+        metaData: ItemBucketMetadata,
+        callback: ResultCallback<UploadedObjectInfo>,
+    ): void;
+    putObject(
+        bucketName: string,
+        objectName: string,
+        stream: ReadableStream | Buffer | string,
+        size?: number,
+        metaData?: ItemBucketMetadata,
+    ): Promise<UploadedObjectInfo>;
+    putObject(
+        bucketName: string,
+        objectName: string,
+        stream: ReadableStream | Buffer | string,
+        metaData?: ItemBucketMetadata,
+    ): Promise<UploadedObjectInfo>;
 
-    fPutObject(bucketName: string, objectName: string, filePath: string, metaData: ItemBucketMetadata, callback: ResultCallback<UploadedObjectInfo>): void;
-    fPutObject(bucketName: string, objectName: string, filePath: string, metaData?: ItemBucketMetadata): Promise<UploadedObjectInfo>;
+    fPutObject(
+        bucketName: string,
+        objectName: string,
+        filePath: string,
+        metaData: ItemBucketMetadata,
+        callback: ResultCallback<UploadedObjectInfo>,
+    ): void;
+    fPutObject(
+        bucketName: string,
+        objectName: string,
+        filePath: string,
+        metaData?: ItemBucketMetadata,
+    ): Promise<UploadedObjectInfo>;
 
-    copyObject(bucketName: string, objectName: string, sourceObject: string, conditions: CopyConditions, callback: ResultCallback<BucketItemCopy>): void;
-    copyObject(bucketName: string, objectName: string, sourceObject: string, conditions: CopyConditions): Promise<BucketItemCopy>;
+    copyObject(
+        bucketName: string,
+        objectName: string,
+        sourceObject: string,
+        conditions: CopyConditions,
+        callback: ResultCallback<BucketItemCopy>,
+    ): void;
+    copyObject(
+        bucketName: string,
+        objectName: string,
+        sourceObject: string,
+        conditions: CopyConditions,
+    ): Promise<BucketItemCopy>;
 
     statObject(bucketName: string, objectName: string, callback: ResultCallback<BucketItemStat>): void;
     statObject(bucketName: string, objectName: string): Promise<BucketItemStat>;
@@ -349,10 +428,20 @@ export class Client {
     removeIncompleteUpload(bucketName: string, objectName: string): Promise<void>;
 
     putObjectRetention(bucketName: string, objectName: string, callback: NoResultCallback): void;
-    putObjectRetention(bucketName: string, objectName: string, retentionOptions: Retention, callback: NoResultCallback): void;
+    putObjectRetention(
+        bucketName: string,
+        objectName: string,
+        retentionOptions: Retention,
+        callback: NoResultCallback,
+    ): void;
     putObjectRetention(bucketName: string, objectName: string, retentionOptions?: Retention): Promise<void>;
 
-    getObjectRetention(bucketName: string, objectName: string, options: VersionIdentificator, callback: ResultCallback<Retention>): void;
+    getObjectRetention(
+        bucketName: string,
+        objectName: string,
+        options: VersionIdentificator,
+        callback: ResultCallback<Retention>,
+    ): void;
     getObjectRetention(bucketName: string, objectName: string, options: VersionIdentificator): Promise<Retention>;
 
     // It seems, putObjectTagging is deprecated in favor or setObjectTagging - there is no such a method in the library source code
@@ -363,50 +452,155 @@ export class Client {
     /**
      * @deprecated Use setObjectTagging instead.
      */
-    putObjectTagging(bucketName: string, objectName: string, tags: TagList, putOptions: VersionIdentificator, callback: NoResultCallback): void;
+    putObjectTagging(
+        bucketName: string,
+        objectName: string,
+        tags: TagList,
+        putOptions: VersionIdentificator,
+        callback: NoResultCallback,
+    ): void;
     /**
      * @deprecated Use setObjectTagging instead.
      */
-    putObjectTagging(bucketName: string, objectName: string, tags: TagList, putOptions?: VersionIdentificator): Promise<void>;
+    putObjectTagging(
+        bucketName: string,
+        objectName: string,
+        tags: TagList,
+        putOptions?: VersionIdentificator,
+    ): Promise<void>;
 
     setObjectTagging(bucketName: string, objectName: string, tags: TagList, callback: NoResultCallback): void;
-    setObjectTagging(bucketName: string, objectName: string, tags: TagList, putOptions: VersionIdentificator, callback: NoResultCallback): void;
-    setObjectTagging(bucketName: string, objectName: string, tags: TagList, putOptions?: VersionIdentificator): Promise<void>;
+    setObjectTagging(
+        bucketName: string,
+        objectName: string,
+        tags: TagList,
+        putOptions: VersionIdentificator,
+        callback: NoResultCallback,
+    ): void;
+    setObjectTagging(
+        bucketName: string,
+        objectName: string,
+        tags: TagList,
+        putOptions?: VersionIdentificator,
+    ): Promise<void>;
 
     removeObjectTagging(bucketName: string, objectName: string, callback: NoResultCallback): void;
-    removeObjectTagging(bucketName: string, objectName: string, removeOptions: VersionIdentificator, callback: NoResultCallback): void;
+    removeObjectTagging(
+        bucketName: string,
+        objectName: string,
+        removeOptions: VersionIdentificator,
+        callback: NoResultCallback,
+    ): void;
     removeObjectTagging(bucketName: string, objectName: string, removeOptions?: VersionIdentificator): Promise<void>;
 
     getObjectTagging(bucketName: string, objectName: string, callback: ResultCallback<Tag[]>): void;
-    getObjectTagging(bucketName: string, objectName: string, getOptions: VersionIdentificator, callback: ResultCallback<Tag[]>): void;
+    getObjectTagging(
+        bucketName: string,
+        objectName: string,
+        getOptions: VersionIdentificator,
+        callback: ResultCallback<Tag[]>,
+    ): void;
     getObjectTagging(bucketName: string, objectName: string, getOptions?: VersionIdentificator): Promise<Tag[]>;
 
     getObjectLegalHold(bucketName: string, objectName: string, callback: ResultCallback<LegalHoldOptions>): void;
-    getObjectLegalHold(bucketName: string, objectName: string, getOptions: VersionIdentificator, callback: ResultCallback<LegalHoldOptions>): void;
-    getObjectLegalHold(bucketName: string, objectName: string, getOptions?: VersionIdentificator): Promise<LegalHoldOptions>;
+    getObjectLegalHold(
+        bucketName: string,
+        objectName: string,
+        getOptions: VersionIdentificator,
+        callback: ResultCallback<LegalHoldOptions>,
+    ): void;
+    getObjectLegalHold(
+        bucketName: string,
+        objectName: string,
+        getOptions?: VersionIdentificator,
+    ): Promise<LegalHoldOptions>;
 
     setObjectLegalHold(bucketName: string, objectName: string, callback: NoResultCallback): void;
-    setObjectLegalHold(bucketName: string, objectName: string, setOptions: LegalHoldOptions, callback: NoResultCallback): void;
+    setObjectLegalHold(
+        bucketName: string,
+        objectName: string,
+        setOptions: LegalHoldOptions,
+        callback: NoResultCallback,
+    ): void;
     setObjectLegalHold(bucketName: string, objectName: string, setOptions?: LegalHoldOptions): Promise<void>;
 
-    composeObject(destObjConfig: CopyDestinationOptions, sourceObjList: CopySourceOptions[], callback: ResultCallback<SourceObjectStats>): void;
-    composeObject(destObjConfig: CopyDestinationOptions, sourceObjList: CopySourceOptions[]): Promise<SourceObjectStats>;
+    composeObject(
+        destObjConfig: CopyDestinationOptions,
+        sourceObjList: CopySourceOptions[],
+        callback: ResultCallback<SourceObjectStats>,
+    ): void;
+    composeObject(
+        destObjConfig: CopyDestinationOptions,
+        sourceObjList: CopySourceOptions[],
+    ): Promise<SourceObjectStats>;
 
-    selectObjectContent(bucketName: string, objectName: string, selectOpts: SelectOptions, callback: NoResultCallback): void;
+    selectObjectContent(
+        bucketName: string,
+        objectName: string,
+        selectOpts: SelectOptions,
+        callback: NoResultCallback,
+    ): void;
     selectObjectContent(bucketName: string, objectName: string, selectOpts: SelectOptions): Promise<void>;
 
     // Presigned operations
     presignedUrl(httpMethod: string, bucketName: string, objectName: string, callback: ResultCallback<string>): void;
-    presignedUrl(httpMethod: string, bucketName: string, objectName: string, expiry: number, callback: ResultCallback<string>): void;
-    presignedUrl(httpMethod: string, bucketName: string, objectName: string, expiry: number, reqParams: { [key: string]: any; }, callback: ResultCallback<string>): void;
-    presignedUrl(httpMethod: string, bucketName: string, objectName: string, expiry: number, reqParams: { [key: string]: any; }, requestDate: Date, callback: ResultCallback<string>): void;
-    presignedUrl(httpMethod: string, bucketName: string, objectName: string, expiry?: number, reqParams?: { [key: string]: any; }, requestDate?: Date): Promise<string>;
+    presignedUrl(
+        httpMethod: string,
+        bucketName: string,
+        objectName: string,
+        expiry: number,
+        callback: ResultCallback<string>,
+    ): void;
+    presignedUrl(
+        httpMethod: string,
+        bucketName: string,
+        objectName: string,
+        expiry: number,
+        reqParams: { [key: string]: any },
+        callback: ResultCallback<string>,
+    ): void;
+    presignedUrl(
+        httpMethod: string,
+        bucketName: string,
+        objectName: string,
+        expiry: number,
+        reqParams: { [key: string]: any },
+        requestDate: Date,
+        callback: ResultCallback<string>,
+    ): void;
+    presignedUrl(
+        httpMethod: string,
+        bucketName: string,
+        objectName: string,
+        expiry?: number,
+        reqParams?: { [key: string]: any },
+        requestDate?: Date,
+    ): Promise<string>;
 
     presignedGetObject(bucketName: string, objectName: string, callback: ResultCallback<string>): void;
     presignedGetObject(bucketName: string, objectName: string, expiry: number, callback: ResultCallback<string>): void;
-    presignedGetObject(bucketName: string, objectName: string, expiry: number, respHeaders: { [key: string]: any; }, callback: ResultCallback<string>): void;
-    presignedGetObject(bucketName: string, objectName: string, expiry: number, respHeaders: { [key: string]: any; }, requestDate: Date, callback: ResultCallback<string>): void;
-    presignedGetObject(bucketName: string, objectName: string, expiry?: number, respHeaders?: { [key: string]: any; }, requestDate?: Date): Promise<string>;
+    presignedGetObject(
+        bucketName: string,
+        objectName: string,
+        expiry: number,
+        respHeaders: { [key: string]: any },
+        callback: ResultCallback<string>,
+    ): void;
+    presignedGetObject(
+        bucketName: string,
+        objectName: string,
+        expiry: number,
+        respHeaders: { [key: string]: any },
+        requestDate: Date,
+        callback: ResultCallback<string>,
+    ): void;
+    presignedGetObject(
+        bucketName: string,
+        objectName: string,
+        expiry?: number,
+        respHeaders?: { [key: string]: any },
+        requestDate?: Date,
+    ): Promise<string>;
 
     presignedPutObject(bucketName: string, objectName: string, callback: ResultCallback<string>): void;
     presignedPutObject(bucketName: string, objectName: string, expiry: number, callback: ResultCallback<string>): void;
@@ -419,7 +613,11 @@ export class Client {
     getBucketNotification(bucketName: string, callback: ResultCallback<NotificationConfig>): void;
     getBucketNotification(bucketName: string): Promise<NotificationConfig>;
 
-    setBucketNotification(bucketName: string, bucketNotificationConfig: NotificationConfig, callback: NoResultCallback): void;
+    setBucketNotification(
+        bucketName: string,
+        bucketNotificationConfig: NotificationConfig,
+        callback: NoResultCallback,
+    ): void;
     setBucketNotification(bucketName: string, bucketNotificationConfig: NotificationConfig): Promise<void>;
 
     removeAllBucketNotification(bucketName: string, callback: NoResultCallback): void;
@@ -431,7 +629,12 @@ export class Client {
     setBucketPolicy(bucketName: string, bucketPolicy: string, callback: NoResultCallback): void;
     setBucketPolicy(bucketName: string, bucketPolicy: string): Promise<void>;
 
-    listenBucketNotification(bucketName: string, prefix: string, suffix: string, events: NotificationEvent[]): NotificationPoller;
+    listenBucketNotification(
+        bucketName: string,
+        prefix: string,
+        suffix: string,
+        events: NotificationEvent[],
+    ): NotificationPoller;
 
     // Custom Settings
     setS3TransferAccelerate(endpoint: string): void;
@@ -442,7 +645,12 @@ export class Client {
 
     // Minio extensions that aren't necessary present for Amazon S3 compatible storage servers
     extensions: {
-        listObjectsV2WithMetadata(bucketName: string, prefix?: string, recursive?: boolean, startAfter?: string): BucketStream<BucketItemWithMetadata>;
+        listObjectsV2WithMetadata(
+            bucketName: string,
+            prefix?: string,
+            recursive?: boolean,
+            startAfter?: string,
+        ): BucketStream<BucketItemWithMetadata>;
     };
 }
 
@@ -497,21 +705,21 @@ export class CloudFunctionConfig extends TargetConfig {
 
 export class CopySourceOptions {
     constructor(options: {
-        Bucket: string,
-        Object: string,
-        VersionID?: string,
-        MatchETag?: string,
-        NoMatchETag?: string,
-        MatchModifiedSince?: string,
-        MatchUnmodifiedSince?: string,
-        MatchRange?: boolean,
-        Start?: number,
-        End?: number,
+        Bucket: string;
+        Object: string;
+        VersionID?: string;
+        MatchETag?: string;
+        NoMatchETag?: string;
+        MatchModifiedSince?: string;
+        MatchUnmodifiedSince?: string;
+        MatchRange?: boolean;
+        Start?: number;
+        End?: number;
         Encryption?: {
             type: string;
             SSEAlgorithm?: string;
             KMSMasterKeyID?: string;
-        },
+        };
     });
 
     getHeaders(): Record<string, string>;
@@ -520,25 +728,31 @@ export class CopySourceOptions {
 
 export class CopyDestinationOptions {
     constructor(options: {
-        Bucket: string,
-        Object: string,
+        Bucket: string;
+        Object: string;
         Encryption?: {
             type: string;
             SSEAlgorithm?: string;
             KMSMasterKeyID?: string;
-        },
-        UserMetadata?: Record<string, unknown>,
-        UserTags?: Record<string, unknown> | string,
-        LegalHold?: LegalHoldStatus,
-        RetainUntilDate?: string,
-        Mode?: Mode,
+        };
+        UserMetadata?: Record<string, unknown>;
+        UserTags?: Record<string, unknown> | string;
+        LegalHold?: LegalHoldStatus;
+        RetainUntilDate?: string;
+        Mode?: Mode;
     });
 
     getHeaders(): Record<string, string>;
     validate(): boolean;
 }
 
-export function buildARN(partition: string, service: string, region: string, accountId: string, resource: string): string;
+export function buildARN(
+    partition: string,
+    service: string,
+    region: string,
+    accountId: string,
+    resource: string,
+): string;
 
 export const ObjectCreatedAll: NotificationEvent; // s3:ObjectCreated:*'
 export const ObjectCreatedPut: NotificationEvent; // s3:ObjectCreated:Put

--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -247,7 +247,7 @@ export class Client {
 
     // Bucket operations
     makeBucket(bucketName: string, region: Region, callback: NoResultCallback): void;
-    makeBucket(bucketName: string, region: Region): Promise<void>;
+    makeBucket(bucketName: string, region?: Region): Promise<void>;
 
     listBuckets(callback: ResultCallback<BucketItemFromList[]>): void;
     listBuckets(): Promise<BucketItemFromList[]>;

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -34,8 +34,9 @@ minio.makeBucket('testBucket', 'ap-southeast-2', (error: Error | null) => {
 minio.makeBucket('testBucket', (error: Error | null) => {
     console.log(error);
 });
-minio.makeBucket('testBucket', 'eu-west-1');
-minio.makeBucket('testBucket');
+await minio.makeBucket('testBucket', 'eu-west-1', { ObjectLocking: false });
+await minio.makeBucket('testBucket', 'eu-west-1');
+await minio.makeBucket('testBucket');
 
 minio.listBuckets((error: Error | null, bucketList: Minio.BucketItemFromList[]) => {
     console.log(error, bucketList);

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -34,9 +34,12 @@ minio.makeBucket('testBucket', 'ap-southeast-2', (error: Error | null) => {
 minio.makeBucket('testBucket', (error: Error | null) => {
     console.log(error);
 });
-await minio.makeBucket('testBucket', 'eu-west-1', { ObjectLocking: false });
-await minio.makeBucket('testBucket', 'eu-west-1');
-await minio.makeBucket('testBucket');
+
+(async () => {
+    await minio.makeBucket('testBucket', 'eu-west-1', { ObjectLocking: false });
+    await minio.makeBucket('testBucket', 'eu-west-1');
+    await minio.makeBucket('testBucket');
+})()
 
 minio.listBuckets((error: Error | null, bucketList: Minio.BucketItemFromList[]) => {
     console.log(error, bucketList);

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -13,33 +13,46 @@ const minio = new Minio.Client({
 
 // Helpers
 function isLockConfig(value: Minio.Lock): value is Minio.LockConfig {
-  return 'mode' in value && 'unit' in value && 'validity' in value;
+    return 'mode' in value && 'unit' in value && 'validity' in value;
 }
 
 function isEncryptionConfig(value: Minio.Encryption): value is Minio.EncryptionConfig {
-  return 'Rule' in value;
+    return 'Rule' in value;
 }
 
 function isRetentionOptions(value: Minio.Retention): value is Minio.RetentionOptions {
-  return 'versionId' in value;
+    return 'versionId' in value;
 }
 
 // Bucket operations
-minio.makeBucket('testBucket', 'ap-southeast-2', (error: Error|null) => { console.log(error); });
+minio.makeBucket('testBucket', 'ap-southeast-2', { ObjectLocking: true }, (error: Error | null) => {
+    console.log(error);
+});
+minio.makeBucket('testBucket', 'ap-southeast-2', (error: Error | null) => {
+    console.log(error);
+});
 minio.makeBucket('testBucket', 'eu-west-1');
-minio.makeBucket('testBucket', 'region-not-from-list');
+minio.makeBucket('testBucket');
 
-minio.listBuckets((error: Error|null, bucketList: Minio.BucketItemFromList[]) => { console.log(error, bucketList); });
+minio.listBuckets((error: Error | null, bucketList: Minio.BucketItemFromList[]) => {
+    console.log(error, bucketList);
+});
 minio.listBuckets();
 
-minio.bucketExists('testBucket', (error: Error|null, exists: boolean) => { console.log(error, exists); });
+minio.bucketExists('testBucket', (error: Error | null, exists: boolean) => {
+    console.log(error, exists);
+});
 minio.bucketExists('testBucket');
 
-minio.removeBucket('testBucket', (error: Error|null) => { console.log(error); });
+minio.removeBucket('testBucket', (error: Error | null) => {
+    console.log(error);
+});
 minio.removeBucket('testBucket');
 
 const objectList = minio.listObjects('testBucket');
-objectList.on('data', (item) => { console.log(item.name); });
+objectList.on('data', item => {
+    console.log(item.name);
+});
 minio.listObjects('testBucket', 'image_');
 minio.listObjects('testBucket', 'audio_', true);
 
@@ -51,277 +64,451 @@ minio.listIncompleteUploads('testBucket');
 minio.listIncompleteUploads('testBucket', 'image_');
 minio.listIncompleteUploads('testBucket', 'audio_', true);
 
-minio.getBucketVersioning('testBucket', (error: Error | null, result: Minio.VersioningConfig) => { console.log(error, Object.keys(result)); });
-minio.getBucketVersioning('testBucket')
-  .then((result) => {
+minio.getBucketVersioning('testBucket', (error: Error | null, result: Minio.VersioningConfig) => {
+    console.log(error, Object.keys(result));
+});
+minio.getBucketVersioning('testBucket').then(result => {
     Object.keys(result);
-  });
+});
 
-minio.setBucketVersioning('testBucket', {Status: 'Enabled'}, (error: Error | null) => { console.log(error); });
-minio.setBucketVersioning('testBucket', {Status: 'Enabled'});
+minio.setBucketVersioning('testBucket', { Status: 'Enabled' }, (error: Error | null) => {
+    console.log(error);
+});
+minio.setBucketVersioning('testBucket', { Status: 'Enabled' });
 
-minio.getBucketTagging('testBucket', (error, tags) => { console.log(error, tags[0].Value); });
-minio.getBucketTagging('testBucket')
-  .then((tags) => {
+minio.getBucketTagging('testBucket', (error, tags) => {
+    console.log(error, tags[0].Value);
+});
+minio.getBucketTagging('testBucket').then(tags => {
     console.log(tags[0].Value);
-  });
+});
 
-minio.setBucketTagging('testBucket', {tagKey: 'tagValue'}, (error: Error | null) => { console.log(error); });
-minio.setBucketTagging('testBucket', {tagKey: 'tagValue'});
+minio.setBucketTagging('testBucket', { tagKey: 'tagValue' }, (error: Error | null) => {
+    console.log(error);
+});
+minio.setBucketTagging('testBucket', { tagKey: 'tagValue' });
 
-minio.removeBucketTagging('testBucket', (error: Error | null) => { console.log(error); });
+minio.removeBucketTagging('testBucket', (error: Error | null) => {
+    console.log(error);
+});
 minio.removeBucketTagging('testBucket');
 
-minio.setBucketLifecycle('testBucket', {Rule: []}, (error: Error | null) => { console.log(error); });
-minio.setBucketLifecycle('testBucket', {Rule: []});
+minio.setBucketLifecycle('testBucket', { Rule: [] }, (error: Error | null) => {
+    console.log(error);
+});
+minio.setBucketLifecycle('testBucket', { Rule: [] });
 minio.setBucketLifecycle('testBucket', null);
 minio.setBucketLifecycle('testBucket', '');
 
-minio.getBucketLifecycle('testBucket', (error: Error | null, result: Minio.Lifecycle) => { console.log(error, result); });
-minio.getBucketLifecycle('testBucket')
-  .then((lifecycle) => {
+minio.getBucketLifecycle('testBucket', (error: Error | null, result: Minio.Lifecycle) => {
+    console.log(error, result);
+});
+minio.getBucketLifecycle('testBucket').then(lifecycle => {
     if (lifecycle) {
-      console.log(lifecycle.Rule);
+        console.log(lifecycle.Rule);
     } else {
-      console.log('Lifecycle is not set.');
+        console.log('Lifecycle is not set.');
     }
-  });
+});
 
-minio.removeBucketLifecycle('testBucket', (error: Error | null) => { console.log(error); });
+minio.removeBucketLifecycle('testBucket', (error: Error | null) => {
+    console.log(error);
+});
 minio.removeBucketLifecycle('testBucket');
 
-minio.setObjectLockConfig('testBucket', (error: Error | null) => { console.log(error); });
-minio.setObjectLockConfig('testBucket', {}, (error: Error | null) => { console.log(error); });
-minio.setObjectLockConfig('testBucket', {mode: 'COMPLIANCE', unit: 'Days', validity: 5}, (error: Error | null) => { console.log(error); });
+minio.setObjectLockConfig('testBucket', (error: Error | null) => {
+    console.log(error);
+});
+minio.setObjectLockConfig('testBucket', {}, (error: Error | null) => {
+    console.log(error);
+});
+minio.setObjectLockConfig('testBucket', { mode: 'COMPLIANCE', unit: 'Days', validity: 5 }, (error: Error | null) => {
+    console.log(error);
+});
 minio.setObjectLockConfig('testBucket');
 minio.setObjectLockConfig('testBucket', {});
-minio.setObjectLockConfig('testBucket', {mode: 'COMPLIANCE', unit: 'Days', validity: 5});
+minio.setObjectLockConfig('testBucket', { mode: 'COMPLIANCE', unit: 'Days', validity: 5 });
 
-minio.getObjectLockConfig('testBucket', (error: Error | null, lockConfig: Minio.Lock) => { console.log(error, lockConfig); });
-minio.getObjectLockConfig('testBucket')
-  .then((lockConfig) => {
+minio.getObjectLockConfig('testBucket', (error: Error | null, lockConfig: Minio.Lock) => {
+    console.log(error, lockConfig);
+});
+minio.getObjectLockConfig('testBucket').then(lockConfig => {
     if (isLockConfig(lockConfig)) {
-      console.log(lockConfig.mode, lockConfig.unit, lockConfig.validity);
+        console.log(lockConfig.mode, lockConfig.unit, lockConfig.validity);
     } else {
-      console.log('Lock config is not set.');
+        console.log('Lock config is not set.');
     }
-  });
+});
 
-minio.getBucketEncryption('testBucket', (error: Error | null, ecnryptionConfig: Minio.Encryption) => { console.log(error, ecnryptionConfig); });
-minio.getBucketEncryption('testBucket')
-  .then((encryptionConfig) => {
+minio.getBucketEncryption('testBucket', (error: Error | null, ecnryptionConfig: Minio.Encryption) => {
+    console.log(error, ecnryptionConfig);
+});
+minio.getBucketEncryption('testBucket').then(encryptionConfig => {
     if (isEncryptionConfig(encryptionConfig)) {
-      console.log(encryptionConfig.Rule);
+        console.log(encryptionConfig.Rule);
     } else {
-      console.log('Encryption config is not set.');
+        console.log('Encryption config is not set.');
     }
-  });
+});
 
-minio.setBucketEncryption('testBucket', {Rule: []}, (error: Error | null) => { console.log(error); });
-minio.setBucketEncryption('testBucket', {Rule: []});
+minio.setBucketEncryption('testBucket', { Rule: [] }, (error: Error | null) => {
+    console.log(error);
+});
+minio.setBucketEncryption('testBucket', { Rule: [] });
 
-minio.removeBucketEncryption('testBucket', (error: Error | null) => { console.log(error); });
+minio.removeBucketEncryption('testBucket', (error: Error | null) => {
+    console.log(error);
+});
 minio.removeBucketEncryption('testBucket');
 
-minio.setBucketReplication('testBucket', {role: 'some:role', rules: []}, (error: Error | null) => { console.log(error); });
-minio.setBucketReplication('testBucket', {role: 'some:role', rules: []});
+minio.setBucketReplication('testBucket', { role: 'some:role', rules: [] }, (error: Error | null) => {
+    console.log(error);
+});
+minio.setBucketReplication('testBucket', { role: 'some:role', rules: [] });
 
-minio.getBucketReplication('testBucket', (error: Error | null, result: Minio.ReplicationConfig) => { console.log(error, result.role); });
-minio.getBucketReplication('testBucket')
-  .then((result) => {
+minio.getBucketReplication('testBucket', (error: Error | null, result: Minio.ReplicationConfig) => {
+    console.log(error, result.role);
+});
+minio.getBucketReplication('testBucket').then(result => {
     console.log(result.role, result.rules);
-  });
+});
 
-minio.removeBucketReplication('testBucket', (error: Error | null) => { console.log(error); });
+minio.removeBucketReplication('testBucket', (error: Error | null) => {
+    console.log(error);
+});
 minio.removeBucketReplication('testBucket');
 
 // Object operations
-minio.getObject('testBucket', 'hello.jpg', (error: Error|null, objectStream: ReadableStream) => { console.log(error, objectStream); });
+minio.getObject('testBucket', 'hello.jpg', (error: Error | null, objectStream: ReadableStream) => {
+    console.log(error, objectStream);
+});
 minio.getObject('testBucket', 'hello.jpg');
 
-minio.getPartialObject('testBucket', 'hello.jpg', 10, (error: Error|null, objectStream: ReadableStream) => { console.log(error, objectStream); });
-minio.getPartialObject('testBucket', 'hello.jpg', 10, 20, (error: Error|null, objectStream: ReadableStream) => { console.log(error, objectStream); });
+minio.getPartialObject('testBucket', 'hello.jpg', 10, (error: Error | null, objectStream: ReadableStream) => {
+    console.log(error, objectStream);
+});
+minio.getPartialObject('testBucket', 'hello.jpg', 10, 20, (error: Error | null, objectStream: ReadableStream) => {
+    console.log(error, objectStream);
+});
 minio.getPartialObject('testBucket', 'hello.jpg', 10);
 minio.getPartialObject('testBucket', 'hello.jpg', 10, 20);
 
-minio.fGetObject('testBucket', 'hello.jpg', 'file/path', (error: Error|null) => { console.log(error); });
+minio.fGetObject('testBucket', 'hello.jpg', 'file/path', (error: Error | null) => {
+    console.log(error);
+});
 minio.fGetObject('testBucket', 'hello.jpg', 'file/path');
 
 const metaData = {
     'Content-Type': 'text/html',
     'Content-Language': 123,
     'X-Amz-Meta-Testing': 1234,
-    example: 5678
+    example: 5678,
 };
-minio.putObject('testBucket', 'hello.jpg', fs.createReadStream('hello.jpg'), (error: Error|null, objInfo: Minio.UploadedObjectInfo) => { console.log(error, objInfo.etag, objInfo.versionId); });
-minio.putObject('testBucket', 'hello.jpg', new Buffer('string'), 100, (error: Error|null, objInfo: Minio.UploadedObjectInfo) => { console.log(error, objInfo.etag, objInfo.versionId); });
-minio.putObject('testBucket', 'hello.txt', 'hello.txt content', 100, metaData, (error: Error|null, objInfo: Minio.UploadedObjectInfo) => { console.log(error, objInfo.etag, objInfo.versionId); });
+minio.putObject(
+    'testBucket',
+    'hello.jpg',
+    fs.createReadStream('hello.jpg'),
+    (error: Error | null, objInfo: Minio.UploadedObjectInfo) => {
+        console.log(error, objInfo.etag, objInfo.versionId);
+    },
+);
+minio.putObject(
+    'testBucket',
+    'hello.jpg',
+    new Buffer('string'),
+    100,
+    (error: Error | null, objInfo: Minio.UploadedObjectInfo) => {
+        console.log(error, objInfo.etag, objInfo.versionId);
+    },
+);
+minio.putObject(
+    'testBucket',
+    'hello.txt',
+    'hello.txt content',
+    100,
+    metaData,
+    (error: Error | null, objInfo: Minio.UploadedObjectInfo) => {
+        console.log(error, objInfo.etag, objInfo.versionId);
+    },
+);
 minio.putObject('testBucket', 'hello.jpg', fs.createReadStream('hello.jpg'));
 minio.putObject('testBucket', 'hello.jpg', new Buffer('string'), 100);
 minio.putObject('testBucket', 'hello.txt', 'hello.txt content', 100, metaData);
 minio.putObject('testBucket', 'hello.txt', 'hello.txt content', metaData);
 
-minio.fPutObject('testBucket', 'hello.jpg', 'file/path', metaData, (error: Error|null, objInfo: Minio.UploadedObjectInfo) => { console.log(error, objInfo.etag, objInfo.versionId); });
+minio.fPutObject(
+    'testBucket',
+    'hello.jpg',
+    'file/path',
+    metaData,
+    (error: Error | null, objInfo: Minio.UploadedObjectInfo) => {
+        console.log(error, objInfo.etag, objInfo.versionId);
+    },
+);
 minio.fPutObject('testBucket', 'hello.jpg', 'file/path', metaData);
 
 const conditions = new Minio.CopyConditions();
 conditions.setMatchETag('bd891862ea3e22c93ed53a098218791d');
-minio.copyObject('testBucket', 'copy-of-hello.jpg', 'hello.jpg', conditions, (error: Error|null, item: Minio.BucketItemCopy) => { console.log(error, item); });
+minio.copyObject(
+    'testBucket',
+    'copy-of-hello.jpg',
+    'hello.jpg',
+    conditions,
+    (error: Error | null, item: Minio.BucketItemCopy) => {
+        console.log(error, item);
+    },
+);
 minio.copyObject('testBucket', 'copy-of-hello.jpg', 'hello.jpg', conditions);
 
-minio.statObject('testBucket', 'hello.jpg', (error: Error|null, stat: Minio.BucketItemStat) => { console.log(error, stat); });
+minio.statObject('testBucket', 'hello.jpg', (error: Error | null, stat: Minio.BucketItemStat) => {
+    console.log(error, stat);
+});
 minio.statObject('testBucket', 'hello.jpg');
 
-minio.removeObject('testBucket', 'hello.jpg', (error: Error|null) => { console.log(error); });
+minio.removeObject('testBucket', 'hello.jpg', (error: Error | null) => {
+    console.log(error);
+});
 minio.removeObject('testBucket', 'hello.jpg');
 
-minio.removeObjects('testBucket', ['hello.jpg', 'hello.txt'], (error: Error|null) => { console.log(error); });
+minio.removeObjects('testBucket', ['hello.jpg', 'hello.txt'], (error: Error | null) => {
+    console.log(error);
+});
 minio.removeObjects('testBucket', ['hello.jpg', 'hello.txt']);
 
-minio.removeIncompleteUpload('testBucket', 'hello.jpg', (error: Error|null) => { console.log(error); });
+minio.removeIncompleteUpload('testBucket', 'hello.jpg', (error: Error | null) => {
+    console.log(error);
+});
 minio.removeIncompleteUpload('testBucket', 'hello.jpg');
 
-minio.putObjectRetention('testBucket', 'hello.jpg', (error: Error|null) => { console.log(error); });
-minio.putObjectRetention('testBucket', 'hello.jpg', {}, (error: Error|null) => { console.log(error); });
-minio.putObjectRetention('testBucket', 'hello.jpg', {mode: 'COMPLIANCE', retainUntilDate: new Date().toISOString(), versionId: 'someVersion'}, (error: Error|null) => { console.log(error); });
+minio.putObjectRetention('testBucket', 'hello.jpg', (error: Error | null) => {
+    console.log(error);
+});
+minio.putObjectRetention('testBucket', 'hello.jpg', {}, (error: Error | null) => {
+    console.log(error);
+});
+minio.putObjectRetention(
+    'testBucket',
+    'hello.jpg',
+    { mode: 'COMPLIANCE', retainUntilDate: new Date().toISOString(), versionId: 'someVersion' },
+    (error: Error | null) => {
+        console.log(error);
+    },
+);
 minio.putObjectRetention('testBucket', 'hello.jpg');
 minio.putObjectRetention('testBucket', 'hello.jpg', {});
-minio.putObjectRetention('testBucket', 'hello.jpg', {mode: 'COMPLIANCE', retainUntilDate: new Date().toISOString(), versionId: 'someVersion'});
-
-minio.getObjectRetention('testBucket', 'hello.jpg', {versionId: 'someVersion'}, (error: Error | null, result: Minio.Retention) => { console.log(error, result); });
-minio.getObjectRetention('testBucket', 'hello.jpg', {versionId: 'someVersion'})
-.then((result) => {
-  if (isRetentionOptions(result)) {
-    console.log(result.versionId);
-  } else {
-    console.log('Retention options are not set.');
-  }
+minio.putObjectRetention('testBucket', 'hello.jpg', {
+    mode: 'COMPLIANCE',
+    retainUntilDate: new Date().toISOString(),
+    versionId: 'someVersion',
 });
 
-minio.putObjectTagging('testBucket', 'hello.jpg', {tagName: 'tagValue'}, (error: Error | null) => { console.log(error); });
-minio.putObjectTagging('testBucket', 'hello.jpg', {tagName: 'tagValue'}, {versionId: 'someVersion'}, (error: Error | null) => { console.log(error); });
-minio.putObjectTagging('testBucket', 'hello.jpg', {tagName: 'tagValue'});
-minio.putObjectTagging('testBucket', 'hello.jpg', {tagName: 'tagValue'}, {versionId: 'someVersion'});
+minio.getObjectRetention(
+    'testBucket',
+    'hello.jpg',
+    { versionId: 'someVersion' },
+    (error: Error | null, result: Minio.Retention) => {
+        console.log(error, result);
+    },
+);
+minio.getObjectRetention('testBucket', 'hello.jpg', { versionId: 'someVersion' }).then(result => {
+    if (isRetentionOptions(result)) {
+        console.log(result.versionId);
+    } else {
+        console.log('Retention options are not set.');
+    }
+});
 
-minio.setObjectTagging('testBucket', 'hello.jpg', {tagName: 'tagValue'}, (error: Error | null) => { console.log(error); });
-minio.setObjectTagging('testBucket', 'hello.jpg', {tagName: 'tagValue'}, {versionId: 'someVersion'}, (error: Error | null) => { console.log(error); });
-minio.setObjectTagging('testBucket', 'hello.jpg', {tagName: 'tagValue'});
-minio.setObjectTagging('testBucket', 'hello.jpg', {tagName: 'tagValue'}, {versionId: 'someVersion'});
+minio.putObjectTagging('testBucket', 'hello.jpg', { tagName: 'tagValue' }, (error: Error | null) => {
+    console.log(error);
+});
+minio.putObjectTagging(
+    'testBucket',
+    'hello.jpg',
+    { tagName: 'tagValue' },
+    { versionId: 'someVersion' },
+    (error: Error | null) => {
+        console.log(error);
+    },
+);
+minio.putObjectTagging('testBucket', 'hello.jpg', { tagName: 'tagValue' });
+minio.putObjectTagging('testBucket', 'hello.jpg', { tagName: 'tagValue' }, { versionId: 'someVersion' });
 
-minio.removeObjectTagging('testBucket', 'hello.jpg', (error: Error | null) => { console.log(error); });
-minio.removeObjectTagging('testBucket', 'hello.jpg', {versionId: 'someVersion'}, (error: Error | null) => { console.log(error); });
+minio.setObjectTagging('testBucket', 'hello.jpg', { tagName: 'tagValue' }, (error: Error | null) => {
+    console.log(error);
+});
+minio.setObjectTagging(
+    'testBucket',
+    'hello.jpg',
+    { tagName: 'tagValue' },
+    { versionId: 'someVersion' },
+    (error: Error | null) => {
+        console.log(error);
+    },
+);
+minio.setObjectTagging('testBucket', 'hello.jpg', { tagName: 'tagValue' });
+minio.setObjectTagging('testBucket', 'hello.jpg', { tagName: 'tagValue' }, { versionId: 'someVersion' });
+
+minio.removeObjectTagging('testBucket', 'hello.jpg', (error: Error | null) => {
+    console.log(error);
+});
+minio.removeObjectTagging('testBucket', 'hello.jpg', { versionId: 'someVersion' }, (error: Error | null) => {
+    console.log(error);
+});
 minio.removeObjectTagging('testBucket', 'hello.jpg');
-minio.removeObjectTagging('testBucket', 'hello.jpg', {versionId: 'someVersion'});
+minio.removeObjectTagging('testBucket', 'hello.jpg', { versionId: 'someVersion' });
 
-minio.getObjectTagging('testBucket', 'hello.jpg', (error: Error | null, tags: Minio.Tag[]) => { console.log(error, tags[0].Value); });
-minio.getObjectTagging('testBucket', 'hello.jpg', {versionId: 'someVersion'}, (error: Error | null, tags: Minio.Tag[]) => { console.log(error, tags[0].Value); });
-minio.getObjectTagging('testBucket', 'hello.jpg')
-  .then((tags) => {
+minio.getObjectTagging('testBucket', 'hello.jpg', (error: Error | null, tags: Minio.Tag[]) => {
+    console.log(error, tags[0].Value);
+});
+minio.getObjectTagging(
+    'testBucket',
+    'hello.jpg',
+    { versionId: 'someVersion' },
+    (error: Error | null, tags: Minio.Tag[]) => {
+        console.log(error, tags[0].Value);
+    },
+);
+minio.getObjectTagging('testBucket', 'hello.jpg').then(tags => {
     console.log(tags[0].Value);
-  });
-minio.getObjectTagging('testBucket', 'hello.jpg', {versionId: 'someVersion'})
-  .then((tags) => {
+});
+minio.getObjectTagging('testBucket', 'hello.jpg', { versionId: 'someVersion' }).then(tags => {
     console.log(tags[0].Value);
-  });
+});
 
-minio.getObjectLegalHold('testBucket', 'hello.jpg', (error: Error | null, result: Minio.LegalHoldOptions) => { console.log(error, result.status); });
-minio.getObjectLegalHold('testBucket', 'hello.jpg', {versionId: 'someVersion'}, (error: Error | null, result: Minio.LegalHoldOptions) => { console.log(error, result.status); });
-minio.getObjectLegalHold('testBucket', 'hello.jpg')
-  .then((result) => {
+minio.getObjectLegalHold('testBucket', 'hello.jpg', (error: Error | null, result: Minio.LegalHoldOptions) => {
+    console.log(error, result.status);
+});
+minio.getObjectLegalHold(
+    'testBucket',
+    'hello.jpg',
+    { versionId: 'someVersion' },
+    (error: Error | null, result: Minio.LegalHoldOptions) => {
+        console.log(error, result.status);
+    },
+);
+minio.getObjectLegalHold('testBucket', 'hello.jpg').then(result => {
     console.log(result.status);
-  });
-minio.getObjectLegalHold('testBucket', 'hello.jpg', {versionId: 'someVersion'})
-  .then((result) => {
+});
+minio.getObjectLegalHold('testBucket', 'hello.jpg', { versionId: 'someVersion' }).then(result => {
     console.log(result.status);
-  });
+});
 
-minio.setObjectLegalHold('testBucket', 'hello.jpg', (error: Error | null) => { console.log(error); });
-minio.setObjectLegalHold('testBucket', 'hello.jpg', {versionId: 'someVersion', status: 'OFF'}, (error: Error | null) => { console.log(error); });
+minio.setObjectLegalHold('testBucket', 'hello.jpg', (error: Error | null) => {
+    console.log(error);
+});
+minio.setObjectLegalHold(
+    'testBucket',
+    'hello.jpg',
+    { versionId: 'someVersion', status: 'OFF' },
+    (error: Error | null) => {
+        console.log(error);
+    },
+);
 minio.setObjectLegalHold('testBucket', 'hello.jpg');
-minio.setObjectLegalHold('testBucket', 'hello.jpg', {versionId: 'someVersion', status: 'OFF'});
+minio.setObjectLegalHold('testBucket', 'hello.jpg', { versionId: 'someVersion', status: 'OFF' });
 
 const destObjConfig = new Minio.CopyDestinationOptions({ Bucket: 'testBucket', Object: '100MB.zip' });
 const sourceObjList = [
-  new Minio.CopySourceOptions({ Bucket: 'testBucket', Object: 'partA' }),
-  new Minio.CopySourceOptions({ Bucket: 'testBucket', Object: 'partB' }),
-  new Minio.CopySourceOptions({ Bucket: 'testBucket', Object: 'partC' }),
+    new Minio.CopySourceOptions({ Bucket: 'testBucket', Object: 'partA' }),
+    new Minio.CopySourceOptions({ Bucket: 'testBucket', Object: 'partB' }),
+    new Minio.CopySourceOptions({ Bucket: 'testBucket', Object: 'partC' }),
 ];
 
-minio.composeObject(destObjConfig, sourceObjList, (error: Error | null, result: Minio.SourceObjectStats) => { console.log(error, result); });
+minio.composeObject(destObjConfig, sourceObjList, (error: Error | null, result: Minio.SourceObjectStats) => {
+    console.log(error, result);
+});
 minio.composeObject(destObjConfig, sourceObjList);
-minio.composeObject(destObjConfig, sourceObjList)
-  .then((result) => {
+minio.composeObject(destObjConfig, sourceObjList).then(result => {
     console.log(result);
-  });
+});
 
 minio.selectObjectContent(
-  'testBucket',
-  'hello.jpg',
-  {
-    expression: "SELECT * FROM s3object s",
+    'testBucket',
+    'hello.jpg',
+    {
+        expression: 'SELECT * FROM s3object s',
+        expressionType: 'SQL',
+        inputSerialization: { CSV: { FileHeaderInfo: 'USE' }, CompressionType: 'NONE' },
+        outputSerialization: { CSV: { RecordDelimiter: '\n', FieldDelimiter: ',' } },
+        requestProgress: { Enabled: true },
+    },
+    (error: Error | null) => {
+        console.log(error);
+    },
+);
+minio.selectObjectContent('testBucket', 'hello.jpg', {
+    expression: 'SELECT * FROM s3object s',
     expressionType: 'SQL',
     inputSerialization: { CSV: { FileHeaderInfo: 'USE' }, CompressionType: 'NONE' },
-    outputSerialization: { CSV: { RecordDelimiter: '\n', FieldDelimiter: ',' }},
+    outputSerialization: { CSV: { RecordDelimiter: '\n', FieldDelimiter: ',' } },
     requestProgress: { Enabled: true },
-  },
-  (error: Error | null) => { console.log(error); }
-);
-minio.selectObjectContent(
-  'testBucket',
-  'hello.jpg',
-  {
-    expression: "SELECT * FROM s3object s",
-    expressionType: 'SQL',
-    inputSerialization: { CSV: { FileHeaderInfo: 'USE' }, CompressionType: 'NONE' },
-    outputSerialization: { CSV: { RecordDelimiter: '\n', FieldDelimiter: ',' }},
-    requestProgress: { Enabled: true },
-  },
-);
+});
 
 // Presigned operations
-minio.presignedUrl('GET', 'testBucket', 'hello.jpg', (error: Error|null, url: string) => { console.log(error, url); });
-minio.presignedUrl('GET', 'testBucket', 'hello.jpg', 84600, (error: Error|null, url: string) => { console.log(error, url); });
-minio.presignedUrl('GET', 'testBucket', 'hello.jpg', 84600, { prefix: 'data', 'max-keys': 1000 }, (error: Error|null, url: string) => { console.log(error, url); });
+minio.presignedUrl('GET', 'testBucket', 'hello.jpg', (error: Error | null, url: string) => {
+    console.log(error, url);
+});
+minio.presignedUrl('GET', 'testBucket', 'hello.jpg', 84600, (error: Error | null, url: string) => {
+    console.log(error, url);
+});
+minio.presignedUrl(
+    'GET',
+    'testBucket',
+    'hello.jpg',
+    84600,
+    { prefix: 'data', 'max-keys': 1000 },
+    (error: Error | null, url: string) => {
+        console.log(error, url);
+    },
+);
 minio.presignedUrl('GET', 'testBucket', 'hello.jpg');
 minio.presignedUrl('GET', 'testBucket', 'hello.jpg', 84600);
 minio.presignedUrl('GET', 'testBucket', 'hello.jpg', 84600, { prefix: 'data', 'max-keys': 1000 });
 
-minio.presignedGetObject('testBucket', 'hello.jpg', (error: Error|null, url: string) => { console.log(error, url); });
-minio.presignedGetObject('testBucket', 'hello.jpg', 84600, (error: Error|null, url: string) => { console.log(error, url); });
-minio.presignedGetObject(
-  'testBucket',
-  'hello.jpg',
-  84600,
-  { 'content-disposition': 'attachment; filename="image.png"' },
-  (error: Error | null, url: string) => {
+minio.presignedGetObject('testBucket', 'hello.jpg', (error: Error | null, url: string) => {
     console.log(error, url);
-  },
+});
+minio.presignedGetObject('testBucket', 'hello.jpg', 84600, (error: Error | null, url: string) => {
+    console.log(error, url);
+});
+minio.presignedGetObject(
+    'testBucket',
+    'hello.jpg',
+    84600,
+    { 'content-disposition': 'attachment; filename="image.png"' },
+    (error: Error | null, url: string) => {
+        console.log(error, url);
+    },
 );
 minio.presignedGetObject(
-  'testBucket',
-  'hello.jpg',
-  84600,
-  { 'content-disposition': 'attachment; filename="image.png"' },
-  new Date(),
-  (error: Error | null, url: string) => {
-    console.log(error, url);
-  },
+    'testBucket',
+    'hello.jpg',
+    84600,
+    { 'content-disposition': 'attachment; filename="image.png"' },
+    new Date(),
+    (error: Error | null, url: string) => {
+        console.log(error, url);
+    },
 );
 minio.presignedGetObject('testBucket', 'hello.jpg');
 minio.presignedGetObject('testBucket', 'hello.jpg', 84600);
 minio.presignedGetObject('testBucket', 'hello.jpg', 84600, {
-  'content-disposition': 'attachment; filename="image.png"',
+    'content-disposition': 'attachment; filename="image.png"',
 });
 minio.presignedGetObject(
-  'testBucket',
-  'hello.jpg',
-  84600,
-  { 'content-disposition': 'attachment; filename="image.png"' },
-  new Date(),
+    'testBucket',
+    'hello.jpg',
+    84600,
+    { 'content-disposition': 'attachment; filename="image.png"' },
+    new Date(),
 );
 
-minio.presignedPutObject('testBucket', 'hello.jpg', (error: Error|null, url: string) => { console.log(error, url); });
-minio.presignedPutObject('testBucket', 'hello.jpg', 84600, (error: Error|null, url: string) => { console.log(error, url); });
+minio.presignedPutObject('testBucket', 'hello.jpg', (error: Error | null, url: string) => {
+    console.log(error, url);
+});
+minio.presignedPutObject('testBucket', 'hello.jpg', 84600, (error: Error | null, url: string) => {
+    console.log(error, url);
+});
 minio.presignedPutObject('testBucket', 'hello.jpg');
 minio.presignedPutObject('testBucket', 'hello.jpg', 84600);
 
@@ -334,27 +521,37 @@ policy.setContentType('image/jpeg');
 policy.setContentTypeStartsWith('image/');
 policy.setUserMetaData({ key: 'value' });
 
-minio.presignedPostPolicy(policy, (error: Error|null, data: Minio.PostPolicyResult) => { console.log(error, data); });
+minio.presignedPostPolicy(policy, (error: Error | null, data: Minio.PostPolicyResult) => {
+    console.log(error, data);
+});
 minio.presignedPostPolicy(policy);
 
-minio.getBucketNotification('testBucket', (error: Error|null, config: Minio.NotificationConfig) => { console.log(error, config); });
+minio.getBucketNotification('testBucket', (error: Error | null, config: Minio.NotificationConfig) => {
+    console.log(error, config);
+});
 minio.getBucketNotification('testBucket');
 
 const notificationConfig = new Minio.NotificationConfig();
 const arn: string = Minio.buildARN('aws', 'sns', 'us-west-2', '408065449417', 'resource');
 const topic = new Minio.TopicConfig(arn);
 notificationConfig.add(topic);
-minio.setBucketNotification('testBucket', notificationConfig, (error: Error|null) => { console.log(error); });
+minio.setBucketNotification('testBucket', notificationConfig, (error: Error | null) => {
+    console.log(error);
+});
 minio.setBucketNotification('testBucket', notificationConfig);
 
-minio.removeAllBucketNotification('testBucket', (error: Error|null) => { console.log(error); });
+minio.removeAllBucketNotification('testBucket', (error: Error | null) => {
+    console.log(error);
+});
 minio.removeAllBucketNotification('testBucket');
 
 const poller = minio.listenBucketNotification('testBucket', 'pref_', '_suf', [Minio.ObjectCreatedAll]);
 poller.start();
 poller.stop();
 
-minio.getBucketPolicy('testBucket', (error: Error|null, policy: string) => { console.log(error, policy); });
+minio.getBucketPolicy('testBucket', (error: Error | null, policy: string) => {
+    console.log(error, policy);
+});
 minio.getBucketPolicy('testBucket');
 
 const testPolicy = `{"Version":"2012-10-17","Statement":[{"Action":["s3:GetBucketLocation"],"Effect":"Allow",
@@ -363,7 +560,9 @@ const testPolicy = `{"Version":"2012-10-17","Statement":[{"Action":["s3:GetBucke
 "Resource":["arn:aws:s3:::bucketName"],"Sid":""},{"Action":["s3:GetObject"],"Effect":"Allow",
 "Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::bucketName/foo*","arn:aws:s3:::bucketName/prefix/*"],"Sid":""}]}
 `;
-minio.setBucketPolicy('testBucket',  testPolicy, (error: Error|null) => { console.log(error); });
+minio.setBucketPolicy('testBucket', testPolicy, (error: Error | null) => {
+    console.log(error);
+});
 minio.setBucketPolicy('testBucket', testPolicy);
 
 minio.extensions.listObjectsV2WithMetadata('testBucket');

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -39,7 +39,7 @@ minio.makeBucket('testBucket', (error: Error | null) => {
     await minio.makeBucket('testBucket', 'eu-west-1', { ObjectLocking: false });
     await minio.makeBucket('testBucket', 'eu-west-1');
     await minio.makeBucket('testBucket');
-})()
+})();
 
 minio.listBuckets((error: Error | null, bucketList: Minio.BucketItemFromList[]) => {
     console.log(error, bucketList);

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -31,6 +31,9 @@ minio.makeBucket('testBucket', 'ap-southeast-2', { ObjectLocking: true }, (error
 minio.makeBucket('testBucket', 'ap-southeast-2', (error: Error | null) => {
     console.log(error);
 });
+minio.makeBucket('testBucket', (error: Error | null) => {
+    console.log(error);
+});
 minio.makeBucket('testBucket', 'eu-west-1');
 minio.makeBucket('testBucket');
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


https://min.io/docs/minio/linux/developers/javascript/API.html#bucket-operations

![image](https://user-images.githubusercontent.com/13553903/222037230-789453f6-1400-4175-b0c7-3734ab386c72.png)


( I run prettier on types/minio and it cause many changes... )