### PR TITLE
[node-telegram-bot-api] sync typings with docs

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -1809,7 +1809,7 @@ declare class TelegramBot extends EventEmitter {
         options?: TelegramBot.GetGameHighScoresOptions,
     ): Promise<TelegramBot.GameHighScore[]>;
 
-    deleteMessage(chatId: TelegramBot.ChatId, messageId: string, options?: any): Promise<boolean>;
+    deleteMessage(chatId: TelegramBot.ChatId, messageId: string | number, options?: any): Promise<boolean>;
 
     sendInvoice(
         chatId: TelegramBot.ChatId,

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -1449,14 +1449,14 @@ declare class TelegramBot extends EventEmitter {
     forwardMessage(
         chatId: TelegramBot.ChatId,
         fromChatId: TelegramBot.ChatId,
-        messageId: number | string,
+        messageId: number,
         options?: TelegramBot.ForwardMessageOptions,
     ): Promise<TelegramBot.Message>;
 
     copyMessage(
         chatId: TelegramBot.ChatId,
         fromChatId: TelegramBot.ChatId,
-        messageId: number | string,
+        messageId: number,
         options?: TelegramBot.CopyMessageOptions,
     ): Promise<TelegramBot.MessageId>;
 
@@ -1740,7 +1740,7 @@ declare class TelegramBot extends EventEmitter {
 
     onReplyToMessage(
         chatId: TelegramBot.ChatId,
-        messageId: number | string,
+        messageId: number,
         callback: (msg: TelegramBot.Message) => void,
     ): number;
 
@@ -1809,7 +1809,7 @@ declare class TelegramBot extends EventEmitter {
         options?: TelegramBot.GetGameHighScoresOptions,
     ): Promise<TelegramBot.GameHighScore[]>;
 
-    deleteMessage(chatId: TelegramBot.ChatId, messageId: string | number, options?: any): Promise<boolean>;
+    deleteMessage(chatId: TelegramBot.ChatId, messageId: number, options?: any): Promise<boolean>;
 
     sendInvoice(
         chatId: TelegramBot.ChatId,

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -18,6 +18,7 @@ import { EventEmitter } from 'events';
 import { ServerOptions } from 'https';
 import { Options } from 'request';
 import { Readable, Stream } from 'stream';
+import { ChatId } from './index.js';
 
 declare namespace TelegramBot {
     interface TextListener {
@@ -360,13 +361,13 @@ declare namespace TelegramBot {
     }
 
     interface EditMessageReplyMarkupOptions {
-        chat_id?: number | string | undefined;
+        chat_id?: ChatId | undefined;
         message_id?: number | undefined;
         inline_message_id?: string | undefined;
     }
 
     interface EditMessageMediaOptions {
-        chat_id?: number | string | undefined;
+        chat_id?: ChatId | undefined;
         message_id?: number | undefined;
         inline_message_id?: string | undefined;
         reply_markup?: InlineKeyboardMarkup | undefined;
@@ -1523,14 +1524,14 @@ declare class TelegramBot extends EventEmitter {
     getCustomEmojiStickers(customEmojiIds: string[], options?: {}): Promise<TelegramBot.Sticker[]>;
 
     uploadStickerFile(
-        userId: string,
+        userId: number,
         pngSticker: string | Stream | Buffer,
         options?: {},
         fileOptions?: TelegramBot.FileOptions,
     ): Promise<TelegramBot.File>;
 
     createNewStickerSet(
-        userId: string,
+        userId: number,
         name: string,
         title: string,
         pngSticker: string | Stream | Buffer,
@@ -1540,7 +1541,7 @@ declare class TelegramBot extends EventEmitter {
     ): Promise<boolean>;
 
     addStickerToSet(
-        userId: string,
+        userId: number,
         name: string,
         sticker: string | Stream | Buffer,
         emojis: string,
@@ -1554,7 +1555,7 @@ declare class TelegramBot extends EventEmitter {
     deleteStickerFromSet(sticker: string, options?: {}): Promise<boolean>;
 
     setStickerSetThumb(
-        userId: string,
+        userId: number,
         name: string,
         pngThumb: string | Stream | Buffer,
         options?: {},
@@ -1588,16 +1589,14 @@ declare class TelegramBot extends EventEmitter {
         options?: TelegramBot.SendChatActionOptions,
     ): Promise<boolean>;
 
-    kickChatMember(chatId: TelegramBot.ChatId, userId: string): Promise<boolean>;
-
     banChatMember(
-        chatId: number | string,
-        userId: string,
+        chatId: TelegramBot.ChatId,
+        userId: number,
         untilDate?: number,
         revokeMessages?: boolean,
     ): Promise<boolean>;
 
-    unbanChatMember(chatId: TelegramBot.ChatId, userId: string): Promise<boolean>;
+    unbanChatMember(chatId: TelegramBot.ChatId, userId: number): Promise<boolean>;
 
     banChatSenderChat(chatId: TelegramBot.ChatId, senderChatId: TelegramBot.ChatId): Promise<boolean>;
 
@@ -1605,13 +1604,13 @@ declare class TelegramBot extends EventEmitter {
 
     restrictChatMember(
         chatId: TelegramBot.ChatId,
-        userId: string,
+        userId: number,
         options?: TelegramBot.RestrictChatMemberOptions,
     ): Promise<boolean>;
 
     promoteChatMember(
         chatId: TelegramBot.ChatId,
-        userId: string,
+        userId: number,
         options?: TelegramBot.PromoteChatMemberOptions,
     ): Promise<boolean>;
 
@@ -1636,9 +1635,9 @@ declare class TelegramBot extends EventEmitter {
 
     revokeChatInviteLink(chatId: TelegramBot.ChatId, inviteLink: string): Promise<TelegramBot.ChatInviteLink>;
 
-    approveChatJoinRequest(chatId: TelegramBot.ChatId, userId: string, form?: object): Promise<boolean>;
+    approveChatJoinRequest(chatId: TelegramBot.ChatId, userId: number, form?: object): Promise<boolean>;
 
-    declineChatJoinRequest(chatId: TelegramBot.ChatId, userId: string, form?: object): Promise<boolean>;
+    declineChatJoinRequest(chatId: TelegramBot.ChatId, userId: number, form?: object): Promise<boolean>;
 
     setChatPhoto(
         chatId: TelegramBot.ChatId,
@@ -1687,7 +1686,7 @@ declare class TelegramBot extends EventEmitter {
     ): Promise<TelegramBot.Message | boolean>;
 
     getUserProfilePhotos(
-        userId: number | string,
+        userId: number,
         options?: TelegramBot.GetUserProfilePhotosOptions,
     ): Promise<TelegramBot.UserProfilePhotos>;
 
@@ -1754,7 +1753,7 @@ declare class TelegramBot extends EventEmitter {
 
     getChatMemberCount(chatId: TelegramBot.ChatId): Promise<number>;
 
-    getChatMember(chatId: TelegramBot.ChatId, userId: string): Promise<TelegramBot.ChatMember>;
+    getChatMember(chatId: TelegramBot.ChatId, userId: number): Promise<TelegramBot.ChatMember>;
 
     leaveChat(chatId: TelegramBot.ChatId): Promise<boolean>;
 
@@ -1799,13 +1798,13 @@ declare class TelegramBot extends EventEmitter {
     ): Promise<TelegramBot.Message>;
 
     setGameScore(
-        userId: string,
+        userId: number,
         score: number,
         options?: TelegramBot.SetGameScoreOptions,
     ): Promise<TelegramBot.Message | boolean>;
 
     getGameHighScores(
-        userId: string,
+        userId: number,
         options?: TelegramBot.GetGameHighScoresOptions,
     ): Promise<TelegramBot.GameHighScore[]>;
 
@@ -2210,7 +2209,7 @@ declare class TelegramBot extends EventEmitter {
         options?: TelegramBot.SetChatPermissionsOptions,
     ): Promise<boolean>;
 
-    setChatAdministratorCustomTitle(chatId: TelegramBot.ChatId, userId: string, customTitle: string): Promise<boolean>;
+    setChatAdministratorCustomTitle(chatId: TelegramBot.ChatId, userId: number, customTitle: string): Promise<boolean>;
 
     getMyCommands(scope?: TelegramBot.BotCommandScope, language_code?: string): Promise<TelegramBot.BotCommand[]>;
 

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -18,7 +18,6 @@ import { EventEmitter } from 'events';
 import { ServerOptions } from 'https';
 import { Options } from 'request';
 import { Readable, Stream } from 'stream';
-import { ChatId } from './index.js';
 
 declare namespace TelegramBot {
     interface TextListener {

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -152,19 +152,18 @@ MyTelegramBot.sendVoice(
 MyTelegramBot.sendVoice(1234, 'voice/path', { filename: 'filename', contentType: 'application/octet-stream' });
 MyTelegramBot.sendAnimation(1234, 'animation/path', { caption: 'Foo', duration: 100, width: 200, height: 300 });
 MyTelegramBot.sendChatAction(1234, 'typing');
-MyTelegramBot.kickChatMember(1234, 'myUserID');
-MyTelegramBot.banChatMember(1234, 'myUserID');
-MyTelegramBot.unbanChatMember(1234, 'myUserID');
-MyTelegramBot.restrictChatMember(1234, 'myUserID', { permissions: { can_add_web_page_previews: true, can_send_polls: false } });
-MyTelegramBot.promoteChatMember(1234, 'myUserID', { can_change_info: true });
+MyTelegramBot.banChatMember(1234, 5678);
+MyTelegramBot.unbanChatMember(1234, 5678);
+MyTelegramBot.restrictChatMember(1234, 5678, { permissions: { can_add_web_page_previews: true, can_send_polls: false } });
+MyTelegramBot.promoteChatMember(1234, 5678, { can_change_info: true });
 MyTelegramBot.exportChatInviteLink(1234);
 MyTelegramBot.createChatInviteLink(1234, 'Foo', 1234, 1234, true);
 MyTelegramBot.editChatInviteLink(1234, '', '', 1234, 1234, true);
 MyTelegramBot.revokeChatInviteLink(1234, '');
-MyTelegramBot.approveChatJoinRequest(1234, 'myUserID');
-MyTelegramBot.approveChatJoinRequest(1234, 'myUserID', {});
-MyTelegramBot.declineChatJoinRequest(1234, 'myUserID');
-MyTelegramBot.declineChatJoinRequest(1234, 'myUserID', {});
+MyTelegramBot.approveChatJoinRequest(1234, 5678);
+MyTelegramBot.approveChatJoinRequest(1234, 5678, {});
+MyTelegramBot.declineChatJoinRequest(1234, 5678);
+MyTelegramBot.declineChatJoinRequest(1234, 5678, {});
 MyTelegramBot.setChatPhoto(1234, 'My/File/ID', {}, { filename: 'filename', contentType: 'application/octet-stream' });
 MyTelegramBot.deleteChatPhoto(1234);
 MyTelegramBot.setChatTitle(1234, 'Chat Title');
@@ -203,7 +202,7 @@ MyTelegramBot.editMessageReplyMarkup(
     },
     { message_id: 1244 },
 );
-MyTelegramBot.getUserProfilePhotos('myUserID', { limit: 10 });
+MyTelegramBot.getUserProfilePhotos(5678, { limit: 10 });
 MyTelegramBot.sendLocation(1234, 100, 200, {
     reply_to_message_id: 1234,
     live_period: 60,
@@ -222,20 +221,20 @@ MyTelegramBot.downloadFile('My/File/ID', 'mydownloaddir/');
 MyTelegramBot.onText(/regex/, (msg, match) => {});
 MyTelegramBot.removeTextListener(/regex/);
 MyTelegramBot.clearTextListeners();
-MyTelegramBot.onReplyToMessage(1234, 567, msg => {});
+MyTelegramBot.onReplyToMessage(1234, 5678, msg => {});
 MyTelegramBot.removeReplyListener(5466);
 MyTelegramBot.clearReplyListeners();
 MyTelegramBot.getChat(1234);
 MyTelegramBot.getChatAdministrators(1234);
 MyTelegramBot.getChatMemberCount(1234);
-MyTelegramBot.getChatMember(1234, 'myUserID');
+MyTelegramBot.getChatMember(1234, 5678);
 MyTelegramBot.leaveChat(1234);
 MyTelegramBot.setChatStickerSet(1234, 'sticker');
 MyTelegramBot.deleteChatStickerSet(1234);
 MyTelegramBot.sendGame(1234, 'MygameName', { reply_to_message_id: 1234 });
-MyTelegramBot.setGameScore('myUserID', 99, { message_id: 1234 });
-MyTelegramBot.getGameHighScores('myUserID', { message_id: 1234 });
-MyTelegramBot.deleteMessage(1234, 567);
+MyTelegramBot.setGameScore(1234, 99, { message_id: 1234 });
+MyTelegramBot.getGameHighScores(1234, { message_id: 1234 });
+MyTelegramBot.deleteMessage(1234, 5678);
 MyTelegramBot.sendInvoice(
     1234,
     'Invoice Title',
@@ -352,7 +351,7 @@ MyTelegramBot.rawListeners('message');
 MyTelegramBot.listenerCount('message');
 MyTelegramBot.setChatPermissions(1234, {});
 MyTelegramBot.sendDice(1234, { disable_notification: true });
-MyTelegramBot.setChatAdministratorCustomTitle(1234, 'user_id', 'some_custom_title');
+MyTelegramBot.setChatAdministratorCustomTitle(1234, 5678, 'some_custom_title');
 MyTelegramBot.getMyCommands();
 MyTelegramBot.setMyCommands([{ command: 'command', description: 'description' }]);
 MyTelegramBot.setMyCommands([{ command: 'command', description: 'description' }], { language_code: 'ru' });
@@ -405,9 +404,9 @@ MyTelegramBot.getMyDefaultAdministratorRights({});
 MyTelegramBot.answerWebAppQuery('query_id', res);
 MyTelegramBot.getStickerSet('custom-set-name');
 MyTelegramBot.getCustomEmojiStickers(['123', '986']);
-MyTelegramBot.uploadStickerFile('user_id', 'my_png_sticker_file');
-MyTelegramBot.createNewStickerSet('user_id', 'short_name', 'my sticker set name', 'my_png_sticker_file', 'hello');
-MyTelegramBot.addStickerToSet('user_id', 'custom_sticker', 'sticker_path', 'emoji', 'png_sticker');
+MyTelegramBot.uploadStickerFile(1234, 'my_png_sticker_file');
+MyTelegramBot.createNewStickerSet(1234, 'short_name', 'my sticker set name', 'my_png_sticker_file', 'hello');
+MyTelegramBot.addStickerToSet(1234, 'custom_sticker', 'sticker_path', 'emoji', 'png_sticker');
 MyTelegramBot.setStickerPositionInSet('sticker_on_position_one', 2);
 MyTelegramBot.deleteStickerFromSet('sticker_on_position_one');
-MyTelegramBot.setStickerSetThumb('user_id', 'my_set_thumb', 'thumb_file');
+MyTelegramBot.setStickerSetThumb(1234, 'my_set_thumb', 'thumb_file');

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -77,8 +77,8 @@ const res: TelegramBot.InlineQueryResultArticle = {
     },
 };
 MyTelegramBot.answerInlineQuery('queryId', [res, res, res], { is_personal: true });
-MyTelegramBot.forwardMessage(1234, 5678, 'memberID', { disable_notification: true });
-MyTelegramBot.copyMessage(1234, 5678, 'msgId', { disable_notification: true, allow_sending_without_reply: false });
+MyTelegramBot.forwardMessage(1234, 5678, 90 , { disable_notification: true });
+MyTelegramBot.copyMessage(1234, 5678, 90, { disable_notification: true, allow_sending_without_reply: false });
 MyTelegramBot.sendPhoto(1234, 'photo/path');
 MyTelegramBot.sendPhoto(1234, 'photo/path', { caption: 'Foo' });
 MyTelegramBot.sendPhoto(
@@ -222,7 +222,7 @@ MyTelegramBot.downloadFile('My/File/ID', 'mydownloaddir/');
 MyTelegramBot.onText(/regex/, (msg, match) => {});
 MyTelegramBot.removeTextListener(/regex/);
 MyTelegramBot.clearTextListeners();
-MyTelegramBot.onReplyToMessage(1234, 'mymessageID', msg => {});
+MyTelegramBot.onReplyToMessage(1234, 567, msg => {});
 MyTelegramBot.removeReplyListener(5466);
 MyTelegramBot.clearReplyListeners();
 MyTelegramBot.getChat(1234);
@@ -235,7 +235,7 @@ MyTelegramBot.deleteChatStickerSet(1234);
 MyTelegramBot.sendGame(1234, 'MygameName', { reply_to_message_id: 1234 });
 MyTelegramBot.setGameScore('myUserID', 99, { message_id: 1234 });
 MyTelegramBot.getGameHighScores('myUserID', { message_id: 1234 });
-MyTelegramBot.deleteMessage(1234, 'mymessageID');
+MyTelegramBot.deleteMessage(1234, 567);
 MyTelegramBot.sendInvoice(
     1234,
     'Invoice Title',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://core.telegram.org/bots/api
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

In [docs](https://core.telegram.org/bots/api) every message_id field is Integer, so I think all messageId fields could only be number type

