### PR TITLE
Fix paths mapping in @delowar/react-circle-progressbar

### DIFF
--- a/types/delowar__react-circle-progressbar/delowar__react-circle-progressbar-tests.tsx
+++ b/types/delowar__react-circle-progressbar/delowar__react-circle-progressbar-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Progress from 'delowar__react-circle-progressbar';
+import Progress from '@delowar/react-circle-progressbar';
 
 // Basic Usage
 const basic = () => <Progress percent={40} />;

--- a/types/delowar__react-circle-progressbar/tsconfig.json
+++ b/types/delowar__react-circle-progressbar/tsconfig.json
@@ -13,6 +13,9 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@delowar/*": ["delowar__*"]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
         "jsx": "react"
@@ -20,8 +23,5 @@
     "files": [
         "index.d.ts",
         "delowar__react-circle-progressbar-tests.tsx"
-    ],
-    "paths": {
-        "@delowar/*": ["delowar__*"]
-    }
+    ]
 }


### PR DESCRIPTION
This paths mapping was misplaced, leading to this package's tests needing to import via the mangled name.