### PR TITLE
[jsrsasign]: fix return type of RSAKey.verifyWithMessageHash

### DIFF
--- a/types/jsrsasign/jsrsasign-tests.ts
+++ b/types/jsrsasign/jsrsasign-tests.ts
@@ -28,7 +28,9 @@ new KJUR.asn1.x509.AuthorityKeyIdentifier({
 KEYUTIL.getKey('pemPKCS1PrivateKey');
 
 const key = new RSAKey();
-key.signWithMessageHash('1234', 'sha256');
+const sig = key.signWithMessageHash('1234', 'sha256');
+
+key.verifyWithMessageHash('1234', sig); // $ExpectType boolean
 
 b64toBA('ZXhhbXBsZQ=='); // $ExpectType number[]
 b64tohex('ZXhhbXBsZQ=='); // $ExpectType string

--- a/types/jsrsasign/modules/RSAKey.d.ts
+++ b/types/jsrsasign/modules/RSAKey.d.ts
@@ -133,9 +133,9 @@ declare namespace jsrsasign {
          * @param sHashHex hexadecimal hash value of message to be verified.
          * @param hSig hexadecimal string of siganture.
          *                 non-hexadecimal charactors including new lines will be ignored.
-         * @return returns 1 if valid, otherwise 0
+         * @return returns true if valid, otherwise false
          */
-        verifyWithMessageHash(sHashHex: string, hSig: string): 0 | 1;
+        verifyWithMessageHash(sHashHex: string, hSig: string): boolean;
 
         /**
          * verifies a sigature for a hash value of message string with RSA public key by PKCS#1 PSS sign.


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [RSAKey.html#.verifyWithMessageHash](https://kjur.github.io/jsrsasign/api/symbols/RSAKey.html#.verifyWithMessageHash)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.