### PR TITLE
fix(googlepay): ensures totalPrice is not always mandatory

### DIFF
--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -1035,36 +1035,39 @@ declare namespace google.payments.api {
          * price. e.g. 'subtotal', 'discount'.
          */
         displayItems?: DisplayItem[] | undefined;
-    } & ({
-        /**
-         * Total price of this transaction.
-         *
-         * The format of this string should follow the regular expression
-         * format:
-         * `[0-9]+(\.[0-9][0-9])?` (e.g., `"10.45"`)
-         *
-         * This field is required if
-         * [[CheckoutOption.TransactionInfo.totalPriceStatus|`CheckoutOption.TransactionInfo.totalPriceStatus`]]
-         * is set to
-         * [[TotalPriceStatus|`ESTIMATED`]] or
-         * [[TotalPriceStatus|`FINAL`]].
-         */
-        totalPrice: string;
-        
-        /**
-         * Status of this transaction's total price.
-         *
-         * This field is required.
-         *
-         * Note: some payment methods require that this field be set to
-         * [[TotalPriceStatus|`FINAL`]] and that
-         * the total price to be specified and final.
-         */
-        totalPriceStatus: Exclude<TotalPriceStatus, 'NOT_CURRENTLY_KNOWN'>;
-    } | {
-        totalPriceStatus: Extract<TotalPriceStatus, 'NOT_CURRENTLY_KNOWN'>;
-        totalPrice?: never;
-    });
+    } & (
+        | {
+              /**
+               * Total price of this transaction.
+               *
+               * The format of this string should follow the regular expression
+               * format:
+               * `[0-9]+(\.[0-9][0-9])?` (e.g., `"10.45"`)
+               *
+               * This field is required if
+               * [[CheckoutOption.TransactionInfo.totalPriceStatus|`CheckoutOption.TransactionInfo.totalPriceStatus`]]
+               * is set to
+               * [[TotalPriceStatus|`ESTIMATED`]] or
+               * [[TotalPriceStatus|`FINAL`]].
+               */
+              totalPrice: string;
+
+              /**
+               * Status of this transaction's total price.
+               *
+               * This field is required.
+               *
+               * Note: some payment methods require that this field be set to
+               * [[TotalPriceStatus|`FINAL`]] and that
+               * the total price to be specified and final.
+               */
+              totalPriceStatus: Exclude<TotalPriceStatus, 'NOT_CURRENTLY_KNOWN'>;
+          }
+        | {
+              totalPriceStatus: Extract<TotalPriceStatus, 'NOT_CURRENTLY_KNOWN'>;
+              totalPrice?: never;
+          }
+    );
 
     /**
      * Data for a payment method.

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -993,21 +993,6 @@ declare namespace google.payments.api {
         countryCode?: string | undefined;
 
         /**
-         * Total price of this transaction.
-         *
-         * The format of this string should follow the regular expression
-         * format:
-         * `[0-9]+(\.[0-9][0-9])?` (e.g., `"10.45"`)
-         *
-         * This field is required if
-         * [[CheckoutOption.TransactionInfo.totalPriceStatus|`CheckoutOption.TransactionInfo.totalPriceStatus`]]
-         * is set to
-         * [[TotalPriceStatus|`ESTIMATED`]] or
-         * [[TotalPriceStatus|`FINAL`]].
-         */
-        totalPrice: string;
-
-        /**
          * Total price label of this transaction.
          *
          * The string will be shown as the total price label on the cart modal
@@ -1018,17 +1003,6 @@ declare namespace google.payments.api {
          * even if transactionInfo.displayItems is set.
          */
         totalPriceLabel?: string | undefined;
-
-        /**
-         * Status of this transaction's total price.
-         *
-         * This field is required.
-         *
-         * Note: some payment methods require that this field be set to
-         * [[TotalPriceStatus|`FINAL`]] and that
-         * the total price to be specified and final.
-         */
-        totalPriceStatus: TotalPriceStatus;
 
         /**
          * Transaction note.
@@ -1061,7 +1035,36 @@ declare namespace google.payments.api {
          * price. e.g. 'subtotal', 'discount'.
          */
         displayItems?: DisplayItem[] | undefined;
-    }
+    } & ({
+        /**
+         * Total price of this transaction.
+         *
+         * The format of this string should follow the regular expression
+         * format:
+         * `[0-9]+(\.[0-9][0-9])?` (e.g., `"10.45"`)
+         *
+         * This field is required if
+         * [[CheckoutOption.TransactionInfo.totalPriceStatus|`CheckoutOption.TransactionInfo.totalPriceStatus`]]
+         * is set to
+         * [[TotalPriceStatus|`ESTIMATED`]] or
+         * [[TotalPriceStatus|`FINAL`]].
+         */
+        totalPrice: string;
+        
+        /**
+         * Status of this transaction's total price.
+         *
+         * This field is required.
+         *
+         * Note: some payment methods require that this field be set to
+         * [[TotalPriceStatus|`FINAL`]] and that
+         * the total price to be specified and final.
+         */
+        totalPriceStatus: Exclude<TotalPriceStatus, 'NOT_CURRENTLY_KNOWN'>;
+    } | {
+        totalPriceStatus: Extract<TotalPriceStatus, 'NOT_CURRENTLY_KNOWN'>;
+        totalPrice?: never;
+    });
 
     /**
      * Data for a payment method.

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -964,7 +964,7 @@ declare namespace google.payments.api {
     /**
      * Detailed information about the transaction.
      */
-    interface TransactionInfo {
+    type TransactionInfo = {
         /**
          * Correlation ID to refer to this transaction.
          *


### PR DESCRIPTION
In the Google Play API, `totalPrice` can't be set if `totalPriceStatus` is set to `NOT_CURRENTLY_KNOWN` otherwise it throws an error.


Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
It's not 100% clear from the documentation but if you use `NOT_CURRENTLY_KNOWN` as a `totalPriceStatus` and you try to pass a `totalPrice` you get an error from the API. And at the moment the types require you to pass a `totalPrice`.
https://developers.google.com/pay/api/web/reference/request-objects

Took some screenshots:
![Screenshot 2023-03-03 at 17 17 35](https://user-images.githubusercontent.com/1956448/222867331-dec95a9b-28b2-42b8-9822-57b41c172f7a.png)
![Screenshot 2023-03-03 at 17 17 59](https://user-images.githubusercontent.com/1956448/222867335-b1b9107f-69bd-44e3-8eb3-25ac09037d39.png)