### PR TITLE
[chai-sorted] Add chai-sorted types

### DIFF
--- a/types/chai-sorted/chai-sorted-tests.ts
+++ b/types/chai-sorted/chai-sorted-tests.ts
@@ -1,0 +1,26 @@
+import chai = require('chai');
+import chaiSorted = require('chai-sorted');
+
+chai.use(chaiSorted);
+const { expect } = chai;
+
+// Test sorted
+expect(["a", "b"]).to.be.sorted();
+expect(["a", "b"]).to.be.sorted({descending: false});
+expect(["b", "apples"]).to.be.sorted({descending: true});
+
+// Test sortedBy
+expect([{id: 2, name: "apple"}, {id: 3, name: "bat"}]).to.be.sortedBy("name");
+expect([{id: 2, name: "bat"}, {id: 3, name: "apples"}]).to.be.sortedBy("name", {descending: true});
+
+// Test ascendingBy
+expect([{id: 2, name: "apple"}, {id: 3, name: "bat"}]).to.be.ascendingBy("name");
+
+// Test descendingBy
+expect([{id: 2, name: "bat"}, {id: 3, name: "apples"}]).to.be.descendingBy("name");
+
+// Test ascending
+expect(["a", "b"]).to.be.ascending;
+
+// Test descending
+expect(["b", "apples"]).to.be.descending;

--- a/types/chai-sorted/index.d.ts
+++ b/types/chai-sorted/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for chai-sorted 0.2
+// Project: https://github.com/johntimothybailey/chai-sorted#readme
+// Definitions by: Reinert Lemmens <https://github.com/reilem>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="chai" />
+
+declare global {
+    namespace Chai {
+        interface Assertion {
+            sorted(options?: { descending: boolean }): Assertion;
+            sortedBy(key: string, options?: { descending: boolean }): Assertion;
+            ascendingBy(key: string): Assertion;
+            descendingBy(key: string): Assertion;
+            ascending: Assertion;
+            descending: Assertion;
+        }
+    }
+}
+
+declare const chaiSorted: Chai.ChaiPlugin;
+declare namespace chaiSorted { }
+export = chaiSorted;

--- a/types/chai-sorted/tsconfig.json
+++ b/types/chai-sorted/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "chai-sorted-tests.ts"
+    ]
+}

--- a/types/chai-sorted/tslint.json
+++ b/types/chai-sorted/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
The `chai` plugin [`chai-sorted`](https://www.npmjs.com/package/chai-sorted) does not come shipped with any types and has not been updated in a while. An issue on the `chai-sorted` repo has been open for a while asking for them: https://github.com/johntimothybailey/chai-sorted/issues/29. 

Files were generated using `dts-gen` and tests were written based off of the `chai-sorted` README.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

