### PR TITLE
[Luxon] Clean up jsdocs

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -220,7 +220,7 @@ export interface ToRelativeOptions extends Omit<ToRelativeCalendarOptions, 'unit
     round?: boolean | undefined;
     /**
      * Padding in milliseconds. This allows you to round up the result if it fits inside the threshold.
-     * Don't use in combination with {round: false} because the decimal output will include the padding.
+     * Do not use this in combination with `{round: false}` because the decimal output will include the padding.
      * @default 0
      */
     padding?: number | undefined;
@@ -347,15 +347,18 @@ export interface DateObjectUnits {
 export type ConversionAccuracy = 'casual' | 'longterm';
 
 /**
- * @deprecated You should use Intl.DateTimeFormatOptions' fields and values instead.
+ * @deprecated You should use `Intl.DateTimeFormatOptions` fields and values instead.
  */
 export type DateTimeFormatPresetValue = 'numeric' | 'short' | 'long';
 /**
- * @deprecated Use Intl.DateTimeFormatOptions instead.
+ * @deprecated Use `Intl.DateTimeFormatOptions` instead.
  */
 export type DateTimeFormatPreset = Intl.DateTimeFormatOptions;
 
 export interface DiffOptions {
+    /**
+     * @default 'casual'
+     */
     conversionAccuracy?: ConversionAccuracy | undefined;
 }
 
@@ -374,17 +377,17 @@ export interface ExplainedFormat {
  * A DateTime is an immutable data structure representing a specific date and time and accompanying methods.
  * It contains class and instance methods for creating, parsing, interrogating, transforming, and formatting them.
  *
- * A DateTime comprises of:
+ * A DateTime consists of the following parts:
  * * A timestamp. Each DateTime instance refers to a specific millisecond of the Unix epoch.
- * * A time zone. Each instance is considered in the context of a specific zone (by default the local system's zone).
- * * Configuration properties that effect how output strings are formatted, such as `locale`, `numberingSystem`, and `outputCalendar`.
+ * * A time zone. Each instance is considered in the context of a specific zone (by default, the local system's zone).
+ * * Configuration properties that affect how output strings are formatted, such as `locale`, `numberingSystem`, and `outputCalendar`.
  *
  * Here is a brief overview of the most commonly used functionality it provides:
  *
  * * **Creation**: To create a DateTime from its components, use one of its factory class methods: {@link DateTime.local}, {@link DateTime.utc}, and (most flexibly) {@link DateTime.fromObject}.
  * To create one from a standard string format, use {@link DateTime.fromISO}, {@link DateTime.fromHTTP}, and {@link DateTime.fromRFC2822}.
  * To create one from a custom string format, use {@link DateTime.fromFormat}. To create one from a native JS date, use {@link DateTime.fromJSDate}.
- * * **Gregorian calendar and time**: To examine the Gregorian properties of a DateTime individually (i.e as opposed to collectively through {@link DateTime#toObject}), use the {@link DateTime#year},
+ * * **Gregorian calendar and time**: To examine the Gregorian properties of a DateTime individually (i.e. as opposed to collectively through {@link DateTime#toObject}), use the {@link DateTime#year},
  * {@link DateTime#month}, {@link DateTime#day}, {@link DateTime#hour}, {@link DateTime#minute}, {@link DateTime#second}, {@link DateTime#millisecond} accessors.
  * * **Week calendar**: For ISO week calendar attributes, see the {@link DateTime#weekYear}, {@link DateTime#weekNumber}, and {@link DateTime#weekday} accessors.
  * * **Configuration** See the {@link DateTime#locale} and {@link DateTime#numberingSystem} accessors.
@@ -417,6 +420,7 @@ export class DateTime {
      * @param minute - The minute of the hour, meaning a number between 0 and 59
      * @param second - The second of the minute, meaning a number between 0 and 59
      * @param millisecond - The millisecond of the second, meaning a number between 0 and 999
+     * @param opts
      *
      * @example
      * DateTime.local()                                  //~> now
@@ -799,17 +803,17 @@ export class DateTime {
     get invalidExplanation(): string | null;
 
     /**
-     * Get the locale of a DateTime, such 'en-GB'. The locale is used when formatting the DateTime
+     * Get the locale of a DateTime, such as 'en-GB'. The locale is used when formatting the DateTime
      */
     get locale(): string;
 
     /**
-     * Get the numbering system of a DateTime, such 'beng'. The numbering system is used when formatting the DateTime
+     * Get the numbering system of a DateTime, such as 'beng'. The numbering system is used when formatting the DateTime
      */
     get numberingSystem(): string;
 
     /**
-     * Get the output calendar of a DateTime, such 'islamic'. The output calendar is used when formatting the DateTime
+     * Get the output calendar of a DateTime, such as 'islamic'. The output calendar is used when formatting the DateTime
      */
     get outputCalendar(): string;
 
@@ -1061,7 +1065,7 @@ export class DateTime {
      * as with {@link DateTime.plus}. You may wish to use {@link DateTime.toLocal} and {@link DateTime.toUTC} which provide simple convenience wrappers for commonly used zones.
      *
      * @param zone - a zone identifier. As a string, that can be any IANA zone supported by the host environment, or a fixed-offset name of the form 'UTC+3', or the strings 'local' or 'utc'.
-     * You may also supply an instance of a {@link DateTime.Zone} class. Defaults to 'local'.
+     * You may also supply an instance of a {@link Zone} class. Defaults to 'local'.
      * @param opts - options
      * @param opts.keepLocalTime - If true, adjust the underlying time so that the local time stays the same, but in the target zone. You should rarely need this. Defaults to false.
      */
@@ -1132,7 +1136,7 @@ export class DateTime {
     minus(duration: DurationLike): DateTime;
 
     /**
-     * "Set" this DateTime to the beginning of a unit of time.
+     * "Set" this DateTime to the beginning of the given unit.
      *
      * @param unit - The unit to go to the beginning of. Can be 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', or 'millisecond'.
      *
@@ -1224,8 +1228,6 @@ export class DateTime {
      * Defaults to the system's locale if no locale has been specified
      * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts
      *
-     * @param opts - Intl.DateTimeFormat constructor options, same as `toLocaleString`.
-     *
      * @example
      * DateTime.now().toLocaleParts(); //=> [
      *                                 //=>   { type: 'day', value: '25' },
@@ -1239,12 +1241,6 @@ export class DateTime {
 
     /**
      * Returns an ISO 8601-compliant string representation of this DateTime
-     *
-     * @param opts - options
-     * @param opts.suppressMilliseconds - exclude milliseconds from the format if they're 0. Defaults to false.
-     * @param opts.suppressSeconds - exclude seconds from the format if they're 0. Defaults to false.
-     * @param opts.includeOffset - include the offset, such as 'Z' or '-04:00'. Defaults to true.
-     * @param opts.format - choose between the basic and extended format. Defaults to 'extended'.
      *
      * @example
      * DateTime.utc(1982, 5, 25).toISO() //=> '1982-05-25T00:00:00.000Z'
@@ -1332,10 +1328,6 @@ export class DateTime {
     /**
      * Returns a string representation of this DateTime appropriate for use in SQL Time
      *
-     * @param opts - options
-     * @param opts.includeZone - include the zone, such as 'America/New_York'. Overrides includeOffset. Defaults to false.
-     * @param opts.includeOffset - include the offset, such as 'Z' or '-04:00'. Defaults to true.
-     *
      * @example
      * DateTime.utc().toSQL() //=> '05:15:16.345'
      * @example
@@ -1348,11 +1340,7 @@ export class DateTime {
     toSQLTime(opts?: ToSQLOptions): string;
 
     /**
-     * Returns a string representation of this DateTime appropriate for use in SQL DateTime
-     *
-     * @param opts - options
-     * @param opts.includeZone - include the zone, such as 'America/New_York'. Overrides includeOffset. Defaults to false.
-     * @param opts.includeOffset - include the offset, such as 'Z' or '-04:00'. Defaults to true.
+     * Returns a string representation of this DateTime for use in SQL DateTime
      *
      * @example
      * DateTime.utc(2014, 7, 13).toSQL() //=> '2014-07-13 00:00:00.000 Z'
@@ -1396,7 +1384,7 @@ export class DateTime {
     toJSON(): string;
 
     /**
-     * Returns a BSON serializable equivalent to this DateTime.
+     * Returns a BSON-serializable equivalent to this DateTime.
      */
     toBSON(): Date;
 
@@ -1428,12 +1416,14 @@ export class DateTime {
      * Return the difference between two DateTimes as a Duration.
      *
      * @param otherDateTime - the DateTime to compare this one to
-     * @param unit- the unit or array of units (such as 'hours' or 'days') to include in the duration. Defaults to ['milliseconds'].
+     * @param unit - the unit or array of units to include in the duration.
+     * Defaults to ['milliseconds'].
      * @param opts - options that affect the creation of the Duration
-     * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
+     * @param opts.conversionAccuracy - the conversion system to use.
+     * Defaults to 'casual'.
      *
      * @example
-     * var i1 = DateTime.fromISO('1982-05-25T09:45'),
+     * let i1 = DateTime.fromISO('1982-05-25T09:45'),
      *     i2 = DateTime.fromISO('1983-10-14T10:30');
      * i2.diff(i1).toObject() //=> { milliseconds: 43807500000 }
      * i2.diff(i1, 'hours').toObject() //=> { hours: 12168.75 }
@@ -1446,7 +1436,7 @@ export class DateTime {
      * Return the difference between this DateTime and right now.
      * See {@link DateTime.diff}
      *
-     * @param unit - the unit or units units (such as 'hours' or 'days') to include in the duration. Defaults to ['milliseconds'].
+     * @param unit - the unit(s) to include in the duration. Defaults to ['milliseconds'].
      * @param opts - options that affect the creation of the Duration
      * @param opts.conversionAccuracy - the conversion system to use. Defaults to 'casual'.
      */
@@ -1472,7 +1462,7 @@ export class DateTime {
     hasSame(otherDateTime: DateTime, unit: DateTimeUnit): boolean;
 
     /**
-     * Equality check
+     * An equality check.
      * Two DateTimes are equal if and only if they represent the same millisecond, have the same zone and location, and are both valid.
      * To compare just the millisecond values, use `+dt1 === +dt2`.
      *
@@ -1481,19 +1471,9 @@ export class DateTime {
     equals(other: DateTime): boolean;
 
     /**
-     * Returns a string representation of a this time relative to now, such as "in two days". Can only internationalize if your
-     * platform supports Intl.RelativeTimeFormat. Rounds down by default.
-     *
-     * @param options - options that affect the output
-     * @param options.base - the DateTime to use as the basis to which this time is compared. Defaults to now.
-     * @param options.style - the style of units, must be "long", "short", or "narrow". Defaults to long.
-     * @param options.unit - use a specific unit or array of units; if omitted, or an array, the method will pick the best unit.
-     * Use an array or one of "years", "quarters", "months", "weeks", "days", "hours", "minutes", or "seconds"
-     * @param options.round - whether to round the numbers in the output. Defaults to true.
-     * @param options.padding - padding in milliseconds. This allows you to round up the result if it fits inside the threshold. Don't use in combination with {round: false}
-     * because the decimal output will include the padding. Defaults to 0.
-     * @param options.locale - override the locale of this DateTime
-     * @param options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this
+     * Returns a string representation of this time relative to now, such as "in two days".
+     * Can only internationalize if your platform supports Intl.RelativeTimeFormat.
+     * Rounds down by default.
      *
      * @example
      * DateTime.now().plus({ days: 1 }).toRelative() //=> "in 1 day"
@@ -1512,13 +1492,7 @@ export class DateTime {
 
     /**
      * Returns a string representation of this date relative to today, such as "yesterday" or "next month".
-     * Only internationalizes on platforms that supports Intl.RelativeTimeFormat.
-     *
-     * @param options - options that affect the output
-     * @param options.base - the DateTime to use as the basis to which this time is compared. Defaults to now.
-     * @param options.locale - override the locale of this DateTime
-     * @param options.unit - use a specific unit; if omitted, the method will pick the unit. Use one of "years", "quarters", "months", "weeks", or "days"
-     * @param options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this
+     * Only internationalizes on platforms that support Intl.RelativeTimeFormat.
      *
      * @example
      * DateTime.now().plus({ days: 1 }).toRelativeCalendar() //=> "tomorrow"

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -43,12 +43,12 @@ export interface ToISOTimeDurationOptions {
      */
     includePrefix?: boolean | undefined;
     /**
-     * Exclude milliseconds from the format if they're 0
+     * Exclude milliseconds from the format if they are 0
      * @default false
      */
     suppressMilliseconds?: boolean | undefined;
     /**
-     * Exclude seconds from the format if they're 0
+     * Exclude seconds from the format if they are 0
      * @default false
      */
     suppressSeconds?: boolean | undefined;
@@ -77,7 +77,7 @@ export type DurationLike = Duration | DurationLikeObject | number;
 
 /**
  * A Duration object represents a period of time, like "2 months" or "1 day, 1 hour".
- * Conceptually, it's just a map of units to their quantities, accompanied by some additional configuration and methods for creating, parsing, interrogating, transforming, and formatting them.
+ * Conceptually, it is just a map of units to their quantities, accompanied by some additional configuration and methods for creating, parsing, interrogating, transforming, and formatting them.
  * They can be used on their own or in conjunction with other Luxon types; for example, you can use {@link DateTime.plus} to add a Duration object to a DateTime, producing another DateTime.
  *
  * Here is a brief overview of commonly used methods and getters in Duration:
@@ -193,12 +193,12 @@ export class Duration {
     private constructor(config: unknown);
 
     /**
-     * Get  the locale of a Duration, such 'en-GB'
+     * Get the locale of a Duration, such as 'en-GB'
      */
     get locale(): string;
 
     /**
-     * Get the numbering system of a Duration, such 'beng'. The numbering system is used when formatting the Duration
+     * Get the numbering system of a Duration, such as 'beng'. The numbering system is used when formatting the Duration
      */
     get numberingSystem(): string;
 
@@ -213,7 +213,7 @@ export class Duration {
      * * `y` for years
      * Notes:
      * * Add padding by repeating the token, e.g. "yy" pads the years to two digits, "hhhh" pads the hours out to four digits
-     * * The duration will be converted to the set of units in the format string using {@link Duration.shiftTo} and the Durations's conversion accuracy setting.
+     * * The duration will be converted to the set of units in the format string using {@link Duration.shiftTo} and the Duration's conversion accuracy setting.
      *
      * @param fmt - the format string
      * @param opts - options
@@ -231,7 +231,7 @@ export class Duration {
     /**
      * Returns a string representation of a Duration with all units included
      * To modify its behavior use the `listStyle` and any Intl.NumberFormat option, though `unitDisplay` is especially relevant. See {@link Intl.NumberFormat}.
-     * @param opts - On option object to override the formatting. Accepts the same keys as the options parameter of the native `Int.NumberFormat` constructor, as well as `listStyle`.
+     *
      * @example
      * ```js
      * var dur = Duration.fromObject({ days: 1, hours: 5, minutes: 6 })
@@ -272,7 +272,7 @@ export class Duration {
      * @see https://en.wikipedia.org/wiki/ISO_8601#Times
      *
      * @param opts - options
-     * @param opts.suppressMilliseconds - exclude milliseconds from the format if they're 0. Defaults to false.
+     * @param opts.suppressMilliseconds - exclude milliseconds from the format if they are 0. Defaults to false.
      * @param opts.suppressSeconds - exclude seconds from the format if they're 0. Defaults to false.
      * @param opts.includePrefix - include the `T` prefix. Defaults to false.
      * @param opts.format - choose between the basic and extended format. Defaults to 'extended'.
@@ -301,12 +301,12 @@ export class Duration {
     toString(): string;
 
     /**
-     * Returns an milliseconds value of this Duration.
+     * Returns a millisecond value of this Duration.
      */
     toMillis(): number;
 
     /**
-     * Returns an milliseconds value of this Duration. Alias of {@link toMillis}
+     * Returns a millisecond value of this Duration. Alias of {@link toMillis}
      */
     valueOf(): number;
 
@@ -468,8 +468,8 @@ export class Duration {
     get milliseconds(): number;
 
     /**
-     * Returns whether the Duration is invalid. Invalid durations are returned by diff operations
-     * on invalid DateTimes or Intervals.
+     * Returns whether the Duration is invalid.
+     * Diff operations on invalid DateTimes or Intervals return invalid Durations.
      */
     get isValid(): boolean;
 
@@ -486,8 +486,6 @@ export class Duration {
     /**
      * Equality check
      * Two Durations are equal iff they have the same units and the same values for each unit.
-     *
-     * @param other
      */
     equals(other: Duration): boolean;
 }

--- a/types/luxon/src/info.d.ts
+++ b/types/luxon/src/info.d.ts
@@ -13,6 +13,9 @@ export interface InfoUnitOptions extends InfoOptions {
 export type UnitOptions = InfoUnitOptions;
 
 export interface InfoCalendarOptions extends InfoUnitOptions {
+    /**
+     * @default gregory
+     */
     outputCalendar?: CalendarSystem | undefined;
 }
 
@@ -65,11 +68,11 @@ export namespace Info {
      * Return an array of standalone month names.
      * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
      *
-     * @param length - the length of the month representation, such as "numeric", "2-digit", "narrow", "short", "long". Defaults to 'long'.
+     * @param length - the length of the month representation. Defaults to 'long'.
      * @param opts - options
      * @param opts.locale - the locale code
-     * @param opts.numberingSystem - the numbering system. Defaults to null.
-     * @param opts.locObj - an existing locale object to use. Defaults to null.
+     * @param opts.numberingSystem - the numbering system.
+     * @param opts.locObj - an existing locale object to use.
      * @param opts.outputCalendar - the calendar. Defaults to 'gregory'.
      *
      * @example
@@ -89,28 +92,28 @@ export namespace Info {
 
     /**
      * Return an array of format month names.
-     * Format months differ from standalone months in that they're meant to appear next to the day of the month. In some languages, that
-     * changes the string.
+     * Format months differ from standalone months in that they are meant to appear next to the day of the month.
+     * In some languages, that changes the string.
      * See {@link Info#months}
      *
-     * @param length - the length of the month representation, such as "numeric", "2-digit", "narrow", "short", "long". Defaults to 'long'.
+     * @param length - the length of the month representation. Defaults to 'long'.
      * @param opts - options
      * @param opts.locale - the locale code
-     * @param opts.numberingSystem - the numbering system. Defaults to null.
-     * @param opts.locObj - an existing locale object to use. Defaults to null.
+     * @param opts.numberingSystem - the numbering system.
+     * @param opts.locObj - an existing locale object to use.
      * @param opts.outputCalendar - the calendar. Defaults to 'gregory'.
      */
-    function monthsFormat(length?: UnitLength, options?: InfoCalendarOptions): string[];
+    function monthsFormat(length?: UnitLength, opts?: InfoCalendarOptions): string[];
 
     /**
      * Return an array of standalone week names.
      * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
      *
-     * @param length - the length of the weekday representation, such as "narrow", "short", "long". Defaults to 'long'.
+     * @param length - the length of the weekday representation. Defaults to 'long'.
      * @param opts - options
      * @param opts.locale - the locale code
-     * @param opts.numberingSystem - the numbering system. Defaults to null.
-     * @param opts.locObj - an existing locale object to use. Defaults to null.
+     * @param opts.numberingSystem - the numbering system.
+     * @param opts.locObj - an existing locale object to use.
      *
      * @example
      * Info.weekdays()[0] //=> 'Monday'
@@ -121,21 +124,21 @@ export namespace Info {
      * @example
      * Info.weekdays('short', { locale: 'ar' })[0] //=> 'الاثنين'
      */
-    function weekdays(length?: StringUnitLength, options?: InfoUnitOptions): string[];
+    function weekdays(length?: StringUnitLength, opts?: InfoUnitOptions): string[];
 
     /**
      * Return an array of format week names.
-     * Format weekdays differ from standalone weekdays in that they're meant to appear next to more date information. In some languages, that
-     * changes the string.
+     * Format weekdays differ from standalone weekdays in that they are meant to appear next to more date information.
+     * In some languages, that changes the string.
      * See {@link Info#weekdays}
      *
-     * @param length - the length of the month representation, such as "narrow", "short", "long". Defaults to 'long'.
+     * @param length - the length of the month representation. Defaults to 'long'.
      * @param opts - options
-     * @param opts.locale - the locale code. Defaults to null.
-     * @param opts.numberingSystem - the numbering system. Defaults to null.
-     * @param opts.locObj - an existing locale object to use. Defaults to null.
+     * @param opts.locale - the locale code.
+     * @param opts.numberingSystem - the numbering system.
+     * @param opts.locObj - an existing locale object to use.
      */
-    function weekdaysFormat(length?: StringUnitLength, options?: InfoUnitOptions): string[];
+    function weekdaysFormat(length?: StringUnitLength, opts?: InfoUnitOptions): string[];
 
     /**
      * Return an array of meridiems.
@@ -148,12 +151,12 @@ export namespace Info {
      * @example
      * Info.meridiems({ locale: 'my' }) //=> [ 'နံနက်', 'ညနေ' ]
      */
-    function meridiems(options?: InfoOptions): string[];
+    function meridiems(opts?: InfoOptions): string[];
 
     /**
      * Return an array of eras, such as ['BC', 'AD']. The locale can be specified, but the calendar system is always Gregorian.
      *
-     * @param length - the length of the era representation, such as "short" or "long". Defaults to 'short'.
+     * @param length - the length of the era representation. Defaults to 'short'.
      * @param opts - options
      * @param opts.locale - the locale code
      *
@@ -164,13 +167,13 @@ export namespace Info {
      * @example
      * Info.eras('long', { locale: 'fr' }) //=> [ 'avant Jésus-Christ', 'après Jésus-Christ' ]
      */
-    function eras(length?: StringUnitLength, options?: InfoOptions): string[];
+    function eras(length?: StringUnitLength, opts?: InfoOptions): string[];
 
     /**
      * Return the set of available features in this environment.
-     * Some features of Luxon are not available in all environments. For example, on older browsers, timezone support is not available. Use this function to figure out if that's the case.
-     * Keys:
-     * * `relative`: whether this environment supports relative time formatting
+     * Some features of Luxon are not available in all environments.
+     * For example, on older browsers, timezone support is not available.
+     * Use this function to figure out if that is the case.
      *
      * @example
      * Info.features() //=> { intl: true, intlTokens: false, zones: true, relative: false }

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -9,7 +9,8 @@ export interface IntervalObject {
 export type DateInput = DateTime | DateObjectUnits | Date;
 
 /**
- * An Interval object represents a half-open interval of time, where each endpoint is a {@link DateTime}. Conceptually, it's a container for those two endpoints, accompanied by methods for
+ * An Interval object represents a half-open interval of time, where each endpoint is a {@link DateTime}.
+ * Conceptually, it is a container for those two endpoints, accompanied by methods for
  * creating, parsing, interrogating, comparing, transforming, and formatting them.
  *
  * Here is a brief overview of the most commonly used methods and getters in Interval:
@@ -29,7 +30,7 @@ export class Interval {
      * Create an invalid Interval.
      *
      * @param reason - simple string of why this Interval is invalid. Should not contain parameters or anything else data-dependent
-     * @param explanation - longer explanation, may include parameters and other useful debugging information. Defaults to null.
+     * @param explanation - longer explanation, may include parameters and other useful debugging information.
      */
     static invalid(reason: string, explanation?: string): Interval;
 
@@ -183,75 +184,55 @@ export class Interval {
 
     /**
      * Return whether this Interval overlaps with the specified Interval
-     *
-     * @param other
      */
     overlaps(other: Interval): boolean;
 
     /**
      * Return whether this Interval's end is adjacent to the specified Interval's start.
-     *
-     * @param other
      */
     abutsStart(other: Interval): boolean;
 
     /**
      * Return whether this Interval's start is adjacent to the specified Interval's end.
-     *
-     * @param other
      */
     abutsEnd(other: Interval): boolean;
 
     /**
      * Return whether this Interval engulfs the start and end of the specified Interval.
-     *
-     * @param other
      */
     engulfs(other: Interval): boolean;
 
     /**
      * Return whether this Interval has the same start and end as the specified Interval.
-     *
-     * @param other
      */
     equals(other: Interval): boolean;
 
     /**
      * Return an Interval representing the intersection of this Interval and the specified Interval.
      * Specifically, the resulting Interval has the maximum start time and the minimum end time of the two Intervals.
-     * Returns null if the intersection is empty, meaning, the intervals don't intersect.
-     *
-     * @param other
+     * Returns null if the intersection is empty, meaning the intervals do not intersect.
      */
     intersection(other: Interval): Interval | null;
 
     /**
      * Return an Interval representing the union of this Interval and the specified Interval.
      * Specifically, the resulting Interval has the minimum start time and the maximum end time of the two Intervals.
-     *
-     * @param other
      */
     union(other: Interval): Interval;
 
     /**
      * Merge an array of Intervals into a equivalent minimal set of Intervals.
      * Combines overlapping and adjacent Intervals.
-     *
-     * @param intervals
      */
     static merge(intervals: Interval[]): Interval[];
 
     /**
      * Return an array of Intervals representing the spans of time that only appear in one of the specified Intervals.
-     *
-     *  @param intervals
      */
     static xor(intervals: Interval[]): Interval[];
 
     /**
-     * Return an Interval representing the span of time in this Interval that doesn't overlap with any of the specified Intervals.
-     *
-     * @param intervals
+     * Return Intervals representing the spans of time in this Interval that not overlap with any of the specified Intervals.
      */
     difference(...intervals: Interval[]): Interval[];
 
@@ -299,14 +280,14 @@ export class Interval {
     toISO(opts?: ToISOTimeOptions): string;
 
     /**
-     * Returns an ISO 8601-compliant string representation of date of this Interval.
+     * Returns an ISO 8601-compliant string representation of the dates in this Interval.
      * The time components are ignored.
      * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
      */
     toISODate(): string;
 
     /**
-     * Returns an ISO 8601-compliant string representation of time of this Interval.
+     * Returns an ISO 8601-compliant string representation of the times in this Interval.
      * The date components are ignored.
      * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
      *
@@ -350,8 +331,6 @@ export class Interval {
 
     /**
      * Run mapFn on the interval start and end, returning a new Interval from the resulting DateTimes
-     *
-     * @param mapFn
      *
      * @example
      * Interval.fromDateTimes(dt1, dt2).mapEndpoints(endpoint => endpoint.toUTC())

--- a/types/luxon/src/settings.d.ts
+++ b/types/luxon/src/settings.d.ts
@@ -1,7 +1,7 @@
 import { Zone } from './zone';
 
 /**
- * Settings contains static getters and setters that control Luxon's overall behavior.
+ * `Settings` contains static getters and setters that control Luxon's overall behavior.
  * Luxon is a simple library with few options, but the ones it does have live here.
  */
 // tslint:disable-next-line:no-unnecessary-class
@@ -16,7 +16,7 @@ export class Settings {
      * The function should return a number, which will be interpreted as an Epoch millisecond count
      *
      * @example Settings.now = () => Date.now() + 3000 // pretend it is 3 seconds in the future
-     * @example Settings.now = () => 0 // always pretend it's Jan 1, 1970 at midnight in UTC time
+     * @example Settings.now = () => 0 // always pretend it is Jan 1, 1970 at midnight in UTC time
      */
     static set now(now: () => number);
 


### PR DESCRIPTION
- Corrected grammar mistakes - anything my editor showed me.
- Removed useless `@param` where they didn't provide any info or they were duplicated by jsdocs on a TS interface.
- Removed param copy that enumerated type values, since we have those defined by TS.