### PR TITLE
[node] Type subscribe and unsubscribe for diagnostics_channel

### DIFF
--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -59,6 +59,45 @@ declare module 'diagnostics_channel' {
     function channel(name: string | symbol): Channel;
     type ChannelListener = (message: unknown, name: string | symbol) => void;
     /**
+     * Register a message handler to subscribe to this channel. This message handler will be run synchronously
+     * whenever a message is published to the channel. Any errors thrown in the message handler will
+     * trigger an 'uncaughtException'.
+     *
+     * ```js
+     * import diagnostics_channel from 'diagnostics_channel';
+     *
+     * diagnostics_channel.subscribe('my-channel', (message, name) => {
+     *   // Received data
+     * });
+     * ```
+     *
+     * @since v18.7.0, v16.17.0
+     * @param name The channel name
+     * @param onMessage The handler to receive channel messages
+     */
+    function subscribe(name: string | symbol, onMessage: ChannelListener): void;
+    /**
+     * Remove a message handler previously registered to this channel with diagnostics_channel.subscribe(name, onMessage).
+     *
+     * ```js
+     * import diagnostics_channel from 'diagnostics_channel';
+     *
+     * function onMessage(message, name) {
+     *  // Received data
+     * }
+     *
+     * diagnostics_channel.subscribe('my-channel', onMessage);
+     *
+     * diagnostics_channel.unsubscribe('my-channel', onMessage);
+     * ```
+     *
+     * @since v18.7.0, v16.17.0
+     * @param name The channel name
+     * @param onMessage The previous subscribed handler to remove
+     * @returns `true` if the handler was found, `false` otherwise
+     */
+    function unsubscribe(name: string | symbol, onMessage: ChannelListener): boolean;
+    /**
      * The class `Channel` represents an individual named channel within the data
      * pipeline. It is use to track subscribers and to publish messages when there
      * are subscribers present. It exists as a separate object to avoid channel

--- a/types/node/test/diagnostics_channel.ts
+++ b/types/node/test/diagnostics_channel.ts
@@ -1,4 +1,4 @@
-import { Channel, channel, hasSubscribers } from 'node:diagnostics_channel';
+import { Channel, channel, hasSubscribers, subscribe, unsubscribe } from 'node:diagnostics_channel';
 
 const ch1: Channel = channel(Symbol.for('test'));
 function listener(data: unknown) {}
@@ -14,5 +14,11 @@ ch1.subscribe(anotherListener);
 
 ch1.unsubscribe(listener);
 ch1.unsubscribe(anotherListener);
+
+subscribe('test', listener);
+unsubscribe('test', listener);
+
+subscribe(Symbol.for('test-symbol'), listener);
+unsubscribe(Symbol.for('test-symbol'), listener);
 
 const hasSubs = hasSubscribers('test');

--- a/types/node/ts4.8/diagnostics_channel.d.ts
+++ b/types/node/ts4.8/diagnostics_channel.d.ts
@@ -20,7 +20,7 @@
  * should generally include the module name to avoid collisions with data from
  * other modules.
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/diagnostics_channel.js)
+ * @see [source](https://github.com/nodejs/node/blob/v18.7.0/lib/diagnostics_channel.js)
  */
 declare module 'diagnostics_channel' {
     /**
@@ -58,6 +58,45 @@ declare module 'diagnostics_channel' {
      */
     function channel(name: string | symbol): Channel;
     type ChannelListener = (message: unknown, name: string | symbol) => void;
+    /**
+     * Register a message handler to subscribe to this channel. This message handler will be run synchronously
+     * whenever a message is published to the channel. Any errors thrown in the message handler will
+     * trigger an 'uncaughtException'.
+     *
+     * ```js
+     * import diagnostics_channel from 'diagnostics_channel';
+     *
+     * diagnostics_channel.subscribe('my-channel', (message, name) => {
+     *   // Received data
+     * });
+     * ```
+     *
+     * @since v18.7.0, v16.17.0
+     * @param name The channel name
+     * @param onMessage The handler to receive channel messages
+     */
+    function subscribe(name: string | symbol, onMessage: ChannelListener): void;
+    /**
+     * Remove a message handler previously registered to this channel with diagnostics_channel.subscribe(name, onMessage).
+     *
+     * ```js
+     * import diagnostics_channel from 'diagnostics_channel';
+     *
+     * function onMessage(message, name) {
+     *  // Received data
+     * }
+     *
+     * diagnostics_channel.subscribe('my-channel', onMessage);
+     *
+     * diagnostics_channel.unsubscribe('my-channel', onMessage);
+     * ```
+     *
+     * @since v18.7.0, v16.17.0
+     * @param name The channel name
+     * @param onMessage The previous subscribed handler to remove
+     * @returns `true` if the handler was found, `false` otherwise
+     */
+    function unsubscribe(name: string | symbol, onMessage: ChannelListener): boolean;
     /**
      * The class `Channel` represents an individual named channel within the data
      * pipeline. It is use to track subscribers and to publish messages when there

--- a/types/node/ts4.8/test/diagnostics_channel.ts
+++ b/types/node/ts4.8/test/diagnostics_channel.ts
@@ -1,4 +1,4 @@
-import { Channel, channel, hasSubscribers } from 'node:diagnostics_channel';
+import { Channel, channel, hasSubscribers, subscribe, unsubscribe } from 'node:diagnostics_channel';
 
 const ch1: Channel = channel(Symbol.for('test'));
 function listener(data: unknown) {}
@@ -14,5 +14,11 @@ ch1.subscribe(anotherListener);
 
 ch1.unsubscribe(listener);
 ch1.unsubscribe(anotherListener);
+
+subscribe('test', listener);
+unsubscribe('test', listener);
+
+subscribe(Symbol.for('test-symbol'), listener);
+unsubscribe(Symbol.for('test-symbol'), listener);
 
 const hasSubs = hasSubscribers('test');

--- a/types/node/v16/diagnostics_channel.d.ts
+++ b/types/node/v16/diagnostics_channel.d.ts
@@ -20,7 +20,7 @@
  * should generally include the module name to avoid collisions with data from
  * other modules.
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v16.9.0/lib/diagnostics_channel.js)
+ * @see [source](https://github.com/nodejs/node/blob/v16.19.1/lib/diagnostics_channel.js)
  */
 declare module 'diagnostics_channel' {
     /**
@@ -58,6 +58,45 @@ declare module 'diagnostics_channel' {
      */
     function channel(name: string | symbol): Channel;
     type ChannelListener = (message: unknown, name: string | symbol) => void;
+    /**
+     * Register a message handler to subscribe to this channel. This message handler will be run synchronously
+     * whenever a message is published to the channel. Any errors thrown in the message handler will
+     * trigger an 'uncaughtException'.
+     *
+     * ```js
+     * import diagnostics_channel from 'diagnostics_channel';
+     *
+     * diagnostics_channel.subscribe('my-channel', (message, name) => {
+     *   // Received data
+     * });
+     * ```
+     *
+     * @since v18.7.0, v16.17.0
+     * @param name The channel name
+     * @param onMessage The handler to receive channel messages
+     */
+    function subscribe(name: string | symbol, onMessage: ChannelListener): void;
+    /**
+     * Remove a message handler previously registered to this channel with diagnostics_channel.subscribe(name, onMessage).
+     *
+     * ```js
+     * import diagnostics_channel from 'diagnostics_channel';
+     *
+     * function onMessage(message, name) {
+     *  // Received data
+     * }
+     *
+     * diagnostics_channel.subscribe('my-channel', onMessage);
+     *
+     * diagnostics_channel.unsubscribe('my-channel', onMessage);
+     * ```
+     *
+     * @since v18.7.0, v16.17.0
+     * @param name The channel name
+     * @param onMessage The previous subscribed handler to remove
+     * @returns `true` if the handler was found, `false` otherwise
+     */
+    function unsubscribe(name: string | symbol, onMessage: ChannelListener): boolean;
     /**
      * The class `Channel` represents an individual named channel within the data
      * pipeline. It is use to track subscribers and to publish messages when there

--- a/types/node/v16/test/diagnostics_channel.ts
+++ b/types/node/v16/test/diagnostics_channel.ts
@@ -1,4 +1,4 @@
-import { Channel, channel, hasSubscribers } from 'node:diagnostics_channel';
+import { Channel, channel, hasSubscribers, subscribe, unsubscribe } from 'node:diagnostics_channel';
 
 const ch1: Channel = channel(Symbol.for('test'));
 function listener(data: unknown) {}
@@ -14,5 +14,11 @@ ch1.subscribe(anotherListener);
 
 ch1.unsubscribe(listener);
 ch1.unsubscribe(anotherListener);
+
+subscribe('test', listener);
+unsubscribe('test', listener);
+
+subscribe(Symbol.for('test-symbol'), listener);
+unsubscribe(Symbol.for('test-symbol'), listener);
 
 const hasSubs = hasSubscribers('test');

--- a/types/node/v16/ts4.8/diagnostics_channel.d.ts
+++ b/types/node/v16/ts4.8/diagnostics_channel.d.ts
@@ -20,7 +20,7 @@
  * should generally include the module name to avoid collisions with data from
  * other modules.
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v16.9.0/lib/diagnostics_channel.js)
+ * @see [source](https://github.com/nodejs/node/blob/v16.19.1/lib/diagnostics_channel.js)
  */
 declare module 'diagnostics_channel' {
     /**
@@ -57,6 +57,45 @@ declare module 'diagnostics_channel' {
      * @return The named channel object
      */
     function channel(name: string | symbol): Channel;
+    /**
+     * Register a message handler to subscribe to this channel. This message handler will be run synchronously
+     * whenever a message is published to the channel. Any errors thrown in the message handler will
+     * trigger an 'uncaughtException'.
+     *
+     * ```js
+     * import diagnostics_channel from 'diagnostics_channel';
+     *
+     * diagnostics_channel.subscribe('my-channel', (message, name) => {
+     *   // Received data
+     * });
+     * ```
+     *
+     * @since v18.7.0, v16.17.0
+     * @param name The channel name
+     * @param onMessage The handler to receive channel messages
+     */
+    function subscribe(name: string | symbol, onMessage: ChannelListener): void;
+    /**
+     * Remove a message handler previously registered to this channel with diagnostics_channel.subscribe(name, onMessage).
+     *
+     * ```js
+     * import diagnostics_channel from 'diagnostics_channel';
+     *
+     * function onMessage(message, name) {
+     *  // Received data
+     * }
+     *
+     * diagnostics_channel.subscribe('my-channel', onMessage);
+     *
+     * diagnostics_channel.unsubscribe('my-channel', onMessage);
+     * ```
+     *
+     * @since v18.7.0, v16.17.0
+     * @param name The channel name
+     * @param onMessage The previous subscribed handler to remove
+     * @returns `true` if the handler was found, `false` otherwise
+     */
+    function unsubscribe(name: string | symbol, onMessage: ChannelListener): boolean;
     type ChannelListener = (message: unknown, name: string | symbol) => void;
     /**
      * The class `Channel` represents an individual named channel within the data

--- a/types/node/v16/ts4.8/test/diagnostics_channel.ts
+++ b/types/node/v16/ts4.8/test/diagnostics_channel.ts
@@ -1,4 +1,4 @@
-import { Channel, channel, hasSubscribers } from 'node:diagnostics_channel';
+import { Channel, channel, hasSubscribers, subscribe, unsubscribe } from 'node:diagnostics_channel';
 
 const ch1: Channel = channel(Symbol.for('test'));
 function listener(data: unknown) {}
@@ -14,5 +14,11 @@ ch1.subscribe(anotherListener);
 
 ch1.unsubscribe(listener);
 ch1.unsubscribe(anotherListener);
+
+subscribe('test', listener);
+unsubscribe('test', listener);
+
+subscribe(Symbol.for('test-symbol'), listener);
+unsubscribe(Symbol.for('test-symbol'), listener);
 
 const hasSubs = hasSubscribers('test');


### PR DESCRIPTION
Node 16 LTS:

- https://nodejs.org/docs/latest-v16.x/api/diagnostics_channel.html#diagnostics_channelsubscribename-onmessage
- https://nodejs.org/docs/latest-v16.x/api/diagnostics_channel.html#diagnostics_channelunsubscribename-onmessage

Node 18 LTS:

- https://nodejs.org/docs/latest-v18.x/api/diagnostics_channel.html#diagnostics_channelsubscribename-onmessage
- https://nodejs.org/docs/latest-v18.x/api/diagnostics_channel.html#diagnostics_channelunsubscribename-onmessage

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

- Node `16.19.1`: https://github.com/nodejs/node/blob/v16.19.1/lib/diagnostics_channel.js
- Node `18.7.0`: https://github.com/nodejs/node/blob/v18.7.0/lib/diagnostics_channel.js

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

Note: [channel.subscribe(onMessage)](https://nodejs.org/docs/latest-v16.x/api/diagnostics_channel.html#channelsubscribeonmessage) and [channel.unsubscribe(onMessage)](https://nodejs.org/docs/latest-v16.x/api/diagnostics_channel.html#channelsubscribeonmessage) are marked as deprecated. Should I open a follow up PR to adjust those types as well?