### PR TITLE
Add support for board in pin

### DIFF
--- a/types/johnny-five/index.d.ts
+++ b/types/johnny-five/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for johnny-five 2.1.0
+// Type definitions for johnny-five 2.1
 // Project: https://github.com/rwaldron/johnny-five
 // Definitions by: Toshiya Nakakura <https://github.com/nakakura>
 //                 Simon Colmer <https://github.com/workshop2>
@@ -772,6 +772,7 @@ export interface PinOption {
     id?: number | string | undefined;
     pin: number | string;
     type?: string | undefined;
+    board?: Board | undefined;
 }
 
 export interface PinState {

--- a/types/johnny-five/johnny-five-tests.ts
+++ b/types/johnny-five/johnny-five-tests.ts
@@ -199,10 +199,14 @@ boards.on('ready', ({ UNO }) => {
 const boards2 = new five.Boards(['UNO', 'UNO_MINI'] as const);
 
 boards2.on('ready', ({ UNO, UNO_MINI }) => {
-    const led = new five.Led({ board: UNO, pin: 13 });
-    const led2 = new five.Led({ board: UNO_MINI, pin: 13 });
+    const led = new five.Led({ board: UNO, pin: 1 });
+    const led2 = new five.Led({ board: UNO_MINI, pin: 2 });
+    const pin = new five.Pin({ board: UNO, pin: 3 });
+    const pin2 = new five.Pin({ board: UNO_MINI, pin: 4 });
     led.blink(500);
     led2.blink(500);
+    pin.high();
+    pin2.low();
 });
 
 new five.Barometer({ controller: 'BMP280' });


### PR DESCRIPTION
When working with multiple board, we are able to pass the matching board, now with the Pin class