### PR TITLE
prompts: revert make `PromptObject.message` required

### DIFF
--- a/types/prompts/index.d.ts
+++ b/types/prompts/index.d.ts
@@ -79,7 +79,7 @@ declare namespace prompts {
     interface PromptObject<T extends string = string> {
         type: PromptType | Falsy | PrevCaller<T, PromptType | Falsy>;
         name: ValueOrFunc<T>;
-        message: ValueOrFunc<string>;
+        message?: ValueOrFunc<string> | undefined;
         initial?: InitialReturnValue | PrevCaller<T, InitialReturnValue | Promise<InitialReturnValue>> | undefined;
         style?: string | PrevCaller<T, string | Falsy> | undefined;
         format?: PrevCaller<T, void> | undefined;

--- a/types/prompts/prompts-tests.ts
+++ b/types/prompts/prompts-tests.ts
@@ -204,25 +204,3 @@ type HasProperty<T, K> = K extends keyof T ? true : false;
         initial: async () => new Date()
     });
 })();
-
-// expect required PromptObject fields
-(async () => {
-    // missing 'type' key
-    // @ts-expect-error
-    const response = await prompts({
-        name: 'value',
-        message: 'true'
-    });
-    // missing 'name' key
-    // @ts-expect-error
-    const response = await prompts({
-        type: 'number',
-        message: 'true'
-    });
-    // missing 'message' key
-    // @ts-expect-error
-    const response = await prompts({
-        type: 'number',
-        name: 'value',
-    });
-})();


### PR DESCRIPTION
#64687 wasn't entirely correct as when `type` returns falsy the Error is not thrown, reverting is the best option right now.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64687#issuecomment-1465655379

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64687#issuecomment-1465655379
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.