### PR TITLE
[chrome] Added documentId to webNavigation callbacks

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10529,8 +10529,16 @@ declare namespace chrome.webNavigation {
     export interface GetFrameResultDetails {
         /** The URL currently associated with this frame, if the frame identified by the frameId existed at one point in the given tab. The fact that an URL is associated with a given frameId does not imply that the corresponding frame still exists. */
         url: string;
+        /** A UUID of the document loaded. */
+        documentId: string;
+        /** The lifecycle the document is in. */
+        documentLifecycle: "prerender" | "active" | "cached" | "pending_deletion";
         /** True if the last navigation in this frame was interrupted by an error, i.e. the onErrorOccurred event fired. */
         errorOccurred: boolean;
+        /** The type of frame the navigation occurred in. */
+        frameType: "outermost_frame" | "fenced_frame" | "sub_frame";
+        /** A UUID of the parent document owning this frame. This is not set if there is no parent. */
+        parentDocumentId?: string | undefined;
         /** ID of frame that wraps the frame. Set to -1 of no parent frame exists. */
         parentFrameId: number;
     }
@@ -10566,6 +10574,14 @@ declare namespace chrome.webNavigation {
     export interface WebNavigationFramedCallbackDetails extends WebNavigationUrlCallbackDetails {
         /** 0 indicates the navigation happens in the tab content window; a positive value indicates navigation in a subframe. Frame IDs are unique for a given tab and process. */
         frameId: number;
+        /** The type of frame the navigation occurred in. */
+        frameType: "outermost_frame" | "fenced_frame" | "sub_frame";
+        /** A UUID of the document loaded. (This is not set for onBeforeNavigate callbacks.) */
+        documentId?: string | undefined;
+        /** The lifecycle the document is in. */
+        documentLifecycle: "prerender" | "active" | "cached" | "pending_deletion";
+        /** A UUID of the parent document owning this frame. This is not set if there is no parent. */
+        parentDocumentId?: string | undefined;
         /**
          * The ID of the process runs the renderer for this tab.
          * @since Chrome 22.


### PR DESCRIPTION
Chrome 106 introduced some new fields to the chrome.webNavigation event callbacks:
  `documentId`
  `documentLifecycle`
  `parentDocumentId`
  `frameType`
More detail here: https://chromium.googlesource.com/chromium/src/+/dbba982d42a9917687ac97d9c0597d835c11beea%5E!/ Up-to-date documentation here (search for "Chrome 106"): https://developer.chrome.com/docs/extensions/reference/webNavigation/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
