### PR TITLE
Bump k6 types

### DIFF
--- a/types/k6/crypto.d.ts
+++ b/types/k6/crypto.d.ts
@@ -205,7 +205,7 @@ export type OutputEncoding = StringEncoding | BinaryEncoding;
 
 /**
  * Output type. Varies with output encoding.
- * @typeParam OE - Output encoding.
+ * @template OE - Output encoding.
  */
 export type Output<OE extends OutputEncoding> = OE extends StringEncoding
     ? string

--- a/types/k6/http.d.ts
+++ b/types/k6/http.d.ts
@@ -625,7 +625,7 @@ export type ResponseBody = string | bytes | null;
 /**
  * Refined response body.
  * Best possible type given `responseType` from request parameters.
- * @typeParam RT - `Params.responseType` value.
+ * @template RT - `Params.responseType` value.
  * @privateRemarks Default type is a union due to depending on program options.
  */
 export type RefinedResponseBody<RT extends ResponseType | undefined> = RT extends 'binary'

--- a/types/k6/index.d.ts
+++ b/types/k6/index.d.ts
@@ -54,7 +54,7 @@ import './net/grpc';
 /**
  * Run checks on a value.
  * https://k6.io/docs/javascript-api/k6/check-val-sets-tags/
- * @typeParam VT - Value type.
+ * @template VT - Value type.
  * @param val - Value to test.
  * @param sets - Tests (checks) to run on the value.
  * @param tags - Extra tags to attach to metrics emitted.
@@ -79,7 +79,7 @@ export function fail(err?: string): never;
 /**
  * Run code inside a group.
  * https://k6.io/docs/javascript-api/k6/group-name-fn/
- * @typeParam RT - Return type.
+ * @template RT - Return type.
  * @param name - Name of the group.
  * @param fn - Group body. Code to be executed in the group context.
  * @returns The return value of `fn`.
@@ -101,7 +101,7 @@ export function sleep(t: number): void;
 
 /**
  * Check procedure.
- * @typeParam VT - Value type.
+ * @template VT - Value type.
  */
 export interface Checker<VT> {
     /**
@@ -114,7 +114,7 @@ export interface Checker<VT> {
 
 /**
  * Named check procedures.
- * @typeParam VT - Value type.
+ * @template VT - Value type.
  */
 export interface Checkers<VT> {
     [description: string]: Checker<VT>;


### PR DESCRIPTION
1. Trivial fix to JSDoc `@typeParam` -> `@template`, which is the standard tag for type parameters.
2. This should make the publisher try a new version 0.43.2 to work around an error in npm.
