### PR TITLE
[fslightbox-react] A general revision.

### DIFF
--- a/types/fslightbox-react/fslightbox-react-tests.tsx
+++ b/types/fslightbox-react/fslightbox-react-tests.tsx
@@ -2,132 +2,102 @@ import * as React from 'react';
 import FsLightbox from 'fslightbox-react';
 
 class Test extends React.Component {
-    handleEvent = (instance: any) => {};
+    handleEvent = (instance: FsLightbox) => {};
 
     render() {
-        return (
-            <div>
-                <FsLightbox toggler={false} sources={['https://i.imgur.com/fsyrScY.jpg']} type={'image'} />
-
-                <FsLightbox toggler={false} sources={['https://i.imgur.com/fsyrScY.jpg']} types={['image']} />
-
-                <FsLightbox
-                    toggler={false}
-                    sources={[
-                        'https://i.imgur.com/fsyrScY.jpg',
-                        'https://www.youtube.com/watch?v=xshEZzpS4CQ',
-                        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
-                    ]}
-                    thumbs={[
-                        null,
-                        'https://www.youtube.com/watch?v=xshEZzpS4CQ',
-                        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
-                    ]}
-                    thumbsIcons={[
-                        <svg xmlns="http://www.w3.org/2000/svg" width="28px" height="28px" viewBox="00 430.118 430.118">
-                            <path d="M0 0 H119.054 V119.054 H0 V0 z M158.946 0 H278 V119.054 H158.946 V0 z M158.946 158.946 H278 V278 H158.946 V158.946 z M0 158.946 H119.054 V278 H0 V158.946 z" />
-                        </svg>,
-                        <svg xmlns="http://www.w3.org/2000/svg" width="30px" height="30px" viewBox="0 0 512 512">
-                            <path d="M0 0 H119.054 V119.054 H0 V0 z M158.946 0 H278 V119.054 H158.946 V0 z M158.946 158.946 H278 V278 H158.946 V158.946 z M0 158.946 H119.054 V278 H0 V158.946 z" />
-                        </svg>,
-                        <svg xmlns="http://www.w3.org/2000/svg" width="28px" height="28px" viewBox="00 430.118 430.118">
-                            <path d="M0 0 H119.054 V119.054 H0 V0 z M158.946 0 H278 V119.054 H158.946 V0 z M158.946 158.946 H278 V278 H158.946 V158.946 z M0 158.946 H119.054 V278 H0 V158.946 z" />
-                        </svg>,
-                    ]}
-                    captions={[<h2>Caption 1</h2>, 'Caption 2', 'Caption 3']}
-                    customAttributes={[
-                        { 'data-custom-attribute': 'custom attribute' },
-                        { 'data-custom-attribute': 'custom attribute' },
-                        { 'data-custom-attribute': 'custom attribute' },
-                    ]}
-                    showThumbsOnMount={false}
-                    disableThumbs={false}
-                    videosPosters={[null, null, 'https://i.imgur.com/fsyrScY.jpg']}
-                    openOnMount={false}
-                    disableLocalStorage={true}
-                    exitFullscreenOnClose={false}
-                    slideDistance={0.5}
-                    slideshowTime={10000}
-                    UIFadeOutTime={10000}
-                    zoomIncrement={0.5}
-                    onInit={this.handleEvent}
-                    onOpen={this.handleEvent}
-                    onShow={this.handleEvent}
-                    onClose={this.handleEvent}
-                    onSlideChange={this.handleEvent}
-                    maxYoutubeVideoDimensions={{ width: 400, height: 300 }}
-                    initialAnimation="example-initial-animation"
-                />
-
-                <FsLightbox
-                    toggler={false}
-                    customSources={[
-                        <iframe
-                            src="https://player.vimeo.com/video/22439234"
-                            width="1920px"
-                            height="1080px"
-                            frameBorder="0"
-                            allow="autoplay; fullscreen"
-                            allowFullScreen
-                        />,
-                        <iframe
-                            src="//maps.google.com/maps?q=?&q=London&output=embed"
-                            width="1920px"
-                            height="1080px"
-                            allowFullScreen
-                            scrolling="no"
-                            allow="autoplay; fullscreen"
-                        />,
-                        <div style={{ width: '200px', height: '100px' }}>
-                            <h3>I'm a completely custom source</h3>
-                        </div>,
-                    ]}
-                    svg={{
-                        toolbarButtons: {
-                            thumbs: {
-                                viewBox: '0 0 278 278',
-                                width: '17px',
-                                height: '17px',
-                                d: 'M0 0 H119.054 V119.054 H0 V0 z M158.946 0 H278 V119.054 H158.946 V0 z M158.946 158.946 H278 V278 H158.946 V158.946 z M0 158.946 H119.054 V278 H0 V158.946 z',
-                                title: 'Preview',
-                            },
-                            zoomIn: {
-                                width: '20px',
-                            },
-                            zoomOut: {
-                                height: '20px',
-                            },
-                            slideshow: {
-                                start: {
-                                    width: '20px',
-                                },
-                                pause: {
-                                    viewBox: '0 0 31 31',
-                                },
-                            },
-                            fullscreen: {
-                                enter: {
-                                    title: 'Fullscreen — Show',
-                                },
-                                exit: {
-                                    title: 'Fullscreen — Exit',
-                                },
-                            },
-                            close: {
-                                height: '32px',
-                            },
+        return <FsLightbox
+            toggler={false}
+            sources={[
+                'https://i.imgur.com/fsyrScY.jpg',
+                'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+                'https://www.youtube.com/watch?v=3nQNiWdeH2Q',
+                <iframe
+                    src="https://player.vimeo.com/video/22439234"
+                    width="1920px"
+                    height="1080px"
+                    frameBorder="0"
+                    allow="autoplay; fullscreen"
+                    allowFullScreen
+                />,
+            ]}
+            type="image"
+            types={[null, 'video', 'youtube']}
+            thumbs={[null, 'yt.jpg', 'bbbunny.jpg', 'vimeo.jpg']}
+            thumbsIcons={[
+                null,
+                <svg xmlns="http://www.w3.org/2000/svg" width="28px" height="28px" viewBox="00 430.118 430.118">
+                    <path d="M0 0 H119.054 V119.054 H0 V0 z M158.946 0 H278 V119.054 H158.946 V0 z M158.946 158.946 H278 V278 H158.946 V158.946 z M0 158.946 H119.054 V278 H0 V158.946 z" />
+                </svg>,
+                <svg xmlns="http://www.w3.org/2000/svg" width="30px" height="30px" viewBox="0 0 512 512">
+                    <path d="M0 0 H119.054 V119.054 H0 V0 z M158.946 0 H278 V119.054 H158.946 V0 z M158.946 158.946 H278 V278 H158.946 V158.946 z M0 158.946 H119.054 V278 H0 V158.946 z" />
+                </svg>,
+                <svg xmlns="http://www.w3.org/2000/svg" width="28px" height="28px" viewBox="00 430.118 430.118">
+                    <path d="M0 0 H119.054 V119.054 H0 V0 z M158.946 0 H278 V119.054 H158.946 V0 z M158.946 158.946 H278 V278 H158.946 V158.946 z M0 158.946 H119.054 V278 H0 V158.946 z" />
+                </svg>,
+            ]}
+            captions={[<h2>Caption 1</h2>, 'Caption 2', 'Caption 3']}
+            customAttributes={[null, { poster: 'bbbunny.jpg' }]}
+            showThumbsOnMount={false}
+            disableThumbs={false}
+            openOnMount={false}
+            disableLocalStorage={true}
+            exitFullscreenOnClose={false}
+            slideDistance={0.5}
+            slideshowTime={10000}
+            UIFadeOutTime={10000}
+            zoomIncrement={0.5}
+            onInit={this.handleEvent}
+            onOpen={this.handleEvent}
+            onShow={this.handleEvent}
+            onClose={this.handleEvent}
+            onSlideChange={this.handleEvent}
+            maxYoutubeVideoDimensions={{ width: 400, height: 300 }}
+            initialAnimation="example-initial-animation"
+            slideChangeAnimation="example-slide-change-animation"
+            svg={{
+                toolbarButtons: {
+                    thumbs: {
+                        viewBox: '0 0 278 278',
+                        width: '17px',
+                        height: '17px',
+                        d: 'M0 0 H119.054 V119.054 H0 V0 z M158.946 0 H278 V119.054 H158.946 V0 z M158.946 158.946 H278 V278 H158.946 V158.946 z M0 158.946 H119.054 V278 H0 V158.946 z',
+                        title: 'Preview',
+                    },
+                    zoomIn: {
+                        width: '20px',
+                    },
+                    zoomOut: {
+                        height: '20px',
+                    },
+                    slideshow: {
+                        start: {
+                            width: '20px',
                         },
-                        slideButtons: {
-                            previous: {
-                                width: '40px',
-                            },
-                            next: {
-                                title: 'Next',
-                            },
+                        pause: {
+                            viewBox: '0 0 31 31',
                         },
-                    }}
-                />
-            </div>
-        );
+                    },
+                    fullscreen: {
+                        enter: {
+                            title: 'Fullscreen — Show',
+                        },
+                        exit: {
+                            title: 'Fullscreen — Exit',
+                        },
+                    },
+                    close: {
+                        height: '32px',
+                    },
+                },
+                slideButtons: {
+                    previous: {
+                        width: '40px',
+                    },
+                    next: {
+                        title: 'Next',
+                    },
+                },
+            }}
+        />;
     }
 }

--- a/types/fslightbox-react/index.d.ts
+++ b/types/fslightbox-react/index.d.ts
@@ -1,13 +1,11 @@
 // Type definitions for fslightbox-react 1.7
 // Project: https://fslightbox.com/
-// Definitions by: Kirill Nikitin <https://github.com/locke23rus>
+// Definitions by: Kirill Nikitin <https://github.com/locke23rus>, Piotr Zdziarski <https://github.com/piotrzdziarski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as React from 'react';
 
 export type SourceType = 'image' | 'video' | 'youtube' | null;
-
-export type VideoPoster = string | null;
 
 export interface VideoDimensions {
     width: number;
@@ -28,16 +26,13 @@ export interface CustomToolbarButtonProps extends Required<ToolbarButtonProps> {
 
 export interface FsLightboxProps {
     toggler: boolean;
-    sources?: string[] | undefined;
+    sources?: Array<string | JSX.Element> | undefined;
 
     // captions
-    captions?: Array<JSX.Element | string> | undefined; // pro feature
-
-    // custom sources
-    customSources?: JSX.Element[] | undefined;
+    captions?: Array<string | JSX.Element> | undefined; // pro feature
 
     // custom attributes
-    customAttributes?: Array<{ [key: string]: string }> | undefined;
+    customAttributes?: Array<{ [key: string]: string } | null> | undefined;
 
     // slide number controlling
     slide?: number | undefined;
@@ -45,11 +40,11 @@ export interface FsLightboxProps {
     sourceIndex?: number | undefined;
 
     // events
-    onOpen?: ((instance: any) => void) | undefined;
-    onClose?: ((instance: any) => void) | undefined;
-    onInit?: ((instance: any) => void) | undefined;
-    onShow?: ((instance: any) => void) | undefined;
-    onSlideChange?: ((instance: any) => void) | undefined; // pro feature
+    onOpen?: ((instance: FsLightbox) => void) | undefined;
+    onClose?: ((instance: FsLightbox) => void) | undefined;
+    onInit?: ((instance: FsLightbox) => void) | undefined;
+    onShow?: ((instance: FsLightbox) => void) | undefined;
+    onSlideChange?: ((instance: FsLightbox) => void) | undefined; // pro feature
 
     // types
     disableLocalStorage?: boolean | undefined;
@@ -57,12 +52,11 @@ export interface FsLightboxProps {
     type?: SourceType | undefined;
 
     // sources
-    videosPosters?: VideoPoster[] | undefined;
     maxYoutubeVideoDimensions?: VideoDimensions | undefined;
 
     // thumbs
     thumbs?: Array<string | null> | undefined; // pro feature
-    thumbsIcons?: JSX.Element[] | undefined; // pro feature
+    thumbsIcons?: Array<JSX.Element | null> | undefined; // pro feature
 
     // animations
     initialAnimation?: string | undefined; // pro feature
@@ -77,7 +71,7 @@ export interface FsLightboxProps {
     disableThumbs?: boolean | undefined; // pro feature
     slideDistance?: number | undefined;
     slideshowTime?: number | undefined; // pro feature
-    UIFadeOutTime?: number | undefined; // pro feature
+    UIFadeOutTime?: number | false | undefined; // pro feature
     zoomIncrement?: number | undefined; // pro feature
     openOnMount?: boolean | undefined;
     exitFullscreenOnClose?: boolean | undefined;


### PR DESCRIPTION
Changes:
1. Removed the obsolete "customSources" prop. Custom sources since the version 1.6.0 can be declared only through the "sources" prop. The "sources" prop's declaration has been updated so as to accept JSX values. The separate lightbox in the test file with custom sources has been removed and a custom source is now tested in the main lightbox.
2. Removed the obsolete "videoPosters" prop. HTML videos' posters since the version 1.6.0 can be declared only through the "customAttributes" prop. The "customAttributes" prop's definition in the test file was edited so as to include a poster for the HTML video placed in the test lightbox.
3. Moved the "svg" prop to the main lightbox in the test.
4. Removed the two separate lightboxes with the definitions of the "type" and "types" props and moved these definitions to the main lightbox. Thanks to this change and the above changes there is now only one lightbox in the test file.
5. Added the "slideChangeAnimation" prop to the test—it was present in the declaration file but not in the test file.
6. Specified that the argument passed to handlers of the lightbox's events is the lightbox's instance.
7. Declared that the "UIFadeOutTime" prop may be set to false to disable the UI's fade-out.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://fslightbox.com/react/documentation>.