### PR TITLE
Update dom-webcodecs for TS 5.1

### DIFF
--- a/types/dom-mediacapture-transform/index.d.ts
+++ b/types/dom-mediacapture-transform/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://w3c.github.io/mediacapture-transform/
 // Definitions by: Ben Wagner <https://github.com/dogben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.9
+// Minimum TypeScript Version: 5.1
 
 // In general, these types are only available behind a command line flag or an origin trial in
 // Chrome 90+.

--- a/types/dom-webcodecs/index.d.ts
+++ b/types/dom-webcodecs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://w3c.github.io/webcodecs/
 // Definitions by: Ben Wagner <https://github.com/dogben>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.9
+// Minimum TypeScript Version: 5.1
 
 // Versioning:
 // Until the WebCodecs spec is finalized, the major version number is 0. I have chosen to use minor

--- a/types/dom-webcodecs/test/dom-webcodecs-tests.ts
+++ b/types/dom-webcodecs/test/dom-webcodecs-tests.ts
@@ -362,9 +362,9 @@ VideoDecoder.isConfigSupported();
 VideoDecoder.isConfigSupported({ description: new Uint8Array(0) });
 
 VideoDecoder.isConfigSupported(videoDecoderConfig).then((result: VideoDecoderSupport) => {
-    // $ExpectType boolean
+    // $ExpectType boolean | undefined
     result.supported;
-    // $ExpectType VideoDecoderConfig
+    // $ExpectType VideoDecoderConfig | undefined
     result.config;
 });
 
@@ -377,7 +377,7 @@ function videoOutput(output: VideoFrame): void {
     output.displayWidth;
     // $ExpectType number
     output.displayHeight;
-    // $ExpectType number | null
+    // $ExpectType number
     output.timestamp;
     // $ExpectType void
     output.close();
@@ -481,9 +481,9 @@ VideoEncoder.isConfigSupported({
 });
 
 VideoEncoder.isConfigSupported(videoEncoderConfig).then((result: VideoEncoderSupport) => {
-    // $ExpectType boolean
+    // $ExpectType boolean | undefined
     result.supported;
-    // $ExpectType VideoEncoderConfig
+    // $ExpectType VideoEncoderConfig | undefined
     result.config;
 });
 
@@ -502,8 +502,8 @@ VideoEncoder.isConfigSupported(futureVideoEncoderConfig);
 
 const videoFrame = new VideoFrame(imageBitmap, { timestamp: 1000000 });
 
-function encodedVideoOutput(output: EncodedVideoChunk, metadata: EncodedVideoChunkMetadata): void {
-    if (metadata.decoderConfig !== undefined) {
+function encodedVideoOutput(output: EncodedVideoChunk, metadata?: EncodedVideoChunkMetadata): void {
+    if (metadata?.decoderConfig !== undefined) {
         videoDecoder.configure(metadata.decoderConfig);
     }
     videoDecoder.decode(output);
@@ -563,7 +563,7 @@ videoFrame.close();
 //////////////////////////////////////////////////
 // video-frame.any.js
 
-// $ExpectType number | null
+// $ExpectType number
 videoFrame.timestamp;
 // $ExpectType number | null
 videoFrame.duration;

--- a/types/dom-webcodecs/webcodecs.generated.d.ts
+++ b/types/dom-webcodecs/webcodecs.generated.d.ts
@@ -129,8 +129,8 @@ interface VideoDecoderInit {
 }
 
 interface VideoDecoderSupport {
-    config: VideoDecoderConfig;
-    supported: boolean;
+    config?: VideoDecoderConfig;
+    supported?: boolean;
 }
 
 interface VideoEncoderConfig {
@@ -150,7 +150,7 @@ interface VideoEncoderConfig {
 }
 
 interface VideoEncoderEncodeOptions {
-    keyFrame?: boolean | null | undefined;
+    keyFrame?: boolean;
 }
 
 interface VideoEncoderInit {
@@ -159,8 +159,8 @@ interface VideoEncoderInit {
 }
 
 interface VideoEncoderSupport {
-    config: VideoEncoderConfig;
-    supported: boolean;
+    config?: VideoEncoderConfig;
+    supported?: boolean;
 }
 
 interface VideoFrameBufferInit {
@@ -366,7 +366,7 @@ interface VideoFrame {
     readonly displayWidth: number;
     readonly duration: number | null;
     readonly format: VideoPixelFormat | null;
-    readonly timestamp: number | null;
+    readonly timestamp: number;
     readonly visibleRect: DOMRectReadOnly | null;
     allocationSize(options?: VideoFrameCopyToOptions): number;
     clone(): VideoFrame;
@@ -401,17 +401,17 @@ interface WebCodecsErrorCallback {
 }
 
 type AllowSharedBufferSource = ArrayBuffer | ArrayBufferView;
-type BitrateMode = "constant" | "variable";
+// type BitrateMode = "constant" | "variable";
 type ImageBufferSource = ArrayBuffer | ArrayBufferView | ReadableStream;
-type AlphaOption = "discard" | "keep";
+// type AlphaOption = "discard" | "keep";
 type AudioSampleFormat = "f32" | "f32-planar" | "s16" | "s16-planar" | "s32" | "s32-planar" | "u8" | "u8-planar";
-type AvcBitstreamFormat = "annexb" | "avc";
-type CodecState = "closed" | "configured" | "unconfigured";
+// type AvcBitstreamFormat = "annexb" | "avc";
+// type CodecState = "closed" | "configured" | "unconfigured";
 type EncodedAudioChunkType = "delta" | "key";
-type EncodedVideoChunkType = "delta" | "key";
+// type EncodedVideoChunkType = "delta" | "key";
 type HardwarePreference = "no-preference" | "prefer-hardware" | "prefer-software";
-type LatencyMode = "quality" | "realtime";
+// type LatencyMode = "quality" | "realtime";
 // type VideoColorPrimaries = "bt470bg" | "bt709" | "smpte170m";
 // type VideoMatrixCoefficients = "bt470bg" | "bt709" | "rgb" | "smpte170m";
-type VideoPixelFormat = "BGRA" | "BGRX" | "I420" | "I420A" | "I422" | "I444" | "NV12" | "RGBA" | "RGBX";
+// type VideoPixelFormat = "BGRA" | "BGRX" | "I420" | "I420A" | "I422" | "I444" | "NV12" | "RGBA" | "RGBX";
 // type VideoTransferCharacteristics = "bt709" | "iec61966-2-1" | "smpte170m";


### PR DESCRIPTION
Typescript 5.1's DOM types add some more of the types as dom-webcodecs. This PR updates the types to make them agree and removes the duplicate type declarations.
