### PR TITLE
[ssh2] update SigningRequestOptions to make `hash` optional

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1798,7 +1798,7 @@ export interface AgentInboundRequest {
 }
 
 export interface SigningRequestOptions {
-    hash: 'sha256' | 'sha512';
+    hash?: 'sha1' | 'sha256' | 'sha512';
 }
 
 export class AgentProtocol extends Duplex {

--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -501,7 +501,8 @@ new ssh2.Client().connect({
         }
         sign(publicKey: string, data: Buffer, options: ssh2.SigningRequestOptions | ssh2.SignCallback, callback?: ssh2.SignCallback): void {
             const cb = typeof options === 'function' ? options : callback;
-            cb && cb(undefined, Buffer.concat([Buffer.from(publicKey), data]));
+            const hash = typeof options !== 'function' && options?.hash ? options.hash : 'sha1';
+            cb && cb(undefined, Buffer.concat([Buffer.from(hash), Buffer.from(publicKey), data]));
         }
     })()
 });


### PR DESCRIPTION
The ssh2 library doesn't always supply a hash prop to the options object and (in those instances) the default algorithm for ssh is 'sha1'.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/ssh2/blob/v1.11.0/lib/client.js#L392-L401
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.~
