### PR TITLE
[node] fix error on `http2.ClientSessionOptions` on typescript 5.1 with `exactOptionalPropertyTypes`

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -1053,10 +1053,10 @@ declare module 'http2' {
          */
         unknownProtocolTimeout?: number | undefined;
         selectPadding?(frameLen: number, maxFrameLen: number): number;
-        createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
     }
     export interface ClientSessionOptions extends SessionOptions {
         maxReservedRemoteStreams?: number | undefined;
+        createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
         protocol?: 'http:' | 'https:' | undefined;
     }
     export interface ServerSessionOptions extends SessionOptions {

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -1053,11 +1053,10 @@ declare module 'http2' {
          */
         unknownProtocolTimeout?: number | undefined;
         selectPadding?(frameLen: number, maxFrameLen: number): number;
-        createConnection?(authority: url.URL, option: SessionOptions): stream.Duplex;
+        createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
     }
     export interface ClientSessionOptions extends SessionOptions {
         maxReservedRemoteStreams?: number | undefined;
-        createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
         protocol?: 'http:' | 'https:' | undefined;
     }
     export interface ServerSessionOptions extends SessionOptions {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -260,7 +260,6 @@ import * as trace_events from 'node:trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },
     });

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -45,9 +45,11 @@ import './test/zlib';
 
 import * as url from 'node:url';
 import * as http from 'node:http';
+import * as http2 from 'node:http2';
 import * as https from 'node:https';
 import * as net from 'node:net';
 import * as inspector from 'node:inspector';
+import * as stream from 'node:stream';
 import * as trace_events from 'node:trace_events';
 
 //////////////////////////////////////////////////////
@@ -247,4 +249,19 @@ import * as trace_events from 'node:trace_events';
     const s2: string = s.trimRight();
     const s3: string = s.trimStart();
     const s4: string = s.trimEnd();
+}
+
+////////////////////////////////////////////////////
+/// Node.js http2 tests
+////////////////////////////////////////////////////
+
+{
+    http2.connect('https://foo.com', {
+        createConnection: (authority, option) => {
+            authority; // $ExpectType url.URL
+            option; // $ExpectType http2.SessionOptions
+            option.createConnection; // $ExpectError
+            return {} as stream.Duplex;
+        },
+    });
 }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -258,8 +258,8 @@ import * as trace_events from 'node:trace_events';
 {
     http2.connect('https://foo.com', {
         createConnection: (authority, option) => {
-            authority; // $ExpectType url.URL
-            option; // $ExpectType http2.SessionOptions
+            authority; // $ExpectType URL
+            option; // $ExpectType SessionOptions
             option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -260,7 +260,7 @@ import * as trace_events from 'node:trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            return {} as stream.Duplex;
+            return new stream.Duplex();
         },
     });
 }

--- a/types/node/ts4.8/http2.d.ts
+++ b/types/node/ts4.8/http2.d.ts
@@ -1053,7 +1053,6 @@ declare module 'http2' {
          */
         unknownProtocolTimeout?: number | undefined;
         selectPadding?(frameLen: number, maxFrameLen: number): number;
-        createConnection?(authority: url.URL, option: SessionOptions): stream.Duplex;
     }
     export interface ClientSessionOptions extends SessionOptions {
         maxReservedRemoteStreams?: number | undefined;

--- a/types/node/ts4.8/node-tests.ts
+++ b/types/node/ts4.8/node-tests.ts
@@ -260,7 +260,6 @@ import * as trace_events from 'node:trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },
     });

--- a/types/node/ts4.8/node-tests.ts
+++ b/types/node/ts4.8/node-tests.ts
@@ -45,9 +45,11 @@ import './test/zlib';
 
 import * as url from 'node:url';
 import * as http from 'node:http';
+import * as http2 from 'node:http2';
 import * as https from 'node:https';
 import * as net from 'node:net';
 import * as inspector from 'node:inspector';
+import * as stream from 'node:stream';
 import * as trace_events from 'node:trace_events';
 
 //////////////////////////////////////////////////////
