### PR TITLE
[leaflet] Add `maxMargin` optional argument to `LatLngBounds.equals`

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -195,7 +195,7 @@ export class LatLngBounds {
     intersects(otherBounds: LatLngBoundsExpression): boolean;
     overlaps(otherBounds: LatLngBoundsExpression): boolean;
     toBBoxString(): string;
-    equals(otherBounds: LatLngBoundsExpression): boolean;
+    equals(otherBounds: LatLngBoundsExpression, maxMargin?: number): boolean;
     isValid(): boolean;
 }
 

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -33,6 +33,9 @@ latLngBounds = new L.LatLngBounds(latLng, latLng);
 latLngBounds = new L.LatLngBounds(latLngLiteral, latLngLiteral);
 latLngBounds = new L.LatLngBounds(latLngTuple, latLngTuple);
 
+latLngBounds.equals(latLngBounds); // $ExpectType boolean
+latLngBounds.equals(latLngBounds, 3); // $ExpectType boolean
+
 const pointTuple: L.PointTuple = [0, 0];
 
 let point: L.Point;


### PR DESCRIPTION
This PR adds an second parameter to the `LatLngBounds.equals` method that is optional in Leaflet but not yet present in its types.

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test leaflet`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Leaflet docs for [LatLngBounds.equals](https://leafletjs.com/reference.html#latlngbounds-equals)
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
  - It does not.
