### PR TITLE
Updated wordpress__media-utils to 4.20

### DIFF
--- a/types/wordpress__media-utils/index.d.ts
+++ b/types/wordpress__media-utils/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @wordpress/media-utils 4.14
+// Type definitions for @wordpress/media-utils 4.20
 // Project: https://github.com/WordPress/gutenberg/tree/master/packages/media-utils/README.md
 // Definitions by: Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/wordpress__media-utils/package.json
+++ b/types/wordpress__media-utils/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
+        "@wordpress/core-data": "^6.0.0",
         "@wordpress/element": "^5.0.0"
     }
 }

--- a/types/wordpress__media-utils/utils/upload-media.d.ts
+++ b/types/wordpress__media-utils/utils/upload-media.d.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@wordpress/core-data';
+import { Attachment } from '@wordpress/core-data';
 
 export type UploadMediaErrorCode =
     | 'MIME_TYPE_NOT_ALLOWED_FOR_USER'
@@ -7,7 +7,7 @@ export type UploadMediaErrorCode =
     | 'EMPTY_FILE'
     | 'GENERAL';
 
-export interface MediaItem extends Omit<Schema.Media<'edit'>, 'alt_text' | 'caption' | 'source_url' | 'title'> {
+export interface MediaItem extends Omit<Attachment, 'alt_text' | 'caption' | 'source_url' | 'title'> {
     alt: string;
     caption: string;
     title: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WordPress/gutenberg/blob/%40wordpress/media-utils%404.20.0/packages/media-utils/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
