### PR TITLE
chore: add types for CircuitBreaker.toJSON() for opossum

### DIFF
--- a/types/opossum/index.d.ts
+++ b/types/opossum/index.d.ts
@@ -35,6 +35,11 @@ declare class CircuitBreaker<TI extends unknown[] = unknown[], TR = unknown> ext
     call(context: any, ...args: TI): Promise<TR>;
 
     /**
+     * Returns the current state of the circuit
+     */
+    toJSON(): { state: CircuitBreaker.State; status: CircuitBreaker.Stats };
+
+    /**
      * Clears the cache of this CircuitBreaker
      */
     clearCache(): void;
@@ -251,6 +256,17 @@ declare namespace CircuitBreaker {
 
     interface Stats extends Bucket {
         latencyMean: number;
+    }
+
+    interface State {
+        name: string;
+        enabled: boolean;
+        closed: boolean;
+        open: boolean;
+        halfOpen: boolean;
+        warmUp: boolean;
+        shutdown: boolean;
+        lastTimerAt: symbol;
     }
 }
 

--- a/types/opossum/opossum-tests.ts
+++ b/types/opossum/opossum-tests.ts
@@ -47,6 +47,7 @@ breaker.close(); // $ExpectType void
 breaker.disable(); // $ExpectType void
 breaker.enable(); // $ExpectType void
 breaker.shutdown(); // $ExpectType void
+breaker.toJSON(); // $ExpectType { state: State; status: Stats; }
 
 // Check the generic types pass down correctly from constructor to `fire` and events.
 const action = async (foo: string, bar: number) => {


### PR DESCRIPTION
Adding type definitions for using `toJSON()` method of the circuit breaker which is crucial to use the library in a effective way across serverless platforms by holding the state and passing it when re-initialising the circuit breaker instance

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [x] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [x] Delete the package's directory.
- [x] Add it to `notNeededPackages.json`.