@@ -247,4 +249,19 @@ import * as trace_events from 'node:trace_events';
     const s2: string = s.trimRight();
     const s3: string = s.trimStart();
     const s4: string = s.trimEnd();
+}
+
+////////////////////////////////////////////////////
+/// Node.js http2 tests
+////////////////////////////////////////////////////
+
+{
+    http2.connect('https://foo.com', {
+        createConnection: (authority, option) => {
+            authority; // $ExpectType url.URL
+            option; // $ExpectType http2.SessionOptions
+            option.createConnection; // $ExpectError
+            return {} as stream.Duplex;
+        },
+    });
 }

--- a/types/node/ts4.8/node-tests.ts
+++ b/types/node/ts4.8/node-tests.ts
@@ -258,8 +258,8 @@ import * as trace_events from 'node:trace_events';
 {
     http2.connect('https://foo.com', {
         createConnection: (authority, option) => {
-            authority; // $ExpectType url.URL
-            option; // $ExpectType http2.SessionOptions
+            authority; // $ExpectType URL
+            option; // $ExpectType SessionOptions
             option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },

--- a/types/node/ts4.8/node-tests.ts
+++ b/types/node/ts4.8/node-tests.ts
@@ -260,7 +260,7 @@ import * as trace_events from 'node:trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            return {} as stream.Duplex;
+            return new stream.Duplex();
         },
     });
 }

--- a/types/node/v14/http2.d.ts
+++ b/types/node/v14/http2.d.ts
@@ -441,7 +441,6 @@ declare module 'http2' {
         settings?: Settings | undefined;
 
         selectPadding?(frameLen: number, maxFrameLen: number): number;
-        createConnection?(authority: url.URL, option: SessionOptions): stream.Duplex;
     }
 
     export interface ClientSessionOptions extends SessionOptions {

--- a/types/node/v14/node-tests.ts
+++ b/types/node/v14/node-tests.ts
@@ -453,7 +453,7 @@ import * as trace_events from 'trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            return {} as stream.Duplex;
+            return new stream.Duplex();
         },
     });
 }

--- a/types/node/v14/node-tests.ts
+++ b/types/node/v14/node-tests.ts
@@ -451,8 +451,8 @@ import * as trace_events from 'trace_events';
 {
     http2.connect('https://foo.com', {
         createConnection: (authority, option) => {
-            authority; // $ExpectType url.URL
-            option; // $ExpectType http2.SessionOptions
+            authority; // $ExpectType URL
+            option; // $ExpectType SessionOptions
             option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },

--- a/types/node/v14/node-tests.ts
+++ b/types/node/v14/node-tests.ts
@@ -453,7 +453,6 @@ import * as trace_events from 'trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },
     });

--- a/types/node/v14/node-tests.ts
+++ b/types/node/v14/node-tests.ts
@@ -46,11 +46,13 @@ import * as fs from 'fs';
 import * as url from 'url';
 import * as util from 'util';
 import * as http from 'http';
+import * as http2 from 'node:http2';
 import * as https from 'https';
 import * as net from 'net';
 import * as console2 from 'console';
 import * as timers from 'timers';
 import * as inspector from 'inspector';
+import * as stream from 'node:stream';
 import * as trace_events from 'trace_events';
 
 //////////////////////////////////////////////////////
@@ -440,4 +442,19 @@ import * as trace_events from 'trace_events';
     b = a.readBigInt64LE(123);
     b = a.readBigUInt64LE(123);
     b = a.readBigUInt64BE(123);
+}
+
+////////////////////////////////////////////////////
+/// Node.js http2 tests
+////////////////////////////////////////////////////
+
+{
+    http2.connect('https://foo.com', {
+        createConnection: (authority, option) => {
+            authority; // $ExpectType url.URL
+            option; // $ExpectType http2.SessionOptions
+            option.createConnection; // $ExpectError
+            return {} as stream.Duplex;
+        },
+    });
 }

