### PR TITLE
[splunk-logging] Add missing field "time"

### DIFF
--- a/types/splunk-logging/index.d.ts
+++ b/types/splunk-logging/index.d.ts
@@ -27,6 +27,7 @@ export interface SendContextMetadata {
     index?: string | undefined;
     source?: string | undefined;
     sourcetype?: string | undefined;
+    time?: number | undefined;  // Milliseconds since epoch, e.g. with Date.now()
 }
 
 export interface SendContext {

--- a/types/splunk-logging/splunk-logging-tests.ts
+++ b/types/splunk-logging/splunk-logging-tests.ts
@@ -32,6 +32,7 @@ const fullPayload = {
         index: 'splunkIndex',
         source: 'source',
         sourcetype: 'sourcetype',
+        time: Date.now(),
     },
 };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

The types correspond to this source code: https://github.com/splunk/splunk-javascript-logging/blob/0.11.0/splunklogger.js#L338

I set the type as `number` since that's the only one I tested. [It technically supports](https://github.com/splunk/splunk-javascript-logging/blob/0.11.0/utils.js#L28) `string | number | Date` but I cannot vouch that those all work.

As that source code is from v0.11.0, which matches the current version of @types/splunk-logging, I did not update the version number.