### PR TITLE
Bump mui-datatables min typescript version

### DIFF
--- a/types/mui-datatables/index.d.ts
+++ b/types/mui-datatables/index.d.ts
@@ -8,7 +8,7 @@
 //                 Bohdan Yavorskyi <https://github.com/BohdanYavorskyi>
 //                 Patrick Erichsen <https://github.com/Patrick-Erichsen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 3.5
+// Minimum TypeScript Version: 4.4
 import { ComponentsProps, ComponentsOverrides, ComponentsVariants } from '@mui/material';
 
 import * as React from 'react';


### PR DESCRIPTION
@mui/system now requires TS 4.4 or higher