### PR TITLE
Add optional event param to react-copy-to-clipboard onCopy

### DIFF
--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -23,7 +23,7 @@ declare namespace CopyToClipboard {
     interface Props {
         children?: React.ReactNode;
         text: string;
-        onCopy?(text: string, result: boolean): void;
+        onCopy?(text: string, result: boolean, event?: React.MouseEvent<HTMLButtonElement>): void;
         options?: Options | undefined;
     }
 }


### PR DESCRIPTION
Code owners: @mabels @BernabeFelix @wdlb

This accompanies a pending updated to [react-copy-to-clipboard](https://github.com/nkbt/react-copy-to-clipboard) that will return the mouse event as a third parameter in the `onCopy` method. The particular use case is to allow event interception and stop propagation where needed. This avoids having to wrap the parent in an element with an `onClick` which violates a11y principles of only having click behavior on interactive elements.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<TBD>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
