### PR TITLE
tabulator-tables: fix the setColumnLayout signature

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -2601,7 +2601,7 @@ declare class Tabulator {
     getColumnLayout: () => ColumnLayout[];
 
     /** If you have previously used the getColumnLayout function to retrieve a tables layout, you can use the setColumnLayout function to apply it to a table. */
-    setColumnLayout: (layout: ColumnLayout) => void;
+    setColumnLayout: (layout: ColumnLayout[]) => void;
 
     /** You can show a hidden column at any point using the showColumn function. */
     showColumn: (column?: ColumnLookup) => void;


### PR DESCRIPTION
`setColumnLayout` is a `getColumnLayout` counterpart. `getColumnLayout` returns an array, `setColumnLayout` actually accepts an array.
