### PR TITLE
Add type definitions for the React jsx runtime

### DIFF
--- a/types/react/jsx-dev-runtime.d.ts
+++ b/types/react/jsx-dev-runtime.d.ts
@@ -1,4 +1,4 @@
-import { ElementType, Fragment, Key } from '.';
+import { ElementType, Fragment, Key, ReactElement } from '.';
 
 export { Fragment };
 
@@ -31,4 +31,4 @@ export function jsxDEV(
     isStatic: boolean,
     source?: JSXSource | undefined,
     self?: unknown,
-): JSX.Element;
+): ReactElement;

--- a/types/react/jsx-dev-runtime.d.ts
+++ b/types/react/jsx-dev-runtime.d.ts
@@ -1,2 +1,34 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import { ElementType, Fragment, Key } from '.';
+
+export { Fragment };
+
+export interface JSXSource {
+    /**
+     * The source file where the element originates from.
+     */
+    fileName?: string;
+
+    /**
+     * The line number where the element was created.
+     */
+    lineNumber?: number;
+
+    /**
+     * The column number where the element was created.
+     */
+    columnNumber?: number;
+}
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxDEV(
+    type: ElementType,
+    props: unknown,
+    key: Key | undefined,
+    isStatic: boolean,
+    source?: JSXSource | undefined,
+    self?: unknown,
+): JSX.Element;

--- a/types/react/jsx-runtime.d.ts
+++ b/types/react/jsx-runtime.d.ts
@@ -1,2 +1,17 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import { ElementType, Fragment, Key } from '.';
+
+export { Fragment };
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsx(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;

--- a/types/react/jsx-runtime.d.ts
+++ b/types/react/jsx-runtime.d.ts
@@ -1,4 +1,4 @@
-import { ElementType, Fragment, Key } from '.';
+import { ElementType, Fragment, Key, ReactElement } from '.';
 
 export { Fragment };
 
@@ -7,11 +7,11 @@ export { Fragment };
  *
  * You should not use this function directly. Use JSX and a transpiler instead.
  */
-export function jsx(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+export function jsx(type: ElementType, props: unknown, key?: Key | undefined): ReactElement;
 
 /**
  * Create a React element.
  *
  * You should not use this function directly. Use JSX and a transpiler instead.
  */
-export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): ReactElement;

--- a/types/react/v15/jsx-dev-runtime.d.ts
+++ b/types/react/v15/jsx-dev-runtime.d.ts
@@ -1,4 +1,4 @@
-import { ElementType, Key } from '.';
+import { ElementType, Key, ReactElement } from '.';
 
 export { Fragment } from './jsx-runtime';
 
@@ -31,4 +31,4 @@ export function jsxDEV(
     isStatic: boolean,
     source?: JSXSource | undefined,
     self?: unknown,
-): JSX.Element;
+): ReactElement;

--- a/types/react/v15/jsx-dev-runtime.d.ts
+++ b/types/react/v15/jsx-dev-runtime.d.ts
@@ -1,2 +1,34 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import { ElementType, Key } from '.';
+
+export { Fragment } from './jsx-runtime';
+
+export interface JSXSource {
+    /**
+     * The source file where the element originates from.
+     */
+    fileName?: string;
+
+    /**
+     * The line number where the element was created.
+     */
+    lineNumber?: number;
+
+    /**
+     * The column number where the element was created.
+     */
+    columnNumber?: number;
+}
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxDEV(
+    type: ElementType,
+    props: unknown,
+    key: Key | undefined,
+    isStatic: boolean,
+    source?: JSXSource | undefined,
+    self?: unknown,
+): JSX.Element;

--- a/types/react/v15/jsx-runtime.d.ts
+++ b/types/react/v15/jsx-runtime.d.ts
@@ -15,11 +15,11 @@ export const Fragment: ExoticComponent<{ children?: ReactNode | undefined }>;
  *
  * You should not use this function directly. Use JSX and a transpiler instead.
  */
-export function jsx(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+export function jsx(type: ElementType, props: unknown, key?: Key | undefined): ReactElement;
 
 /**
  * Create a React element.
  *
  * You should not use this function directly. Use JSX and a transpiler instead.
  */
-export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): ReactElement;

--- a/types/react/v15/jsx-runtime.d.ts
+++ b/types/react/v15/jsx-runtime.d.ts
@@ -1,2 +1,25 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import { ElementType, Key, ReactElement, ReactNode } from '.';
+
+interface ExoticComponent<P = {}> {
+    /**
+     * **NOTE**: Exotic components are not callable.
+     */
+    (props: P): ReactElement | null;
+    readonly $$typeof: symbol;
+}
+
+export const Fragment: ExoticComponent<{ children?: ReactNode | undefined }>;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsx(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;

--- a/types/react/v16/jsx-dev-runtime.d.ts
+++ b/types/react/v16/jsx-dev-runtime.d.ts
@@ -1,4 +1,4 @@
-import { ElementType, Fragment, Key } from '.';
+import { ElementType, Fragment, Key, ReactElement } from '.';
 
 export { Fragment };
 
@@ -31,4 +31,4 @@ export function jsxDEV(
     isStatic: boolean,
     source?: JSXSource | undefined,
     self?: unknown,
-): JSX.Element;
+): ReactElement;

