### PR TITLE
[koa] Fix return type of callback function

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -516,7 +516,7 @@ declare class Application<
      * Return a request handler callback
      * for node's native http/http2 server.
      */
-    callback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => void;
+    callback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
 
     /**
      * Initialize a new context.


### PR DESCRIPTION
Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[`callback` returns `handleRequest` result](https://github.com/koajs/koa/blob/bec13ecccdf7c734bccd5dd0ee9892621415af41/lib/application.js#L163) and [`handleRequest` returns a void promise](https://github.com/koajs/koa/blob/bec13ecccdf7c734bccd5dd0ee9892621415af41/lib/application.js#L188).

Small thing to remove wrong ts warning of `'await' has no effect on the type of this expression.` for a callback call.