### PR TITLE
[react] fix: use SubmitEvent in FormEvent

### DIFF
--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -20,6 +20,7 @@ interface PointerEvent extends Event { }
 interface TransitionEvent extends Event { }
 interface UIEvent extends Event { }
 interface WheelEvent extends Event { }
+interface SubmitEvent extends Event { }
 
 interface EventTarget { }
 interface Document { }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -52,6 +52,7 @@ type NativePointerEvent = PointerEvent;
 type NativeTransitionEvent = TransitionEvent;
 type NativeUIEvent = UIEvent;
 type NativeWheelEvent = WheelEvent;
+type NativeSubmitEvent = SubmitEvent;
 type Booleanish = boolean | 'true' | 'false';
 
 declare const UNDEFINED_VOID_ONLY: unique symbol;
@@ -1239,7 +1240,7 @@ declare namespace React {
         target: EventTarget & Target;
     }
 
-    interface FormEvent<T = Element> extends SyntheticEvent<T> {
+    interface FormEvent<T = Element> extends SyntheticEvent<T, NativeSubmitEvent> {
     }
 
     interface InvalidEvent<T = Element> extends SyntheticEvent<T> {

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -62,6 +62,7 @@ type NativeTouchEvent = TouchEvent;
 type NativeTransitionEvent = TransitionEvent;
 type NativeUIEvent = UIEvent;
 type NativeWheelEvent = WheelEvent;
+type NativeSubmitEvent = SubmitEvent
 
 // eslint-disable-next-line export-just-namespace
 export = React;
@@ -453,6 +454,7 @@ declare namespace React {
     }
 
     interface FormEvent<T> extends SyntheticEvent<T> {
+      nativeEvent: NativeSubmitEvent;
     }
 
     interface InvalidEvent<T> extends SyntheticEvent<T> {

--- a/types/react/v16/global.d.ts
+++ b/types/react/v16/global.d.ts
@@ -20,6 +20,7 @@ interface PointerEvent extends Event { }
 interface TransitionEvent extends Event { }
 interface UIEvent extends Event { }
 interface WheelEvent extends Event { }
+interface SubmitEvent extends Event { }
 
 interface EventTarget { }
 interface Document { }

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -51,6 +51,7 @@ type NativePointerEvent = PointerEvent;
 type NativeTransitionEvent = TransitionEvent;
 type NativeUIEvent = UIEvent;
 type NativeWheelEvent = WheelEvent;
+type NativeSubmitEvent = SubmitEvent;
 type Booleanish = boolean | 'true' | 'false';
 
 declare const UNDEFINED_VOID_ONLY: unique symbol;
@@ -1187,7 +1188,7 @@ declare namespace React {
     }
 
     // tslint:disable-next-line:no-empty-interface
-    interface FormEvent<T = Element> extends SyntheticEvent<T> {
+    interface FormEvent<T = Element> extends SyntheticEvent<T, NativeSubmitEvent> {
     }
 
     interface InvalidEvent<T = Element> extends SyntheticEvent<T> {

--- a/types/react/v17/global.d.ts
+++ b/types/react/v17/global.d.ts
@@ -20,6 +20,7 @@ interface PointerEvent extends Event { }
 interface TransitionEvent extends Event { }
 interface UIEvent extends Event { }
 interface WheelEvent extends Event { }
+interface SubmitEvent extends Event { }
 
 interface EventTarget { }
 interface Document { }

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -47,6 +47,7 @@ type NativePointerEvent = PointerEvent;
 type NativeTransitionEvent = TransitionEvent;
 type NativeUIEvent = UIEvent;
 type NativeWheelEvent = WheelEvent;
+type NativeSubmitEvent = SubmitEvent;
 type Booleanish = boolean | 'true' | 'false';
 
 declare const UNDEFINED_VOID_ONLY: unique symbol;
@@ -1185,7 +1186,7 @@ declare namespace React {
         target: EventTarget & Target;
     }
 
-    interface FormEvent<T = Element> extends SyntheticEvent<T> {
+    interface FormEvent<T = Element> extends SyntheticEvent<T, NativeSubmitEvent> {
     }
 
     interface InvalidEvent<T = Element> extends SyntheticEvent<T> {


### PR DESCRIPTION
The type of `nativeEvent` used in `FormEvent` was not `SubmitEvent` but `Event`.
As a result, the completion of properties such as `submitter` in `SubmitEvent` were not performed in `FormEvent`.
This PR fixes that issue.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[url here](https://github.com/facebook/react/blob/977bccd24de2b062d2c114e6cf160d2bd9ed9493/packages/react-dom-bindings/src/events/SyntheticEvent.js)>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.