### PR TITLE
[leaflet.vectorgrid] Extend VectorGridOptions from L.GridLayerOptions

### DIFF
--- a/types/leaflet.vectorgrid/index.d.ts
+++ b/types/leaflet.vectorgrid/index.d.ts
@@ -73,7 +73,7 @@ declare module 'leaflet' {
         const tile: TileFactoryFunction<SVG.Tile>;
     }
 
-    type VectorGridOptions<T extends Canvas.Tile | SVG.Tile = Canvas.Tile | SVG.Tile> = geojsonvt.Options & {
+    interface VectorGridOptions<T extends Canvas.Tile | SVG.Tile = Canvas.Tile | SVG.Tile> extends geojsonvt.Options, GridLayerOptions {
         /** A factory method which will be used to instantiate the per-tile renderers. */
         rendererFactory?: TileFactoryFunction<T>;
         /** A data structure holding initial symbolizer definitions for the vector features. */
@@ -93,7 +93,7 @@ declare module 'leaflet' {
          * The default is to include all features. Similar to GeoJSON filter option.
          */
         filter?: (properties: geojsonvt.Feature, zoom: number) => boolean;
-    };
+    }
     type GetVectorGridRendererHelper<T extends HTMLCanvasElement | SVGViewElement> = T extends
         | HTMLCanvasElement
         | SVGViewElement

--- a/types/leaflet.vectorgrid/leaflet.vectorgrid-tests.ts
+++ b/types/leaflet.vectorgrid/leaflet.vectorgrid-tests.ts
@@ -53,3 +53,40 @@ protobuf('', protobufOptions).bindTooltip(null!); // $ExpectType Protobuf
 
 const protobufClass = L.VectorGrid.Protobuf;
 new protobufClass('', protobufOptions); // $ExpectType Protobuf
+
+let vectorgridOptions: L.VectorGridOptions;
+vectorgridOptions = {
+    // L.GridLayer options
+    attribution: '',
+    tileSize: 256,
+    opacity: 1.0,
+    updateWhenIdle: true,
+    updateWhenZooming: true,
+    updateInterval: 200,
+    zIndex: 1,
+    bounds: undefined,
+    minZoom: 0,
+    maxZoom: undefined,
+    maxNativeZoom: undefined,
+    minNativeZoom: undefined,
+    noWrap: false,
+    pane: 'tilePane',
+    className: '',
+    keepBuffer: 2,
+    // geojsonvt.options
+    tolerance: undefined,
+    extent: undefined,
+    buffer: undefined,
+    debug: undefined,
+    lineMetrics: false,
+    promoteId: null,
+    generateId: false,
+    indexMaxZoom: undefined,
+    indexMaxPoints: undefined,
+    // VectorGridOptions
+    rendererFactory: undefined,
+    vectorTileLayerStyles: undefined,
+    interactive: true,
+    getFeatureId: undefined,
+    filter: undefined,
+};


### PR DESCRIPTION
This PR updates the definition of the `VectorGridOptions` type to an interface that extends from `L.GridLayerOptions` in addition to its existing properties.

I have submitted #64705 to include the `options` property on all Layer types, but it led to an error in the types for `leaflet.vectorgrid` because `VectorGrid` extends `L.GridLayer` but `VectorGrid.options` does not (yet) extend `L.GridLayerOptions`. This PR is required in order to correctly update Leaflet's types.

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] ~Test the change in your own code. (Compile and run.)~
  - I am not using this in my own projects, just the above PR.
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test leaflet.vectorgrid`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Above-mentioned PR to update `@types/leaflet` that leads to failures in `leaflet.vectorgrid` without this change.
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
  - It does not.
