### PR TITLE
Update vk-openapi tests

### DIFF
--- a/types/vk-openapi/vk-openapi-tests.ts
+++ b/types/vk-openapi/vk-openapi-tests.ts
@@ -2248,7 +2248,7 @@ const params2: vk.OpenAPI.Retargeting.ProductEventParams = {
     // @ts-expect-error
     business_value: '100',
     // @ts-expect-error
-    currency_code: 007,
+    currency_code: 0o7,
     // @ts-expect-error
     total_price: '666',
     // @ts-expect-error


### PR DESCRIPTION
Old-style octal literals become syntax errors in an upcoming TS PR: https://github.com/microsoft/TypeScript/pull/51837 But syntax errors can't be silenced with ts-expect-error, and the octal literal is not important to the vk-openapi test in question, so change it to use new octal syntax.
