### PR TITLE
Fix inquirer tests for TS 5.1

### DIFF
--- a/types/inquirer/inquirer-tests.ts
+++ b/types/inquirer/inquirer-tests.ts
@@ -230,8 +230,7 @@ fetchAsyncQuestionProperty(
         },
     });
     // @ts-expect-error
-    promptResult.ui.process.subscribe({
-        next: (value: {name_: string, answer: number}) => {
+    promptResult.ui.process.subscribe({ next: (value: {name_: string, answer: number}) => {
             // DO NOTHING
         },
     });
@@ -258,8 +257,7 @@ fetchAsyncQuestionProperty(
         },
     });
     // @ts-expect-error
-    promptResult.ui.process.subscribe({
-        next: (value: {name: string, answer: number}) => {
+    promptResult.ui.process.subscribe({ next: (value: {name: string, answer: number}) => {
             // DO NOTHING
         },
     });

--- a/types/inquirer/v8/inquirer-tests.ts
+++ b/types/inquirer/v8/inquirer-tests.ts
@@ -232,8 +232,7 @@ fetchAsyncQuestionProperty(
         },
     });
     // @ts-expect-error
-    promptResult.ui.process.subscribe({
-        next: (value: {name_: string, answer: number}) => {
+    promptResult.ui.process.subscribe({ next: (value: {name_: string, answer: number}) => {
             // DO NOTHING
         },
     });
@@ -260,8 +259,7 @@ fetchAsyncQuestionProperty(
         },
     });
     // @ts-expect-error
-    promptResult.ui.process.subscribe({
-        next: (value: {name: string, answer: number}) => {
+    promptResult.ui.process.subscribe({ next: (value: {name: string, answer: number}) => {
             // DO NOTHING
         },
     });


### PR DESCRIPTION
TS 5.1's error spans for object literals is now more precise, pointing to the specific property with an error. However, this means that ts-expect-errors need to be in different locations.

This PR mangles the formatting of the tests in a couple of places so that they pass in TS 5.1 and earlier.