### PR TITLE
[react] Explain why `null` is in ref.current

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -132,9 +132,19 @@ declare namespace React {
         key?: Key | null | undefined;
     }
     interface RefAttributes<T> extends Attributes {
+        /**
+         * Allows getting a ref to the component instance.
+         * React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref) once that particular component unmounts.
+         * @see https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom
+         */
         ref?: Ref<T> | undefined;
     }
     interface ClassAttributes<T> extends Attributes {
+        /**
+         * Allows getting a ref to the component instance.
+         * React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref) once that particular component unmounts.
+         * @see https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom
+         */
         ref?: LegacyRef<T> | undefined;
     }
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -134,7 +134,7 @@ declare namespace React {
     interface RefAttributes<T> extends Attributes {
         /**
          * Allows getting a ref to the component instance.
-         * React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref) once that particular component unmounts.
+         * Once the component unmounts, React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref).
          * @see https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom
          */
         ref?: Ref<T> | undefined;
@@ -142,7 +142,7 @@ declare namespace React {
     interface ClassAttributes<T> extends Attributes {
         /**
          * Allows getting a ref to the component instance.
-         * React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref) once that particular component unmounts.
+         * Once the component unmounts, React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref).
          * @see https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom
          */
         ref?: LegacyRef<T> | undefined;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -383,6 +383,7 @@ const ForwardRef = React.forwardRef((props: JSX.IntrinsicElements['div'], ref?: 
 const ForwardRef2 = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <ForwardRef {...props} ref={ref}/>);
 const divFnRef = (ref: HTMLDivElement|null) => { /* empty */ };
 const divRef = React.createRef<HTMLDivElement>();
+const badlyAuthoredRef: React.RefObject<HTMLDivElement | null | undefined> = { current: undefined };
 
 <ForwardRef ref={divFnRef}/>;
 <ForwardRef ref={divRef}/>;
@@ -392,6 +393,8 @@ const divRef = React.createRef<HTMLDivElement>();
 <ForwardRef2 ref={divRef}/>;
 // @ts-expect-error
 <ForwardRef2 ref='string'/>;
+// @ts-expect-error
+<ForwardRef2 ref={badlyAuthoredRef} />;
 
 const htmlElementFnRef = (instance: HTMLElement | null) => {};
 const htmlElementRef = React.createRef<HTMLElement>();

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -383,6 +383,10 @@ const ForwardRef = React.forwardRef((props: JSX.IntrinsicElements['div'], ref?: 
 const ForwardRef2 = React.forwardRef((props: React.ComponentProps<typeof ForwardRef>, ref?: React.Ref<HTMLDivElement>) => <ForwardRef {...props} ref={ref}/>);
 const divFnRef = (ref: HTMLDivElement|null) => { /* empty */ };
 const divRef = React.createRef<HTMLDivElement>();
+/**
+ * This should be fine to give React to manage i.e. pass it to `<div ref />`.
+ * However, TypeScript has no notion of write-only properties: https://github.com/microsoft/TypeScript/issues/21759
+ */
 const badlyAuthoredRef: React.RefObject<HTMLDivElement | null | undefined> = { current: undefined };
 
 <ForwardRef ref={divFnRef}/>;
@@ -393,7 +397,7 @@ const badlyAuthoredRef: React.RefObject<HTMLDivElement | null | undefined> = { c
 <ForwardRef2 ref={divRef}/>;
 // @ts-expect-error
 <ForwardRef2 ref='string'/>;
-// @ts-expect-error
+// @ts-expect-error Undesired behavior
 <ForwardRef2 ref={badlyAuthoredRef} />;
 
 const htmlElementFnRef = (instance: HTMLElement | null) => {};


### PR DESCRIPTION

Trying to remove the 2nd gotcha in https://twitter.com/mattpocockuk/status/1636098722982404096/photo/1

This hopefully reduces confusion about where the `null` is comming from in `ref.current` and why it needs to be included in the type.

![Screenshot 2023-03-28 at 10 17 56](https://user-images.githubusercontent.com/12292047/228174865-f5835b1e-cc28-4fa8-aaf5-a9577aeba5c8.png)



Full context: https://twitter.com/sebsilbermann/status/1640627543463153664
