### PR TITLE
[node-forge] Support MessageDigest signature

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -370,6 +370,9 @@ declare module 'node-forge' {
 
             type ToNativeBufferParameters =
                 | {
+                      md: md.MessageDigest;
+                  }
+                | {
                       message: NativeBuffer | util.ByteBuffer;
                   }
                 | {

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -638,8 +638,8 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
         privateKey,
     });
 
-    const md = forge.md.sha256.create()
-    md.update('abc', 'utf8')
+    const md = forge.md.sha256.create();
+    md.update('abc', 'utf8');
 
     forge.pki.ed25519.sign({
         md,

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -637,6 +637,14 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
         encoding: 'utf8',
         privateKey,
     });
+
+    const md = forge.md.sha256.create()
+    md.update('abc', 'utf8')
+
+    forge.pki.ed25519.sign({
+        md,
+        privateKey,
+    });
 }
 
 {


### PR DESCRIPTION
As per documentation and confirmed by tests, signing/verifying a md.MessageDigest using md key instead of message key is also possible:

https://github.com/digitalbazaar/forge#ed25519

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/digitalbazaar/forge#ed25519)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.