### PR TITLE
Allow jsonwebtoken to use empty key with algorith none on sign (not on verify).

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -178,6 +178,11 @@ export function sign(
     secretOrPrivateKey: Secret,
     options?: SignOptions,
 ): string;
+export function sign(
+    payload: string | Buffer | object,
+    secretOrPrivateKey: null,
+    options?: SignOptions & { algorithm: "none" },
+): string;
 
 /**
  * Sign the given payload into a JSON Web Token string
@@ -195,6 +200,12 @@ export function sign(
     payload: string | Buffer | object,
     secretOrPrivateKey: Secret,
     options: SignOptions,
+    callback: SignCallback,
+): void;
+export function sign(
+    payload: string | Buffer | object,
+    secretOrPrivateKey: null,
+    options: SignOptions & { algorithm: "none" },
     callback: SignCallback,
 ): void;
 

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -57,8 +57,38 @@ token = jwt.sign({ foo: 'bar' }, 'shhhhh', { algorithm: 'RS256', allowInsecureKe
 // sign with invalid asymmetric key type for algorithm
 token = jwt.sign({ foo: 'bar' }, 'shhhhh', { algorithm: 'RS256', allowInvalidAsymmetricKeyTypes: true });
 
+// sign with algorithm none
+token = jwt.sign(testObject, null, { algorithm: "none" });
+// @ts-expect-error
+token = jwt.sign({ foo: 'bar' }, null, { algorithm: 'RS256', allowInvalidAsymmetricKeyTypes: true });
+
 // sign asynchronously
 jwt.sign(testObject, cert, { algorithm: "RS256" }, (
+    err: Error | null,
+    token: string | undefined,
+) => {
+    if (err) {
+        console.log(err);
+        return;
+    }
+
+    console.log(token);
+});
+
+// sign asynchronously with algorithm none
+jwt.sign(testObject, null, { algorithm: "none" }, (
+    err: Error | null,
+    token: string | undefined,
+) => {
+    if (err) {
+        console.log(err);
+        return;
+    }
+
+    console.log(token);
+});
+// @ts-expect-error
+jwt.sign(testObject, null, { algorithm: "RS256" }, (
     err: Error | null,
     token: string | undefined,
 ) => {


### PR DESCRIPTION
Algorithm none is (of course) insecure, but it is a part of JWT standard. I am using it in tests, to test that my server doesn't let an unsigned JWT in.

I was thinking about also adding it somehow to verify, but that seemed a little harder and honestly shouldn't be really used :)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
        - there is none, but the code is here - https://github.com/auth0/node-jsonwebtoken/blob/e1fa9dcc12054a8681db4e6373da1b30cf7016e3/sign.js#L104
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
