### PR TITLE
Add type definitions for postcss-media-query-parser

### DIFF
--- a/types/postcss-media-query-parser/index.d.ts
+++ b/types/postcss-media-query-parser/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for postcss-media-query-parser 0.2
+// Project: https://github.com/dryoma/postcss-media-query-parser
+// Definitions by: Remco Haszing <https://github.com/remcohaszing>
+//                 Masafumi Koba <https://github.com/ybiquitous>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type WalkerCallback = (node: Child, index: number, nodes: Child[]) => boolean | void;
+
+export interface Node {
+    type: string;
+    value: string;
+    after: string;
+    before: string;
+    sourceIndex: number;
+    nodes?: Child[];
+
+    walk(filter: string | RegExp, callback: WalkerCallback): void;
+    walk(callback: WalkerCallback): void;
+}
+
+export interface Child extends Node {
+    type: 'media-query' | 'media-feature-expression' | 'media-feature' | 'media-type' | 'colon' | 'value' | 'keyword';
+    parent: Node;
+}
+
+export interface Root extends Node {
+    type: 'media-query-list';
+}
+
+declare function mediaQueryParser(mediaQuery: string): Root;
+
+export default mediaQueryParser;

--- a/types/postcss-media-query-parser/index.d.ts
+++ b/types/postcss-media-query-parser/index.d.ts
@@ -12,7 +12,7 @@ export interface Node {
     after: string;
     before: string;
     sourceIndex: number;
-    nodes?: Child[];
+    nodes?: Child[] | undefined;
 
     walk(filter: string | RegExp, callback: WalkerCallback): void;
     walk(callback: WalkerCallback): void;

--- a/types/postcss-media-query-parser/postcss-media-query-parser-tests.ts
+++ b/types/postcss-media-query-parser/postcss-media-query-parser-tests.ts
@@ -1,0 +1,32 @@
+import mediaParser from 'postcss-media-query-parser';
+
+const mediaQueryString = '(max-width: 100px), not print';
+const result = mediaParser(mediaQueryString);
+
+// $ExpectType "media-query-list"
+result.type;
+
+// $ExpectType string
+result.value;
+
+// $ExpectType string
+result.after;
+
+// $ExpectType string
+result.before;
+
+// $ExpectType number
+result.sourceIndex;
+
+if (result.nodes) {
+    for (const node of result.nodes) {
+        node.type;
+    }
+}
+
+result.walk('', child => {
+    child.parent.type;
+});
+result.walk(child => {
+    child.parent.type;
+});

--- a/types/postcss-media-query-parser/tsconfig.json
+++ b/types/postcss-media-query-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "postcss-media-query-parser-tests.ts"
+    ]
+}

--- a/types/postcss-media-query-parser/tslint.json
+++ b/types/postcss-media-query-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
This has been extracted from
https://github.com/stylelint/stylelint/blob/main/types/postcss-media-query-parser/index.d.ts with the following modifications:

- `Node` was transformed from a class into an interface, because it’s not exported at runtime.
- Object literal types were transformed into interfaces.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

@ybiquitous I added you as a co-maintainer, because you wrote them originally in the Stylelint repository. If you don’t want this, please let me know and I’ll remove it.