--- a/types/node/v14/ts4.8/http2.d.ts
+++ b/types/node/v14/ts4.8/http2.d.ts
@@ -441,7 +441,6 @@ declare module 'http2' {
         settings?: Settings | undefined;
 
         selectPadding?(frameLen: number, maxFrameLen: number): number;
-        createConnection?(authority: url.URL, option: SessionOptions): stream.Duplex;
     }
 
     export interface ClientSessionOptions extends SessionOptions {

--- a/types/node/v14/ts4.8/node-tests.ts
+++ b/types/node/v14/ts4.8/node-tests.ts
@@ -453,7 +453,7 @@ import * as trace_events from 'trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            return {} as stream.Duplex;
+            return new stream.Duplex();
         },
     });
 }

--- a/types/node/v14/ts4.8/node-tests.ts
+++ b/types/node/v14/ts4.8/node-tests.ts
@@ -451,8 +451,8 @@ import * as trace_events from 'trace_events';
 {
     http2.connect('https://foo.com', {
         createConnection: (authority, option) => {
-            authority; // $ExpectType url.URL
-            option; // $ExpectType http2.SessionOptions
+            authority; // $ExpectType URL
+            option; // $ExpectType SessionOptions
             option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },

--- a/types/node/v14/ts4.8/node-tests.ts
+++ b/types/node/v14/ts4.8/node-tests.ts
@@ -453,7 +453,6 @@ import * as trace_events from 'trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },
     });

--- a/types/node/v14/ts4.8/node-tests.ts
+++ b/types/node/v14/ts4.8/node-tests.ts
@@ -46,11 +46,13 @@ import * as fs from 'fs';
 import * as url from 'url';
 import * as util from 'util';
 import * as http from 'http';
+import * as http2 from 'node:http2';
 import * as https from 'https';
 import * as net from 'net';
 import * as console2 from 'console';
 import * as timers from 'timers';
 import * as inspector from 'inspector';
+import * as stream from 'node:stream';
 import * as trace_events from 'trace_events';
 
 //////////////////////////////////////////////////////
@@ -440,4 +442,19 @@ import * as trace_events from 'trace_events';
     b = a.readBigInt64LE(123);
     b = a.readBigUInt64LE(123);
     b = a.readBigUInt64BE(123);
+}
+
+////////////////////////////////////////////////////
+/// Node.js http2 tests
+////////////////////////////////////////////////////
+
+{
+    http2.connect('https://foo.com', {
+        createConnection: (authority, option) => {
+            authority; // $ExpectType url.URL
+            option; // $ExpectType http2.SessionOptions
+            option.createConnection; // $ExpectError
+            return {} as stream.Duplex;
+        },
+    });
 }

--- a/types/node/v16/http2.d.ts
+++ b/types/node/v16/http2.d.ts
@@ -1048,7 +1048,6 @@ declare module 'http2' {
          */
         unknownProtocolTimeout?: number | undefined;
         selectPadding?(frameLen: number, maxFrameLen: number): number;
-        createConnection?(authority: url.URL, option: SessionOptions): stream.Duplex;
     }
     export interface ClientSessionOptions extends SessionOptions {
         maxReservedRemoteStreams?: number | undefined;

--- a/types/node/v16/node-tests.ts
+++ b/types/node/v16/node-tests.ts
@@ -259,7 +259,6 @@ import * as trace_events from 'node:trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },
     });

