### PR TITLE
[openui5] Update the definition files for OpenUI5 1.112

### DIFF
--- a/types/openui5/index.d.ts
+++ b/types/openui5/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for OpenUI5 1.111
+// Type definitions for OpenUI5 1.112
 // Project: https://github.com/SAP/openui5
 // Definitions by: OpenUI5 Bot <https://github.com/openui5bot>
 //                 Peter Muessig <https://github.com/petermuessig>

--- a/types/openui5/openui5-tests.ts
+++ b/types/openui5/openui5-tests.ts
@@ -28,6 +28,7 @@ import NumberFormat from "sap/ui/core/format/NumberFormat";
 import CalendarUtils from "sap/ui/core/date/CalendarUtils";
 import PlanningCalendar from "sap/m/PlanningCalendar";
 import WebSocket from "sap/ui/core/ws/WebSocket";
+import QUnit from "sap/ui/thirdparty/qunit-2";
 
 /*
  * REMARK: the type definition files are automatically generated and this generation is tested,
@@ -187,3 +188,6 @@ pc.getSecondaryCalendarType();
 
 const ws = new WebSocket("someUrl");
 ws.close("end");
+
+// 1.112: QUnit declared as importable module instead of just globally available
+QUnit.config.autostart = false;

--- a/types/openui5/sap.ui.core.d.ts
+++ b/types/openui5/sap.ui.core.d.ts
@@ -266,7 +266,21 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
   ): jQuery;
 }
 
-// For Library Version: 1.111.0
+declare module "sap/ui/thirdparty/jquery" {
+  export default jQuery;
+}
+declare module "sap/ui/thirdparty/qunit-2" {
+  export default QUnit;
+}
+
+declare namespace sap {
+  interface IUI5DefineDependencyNames {
+    "sap/ui/thirdparty/jquery": undefined;
+    "sap/ui/thirdparty/qunit-2": undefined;
+  }
+}
+
+// For Library Version: 1.112.0
 
 declare module "sap/base/assert" {
   /**
@@ -2536,7 +2550,8 @@ declare module "sap/ui/core/date/UI5Date" {
      */
     getUTCSeconds(): int;
     /**
-     * @deprecated (since 1.111.0) - as it is deprecated in JavaScript Date; use {@link #getFullYear} instead
+     * @deprecated (since 1.111) - as it is deprecated in the base class JavaScript Date; use {@link #getFullYear}
+     * instead
      *
      * Returns the year of this date instance minus 1900 according to the configured time zone, see `Date.prototype.getYear`.
      *
@@ -2800,7 +2815,8 @@ declare module "sap/ui/core/date/UI5Date" {
       iMilliseconds?: int
     ): int;
     /**
-     * @deprecated (since 1.111.0) - as it is deprecated in JavaScript Date; use {@link #setFullYear} instead
+     * @deprecated (since 1.111) - as it is deprecated in the base class JavaScript Date; use {@link #setFullYear}
+     * instead
      *
      * Sets the year for this date instance plus 1900 considering the configured time zone, see `Date.prototype.setYear`.
      *
@@ -9300,7 +9316,7 @@ declare module "sap/ui/base/Object" {
      *
      * @returns Whether the given object is an instance of the given type or of any of the given types
      */
-    static isA(
+    static isA<T extends BaseObject = BaseObject>(
       /**
        * Object which will be checked whether it is an instance of the given type
        */
@@ -9309,7 +9325,7 @@ declare module "sap/ui/base/Object" {
        * Type or types to check for
        */
       vTypeName: string | string[]
-    ): boolean;
+    ): oObject is T;
     /**
      * Destructor method for objects.
      */
@@ -9353,12 +9369,12 @@ declare module "sap/ui/base/Object" {
      *
      * @returns Whether this object is an instance of the given type or of any of the given types
      */
-    isA(
+    isA<T extends BaseObject = BaseObject>(
       /**
        * Type or types to check for
        */
       vTypeName: string | string[]
-    ): boolean;
+    ): this is T;
   }
   /**
    * The structure of the "metadata" object which is passed when inheriting from sap.ui.base.Object using
@@ -52739,7 +52755,7 @@ declare module "sap/ui/model/odata/ODataUtils" {
        * if `true`, the string values `vValue1` and `vValue2` are compared as a decimal number (only sign, integer
        * and fraction digits; no exponential format). Otherwise they are recognized by looking at their types.
        */
-      bAsDecimal?: string
+      bAsDecimal?: boolean
     ): int;
     /**
      * Formats a JavaScript value according to the given
@@ -52821,9 +52837,9 @@ declare module "sap/ui/model/odata/ODataUtils" {
              */
             client: string;
             /**
-             * setting this flag to 'true' overrides the already existing origin
+             * setting this flag to `true` overrides the already existing origin
              */
-            force: string;
+            force: boolean;
           }
         | string
     ): string;
