### PR TITLE
[sharedb] Add middleware `$fixup` helper

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -242,6 +242,7 @@ declare namespace sharedb {
         }
 
         interface ApplyContext extends BaseContext, SubmitRequest {
+            $fixup: (op: any) => void;
         }
 
         interface CommitContext extends BaseContext, SubmitRequest {

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -210,6 +210,17 @@ backend.use('sendPresence', (context, callback) => {
     callback();
 });
 
+backend.use('apply', (context, callback) => {
+    context.$fixup([{insert: 'foo'}]);
+    callback();
+});
+
+backend.use('commit', (context, callback) => {
+    // @ts-expect-error :: don't allow $fixup outside of 'apply'
+    context.$fixup([{insert: 'foo'}]);
+    callback();
+});
+
 backend.on('submitRequestEnd', (error, request) => {
     console.log(request.op);
 });


### PR DESCRIPTION
`sharedb` added a [`$fixup` helper][1], which can be used in the `apply` middleware to synchronously submit fixup ops. These are defined as `any` similarly to `doc.submitOp()`, since the shape of these ops is dependent on the type being used.

[1]: https://github.com/share/sharedb/pull/581

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
