### PR TITLE
[Luxon] Fix DateTime.toObject types to reflect conditional locale output

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -201,15 +201,9 @@ export type PossibleDaysInMonth = 28 | 29 | 30 | 31;
 export type PossibleDaysInYear = 365 | 366;
 export type PossibleWeeksInYear = 52 | 53;
 
-export interface ToObjectOutput extends DateTimeJSOptions {
-    year: number;
-    month: number;
-    day: number;
-    hour: number;
-    minute: number;
-    second: number;
-    millisecond: number;
-}
+export type ToObjectOutput<IncludeConfig extends boolean | undefined = true> =
+    & Record<Exclude<DateTimeUnit, 'quarter' | 'week'>, number>
+    & (IncludeConfig extends true ? LocaleOptions : unknown);
 
 export interface ToRelativeOptions extends Omit<ToRelativeCalendarOptions, 'unit'> {
     /**
@@ -1397,13 +1391,13 @@ export class DateTime {
      * @example
      * DateTime.now().toObject() //=> { year: 2017, month: 4, day: 22, hour: 20, minute: 49, second: 42, millisecond: 268 }
      */
-    toObject(opts?: {
+    toObject<IncludeConfig extends boolean | undefined>(opts?: {
         /**
          * Include configuration attributes in the output
          * @defaultValue false
          */
-        includeConfig?: boolean | undefined;
-    }): ToObjectOutput;
+        includeConfig?: IncludeConfig;
+    }): ToObjectOutput<IncludeConfig>;
 
     /**
      * Returns a JavaScript Date equivalent to this DateTime.

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -476,12 +476,12 @@ export class Duration {
     /**
      * Returns an error code if this Duration became invalid, or null if the Duration is valid
      */
-    get invalidReason(): string;
+    get invalidReason(): string | null;
 
     /**
      * Returns an explanation of why this Duration became invalid, or null if the Duration is valid
      */
-    get invalidExplanation(): string;
+    get invalidExplanation(): string | null;
 
     /**
      * Equality check

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -95,12 +95,12 @@ export class Interval {
     /**
      * Returns an error code if this Interval is invalid, or null if the Interval is valid
      */
-    get invalidReason(): string;
+    get invalidReason(): string | null;
 
     /**
      * Returns an explanation of why this Interval became invalid, or null if the Interval is valid
      */
-    get invalidExplanation(): string;
+    get invalidExplanation(): string | null;
 
     /**
      * Returns the length of the Interval in the specified unit.

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -137,8 +137,11 @@ dt.toSQLTime(); // $ExpectType string
 dt.toSQLTime({ includeOffset: false, includeZone: true }); // $ExpectType string
 dt.toSQLTime({ includeOffsetSpace: false, includeZone: true }); // $ExpectType string
 dt.valueOf(); // $ExpectType number
-dt.toObject(); // $ExpectType ToObjectOutput
-dt.toObject({ includeConfig: true }); // $ExpectType ToObjectOutput
+dt.toObject(); // $ExpectType Record<"day" | "hour" | "minute" | "month" | "second" | "year" | "millisecond", number>
+// @ts-expect-error
+dt.toObject().locale;
+dt.toObject({ includeConfig: true }); // $ExpectType ToObjectOutput<true>
+dt.toObject({ includeConfig: true }).locale; // $ExpectType string | undefined
 dt.toUnixInteger(); // $ExpectType number
 
 // $ExpectType string | null

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -257,6 +257,9 @@ i.set({ end: DateTime.local(2020) }); // $ExpectType Interval
 i.mapEndpoints(d => d); // $ExpectType Interval
 i.intersection(i); // $ExpectType Interval | null
 
+i.invalidReason; // $ExpectType string | null
+i.invalidExplanation; // $ExpectType string | null
+
 i.toISO(); // $ExpectType string
 i.toISODate(); // $ExpectType string
 i.toISOTime(); // $ExpectType string
@@ -452,6 +455,9 @@ dur.reconfigure({ conversionAccuracy: 'longterm' }); // $ExpectType Duration
 
 start.until(end); // $ExpectType Interval
 i.toDuration(['years', 'months', 'days']); // $ExpectType Duration
+
+dur.invalidReason; // $ExpectType string | null
+dur.invalidExplanation; // $ExpectType string | null
 
 /* Sample Zone Implementation */
 class SampleZone extends Zone {


### PR DESCRIPTION
Also correct invalid reason and explanation to be nullable.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
