### PR TITLE
[react-html-email] add missing `platforms` field

### DIFF
--- a/types/react-html-email/index.d.ts
+++ b/types/react-html-email/index.d.ts
@@ -83,6 +83,7 @@ export interface SpanProps {
 export const Span: FunctionComponent<SpanProps>;
 
 export function configStyleValidator(config: {
+    platforms?: string[] | undefined;
     strict?: boolean | undefined;
     warn?: boolean | undefined;
 }): void;


### PR DESCRIPTION
If you look at react-html-email's source ([1](https://github.com/chromakode/react-html-email/blob/master/src/PropTypes.js#L6-L8), [2](https://github.com/chromakode/react-html-email/blob/master/src/StyleValidator.js#L11-L25), [3](https://github.com/chromakode/react-html-email#configstylevalidatorconfig)), you can see that `configStyleValidator` also accepts a `platforms` parameter, which is an array of strings.

This is causing TS errors in our codebase, so I'm hoping to push this fix upstream.

I did not write tests, this specific package is unmaintained and there already aren't great tests here... However I am confident in the fix. Sorry in advance if you hear this a lot and this causes you anxiety 🙂 

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [1](https://github.com/chromakode/react-html-email/blob/master/src/PropTypes.js#L6-L8), [2](https://github.com/chromakode/react-html-email/blob/master/src/StyleValidator.js#L11-L25), [3](https://github.com/chromakode/react-html-email#configstylevalidatorconfig)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
  - this does not apply, version is not changing