### PR TITLE
firefox-webext-browser: add `world` argument to `RegisteredContentScript`

### DIFF
--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -4542,9 +4542,9 @@ declare namespace browser.scripting {
     }
 
     /**
-     * The JavaScript world for a script to execute within. We currently only support the `'ISOLATED'` world.
+     * The JavaScript world for a script to execute within.
      */
-    type ExecutionWorld = 'ISOLATED';
+    type ExecutionWorld = 'ISOLATED' | 'MAIN';
 
     interface RegisteredContentScript {
         /**
@@ -4573,6 +4573,10 @@ declare namespace browser.scripting {
          * The list of CSS files to be injected into matching pages. These are injected in the order they appear in this array.
          */
         css?: _manifest.ExtensionURL[] | undefined;
+        /**
+         * The JavaScript "world" to run the script in. Defaults to ISOLATED.
+         */
+        world?: ExecutionWorld | undefined;
     }
 
     /** The style origin for the injection. Defaults to `'AUTHOR'`. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/RegisteredContentScript
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
