### PR TITLE
[jest] constrain type of the `jest.replacedProperty()` argument

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -328,7 +328,7 @@ declare namespace jest {
      * @remarks
      * For mocking functions, and 'get' or 'set' accessors, use `jest.spyOn()` instead.
      */
-    function replaceProperty<T extends {}, K extends keyof T>(obj: T, key: K, value: T[K]): ReplaceProperty<T[K]>;
+    function replaceProperty<T extends object, K extends keyof T>(obj: T, key: K, value: T[K]): ReplaceProperty<T[K]>;
     /**
      * Exhausts tasks queued by `setImmediate()`.
      *

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -328,7 +328,7 @@ declare namespace jest {
      * @remarks
      * For mocking functions, and 'get' or 'set' accessors, use `jest.spyOn()` instead.
      */
-    function replaceProperty<T, K extends keyof T>(obj: T, key: K, value: T[K]): ReplaceProperty<T[K]>;
+    function replaceProperty<T extends {}, K extends keyof T>(obj: T, key: K, value: T[K]): ReplaceProperty<T[K]>;
     /**
      * Exhausts tasks queued by `setImmediate()`.
      *

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -461,6 +461,10 @@ jest.replaceProperty(replaceObjectA, 'property', 2).replaceValue(3).restore();
 
 // @ts-expect-error: nullish target object
 jest.replaceProperty(null, 'invalid', 1);
+// @ts-expect-error: primitive cannot have properties replaced
+jest.replaceProperty(true, 'valueOf', () => 'false');
+// @ts-expect-error: primitive cannot have properties replaced
+jest.replaceProperty(123, 'toFixed', () => '123');
 // @ts-expect-error: property does not exist
 jest.replaceProperty(replaceObjectA, 'invalid', 1);
 // @ts-expect-error: wrong type of the value

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -459,6 +459,8 @@ replaced = jest.replaceProperty(replaceObjectA, 'property', 2);
 // $ExpectType void
 jest.replaceProperty(replaceObjectA, 'property', 2).replaceValue(3).restore();
 
+// @ts-expect-error: nullish target object
+jest.replaceProperty(null, 'invalid', 1);
 // @ts-expect-error: property does not exist
 jest.replaceProperty(replaceObjectA, 'invalid', 1);
 // @ts-expect-error: wrong type of the value


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/pull/14008#discussion_r1151035611

## Summary

Based on user report (see link above). Currently if compiler option `"skipLibCheck": false` is set and `@types/jest` are used with Jest’s built-in types, the compiler gives following error:

```bash
node_modules/@jest/environment/build/index.d.ts:401:26 - error TS2430: Interface 'JestImportMeta' incorrectly extends interface 'ImportMeta'.
  The types of 'jest.replaceProperty' are incompatible between these types.
    Type '<T extends object, K extends Exclude<keyof T, keyof { [K in keyof T as Required<T>[K] extends ClassLike ? K : never]: T[K]; } | keyof { [K in keyof T as Required<T>[K] extends FunctionLike ? K : never]: T[K]; }>, V extends T[K]>(object: T, propertyKey: K, value: V) => Replaced<...>' is not assignable to type '<T, K extends keyof T>(obj: T, key: K, value: T[K]) => ReplaceProperty<T[K]>'.
      Types of parameters 'object' and 'obj' are incompatible.
        Type 'T' is not assignable to type 'object'.

401 export declare interface JestImportMeta extends ImportMeta {
                             ~~~~~~~~~~~~~~

  node_modules/@types/jest/index.d.ts:331:30
    331     function replaceProperty<T, K extends keyof T>(obj: T, key: K, value: T[K]): ReplaceProperty<T[K]>;
                                     ~
    This type parameter might need an `extends object` constraint.
```

This is because the `jest.replacedProperty()` argument is missing a constrain in `@types/jest`. `jest.spyOn()` is similar, so I added the same `{}` constrain (note that in Jest built-in types the constrain is `object`):

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/498a65e3da2f685fc7b86e99f4094bddf1512459/types/jest/index.d.ts#L447