@@ -57422,6 +57438,13 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
          */
         headers?: Record<string, string>;
         /**
+         * **Experimental** as of version 1.112.0; may change behavior or be removed in future versions. Whether
+         * to ignore all annotations from service metadata, so that they are not available as V4 annotations in
+         * this model's metamodel; see {@link #getMetaModel}. Only annotations from annotation files are loaded;
+         * see the `annotationURI` parameter.
+         */
+        ignoreAnnotationsFromMetadata?: boolean;
+        /**
          * If set to `true`, request payloads will be JSON, XML for `false`
          */
         json?: boolean;
@@ -57477,12 +57500,6 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
          */
         serviceUrlParams?: Record<string, string>;
         /**
-         * Whether to skip the automated loading of annotations from the metadata document. Loading annotations
-         * from metadata does not have any effects (except the lost performance by invoking the parser) if there
-         * are not annotations inside the metadata document
-         */
-        skipMetadataAnnotationParsing?: boolean;
-        /**
          * Enable/disable security token handling
          */
         tokenHandling?: boolean;
@@ -57505,6 +57522,13 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
          * service.
          */
         password?: string;
+        /**
+         * **Deprecated** This parameter does not prevent creation of annotations from the metadata document in
+         * this model's metamodel. Whether to skip the automated loading of annotations from the metadata document.
+         * Loading annotations from metadata does not have any effects (except the lost performance by invoking
+         * the parser) if there are no annotations inside the metadata document
+         */
+        skipMetadataAnnotationParsing?: boolean;
         /**
          * **Deprecated** for security reasons. Use strong server side authentication instead. UserID for the service.
          */
@@ -58416,7 +58440,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
          * for dependent bindings into fewer $batch requests. For more information, see {@link topic:6c47b2b39db9404582994070ec3d57a2#loio62149734b5c24507868e722fe87a75db
          * Optimizing Dependent Bindings}
          */
-        preliminaryContext?: boolean;
+        createPreliminaryContext?: boolean;
         /**
          * Optional map of custom query parameters, names of custom parameters must not start with `$`.
          */
@@ -59821,10 +59845,6 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
        */
       mParameters?: {
         /**
-         * Deprecated - use `groupId` instead
-         */
-        batchGroupId?: string;
-        /**
          * Defines the group that should be submitted. If not specified, all deferred groups will be submitted.
          * Requests belonging to the same group will be bundled in one batch request.
          */
@@ -59843,6 +59863,16 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
          * which contains additional error information
          */
         error?: Function;
+        /**
+         * **Deprecated**, use `groupId` instead
+         */
+        batchGroupId?: string;
+        /**
+         * **Deprecated** since 1.38.0; use the `defaultUpdateMethod` constructor parameter instead. If unset, the
+         * update method is determined from the `defaultUpdateMethod` constructor parameter. If `true`, `sap.ui.model.odata.UpdateMethod.Merge`
+         * is used for update operations; if set to `false`, `sap.ui.model.odata.UpdateMethod.Put` is used.
+         */
+        merge?: boolean;
       }
     ): object;
     /**
@@ -62176,8 +62206,12 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
      * set `bSkipRefresh` to `true`. To avoid errors you must skip this refresh when using {@link sap.ui.model.odata.v4.Context#requestSideEffects}
      * in the same $batch to refresh the complete collection containing the newly created entity.
      *
-     * Note: A deep create is not supported. The dependent entity has to be created using a second list binding.
-     * Note that it is not supported to bind relative to a transient context.
+     * Since 1.112.0 it is possible to create nested entities in a collection-valued navigation property together
+     * with the entity (so-called "deep create"), for example a list of items for an order. For this purpose,
+     * bind the list relative to a transient context. Calling this method then adds a transient entity to the
+     * parent's navigation property, which is sent with the payload of the parent entity. Such a nested context
+     * also has a {@link sap.ui.model.odata.v4.Context#created created} promise, which resolves when the deep
+     * create resolves. Deep create is an **experimental** API.
      *
      * Note: Creating at the end is only allowed if the final length of the binding is known (see {@link #isLengthFinal}),
      * so that there is a clear position to place this entity at. This is the case if the complete collection
@@ -62193,7 +62227,8 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
        */
       oInitialData?: object,
       /**
-       * Whether an automatic refresh of the created entity will be skipped
+       * Whether an automatic refresh of the created entity will be skipped; ignored within a deep create (when
+       * the binding's parent context is transient)
        */
       bSkipRefresh?: boolean,
       /**
@@ -63305,8 +63340,8 @@ declare module "sap/ui/model/odata/v4/ODataMetaModel" {
     getOriginalProperty(): void;
     /**
      * @SINCE 1.37.0
-     * @deprecated (since 1.37.0) - use {@link #getObject}.
      *
+     * Use {@link #getObject}.
      * See:
      * 	sap.ui.model.Model#getProperty
      */
