### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ You may need to add a `types` reference if you're not using modules:
 See more in the [handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html).
 
 For an npm package "foo", typings for it will be at "@types/foo".
-If you can't find your package, look for it on [TypeSearch](https://microsoft.github.io/TypeSearch/).
 
-If you still can't find it, check if it [bundles](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) its own typings.
-This is usually provided in a `"types"` or `"typings"` field in the `package.json`,
-or just look for any ".d.ts" files in the package and manually include them with a `/// <reference path="" />`.
+If your package has typings specified using the ``types`` or ``typings`` key in its ``package.json``, the npm registry will display that the package has available bindings like so:
+
+![image](https://user-images.githubusercontent.com/30049719/228748963-56fabfd1-9101-42c2-9891-b586b775b01e.png)
+
+If you still can't find the typings, just look for any ".d.ts" files in the package and manually include them with a `/// <reference path="" />`.
 
 ### Support Window
 


### PR DESCRIPTION
**Summary:** Removed link to page that is "no longer necessary" and add updated information.

**Details:**

In the section of the README: [What are declaration files and how do I get them?](https://github.com/DefinitelyTyped/DefinitelyTyped#what-are-declaration-files-and-how-do-i-get-them), there is this line meant to guide users searching for types:
> For an npm package "foo", typings for it will be at "@types/foo". If you can't find your package, look for it on [TypeSearch](https://microsoft.github.io/TypeSearch/).

However, according to the [linked site](https://www.typescriptlang.org/dt/search), "that page is no longer necessary".

This is because, the npm registry now lets developers know which packages have built-in TypeScript declarations.
See this [changelog](https://github.blog/changelog/2020-12-16-npm-displays-packages-with-bundled-typescript-declarations/).

I have updated this section of the README accordingly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

