### PR TITLE
Update api-gateway-authorizer.d.ts

### DIFF
--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -574,6 +574,7 @@ const simpleRequestAuthorizerV2WithContext: APIGatewayRequestSimpleAuthorizerHan
 const iamRequestAuthorizerV2: APIGatewayRequestIAMAuthorizerHandlerV2 = async (event, context, callback) => {
     str = event.version;
     str = event.type;
+    str = event.methodArn;
     str = event.routeArn;
     array = event.identitySource;
     str = event.routeKey;

--- a/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
@@ -34,6 +34,7 @@ export interface APIGatewayTokenAuthorizerEvent {
 export interface APIGatewayRequestAuthorizerEventV2 {
     version: string;
     type: 'REQUEST';
+    methodArn: string;
     routeArn: string;
     identitySource: string[];
     routeKey: string;


### PR DESCRIPTION
Add methodArn to the AuthorizerV2 type definition. Allows the AWS api Gateway WS authorizer example code to run.  See https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-lambda-auth.html

I'm writing an authorizer for an api gateway websocket, and unless i'm mistaken, there's an additional methodArn field thats missing from the type definition.
I hope this helps.
Best, 

Here's a sample event received by my lambda authorizer where we see methodArn

```
{
  type: 'REQUEST',
  methodArn: 'arn:aws:execute-api:xxxxxx/$connect',
  headers: {
    Connection: 'upgrade',
    'content-length': '0',
    Host: 'xxxx.execute-api.xxxx.amazonaws.com',
    'Sec-WebSocket-Extensions': 'permessage-deflate; client_max_window_bits',
    'Sec-WebSocket-Key': 'xxxxx==',
    'Sec-WebSocket-Version': '13',
    Upgrade: 'websocket',
    'X-Amzn-Trace-Id': 'Root=1-xxx-xx',
    'X-Forwarded-For': 'xxxx',
    'X-Forwarded-Port': '443',
    'X-Forwarded-Proto': 'https'
  },
  multiValueHeaders: {
    Connection: [ 'upgrade' ],
    'content-length': [ '0' ],
    Host: [ 'xxx.execute-api.xxx.amazonaws.com' ],
    'Sec-WebSocket-Extensions': [ 'permessage-deflate; client_max_window_bits' ],
    'Sec-WebSocket-Key': [ 'xxx==' ],
    'Sec-WebSocket-Version': [ '13' ],
    Upgrade: [ 'websocket' ],
    'X-Amzn-Trace-Id': [ 'Root=xxxx' ],
    'X-Forwarded-For': [ 'xxx' ],
    'X-Forwarded-Port': [ '443' ],
    'X-Forwarded-Proto': [ 'https' ]
  },
  queryStringParameters: { aaa: 'xxx' },
  multiValueQueryStringParameters: { aaa: [ 'xxx' ] },
  stageVariables: {},
  requestContext: {
    routeKey: '$connect',
    eventType: 'CONNECT',
    extendedRequestId: 'xxx-g=',
    requestTime: 'xxx:xxx +0000',
    messageDirection: 'IN',
    stage: 'xxx',
    connectedAt: xx,
    requestTimeEpoch: xx,
    identity: { sourceIp: 'xxx' },
    requestId: 'xxx-g=',
    domainName: 'xxx.execute-apxxxonaws.com',
    connectionId: 'xx=',
    apiId: 'xx'
  }
}
```