### PR TITLE
[mailparser] Fix address field and reference types

### DIFF
--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mailparser 3.4
+// Type definitions for mailparser 3.6
 // Project: https://github.com/nodemailer/mailparser
 // Definitions by: Peter Snider <https://github.com/psnider>
 //                 Andrey Volynkin <https://github.com/Avol-V>
@@ -31,7 +31,7 @@ export interface StructuredHeader {
     /**
      * Additional arguments.
      */
-    params: {[key: string]: string};
+    params: { [key: string]: string };
 }
 
 /**
@@ -134,7 +134,7 @@ export interface AttachmentCommon {
     /**
      * `contentId` without `<` and `>`.
      */
-    cid?: string | undefined;   // e.g. '5.1321281380971@localhost'
+    cid?: string | undefined; // e.g. '5.1321281380971@localhost'
     /**
      * If true then this attachment should not be offered for download
      * (at least not in the main attachments list).
@@ -224,22 +224,22 @@ export interface ParsedMail {
      */
     date?: Date | undefined;
     /**
-     * An address object or array of address objects for the `To:` header.
+     * An address object for the `To:` header.
      */
-    to?: AddressObject | AddressObject[] | undefined;
+    to?: AddressObject | undefined;
     /**
      * An address object for the `From:` header.
      */
     from?: AddressObject | undefined;
     /**
-     * An address object or array of address objects for the `Cc:` header.
+     * An address object for the `Cc:` header.
      */
-    cc?: AddressObject | AddressObject[] | undefined;
+    cc?: AddressObject | undefined;
     /**
-     * An address object or array of address objects for the `Bcc:` header.
+     * An address object for the `Bcc:` header.
      * (usually not present)
      */
-    bcc?: AddressObject | AddressObject[] | undefined;
+    bcc?: AddressObject | undefined;
     /**
      * An address object for the `Reply-To:` header.
      */
