### PR TITLE
Updated wordpress__rich-text to 6.4

### DIFF
--- a/types/wordpress__rich-text/index.d.ts
+++ b/types/wordpress__rich-text/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/rich-text 6.0
+// Type definitions for @wordpress/rich-text 6.4
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/rich-text/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,7 +6,7 @@
 
 import { create, Format, Value } from './create';
 import { ComponentType } from 'react';
-import { dispatch, select } from '@wordpress/data';
+import { dispatch, select, StoreDescriptor } from '@wordpress/data';
 
 export { create, Format, Value };
 export * from './component';
@@ -14,6 +14,14 @@ export * from './component';
 declare module '@wordpress/data' {
     function dispatch(key: 'core/rich-text'): typeof import('./store/actions');
     function select(key: 'core/rich-text'): typeof import('./store/selectors');
+}
+
+export interface RichTextStoreDescriptor extends StoreDescriptor {
+    name: 'core/rich-text';
+}
+
+declare module '@wordpress/rich-text' {
+    const store: RichTextStoreDescriptor;
 }
 
 export interface FormatProps {

--- a/types/wordpress__rich-text/package.json
+++ b/types/wordpress__rich-text/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "@wordpress/data": "^8.5.0"
+    }
+}

--- a/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
+++ b/types/wordpress__rich-text/wordpress__rich-text-tests.tsx
@@ -2,6 +2,12 @@ import { createRef } from 'react';
 import { dispatch, select } from '@wordpress/data';
 import * as RT from '@wordpress/rich-text';
 
+// $ExpectType RichTextStoreDescriptor
+RT.store;
+
+// $ExpectType "core/rich-text"
+RT.store.name;
+
 const VALUE: RT.Value = {
     formats: [],
     replacements: [],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/%40wordpress/rich-text%406.4.0/packages/rich-text/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
