### PR TITLE
fix(node-telegram-bot-api): pinChatMessage can accept a 3rd optional option argument 

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -1655,7 +1655,7 @@ declare class TelegramBot extends EventEmitter {
 
     setChatDescription(chatId: TelegramBot.ChatId, description: string): Promise<boolean>;
 
-    pinChatMessage(chatId: TelegramBot.ChatId, messageId: number, options?: PinChatMessageOptions): Promise<boolean>;
+    pinChatMessage(chatId: TelegramBot.ChatId, messageId: number, options?: TelegramBot.PinChatMessageOptions): Promise<boolean>;
 
     unpinChatMessage(chatId: TelegramBot.ChatId, messageId?: number): Promise<boolean>;
 

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -404,6 +404,10 @@ declare namespace TelegramBot {
         emoji?: string | undefined;
     }
 
+    interface PinChatMessageOptions {
+        disable_notification?: boolean | undefined;
+    }
+
     /// TELEGRAM TYPES ///
     interface PassportFile {
         file_id: string;
@@ -1651,7 +1655,7 @@ declare class TelegramBot extends EventEmitter {
 
     setChatDescription(chatId: TelegramBot.ChatId, description: string): Promise<boolean>;
 
-    pinChatMessage(chatId: TelegramBot.ChatId, messageId: number): Promise<boolean>;
+    pinChatMessage(chatId: TelegramBot.ChatId, messageId: number, options?: PinChatMessageOptions): Promise<boolean>;
 
     unpinChatMessage(chatId: TelegramBot.ChatId, messageId?: number): Promise<boolean>;
 

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -169,6 +169,7 @@ MyTelegramBot.deleteChatPhoto(1234);
 MyTelegramBot.setChatTitle(1234, 'Chat Title');
 MyTelegramBot.setChatDescription(1234, 'Chat Description');
 MyTelegramBot.pinChatMessage(1234, 12);
+MyTelegramBot.pinChatMessage(1234, 12, { disable_notification: false });
 MyTelegramBot.unpinChatMessage(1234, 12);
 MyTelegramBot.unpinAllChatMessages(1234);
 MyTelegramBot.answerCallbackQuery('432832');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://core.telegram.org/bots/api#pinchatmessage

Corresponding JS library code:

```js
  /**
   * Use this method to pin a message in a supergroup.
   *
   * If the chat is not a private chat, the **bot must be an administrator in the chat** for this to work and must have the `can_pin_messages` administrator
   * right in a supergroup or `can_edit_messages` administrator right in a channel.
   *
   * @param  {Number|String} chatId  Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
   * @param  {Number} messageId Identifier of a message to pin
   * @param  {Object} [options] Additional Telegram query options
   * @return {Promise} True on success
   * @see https://core.telegram.org/bots/api#pinchatmessage
   */
  pinChatMessage(chatId, messageId, form = {}) {
    form.chat_id = chatId;
    form.message_id = messageId;
    return this._request('pinChatMessage', { form });
  }
```

