### PR TITLE
typo agregatorName should be aggregatorName

### DIFF
--- a/types/react-pivottable/Utilities.d.ts
+++ b/types/react-pivottable/Utilities.d.ts
@@ -32,7 +32,7 @@ interface Pivot {
     /**
      * key to aggregators object specifying the aggregator to use for computations
      */
-    agregatorName?: string;
+    aggregatorName?: string;
 
     /**
      * @link https://github.com/nicolaskruchten/pivottable/wiki/Aggregators


### PR DESCRIPTION
This bug causes a warning in editors because the property is different than the current type name:
<img width="341" alt="image" src="https://user-images.githubusercontent.com/109985/223906630-40e69c27-dc78-41b2-a21e-8cf9eaedef1f.png">
