### PR TITLE
[jest]: remove unnecessary `ExtractEachCallbackArgs` type helper

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -45,40 +45,6 @@ declare var xtest: jest.It;
 
 declare const expect: jest.Expect;
 
-type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
-    1: [T[0]];
-    2: [T[0], T[1]];
-    3: [T[0], T[1], T[2]];
-    4: [T[0], T[1], T[2], T[3]];
-    5: [T[0], T[1], T[2], T[3], T[4]];
-    6: [T[0], T[1], T[2], T[3], T[4], T[5]];
-    7: [T[0], T[1], T[2], T[3], T[4], T[5], T[6]];
-    8: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]];
-    9: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]];
-    10: [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]];
-    fallback: Array<T extends ReadonlyArray<infer U> ? U : any>;
-}[T extends Readonly<[any]>
-    ? 1
-    : T extends Readonly<[any, any]>
-    ? 2
-    : T extends Readonly<[any, any, any]>
-    ? 3
-    : T extends Readonly<[any, any, any, any]>
-    ? 4
-    : T extends Readonly<[any, any, any, any, any]>
-    ? 5
-    : T extends Readonly<[any, any, any, any, any, any]>
-    ? 6
-    : T extends Readonly<[any, any, any, any, any, any, any]>
-    ? 7
-    : T extends Readonly<[any, any, any, any, any, any, any, any]>
-    ? 8
-    : T extends Readonly<[any, any, any, any, any, any, any, any, any]>
-    ? 9
-    : T extends Readonly<[any, any, any, any, any, any, any, any, any, any]>
-    ? 10
-    : 'fallback'];
-
 type FakeableAPI =
     | 'Date'
     | 'hrtime'
@@ -516,7 +482,7 @@ declare namespace jest {
         ) => void;
         <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (
             name: string,
-            fn: (...args: ExtractEachCallbackArgs<T>) => any,
+            fn: (...args: T) => any,
             timeout?: number,
         ) => void;
         // Not arrays.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1756,8 +1756,7 @@ test.each([
 
 declare const constCases: [['a', 'b', 'ab'], ['d', 2, 'd2']];
 test.each(constCases)('%s + %s', (...args) => {
-    // following assertion is skipped because of flaky testing
-    // _$ExpectType ["a", "b", "ab"] | ["d", 2, "d2"]
+    // $ExpectType ["a", "b", "ab"] | ["d", 2, "d2"]
     args;
 });
 
@@ -1767,8 +1766,7 @@ declare const constCasesWithMoreThanTen: [
 ];
 
 test.each(constCasesWithMoreThanTen)('should fall back with more than 10 args', (...args) => {
-    // following assertion is skipped because of flaky testing
-    // _$ExpectType [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
+    // $ExpectType [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | [91, 92, 93, 94, 95, 96, 97, 98, 99, 910, 911]
     args;
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`Each` implementation in Jest repo](https://github.com/facebook/jest/blob/39f3beda6b396665bebffab94e8d7c45be30454c/packages/jest-types/src/Global.ts#L58)

## Summary

Hm.. Is `ExtractEachCallbackArgs` type helper still needed? Seems like not. Tests are passing (including the ones marked as flaky). Jest repo (see link above) does not have similar helper. Is this just a leftover needed for older TS versions?