### PR TITLE
mdast: fix a couple incorrectly-keyed ContentMap entries

### DIFF
--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -31,7 +31,7 @@ export type ReferenceType = 'shortcut' | 'collapsed' | 'full';
 export interface BlockContentMap {
     paragraph: Paragraph;
     heading: Heading;
-    thematicbreak: ThematicBreak;
+    thematicBreak: ThematicBreak;
     blockquote: Blockquote;
     list: List;
     table: Table;
@@ -92,12 +92,12 @@ export interface StaticPhrasingContentMap {
     strong: Strong;
     delete: Delete;
     html: HTML;
-    inlinecode: InlineCode;
+    inlineCode: InlineCode;
     break: Break;
     image: Image;
-    imagereference: ImageReference;
+    imageReference: ImageReference;
     footnote: Footnote;
-    footnotereference: FootnoteReference;
+    footnoteReference: FootnoteReference;
 }
 
 /**

--- a/types/mdast/mdast-tests.ts
+++ b/types/mdast/mdast-tests.ts
@@ -94,5 +94,30 @@ const link: Mdast.Link = {
     type: 'link',
     children: [text],
     url: 'https://example.com',
-    title: null
+    title: null,
 };
+
+// Combination of all the declared ContentMap interfaces.
+interface ContentMap
+    extends Mdast.BlockContentMap,
+        Mdast.DefinitionContentMap,
+        Mdast.FrontmatterContentMap,
+        Mdast.ListContentMap,
+        Mdast.PhrasingContentMap,
+        Mdast.RowContentMap,
+        Mdast.StaticPhrasingContentMap,
+        Mdast.TableContentMap {}
+
+// Type with all …ContentMap keys corresponding to something whose `{type: "…"}` field does not match the key.
+// This should be empty. A previous version of these type definitions named a few entries like
+// "inlinecode" referring to a type keyed as "inlineCode", and so on.
+//
+// The ContentMap interfaces themselves aren't used at runtime: they're just groupings of types.
+// However that inconsistency prevented them from being used for things like defining rendering/handling
+// functions keyed on the node type names.
+type TypeMapIssues<M extends {}> = {
+    [K in keyof M as M[K] extends { type: K } ? never : K]: [K, M[K]];
+};
+
+// Assert that there are no incorrect keys. If there are, this is not assignable.
+const typeMapIssues: TypeMapIssues<ContentMap> = {};


### PR DESCRIPTION
A few of the `…ContentMap` entries were declared inconsistently from the type tags of the nodes they described.

This means they were not usable as actual type maps for things like mapped handler types.

(Note that the `…ContentMap` interfaces declare groupings of types, i.e. they do not directly represent runtime objects).

This fixes those few entries (thematicbreak ⇒ thematicBreak; inlineCode, imageReference, footnoteReference) and adds a type test asserting that all of the content map types in this module are self-consistent.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/syntax-tree/mdast
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
