### PR TITLE
fix(sanitize-html): bump to 2.9

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sanitize-html 2.8
+// Type definitions for sanitize-html 2.9
 // Project: https://github.com/punkave/sanitize-html
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten>
 //                 Afshin Darian <https://github.com/afshin>
@@ -71,6 +71,8 @@ declare namespace sanitize {
     exclusiveFilter?: ((frame: IFrame) => boolean) | undefined;
     nestingLimit?: number | undefined;
     nonTextTags?: string[] | undefined;
+    /** @default true */
+    parseStyleAttributes?: boolean | undefined;
     selfClosing?: string[] | undefined;
     transformTags?: { [tagName: string]: string | Transformer } | undefined;
     parser?: ParserOptions | undefined;

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -74,4 +74,5 @@ sanitize(unsafe, {
     allowedTags: false,
     allowedAttributes: false,
     nestingLimit: 6,
+    parseStyleAttributes: false,
 });


### PR DESCRIPTION
- support `parseStyleAttributes`

https://github.com/apostrophecms/sanitize-html/releases/tag/2.9.0

/cc @vishaltyagi-jtg

Thanks!

Fixes #64725


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.