### PR TITLE
Fix: Async IterableCollection shouldn't expect an IterableIterator

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -15,7 +15,7 @@
 export as namespace async;
 
 export interface Dictionary<T> { [key: string]: T; }
-export type IterableCollection<T> = T[] | IterableIterator<T> | AsyncIterable<T> | Dictionary<T>;
+export type IterableCollection<T> = T[] | Iterable<T> | AsyncIterable<T> | Dictionary<T>;
 
 export interface ErrorCallback<E = Error> { (err?: E | null): void; }
 export interface AsyncBooleanResultCallback<E = Error> { (err?: E | null, truthValue?: boolean): void; }


### PR DESCRIPTION
Please fill in this template.

Note the tests fail for me locally, because of 
```ERROR: 1:1  no-outside-dependencies  File DefinitelyTyped/node_modules/@types/node/assert.d.ts comes from a `node_modules` but is not declared in this type's `package.json``` 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://caolan.github.io/async/v3/docs.html#eachLimit)
  - The `coll` parameter is specified as `Array | **Iterable** | AsyncIterable | Object`
- ~~[ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~~

