### PR TITLE
Fix typo in `Model.predict` definition.

### DIFF
--- a/types/node-replicate/index.d.ts
+++ b/types/node-replicate/index.d.ts
@@ -67,7 +67,7 @@ declare class Model {
             onUpdate: (prediction: PredictionResponse) => void;
         },
         arg2?: {
-            pollingInteral: number;
+            pollingInterval: number;
         },
     ): Promise<PredictionResponse>;
     createPrediction(inputs: PredictInput): Promise<Prediction>;


### PR DESCRIPTION
- [x] Fix typo in `Model.predict` definition.
- [x] The argument `pollingInterval` was mispelled to `pollingInteral`. Fix this.
- [x] Context for change: https://github.com/oelin/node-replicate/blob/master/src/Model.js#L25
