### PR TITLE
Fix ink-text-animation

### DIFF
--- a/types/ink-text-animation/ink-text-animation-tests.tsx
+++ b/types/ink-text-animation/ink-text-animation-tests.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import { Text, render } from 'ink';
 import TextAnimation from 'ink-text-animation';
 
 const Demo = () => (
     <div>
         <TextAnimation>
-            <Text>Look at me, I'm moving!</Text>
         </TextAnimation>
     </div>
 );
-
-render(<Demo />);
+Demo();

--- a/types/ink-text-animation/package.json
+++ b/types/ink-text-animation/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "@types/ink": "^2.0.3"
-    }
-}


### PR DESCRIPTION
This package and its implementation package are both dead, so just fix the tests by removing the external dependency on `ink`, which has moved on substantially since this package was last updated.
