### PR TITLE
Fix @types/ldapjs: SubstringFilter constructor parameter don't match

### DIFF
--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -499,9 +499,9 @@ export class PresenceFilter extends Filter {
 export class SubstringFilter extends Filter {
     constructor(options: {
         attribute: string;
-        initial: string;
-        any?: string[] | undefined;
-        final?: string | undefined;
+        subInitial: string;
+        subAny?: string[] | undefined;
+        subFinal?: string | undefined;
     });
 }
 

--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ldapjs 2.2
+// Type definitions for ldapjs 3.0.1
 // Project: http://ldapjs.org
 // Definitions by: Charles Villemure <https://github.com/cvillemure>, Peter Kooijmans <https://github.com/peterkooijmans>, Pablo Moleri <https://github.com/pmoleri>, Michael Scott-Nelson <https://github.com/mscottnelson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ldapjs/index.d.ts
+++ b/types/ldapjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ldapjs 3.0.1
+// Type definitions for ldapjs 3.0
 // Project: http://ldapjs.org
 // Definitions by: Charles Villemure <https://github.com/cvillemure>, Peter Kooijmans <https://github.com/peterkooijmans>, Pablo Moleri <https://github.com/pmoleri>, Michael Scott-Nelson <https://github.com/mscottnelson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ldapjs/ldapjs-tests.ts
+++ b/types/ldapjs/ldapjs-tests.ts
@@ -105,9 +105,9 @@ presenceFilter.matches({ cn: 'foo' });
 
 let substringFilter = new ldap.SubstringFilter({
     attribute: 'cn',
-    initial: 'foo',
-    any: ['bar'],
-    final: 'baz',
+    subInitial: 'foo',
+    subAny: ['bar'],
+    subFinal: 'baz',
 });
 substringFilter.matches({ cn: 'foobigbardogbaz' });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [github @ldajs/filter](https://github.com/ldapjs/filter/blob/e70a7cba6c17310956e87a9b28e6bea61db48d93/lib/filters/substring.js#L37)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
