### PR TITLE
[RFC] Make all refs mutable

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -80,7 +80,7 @@ declare namespace React {
         | (new (props: P) => Component<any, any>);
 
     interface RefObject<T> {
-        readonly current: T | null;
+        current: T | null;
     }
     // Bivariance hack for consistent unsoundness with RefObject
     type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
@@ -541,7 +541,7 @@ declare namespace React {
         displayName?: string | undefined;
     }
 
-    type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
+    type ForwardedRef<T> = ((instance: T | null) => void) | RefObject<T | null> | null;
 
     interface ForwardRefRenderFunction<T, P = {}> {
         (props: P, ref: ForwardedRef<T>): ReactElement | null;
@@ -876,10 +876,6 @@ declare namespace React {
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
     type EffectCallback = () => (void | Destructor);
 
-    interface MutableRefObject<T> {
-        current: T;
-    }
-
     // This will technically work if you give a Consumer<T> or Provider<T> but it's deprecated and warns
     /**
      * Accepts a context object (the value returned from `React.createContext`) and returns the current
@@ -1005,7 +1001,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    function useRef<T>(initialValue: T): MutableRefObject<T>;
+    function useRef<T>(initialValue: T): RefObject<T>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1006,34 +1006,6 @@ declare namespace React {
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
     function useRef<T>(initialValue: T): MutableRefObject<T>;
-    // convenience overload for refs given as a ref prop as they typically start with a null value
-    /**
-     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
-     * (`initialValue`). The returned object will persist for the full lifetime of the component.
-     *
-     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
-     * value around similar to how you’d use instance fields in classes.
-     *
-     * Usage note: if you need the result of useRef to be directly mutable, include `| null` in the type
-     * of the generic argument.
-     *
-     * @version 16.8.0
-     * @see https://reactjs.org/docs/hooks-reference.html#useref
-     */
-    function useRef<T>(initialValue: T|null): RefObject<T>;
-    // convenience overload for potentially undefined initialValue / call with 0 arguments
-    // has a default to stop it from defaulting to {} instead
-    /**
-     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
-     * (`initialValue`). The returned object will persist for the full lifetime of the component.
-     *
-     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
-     * value around similar to how you’d use instance fields in classes.
-     *
-     * @version 16.8.0
-     * @see https://reactjs.org/docs/hooks-reference.html#useref
-     */
-    function useRef<T = undefined>(): MutableRefObject<T | undefined>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -876,6 +876,10 @@ declare namespace React {
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
     type EffectCallback = () => (void | Destructor);
 
+    // These types were previously distinct, but that was not correct: all refs are technically mutable.
+    // TODO: Remove MutableRefObject completely in a future version.
+    type MutableRefObject<T> = RefObject<T>;
+
     // This will technically work if you give a Consumer<T> or Provider<T> but it's deprecated and warns
     /**
      * Accepts a context object (the value returned from `React.createContext`) and returns the current
@@ -1002,6 +1006,31 @@ declare namespace React {
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
     function useRef<T>(initialValue: T): RefObject<T>;
+    // convenience overload for refs given as a ref prop as they typically start with a null value
+    /**
+     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+     * (`initialValue`). The returned object will persist for the full lifetime of the component.
+     *
+     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+     * value around similar to how you’d use instance fields in classes.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#useref
+     */
+    function useRef<T>(initialValue: T|null): RefObject<T>;
+    // convenience overload for potentially undefined initialValue / call with 0 arguments
+    // has a default to stop it from defaulting to {} instead
+    /**
+     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+     * (`initialValue`). The returned object will persist for the full lifetime of the component.
+     *
+     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+     * value around similar to how you’d use instance fields in classes.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#useref
+     */
+    function useRef<T = undefined>(): RefObject<T | undefined>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside


### PR DESCRIPTION
This probably doesn't build etc but I wanted to kick off the discussion.

In [this tweet](https://twitter.com/mattpocockuk/status/1636098722982404096), we see two consequences of how the `useRef` types are set up:

- `useRef(null)` "opts into" `RefObject` with `readonly current` (instead of `MutableRefObject`). This is very unintuitive — there is really no special meaning to `null` as an argument except that the types claim that.
- <s>Also, `useRef()` without an argument probably doesn't make sense — we consider the initial value conceptually required.</s>

In this PR:

- [ ] <s>What if we remove these overloads and keep it plain `useRef<T>(initialValue: T): { current: T }`? I think that's what we originally defined it as (at least, that's how it appears in the React code). I get that it might be a PITA now but I was wondering how bad it is, and would it be worth to remove the confusing gotchas.</s>

- [x] I'm also wondering if it makes sense to keep the `MutableRefObject` vs `RefObject` distinction, or not. I think I agree with @ferdaber in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30036/files#r229452449.

I'd like to chat whether this is desirable. If yes, what's the path to shipping it and how much would it break. Thanks.