### PR TITLE
Revert "🤖 Merge PR #64711 Update api-gateway-authorizer.d.ts

### DIFF
--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -574,7 +574,6 @@ const simpleRequestAuthorizerV2WithContext: APIGatewayRequestSimpleAuthorizerHan
 const iamRequestAuthorizerV2: APIGatewayRequestIAMAuthorizerHandlerV2 = async (event, context, callback) => {
     str = event.version;
     str = event.type;
-    str = event.methodArn;
     str = event.routeArn;
     array = event.identitySource;
     str = event.routeKey;

--- a/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
@@ -34,7 +34,6 @@ export interface APIGatewayTokenAuthorizerEvent {
 export interface APIGatewayRequestAuthorizerEventV2 {
     version: string;
     type: 'REQUEST';
-    methodArn: string;
     routeArn: string;
     identitySource: string[];
     routeKey: string;


### PR DESCRIPTION
This reverts commit 8f16470808707495a8f5b1b69431305f9224f3da.

As described at [Working with AWS Lambda authorizers for HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html) there are different versions of the authorizer-request-payload.

The example of #64711 is payload v1 which has type definition `APIGatewayRequestAuthorizerEvent` and contains `methodArn`.

Payload v2 does **not** contain `methodArn` but `routeArn` and has type definition `APIGatewayRequestAuthorizerEventV2`.