### PR TITLE
[fix]: remove exported mixpanel-browser functions

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -91,6 +91,10 @@ export interface Config {
     batch_request_timeout_ms: number;
 }
 
+// The methods above should NOT be exported as standalone functions
+// The analysis done by DT's PR bot suggests that they are missing, but they are not.
+// mixpanel-browser exports a Singleton rather than a class, so this confuses the bot
+
 export type VerboseResponse =
     | {
           status: 1;

--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -183,48 +183,5 @@ export interface OverridedMixpanel extends Mixpanel {
     init(token: string, config?: Partial<Config>): undefined;
 }
 
-export function add_group(group_key: string, group_id: string, callback?: Callback): void;
-export function alias(alias: string, original?: string): void;
-export function clear_opt_in_out_tracking(options?: Partial<ClearOptOutInOutOptions>): void;
-export function disable(events?: string[]): void;
-export function get_config(prop_name?: string): any;
-export function get_distinct_id(): any;
-export function get_group(group_key: string, group_id: string): Group;
-export function get_property(property_name: string): any;
-export function has_opted_in_tracking(options?: Partial<HasOptedInOutOptions>): boolean;
-export function has_opted_out_tracking(options?: Partial<HasOptedInOutOptions>): boolean;
-export function identify(unique_id?: string): any;
-export function init(token: string, config: Partial<Config>, name: string): Mixpanel;
-export function init(token: string, config?: Partial<Config>): undefined;
-export function opt_in_tracking(options?: Partial<InTrackingOptions>): void;
-export function opt_out_tracking(options?: Partial<OutTrackingOptions>): void;
-export function push(item: PushItem): void;
-export function register(props: Dict, days?: number): void;
-export function register_once(props: Dict, default_value?: any, days?: number): void;
-export function remove_group(
-    group_key: string,
-    group_ids: string | string[] | number | number[],
-    callback?: Callback,
-): void;
-export function reset(): void;
-export function set_config(config: Partial<Config>): void;
-export function set_group(
-    group_key: string,
-    group_ids: string | string[] | number | number[],
-    callback?: Callback,
-): void;
-export function time_event(event_name: string): void;
-export function track(
-    event_name: string,
-    properties?: Dict,
-    optionsOrCallback?: RequestOptions | Callback,
-    callback?: Callback,
-): void;
-export function track_forms(query: Query, event_name: string, properties?: Dict | (() => void)): void;
-export function track_links(query: Query, event_name: string, properties?: Dict | (() => void)): void;
-export function track_with_groups(event_name: string, properties: Dict, groups: Dict, callback?: Callback): void;
-export function unregister(property: string): void;
-export const people: People;
-
 declare const mixpanel: OverridedMixpanel;
 export default mixpanel;


### PR DESCRIPTION
This removes all the exported, standalone, functions from the type definition.

Here's the API URL: https://developer.mixpanel.com/docs/javascript-quickstart

`mixpanel-browser` does not export its functions, standalone. While you _can_ import those functions, they don't work because calling them directly means that the `this` object is undefined. They can only be used as methods.


