### PR TITLE
[leaflet] Add `options` property to `L.Layer`, extend `GridLayerOptions` from `LayerOptions`

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1226,6 +1226,8 @@ export class Layer extends Evented {
     beforeAdd?(map: Map): this;
 
     protected _map: Map;
+
+    options: LayerOptions;
 }
 
 export interface GridLayerOptions {

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1230,13 +1230,12 @@ export class Layer extends Evented {
     options: LayerOptions;
 }
 
-export interface GridLayerOptions {
+export interface GridLayerOptions extends LayerOptions {
     tileSize?: number | Point | undefined;
     opacity?: number | undefined;
     updateWhenIdle?: boolean | undefined;
     updateWhenZooming?: boolean | undefined;
     updateInterval?: number | undefined;
-    attribution?: string | undefined;
     zIndex?: number | undefined;
     bounds?: LatLngBoundsExpression | undefined;
     minZoom?: number | undefined;
@@ -1379,7 +1378,6 @@ export interface ImageOverlayOptions extends InteractiveLayerOptions {
     opacity?: number | undefined;
     alt?: string | undefined;
     interactive?: boolean | undefined;
-    attribution?: string | undefined;
     crossOrigin?: CrossOrigin | boolean | undefined;
     errorOverlayUrl?: string | undefined;
     zIndex?: number | undefined;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -163,6 +163,14 @@ const htmlElement = document.getElementById('foo');
 
 layer.addInteractiveTarget(htmlElement);
 layer.removeInteractiveTarget(htmlElement);
+// $ExpectType LayerOptions
+layer.options;
+
+let layerOptions: L.LayerOptions;
+layerOptions = {
+    attribution: 'anon',
+    pane: 'overlay',
+};
 
 const popupOptions: L.PopupOptions = {};
 

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -300,6 +300,26 @@ mapPixelBounds = map.getPixelWorldBounds(12);
 let attributionControl: L.Control.Attribution;
 attributionControl = map.attributionControl;
 
+let gridLayerOptions: L.GridLayerOptions;
+gridLayerOptions = {
+    attribution: 'anon',
+    pane: 'overlay',
+    tileSize: 256,
+    opacity: 1,
+    updateWhenIdle: true,
+    updateWhenZooming: true,
+    updateInterval: 200,
+    zIndex: 1,
+    bounds: undefined,
+    minZoom: 1,
+    maxZoom: 12,
+    maxNativeZoom: 3,
+    minNativeZoom: 10,
+    noWrap: false,
+    className: 'none',
+    keepBuffer: 2,
+};
+
 let tileLayerOptions: L.TileLayerOptions = {};
 tileLayerOptions = {
     id: 'mapbox.streets',


### PR DESCRIPTION
This PR adds the previously missing `options` property to the definition of `L.Layer`, and also updates `L.GridLayerOptions` to extend from `L.LayerOptions`.

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Discussion with motivation and links to source](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64691#discussion-4952587)
- [X] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
