### PR TITLE
Fix use-color-scheme test for TS 5.1

### DIFF
--- a/types/use-color-scheme/use-color-scheme-tests.ts
+++ b/types/use-color-scheme/use-color-scheme-tests.ts
@@ -5,4 +5,4 @@ _useColorScheme.getPreference(["dark", "light"]);
 _useColorScheme.makeQuery("light");
 _useColorScheme.matchPreference("no-preference");
 _useColorScheme.useColorScheme();
-_useColorScheme.values[0]; // $ExpectType "dark" | "light" | "no-preference"
+_useColorScheme.values[0]; // $ExpectType "dark" | "light" | "no-preference" || "no-preference" | "dark" | "light"


### PR DESCRIPTION
This union ordering appears to have changed in TS 5.1.

I bisected it to https://github.com/microsoft/TypeScript/pull/53133; I _think_ what's happening is that the DOM types now include the string literal `"no-preference"`, and so it's getting a lower type ID for union sorting.

Why we're not checking the _origin_ union, or using hover, or something, no clue, but just make this work.