### PR TITLE
`snowflake-sdk`'s `Bind`  type includes `null`

### DIFF
--- a/types/snowflake-sdk/index.d.ts
+++ b/types/snowflake-sdk/index.d.ts
@@ -468,7 +468,7 @@ export interface Statement {
     streamRows(options?: StreamOptions): Readable;
 }
 
-export type Bind = string | number;
+export type Bind = string | number | null;
 
 /**
  * Snowflake supports two variations of binding syntax.


### PR DESCRIPTION
You can parameterize snowflake queries with `null` and not just `string | number`

Current main branch:
https://github.com/snowflakedb/snowflake-connector-nodejs/blob/c7f4bf6735aa56d446ac4c5912621742eadd23ec/lib/connection/statement.js#L400

v 1.6.12
https://github.com/snowflakedb/snowflake-connector-nodejs/blob/v1.6.12/lib/connection/statement.js#L290

```
➜  node
> JSON.stringify(null) !== undefined
true
```

Sending `null` as a parameter has been tested on my local snowflake setup and works correctly

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
