### PR TITLE
Update useRef types to reflect normal usage

### DIFF
--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -170,6 +170,12 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     const c: React.MutableRefObject<number | null> = React.useRef(null);
     const d: React.RefObject<number> = React.useRef(null);
 
+    // checks for https://twitter.com/mattpocockuk/status/1636098722982404096
+    const pocockukA = React.useRef<string>(null);
+    pocockukA.current = "Hello";
+    const pocockukB = React.useRef<HTMLDivElement>();
+    const el = <div ref={pocockukB}/>
+
     const id = React.useMemo(() => Math.random(), []);
     React.useImperativeHandle(ref, () => ({ id }), [id]);
     // was named like this in the first alpha, renamed before release


### PR DESCRIPTION
Updates to reflect concern brought up by @gaearon in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772 regarding [this tweet](https://twitter.com/mattpocockuk/status/1636098722982404096).

Specifically:
* All refs are now mutable as they always have technically been.
* `RefObject` is now deprecated. 
* Components that took a `ref` previously only allowed ref variants that looked like `{ current: T | null } | { current: T }` and they now accept variants that are like `{ current: T | undefined }`. 