### PR TITLE
gpt: slot.getResponseInformation() might be null

### DIFF
--- a/types/doubleclick-gpt/doubleclick-gpt-tests.ts
+++ b/types/doubleclick-gpt/doubleclick-gpt-tests.ts
@@ -490,6 +490,9 @@ googletag.display(new HTMLElement());
 // googletag.display accepts a slot
 googletag.display(slot);
 
+// ResponseInformation is available after the SlotOnloadEvent (only if an ad returned).
+slot.getResponseInformation();
+
 // pubads.display accepts a div element.
 googletag.pubads().display("/1234567/science", [300, 250], new HTMLElement());
 

--- a/types/doubleclick-gpt/index.d.ts
+++ b/types/doubleclick-gpt/index.d.ts
@@ -130,7 +130,7 @@ declare namespace googletag {
         getAdUnitPath(): string;
         getAttributeKeys(): string[];
         getCategoryExclusions(): string[];
-        getResponseInformation(): ResponseInformation;
+        getResponseInformation(): ResponseInformation | null;
         getSlotElementId(): string;
         getTargeting(key: string): string[];
         getTargetingKeys(): string[];


### PR DESCRIPTION
GPT's documentation: https://developers.google.com/publisher-tag/reference#googletag.Slot_getResponseInformation

<img width="902" alt="image" src="https://user-images.githubusercontent.com/640840/225430163-1a205e0b-ab67-4baa-b453-35af3754f369.png">
