### PR TITLE
Add overload for chrome.devtools.panels.openResource (chrome typings).

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2642,8 +2642,18 @@ declare namespace chrome.devtools.panels {
      * @param lineNumber Specifies the line number to scroll to when the resource is loaded.
      * @param callback A function that is called when the resource has been successfully loaded.
      */
-    export function openResource(url: string, lineNumber: number, callback: () => void): void;
-
+    export function openResource(url: string, lineNumber: number, callback?: () => void): void;
+    /**
+     * Since Chrome 96.
+     * Requests DevTools to open a URL in a Developer Tools panel.
+     * @param url The URL of the resource to open.
+     * @param lineNumber Specifies the line number to scroll to when the resource is loaded.
+     * @param columnNumber Specifies the column number to scroll to when the resource is loaded.
+     * @param callback A function that is called when the resource has been successfully loaded.
+     */
+    export function openResource(
+      url: string, lineNumber: number, columnNumber: number, callback?: (response: unknown) => unknown,
+    ): void;
     /**
      * @since Chrome 59.
      * The name of the color theme set in user's DevTools settings.


### PR DESCRIPTION
Regarding to the implementation, openResource should have an optional callback parameter and an overload, accepting a column parameter: third_party/devtools-frontend/src/front_end/models/extensions/ExtensionAPI.ts

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/models/extensions/ExtensionAPI.ts;drc=9169474e0b2de2564fbf29cab349f3528f3fb0a1;l=706
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