@@ -64245,11 +64280,10 @@ declare module "sap/ui/model/odata/v4/ODataModel" {
          */
         $$ownRequest?: boolean;
         /**
-         * Whether multiple bindings for the same resource path share the data, so that it is requested only once;
-         * only the value `true` is allowed. This parameter can be inherited from the model's parameter "sharedRequests",
-         * see {@link sap.ui.model.odata.v4.ODataModel#constructor}. Supported since 1.80.0 **Note:** These bindings
-         * are read-only, so they may be especially useful for value lists; state messages (since 1.108.0) and the
-         * following APIs are **not** allowed
+         * Whether multiple bindings for the same resource path share the data, so that it is requested only once.
+         * This parameter can be inherited from the model's parameter "sharedRequests", see {@link sap.ui.model.odata.v4.ODataModel#constructor}.
+         * Supported since 1.80.0 **Note:** These bindings are read-only, so they may be especially useful for value
+         * lists; state messages (since 1.108.0) and the following APIs are **not** allowed
          * 	 for the list binding itself:
          * 	 {@link sap.ui.model.odata.v4.ODataListBinding#create}  {@link sap.ui.model.odata.v4.ODataListBinding#getKeepAliveContext}
          * or {@link #getKeepAliveContext} as far as it affects such a list binding  {@link sap.ui.model.odata.v4.ODataListBinding#resetChanges}
@@ -71757,6 +71791,8 @@ declare module "sap/ui/test/Opa5" {
 
   import OpaPlugin from "sap/ui/test/OpaPlugin";
 
+  import UI5Element from "sap/ui/core/Element";
+
   import Matcher from "sap/ui/test/matchers/Matcher";
 
   import Action from "sap/ui/test/actions/Action";
@@ -72333,7 +72369,13 @@ declare module "sap/ui/test/Opa5" {
          *             ]}
          * ```
          */
-        matchers?: Function | any[] | object | Matcher;
+        matchers?:
+          | ((p1: UI5Element) => void)
+          | Record<string, object>
+          | Matcher
+          | Array<(p1: UI5Element) => void>
+          | Array<Record<string, object>>
+          | Matcher[];
         /**
          * Selects all control by their type. It is usually combined with a viewName or searchOpenDialogs. If no
          * control is matching the type, an empty array will be returned. Here are some samples:
@@ -72416,7 +72458,7 @@ declare module "sap/ui/test/Opa5" {
          * will stop. The first parameter passed into the function is the same value that gets passed to the success
          * function. Returning something other than boolean in check will not change the first parameter of success.
          */
-        check?: Function;
+        check?: (p1: UI5Element | UI5Element[]) => boolean;
         /**
          * Will get invoked after the following conditions are met:
          * 	 -  One or multiple controls were found using controlType, Id, viewName. If visible is true (it is by
@@ -72427,7 +72469,7 @@ declare module "sap/ui/test/Opa5" {
          * 			(viewName, controlType, multiple ID's, regex ID's) that matched all matchers. Matchers can alter the
          * 			array or single control to something different. Please read the documentation of waitFor's matcher parameter.
          */
-        success?: Function;
+        success?: (p1: UI5Element | UI5Element[]) => void;
         /**
          * Invoked when the timeout is reached and the check never returned true.
          */

--- a/types/openui5/sap.ui.fl.d.ts
+++ b/types/openui5/sap.ui.fl.d.ts
@@ -1,4 +1,4 @@
-// For Library Version: 1.110.0
+// For Library Version: 1.112.0
 
 declare module "sap/ui/fl/library" {}
 
@@ -1410,9 +1410,13 @@ declare namespace sap {
   interface IUI5DefineDependencyNames {
     "sap/ui/fl/apply/_internal/changes/descriptor/app/AddAnnotationsToOData": undefined;
 
+    "sap/ui/fl/apply/_internal/changes/descriptor/app/AddNewInbound": undefined;
+
     "sap/ui/fl/apply/_internal/changes/descriptor/app/ChangeDataSource": undefined;
 
     "sap/ui/fl/apply/_internal/changes/descriptor/app/ChangeInbound": undefined;
+
+    "sap/ui/fl/apply/_internal/changes/descriptor/app/RemoveAllInboundsExceptOne": undefined;
 
     "sap/ui/fl/apply/_internal/changes/descriptor/app/SetTitle": undefined;
 

--- a/types/openui5/sap.ui.integration.d.ts
+++ b/types/openui5/sap.ui.integration.d.ts
@@ -1833,8 +1833,8 @@ declare module "sap/ui/integration/Host" {
          * ```javascript
          *
          *  {
-         *  	"/sap.card/configuration/filters/shipper/value": "key3",
-         *  	"/sap.card/configuration/filters/item/value": "key2"
+         *     "/sap.card/configuration/filters/shipper/value": "key3",
+         *     "/sap.card/configuration/filters/item/value": "key2"
          *  }
          * ```
          */

--- a/types/openui5/sap.ui.integration.d.ts
+++ b/types/openui5/sap.ui.integration.d.ts
@@ -1,4 +1,4 @@
-// For Library Version: 1.111.0
+// For Library Version: 1.112.0
 
 declare module "sap/ui/integration/library" {
   import { URI } from "sap/ui/core/library";
@@ -164,6 +164,28 @@ declare module "sap/ui/integration/library" {
      */
     parameters: object;
   };
+
+  /**
+   * @SINCE 1.112
+   * @EXPERIMENTAL (since 1.112)
+   *
+   * Preview modes for `{@link sap.ui.integration.widgets.Card}`. Helpful in scenarios when the end user is
+   * choosing or configuring a card.
+   */
+  export enum CardPreviewMode {
+    /**
+     * Card displays abstract preview. No data requests are made.
+     */
+    Abstract = "Abstract",
+    /**
+     * Card displays mocked data, loaded using a data request as configured in the manifest.
+     */
+    MockData = "MockData",
+    /**
+     * Card displays real data.
+     */
+    Off = "Off",
+  }
 }
 
 declare module "sap/ui/integration/ActionDefinition" {
@@ -1151,6 +1173,10 @@ declare module "sap/ui/integration/Extension" {
      *
      * Fired when an action is triggered in the card.
      *
+     * When an action is triggered in the card it can be handled on several places by "action" event handlers.
+     * In consecutive order those places are: `Extension`, `Card`, `Host`. Each of them can prevent the next
+     * one to handle the action by calling `oEvent.preventDefault()`.
+     *
      * @returns Reference to `this` in order to allow method chaining
      */
     attachAction(
@@ -1178,6 +1204,10 @@ declare module "sap/ui/integration/Extension" {
      * otherwise it will be bound to this `sap.ui.integration.Extension` itself.
      *
      * Fired when an action is triggered in the card.
+     *
+     * When an action is triggered in the card it can be handled on several places by "action" event handlers.
+     * In consecutive order those places are: `Extension`, `Card`, `Host`. Each of them can prevent the next
+     * one to handle the action by calling `oEvent.preventDefault()`.
      *
      * @returns Reference to `this` in order to allow method chaining
      */
@@ -1326,6 +1356,10 @@ declare module "sap/ui/integration/Extension" {
      * be done before its official public release. Use at your own discretion.
      *
      * Fired when an action is triggered in the card.
+     *
+     * When an action is triggered in the card it can be handled on several places by "action" event handlers.
+     * In consecutive order those places are: `Extension`, `Card`, `Host`. Each of them can prevent the next
+     * one to handle the action by calling `oEvent.preventDefault()`.
      */
     action?: (oEvent: Event) => void;
   }
@@ -1426,6 +1460,10 @@ declare module "sap/ui/integration/Host" {
      *
      * Fired when an action is triggered.
      *
+     * When an action is triggered in the card it can be handled on several places by "action" event handlers.
+     * In consecutive order those places are: `Extension`, `Card`, `Host`. Each of them can prevent the next
+     * one to handle the action by calling `oEvent.preventDefault()`.
+     *
      * @returns Reference to `this` in order to allow method chaining
      */
     attachAction(
@@ -1453,6 +1491,10 @@ declare module "sap/ui/integration/Host" {
      * otherwise it will be bound to this `sap.ui.integration.Host` itself.
      *
      * Fired when an action is triggered.
+     *
+     * When an action is triggered in the card it can be handled on several places by "action" event handlers.
+     * In consecutive order those places are: `Extension`, `Card`, `Host`. Each of them can prevent the next
+     * one to handle the action by calling `oEvent.preventDefault()`.
      *
      * @returns Reference to `this` in order to allow method chaining
      */
@@ -2004,6 +2046,10 @@ declare module "sap/ui/integration/Host" {
      * be done before its official public release. Use at your own discretion.
      *
      * Fired when an action is triggered.
+     *
+     * When an action is triggered in the card it can be handled on several places by "action" event handlers.
+     * In consecutive order those places are: `Extension`, `Card`, `Host`. Each of them can prevent the next
+     * one to handle the action by calling `oEvent.preventDefault()`.
      */
     action?: (oEvent: Event) => void;
 
@@ -2045,6 +2091,7 @@ declare module "sap/ui/integration/widgets/Card" {
     CardActionType,
     CardDataMode,
     CardDesign,
+    CardPreviewMode,
     CardArea,
   } from "sap/ui/integration/library";
 
@@ -2192,6 +2239,10 @@ declare module "sap/ui/integration/widgets/Card" {
      *
      * Fired when an action is triggered on the card.
      *
+     * When an action is triggered in the card it can be handled on several places by "action" event handlers.
+     * In consecutive order those places are: `Extension`, `Card`, `Host`. Each of them can prevent the next
+     * one to handle the action by calling `oEvent.preventDefault()`.
+     *
      * @returns Reference to `this` in order to allow method chaining
      */
     attachAction(
@@ -2219,6 +2270,10 @@ declare module "sap/ui/integration/widgets/Card" {
      * otherwise it will be bound to this `sap.ui.integration.widgets.Card` itself.
      *
      * Fired when an action is triggered on the card.
+     *
+     * When an action is triggered in the card it can be handled on several places by "action" event handlers.
+     * In consecutive order those places are: `Extension`, `Card`, `Host`. Each of them can prevent the next
+     * one to handle the action by calling `oEvent.preventDefault()`.
      *
      * @returns Reference to `this` in order to allow method chaining
      */
@@ -2793,6 +2848,24 @@ declare module "sap/ui/integration/widgets/Card" {
       sPath: string
     ): any;
     /**
+     * @SINCE 1.112
+     * @EXPERIMENTAL (since 1.112)
+     *
+     * Gets current value of property {@link #getPreviewMode previewMode}.
+     *
+     * Preview mode of the `Card`. Helpful in scenarios when the end user is choosing or configuring a card.
+     *
+     * 	 - When set to "MockData", the card data is loaded, using a data request, as configured in the "data/mockData"
+     * 			in the manifest. If such configuration is missing, then the real data is loaded.
+     * 	 - When set to "Abstract", the card shows abstract placeholder without loading data.
+     * 	 - When set to "Off", the card displays real data.
+     *
+     * Default value is `Off`.
+     *
+     * @returns Value of property `previewMode`
+     */
+    getPreviewMode(): CardPreviewMode | keyof typeof CardPreviewMode;
+    /**
      * Gets current value of property {@link #getReferenceId referenceId}.
      *
      * Optional property which can be used by the host to reference the card. It will be forwarded to any children
@@ -3128,6 +3201,31 @@ declare module "sap/ui/integration/widgets/Card" {
        * New value for property `manifestChanges`
        */
       sManifestChanges: object[]
+    ): this;
+    /**
+     * @SINCE 1.112
+     * @EXPERIMENTAL (since 1.112)
+     *
+     * Sets a new value for property {@link #getPreviewMode previewMode}.
+     *
+     * Preview mode of the `Card`. Helpful in scenarios when the end user is choosing or configuring a card.
+     *
+     * 	 - When set to "MockData", the card data is loaded, using a data request, as configured in the "data/mockData"
+     * 			in the manifest. If such configuration is missing, then the real data is loaded.
+     * 	 - When set to "Abstract", the card shows abstract placeholder without loading data.
+     * 	 - When set to "Off", the card displays real data.
+     *
+     * When called with a value of `null` or `undefined`, the default value of the property will be restored.
+     *
+     * Default value is `Off`.
+     *
+     * @returns Reference to `this` in order to allow method chaining
+     */
+    setPreviewMode(
+      /**
+       * New value for property `previewMode`
+       */
+      sPreviewMode?: CardPreviewMode | keyof typeof CardPreviewMode
     ): this;
     /**
      * Sets a new value for property {@link #getReferenceId referenceId}.
@@ -3624,6 +3722,22 @@ declare module "sap/ui/integration/widgets/Card" {
       | `{${string}}`;
 
     /**
+     * @SINCE 1.112
+     * @EXPERIMENTAL (since 1.112)
+     *
+     * Preview mode of the `Card`. Helpful in scenarios when the end user is choosing or configuring a card.
+     *
+     * 	 - When set to "MockData", the card data is loaded, using a data request, as configured in the "data/mockData"
+     * 			in the manifest. If such configuration is missing, then the real data is loaded.
+     * 	 - When set to "Abstract", the card shows abstract placeholder without loading data.
+     * 	 - When set to "Off", the card displays real data.
+     */
+    previewMode?:
+      | (CardPreviewMode | keyof typeof CardPreviewMode)
+      | PropertyBindingInfo
+      | `{${string}}`;
+
+    /**
      * @SINCE 1.85
      * @EXPERIMENTAL (since 1.85) - Disclaimer: this aggregation is in a beta state - incompatible API changes
      * may be done before its official public release. Use at your own discretion.
@@ -3647,6 +3761,10 @@ declare module "sap/ui/integration/widgets/Card" {
      * be done before its official public release. Use at your own discretion.
      *
      * Fired when an action is triggered on the card.
+     *
+     * When an action is triggered in the card it can be handled on several places by "action" event handlers.
+     * In consecutive order those places are: `Extension`, `Card`, `Host`. Each of them can prevent the next
+     * one to handle the action by calling `oEvent.preventDefault()`.
      */
     action?: (oEvent: Event) => void;
 
@@ -3815,6 +3933,8 @@ declare namespace sap {
     "sap/ui/integration/designtime/editor/CardPreview": undefined;
 
     "sap/ui/integration/editor/Editor": undefined;
+
+    "sap/ui/integration/editor/EditorResourceBundles": undefined;
 
     "sap/ui/integration/editor/Extension": undefined;
 

--- a/types/openui5/sap.ui.mdc.d.ts
+++ b/types/openui5/sap.ui.mdc.d.ts
@@ -1,4 +1,4 @@
-// For Library Version: 1.111.0
+// For Library Version: 1.112.0
 
 declare module "sap/ui/mdc/enum/FilterBarValidationStatus" {
   /**
@@ -350,6 +350,8 @@ declare namespace sap {
 
     "sap/ui/mdc/filterbar/FilterBarBase": undefined;
 
+    "sap/ui/mdc/filterbar/p13n/AdaptationFilterBar": undefined;
+
     "sap/ui/mdc/filterbar/vh/CollectiveSearchSelect": undefined;
 
     "sap/ui/mdc/filterbar/vh/FilterBar": undefined;
@@ -390,13 +392,9 @@ declare namespace sap {
 
     "sap/ui/mdc/odata/v4/ValueHelpDelegate": undefined;
 
-    "sap/ui/mdc/p13n/Engine": undefined;
-
     "sap/ui/mdc/p13n/panels/FilterPanel": undefined;
 
     "sap/ui/mdc/p13n/StateUtil": undefined;
-
-    "sap/ui/mdc/p13n/subcontroller/BaseController": undefined;
 
     "sap/ui/mdc/p13n/UIManager": undefined;
 

--- a/types/openui5/sap.ui.table.d.ts
+++ b/types/openui5/sap.ui.table.d.ts
@@ -1,4 +1,4 @@
-// For Library Version: 1.110.0
+// For Library Version: 1.112.0
 
 declare module "sap/ui/table/library" {
   import TreeAutoExpandMode1 from "sap/ui/model/TreeAutoExpandMode";
@@ -1590,7 +1590,7 @@ declare module "sap/ui/table/Column" {
      */
     getHAlign(): HorizontalAlign | keyof typeof HorizontalAlign;
     /**
-     * @SINCE 1.104
+     * @SINCE 1.110
      *
      * ID of the element which is the current target of the association {@link #getHeaderMenu headerMenu}, or
      * `null`.
@@ -2035,7 +2035,7 @@ declare module "sap/ui/table/Column" {
       sHAlign?: HorizontalAlign | keyof typeof HorizontalAlign
     ): this;
     /**
-     * @SINCE 1.104
+     * @SINCE 1.110
      *
      * Sets the associated {@link #getHeaderMenu headerMenu}.
      *
@@ -2544,7 +2544,7 @@ declare module "sap/ui/table/Column" {
     menu?: Menu;
 
     /**
-     * @SINCE 1.104
+     * @SINCE 1.110
      *
      * The menu that can be opened by the header element of this column.
      */
@@ -2667,16 +2667,16 @@ declare module "sap/ui/table/plugins/MultiSelectionPlugin" {
    * Implements a plugin to enable a special multi-selection behavior:
    * 	 - No Select All checkbox, select all can only be done via range selection
    * 	 - Dedicated Deselect All button to clear the selection
-   * 	 - The number of indices which can be selected in a range is defined by the `limit` property by the
-   * 			application. If the user tries to select more indices, the selection is automatically limited, and the
-   * 			table scrolls to the last selected index.
+   * 	 - The number of indices which can be selected in a range is defined by the `limit` property. If the
+   * 			user tries to select more indices, the selection is automatically limited, and the table scrolls to the
+   * 			last selected index.
    * 	 - The plugin makes sure that the corresponding binding contexts up to the given limit are available,
    * 			by requesting them from the binding.
    * 	 - Multiple consecutive selections are possible
    *
-   * This plugin is intended for the multi-selection mode, but also supports single selection for ease of
-   * use. When this plugin is applied to the table, the table's selection mode is automatically set to MultiToggle
-   * and cannot be changed.
+   * This plugin is intended for server-side models and multi-selection mode. Range selections, including
+   * Select All, only work properly if the count is known. Make sure the model/binding is configured to request
+   * the count from the service. For ease of use, client-side models and single selection are also supported.
    */
   export default class MultiSelectionPlugin extends SelectionPlugin {
     /**
@@ -2858,14 +2858,16 @@ declare module "sap/ui/table/plugins/MultiSelectionPlugin" {
      * Gets current value of property {@link #getLimit limit}.
      *
      * Number of indices which can be selected in a range. Accepts positive integer values. If set to 0, the
-     * limit is disabled, and the Select All checkbox appears instead of the Deselect All button. **Note:**
-     * To avoid severe performance problems, the limit should only be set to 0 in the following cases:
+     * limit is disabled, and the Select All checkbox appears instead of the Deselect All button.
+     *
+     * **Note:** To avoid severe performance problems, the limit should only be set to 0 in the following cases:
      *
      * 	 - With client-side models
      * 	 - With server-side models if they are used in client mode
-     * 	 - If the entity set is small  In other cases, we recommend to set the limit to at least double
-     * 			the value of the {@link sap.ui.table.Table#getThreshold threshold} property of the related `sap.ui.table.Table`
-     * 			control.
+     * 	 - If the entity set is small
+     *
+     * In other cases, we recommend to set the limit to at least double the value of the {@link sap.ui.table.Table#getThreshold
+     * threshold} property of the related `sap.ui.table.Table` control.
      *
      * Default value is `200`.
      *
@@ -2966,14 +2968,16 @@ declare module "sap/ui/table/plugins/MultiSelectionPlugin" {
      * Sets a new value for property {@link #getLimit limit}.
      *
      * Number of indices which can be selected in a range. Accepts positive integer values. If set to 0, the
-     * limit is disabled, and the Select All checkbox appears instead of the Deselect All button. **Note:**
-     * To avoid severe performance problems, the limit should only be set to 0 in the following cases:
+     * limit is disabled, and the Select All checkbox appears instead of the Deselect All button.
+     *
+     * **Note:** To avoid severe performance problems, the limit should only be set to 0 in the following cases:
      *
      * 	 - With client-side models
      * 	 - With server-side models if they are used in client mode
-     * 	 - If the entity set is small  In other cases, we recommend to set the limit to at least double
-     * 			the value of the {@link sap.ui.table.Table#getThreshold threshold} property of the related `sap.ui.table.Table`
-     * 			control.
+     * 	 - If the entity set is small
+     *
+     * In other cases, we recommend to set the limit to at least double the value of the {@link sap.ui.table.Table#getThreshold
+     * threshold} property of the related `sap.ui.table.Table` control.
      *
      * When called with a value of `null` or `undefined`, the default value of the property will be restored.
      *
@@ -3069,14 +3073,16 @@ declare module "sap/ui/table/plugins/MultiSelectionPlugin" {
     extends $SelectionPluginSettings {
     /**
      * Number of indices which can be selected in a range. Accepts positive integer values. If set to 0, the
-     * limit is disabled, and the Select All checkbox appears instead of the Deselect All button. **Note:**
-     * To avoid severe performance problems, the limit should only be set to 0 in the following cases:
+     * limit is disabled, and the Select All checkbox appears instead of the Deselect All button.
+     *
+     * **Note:** To avoid severe performance problems, the limit should only be set to 0 in the following cases:
      *
      * 	 - With client-side models
      * 	 - With server-side models if they are used in client mode
-     * 	 - If the entity set is small  In other cases, we recommend to set the limit to at least double
-     * 			the value of the {@link sap.ui.table.Table#getThreshold threshold} property of the related `sap.ui.table.Table`
-     * 			control.
+     * 	 - If the entity set is small
+     *
+     * In other cases, we recommend to set the limit to at least double the value of the {@link sap.ui.table.Table#getThreshold
+     * threshold} property of the related `sap.ui.table.Table` control.
      */
     limit?: int | PropertyBindingInfo | `{${string}}`;
 

--- a/types/openui5/sap.ui.table.d.ts
+++ b/types/openui5/sap.ui.table.d.ts
@@ -532,9 +532,9 @@ declare module "sap/ui/table/AnalyticalTable" {
      * objects as well as event handlers. See {@link sap.ui.base.ManagedObject#constructor} for a general description
      * of the syntax of the settings object.
      * See:
-     * 	https://github.com/SAP/odata-vocabularies/blob/main/docs/v2-annotations.md
-     * 	{@link topic:08197fa68e4f479cbe30f639cc1cd22c sap.ui.table}
-     * 	{@link fiori:/analytical-table-alv/ Analytical Table}
+     *    https://github.com/SAP/odata-vocabularies/blob/main/docs/v2-annotations.md
+     *    {@link topic:08197fa68e4f479cbe30f639cc1cd22c sap.ui.table}
+     *    {@link fiori:/analytical-table-alv/ Analytical Table}
      */
     constructor(
       /**

--- a/types/openui5/sap.ui.webc.main.d.ts
+++ b/types/openui5/sap.ui.webc.main.d.ts
@@ -9711,7 +9711,7 @@ declare module "sap/ui/webc/main/DatePicker" {
       /**
        * A Java Script date object to be formatted as string
        */
-      date: object
+      date: Date
     ): void;
     /**
      * Gets current value of property {@link #getAccessibleName accessibleName}.
@@ -10676,7 +10676,7 @@ declare module "sap/ui/webc/main/DateRangePicker" {
       /**
        * A Java Script date object to be formatted as string
        */
-      date: object
+      date: Date
     ): void;
     /**
      * Gets current value of property {@link #getAccessibleName accessibleName}.
@@ -11721,7 +11721,7 @@ declare module "sap/ui/webc/main/DateTimePicker" {
       /**
        * A Java Script date object to be formatted as string
        */
-      date: object
+      date: Date
     ): void;
     /**
      * Gets current value of property {@link #getAccessibleName accessibleName}.
@@ -37142,7 +37142,7 @@ declare module "sap/ui/webc/main/TimePicker" {
       /**
        * A Java Script date object to be formatted as string
        */
-      date: object
+      date: Date
     ): void;
     /**
      * Returns the currently selected time represented as JavaScript Date instance

--- a/types/openui5/sap.ui.webc.main.d.ts
+++ b/types/openui5/sap.ui.webc.main.d.ts
@@ -1,4 +1,4 @@
-// For Library Version: 1.110.0
+// For Library Version: 1.112.0
 
 declare module "sap/ui/webc/main/library" {
   /**
@@ -9711,7 +9711,7 @@ declare module "sap/ui/webc/main/DatePicker" {
       /**
        * A Java Script date object to be formatted as string
        */
-      date: Date
+      date: object
     ): void;
     /**
      * Gets current value of property {@link #getAccessibleName accessibleName}.
@@ -10676,7 +10676,7 @@ declare module "sap/ui/webc/main/DateRangePicker" {
       /**
        * A Java Script date object to be formatted as string
        */
-      date: Date
+      date: object
     ): void;
     /**
      * Gets current value of property {@link #getAccessibleName accessibleName}.
@@ -11721,7 +11721,7 @@ declare module "sap/ui/webc/main/DateTimePicker" {
       /**
        * A Java Script date object to be formatted as string
        */
-      date: Date
+      date: object
     ): void;
     /**
      * Gets current value of property {@link #getAccessibleName accessibleName}.
@@ -14585,10 +14585,9 @@ declare module "sap/ui/webc/main/Icon" {
      * Defines the unique identifier (icon name) of the component.
      *
      *
-     * To browse all available icons, see the {@link demo:sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons
-     * SAP Icons}, {@link demo:sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons-TNT SAP TNT
-     * Icons} and {@link https://ui5.sap.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html#/overview/BusinessSuiteInAppSymbols
-     * SAP Business Suite Icons} collections.
+     * To browse all available icons, see the {@link demo:sap/m/demokit/iconExplorer/webapp/index.html SAP Icons},
+     * {@link demo:sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons-TNT SAP Fiori Tools} and
+     * {@link demo:sap/m/demokit/iconExplorer/webapp/index.html SAP Business Suite} collections.
      *
      *
      * Example:
@@ -14740,10 +14739,9 @@ declare module "sap/ui/webc/main/Icon" {
      * Defines the unique identifier (icon name) of the component.
      *
      *
-     * To browse all available icons, see the {@link demo:sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons
-     * SAP Icons}, {@link demo:sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons-TNT SAP TNT
-     * Icons} and {@link https://ui5.sap.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html#/overview/BusinessSuiteInAppSymbols
-     * SAP Business Suite Icons} collections.
+     * To browse all available icons, see the {@link demo:sap/m/demokit/iconExplorer/webapp/index.html SAP Icons},
+     * {@link demo:sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons-TNT SAP Fiori Tools} and
+     * {@link demo:sap/m/demokit/iconExplorer/webapp/index.html SAP Business Suite} collections.
      *
      *
      * Example:
@@ -14851,10 +14849,9 @@ declare module "sap/ui/webc/main/Icon" {
      * Defines the unique identifier (icon name) of the component.
      *
      *
-     * To browse all available icons, see the {@link demo:sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons
-     * SAP Icons}, {@link demo:sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons-TNT SAP TNT
-     * Icons} and {@link https://ui5.sap.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html#/overview/BusinessSuiteInAppSymbols
-     * SAP Business Suite Icons} collections.
+     * To browse all available icons, see the {@link demo:sap/m/demokit/iconExplorer/webapp/index.html SAP Icons},
+     * {@link demo:sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons-TNT SAP Fiori Tools} and
+     * {@link demo:sap/m/demokit/iconExplorer/webapp/index.html SAP Business Suite} collections.
      *
      *
      * Example:
@@ -37145,7 +37142,7 @@ declare module "sap/ui/webc/main/TimePicker" {
       /**
        * A Java Script date object to be formatted as string
        */
-      date: Date
+      date: object
     ): void;
     /**
      * Returns the currently selected time represented as JavaScript Date instance

--- a/types/openui5/tslint.json
+++ b/types/openui5/tslint.json
@@ -10,6 +10,7 @@
         "interface-name": false,
         "max-line-length": false,
         "no-single-declare-module": false,
-        "interface-over-type-literal": false
+        "interface-over-type-literal": false,
+        "no-mergeable-namespace": false
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).  → as detailed in the [previous pull request for 1.90](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53680), some are unavoidable at this point
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: → no specific URL about the changes, it's just a new release: https://sdk.openui5.org/1.112.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

@ DefinitelyTyped maintainers: the lint rule "no-mergeable-namespace" had to be disabled because of one violation which had to be newly introduced: the respective d.ts file is composed from pieces from different sources where both have to amend the same module. (Note: the entire type definitions are generated from JSDoc, so seemingly "easy" manual tweaks cannot be done easily.
