### PR TITLE
react-native: Ensure elements narrowed by isValidElement are valid props

### DIFF
--- a/types/react-native/Libraries/Lists/FlatList.d.ts
+++ b/types/react-native/Libraries/Lists/FlatList.d.ts
@@ -20,7 +20,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
    */
   ListEmptyComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 
@@ -29,7 +29,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
    */
   ListFooterComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 
@@ -43,7 +43,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
    */
   ListHeaderComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 

--- a/types/react-native/Libraries/Lists/SectionList.d.ts
+++ b/types/react-native/Libraries/Lists/SectionList.d.ts
@@ -62,7 +62,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
    */
   ListEmptyComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 
@@ -71,7 +71,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
    */
   ListFooterComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 
@@ -85,7 +85,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
    */
   ListHeaderComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 
@@ -99,7 +99,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
    */
   SectionSeparatorComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 

--- a/types/react-native/Libraries/Lists/VirtualizedList.d.ts
+++ b/types/react-native/Libraries/Lists/VirtualizedList.d.ts
@@ -128,7 +128,7 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
    */
   ListEmptyComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 
@@ -138,7 +138,7 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
    */
   ListFooterComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 
@@ -153,7 +153,7 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
    */
   ListHeaderComponent?:
     | React.ComponentType<any>
