### PR TITLE
Fix paths mapping in @zedit/upf

### DIFF
--- a/types/zedit__upf/tsconfig.json
+++ b/types/zedit__upf/tsconfig.json
@@ -14,6 +14,9 @@
             "../"
         ],
         "types": [],
+        "paths": {
+            "@zedit/upf": ["zedit__upf"]
+        },
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
@@ -21,7 +24,4 @@
         "index.d.ts",
         "zedit__upf-tests.ts"
     ],
-    "paths": {
-        "@zedit/upf": ["zedit__upf"]
-    }
 }

--- a/types/zedit__upf/tsconfig.json
+++ b/types/zedit__upf/tsconfig.json
@@ -23,5 +23,5 @@
     "files": [
         "index.d.ts",
         "zedit__upf-tests.ts"
-    ],
+    ]
 }


### PR DESCRIPTION
The tests don't need this as this package augments another package's types, but this config is misplaced anyhow.