### PR TITLE
fix(metro-config): return type of GetTransformOptions should be partial

### DIFF
--- a/types/metro-config/configTypes.d.ts
+++ b/types/metro-config/configTypes.d.ts
@@ -33,7 +33,7 @@ export type GetTransformOptions = (
     entryPoints: ReadonlyArray<string>,
     options: GetTransformOptionsOpts,
     getDependenciesOf: (filePath: string) => Promise<string[]>,
-) => Promise<ExtraTransformOptions>;
+) => Promise<Partial<ExtraTransformOptions>>;
 
 export type Middleware = (
     incomingMessage: IncomingMessage,

--- a/types/metro-config/test/configTypes-tests.ts
+++ b/types/metro-config/test/configTypes-tests.ts
@@ -36,11 +36,24 @@ export const getTransformOptionsOpts: GetTransformOptionsOpts = {
 };
 
 export const getTransformOptions: GetTransformOptions = (
-    entryPoints: ReadonlyArray<string>,
-    options: GetTransformOptionsOpts,
-    getDependenciesOf: (filePath: string) => Promise<string[]>,
-): Promise<ExtraTransformOptions> => {
+    entryPoints,
+    options,
+    getDependenciesOf,
+) => {
     return Promise.resolve(extraTransformOptions);
+};
+
+export const getTransformOptionsPartial: GetTransformOptions = (
+    entryPoints,
+    options,
+    getDependenciesOf,
+) => {
+    return Promise.resolve({
+        transform: {
+            experimentalImportSupport: true,
+            inlineRequires: false,
+        },
+    });
 };
 
 export const middleware: Middleware = (
@@ -123,14 +136,8 @@ export const transformerConfig: TransformerConfigT = {
     unstable_disableModuleWrapping: true,
     unstable_disableNormalizePseudoGlobals: true,
     unstable_compactOutput: true,
-    getTransformOptions: async (
-        entryPoints: ReadonlyArray<string>,
-        options: GetTransformOptionsOpts,
-        getDependenciesOf: (filePath: string) => Promise<string[]>,
-    ): Promise<ExtraTransformOptions> => {
+    getTransformOptions: async (entryPoints, options, getDependenciesOf) => {
         return {
-            preloadedModules: {},
-            ramGroups: [],
             transform: {
                 experimentalImportSupport: false,
                 inlineRequires: false,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/0a3c55562b5ba43b00c21ca4d7b2cba0c8eb6206/template/metro.config.js#LL10-L15C8
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.