--- a/types/node/v16/node-tests.ts
+++ b/types/node/v16/node-tests.ts
@@ -257,8 +257,8 @@ import * as trace_events from 'node:trace_events';
 {
     http2.connect('https://foo.com', {
         createConnection: (authority, option) => {
-            authority; // $ExpectType url.URL
-            option; // $ExpectType http2.SessionOptions
+            authority; // $ExpectType URL
+            option; // $ExpectType SessionOptions
             option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },

--- a/types/node/v16/node-tests.ts
+++ b/types/node/v16/node-tests.ts
@@ -44,9 +44,11 @@ import './test/zlib';
 
 import * as url from 'node:url';
 import * as http from 'node:http';
+import * as http2 from 'node:http2';
 import * as https from 'node:https';
 import * as net from 'node:net';
 import * as inspector from 'node:inspector';
+import * as stream from 'node:stream';
 import * as trace_events from 'node:trace_events';
 
 //////////////////////////////////////////////////////
@@ -246,4 +248,19 @@ import * as trace_events from 'node:trace_events';
     const s2: string = s.trimRight();
     const s3: string = s.trimStart();
     const s4: string = s.trimEnd();
+}
+
+////////////////////////////////////////////////////
+/// Node.js http2 tests
+////////////////////////////////////////////////////
+
+{
+    http2.connect('https://foo.com', {
+        createConnection: (authority, option) => {
+            authority; // $ExpectType url.URL
+            option; // $ExpectType http2.SessionOptions
+            option.createConnection; // $ExpectError
+            return {} as stream.Duplex;
+        },
+    });
 }

--- a/types/node/v16/node-tests.ts
+++ b/types/node/v16/node-tests.ts
@@ -259,7 +259,7 @@ import * as trace_events from 'node:trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            return {} as stream.Duplex;
+            return new stream.Duplex();
         },
     });
 }

--- a/types/node/v16/ts4.8/http2.d.ts
+++ b/types/node/v16/ts4.8/http2.d.ts
@@ -1048,7 +1048,6 @@ declare module 'http2' {
          */
         unknownProtocolTimeout?: number | undefined;
         selectPadding?(frameLen: number, maxFrameLen: number): number;
-        createConnection?(authority: url.URL, option: SessionOptions): stream.Duplex;
     }
     export interface ClientSessionOptions extends SessionOptions {
         maxReservedRemoteStreams?: number | undefined;

--- a/types/node/v16/ts4.8/node-tests.ts
+++ b/types/node/v16/ts4.8/node-tests.ts
@@ -259,7 +259,6 @@ import * as trace_events from 'node:trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },
     });

--- a/types/node/v16/ts4.8/node-tests.ts
+++ b/types/node/v16/ts4.8/node-tests.ts
@@ -257,8 +257,8 @@ import * as trace_events from 'node:trace_events';
 {
     http2.connect('https://foo.com', {
         createConnection: (authority, option) => {
-            authority; // $ExpectType url.URL
-            option; // $ExpectType http2.SessionOptions
+            authority; // $ExpectType URL
+            option; // $ExpectType SessionOptions
             option.createConnection; // $ExpectError
             return {} as stream.Duplex;
         },

--- a/types/node/v16/ts4.8/node-tests.ts
+++ b/types/node/v16/ts4.8/node-tests.ts
@@ -44,9 +44,11 @@ import './test/zlib';
 
 import * as url from 'node:url';
 import * as http from 'node:http';
+import * as http2 from 'node:http2';
 import * as https from 'node:https';
 import * as net from 'node:net';
 import * as inspector from 'node:inspector';
+import * as stream from 'node:stream';
 import * as trace_events from 'node:trace_events';
 
 //////////////////////////////////////////////////////
@@ -246,4 +248,19 @@ import * as trace_events from 'node:trace_events';
     const s2: string = s.trimRight();
     const s3: string = s.trimStart();
     const s4: string = s.trimEnd();
+}
+
+////////////////////////////////////////////////////
+/// Node.js http2 tests
+////////////////////////////////////////////////////
+
+{
+    http2.connect('https://foo.com', {
+        createConnection: (authority, option) => {
+            authority; // $ExpectType url.URL
+            option; // $ExpectType http2.SessionOptions
+            option.createConnection; // $ExpectError
+            return {} as stream.Duplex;
+        },
+    });
 }

--- a/types/node/v16/ts4.8/node-tests.ts
+++ b/types/node/v16/ts4.8/node-tests.ts
@@ -259,7 +259,7 @@ import * as trace_events from 'node:trace_events';
         createConnection: (authority, option) => {
             authority; // $ExpectType URL
             option; // $ExpectType SessionOptions
-            return {} as stream.Duplex;
+            return new stream.Duplex();
         },
     });
 }


### PR DESCRIPTION
fixes #64613

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes
