### PR TITLE
Exempt resolve-bin from redundant-jsdoc lint rule

### DIFF
--- a/types/resolve-bin/tslint.json
+++ b/types/resolve-bin/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "@definitelytyped/dtslint/dt.json" }
+{
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "no-redundant-jsdoc-2": false
+    }
+}


### PR DESCRIPTION
Previously this rule crashed sometimes; now that it's reporting results everywhere, it looks like resolve-bin's uses of `@` are not actually jsdoc tags, so the rule doesn't apply.