### PR TITLE
Exempt react-relay from jsdoc rule

### DIFF
--- a/types/react-relay/tslint.json
+++ b/types/react-relay/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "no-redundant-jsdoc-2": false
+    }
 }

--- a/types/react-relay/v7/tslint.json
+++ b/types/react-relay/v7/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "@definitelytyped/dtslint/dt.json"
+    "extends": "@definitelytyped/dtslint/dt.json",
+    "rules": {
+        "no-redundant-jsdoc-2": false
+    }
 }


### PR DESCRIPTION
Previously this rule crashed sometimes; now that it's reporting results everywhere, it looks like react-relay's uses of @ are not actually jsdoc tags, so the rule doesn't apply.
