### PR TITLE
Remove unused package.json files

### DIFF
--- a/types/apptimize__apptimize-web-sdk/package.json
+++ b/types/apptimize__apptimize-web-sdk/package.json
@@ -1,4 +1,0 @@
-{
-    "private": true,
-    "dependencies": {}
-}

--- a/types/arangodb/package.json
+++ b/types/arangodb/package.json
@@ -1,4 +1,0 @@
-{
-  "private": true,
-  "dependencies": {}
-}

--- a/types/crocks/package.json
+++ b/types/crocks/package.json
@@ -1,3 +1,0 @@
-{
-    "private": true
-}

--- a/types/cron/package.json
+++ b/types/cron/package.json
@@ -1,3 +1,0 @@
-{
-    "private": true
-}

--- a/types/eyevinn-iaf/package.json
+++ b/types/eyevinn-iaf/package.json
@@ -1,4 +1,0 @@
-{
-  "private": true,
-  "dependencies": {}
-}

--- a/types/gestalt-datepicker/package.json
+++ b/types/gestalt-datepicker/package.json
@@ -1,3 +1,0 @@
-{
-    "private": true
-}

--- a/types/iitc/package.json
+++ b/types/iitc/package.json
@@ -1,3 +1,0 @@
-{
-    "private": true
-}

--- a/types/mock-knex/package.json
+++ b/types/mock-knex/package.json
@@ -1,3 +1,0 @@
-{
-    "private": true
-}

--- a/types/react-beautiful-dnd/package.json
+++ b/types/react-beautiful-dnd/package.json
@@ -1,3 +1,0 @@
-{
-    "private": true
-}

--- a/types/react-beautiful-dnd/v12/package.json
+++ b/types/react-beautiful-dnd/v12/package.json
@@ -1,3 +1,0 @@
-{
-    "private": true
-}

--- a/types/react-ellipsis-with-tooltip/package.json
+++ b/types/react-ellipsis-with-tooltip/package.json
@@ -1,3 +1,0 @@
-{
-    "private": true
-}

--- a/types/react-native-zss-rich-text-editor/package.json
+++ b/types/react-native-zss-rich-text-editor/package.json
@@ -1,4 +1,0 @@
-{
-    "private": true,
-    "dependencies": {}
-}

--- a/types/watchpack/package.json
+++ b/types/watchpack/package.json
@@ -1,3 +1,0 @@
-{
-  "private": true
-}


### PR DESCRIPTION
All of these package.json files are empty and can be safely removed. This saves a _little_ CI time installing empty packages.

I feel like this should be a lint rule.