### PR TITLE
`tape`: fix: properly export the type

### DIFF
--- a/types/tape/lib/test.d.ts
+++ b/types/tape/lib/test.d.ts
@@ -2,4 +2,4 @@ type Test = import('../').Test;
 
 declare const test: Test;
 
-export = Test;
+export = test;


### PR DESCRIPTION
Followup to #64696.