### PR TITLE
Nightwatch: delete unused jsdoc types

### DIFF
--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -2129,15 +2129,6 @@ export type NightwatchAssert = (
 
 /**
  * Abstract assertion class that will subclass all defined assertions
- *
- * All assertions must implement the following api:
- *
- * - @param {T|function} expected
- * - @param {string} message
- * - @param {function} pass
- * - @param {function} value
- * - @param {function} command
- * - @param {function} - Optional failure
  */
 export interface NightwatchAssertion<T, U = any> {
     expected: (() => T) | T;


### PR DESCRIPTION
Previously, the lint rule forbidding types in jsdoc was crashing. Now that it's not, it found some types in nightwatch's jsdoc. After the types are gone, there's not really any additional text in the param tags, so I deleted them, too. The whole thing is redundant with the type annotations.
