### PR TITLE
fix: relay-runtime - include readerInlineDataFragment in GraphqlTaggedNode union type

### DIFF
--- a/types/relay-runtime/lib/query/RelayModernGraphQLTag.d.ts
+++ b/types/relay-runtime/lib/query/RelayModernGraphQLTag.d.ts
@@ -7,7 +7,7 @@ import {
 import { ConcreteRequest } from '../util/RelayConcreteNode';
 
 // The type of a graphql`...` tagged template expression.
-export type GraphQLTaggedNode = ReaderFragment | ConcreteRequest | (() => ReaderFragment | ConcreteRequest);
+export type GraphQLTaggedNode = ReaderFragment | ConcreteRequest | ReaderInlineDataFragment | (() => ReaderFragment | ConcreteRequest | ReaderInlineDataFragment);
 
 /**
  * Runtime function to correspond to the `graphql` tagged template function.

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -26,6 +26,7 @@ import {
     requestSubscription,
     fetchQuery,
     ConnectionInterface,
+    ReaderInlineDataFragment,
 } from 'relay-runtime';
 
 import * as multiActorEnvironment from 'relay-runtime/multi-actor-environment';
@@ -475,8 +476,12 @@ function readData(dataRef: Module_data$key) {
     );
 }
 
-function readNullableData(dataRef: Module_data$key | null) {
-    // $ExpectType Module_data | null
+interface Module_InlineDataFragment {
+    readonly kind: 'InlineDataFragment';
+    readonly name: string;
+}
+function readNullableData(dataRef: Module_data$key) {
+    // $ExpectType Module_data
     readInlineData(
         graphql`
             fragment Module_data on Data @inline {
@@ -485,6 +490,15 @@ function readNullableData(dataRef: Module_data$key | null) {
         `,
         dataRef,
     );
+}
+
+const readerInlineDataFragment: ReaderInlineDataFragment = {
+    kind: 'InlineDataFragment',
+    name: 'myFragment_data',
+};
+function readInlineDataFragment(dataRef: Module_data$key) {
+    // $ExpectType Module_data
+    readInlineData(readerInlineDataFragment, dataRef);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -682,27 +696,26 @@ requestSubscription(environment, {
     cacheConfig: { force: true, poll: 1234 },
     subscription: node,
     variables: { variable: true },
-    onCompleted: () => { return; },
-    onError: (_error) => { return; },
-    onNext: (_response) => { return; },
-    updater: (_store, _data) => { return; },
+    onCompleted: () => {
+        return;
+    },
+    onError: _error => {
+        return;
+    },
+    onNext: _response => {
+        return;
+    },
+    updater: (_store, _data) => {
+        return;
+    },
 });
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // ConnectionInterface
 // ~~~~~~~~~~~~~~~~~~~~~
 
-const {
-    CURSOR,
-    EDGES,
-    END_CURSOR,
-    HAS_NEXT_PAGE,
-    HAS_PREV_PAGE,
-    NODE,
-    PAGE_INFO,
-    PAGE_INFO_TYPE,
-    START_CURSOR
-} = ConnectionInterface.get();
+const { CURSOR, EDGES, END_CURSOR, HAS_NEXT_PAGE, HAS_PREV_PAGE, NODE, PAGE_INFO, PAGE_INFO_TYPE, START_CURSOR } =
+    ConnectionInterface.get();
 
 ConnectionInterface.inject({
     CURSOR: 'cursor',


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/facebook/relay/blob/main/packages/relay-runtime/query/GraphQLTag.js#L30>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
