### PR TITLE
Add type definitions for postcss-resolve-nested-selector

### DIFF
--- a/types/postcss-resolve-nested-selector/index.d.ts
+++ b/types/postcss-resolve-nested-selector/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for postcss-resolve-nested-selector 0.1
+// Project: https://github.com/davidtheclark/postcss-resolve-nested-selector
+// Definitions by: Remco Haszing <https://github.com/remcohaszing>
+//                 Masafumi Koba <https://github.com/ybiquitous>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Node } from 'postcss';
+
+/**
+ * Returns an array of selectors resolved from `selector`.
+ */
+declare function resolvedNestedSelector(selector: string, node: Node): string[];
+
+export = resolvedNestedSelector;

--- a/types/postcss-resolve-nested-selector/package.json
+++ b/types/postcss-resolve-nested-selector/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "postcss": "^8.0.0"
+    }
+}

--- a/types/postcss-resolve-nested-selector/postcss-resolve-nested-selector-tests.ts
+++ b/types/postcss-resolve-nested-selector/postcss-resolve-nested-selector-tests.ts
@@ -1,0 +1,9 @@
+import postcss from 'postcss';
+import resolvedNestedSelector = require('postcss-resolve-nested-selector');
+
+const processor = postcss();
+
+processor.process('').then(result => {
+    // $ExpectType string[]
+    resolvedNestedSelector('', result.root);
+});

--- a/types/postcss-resolve-nested-selector/tsconfig.json
+++ b/types/postcss-resolve-nested-selector/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es2018"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "postcss-resolve-nested-selector-tests.ts"
+    ]
+}

--- a/types/postcss-resolve-nested-selector/tslint.json
+++ b/types/postcss-resolve-nested-selector/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "@definitelytyped/dtslint/dt.json" }


### PR DESCRIPTION
This has been extracted from
https://github.com/stylelint/stylelint/blob/main/types/postcss-resolve-nested-selector/index.d.ts.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

@ybiquitous I added you as a co-maintainer, because you wrote them originally in the Stylelint repository. If you don’t want this, please let me know and I’ll remove it.