### PR TITLE
fix: luxon toISODate, toISO and toSQLDate method could return null when an InvalidDate is provided

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -1267,8 +1267,10 @@ export class DateTime {
      * DateTime.utc(1982, 5, 25).toISODate() //=> '1982-05-25'
      * @example
      * DateTime.utc(1982, 5, 25).toISODate({ format: 'basic' }) //=> '19820525'
+     * @example
+     * DateTime.utc(2000, 15, 63).toISODate() //=> null
      */
-    toISODate(opts?: ToISODateOptions): string;
+    toISODate(opts?: ToISODateOptions): string | null;
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime's week date

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -110,8 +110,8 @@ dt.toHTTP(); // $ExpectType string
 dt.toISO(); // $ExpectType string
 dt.toISO({ includeOffset: true, format: 'extended' }); // $ExpectType string
 dt.toISO({ extendedZone: true, format: 'extended' }); // $ExpectType string
-dt.toISODate(); // $ExpectType string
-dt.toISODate({ format: 'basic' }); // $ExpectType string
+dt.toISODate(); // $ExpectType string | null
+dt.toISODate({ format: 'basic' }); // $ExpectType string | null
 dt.toISOTime(); // $ExpectType string
 dt.toISOTime({ format: 'basic' }); // $ExpectType string
 dt.toISOWeekDate(); // $ExpectType string


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Test the change in your own code. (Compile and run.)
- [x] [Run `npm test luxon`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/pull/1406
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.