### PR TITLE
Update chrome.fileSystemProvider in chrome/index.d.ts

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3562,17 +3562,17 @@ declare namespace chrome.fileSystemProvider {
     }
 
     export interface EntryMetadata {
-        /** True if it is a directory. */
+        /** True if it is a directory. Must be provided if requested in `options`. */
         isDirectory?: boolean;
-        /** Name of this entry (not full path name). Must not contain '/'. For root it must be empty. */
+        /** Name of this entry (not full path name). Must not contain '/'. For root it must be empty. Must be provided if requested in `options`. */
         name?: string;
-        /** File size in bytes. */
+        /** File size in bytes. Must be provided if requested in `options`. */
         size?: number;
-        /** The last modified time of this entry. */
+        /** The last modified time of this entry. Must be provided if requested in `options`. */
         modificationTime?: Date;
-        /** Optional. Mime type for the entry.  */
+        /** Optional. Mime type for the entry. Always optional, but should provided if requested in `options`. */
         mimeType?: string | undefined;
-        /** Optional. Thumbnail image as a data URI in either PNG, JPEG or WEBP format, at most 32 KB in size. Optional, but can be provided only when explicitly requested by the onGetMetadataRequested event.  */
+        /** Optional. Thumbnail image as a data URI in either PNG, JPEG or WEBP format, at most 32 KB in size. Optional, but can be provided only when explicitly requested by the onGetMetadataRequested event. */
         thumbnail?: string | undefined;
     }
 

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2561,6 +2561,7 @@ declare namespace chrome.devtools.panels {
 
     export interface ExtensionSidebarPaneHiddenEvent extends chrome.events.Event<() => void> { }
 
+
     /** A sidebar created by the extension. */
     export interface ExtensionSidebarPane {
         /**
@@ -3563,13 +3564,13 @@ declare namespace chrome.fileSystemProvider {
 
     export interface EntryMetadata {
         /** True if it is a directory. */
-        isDirectory: boolean;
+        isDirectory?: boolean;
         /** Name of this entry (not full path name). Must not contain '/'. For root it must be empty. */
-        name: string;
+        name?: string;
         /** File size in bytes. */
-        size: number;
+        size?: number;
         /** The last modified time of this entry. */
-        modificationTime: Date;
+        modificationTime?: Date;
         /** Optional. Mime type for the entry.  */
         mimeType?: string | undefined;
         /** Optional. Thumbnail image as a data URI in either PNG, JPEG or WEBP format, at most 32 KB in size. Optional, but can be provided only when explicitly requested by the onGetMetadataRequested event.  */
@@ -3612,8 +3613,8 @@ declare namespace chrome.fileSystemProvider {
         fileSystemId: string;
         /** The unique identifier of this request. */
         requestId: number;
-        /** The path of the entry to return the list of actions for. */
-        entryPath: string;
+        /** List of paths of entries for the list of actions. */
+        entryPaths: string[];
     }
 
     /** @since Since Chrome 45. Warning: this is the current Beta channel. */
@@ -3630,8 +3631,8 @@ declare namespace chrome.fileSystemProvider {
         fileSystemId: string;
         /** The unique identifier of this request. */
         requestId: number;
-        /** The path of the entry to be used for the action. */
-        entryPath: string;
+        /** The set of paths of the entries to be used for the action. */
+        entryPaths: string[];
         /** The identifier of the action to be executed. */
         actionId: string;
     }
@@ -3699,11 +3700,33 @@ declare namespace chrome.fileSystemProvider {
     export interface MetadataRequestedEventOptions extends EntryPathRequestedEventOptions {
         /** Set to true if the thumbnail is requested. */
         thumbnail: boolean;
+        /** Set to true if is_directory value is requested. */
+        isDirectory: boolean;
+        /** Set to true if is_directory value is requested. */
+        name: boolean;
+        /** Set to true if size value is requested. */
+        size: boolean;
+        /** Set to true if modificationTime value is requested. */
+        modificationTime: boolean;
+        /** Set to true if mimeType value is requested. */
+        mimeType: boolean;
     }
 
     export interface DirectoryPathRequestedEventOptions extends RequestedEventOptions {
         /** The path of the directory which is to be operated on. */
         directoryPath: string;
+        /** Set to true if is_directory value is requested. */
+        isDirectory: boolean;
+        /** Set to true if is_directory value is requested. */
+        name: boolean;
+        /** Set to true if size value is requested. */
+        size: boolean;
+        /** Set to true if modificationTime value is requested. */
+        modificationTime: boolean;
+        /** Set to true if mimeType value is requested. */
+        mimeType: boolean;
+        /** Set to true if the thumbnail is requested. */
+        thumbnail: boolean;
     }
 
     export interface FilePathRequestedEventOptions extends RequestedEventOptions {
@@ -3878,6 +3901,24 @@ declare namespace chrome.fileSystemProvider {
     export interface OptionlessRequestedEvent
         extends chrome.events.Event<(successCallback: Function, errorCallback: (error: string) => void) => void> { }
 
+    export interface GetActionsRequested
+        extends chrome.events.Event<
+            (
+                options: GetActionsRequestedOptions,
+                successCallback: (actions: Action[]) => void,
+                errorCallback: (error: string) => void,
+            ) => void
+        > {}
+
+    export interface ExecuteActionRequested
+        extends chrome.events.Event<
+            (
+                options: ExecuteActionRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (error: string) => void,
+            ) => void
+        > {}
+
     /**
      * Mounts a file system with the given fileSystemId and displayName. displayName will be shown in the left panel of Files.app. displayName can contain any characters including '/', but cannot be an empty string. displayName must be descriptive but doesn't have to be unique. The fileSystemId must not be an empty string.
      * Depending on the type of the file system being mounted, the source option must be set appropriately.
@@ -3961,6 +4002,23 @@ declare namespace chrome.fileSystemProvider {
      * @since Since Chrome 45. Warning: this is the current Beta channel.
      */
     export var onRemoveWatcherRequested: EntryPathRecursiveRequestedEvent;
+
+    /**
+     * Raised when a list of actions for a set of files or directories at
+     * `entryPaths` is requested. All of the returned actions must
+     * be applicable to each entry. If there are no such actions, an empty array
+     * should be returned. The actions must be returned with the
+     * `successCallback` call. In case of an error,
+     * `errorCallback` must be called.
+     */
+    export var onGetActionsRequested: GetActionsRequested;
+
+    /**
+     * Raised when executing an action for a set of files or directories is
+     * requested. After the action is completed, `successCallback`
+     * must be called. On error, `errorCallback` must be called.
+     */
+    export var onExecuteActionRequested: ExecuteActionRequested;
 }
 
 ////////////////////

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2561,7 +2561,6 @@ declare namespace chrome.devtools.panels {
 
     export interface ExtensionSidebarPaneHiddenEvent extends chrome.events.Event<() => void> { }
 
-
     /** A sidebar created by the extension. */
     export interface ExtensionSidebarPane {
         /**
@@ -3702,7 +3701,7 @@ declare namespace chrome.fileSystemProvider {
         thumbnail: boolean;
         /** Set to true if is_directory value is requested. */
         isDirectory: boolean;
-        /** Set to true if is_directory value is requested. */
+        /** Set to true if name value is requested. */
         name: boolean;
         /** Set to true if size value is requested. */
         size: boolean;
@@ -3717,7 +3716,7 @@ declare namespace chrome.fileSystemProvider {
         directoryPath: string;
         /** Set to true if is_directory value is requested. */
         isDirectory: boolean;
-        /** Set to true if is_directory value is requested. */
+        /** Set to true if name value is requested. */
         name: boolean;
         /** Set to true if size value is requested. */
         size: boolean;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1920,52 +1920,52 @@ async function testOffscreenDocument() {
 // https://developer.chrome.com/docs/extensions/reference/fileSystemProvider/
 function testFileSystemProvider() {
     // Checking onGetMetadataRequested, its option and EntryMetadata.
-    chrome.fileSystemProvider.onGetMetadataRequested.addListener((
-        options: chrome.fileSystemProvider.MetadataRequestedEventOptions,
-        successCallback: (
-          metadata: chrome.fileSystemProvider.EntryMetadata
-        ) => void,
-        errorCallback: (error: string) => void,
-    ) => {
-        const entryMetadata: chrome.fileSystemProvider.EntryMetadata = {};
-        if (options.isDirectory) {
-          entryMetadata.isDirectory = true;
-        }
-        if (options.name) {
-          entryMetadata.name = 'some-file.txt';
-        }
-        if (options.size) {
-          entryMetadata.size = 42;
-        }
-        if (options.mimeType) {
-          entryMetadata.mimeType = 'text/plain';
-        }
-    }
+    chrome.fileSystemProvider.onGetMetadataRequested.addListener(
+        (
+            options: chrome.fileSystemProvider.MetadataRequestedEventOptions,
+            successCallback: (metadata: chrome.fileSystemProvider.EntryMetadata) => void,
+            errorCallback: (error: string) => void,
+        ) => {
+            const entryMetadata: chrome.fileSystemProvider.EntryMetadata = {};
+            if (options.isDirectory) {
+                entryMetadata.isDirectory = true;
+            }
+            if (options.name) {
+                entryMetadata.name = 'some-file.txt';
+            }
+            if (options.size) {
+                entryMetadata.size = 42;
+            }
+            if (options.mimeType) {
+                entryMetadata.mimeType = 'text/plain';
+            }
+        },
     );
 
     // Checking onReadDirectoryRequested.
-    chrome.fileSystemProvider.onReadDirectoryRequested.addListener((
-        options: chrome.fileSystemProvider.DirectoryPathRequestedEventOptions,
-        successCallback: (
-          entries: chrome.fileSystemProvider.EntryMetadata[],
-          hasMore: boolean
-        ) => void,
-        errorCallback: (error: string) => void) => {
-        }
-      );
+    chrome.fileSystemProvider.onReadDirectoryRequested.addListener(
+        (
+            options: chrome.fileSystemProvider.DirectoryPathRequestedEventOptions,
+            successCallback: (entries: chrome.fileSystemProvider.EntryMetadata[], hasMore: boolean) => void,
+            errorCallback: (error: string) => void,
+        ) => {},
+    );
 
     // Checking onGetActionsRequested.
-    chrome.fileSystemProvider.onGetActionsRequested.addListener((
-        options: chrome.fileSystemProvider.GetActionsRequestedOptions,
-        successCallback: (actions: chrome.fileSystemProvider.Action[]) => void,
-        errorCallback: (error: string) => void) => {}
+    chrome.fileSystemProvider.onGetActionsRequested.addListener(
+        (
+            options: chrome.fileSystemProvider.GetActionsRequestedOptions,
+            successCallback: (actions: chrome.fileSystemProvider.Action[]) => void,
+            errorCallback: (error: string) => void,
+        ) => {},
     );
 
     // Checking onExecuteActionRequested.
-    chrome.fileSystemProvider.onExecuteActionRequested.addListener((
-        options: chrome.fileSystemProvider.ExecuteActionRequestedOptions,
-        successCallback: () => void,
-        errorCallback: (error: string) => void) => {}
-      );
-
+    chrome.fileSystemProvider.onExecuteActionRequested.addListener(
+        (
+            options: chrome.fileSystemProvider.ExecuteActionRequestedOptions,
+            successCallback: () => void,
+            errorCallback: (error: string) => void,
+        ) => {},
+    );
 }

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1916,3 +1916,56 @@ async function testOffscreenDocument() {
     await chrome.offscreen.hasDocument();
     await chrome.offscreen.closeDocument();
 }
+
+// https://developer.chrome.com/docs/extensions/reference/fileSystemProvider/
+function testFileSystemProvider() {
+    // Checking onGetMetadataRequested, its option and EntryMetadata.
+    chrome.fileSystemProvider.onGetMetadataRequested.addListener((
+        options: chrome.fileSystemProvider.MetadataRequestedEventOptions,
+        successCallback: (
+          metadata: chrome.fileSystemProvider.EntryMetadata
+        ) => void,
+        errorCallback: (error: string) => void,
+    ) => {
+        const entryMetadata: chrome.fileSystemProvider.EntryMetadata = {};
+        if (options.isDirectory) {
+          entryMetadata.isDirectory = true;
+        }
+        if (options.name) {
+          entryMetadata.name = 'some-file.txt';
+        }
+        if (options.size) {
+          entryMetadata.size = 42;
+        }
+        if (options.mimeType) {
+          entryMetadata.mimeType = 'text/plain';
+        }
+    }
+    );
+
+    // Checking onReadDirectoryRequested.
+    chrome.fileSystemProvider.onReadDirectoryRequested.addListener((
+        options: chrome.fileSystemProvider.DirectoryPathRequestedEventOptions,
+        successCallback: (
+          entries: chrome.fileSystemProvider.EntryMetadata[],
+          hasMore: boolean
+        ) => void,
+        errorCallback: (error: string) => void) => {
+        }
+      );
+
+    // Checking onGetActionsRequested.
+    chrome.fileSystemProvider.onGetActionsRequested.addListener((
+        options: chrome.fileSystemProvider.GetActionsRequestedOptions,
+        successCallback: (actions: chrome.fileSystemProvider.Action[]) => void,
+        errorCallback: (error: string) => void) => {}
+    );
+
+    // Checking onExecuteActionRequested.
+    chrome.fileSystemProvider.onExecuteActionRequested.addListener((
+        options: chrome.fileSystemProvider.ExecuteActionRequestedOptions,
+        successCallback: () => void,
+        errorCallback: (error: string) => void) => {}
+      );
+
+}


### PR DESCRIPTION
This updates some parts of chrome.fileSystemProvider which is an API used in ChromeOS to provide third-party file system in the file manager.

I'm not aware why this is out of sync, because these types haven't been updated in a long time.  

This API isn't very popular, so that's why this wasn't noticed by others.

I'm one of the maintainers of the API and the ChromeOS File Manager.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test chrome`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Docs]( https://developer.chrome.com/docs/extensions/reference/fileSystemProvider/) & [Actual source](https://source.chromium.org/chromium/chromium/src/+/main:chrome/common/extensions/api/file_system_provider.idl)
