### PR TITLE
react-resizable: use named tuple for constraints

### DIFF
--- a/types/react-resizable/index.d.ts
+++ b/types/react-resizable/index.d.ts
@@ -39,8 +39,8 @@ export type ResizableProps = {
     handle?: React.ReactNode | ((resizeHandle: ResizeHandle, ref: React.RefObject<any>) => React.ReactNode) | undefined;
     handleSize?: [number, number] | undefined;
     lockAspectRatio?: boolean | undefined;
-    minConstraints?: [number, number] | undefined;
-    maxConstraints?: [number, number] | undefined;
+    minConstraints?: [width: number, height: number] | undefined;
+    maxConstraints?: [width: number, height: number] | undefined;
     onResizeStop?: ((e: React.SyntheticEvent, data: ResizeCallbackData) => any) | undefined;
     onResizeStart?: ((e: React.SyntheticEvent, data: ResizeCallbackData) => any) | undefined;
     onResize?: ((e: React.SyntheticEvent, data: ResizeCallbackData) => any) | undefined;


### PR DESCRIPTION
Being a simple list of two numbers, width and height, without looking at the code it was unclear in what order those numbers are supposed to be specified. This change uses named tuple syntax to avoid the need to peek at the implementation when using constraints. I am not sure on how to test this change specifically.

The evidence for the order comes [from this bit](https://github.com/react-grid-layout/react-resizable/blob/6d08477d623cbd2a0299baddb65a16139a3b5574/lib/Resizable.js#L36-L40) of implementation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test react-resizable`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-grid-layout/react-resizable/blob/6d08477d623cbd2a0299baddb65a16139a3b5574/lib/Resizable.js#L36-L40
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.