### PR TITLE
[sinon] extend replacement type in replace function

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1628,7 +1628,7 @@ declare namespace Sinon {
          * replacement can be any value, including spies, stubs and fakes.
          * This method only works on non-accessor properties, for replacing accessors, use sandbox.replaceGetter() and sandbox.replaceSetter().
          */
-        replace<T, TKey extends keyof T>(obj: T, prop: TKey, replacement: T[TKey]): T[TKey];
+        replace<T, TKey extends keyof T, R extends T[TKey] = T[TKey]>(obj: T, prop: TKey, replacement: R): R;
         /**
          * Replaces getter for property on object with replacement argument. Attempts to replace an already replaced getter cause an exception.
          * replacement must be a Function, and can be instances of spies, stubs and fakes.

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -72,6 +72,8 @@ function testSandbox() {
 
     sb.replace(replaceMe, 'prop', 10);
     sb.replace(replaceMe, 'method', sb.spy());
+    const fake = sb.replace(replaceMe, 'method', sb.fake.returns(2));
+    fake.callCount;
     sb.replaceGetter(replaceMe, 'getter', () => 14);
     sb.replaceSetter(replaceMe, 'setter', v => {});
 


### PR DESCRIPTION
If we use a replacement object that extends the original one when using `sandbox.replace` we cannot access to the other properties.

When trying to replace a function with a `fake` like in this example from [sinon doc](https://sinonjs.org/releases/latest/fakes/)
![Schermata 2023-03-30 alle 13 43 42](https://user-images.githubusercontent.com/37539937/228825729-15bc5aa1-68f8-41a0-9f7e-870b066e8430.png)
I noticed that `fake.callCount` gives an error because `property 'callCount' does not exists`, but in the [source code](https://github.com/sinonjs/sinon/blob/main/lib/sinon/sandbox.js#L242-L280) we can see that the whole `replacement` object is used in place of the first one and then returned.
I don't know what types of tests I could add for this change, please tell me if I'm missing something. Thank you in advance!


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
