### PR TITLE
[chai] Add type narrowing to some assertions

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1528,10 +1528,11 @@ suite('assert', () => {
         }
 
         {
-            const value = 5 as number;
-            assert.instanceOf(5, Foo);
+            // tslint:disable-next-line:no-construct
+            const value = new Number(5);
+            assert.instanceOf(5, Number);
 
-            // $ExpectType never
+            // $ExpectType Number
             value;
         }
 
@@ -1540,6 +1541,14 @@ suite('assert', () => {
             assert.instanceOf(value, CrashyObject);
 
             // $ExpectType CrashyObject
+            value;
+        }
+
+        {
+            const value = 5 as number;
+            assert.instanceOf(5, Foo);
+
+            // $ExpectType never
             value;
         }
     });

--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1,4 +1,6 @@
 /// <reference types="node" />
+// noinspection BadExpressionStatementJS
+
 import * as chai from 'chai';
 
 const expect = chai.expect;
@@ -1413,10 +1415,37 @@ suite('assert', () => {
     });
 
     test('isTrue', () => {
-        assert.isTrue(true);
-        assert.isTrue(false);
-        assert.isTrue(1);
-        assert.isTrue('test');
+        {
+            const variable = true;
+            assert.isTrue(variable);
+
+            // $ExpectType true
+            variable;
+        }
+
+        {
+            const variable = false;
+            assert.isTrue(variable);
+
+            // $ExpectType never
+            variable;
+        }
+
+        {
+            const variable = 1;
+            assert.isTrue(variable);
+
+            // $ExpectType never
+            variable;
+        }
+
+        {
+            const variable = 'test';
+            assert.isTrue(variable);
+
+            // $ExpectType never
+            variable;
+        }
     });
 
     test('ok', () => {
@@ -1444,9 +1473,29 @@ suite('assert', () => {
     });
 
     test('isFalse', () => {
-        assert.isFalse(false);
-        assert.isFalse(true);
-        assert.isFalse(0);
+        {
+            const value = false;
+            assert.isFalse(value);
+
+            // $ExpectType false
+            value;
+        }
+
+        {
+            const value = true;
+            assert.isFalse(value);
+
+            // $ExpectType never
+            value;
+        }
+
+        {
+            const value = 0;
+            assert.isFalse(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('finite', () => {
@@ -1470,9 +1519,29 @@ suite('assert', () => {
     });
 
     test('instanceOf', () => {
-        assert.instanceOf(new Foo(), Foo);
-        assert.instanceOf(5, Foo);
-        assert.instanceOf(new CrashyObject(), CrashyObject);
+        {
+            const value = new Foo();
+            assert.instanceOf(value, Foo);
+
+            // $ExpectType Foo
+            value;
+        }
+
+        {
+            const value = 5 as number;
+            assert.instanceOf(5, Foo);
+
+            // $ExpectType never
+            value;
+        }
+
+        {
+            const value = new CrashyObject();
+            assert.instanceOf(value, CrashyObject);
+
+            // $ExpectType CrashyObject
+            value;
+        }
     });
 
     test('notInstanceOf', () => {
@@ -1590,18 +1659,73 @@ suite('assert', () => {
     });
 
     test('isNull', () => {
-        assert.isNull(null);
-        assert.isNull(undefined);
+        {
+            const value = null;
+            assert.isNull(value);
+
+            // $ExpectType null
+            value;
+        }
+
+        {
+            const value = undefined;
+            assert.isNull(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('isNotNull', () => {
-        assert.isNotNull(undefined);
-        assert.isNotNull(null);
+        {
+            const value = undefined;
+            assert.isNotNull(value);
+
+            // $ExpectType undefined
+            value;
+        }
+
+        {
+            const value = null;
+            assert.isNotNull(value);
+
+            // $ExpectType never
+            value;
+        }
+
+        {
+            const value = 12345 as number;
+            assert.isNotNull(value);
+
+            // $ExpectType number
+            value;
+        }
+
+        {
+            const value = { a: 'b' };
+            assert.isNotNull(value);
+
+            // $ExpectType { a: string; }
+            value;
+        }
     });
 
     test('isUndefined', () => {
-        assert.isUndefined(undefined);
-        assert.isUndefined(null);
+        {
+            const value = undefined;
+            assert.isUndefined(value);
+
+            // $ExpectType undefined
+            value;
+        }
+
+        {
+            const value = null;
+            assert.isUndefined(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('isDefined', () => {
@@ -1610,13 +1734,52 @@ suite('assert', () => {
     });
 
     test('isNaN', () => {
-        assert.isNaN(NaN);
-        assert.isNaN(12);
+        {
+            const value = NaN;
+            assert.isNaN(value);
+
+            // $ExpectType number
+            value;
+        }
+
+        {
+            const value = 12 as number;
+            assert.isNaN(value);
+
+            // $ExpectType number
+            value;
+        }
     });
 
     test('isNotNaN', () => {
         assert.isNotNaN(12);
         assert.isNotNaN(NaN);
+    });
+
+    test('exists', () => {
+        {
+            const value = true as boolean;
+            assert.exists(value);
+
+            // $ExpectType boolean
+            value;
+        }
+
+        {
+            const value = "hello world" as string | null;
+            assert.exists(value);
+
+            // $ExpectType string
+            value;
+        }
+
+        {
+            const value = 12345 as number | undefined;
+            assert.exists(value);
+
+            // $ExpectType number
+            value;
+        }
     });
 
     test('isFunction', () => {
@@ -1633,52 +1796,212 @@ suite('assert', () => {
     });
 
     test('isArray', () => {
-        assert.isArray([]);
-        assert.isArray(new Array<any>());
-        assert.isArray({});
+        {
+            const value: any[] = [];
+            assert.isArray(value);
+
+            // $ExpectType any[]
+            value;
+        }
+
+        {
+            const value = new Array<any>();
+            assert.isArray(value);
+
+            // $ExpectType any[]
+            value;
+        }
+
+        {
+            const value = {};
+            assert.isArray(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('isNotArray', () => {
-        assert.isNotArray(3);
-        assert.isNotArray([]);
-        assert.isNotArray(new Array<any>());
+        {
+            const value = 3 as number;
+            assert.isNotArray(value);
+
+            // $ExpectType number
+            value;
+        }
+
+        {
+            const value: any[] = [];
+            assert.isNotArray(value);
+
+            // $ExpectType never
+            value;
+        }
+
+        {
+            const value = new Array<any>();
+            assert.isNotArray(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('isString', () => {
-        assert.isString('Foo');
-        // tslint:disable-next-line:no-construct
-        assert.isString(new String('foo'));
-        assert.isString(1);
+        {
+            const value = 'Foo' as string;
+            assert.isString(value);
+
+            // $ExpectType string
+            value;
+        }
+
+        {
+            // tslint:disable-next-line:no-construct
+            const value = new String('foo');
+            assert.isString(value);
+
+            // $ExpectType String
+            value;
+        }
+
+        {
+            const value = 1 as number;
+            assert.isString(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('isNotString', () => {
-        assert.isNotString(3);
-        assert.isNotString(['hello']);
-        assert.isNotString('hello');
+        {
+            const value = 3 as number;
+            assert.isNotString(value);
+
+            // $ExpectType number
+            value;
+        }
+
+        {
+            const value = ['hello'];
+            assert.isNotString(value);
+
+            // $ExpectType string[]
+            value;
+        }
+
+        {
+            const value = 'hello' as string;
+            assert.isNotString(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('isNumber', () => {
-        assert.isNumber(1);
-        assert.isNumber(Number('3'));
-        assert.isNumber('1');
+        {
+            const value = 1 as number;
+            assert.isNumber(value);
+
+            // $ExpectType
+            value;
+        }
+
+        {
+            const value = Number('3');
+            assert.isNumber(value);
+
+            // $ExpectType number
+            value;
+        }
+
+        {
+            const value = '1' as string;
+            assert.isNumber(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('isNotNumber', () => {
-        assert.isNotNumber('hello');
-        assert.isNotNumber([5]);
-        assert.isNotNumber(4);
+        {
+            const value = 'hello' as string;
+            assert.isNotNumber(value);
+
+            // $ExpectType string
+            value;
+        }
+
+        {
+            const value = [5];
+            assert.isNotNumber(value);
+
+            // $ExpectType number[]
+            value;
+        }
+
+        {
+            const value = 4 as number;
+            assert.isNotNumber(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('isBoolean', () => {
-        assert.isBoolean(true);
-        assert.isBoolean(false);
-        assert.isBoolean('1');
+        {
+            const value = true as boolean;
+            assert.isBoolean(value);
+
+            // $ExpectType
+            value;
+        }
+
+        {
+            const value = false as boolean;
+            assert.isBoolean(value);
+
+            // $ExpectType boolean
+            value;
+        }
+
+        {
+            const value = '1' as string;
+            assert.isBoolean(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('isNotBoolean', () => {
-        assert.isNotBoolean('true');
-        assert.isNotBoolean(true);
-        assert.isNotBoolean(false);
+        {
+            const value = 'true' as string;
+            assert.isNotBoolean(value);
+
+            // $ExpectType string
+            value;
+        }
+
+        {
+            const value = true;
+            assert.isNotBoolean(value);
+
+            // $ExpectType never
+            value;
+        }
+
+        {
+            const value = false;
+            assert.isNotBoolean(value);
+
+            // $ExpectType never
+            value;
+        }
     });
 
     test('include', () => {
@@ -1775,6 +2098,7 @@ suite('assert', () => {
         const obj = {foo: {bar: 'baz'}};
         const simpleObj = {foo: 'bar'} as any;
         assert.property(obj, 'foo');
+
         assert.deepProperty(obj, 'foo.bar');
         assert.notDeepProperty(obj, 'foo.baz');
         assert.deepPropertyVal(obj, 'foo.bar', 'baz');

--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1,6 +1,4 @@
 /// <reference types="node" />
-// noinspection BadExpressionStatementJS
-
 import * as chai from 'chai';
 
 const expect = chai.expect;

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -16,6 +16,9 @@
 declare namespace Chai {
     type Message = string | (() => string);
     type ObjectProperty = string | symbol | number;
+    type Numberish = number | Number;
+    type Stringish = string | String;
+    type Booleanish = boolean | Boolean;
 
     interface PathInfo {
         parent: object;
@@ -574,20 +577,18 @@ declare namespace Chai {
         /**
          * Asserts that value is true.
          *
-         * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isTrue<T>(value: T, message?: string): void;
+        isTrue(value: unknown, message?: string): asserts value is true;
 
         /**
          * Asserts that value is false.
          *
-         * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isFalse<T>(value: T, message?: string): void;
+        isFalse(value: unknown, message?: string): asserts value is false;
 
         /**
          * Asserts that value is not true.
@@ -610,11 +611,10 @@ declare namespace Chai {
         /**
          * Asserts that value is null.
          *
-         * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNull<T>(value: T, message?: string): void;
+        isNull(value: unknown, message?: string): asserts value is null;
 
         /**
          * Asserts that value is not null.
@@ -623,16 +623,15 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotNull<T>(value: T, message?: string): void;
+        isNotNull<T>(value: T, message?: string): asserts value is (T extends null ? never : T);
 
         /**
          * Asserts that value is NaN.
          *
-         * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNaN<T>(value: T, message?: string): void;
+        isNaN<T>(value: T, message?: string): asserts value is (T extends number ? T : never);
 
         /**
          * Asserts that value is not NaN.
@@ -650,7 +649,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message    Message to display on error.
          */
-        exists<T>(value: T, message?: string): void;
+        exists<T>(value: T, message?: string): asserts value is NonNullable<T>;
 
         /**
          * Asserts that the target is either null or undefined.
@@ -668,7 +667,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isUndefined<T>(value: T, message?: string): void;
+        isUndefined(value: unknown, message?: string): asserts value is undefined;
 
         /**
          * Asserts that value is not undefined.
@@ -725,7 +724,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isArray<T>(value: T, message?: string): void;
+        isArray<T>(value: T, message?: string): asserts value is (T extends any[] ? T : never);
 
         /**
          * Asserts that value is not an array.
@@ -734,7 +733,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotArray<T>(value: T, message?: string): void;
+        isNotArray<T>(value: T, message?: string): asserts value is (T extends any[] ? never : T);
 
         /**
          * Asserts that value is a string.
@@ -743,7 +742,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isString<T>(value: T, message?: string): void;
+        isString<T>(value: T, message?: string): asserts value is (T extends Stringish ? T : never);
 
         /**
          * Asserts that value is not a string.
@@ -752,7 +751,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotString<T>(value: T, message?: string): void;
+        isNotString<T>(value: T, message?: string): asserts value is (T extends Stringish ? never : T);
 
         /**
          * Asserts that value is a number.
@@ -761,7 +760,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNumber<T>(value: T, message?: string): void;
+        isNumber<T>(value: T, message?: string): asserts value is (T extends Numberish ? T : never);
 
         /**
          * Asserts that value is not a number.
@@ -770,7 +769,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotNumber<T>(value: T, message?: string): void;
+        isNotNumber<T>(value: T, message?: string): asserts value is (T extends Numberish ? never : T);
 
         /**
          * Asserts that value is a finite number.
@@ -780,7 +779,7 @@ declare namespace Chai {
          * @param value    Actual value
          * @param message   Message to display on error.
          */
-        isFinite<T>(value: T, message?: string): void;
+        isFinite<T>(value: T, message?: string): asserts value is (T extends Numberish ? T : never);
 
         /**
          * Asserts that value is a boolean.
@@ -789,7 +788,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isBoolean<T>(value: T, message?: string): void;
+        isBoolean<T>(value: T, message?: string): asserts value is (T extends Booleanish ? T : never);
 
         /**
          * Asserts that value is not a boolean.
@@ -798,7 +797,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotBoolean<T>(value: T, message?: string): void;
+        isNotBoolean<T>(value: T, message?: string): asserts value is (T extends Booleanish ? never : T);
 
         /**
          * Asserts that value's type is name, as determined by Object.prototype.toString.
@@ -828,7 +827,7 @@ declare namespace Chai {
          * @param constructor   Potential expected contructor of value.
          * @param message   Message to display on error.
          */
-        instanceOf<T>(value: T, constructor: Function, message?: string): void;
+        instanceOf<T, C extends new(...args: any) => any>(value: T, constructor: C, message?: string): asserts value is InstanceType<C>;
 
         /**
          * Asserts that value is not an instance of constructor.
@@ -1105,7 +1104,7 @@ declare namespace Chai {
         property<T>(object: T, property: string /* keyof T */, message?: string): void;
 
         /**
-         * Asserts that object has a property named by property.
+         * Asserts that object does not have a property named by property.
          *
          * @type T   Type of object.
          * @param object   Container object.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -827,7 +827,7 @@ declare namespace Chai {
          * @param constructor   Potential expected contructor of value.
          * @param message   Message to display on error.
          */
-        instanceOf<T, C extends new(...args: any) => any>(value: T, constructor: C, message?: string): asserts value is InstanceType<C>;
+        instanceOf<T, C extends new(...args: any[]) => any>(value: T, constructor: C, message?: string): asserts value is (T extends boolean | number | string ? never : InstanceType<C>);
 
         /**
          * Asserts that value is not an instance of constructor.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chaijs.com/api/assert/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

---

I saw that #60464 first attempted adding type predicates but was later abandoned and ran into limitations about negating types on certain functions. Here's another attempt that hopefully is less ambitious but still helpful.