-    | React.ReactElement
+    | React.ReactElement<unknown>
     | null
     | undefined;
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -652,6 +652,11 @@ export class FlatListTest extends React.Component<FlatListProps<number>, {}> {
   );
 
   render() {
+    const { ListEmptyComponent } = this.props;
+    const listEmptyComponent: JSX.Element | null | undefined = React.isValidElement(ListEmptyComponent)
+        ? ListEmptyComponent
+        : ListEmptyComponent && <ListEmptyComponent />;
+
     return (
       <FlatList
         ref={list => (this.list = list)}

--- a/types/react-native/v0.63/index.d.ts
+++ b/types/react-native/v0.63/index.d.ts
@@ -4233,7 +4233,7 @@ export interface SectionListRenderItemInfo<ItemT, SectionT = DefaultSectionT> ex
 
 export type SectionListRenderItem<ItemT, SectionT = DefaultSectionT> = (
     info: SectionListRenderItemInfo<ItemT, SectionT>,
-) => React.ReactElement<unknown> | null;
+) => React.ReactElement | null;
 
 export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     extends VirtualizedListWithoutRenderItemProps<ItemT> {

--- a/types/react-native/v0.63/index.d.ts
+++ b/types/react-native/v0.63/index.d.ts
@@ -8315,7 +8315,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement<unknown> | number,
+        view?: 'window' | React.ReactElement | number,
         options?: {
             width?: number;
             height?: number;

--- a/types/react-native/v0.63/index.d.ts
+++ b/types/react-native/v0.63/index.d.ts
@@ -3975,12 +3975,12 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -3990,7 +3990,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4233,7 +4233,7 @@ export interface SectionListRenderItemInfo<ItemT, SectionT = DefaultSectionT> ex
 
 export type SectionListRenderItem<ItemT, SectionT = DefaultSectionT> = (
     info: SectionListRenderItemInfo<ItemT, SectionT>,
-) => React.ReactElement | null;
+) => React.ReactElement<unknown> | null;
 
 export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     extends VirtualizedListWithoutRenderItemProps<ItemT> {
@@ -4245,22 +4245,22 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement | null;
+    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
@@ -4467,19 +4467,19 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override
@@ -8315,7 +8315,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement | number,
+        view?: 'window' | React.ReactElement<unknown> | number,
         options?: {
             width?: number;
             height?: number;

--- a/types/react-native/v0.64/index.d.ts
+++ b/types/react-native/v0.64/index.d.ts
@@ -8309,7 +8309,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement<unknown> | number,
+        view?: 'window' | React.ReactElement | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.64/index.d.ts
+++ b/types/react-native/v0.64/index.d.ts
@@ -3992,12 +3992,12 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -4007,7 +4007,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4262,22 +4262,22 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
@@ -4484,19 +4484,19 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override
@@ -8309,7 +8309,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement | number,
+        view?: 'window' | React.ReactElement<unknown> | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.65/index.d.ts
+++ b/types/react-native/v0.65/index.d.ts
@@ -8408,7 +8408,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement<unknown> | number,
+        view?: 'window' | React.ReactElement | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.65/index.d.ts
+++ b/types/react-native/v0.65/index.d.ts
@@ -4015,12 +4015,12 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -4030,7 +4030,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4285,22 +4285,22 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
@@ -4507,19 +4507,19 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override
@@ -8408,7 +8408,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement | number,
+        view?: 'window' | React.ReactElement<unknown> | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.66/index.d.ts
+++ b/types/react-native/v0.66/index.d.ts
@@ -8343,7 +8343,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement<unknown> | number,
+        view?: 'window' | React.ReactElement | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.66/index.d.ts
+++ b/types/react-native/v0.66/index.d.ts
@@ -3939,12 +3939,12 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -3954,7 +3954,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4209,12 +4209,12 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -4224,7 +4224,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4234,7 +4234,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
@@ -4441,19 +4441,19 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override
@@ -8343,7 +8343,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement | number,
+        view?: 'window' | React.ReactElement<unknown> | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.67/index.d.ts
+++ b/types/react-native/v0.67/index.d.ts
@@ -8341,7 +8341,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement<unknown> | number,
+        view?: 'window' | React.ReactElement | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.67/index.d.ts
+++ b/types/react-native/v0.67/index.d.ts
@@ -3932,12 +3932,12 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -3947,7 +3947,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4202,12 +4202,12 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -4217,7 +4217,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4227,7 +4227,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
@@ -4434,19 +4434,19 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override
@@ -8341,7 +8341,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement | number,
+        view?: 'window' | React.ReactElement<unknown> | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.68/index.d.ts
+++ b/types/react-native/v0.68/index.d.ts
@@ -8388,7 +8388,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement<unknown> | number,
+        view?: 'window' | React.ReactElement | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.68/index.d.ts
+++ b/types/react-native/v0.68/index.d.ts
@@ -3962,12 +3962,12 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -3977,7 +3977,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4232,12 +4232,12 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -4247,7 +4247,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4257,7 +4257,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
@@ -4464,19 +4464,19 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override
@@ -8388,7 +8388,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement | number,
+        view?: 'window' | React.ReactElement<unknown> | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.69/index.d.ts
+++ b/types/react-native/v0.69/index.d.ts
@@ -3897,12 +3897,12 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -3912,7 +3912,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4167,12 +4167,12 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -4182,7 +4182,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4192,7 +4192,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
@@ -4399,19 +4399,19 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override
@@ -8323,7 +8323,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement | number,
+        view?: 'window' | React.ReactElement<unknown> | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.69/index.d.ts
+++ b/types/react-native/v0.69/index.d.ts
@@ -8323,7 +8323,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement<unknown> | number,
+        view?: 'window' | React.ReactElement | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.70/index.d.ts
+++ b/types/react-native/v0.70/index.d.ts
@@ -4032,12 +4032,12 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -4047,7 +4047,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4312,12 +4312,12 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -4327,7 +4327,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -4337,7 +4337,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    SectionSeparatorComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
@@ -4558,13 +4558,13 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -4575,7 +4575,7 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement<unknown> | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -8498,7 +8498,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement | number,
+        view?: 'window' | React.ReactElement<unknown> | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;

--- a/types/react-native/v0.70/index.d.ts
+++ b/types/react-native/v0.70/index.d.ts
@@ -8498,7 +8498,7 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view?: 'window' | React.ReactElement<unknown> | number,
+        view?: 'window' | React.ReactElement | number,
         options?: {
             width?: number | undefined;
             height?: number | undefined;


### PR DESCRIPTION
Works around a [TypeScript bug introduced between 5.0 Beta and RC](https://github.com/microsoft/TypeScript/issues/53178) that doesn't get attention. To unblock the ecosystem while keeping the blast radius minimal, I'll change the RN types. 

This probably doesn't fix all problems caused by TS 5.0 but it fixes the ones I encountered.

We should default the props of `React.ReactElement` to `unknown` anyway which would at least call out explicit breakage when props accept `React.ReactElement<any>`. But that has considerable larger blast-radius so for now libraries have to fix these issues on the spot.