### PR TITLE
[@types/parse] Handle nullable types in Parse.Object's array accessors

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -559,11 +559,11 @@ declare global {
 
             add<K extends { [K in keyof T]: NonNullable<T[K]> extends any[] ? K : never }[keyof T]>(
                 attr: K,
-                item: T[K][number],
+                item: NonNullable<T[K]>[number],
             ): this | false;
             addAll<K extends { [K in keyof T]: NonNullable<T[K]> extends any[] ? K : never }[keyof T]>(
                 attr: K,
-                items: T[K],
+                items: NonNullable<T[K]>,
             ): this | false;
             addAllUnique: this['addAll'];
             addUnique: this['add'];

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -557,11 +557,11 @@ declare global {
             attributes: T;
             className: string;
 
-            add<K extends { [K in keyof T]: T[K] extends any[] ? K : never }[keyof T]>(
+            add<K extends { [K in keyof T]: NonNullable<T[K]> extends any[] ? K : never }[keyof T]>(
                 attr: K,
                 item: T[K][number],
             ): this | false;
-            addAll<K extends { [K in keyof T]: T[K] extends any[] ? K : never }[keyof T]>(
+            addAll<K extends { [K in keyof T]: NonNullable<T[K]> extends any[] ? K : never }[keyof T]>(
                 attr: K,
                 items: T[K],
             ): this | false;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1689,43 +1689,43 @@ function testObject() {
     }
 
     function testNullableArrays(
-        objTyped: Parse.Object<{ unionList?: Array<'foo' | 'bar'> | null }>
+        objTyped: Parse.Object<{ stringList?: string[] | null }>
     ) {
-        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
-        objTyped.add('unionList', 'foo');
+        // $ExpectType false | Object<{ stringList?: string[] | null | undefined; }>
+        objTyped.add('stringList', 'foo');
 
         // @ts-expect-error
-        objTyped.add('unionList', "baz");
+        objTyped.add('stringList', 4);
 
-        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
-        objTyped.addAll('unionList', ['foo']);
-
-        // @ts-expect-error
-        objTyped.addAll('unionList', ["baz"]);
-
-        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
-        objTyped.addAllUnique('unionList', ['foo', 'bar']);
+        // $ExpectType false | Object<{ stringList?: string[] | null | undefined; }>
+        objTyped.addAll('stringList', ['foo']);
 
         // @ts-expect-error
-        objTyped.addAllUnique('unionList', ["baz"]);
+        objTyped.addAll('stringList', [4]);
 
-        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
-        objTyped.addUnique('unionList', 'foo');
-
-        // @ts-expect-error
-        objTyped.addUnique('unionList', "baz");
-
-        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
-        objTyped.remove('unionList', 'bar');
+        // $ExpectType false | Object<{ stringList?: string[] | null | undefined; }>
+        objTyped.addAllUnique('stringList', ['foo', 'bar']);
 
         // @ts-expect-error
-        objTyped.remove('unionList', "baz");
+        objTyped.addAllUnique('stringList', [4]);
 
-        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
-        objTyped.removeAll('unionList', ['bar']);
+        // $ExpectType false | Object<{ stringList?: string[] | null | undefined; }>
+        objTyped.addUnique('stringList', 'foo');
 
         // @ts-expect-error
-        objTyped.removeAll('unionList', ["baz"]);
+        objTyped.addUnique('stringList', 4);
+
+        // $ExpectType false | Object<{ stringList?: string[] | null | undefined; }>
+        objTyped.remove('stringList', 'bar');
+
+        // @ts-expect-error
+        objTyped.remove('stringList', 4);
+
+        // $ExpectType false | Object<{ stringList?: string[] | null | undefined; }>
+        objTyped.removeAll('stringList', ['bar']);
+
+        // @ts-expect-error
+        objTyped.removeAll('stringList', [4]);
     }
 }
 

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1691,37 +1691,37 @@ function testObject() {
     function testNullableArrays(
         objTyped: Parse.Object<{ unionList?: Array<'foo' | 'bar'> | null }>
     ) {
-        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
+        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
         objTyped.add('unionList', 'foo');
 
         // @ts-expect-error
         objTyped.add('unionList', "baz");
 
-        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
+        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
         objTyped.addAll('unionList', ['foo']);
 
         // @ts-expect-error
         objTyped.addAll('unionList', ["baz"]);
 
-        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
+        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
         objTyped.addAllUnique('unionList', ['foo', 'bar']);
 
         // @ts-expect-error
         objTyped.addAllUnique('unionList', ["baz"]);
 
-        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
+        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
         objTyped.addUnique('unionList', 'foo');
 
         // @ts-expect-error
         objTyped.addUnique('unionList', "baz");
 
-        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
+        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
         objTyped.remove('unionList', 'bar');
 
         // @ts-expect-error
         objTyped.remove('unionList', "baz");
 
-        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
+        // $ExpectType false | Object<{ unionList?: ("foo" | "bar")[] | null | undefined; }>
         objTyped.removeAll('unionList', ['bar']);
 
         // @ts-expect-error

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1692,37 +1692,37 @@ function testObject() {
         objTyped: Parse.Object<{ unionList?: ('foo' | 'bar')[] | null }>
     ) {
         // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
-        const addFooOrBar = (a:'foo'|'bar') => objTyped.add('unionList', a);
+        objTyped.add('unionList', 'foo');
 
         // @ts-expect-error
         objTyped.add('unionList', "baz");
 
         // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
-        const addAllFooOrBar = (a:('foo' | 'bar')[]) => objTyped.addAll('unionList', a);
+        objTyped.addAll('unionList', ['foo']);
 
         // @ts-expect-error
         objTyped.addAll('unionList', ["baz"]);
 
         // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
-        const addAllUniqueFooOrBar = (a:('foo' | 'bar')[]) => objTyped.addAllUnique('unionList', a);
+        objTyped.addAllUnique('unionList', ['foo', 'bar']);
 
         // @ts-expect-error
         objTyped.addAllUnique('unionList', ["baz"]);
 
         // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
-        const addUniqueFooOrBar = (a:('foo' | 'bar')) => objTyped.addUnique('unionList', a);
+        objTyped.addUnique('unionList', 'foo');
 
         // @ts-expect-error
         objTyped.addUnique('unionList', "baz");
 
         // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
-        const removeFooOrBar = (a:'foo'|'bar') => objTyped.remove('unionList', a);
+        objTyped.remove('unionList', 'bar');
 
         // @ts-expect-error
         objTyped.remove('unionList', "baz");
 
         // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
-        const removeAllFooOrBar = (a:('foo' | 'bar')[]) => objTyped.removeAll('unionList', a);
+        objTyped.removeAll('unionList', ['bar']);
 
         // @ts-expect-error
         objTyped.removeAll('unionList', ["baz"]);

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1687,6 +1687,46 @@ function testObject() {
         // $ExpectType false | Error
         obj.validate({ someAttrToValidate: 'hello' });
     }
+
+    function testNullableArrays(
+        objTyped: Parse.Object<{ unionList?: ('foo' | 'bar')[] | null }>
+    ) {
+        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        const addFooOrBar = (a:'foo'|'bar') => objTyped.add('unionList', a);
+
+        // @ts-expect-error
+        objTyped.add('unionList', "baz");
+
+        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        const addAllFooOrBar = (a:('foo' | 'bar')[]) => objTyped.addAll('unionList', a);
+
+        // @ts-expect-error
+        objTyped.addAll('unionList', ["baz"]);
+
+        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        const addAllUniqueFooOrBar = (a:('foo' | 'bar')[]) => objTyped.addAllUnique('unionList', a);
+
+        // @ts-expect-error
+        objTyped.addAllUnique('unionList', ["baz"]);
+
+        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        const addUniqueFooOrBar = (a:('foo' | 'bar')) => objTyped.addUnique('unionList', a);
+
+        // @ts-expect-error
+        objTyped.addUnique('unionList', "baz");
+
+        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        const removeFooOrBar = (a:'foo'|'bar') => objTyped.remove('unionList', a);
+
+        // @ts-expect-error
+        objTyped.remove('unionList', "baz");
+
+        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        const removeAllFooOrBar = (a:('foo' | 'bar')[]) => objTyped.removeAll('unionList', a);
+
+        // @ts-expect-error
+        objTyped.removeAll('unionList', ["baz"]);
+    }
 }
 
 function testInstallation() {

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1689,39 +1689,39 @@ function testObject() {
     }
 
     function testNullableArrays(
-        objTyped: Parse.Object<{ unionList?: ('foo' | 'bar')[] | null }>
+        objTyped: Parse.Object<{ unionList?: Array<'foo' | 'bar'> | null }>
     ) {
-        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
         objTyped.add('unionList', 'foo');
 
         // @ts-expect-error
         objTyped.add('unionList', "baz");
 
-        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
         objTyped.addAll('unionList', ['foo']);
 
         // @ts-expect-error
         objTyped.addAll('unionList', ["baz"]);
 
-        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
         objTyped.addAllUnique('unionList', ['foo', 'bar']);
 
         // @ts-expect-error
         objTyped.addAllUnique('unionList', ["baz"]);
 
-        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
         objTyped.addUnique('unionList', 'foo');
 
         // @ts-expect-error
         objTyped.addUnique('unionList', "baz");
 
-        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
         objTyped.remove('unionList', 'bar');
 
         // @ts-expect-error
         objTyped.remove('unionList', "baz");
 
-        // $ExpectType false | Object<{ unionList?: ('foo' | 'bar')[]; }>
+        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
         objTyped.removeAll('unionList', ['bar']);
 
         // @ts-expect-error

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -1691,37 +1691,37 @@ function testObject() {
     function testNullableArrays(
         objTyped: Parse.Object<{ unionList?: Array<'foo' | 'bar'> | null }>
     ) {
-        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
+        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
         objTyped.add('unionList', 'foo');
 
         // @ts-expect-error
         objTyped.add('unionList', "baz");
 
-        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
+        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
         objTyped.addAll('unionList', ['foo']);
 
         // @ts-expect-error
         objTyped.addAll('unionList', ["baz"]);
 
-        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
+        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
         objTyped.addAllUnique('unionList', ['foo', 'bar']);
 
         // @ts-expect-error
         objTyped.addAllUnique('unionList', ["baz"]);
 
-        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
+        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
         objTyped.addUnique('unionList', 'foo');
 
         // @ts-expect-error
         objTyped.addUnique('unionList', "baz");
 
-        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
+        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
         objTyped.remove('unionList', 'bar');
 
         // @ts-expect-error
         objTyped.remove('unionList', "baz");
 
-        // $ExpectType false | Object<{ unionList?: Array<'foo' | 'bar'>; }>
+        // $ExpectType false | Object<{ unionList?: ("bar" | "foo")[] | null | undefined; }>
         objTyped.removeAll('unionList', ['bar']);
 
         // @ts-expect-error


### PR DESCRIPTION
This reflects the [implementation](https://github.com/parse-community/Parse-SDK-JS/blob/3.5.1/src/ParseOp.js#L157) in Parse SDK, where null initial values are handled for array types, and will allow nullable attributes to show up as suggestions for add, addAll, addUnique, addAllUnique, remove, and removeAll


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.


