### PR TITLE
[eslint] Flat config parser must be an object

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -897,3 +897,30 @@ ruleTester.run('simple-valid-test', rule, {
 });
 
 //#endregion
+
+//#region FlatConfig
+
+(): Linter.FlatConfig => ({
+    languageOptions: {
+        parser: {
+            parse: () => AST
+        }
+    }
+});
+
+(): Linter.FlatConfig => ({
+    languageOptions: {
+        parser: {
+            parseForESLint: () => ({ ast: AST })
+        }
+    }
+});
+
+(): Linter.FlatConfig => ({
+    languageOptions: {
+        // @ts-expect-error
+        parser: "foo-parser"
+    }
+});
+
+//#endregion

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for eslint 8.21
+// Type definitions for eslint 8.37
 // Project: https://eslint.org
 // Definitions by: Pierre-Marie Dartus <https://github.com/pmdartus>
 //                 Jed Fox <https://github.com/j-f1>
@@ -952,11 +952,10 @@ export namespace Linter {
          */
         globals?: ESLint.Environment["globals"],
         /**
-         * Either an object containing a parse() method or a string indicating the
-         * name of a parser inside of a plugin (i.e., "pluginName/parserName").
-         * @default "@/espree"
+         * An object containing a parse() or parseForESLint() method.
+         * If not configured, the default ESLint parser (Espree) will be used.
          */
-        parser?: string,
+        parser?: ParserModule,
         /**
          * An object specifying additional options that are passed directly to the
          * parser() method on the parser. The available options are parser-dependent


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 - https://github.com/eslint/eslint/pull/16985
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

As of ESLint 8.37, the `languageOptions.parser` property of a flat config must be an object. String values are no longer supported.