### PR TITLE
chrome: update chrome.input.ime onKeyEvent params

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4783,7 +4783,7 @@ declare namespace chrome.input.ime {
         altgrKey?: boolean | undefined;
         /**
          * Optional.
-         * The ID of the request.
+         * The ID of the request. Use the requestId param from the onKeyEvent event instead.
          * @deprecated since Chrome 79.
          */
         requestId?: string | undefined;
@@ -5060,7 +5060,7 @@ declare namespace chrome.input.ime {
     export interface CandidateClickedEvent
         extends chrome.events.Event<(engineID: string, candidateID: number, button: string) => void> { }
 
-    export interface KeyEventEvent extends chrome.events.Event<(engineID: string, keyData: KeyboardEvent) => void> { }
+    export interface KeyEventEvent extends chrome.events.Event<(engineID: string, keyData: KeyboardEvent, requestId: string) => void> { }
 
     export interface DeactivatedEvent extends chrome.events.Event<(engineID: string) => void> { }
 


### PR DESCRIPTION
requestId has been moved to parameters of the event. 

See https://developer.chrome.com/docs/extensions/reference/input_ime/#event-onKeyEvent

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Chrome Documentation](https://developer.chrome.com/docs/extensions/reference/input_ime/#event-onKeyEvent)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
