### PR TITLE
fix: Improve typings for `dat.gui` for better typings for `func` parameters

### DIFF
--- a/types/dat.gui/index.d.ts
+++ b/types/dat.gui/index.d.ts
@@ -5,6 +5,10 @@
 
 export as namespace dat;
 
+type ExcludeFuntions<T> = { 
+    [K in keyof T]: T[K] extends Function ? K : never 
+}[keyof T];
+
 export interface GUIParams {
     /**
      * Handles GUI's element placement for you.
@@ -44,7 +48,7 @@ export interface GUIParams {
     width?: number | undefined;
 }
 
-export class GUI {
+export class GUI<T> {
     static CLASS_AUTO_PLACE: string;
     static CLASS_AUTO_PLACE_CONTAINER: string;
     static CLASS_MAIN: string;
@@ -61,29 +65,29 @@ export class GUI {
 
     constructor(option?: GUIParams);
 
-    __controllers: GUIController[];
-    __folders: { [folderName: string]: GUI };
+    __controllers: GUIController<T>[];
+    __folders: { [folderName: string]: GUI<T> };
     domElement: HTMLElement;
 
-    add<T extends Record<string, unknown>>(
+    add(
         target: T,
-        propName: keyof T,
+        propName: keyof  Omit<T, ExcludeFuntions<T>>,
         min?: number,
         max?: number,
         step?: number,
-    ): GUIController;
-    add<T extends Record<string, unknown>>(target: T, propName: keyof T, status: boolean): GUIController;
-    add<T extends Record<string, unknown>>(target: T, propName: keyof T, items: string[]): GUIController;
-    add<T extends Record<string, unknown>>(target: T, propName: keyof T, items: number[]): GUIController;
-    add<T extends Record<string, unknown>>(target: T, propName: keyof T, items: Object): GUIController;
+    ): GUIController<T>;
+    add(target: T, propName: keyof  Omit<T, ExcludeFuntions<T>>, status: boolean): GUIController<T>;
+    add(target: T, propName: keyof  Omit<T, ExcludeFuntions<T>>, items: string[]): GUIController<T>;
+    add(target: T, propName: keyof  Omit<T, ExcludeFuntions<T>>, items: number[]): GUIController<T>
+    add(target: T, propName: keyof  Omit<T, ExcludeFuntions<T>>, items: Object): GUIController<T>;
 
-    addColor(target: Object, propName: string): GUIController;
+    addColor(target: Object, propName: string): GUIController<T>;
 
-    remove(controller: GUIController): void;
+    remove(controller: GUIController<T>): void;
     destroy(): void;
 
-    addFolder(propName: string): GUI;
-    removeFolder(subFolder: GUI): void;
+    addFolder(propName: string): GUI<T>;
+    removeFolder(subFolder: GUI<T>): void;
 
     open(): void;
     close(): void;
@@ -91,18 +95,18 @@ export class GUI {
     show(): void;
 
     remember(target: Object, ...additionalTargets: Object[]): void;
-    getRoot(): GUI;
+    getRoot(): GUI<T>;
 
     getSaveObject(): Object;
     save(): void;
     saveAs(presetName: string): void;
-    revert(gui: GUI): void;
+    revert(gui: GUI<T>): void;
 
-    listen(controller: GUIController): void;
+    listen(controller: GUIController<T>): void;
     updateDisplay(): void;
 
     // gui properties in dat/gui/GUI.js
-    readonly parent: GUI;
+    readonly parent: GUI<T>;
     readonly scrollable: boolean;
     readonly autoPlace: boolean;
     preset: string;
@@ -113,33 +117,33 @@ export class GUI {
     useLocalStorage: boolean;
 }
 
-export class GUIController<T extends Record<string, unknown> = Record<string, unknown>> {
+export class GUIController<T> {
     domElement: HTMLElement;
     object: Object;
     property: string;
 
     constructor(object: T, property: keyof T);
 
-    options(option: any): GUIController;
-    name(name: string): GUIController;
+    options(option: any): GUIController<T>;
+    name(name: string): GUIController<T>;
 
-    listen(): GUIController;
-    remove(): GUIController;
+    listen(): GUIController<T>;
+    remove(): GUIController<T>;
 
-    onChange(fnc: (value?: any) => void): GUIController;
-    onFinishChange(fnc: (value?: any) => void): GUIController;
+    onChange(fnc: (value?: any) => void): GUIController<T>;
+    onFinishChange(fnc: (value?: any) => void): GUIController<T>;
 
-    setValue(value: any): GUIController;
+    setValue(value: any): GUIController<T>;
     getValue(): any;
 
-    updateDisplay(): GUIController;
+    updateDisplay(): GUIController<T>;
     isModified(): boolean;
 
     // NumberController
-    min(n: number): GUIController;
-    max(n: number): GUIController;
-    step(n: number): GUIController;
+    min(n: number): GUIController<T>;
+    max(n: number): GUIController<T>;
+    step(n: number): GUIController<T>;
 
     // FunctionController
-    fire(): GUIController;
+    fire(): GUIController<T>;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: Example https://codesandbox.io/s/modest-swartz-hvfwff?file=/src/App.js

The generics here are extended using `Record<string, unknown>` which is getting the job done. But the fun parameters and validations can be improved more by passing `T` generic on type of object the `GUI` is willing to store. And inherit it for the param validation.

<img width="649" alt="Screenshot 2023-03-24 at 22 32 46" src="https://user-images.githubusercontent.com/11075561/227645890-74efde4f-2c18-4d6d-8a88-f0b4ea366a72.png">

After the new changes
<img width="1024" alt="Screenshot 2023-03-24 at 22 59 31" src="https://user-images.githubusercontent.com/11075561/227651372-c9a611eb-8cca-40e0-8a79-f87d4fe52894.png">