@@ -338,7 +338,11 @@ export function simpleParser(source: Source, callback: (err: any, mail: ParsedMa
  * @param options Transform options passed to MailParser's constructor
  * @param callback Function to get a structured email object.
  */
-export function simpleParser(source: Source, options: SimpleParserOptions, callback: (err: any, mail: ParsedMail) => void): void;
+export function simpleParser(
+    source: Source,
+    options: SimpleParserOptions,
+    callback: (err: any, mail: ParsedMail) => void,
+): void;
 
 /**
  * Parse email message to structure object.

--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -218,7 +218,7 @@ export interface ParsedMail {
      *
      * Not set if no reference values present.
      */
-    references?: string[] | string | undefined;
+    references?: string[] | undefined;
     /**
      * A Date object for the `Date:` header.
      */

--- a/types/mailparser/mailparser-tests.ts
+++ b/types/mailparser/mailparser-tests.ts
@@ -1,85 +1,222 @@
-import { MailParser, simpleParser } from 'mailparser';
+import { AttachmentStream, MailParser, MailParserOptions, MessageText, simpleParser } from 'mailparser';
 import { getDecoder } from 'iconv-lite';
 
 const mailparser = new MailParser();
 
-mailparser.on('headers', (headers) => {
-        console.log('Subject:', headers.get('subject'));
-    });
+mailparser.on('headers', headers => {
+    const subjectHeader = headers.get('subject');
+    subjectHeader; // $ExpectType HeaderValue | undefined
+});
+
+const isAttachment = (data: AttachmentStream | MessageText): data is AttachmentStream => {
+    return data.type === 'attachment';
+};
+
+const isMessageText = (data: AttachmentStream | MessageText): data is MessageText => {
+    return data.type === 'text';
+};
 
 // Attachments
 mailparser.on('data', data => {
-    if (data.type === 'attachment') {
-        console.log(data.filename);
-        data.content.pipe(process.stdout);
-        data.content.on('end', () => data.release());
+    if (isAttachment(data)) {
+        const filename = data.filename;
+        const content = data.content;
+        filename; // $ExpectType string | undefined
+        content; // $ExpectType Stream
     }
 });
 
 mailparser.on('data', data => {
-    if (data.type === 'text') {
-        console.log(data.html);
+    if (isMessageText(data)) {
+        const html = data.html;
+        html; // $ExpectType string | boolean | undefined
     }
 });
 
 // Validate options
-const mailparser2 = new MailParser(
-    {
-       skipHtmlToText: true,
-       maxHtmlLengthToParse: 88,
-       formatDateString: (d: Date) => d.toDateString(),
-       skipImageLinks: true,
-       skipTextToHtml: true,
-       skipTextLinks: true,
-       Iconv: getDecoder("ascii"),
-       keepCidLinks: true
-    }
-);
+const mailparserOptions: MailParserOptions = {
+    skipHtmlToText: true,
+    maxHtmlLengthToParse: 88,
+    formatDateString: (d: Date) => d.toDateString(),
+    skipImageLinks: true,
+    skipTextToHtml: true,
+    skipTextLinks: true,
+    Iconv: getDecoder('ascii'),
+    keepCidLinks: true,
+};
+
+mailparserOptions.skipHtmlToText; // $ExpectType boolean | undefined
+mailparserOptions.maxHtmlLengthToParse; // $ExpectType number | undefined
+mailparserOptions.formatDateString; // $ExpectType ((d: Date) => string) | undefined
+mailparserOptions.skipImageLinks; // $ExpectType boolean | undefined
+mailparserOptions.skipTextToHtml; // $ExpectType boolean | undefined
+mailparserOptions.skipTextLinks; // $ExpectType boolean | undefined
+mailparserOptions.Iconv; // $ExpectType DecoderStream | undefined
+mailparserOptions.keepCidLinks; // $ExpectType boolean | undefined
 
 // Pipe file to MailParser
 // This example pipes a readableStream file to MailParser
 import fs = require('fs');
 fs.createReadStream('email.eml').pipe(mailparser);
 
-// check different sources and promise/callback api for simpleParser
+// check different sources and async/await api for simpleParser
 const sourceString = '';
 const sourceBuffer = new Buffer('');
 const sourceStream = fs.createReadStream('foo.eml');
 
-simpleParser(sourceString, (err, mail) => err ? err : mail.html);
-simpleParser(sourceBuffer, (err, mail) => err ? err : mail.html);
-simpleParser(sourceStream, (err, mail) => err ? err : mail.html);
-simpleParser(sourceString, { keepCidLinks: true }, (err, mail) => err ? err : mail.html);
-simpleParser(sourceBuffer, { keepCidLinks: true }, (err, mail) => err ? err : mail.html);
-simpleParser(sourceStream, { keepCidLinks: true }, (err, mail) => err ? err : mail.html);
+(async () => {
+    const res = await simpleParser(sourceString);
+    res; // $ExpectType ParsedMail
+    res.html; // $ExpectType string | false
+})();
 
-simpleParser(sourceString).then(mail => mail.html).catch(err => err);
-simpleParser(sourceBuffer).then(mail => mail.html).catch(err => err);
-simpleParser(sourceStream).then(mail => mail.html).catch(err => err);
-simpleParser(sourceString, { keepCidLinks: true }).then(mail => mail.html).catch(err => err);
-simpleParser(sourceBuffer, { keepCidLinks: true }).then(mail => mail.html).catch(err => err);
-simpleParser(sourceStream, { keepCidLinks: true }).then(mail => mail.html).catch(err => err);
+(async () => {
+    const res = await simpleParser(sourceBuffer);
+    res; // $ExpectType ParsedMail
+    res.html; // $ExpectType string | false
+})();
+
+(async () => {
+    const res = await simpleParser(sourceStream);
+    res; // $ExpectType ParsedMail
+    res.html; // $ExpectType string | false
+})();
+
+(async () => {
+    const res = await simpleParser(sourceString, { keepCidLinks: true });
+    res; // $ExpectType ParsedMail
+    res.html; // $ExpectType string | false
+})();
+
+(async () => {
+    const res = await simpleParser(sourceBuffer, { keepCidLinks: true });
+    res; // $ExpectType ParsedMail
+    res.html; // $ExpectType string | false
+})();
+
+(async () => {
+    const res = await simpleParser(sourceStream, { keepCidLinks: true });
+    res; // $ExpectType ParsedMail
+    res.html; // $ExpectType string | false
+})();
+
+(async () => {
+    const mail = await simpleParser(sourceString);
+    const subjectHeader = mail.headers.get('subject');
+    const subject = mail.subject;
+    subjectHeader; // $ExpectType HeaderValue | undefined
+    subject; // $ExpectType string | undefined
+
+    mail.attachments.forEach(attachment => {
+        const filename = attachment.filename;
+        filename; // $ExpectType string | undefined
+    });
+
+    [mail.to, mail.from, mail.cc, mail.bcc].forEach(addressField => {
+        addressField; // $ExpectType AddressObject | undefined
+        const value = addressField!.value;
+        value; // $ExpectType EmailAddress[]
+    });
+
+    const text = mail.text;
+    const html = mail.html;
+    const textAsHtml = mail.textAsHtml;
+
+    text; // $ExpectType string | undefined
+    html; // $ExpectType string | false
+    textAsHtml; // $ExpectType string | undefined
+
+    const references = mail.references;
+    references; // $ExpectType string[] | undefined
+})();
 
 simpleParser(sourceString, (err, mail) => {
-    console.log(mail.headers.get('subject'));
-    console.log(mail.subject);
+    const res = err ? err : mail.html;
+    res; // $ExpectType any
+});
+simpleParser(sourceBuffer, (err, mail) => {
+    const res = err ? err : mail.html;
+    res; // $ExpectType any
+});
+simpleParser(sourceStream, (err, mail) => {
+    const res = err ? err : mail.html;
+    res; // $ExpectType any
+});
+simpleParser(sourceString, { keepCidLinks: true }, (err, mail) => {
+    const res = err ? err : mail.html;
+    res; // $ExpectType any
+});
+simpleParser(sourceBuffer, { keepCidLinks: true }, (err, mail) => {
+    const res = err ? err : mail.html;
+    res; // $ExpectType any
+});
+simpleParser(sourceStream, { keepCidLinks: true }, (err, mail) => {
+    const res = err ? err : mail.html;
+    res; // $ExpectType any
+});
 
-    // Attachments
-    mail.attachments.forEach(attachment => console.log(attachment.filename));
+simpleParser(sourceString)
+    .then(mail => {
+        const html = mail.html;
+        html; // $ExpectType string | false
+    })
+    .catch(err => err);
+simpleParser(sourceBuffer)
+    .then(mail => {
+        const html = mail.html;
+        html; // $ExpectType string | false
+    })
+    .catch(err => err);
+simpleParser(sourceStream)
+    .then(mail => {
+        const html = mail.html;
+        html; // $ExpectType string | false
+    })
+    .catch(err => err);
+simpleParser(sourceString, { keepCidLinks: true })
+    .then(mail => {
+        const html = mail.html;
+        html; // $ExpectType string | false
+    })
+    .catch(err => err);
+simpleParser(sourceBuffer, { keepCidLinks: true })
+    .then(mail => {
+        const html = mail.html;
+        html; // $ExpectType string | false
+    })
+    .catch(err => err);
+simpleParser(sourceStream, { keepCidLinks: true })
+    .then(mail => {
+        const html = mail.html;
+        html; // $ExpectType string | false
+    })
+    .catch(err => err);
 
-    // TO Recipieints
-    if (Array.isArray(mail.to)) {
-        mail.to.forEach(recipient => console.log(recipient));
-    } else {
-        console.log(mail.to);
-    }
+simpleParser(sourceString, (err, mail) => {
+    const subjectHeader = mail.headers.get('subject');
+    const subject = mail.subject;
+    subjectHeader; // $ExpectType HeaderValue | undefined
+    subject; // $ExpectType string | undefined
 
-    // Texte
-    console.log(mail.text);
-    console.log(mail.html);
-    console.log(mail.textAsHtml);
+    mail.attachments.forEach(attachment => {
+        const filename = attachment.filename;
+        filename; // $ExpectType string | undefined
+    });
 
-    // References are either arrays or strings
-    if (mail.references && !Array.isArray(mail.references))
-        mail.references.toLowerCase();
+    [mail.to, mail.from, mail.cc, mail.bcc].forEach(addressField => {
+        addressField; // $ExpectType AddressObject | undefined
+        const value = addressField!.value;
+        value; // $ExpectType EmailAddress[]
+    });
+
+    const text = mail.text;
+    const html = mail.html;
+    const textAsHtml = mail.textAsHtml;
+
+    text; // $ExpectType string | undefined
+    html; // $ExpectType string | false
+    textAsHtml; // $ExpectType string | undefined
+
+    const references = mail.references;
+    references; // $ExpectType string[] | undefined
 });


### PR DESCRIPTION
I saw the original PR that made the changes to the address fields, and I don't think it should've been merged.

There have been multiple issues opened agains the mailparser library to call out that the types for this are incorrect at runtime.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - for the change to `ParsedMail.references`: [this](https://github.com/nodemailer/mailparser/blob/master/lib/mail-parser.js#L342) line of code sets the value, and due to the split, this will never be `string`. It is `string[] | undefined`.
  - for the changes to `ParsedMail.to`, `ParsedMail.from`, `ParsedMail.cc`, and `ParsedMail.bcc`, the value is set [here](https://github.com/nodemailer/mailparser/blob/master/lib/mail-parser.js#L360-L375). It is always an `AddressObject`, never `AddressObject[]`. The `value` field of the `AddressObject` contains an array of the addresses present in the field. 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
