### PR TITLE
feat(geometric): Add optional epsilon type on supported functions

### DIFF
--- a/types/geometric/geometric-tests.ts
+++ b/types/geometric/geometric-tests.ts
@@ -58,3 +58,6 @@ const t36: Polygon = geometric.polygonTranslate(polygon, 45, 100);
 const t37: Line = geometric.lineRotate(line, 1);
 const t38: Polygon = geometric.polygonScaleX(polygon, 1.2);
 const t39: Polygon = geometric.polygonScaleY(polygon, 1.2);
+const t40: boolean = geometric.pointOnLine(point, line, 1e-10);
+const t41: boolean = geometric.pointOnPolygon(point, polygon, 1e-10);
+const t42: boolean = geometric.pointWithLine(point, line, 1e-10);

--- a/types/geometric/index.d.ts
+++ b/types/geometric/index.d.ts
@@ -171,19 +171,23 @@ export function pointInPolygon(point: Point, polygon: Polygon): boolean;
 
 /**
  * Returns a boolean representing whether a point is located on one of the edges of a polygon.
+ * An optional epsilon number, such as 1e-6, can be passed to reduce the precision with which the relationship is measured.
  */
-export function pointOnPolygon(point: Point, polygon: Polygon): boolean;
+export function pointOnPolygon(point: Point, polygon: Polygon, epsilon?: number): boolean;
 
 /**
  * Returns a boolean representing whether a point is collinear with a line and is also located on the line segment.
+ * An optional epsilon number, such as 1e-6, can be passed to reduce the precision with which the relationship is measured.
  * See also pointWithLine.
  */
-export function pointOnLine(point: Point, line: Line): boolean;
+export function pointOnLine(point: Point, line: Line, epsilon?: number): boolean;
 
 /**
- * Returns a boolean representing whether a point is collinear with a line. See also pointOnLine.
+ * Returns a boolean representing whether a point is collinear with a line.
+ * An optional epsilon number, such as 1e-6, can be passed to reduce the precision with which the relationship is measured.
+ * See also pointOnLine.
  */
-export function pointWithLine(point: Point, line: Line): boolean;
+export function pointWithLine(point: Point, line: Line, epsilon?: number): boolean;
 
 /**
  * Returns a boolean representing whether a point is to the left of a line.


### PR DESCRIPTION
Updated functions: `pointOnLine`, `pointWithLine` and `pointOnPolygon` 
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [see changes](https://github.com/HarryStevens/geometric/commit/d1e08aaed735fdb86c29b43b120165f577488dfb)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
