### PR TITLE
fix(types/arangodb): :adhesive_bandage: change return type for queue.push to match API docs

### DIFF
--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -5,6 +5,7 @@ import sessionsMiddleware = require("@arangodb/foxx/sessions");
 import jwtStorage = require("@arangodb/foxx/sessions/storages/jwt");
 import cookieTransport = require("@arangodb/foxx/sessions/transports/cookie");
 import createAuth = require("@arangodb/foxx/auth");
+import { create } from '@arangodb/foxx/queues';
 
 console.warnStack(new Error(), "something went wrong");
 
@@ -174,5 +175,10 @@ view.properties({
         segmentThreshold: 234
     }
 });
+
+// $ExpectType Queue
+const myQueue = create("myQueue");
+// $ExpectType string
+const myString = myQueue.push({mount: '/mount', name: 'myItem'}, {});
 
 console.log(Buffer.concat([Buffer.allocUnsafe(4), genRandomBytes(4)], 8));

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1515,7 +1515,7 @@ declare module "@arangodb/foxx/queues" {
     }
 
     interface Queue {
-        push(item: QueueItem, data: any, opts?: JobOptions): void;
+        push(item: QueueItem, data: any, opts?: JobOptions): string;
         get(jobId: string): ArangoDB.Document<Job>;
         delete(jobId: string): boolean;
         pending(script?: Script): string[];


### PR DESCRIPTION
See the API docs here - https://www.arangodb.com/docs/stable/foxx-reference-modules-queues.html#queuepush

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://www.arangodb.com/docs/stable/foxx-reference-modules-queues.html#queuepush)
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ All documented versions of the API have this signature https://www.arangodb.com/docs/3.7/foxx-reference-modules-queues.html#queuepush
