### PR TITLE
Delete redundant jsdoc types

### DIFF
--- a/types/ckeditor__ckeditor5-utils/src/ckeditorerror.d.ts
+++ b/types/ckeditor__ckeditor5-utils/src/ckeditorerror.d.ts
@@ -68,7 +68,7 @@ export default class CKEditorError<
  *   * name does not exist, so it was omitted when rendering the toolbar.
  *   *
  *   * @error toolbarview-item-unavailable
- *   * @param {String} name The name of the component.
+ *   * @param name The name of the component.
  *   * /
  *  logWarning( 'toolbarview-item-unavailable', { name } );
  *
@@ -86,7 +86,7 @@ export function logWarning(errorName: string, data?: Record<string, unknown>): v
  *   * name does not exist, so it was omitted when rendering the toolbar.
  *   *
  *   * @error toolbarview-item-unavailable
- *   * @param {String} name The name of the component.
+ *   * @param name The name of the component.
  *   * /
  *   logError( 'toolbarview-item-unavailable', { name } );
  *

--- a/types/nedb/index.d.ts
+++ b/types/nedb/index.d.ts
@@ -102,7 +102,7 @@ declare class Nedb<G = any> extends EventEmitter {
     /**
      * Find all documents matching the query
      * If no callback is passed, we return the cursor so that user can limit, skip and finally exec
-     * * @param {any} query MongoDB-style query
+     * * @param query MongoDB-style query
      */
     find<T extends G>(query: any, callback: (err: Error | null, documents: T[]) => void): void;
 

--- a/types/nestdb/index.d.ts
+++ b/types/nestdb/index.d.ts
@@ -100,7 +100,7 @@ declare class NestDb<G = any> extends EventEmitter {
     /**
      * Find all documents matching the query
      * If no callback is passed, we return the cursor so that user can limit, skip and finally exec
-     * * @param {any} query MongoDB-style query
+     * * @param query MongoDB-style query
      */
     find<T extends G>(query: any, callback: (err: Error, documents: T[]) => void): void;
 


### PR DESCRIPTION
Previously the redundant-jsdoc lint rule crashed; now that it's fixed it found a few redundant jsdoc types.
