### PR TITLE
Add ReactChild fixed Can't used as a JSX component

### DIFF
--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -21,7 +21,7 @@ declare namespace CopyToClipboard {
     }
 
     interface Props {
-        children?: React.ReactNode;
+        children?: React.ReactChild | React.ReactNode;
         text: string;
         onCopy?(text: string, result: boolean): void;
         options?: Options | undefined;

--- a/types/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
+++ b/types/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
@@ -20,3 +20,21 @@ function AllProps() {
         </CopyToClipboard>
     );
 }
+
+/**
+  * ReactChild refers to a single child element within a component.
+  * It can be a React element (created using React.createElement() or JSX),
+  * a string, a number, a boolean, or null.
+  */
+function ReactChildProps() {
+    const element = React.createElement('span', {}, 'Copy to clipboard with span');
+    return (
+        <CopyToClipboard
+            text={'Hello World'}
+            onCopy={() => {}}
+            options={{ debug: true, message: 'message', format: 'text/plain' }}
+        >
+            {element}
+        </CopyToClipboard>
+    );
+}

--- a/types/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
+++ b/types/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
@@ -21,11 +21,6 @@ function AllProps() {
     );
 }
 
-/**
-  * ReactChild refers to a single child element within a component.
-  * It can be a React element (created using React.createElement() or JSX),
-  * a string, a number, a boolean, or null.
-  */
 function ReactChildProps() {
     const element = React.createElement('span', {}, 'Copy to clipboard with span');
     return (


### PR DESCRIPTION
Have a problem on this issued
https://github.com/nkbt/react-copy-to-clipboard/issues/180

If add React.ReactChild can fixed this problem

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
