### PR TITLE
Fix `useCallback` for optional props

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1081,7 +1081,7 @@ declare namespace React {
     // A specific function type would not trigger implicit any.
     // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52873#issuecomment-845806435 for a comparison between `Function` and more specific types.
     // tslint:disable-next-line ban-types
-    function useCallback<T extends Function>(callback: T, deps: DependencyList): T;
+    function useCallback<T extends Function | null | undefined>(callback: NonNullable<T>, deps: DependencyList): NonNullable<T>;
     /**
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
      *

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const {useSyncExternalStore} = React;
+const {useSyncExternalStore, useCallback} = React;
 
 interface PersonProps {
     name: string;
@@ -82,6 +82,10 @@ export function App() {
         <FancyButton onClick={() => dispatch({ type: "resetAge" })}>
             Let's start over.
         </FancyButton>
+        <div onClick={useCallback((e) => {
+            // e's type should infer from onClick, even though onClick is nullable
+            console.log(e.target);   
+        }, [])} />
     </>;
 }
 

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -63,6 +63,7 @@ const initialState = {
 export function App() {
     const [state, dispatch] = React.useReducer(reducer, initialState);
     const birthdayRef = React.useRef<React.ComponentRef<typeof FancyButton>>(null);
+    const [, setTarget] = React.useState<React.MouseEvent<HTMLDivElement, MouseEvent>['target']>()
 
     React.useLayoutEffect(() => {
         if (birthdayRef.current !== null) {
@@ -84,7 +85,7 @@ export function App() {
         </FancyButton>
         <div onClick={useCallback((e) => {
             // e's type should infer from onClick, even though onClick is nullable
-            console.log(e.target);   
+            setTarget(e.target);   
         }, [])} />
     </>;
 }


### PR DESCRIPTION
# Motivation

The following code block currently provides no TS suggestions for `e` when `onPointerMove` is nullable:

```tsx
<View 
  onPointerMove={useCallback(e => {  }, [])}
/>
```

The reason is, `Function` isn't matching the type for the current type declaration:

```ts
    function useCallback<T extends Function>(callback: T, deps: DependencyList): T;
```

The only fix is to do `useMemo(() => e => {}, [])` instead of `useCallback`.

This PR fixes `useCallback` by accounting for nullable generics. I'm using the patch in my app and it's working. I don't really have time to write tests, but it's a pretty intuitive update, so hopefully it's enough to land. Appreciate it.

# Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