--- a/types/react/v16/jsx-dev-runtime.d.ts
+++ b/types/react/v16/jsx-dev-runtime.d.ts
@@ -1,2 +1,34 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import { ElementType, Fragment, Key } from '.';
+
+export { Fragment };
+
+export interface JSXSource {
+    /**
+     * The source file where the element originates from.
+     */
+    fileName?: string;
+
+    /**
+     * The line number where the element was created.
+     */
+    lineNumber?: number;
+
+    /**
+     * The column number where the element was created.
+     */
+    columnNumber?: number;
+}
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxDEV(
+    type: ElementType,
+    props: unknown,
+    key: Key | undefined,
+    isStatic: boolean,
+    source?: JSXSource | undefined,
+    self?: unknown,
+): JSX.Element;

--- a/types/react/v16/jsx-runtime.d.ts
+++ b/types/react/v16/jsx-runtime.d.ts
@@ -1,2 +1,17 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import { ElementType, Fragment, Key } from '.';
+
+export { Fragment };
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsx(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;

--- a/types/react/v16/jsx-runtime.d.ts
+++ b/types/react/v16/jsx-runtime.d.ts
@@ -1,4 +1,4 @@
-import { ElementType, Fragment, Key } from '.';
+import { ElementType, Fragment, Key, ReactElement } from '.';
 
 export { Fragment };
 
@@ -7,11 +7,11 @@ export { Fragment };
  *
  * You should not use this function directly. Use JSX and a transpiler instead.
  */
-export function jsx(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+export function jsx(type: ElementType, props: unknown, key?: Key | undefined): ReactElement;
 
 /**
  * Create a React element.
  *
  * You should not use this function directly. Use JSX and a transpiler instead.
  */
-export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): ReactElement;

--- a/types/react/v17/jsx-dev-runtime.d.ts
+++ b/types/react/v17/jsx-dev-runtime.d.ts
@@ -1,4 +1,4 @@
-import { ElementType, Fragment, Key } from '.';
+import { ElementType, Fragment, Key, ReactElement } from '.';
 
 export { Fragment };
 
@@ -31,4 +31,4 @@ export function jsxDEV(
     isStatic: boolean,
     source?: JSXSource | undefined,
     self?: unknown,
-): JSX.Element;
+): ReactElement;

--- a/types/react/v17/jsx-dev-runtime.d.ts
+++ b/types/react/v17/jsx-dev-runtime.d.ts
@@ -1,2 +1,34 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import { ElementType, Fragment, Key } from '.';
+
+export { Fragment };
+
+export interface JSXSource {
+    /**
+     * The source file where the element originates from.
+     */
+    fileName?: string;
+
+    /**
+     * The line number where the element was created.
+     */
+    lineNumber?: number;
+
+    /**
+     * The column number where the element was created.
+     */
+    columnNumber?: number;
+}
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxDEV(
+    type: ElementType,
+    props: unknown,
+    key: Key | undefined,
+    isStatic: boolean,
+    source?: JSXSource | undefined,
+    self?: unknown,
+): JSX.Element;

--- a/types/react/v17/jsx-runtime.d.ts
+++ b/types/react/v17/jsx-runtime.d.ts
@@ -1,2 +1,17 @@
-// Expose `JSX` namespace in `global` namespace
-import './';
+import { ElementType, Fragment, Key } from '.';
+
+export { Fragment };
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsx(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;

--- a/types/react/v17/jsx-runtime.d.ts
+++ b/types/react/v17/jsx-runtime.d.ts
@@ -1,4 +1,4 @@
-import { ElementType, Fragment, Key } from '.';
+import { ElementType, Fragment, Key, ReactElement } from '.';
 
 export { Fragment };
 
@@ -7,11 +7,11 @@ export { Fragment };
  *
  * You should not use this function directly. Use JSX and a transpiler instead.
  */
-export function jsx(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+export function jsx(type: ElementType, props: unknown, key?: Key | undefined): ReactElement;
 
 /**
  * Create a React element.
  *
  * You should not use this function directly. Use JSX and a transpiler instead.
  */
-export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): JSX.Element;
+export function jsxs(type: ElementType, props: unknown, key?: Key | undefined): ReactElement;


### PR DESCRIPTION
Although one typically shouldn’t use this directly, there are some legitimate use cases for it.

React 15 provides `Fragment` only through the automatic runtime, not via the index file. The type for `Fragment` has been backported into the jsx runtime from a newer version.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/main/packages/react/jsx-runtime.js https://github.com/facebook/react/blob/main/packages/react/jsx-dev-runtime.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
