### PR TITLE
[node-telegram-bot-api] use eventemitter3

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -14,7 +14,7 @@
 
 /// <reference types="node" />
 
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'eventemitter3';
 import { ServerOptions } from 'https';
 import { Options } from 'request';
 import { Readable, Stream } from 'stream';
@@ -2108,30 +2108,6 @@ declare class TelegramBot extends EventEmitter {
             | 'webhook_error'
             | 'error',
     ): this;
-
-    listeners(
-        event:
-            | TelegramBot.MessageType
-            | 'message'
-            | 'callback_query'
-            | 'inline_query'
-            | 'poll_answer'
-            | 'chat_member'
-            | 'my_chat_member'
-            | 'chosen_inline_result'
-            | 'channel_post'
-            | 'edited_message'
-            | 'edited_message_text'
-            | 'edited_message_caption'
-            | 'edited_channel_post'
-            | 'edited_channel_post_text'
-            | 'edited_channel_post_caption'
-            | 'shipping_query'
-            | 'pre_checkout_query'
-            | 'polling_error'
-            | 'webhook_error'
-            | 'error',
-    ): Array<(data: any, metadata?: TelegramBot.Metadata) => void>;
 
     rawListeners(
         event:

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -1399,7 +1399,28 @@ declare namespace TelegramBot {
     }
 }
 
-declare class TelegramBot extends EventEmitter {
+declare class TelegramBot extends EventEmitter<
+    | TelegramBot.MessageType
+    | 'message'
+    | 'callback_query'
+    | 'inline_query'
+    | 'poll_answer'
+    | 'chat_member'
+    | 'my_chat_member'
+    | 'chosen_inline_result'
+    | 'channel_post'
+    | 'edited_message'
+    | 'edited_message_text'
+    | 'edited_message_caption'
+    | 'edited_channel_post'
+    | 'edited_channel_post_text'
+    | 'edited_channel_post_caption'
+    | 'shipping_query'
+    | 'pre_checkout_query'
+    | 'polling_error'
+    | 'webhook_error'
+    | 'error'
+> {
     constructor(token: string, options?: TelegramBot.ConstructorOptions);
 
     startPolling(options?: TelegramBot.StartPollingOptions): Promise<any>;
@@ -2108,6 +2129,30 @@ declare class TelegramBot extends EventEmitter {
             | 'webhook_error'
             | 'error',
     ): this;
+
+    listeners(
+        event:
+            | TelegramBot.MessageType
+            | 'message'
+            | 'callback_query'
+            | 'inline_query'
+            | 'poll_answer'
+            | 'chat_member'
+            | 'my_chat_member'
+            | 'chosen_inline_result'
+            | 'channel_post'
+            | 'edited_message'
+            | 'edited_message_text'
+            | 'edited_message_caption'
+            | 'edited_channel_post'
+            | 'edited_channel_post_text'
+            | 'edited_channel_post_caption'
+            | 'shipping_query'
+            | 'pre_checkout_query'
+            | 'polling_error'
+            | 'webhook_error'
+            | 'error',
+    ): Array<(data: any, metadata?: TelegramBot.Metadata) => void>;
 
     rawListeners(
         event:

--- a/types/node-telegram-bot-api/package.json
+++ b/types/node-telegram-bot-api/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "eventemitter3": ">=3.0.0"
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yagop/node-telegram-bot-api/blob/master/src/telegram.js#L8

Library uses `eventemitter3` instead of the built-in `events`, which may cause error using methods that are not available in `eventemitter3`, such as `removeListener`, `setMaxListeners` and etc

