### PR TITLE
Fix waterline for fixed TS bug

### DIFF
--- a/types/waterline/waterline-tests.ts
+++ b/types/waterline/waterline-tests.ts
@@ -119,7 +119,6 @@ const Person = Waterline.Collection.extend({
 });
 const attributes: Waterline.Attribute = {
     type: 'string',
-    autoIncrement: true,
     required: true,
 };
 


### PR DESCRIPTION
See: https://github.com/microsoft/TypeScript/pull/51884#issuecomment-1472736068

This property is now correctly detected as excess in TS 5.1.