### PR TITLE
[react-calendar-rimeline] Fix selected prop type

### DIFF
--- a/types/react-calendar-timeline/index.d.ts
+++ b/types/react-calendar-timeline/index.d.ts
@@ -202,7 +202,7 @@ declare module 'react-calendar-timeline' {
         defaultTimeEnd?: Date | Moment | undefined;
         visibleTimeStart?: Date | Moment | number | undefined;
         visibleTimeEnd?: Date | Moment | number | undefined;
-        selected?: number[] | undefined;
+        selected?: Id[] | undefined;
         sidebarWidth?: number | undefined;
         sidebarContent?: React.ReactNode | undefined;
         rightSidebarWidth?: number | undefined;

--- a/types/react-calendar-timeline/react-calendar-timeline-tests.tsx
+++ b/types/react-calendar-timeline/react-calendar-timeline-tests.tsx
@@ -50,23 +50,23 @@ type TimelineGroupCustom = TimelineGroup<{ data: string }>;
 type TimelineItemCustom = TimelineItem<{ data: string }, Moment>;
 
 const groups2: TimelineGroupCustom[] = [
-    { id: 1, title: 'group 1', data: '1' },
-    { id: 2, title: 'group 2', data: '1' },
+    { id: '1', title: 'group 1', data: '1' },
+    { id: 'two', title: 'group 2', data: '1' },
 ];
 
 const items2: TimelineItemCustom[] = [
-    { id: 1, group: 1, title: 'item 1', start_time: moment(), end_time: moment().add(1, 'hour'), data: '1' },
+    { id: '1', group: '1', title: 'item 1', start_time: moment(), end_time: moment().add(1, 'hour'), data: '1' },
     {
-        id: 2,
-        group: 2,
+        id: '2',
+        group: 'two',
         title: 'item 2',
         start_time: moment().add(-0.5, 'hour'),
         end_time: moment().add(0.5, 'hour'),
         data: '1',
     },
     {
-        id: 3,
-        group: 1,
+        id: '3',
+        group: '1',
         title: 'item 3',
         start_time: moment().add(2, 'hour'),
         end_time: moment().add(3, 'hour'),
@@ -84,6 +84,7 @@ class ExampleOfUsingReactCalendarTimelineWithCustomGroupAndItemExtension extends
                     items={items2}
                     defaultTimeStart={moment().add(-12, 'hour')}
                     defaultTimeEnd={moment().add(12, 'hour')}
+                    selected={[1, 'two']}
                 />
             </div>
         );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/namespace-ee/react-calendar-timeline#selected>
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~

______

As shown [in the provided link](https://github.com/namespace-ee/react-calendar-timeline#selected), the `selected` prop accepts the same type as `item.id`, which is `number | string`. This type is already exposed as `Id` in here, but it wasn't used inside the `selected` prop.
