### PR TITLE
Fix conflicting peer deps in wordpress__block-editor

### DIFF
--- a/types/wordpress__block-editor/package.json
+++ b/types/wordpress__block-editor/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "@wordpress/data": "^8.5.0",
+        "@wordpress/data": "6.1.5",
         "@wordpress/element": "^5.0.0",
         "react-autosize-textarea": "^7.1.0"
     }


### PR DESCRIPTION
Added in #64680, not sure how it passed CI since it should be the same runner as the overnight run. Could be a different npm version.