### PR TITLE
Fix `gm` `delay` parameter name from `milliseconds` to `centiseconds`

### DIFF
--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -133,7 +133,7 @@ declare namespace m {
         cycle(amount: number): State;
         deconstruct(): State;
         define(value: string): State;
-        delay(milliseconds: number): State;
+        delay(centiseconds: number): State;
         density(width: number, height: number): State;
         despeckle(): State;
         displace(horizontal: number, vertical: number): State;


### PR DESCRIPTION
Fix `gm` `delay` method param to hundredths of a second, not milliseconds.
graphicsmagick docs: http://www.graphicsmagick.org/GraphicsMagick.html#details-delay
imagemagick docs: https://imagemagick.org/script/command-line-options.php#delay

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
