### PR TITLE
[@koa/cors] bump the major version after breaking changes

### DIFF
--- a/types/koa__cors/index.d.ts
+++ b/types/koa__cors/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @koa/cors 3.3
+// Type definitions for @koa/cors 4.0
 // Project: https://github.com/koajs/cors
 // Definitions by: Xavier Stouder <https://github.com/Xstoudi>
 //                 Steve Hipwell <https://github.com/stevehipwell>


### PR DESCRIPTION
I've noticed that the DT types are not matching the version of the package, although there has been no change in the package's API there has been a major version bump because of internal logic changes causing the breaking changes.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [3.3.0..4.0.0](https://github.com/koajs/cors/compare/3.3.0..4.0.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.