### PR TITLE
[jsrsasign]: add overload for KEYUTIL.generateKeypair

### DIFF
--- a/types/jsrsasign/jsrsasign-tests.ts
+++ b/types/jsrsasign/jsrsasign-tests.ts
@@ -27,6 +27,9 @@ new KJUR.asn1.x509.AuthorityKeyIdentifier({
 
 KEYUTIL.getKey('pemPKCS1PrivateKey');
 
+KEYUTIL.generateKeypair('RSA', 2048); // $ExpectType { prvKeyObj: RSAKey; pubKeyObj: RSAKey; }
+KEYUTIL.generateKeypair('EC', 'secp256r1'); // $ExpectType { prvKeyObj: ECDSA; pubKeyObj: ECDSA; }
+
 const key = new RSAKey();
 key.signWithMessageHash('1234', 'sha256');
 

--- a/types/jsrsasign/modules/KEYUTIL.d.ts
+++ b/types/jsrsasign/modules/KEYUTIL.d.ts
@@ -441,31 +441,52 @@ declare namespace jsrsasign {
         parsePublicPKCS8Hex(pkcs8PubHex: string): PublicPKCS8HexResult;
 
         /**
-         * @param alg 'RSA' or 'EC'
-         * @param keylenOrCurve key length for RSA or curve name for EC
+         * @param alg 'RSA'
+         * @param keylen key length
          * @return associative array of keypair which has prvKeyObj and pubKeyObj parameters
          * @description
          * This method generates a key pair of public key algorithm.
          * The result will be an associative array which has following
          * parameters:
          *
-         * - prvKeyObj - RSAKey or ECDSA object of private key
-         * - pubKeyObj - RSAKey or ECDSA object of public key
+         * - prvKeyObj - RSAKey object of private key
+         * - pubKeyObj - RSAKey object of public key
          *
-         * NOTE1: As for RSA algoirthm, public exponent has fixed
-         * value '0x10001'.
-         * NOTE2: As for EC algorithm, supported names of curve are
-         * secp256r1, secp256k1 and secp384r1.
-         * NOTE3: DSA is not supported yet.
+         * NOTE1: public exponent has fixed value '0x10001'.
+         * NOTE2: DSA algorithm is not supported yet.
          * @example
          * var rsaKeypair = KEYUTIL.generateKeypair("RSA", 1024);
          * var ecKeypair = KEYUTIL.generateKeypair("EC", "secp256r1");
          *
          */
         static generateKeypair(
-            alg: 'RSA' | 'EC',
-            keylenOrCurve: number | string,
-        ): { prvKeyObj: RSAKey | KJUR.crypto.ECDSA; pubKeyObj: RSAKey | KJUR.crypto.ECDSA };
+            alg: 'RSA',
+            keylen: number,
+        ): { prvKeyObj: RSAKey; pubKeyObj: RSAKey };
+
+        /**
+         * @param alg 'EC'
+         * @param curve curve name
+         * @return associative array of keypair which has prvKeyObj and pubKeyObj parameters
+         * @description
+         * This method generates a key pair of public key algorithm.
+         * The result will be an associative array which has following
+         * parameters:
+         *
+         * - prvKeyObj - ECDSA object of private key
+         * - pubKeyObj - ECDSA object of public key
+         *
+         * NOTE1: supported names of curve are secp256r1, secp256k1 and
+         * secp384r1.
+         * NOTE2: DSA algorithm is not supported yet.
+         * @example
+         * var ecKeypair = KEYUTIL.generateKeypair("EC", "secp256r1");
+         *
+         */
+        static generateKeypair(
+            alg: 'EC',
+            curve: 'secp256r1' | 'secp256k1' | 'secp384r1',
+        ): { prvKeyObj: KJUR.crypto.ECDSA; pubKeyObj: KJUR.crypto.ECDSA };
 
         /**
          * decrypt PEM formatted protected PKCS#5 private key with passcode


### PR DESCRIPTION
This adds better ergonomics for users of `KEYUTIL.generateKeypair`, as it's no longer needed to cast the result to the correct type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [KEYUTIL.html#.generateKeypair](https://kjur.github.io/jsrsasign/api/symbols/KEYUTIL.html#.generateKeypair)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.