### PR TITLE
chrome: update CandidateWindowParameterProperties

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5015,6 +5015,18 @@ declare namespace chrome.input.ime {
          * @since Chrome 28.
          */
         windowPosition?: string | undefined;
+        /**
+         * Optional.
+         * The index of the current chosen candidate out of total candidates.
+         * @since Chrome 84.
+         */
+        currentCandidateIndex?: number | undefined;
+        /**
+         * Optional.
+         * The total number of candidates for the candidate window.
+         * @since Chrome 84.
+         */
+        totalCandidates?: number | undefined;
     }
 
     export interface CandidateWindowParameter {

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4839,6 +4839,11 @@ declare namespace chrome.input.ime {
         capsLock?: boolean | undefined;
     }
 
+    /**
+      * The auto-capitalize type of the text field.
+      * @since Chrome 69.
+      */
+    export type AutoCapitalizeType = 'characters' | 'words' | 'sentences';
     /** Describes an input Context */
     export interface InputContext {
         /** This is used to specify targets of text field operations. This ID becomes invalid as soon as onBlur is called. */
@@ -4860,6 +4865,16 @@ declare namespace chrome.input.ime {
          * @since Chrome 40.
          */
         spellCheck: boolean;
+        /**
+         * The auto-capitalize type of the text field.
+         * @since Chrome 69.
+         */
+        autoCaptialize: AutoCapitalizeType;
+        /**
+         * Whether text entered into the text field should be used to improve typing suggestions for the user.
+         * @since Chrome 68.
+         */
+        shouldDoLearning: boolean;
     }
 
     /**


### PR DESCRIPTION
Two new properties, currentCandidateIndex and totalCandidates, have been added to CandidateWindowParameterProperties since Chrome 84.

https://developer.chrome.com/docs/extensions/reference/input_ime/#method-setCandidateWindowProperties

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [*] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
