### PR TITLE
fix(diff): discrepancy in Hunk

### DIFF
--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -141,7 +141,8 @@ export interface Hunk {
     newStart: number;
     newLines: number;
     lines: string[];
-    linedelimiters: string[];
+    // Line Delimiters is only returned by parsePatch()
+    linedelimiters?: string[];
 }
 
 export interface BestPath {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>


## Why?

When using `structuredPatch()` the returned property `hunks` does not contains `linedelimiters` as seen here:
https://github.com/kpdecker/jsdiff/blob/3b654c2ed7d5262ed9946de841ad8dae990286c7/src/patch/create.js#L67-L73

However, the method `parsePatch()` does output the property `linedelimiters` as seen here:
https://github.com/kpdecker/jsdiff/blob/3b654c2ed7d5262ed9946de841ad8dae990286c7/src/patch/parse.js#L78-L85

Since all methods in the library output and accept `ParsedDiff` that means the presence of `linedelimiters` is not a factor of success and it can be made undefined.

