### PR TITLE
Update dom-screen-wake-lock for TS 5.1

### DIFF
--- a/types/dom-screen-wake-lock/index.d.ts
+++ b/types/dom-screen-wake-lock/index.d.ts
@@ -2,8 +2,7 @@
 // Project: https://w3c.github.io/screen-wake-lock/
 // Definitions by: Chris Milson <https://github.com/chrismilson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-type WakeLockType = 'screen';
+// Minimum TypeScript Version: 5.1
 
 /**
  * A WakeLockSentinel provides a handle to a platform wake lock, and it holds on
@@ -25,7 +24,7 @@ interface WakeLockSentinel extends EventTarget {
      * WakeLockSentinel's handle being released does not necessarily mean that
      * the underlying wake lock has been released.
      */
-    onrelease: EventListener;
+    onrelease: ((this: WakeLockSentinel, ev: Event) => any) | null;
 }
 
 /**


### PR DESCRIPTION
Typescript 5.1's DOM types add the same types as dom-screen-wake-lock. This PR updates the types to make them agree so that people can keep installing (the latest version of) this package.

However, I don't think this package will actually be needed after 5.1, because all of its types are now in the standard library.