### PR TITLE
[chrome] Add chrome.downloads.setUiOptions

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2890,6 +2890,11 @@ declare namespace chrome.downloads {
         conflictAction?: string | undefined;
     }
 
+    export interface UiOptions {
+        /** Enable or disable the download UI. */
+        enabled: boolean;
+    }
+
     export interface DownloadChangedEvent extends chrome.events.Event<(downloadDelta: DownloadDelta) => void> { }
 
     export interface DownloadCreatedEvent extends chrome.events.Event<(downloadItem: DownloadItem) => void> { }
@@ -3026,6 +3031,19 @@ declare namespace chrome.downloads {
     export function drag(downloadId: number): void;
     /** Enable or disable the gray shelf at the bottom of every window associated with the current browser profile. The shelf will be disabled as long as at least one extension has disabled it. Enabling the shelf while at least one other extension has disabled it will return an error through runtime.lastError. Requires the "downloads.shelf" permission in addition to the "downloads" permission. */
     export function setShelfEnabled(enabled: boolean): void;
+    /**
+     * Change the download UI of every window associated with the current browser profile. As long as at least one extension has set UiOptions.enabled to false, the download UI will be hidden. Setting UiOptions.enabled to true while at least one other extension has disabled it will return an error through runtime.lastError. Requires the "downloads.ui" permission in addition to the "downloads" permission.
+     * @param options Encapsulate a change to the download UI.
+     * @since Chrome 105
+     */
+    export function setUiOptions(options: UiOptions): Promise<void>;
+    /**
+     * Change the download UI of every window associated with the current browser profile. As long as at least one extension has set UiOptions.enabled to false, the download UI will be hidden. Setting UiOptions.enabled to true while at least one other extension has disabled it will return an error through runtime.lastError. Requires the "downloads.ui" permission in addition to the "downloads" permission.
+     * @param options Encapsulate a change to the download UI.
+     * @param callback Called when the setUiOptions request is completed.
+     * @since Chrome 105
+     */
+    export function setUiOptions(options: UiOptions, callback: () => void): void;
 
     /** When any of a DownloadItem's properties except bytesReceived and estimatedEndTime changes, this event fires with the downloadId and an object containing the properties that changed. */
     export var onChanged: DownloadChangedEvent;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1777,6 +1777,7 @@ function testDownloads() {
     chrome.downloads.acceptDanger(1, () => { })
     chrome.downloads.drag(1)
     chrome.downloads.setShelfEnabled(true)
+    chrome.downloads.setUiOptions({ enabled: true }, () => { })
 }
 
 // https://developer.chrome.com/docs/extensions/reference/downloads
@@ -1791,6 +1792,7 @@ async function testDownloadsForPromise() {
     await chrome.downloads.erase({})
     await chrome.downloads.removeFile(1)
     await chrome.downloads.acceptDanger(1)
+    await chrome.downloads.setUiOptions({ enabled: true })
 }
 
 // https://developer.chrome.com/docs/extensions/reference/extension


### PR DESCRIPTION
Chrome 105 introduces [`chrome.downloads.setUiOptions`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-setUiOptions); this pull request adds a typing for it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/downloads/#method-setUiOptions
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~ (not applicable)
