### PR TITLE
[chrome] Fix methods in chrome.browserAction namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -806,7 +806,7 @@ declare namespace chrome.browserAction {
      * @param tabId The id of the tab for which you want to modify the browser action.
      * @return The `enable` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
      */
-    export function enable(tabId?: number): Promise<void>;
+    export function enable(tabId?: number | null): Promise<void>;
     /**
      * Since Chrome 22.
      * Enables the browser action for a tab. By default, browser actions are enabled.
@@ -814,7 +814,7 @@ declare namespace chrome.browserAction {
      * @param callback Supported since Chrome 67
      */
     export function enable(callback?: () => void): void;
-    export function enable(tabId: number, callback?: () => void): void;
+    export function enable(tabId: number | null | undefined, callback?: () => void): void;
     /**
      * Sets the background color for the badge.
      * Strictly speaking, browserAction.setBadgeBackgroundColor() returns void and not a promise, but this is kept for backwards compatibility.
@@ -874,7 +874,7 @@ declare namespace chrome.browserAction {
      * @param tabId The id of the tab for which you want to modify the browser action.
      * @return The `disable` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
      */
-    export function disable(tabId?: number): Promise<void>;
+    export function disable(tabId?: number | null): Promise<void>;
     /**
      * Since Chrome 22.
      * Disables the browser action for a tab.
@@ -882,7 +882,7 @@ declare namespace chrome.browserAction {
      * @param callback Supported since Chrome 67
      */
     export function disable(callback: () => void): void;
-    export function disable(tabId: number, callback: () => void): void;
+    export function disable(tabId: number | null | undefined, callback: () => void): void;
     /**
      * Since Chrome 19.
      * Gets the title of the browser action.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -813,8 +813,8 @@ declare namespace chrome.browserAction {
      * @param tabId The id of the tab for which you want to modify the browser action.
      * @param callback Supported since Chrome 67
      */
-    export function enable(callback: () => void): void;
-    export function enable(tabId: number, callback: () => void): void;
+    export function enable(callback?: () => void): void;
+    export function enable(tabId: number, callback?: () => void): void;
     /**
      * Sets the background color for the badge.
      * Strictly speaking, browserAction.setBadgeBackgroundColor() returns void and not a promise, but this is kept for backwards compatibility.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -817,7 +817,6 @@ declare namespace chrome.browserAction {
     export function enable(tabId: number | null | undefined, callback?: () => void): void;
     /**
      * Sets the background color for the badge.
-     * Strictly speaking, browserAction.setBadgeBackgroundColor() returns void and not a promise, but this is kept for backwards compatibility.
      * @return The `setBadgeBackgroundColor` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
      */
     export function setBadgeBackgroundColor(details: BadgeBackgroundColorDetails): Promise<void>;

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -817,6 +817,7 @@ declare namespace chrome.browserAction {
     export function enable(tabId: number, callback: () => void): void;
     /**
      * Sets the background color for the badge.
+     * Strictly speaking, browserAction.setBadgeBackgroundColor() returns void and not a promise, but this is kept for backwards compatibility.
      * @return The `setBadgeBackgroundColor` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
      */
     export function setBadgeBackgroundColor(details: BadgeBackgroundColorDetails): Promise<void>;
@@ -824,7 +825,7 @@ declare namespace chrome.browserAction {
      * Sets the background color for the badge.
      * @param callback Supported since Chrome 67
      */
-    export function setBadgeBackgroundColor(details: BadgeBackgroundColorDetails, callback: () => void): void;
+    export function setBadgeBackgroundColor(details: BadgeBackgroundColorDetails, callback?: () => void): void;
     /**
      * Sets the badge text for the browser action. The badge is displayed on top of the icon.
      * @return The `setBadgeText` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -918,7 +918,7 @@ declare namespace chrome.browserAction {
     /**
      * Sets the icon for the browser action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the path or the imageData property must be specified.
      */
-    export function setIcon(details: TabIconDetails, callback: Function): void;
+    export function setIcon(details: TabIconDetails, callback?: Function): void;
 
     /** Fired when a browser action icon is clicked. This event will not fire if the browser action has a popup. */
     export var onClicked: BrowserClickedEvent;

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -774,7 +774,7 @@ declare namespace chrome.browserAction {
         /** The string the browser action should display when moused over. */
         title: string;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number | undefined;
+        tabId?: number | null | undefined;
     }
 
     export interface TabDetails {

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -779,7 +779,7 @@ declare namespace chrome.browserAction {
 
     export interface TabDetails {
         /** Optional. Specify the tab to get the information. If no tab is specified, the non-tab-specific information is returned.  */
-        tabId?: number | undefined;
+        tabId?: number | null | undefined;
     }
 
     export interface TabIconDetails {

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -774,12 +774,12 @@ declare namespace chrome.browserAction {
         /** The string the browser action should display when moused over. */
         title: string;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number | null | undefined;
+        tabId?: number | null;
     }
 
     export interface TabDetails {
         /** Optional. Specify the tab to get the information. If no tab is specified, the non-tab-specific information is returned.  */
-        tabId?: number | null | undefined;
+        tabId?: number | null;
     }
 
     export interface TabIconDetails {
@@ -793,7 +793,7 @@ declare namespace chrome.browserAction {
 
     export interface PopupDetails {
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number | null | undefined;
+        tabId?: number | null;
         /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
         popup: string;
     }
@@ -881,7 +881,7 @@ declare namespace chrome.browserAction {
      * @param callback Supported since Chrome 67
      */
     export function disable(callback: () => void): void;
-    export function disable(tabId: number | null | undefined, callback: () => void): void;
+    export function disable(tabId?: number | null, callback?: () => void): void;
     /**
      * Since Chrome 19.
      * Gets the title of the browser action.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -793,7 +793,7 @@ declare namespace chrome.browserAction {
 
     export interface PopupDetails {
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-        tabId?: number | undefined;
+        tabId?: number | null | undefined;
         /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
         popup: string;
     }
@@ -867,7 +867,7 @@ declare namespace chrome.browserAction {
      * Sets the html document to be opened as a popup when the user clicks on the browser action's icon.
      * @param callback Supported since Chrome 67
      */
-    export function setPopup(details: PopupDetails, callback: () => void): void;
+    export function setPopup(details: PopupDetails, callback?: () => void): void;
     /**
      * Since Chrome 22.
      * Disables the browser action for a tab.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1014,6 +1014,23 @@ function testBrowserAcionGetBadgeBackgroundColor() {
     chrome.browserAction.getBadgeBackgroundColor(undefined);
 }
 
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getBadgeText
+function testBrowserAcionGetBadgeText() {
+    chrome.browserAction.getBadgeText({}, console.log);
+    chrome.browserAction.getBadgeText({ tabId: 0 }, console.log);
+    chrome.browserAction.getBadgeText({ tabId: null }, console.log);
+    chrome.browserAction.getBadgeText({ tabId: undefined }, console.log);
+
+    // @ts-expect-error
+    chrome.browserAction.getBadgeText();
+    // @ts-expect-error
+    chrome.browserAction.getBadgeText(null);
+    // @ts-expect-error
+    chrome.browserAction.getBadgeText(undefined);
+    // @ts-expect-error
+    chrome.browserAction.getBadgeText(console.log);
+}
+
 // https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getPopup
 function testBrowserAcionGetPopup() {
     chrome.browserAction.getPopup({});
@@ -1031,6 +1048,8 @@ function testBrowserAcionGetPopup() {
     chrome.browserAction.getPopup(null);
     // @ts-expect-error
     chrome.browserAction.getPopup(undefined);
+    // @ts-expect-error
+    chrome.browserAction.getPopup(console.log);
 }
 
 // https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeBackgroundColor

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1052,6 +1052,27 @@ function testBrowserAcionGetPopup() {
     chrome.browserAction.getPopup(console.log);
 }
 
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getPopup
+function testBrowserAcionGetTitle() {
+    chrome.browserAction.getTitle({});
+    chrome.browserAction.getTitle({}, console.log);
+    chrome.browserAction.getTitle({ tabId: 0 });
+    chrome.browserAction.getTitle({ tabId: 0 }, console.log);
+    chrome.browserAction.getTitle({ tabId: null });
+    chrome.browserAction.getTitle({ tabId: null }, console.log);
+    chrome.browserAction.getTitle({ tabId: undefined });
+    chrome.browserAction.getTitle({ tabId: undefined }, console.log);
+
+    // @ts-expect-error
+    chrome.browserAction.getTitle();
+    // @ts-expect-error
+    chrome.browserAction.getTitle(null);
+    // @ts-expect-error
+    chrome.browserAction.getTitle(undefined);
+    // @ts-expect-error
+    chrome.browserAction.getTitle(console.log);
+}
+
 // https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeBackgroundColor
 function testBrowserAcionSetBadgeBackgroundColor() {
     chrome.browserAction.setBadgeBackgroundColor({ color: 'red' });

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1055,6 +1055,25 @@ function testBrowserAcionSetIcon() {
     chrome.browserAction.setIcon(undefined);
 }
 
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setIcon
+function testBrowserAcionSetTitle() {
+    chrome.browserAction.setTitle({ title: 'Title' });
+    chrome.browserAction.setTitle({ title: 'Title' }, console.log);
+    chrome.browserAction.setTitle({ title: 'Title', tabId: 0 });
+    chrome.browserAction.setTitle({ title: 'Title', tabId: 0 }, console.log);
+    chrome.browserAction.setTitle({ title: 'Title', tabId: null });
+    chrome.browserAction.setTitle({ title: 'Title', tabId: null }, console.log);
+    chrome.browserAction.setTitle({ title: 'Title', tabId: undefined });
+    chrome.browserAction.setTitle({ title: 'Title', tabId: undefined }, console.log);
+
+    // @ts-expect-error
+    chrome.browserAction.setTitle();
+    // @ts-expect-error
+    chrome.browserAction.setTitle(null);
+    // @ts-expect-error
+    chrome.browserAction.setTitle(undefined);
+}
+
 // https://developer.chrome.com/docs/extensions/reference/action/
 async function testActionForPromise() {
     await chrome.action.disable();

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -999,6 +999,21 @@ function testBrowserAcionDisable() {
     chrome.browserAction.disable(undefined, console.log);
 }
 
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getBadgeBackgroundColor
+function testBrowserAcionGetBadgeBackgroundColor() {
+    chrome.browserAction.getBadgeBackgroundColor({}, console.log);
+    chrome.browserAction.getBadgeBackgroundColor({ tabId: 0 }, console.log);
+    chrome.browserAction.getBadgeBackgroundColor({ tabId: null }, console.log);
+    chrome.browserAction.getBadgeBackgroundColor({ tabId: undefined }, console.log);
+
+    // @ts-expect-error
+    chrome.browserAction.getBadgeBackgroundColor();
+    // @ts-expect-error
+    chrome.browserAction.getBadgeBackgroundColor(null);
+    // @ts-expect-error
+    chrome.browserAction.getBadgeBackgroundColor(undefined);
+}
+
 // https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getPopup
 function testBrowserAcionGetPopup() {
     chrome.browserAction.getPopup({});

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1055,7 +1055,26 @@ function testBrowserAcionSetIcon() {
     chrome.browserAction.setIcon(undefined);
 }
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setIcon
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setPopup
+function testBrowserAcionSetPopup() {
+    chrome.browserAction.setPopup({ popup: 'index.html' });
+    chrome.browserAction.setPopup({ popup: 'index.html' }, console.log);
+    chrome.browserAction.setPopup({ popup: 'index.html', tabId: 0 });
+    chrome.browserAction.setPopup({ popup: 'index.html', tabId: 0 }, console.log);
+    chrome.browserAction.setPopup({ popup: 'index.html', tabId: null });
+    chrome.browserAction.setPopup({ popup: 'index.html', tabId: null }, console.log);
+    chrome.browserAction.setPopup({ popup: 'index.html', tabId: undefined });
+    chrome.browserAction.setPopup({ popup: 'index.html', tabId: undefined }, console.log);
+
+    // @ts-expect-error
+    chrome.browserAction.setPopup();
+    // @ts-expect-error
+    chrome.browserAction.setPopup(null);
+    // @ts-expect-error
+    chrome.browserAction.setPopup(undefined);
+}
+
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setTitle
 function testBrowserAcionSetTitle() {
     chrome.browserAction.setTitle({ title: 'Title' });
     chrome.browserAction.setTitle({ title: 'Title' }, console.log);

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -975,8 +975,31 @@ async function testDeclarativeNetRequest() {
     })
 }
 
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeBackgroundColor
+function testBrowserAcionSetBadgeBackgroundColor() {
+    chrome.browserAction.setBadgeBackgroundColor({ color: 'red' });
+    chrome.browserAction.setBadgeBackgroundColor({ color: 'red' }, console.log);
+    chrome.browserAction.setBadgeBackgroundColor({ color: 'red', tabId: 0 });
+    chrome.browserAction.setBadgeBackgroundColor({ color: 'red', tabId: 0 }, console.log);
+    chrome.browserAction.setBadgeBackgroundColor({ color: [1, 2, 3, 4], tabId: 0 });
+    chrome.browserAction.setBadgeBackgroundColor({ color: [1, 2, 3, 4], tabId: 0 }, console.log);
+
+    // @ts-expect-error
+    chrome.browserAction.setBadgeBackgroundColor();
+    // @ts-expect-error
+    chrome.browserAction.setBadgeBackgroundColor({});
+    // @ts-expect-error
+    chrome.browserAction.setBadgeBackgroundColor({ tabId: 0 });
+    // @ts-expect-error
+    chrome.browserAction.setBadgeBackgroundColor({ color: [1, 2, 3] }, console.log);
+    // @ts-expect-error
+    chrome.browserAction.setBadgeBackgroundColor(null);
+    // @ts-expect-error
+    chrome.browserAction.setBadgeBackgroundColor(undefined);
+}
+
 // https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeText
-function testSetBrowserBadgeText() {
+function testBrowserActionSetBrowserBadgeText() {
     chrome.browserAction.setBadgeText({});
     chrome.browserAction.setBadgeText({ text: "test" });
     chrome.browserAction.setBadgeText({ text: null });

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -999,6 +999,25 @@ function testBrowserAcionDisable() {
     chrome.browserAction.disable(undefined, console.log);
 }
 
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getPopup
+function testBrowserAcionGetPopup() {
+    chrome.browserAction.getPopup({});
+    chrome.browserAction.getPopup({}, console.log);
+    chrome.browserAction.getPopup({ tabId: 0 });
+    chrome.browserAction.getPopup({ tabId: 0 }, console.log);
+    chrome.browserAction.getPopup({ tabId: null });
+    chrome.browserAction.getPopup({ tabId: null }, console.log);
+    chrome.browserAction.getPopup({ tabId: undefined });
+    chrome.browserAction.getPopup({ tabId: undefined }, console.log);
+
+    // @ts-expect-error
+    chrome.browserAction.getPopup();
+    // @ts-expect-error
+    chrome.browserAction.getPopup(null);
+    // @ts-expect-error
+    chrome.browserAction.getPopup(undefined);
+}
+
 // https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeBackgroundColor
 function testBrowserAcionSetBadgeBackgroundColor() {
     chrome.browserAction.setBadgeBackgroundColor({ color: 'red' });

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -991,6 +991,23 @@ function testSetBrowserBadgeText() {
     chrome.browserAction.setBadgeText(undefined);
 }
 
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setIcon
+function testBrowserAcionSetIcon() {
+    chrome.browserAction.setIcon({ path: '/icon.png' });
+    chrome.browserAction.setIcon({ path: '/icon.png' }, console.log);
+    chrome.browserAction.setIcon({ path: { 16: '/icon.png' } });
+    chrome.browserAction.setIcon({ path: { 16: '/icon.png' } }, console.log);
+    chrome.browserAction.setIcon({ path: { 16: '/icon.png' }, tabId: 0 });
+    chrome.browserAction.setIcon({ path: { 16: '/icon.png' }, tabId: 0 }, console.log);
+
+    // @ts-expect-error
+    chrome.browserAction.setIcon();
+    // @ts-expect-error
+    chrome.browserAction.setIcon(null);
+    // @ts-expect-error
+    chrome.browserAction.setIcon(undefined);
+}
+
 // https://developer.chrome.com/docs/extensions/reference/action/
 async function testActionForPromise() {
     await chrome.action.disable();

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -975,6 +975,19 @@ async function testDeclarativeNetRequest() {
     })
 }
 
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-enable
+function testBrowserAcionEnable() {
+    chrome.browserAction.enable();
+    chrome.browserAction.enable(console.log);
+    chrome.browserAction.enable(0);
+    chrome.browserAction.enable(0, console.log);
+
+    // @ts-expect-error
+    chrome.browserAction.setBadgeBackgroundColor(null);
+    // @ts-expect-error
+    chrome.browserAction.setBadgeBackgroundColor(undefined);
+}
+
 // https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeBackgroundColor
 function testBrowserAcionSetBadgeBackgroundColor() {
     chrome.browserAction.setBadgeBackgroundColor({ color: 'red' });

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -981,11 +981,22 @@ function testBrowserAcionEnable() {
     chrome.browserAction.enable(console.log);
     chrome.browserAction.enable(0);
     chrome.browserAction.enable(0, console.log);
+    chrome.browserAction.enable(null);
+    chrome.browserAction.enable(null, console.log);
+    chrome.browserAction.enable(undefined);
+    chrome.browserAction.enable(undefined, console.log);
+}
 
-    // @ts-expect-error
-    chrome.browserAction.setBadgeBackgroundColor(null);
-    // @ts-expect-error
-    chrome.browserAction.setBadgeBackgroundColor(undefined);
+// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-disable
+function testBrowserAcionDisable() {
+    chrome.browserAction.disable();
+    chrome.browserAction.disable(console.log);
+    chrome.browserAction.disable(0);
+    chrome.browserAction.disable(0, console.log);
+    chrome.browserAction.disable(null);
+    chrome.browserAction.disable(null, console.log);
+    chrome.browserAction.disable(undefined);
+    chrome.browserAction.disable(undefined, console.log);
 }
 
 // https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeBackgroundColor


### PR DESCRIPTION
This fixes regressions in `chrome.browserAction.*` methods and adds some tests. This fixes regressions introduced in #64272. Test cases were checked for actual behavior in Chromium Version 110.0.5481.100 manually. Promise-style declarations were left as before for backwards compatibility, even though tested browser does not return promises ever.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Google Chrome docs](https://developer.chrome.com/docs/extensions/reference/browserAction/)