### PR TITLE
[metro] Fix types on 0.76

### DIFF
--- a/types/metro-config/configTypes.d.ts
+++ b/types/metro-config/configTypes.d.ts
@@ -178,21 +178,23 @@ export interface WatcherConfigT {
     };
 }
 
-export interface WatcherInputConfigT extends Omit<WatcherConfigT, 'healthCheck'> {
+export interface WatcherInputConfigT extends Partial<Omit<WatcherConfigT, 'healthCheck'>> {
     healthCheck?: Partial<WatcherConfigT['healthCheck']>;
 }
 
-export interface InputConfigT extends Omit<MetalConfigT, 'cacheStores'> {
+export interface InputConfigT extends Partial<Omit<MetalConfigT, 'cacheStores'>> {
     readonly cacheStores?:
         | ReadonlyArray<CacheStore<TransformResult>>
         | ((metroCache: MetroCache) => ReadonlyArray<CacheStore<TransformResult>>);
-    readonly resolver?: ResolverConfigT;
-    readonly server?: ServerConfigT;
-    readonly serializer?: SerializerConfigT;
-    readonly symbolicator?: SymbolicatorConfigT;
-    readonly transformer?: TransformerConfigT;
+    readonly resolver?: Partial<ResolverConfigT>;
+    readonly server?: Partial<ServerConfigT>;
+    readonly serializer?: Partial<SerializerConfigT>;
+    readonly symbolicator?: Partial<SymbolicatorConfigT>;
+    readonly transformer?: Partial<TransformerConfigT>;
     readonly watcher?: Partial<WatcherInputConfigT>;
 }
+
+export type MetroConfig = InputConfigT;
 
 export interface IntermediateConfigT extends MetalConfigT {
     resolver: ResolverConfigT;

--- a/types/metro-config/loadConfig.d.ts
+++ b/types/metro-config/loadConfig.d.ts
@@ -10,4 +10,4 @@ export function loadConfig(argv?: YargArguments, defaultConfigOverrides?: InputC
 
 export function resolveConfig(filePath?: string, cwd?: string): Promise<ConfigT>;
 
-export function mergeConfig(defaultConfig: InputConfigT, ...configs: InputConfigT[]): Promise<ConfigT>;
+export function mergeConfig(defaultConfig: InputConfigT, ...configs: InputConfigT[]): ConfigT;

--- a/types/metro-resolver/types.d.ts
+++ b/types/metro-resolver/types.d.ts
@@ -131,7 +131,11 @@ export interface CustomResolutionContext extends ResolutionContext {
     readonly resolveRequest: CustomResolver;
 }
 
-export type CustomResolver = (context: ResolutionContext, moduleName: string, platform: string | null) => Resolution;
+export type CustomResolver = (
+    context: CustomResolutionContext,
+    moduleName: string,
+    platform: string | null,
+) => Resolution;
 
 export type CustomResolverOptions = Readonly<{
     [option: string]: unknown;


### PR DESCRIPTION
Small set of fixes following https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64735 — encountered while consuming these types in [react-native-community/cli](https://github.com/react-native-community/cli).

I'm assuming that `typescript-bot` can ship this as a patch release.